### PR TITLE
genesis-tool: Byron genesis generator CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 dist-newstyle/
 dist/
 *~
+\#*
+*.swp
 result*
 launch-*
 .stack-to-nix.cache
+/genesis.*

--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@
 Integration of the [ledger](https://github.com/input-output-hk/cardano-ledger), [consensus](https://github.com/input-output-hk/ouroboros-network/tree/master/ouroboros-consensus), [networking](https://github.com/input-output-hk/ouroboros-network/tree/master/ouroboros-network) and [node shell](https://github.com/input-output-hk/cardano-shell) repositories.
 [Logging](https://github.com/input-output-hk/iohk-monitoring-framework) is provided as a [feature](https://github.com/input-output-hk/cardano-shell/blob/master/app/Cardano/Shell/Features/Logging.hs) by the node shell to the other packages.
 
+# `genesis-tool`
 
-# demonstration
+A CLI utility to support a variety of key material operations (genesis, migration, pretty-printing..) for different system generations.
+
+Detailed documentation in its attendant [README](https://github.com/input-output-hk/cardano-shell/blob/master/app/genesis-tool/README.md).
+
+# Node demonstration
 
 The demonstration starts up three nodes that are connected to each other and produce blocks according to the algorithm selected (e.g. "BFT").
 The blocks are shared among the nodes and after verification integrated into a nodes ledger.
@@ -31,7 +36,7 @@ The user can submit transactions to a node which includes them in its local memp
 
 ```
 
-## startup of the demonstration
+## Startup of the demonstration
 
 Write the following commands in a terminal:
 

--- a/app/TxSubmission.hs
+++ b/app/TxSubmission.hs
@@ -57,6 +57,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.NodeToClient
 
+import           NodeLib
+
 import           Topology
 
 {-------------------------------------------------------------------------------
@@ -93,16 +95,6 @@ parseMockTxOut = (,)
           , help "Amount to transfer"
           ])
 
-
-{-------------------------------------------------------------------------------
-  optparse-applicative auxiliary
--------------------------------------------------------------------------------}
-
-command' :: String -> String -> Parser a -> Mod CommandFields a
-command' c descr p =
-    command c $ info (p <**> helper) $ mconcat [
-        progDesc descr
-      ]
 
 {-------------------------------------------------------------------------------
   Main logic

--- a/app/TxSubmission.hs
+++ b/app/TxSubmission.hs
@@ -57,7 +57,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.NodeToClient
 
-import           NodeLib
+import           Cardano.Node.CLI
 
 import           Topology
 

--- a/app/genesis-tool/Byron/Legacy.hs
+++ b/app/genesis-tool/Byron/Legacy.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+
+module Byron.Legacy (
+      LegacyDelegateKey(..)
+    , encodeLegacyDelegateKey
+    , decodeLegacyDelegateKey
+    ) where
+
+import qualified Codec.CBOR.Decoding as D
+import qualified Codec.CBOR.Encoding as E
+import           Control.Lens (LensLike, _Left)
+import           Control.Monad
+import qualified Data.Binary as Binary
+import           Data.Coerce
+import           Data.Semigroup ((<>))
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy as LB
+
+import qualified Crypto.SCRAPE as Scrape
+
+import           Cardano.Prelude hiding (option)
+
+import qualified Cardano.Crypto.Wallet as CC
+import           Cardano.Crypto.Signing (SigningKey(..))
+
+-- LegacyDelegateKey is a subset of the UserSecret's from the legacy codebase:
+-- 1. the VSS keypair must be present
+-- 2. the signing key must be present
+-- 3. the rest must be absent (Nothing)
+--
+-- Legacy reference: https://github.com/input-output-hk/cardano-sl/blob/release/3.0.1/lib/src/Pos/Util/UserSecret.hs#L189
+data LegacyDelegateKey
+  =  LegacyDelegateKey
+  { lrkSigningKey :: SigningKey
+  , lrkVSSKeyPair :: Scrape.KeyPair
+  }
+
+-- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+encodeBinary :: Binary.Binary a => a -> E.Encoding
+encodeBinary = E.encodeBytes . LB.toStrict . Binary.encode
+
+-- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+decodeBinary :: Binary.Binary a => D.Decoder s a
+decodeBinary = do
+    x <- D.decodeBytesCanonical
+    toCborError $ case Binary.decodeOrFail (LB.fromStrict x) of
+        Left (_, _, err) -> Left (T.pack err)
+        Right (bs, _, res)
+            | LB.null bs -> Right res
+            | otherwise  -> Left "decodeBinary: unconsumed input"
+
+encodeXPrv :: CC.XPrv -> E.Encoding
+encodeXPrv a = E.encodeBytes $ CC.unXPrv a
+
+decodeXPrv :: D.Decoder s CC.XPrv
+decodeXPrv = toCborError . over _Left T.pack . CC.xprv =<< D.decodeBytesCanonical
+  where over :: LensLike Identity s t a b -> (a -> b) -> s -> t
+        over = coerce
+
+-- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+-- | Enforces that the input size is the same as the decoded one, failing in
+-- case it's not.
+enforceSize :: Text -> Int -> D.Decoder s ()
+enforceSize lbl requestedSize = D.decodeListLenCanonical >>= matchSize requestedSize lbl
+
+-- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+-- | Compare two sizes, failing if they are not equal.
+matchSize :: Int -> Text -> Int -> D.Decoder s ()
+matchSize requestedSize lbl actualSize =
+  when (actualSize /= requestedSize) $
+    cborError (lbl <> " failed the size check. Expected " <> show requestedSize <> ", found " <> show actualSize)
+
+-- Reverse-engineered from cardano-sl legacy codebase.
+encodeLegacyDelegateKey :: LegacyDelegateKey -> E.Encoding
+encodeLegacyDelegateKey LegacyDelegateKey{lrkSigningKey=(SigningKey sk),..}
+  =  E.encodeListLen 4
+  <> E.encodeListLen 1 <> encodeBinary lrkVSSKeyPair
+  <> E.encodeListLen 1 <> encodeXPrv sk
+  <> E.encodeListLenIndef <> E.encodeBreak
+  <> E.encodeListLen 0
+
+-- Reverse-engineered from cardano-sl legacy codebase.
+decodeLegacyDelegateKey :: D.Decoder s LegacyDelegateKey
+decodeLegacyDelegateKey = do
+    enforceSize "UserSecret" 4
+    vss  <- do
+      enforceSize "vss" 1
+      decodeBinary
+    pkey <- do
+      enforceSize "pkey" 1
+      SigningKey <$> decodeXPrv
+    _    <- do
+      D.decodeListLenIndef
+      D.decodeSequenceLenIndef (flip (:)) [] reverse D.decodeNull
+    _    <- do
+      enforceSize "wallet" 0
+    pure $ LegacyDelegateKey pkey vss

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -55,14 +55,14 @@ parseCLI = CLI
 
 parseCommand :: Parser Command
 parseCommand = subparser $ mconcat [
-    command' "keygen" "Generate a keypair." $
+    command' "keygen"                         "Generate a Byron/OBFT keypair." $
       KeyGen
       <$> (SigningFilePath      <$>
            parseFilePath   "out-signing"              "Signing key output file path.")
       <*> (VerificationFilePath <$>
            parseFilePath   "out-verification"         "Verification key output file path.")
-  , command' "full-byron-genesis" "Generate a fully-parametrised Byron genesis from scratch." $
-      FullByronGenesis 
+  , command' "full-byron-genesis"             "Generate a fully-parametrised Byron genesis from scratch." $
+      FullByronGenesis
       <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
       <*> parseUTCTime     "start-time"               "Start time of the new cluster to be enshrined in the new genesis."
       <*> parseFilePath    "protocol-parameters-file" "JSON file with protocol parameters."

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE GADTs #-}
+
+module CLI (
+    -- * CLI
+    CLI(..)
+  , Command(..)
+  , parseCLI
+    --
+  , SigningFilePath,      fromSigningPath
+  , VerificationFilePath, fromVerificationPath
+  ) where
+
+import           Data.Foldable (asum)
+import           Data.Semigroup ((<>))
+import           Data.String (IsString)
+import           Options.Applicative
+
+import           NodeLib
+
+{-------------------------------------------------------------------------------
+  Command line arguments
+-------------------------------------------------------------------------------}
+
+data CLI = CLI {
+    command      :: Command
+  }
+
+data Command =
+    DummyGenesis !FilePath
+  | RTByronGenesis !FilePath
+  | FullByronGenesis
+  | KeyGen !SigningFilePath !VerificationFilePath
+
+newtype SigningFilePath      = SigningFilePath      { fromSigningPath      :: FilePath }
+newtype VerificationFilePath = VerificationFilePath { fromVerificationPath :: FilePath }
+
+parseCLI :: Parser CLI
+parseCLI = CLI
+    <$> parseCommand
+
+parseCommand :: Parser Command
+parseCommand = subparser $ mconcat [
+    command' "dummy-genesis" "Write out a dummy genesis into FILE." $
+      DummyGenesis
+      <$> parseFilePath "genesis-output" "Path of the genesis JSON output file."
+  , command' "full-byron-genesis" "Generate a fully-parametrised Byron genesis from scratch." $
+      pure FullByronGenesis
+  , command' "rt-byron-genesis" "Roundtrip a Byron genesis JSON file." $
+      RTByronGenesis
+      <$> parseFilePath "genesis" "Path of the genesis input JSON file."
+  , command' "keygen" "Generate a keypair." $
+      KeyGen
+      <$> (SigningFilePath      <$> parseFilePath "out-signing"      "Signing key output file path.")
+      <*> (VerificationFilePath <$> parseFilePath "out-verification" "Verification key output file path.")
+  ]
+
+parseFilePath :: String -> String -> Parser FilePath
+parseFilePath optname role =
+    strOption (
+            long optname
+         <> metavar "FILEPATH"
+         <> help role
+    )

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -11,18 +11,15 @@ module CLI (
 
 import qualified Data.ByteString.Lazy as LB
 import           Data.Maybe (fromMaybe)
-import           Data.Semigroup ((<>))
 import           Data.Time (UTCTime)
-import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Options.Applicative
 
-import           Cardano.Binary (Annotated(..))
 import           Cardano.Crypto.ProtocolMagic
 import           Cardano.Crypto.Signing
 import           Cardano.Chain.Common
 import           Cardano.Chain.Genesis
 
-import           NodeLib
+import           Cardano.Node.CLI
 
 {-------------------------------------------------------------------------------
 -------------------------------------------------------------------------------}
@@ -105,69 +102,3 @@ parseCommand = subparser $ mconcat
       <*> parseFilePath    "to"                       "Output secret key file."
       <*> parseFilePath    "from"                     "Secret key file to migrate."
   ]
-
-parseTestnetBalanceOptions :: Parser TestnetBalanceOptions
-parseTestnetBalanceOptions =
-  TestnetBalanceOptions
-  <$> parseIntegral        "n-poor-addresses"         "Number of poor nodes (with small balance)."
-  <*> parseIntegral        "n-delegate-addresses"     "Number of delegate nodes (with huge balance)."
-  <*> parseLovelace        "total-balance"            "Total balance owned by these nodes."
-  <*> parseLovelacePortion "delegate-share"           "Portion of stake owned by all delegates together."
-  <*> parseFlag            "use-hd-addresses"         "Whether generate plain addresses or with hd payload."
-
-parseLovelace :: String -> String -> Parser Lovelace
-parseLovelace optname desc =
-  either (error . show) id . mkLovelace
-  <$> parseIntegral optname desc
-
-parseLovelacePortion :: String -> String -> Parser LovelacePortion
-parseLovelacePortion optname desc =
-  either (error . show) id . mkLovelacePortion
-  <$> parseIntegral optname desc
-
-parseFakeAvvmOptions :: Parser FakeAvvmOptions
-parseFakeAvvmOptions =
-  FakeAvvmOptions
-  <$> parseIntegral        "avvm-entry-count"         "Number of AVVM addresses."
-  <*> parseLovelace        "avvm-entry-balance"       "AVVM address."
-
-parseK :: Parser BlockCount
-parseK =
-  BlockCount
-  <$> parseIntegral        "k"                        "The security parameter of the Ouroboros protocol."
-
-parseProtocolMagic :: Parser ProtocolMagic
-parseProtocolMagic =
-  flip AProtocolMagic RequiresMagic . flip Annotated () . ProtocolMagicId
-  <$> parseIntegral        "protocol-magic"           "The magic number unique to any instance of Cardano."
-
-parseFilePath :: String -> String -> Parser FilePath
-parseFilePath optname desc =
-    strOption (
-            long optname
-         <> metavar "FILEPATH"
-         <> help desc
-    )
-
-parseIntegral :: Integral a => String -> String -> Parser a
-parseIntegral optname desc =
-    option (fromInteger <$> auto) (
-            long optname
-         <> metavar "INT"
-         <> help desc
-    )
-
-parseFlag :: String -> String -> Parser Bool
-parseFlag optname desc =
-    flag False True (
-            long optname
-         <> help desc
-    )
-
-parseUTCTime :: String -> String -> Parser UTCTime
-parseUTCTime optname desc =
-    option (posixSecondsToUTCTime . fromInteger <$> auto) (
-            long optname
-         <> metavar "POSIXSECONDS"
-         <> help desc
-    )

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -45,7 +45,7 @@ data Command
     !FakeAvvmOptions
     !LovelacePortion
     !Integer
-  | PrettySecretKeyPublicHash
+  | PrettySecretKeyPublic
     !FilePath
   | MigrateDelegateKeyFrom
     !SystemVersion
@@ -93,8 +93,8 @@ parseCommand = subparser $ mconcat
            (optional $
             parseIntegral  "avvm-balance-factor"      "AVVM balances will be multiplied by this factor (defaults to 1)."))
       <*> parseIntegral    "secret-seed"              "Optionally specify the seed of generation."
-  , command' "pretty-secret-key-public-hash"  "Print a hash of secret key's public key (not a secret)." $
-      PrettySecretKeyPublicHash
+  , command' "pretty-secret-key-public"       "Pretty-print a secret key's public key (not a secret)." $
+      PrettySecretKeyPublic
       <$> parseFilePath    "secret"                   "File name of the secret key to pretty-print."
   , command' "migrate-delegate-key-from"      "Migrate a delegate key from an older version." $
       MigrateDelegateKeyFrom

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -10,10 +10,16 @@ module CLI (
   , VerificationFilePath, fromVerificationPath
   ) where
 
-import           Data.Foldable (asum)
+import           Data.Maybe (fromMaybe)
 import           Data.Semigroup ((<>))
-import           Data.String (IsString)
+import           Data.Time (UTCTime)
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Options.Applicative
+
+import           Cardano.Binary (Annotated(..))
+import           Cardano.Crypto.ProtocolMagic
+import           Cardano.Chain.Common
+import           Cardano.Chain.Genesis
 
 import           NodeLib
 
@@ -26,10 +32,19 @@ data CLI = CLI {
   }
 
 data Command =
-    DummyGenesis !FilePath
-  | RTByronGenesis !FilePath
+    KeyGen
+    !SigningFilePath
+    !VerificationFilePath
   | FullByronGenesis
-  | KeyGen !SigningFilePath !VerificationFilePath
+    !FilePath
+    !UTCTime
+    !FilePath
+    !BlockCount
+    !ProtocolMagic
+    !TestnetBalanceOptions
+    !FakeAvvmOptions
+    !LovelacePortion
+    !Integer
 
 newtype SigningFilePath      = SigningFilePath      { fromSigningPath      :: FilePath }
 newtype VerificationFilePath = VerificationFilePath { fromVerificationPath :: FilePath }
@@ -40,24 +55,89 @@ parseCLI = CLI
 
 parseCommand :: Parser Command
 parseCommand = subparser $ mconcat [
-    command' "dummy-genesis" "Write out a dummy genesis into FILE." $
-      DummyGenesis
-      <$> parseFilePath "genesis-output" "Path of the genesis JSON output file."
-  , command' "full-byron-genesis" "Generate a fully-parametrised Byron genesis from scratch." $
-      pure FullByronGenesis
-  , command' "rt-byron-genesis" "Roundtrip a Byron genesis JSON file." $
-      RTByronGenesis
-      <$> parseFilePath "genesis" "Path of the genesis input JSON file."
-  , command' "keygen" "Generate a keypair." $
+    command' "keygen" "Generate a keypair." $
       KeyGen
-      <$> (SigningFilePath      <$> parseFilePath "out-signing"      "Signing key output file path.")
-      <*> (VerificationFilePath <$> parseFilePath "out-verification" "Verification key output file path.")
+      <$> (SigningFilePath      <$>
+           parseFilePath   "out-signing"              "Signing key output file path.")
+      <*> (VerificationFilePath <$>
+           parseFilePath   "out-verification"         "Verification key output file path.")
+  , command' "full-byron-genesis" "Generate a fully-parametrised Byron genesis from scratch." $
+      FullByronGenesis 
+      <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
+      <*> parseUTCTime     "start-time"               "Start time of the new cluster to be enshrined in the new genesis."
+      <*> parseFilePath    "protocol-parameters-file" "JSON file with protocol parameters."
+      <*> parseK
+      <*> parseProtocolMagic
+      <*> parseTestnetBalanceOptions
+      <*> parseFakeAvvmOptions
+      <*> (LovelacePortion . fromInteger . fromMaybe 1 <$>
+           (optional $
+            parseIntegral  "avvm-balance-factor"      "AVVM balances will be multiplied by this factor (defaults to 1)."))
+      <*> parseIntegral    "secret-seed"              "Optionally specify the seed of generation."
   ]
 
+parseTestnetBalanceOptions :: Parser TestnetBalanceOptions
+parseTestnetBalanceOptions =
+  TestnetBalanceOptions
+  <$> parseIntegral        "n-poor-addresses"         "Number of poor nodes (with small balance)."
+  <*> parseIntegral        "n-richmen-addresses"      "Number of rich nodes (with huge balance)."
+  <*> parseLovelace        "total-balance"            "Total balance owned by these nodes."
+  <*> parseLovelacePortion "richmen-share"            "Portion of stake owned by all richmen together."
+  <*> parseFlag            "use-hd-addresses"         "Whether generate plain addresses or with hd payload."
+
+parseLovelace :: String -> String -> Parser Lovelace
+parseLovelace optname desc =
+  either (error . show) id . mkLovelace
+  <$> parseIntegral optname desc
+
+parseLovelacePortion :: String -> String -> Parser LovelacePortion
+parseLovelacePortion optname desc =
+  either (error . show) id . mkLovelacePortion
+  <$> parseIntegral optname desc
+
+parseFakeAvvmOptions :: Parser FakeAvvmOptions
+parseFakeAvvmOptions =
+  FakeAvvmOptions
+  <$> parseIntegral        "avvm-entry-count"         "Number of AVVM addresses."
+  <*> parseLovelace        "avvm-entry-balance"       "AVVM address."
+
+parseK :: Parser BlockCount
+parseK =
+  BlockCount
+  <$> parseIntegral        "k"                        "The security parameter of the Ouroboros protocol."
+
+parseProtocolMagic :: Parser ProtocolMagic
+parseProtocolMagic =
+  flip AProtocolMagic RequiresMagic . flip Annotated () . ProtocolMagicId
+  <$> parseIntegral        "protocol-magic"           "The magic number unique to any instance of Cardano."
+
 parseFilePath :: String -> String -> Parser FilePath
-parseFilePath optname role =
+parseFilePath optname desc =
     strOption (
             long optname
          <> metavar "FILEPATH"
-         <> help role
+         <> help desc
+    )
+
+parseIntegral :: Integral a => String -> String -> Parser a
+parseIntegral optname desc =
+    option (fromInteger <$> auto) (
+            long optname
+         <> metavar "INT"
+         <> help desc
+    )
+
+parseFlag :: String -> String -> Parser Bool
+parseFlag optname desc =
+    flag False True (
+            long optname
+         <> help desc
+    )
+
+parseUTCTime :: String -> String -> Parser UTCTime
+parseUTCTime optname desc =
+    option (posixSecondsToUTCTime . fromInteger <$> auto) (
+            long optname
+         <> metavar "POSIXSECONDS"
+         <> help desc
     )

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -38,8 +38,8 @@ data SystemVersion
   | ByronPBFT
   deriving Show
 
-data Command =
-    Genesis
+data Command
+  = Genesis
     !FilePath
     !UTCTime
     !FilePath
@@ -49,13 +49,16 @@ data Command =
     !FakeAvvmOptions
     !LovelacePortion
     !Integer
+  | PrettySecretKeyPublicHash
+    !FilePath
 
 data KeyMaterialOps m
   = KeyMaterialOps
-  { kmoSerialiseGenesisKey  :: SigningKey  -> m LB.ByteString
-  , kmoSerialiseDelegateKey :: SigningKey  -> m LB.ByteString
-  , kmoSerialisePoorKey     :: PoorSecret  -> m LB.ByteString
-  , kmoSerialiseGenesis     :: GenesisData -> m LB.ByteString
+  { kmoSerialiseGenesisKey       :: SigningKey  -> m LB.ByteString
+  , kmoSerialiseDelegateKey      :: SigningKey  -> m LB.ByteString
+  , kmoSerialisePoorKey          :: PoorSecret  -> m LB.ByteString
+  , kmoSerialiseGenesis          :: GenesisData -> m LB.ByteString
+  , kmoDeserialiseDelegateKey    :: LB.ByteString -> SigningKey
   }
 
 {-------------------------------------------------------------------------------
@@ -88,6 +91,9 @@ parseCommand = subparser $ mconcat [
            (optional $
             parseIntegral  "avvm-balance-factor"      "AVVM balances will be multiplied by this factor (defaults to 1)."))
       <*> parseIntegral    "secret-seed"              "Optionally specify the seed of generation."
+  , command' "pretty-secret-key-public-hash"  "Print a hash of secret key's public key (not a secret)." $
+      PrettySecretKeyPublicHash
+      <$> parseFilePath    "secret"                   "File name of the secret key to pretty-print."
   ]
 
 parseTestnetBalanceOptions :: Parser TestnetBalanceOptions

--- a/app/genesis-tool/CLI.hs
+++ b/app/genesis-tool/CLI.hs
@@ -35,6 +35,9 @@ data Command =
     KeyGen
     !SigningFilePath
     !VerificationFilePath
+  | RtByronLegacyRichmanKey
+    !FilePath
+    !FilePath
   | FullByronGenesis
     !FilePath
     !UTCTime
@@ -61,6 +64,10 @@ parseCommand = subparser $ mconcat [
            parseFilePath   "out-signing"              "Signing key output file path.")
       <*> (VerificationFilePath <$>
            parseFilePath   "out-verification"         "Verification key output file path.")
+  , command' "rt-byron-legacy-richman-key"    "Roundtrip a Byron/Legacy richman keypair." $
+      RtByronLegacyRichmanKey
+      <$> parseFilePath    "key-from"                 "Input keyfile."
+      <*> parseFilePath    "key-to"                   "Output keyfile."
   , command' "full-byron-genesis"             "Generate a fully-parametrised Byron genesis from scratch." $
       FullByronGenesis
       <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."

--- a/app/genesis-tool/Main.hs
+++ b/app/genesis-tool/Main.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE RankNTypes          #-}
 
 
 module Main (main) where
@@ -34,5 +35,5 @@ opts = info (commandLineParser <**> helper)
 -- | Main function.
 main :: IO ()
 main = do
-    ArgParser cli      <- execParser opts
-    runCLI cli
+    ArgParser CLI{..} <- execParser opts
+    runCommand (decideKeyMaterialOps systemVersion) mainCommand

--- a/app/genesis-tool/Main.hs
+++ b/app/genesis-tool/Main.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+
+
+module Main (main) where
+
+import           Data.Semigroup ((<>))
+
+import           Options.Applicative
+
+import           Cardano.Prelude hiding (option)
+
+import           CLI
+import           Run
+
+
+-- | The product type of all command line arguments
+data ArgParser = ArgParser !CLI
+
+-- | The product parser for all the CLI arguments.
+commandLineParser :: Parser ArgParser
+commandLineParser = ArgParser
+    <$> parseCLI
+
+-- | Top level parser with info.
+opts :: ParserInfo ArgParser
+opts = info (commandLineParser <**> helper)
+    ( fullDesc
+    <> progDesc "Cardano genesis tool."
+    <> header "Cardano genesis tool."
+    )
+
+-- | Main function.
+main :: IO ()
+main = do
+    ArgParser cli      <- execParser opts
+    runCLI cli

--- a/app/genesis-tool/README.md
+++ b/app/genesis-tool/README.md
@@ -1,0 +1,19 @@
+# `genesis-tool`
+
+A CLI utility to support a variety of key material operations (genesis, migration, pretty-printing..) for different system generations.
+
+The general synopsis is as follows:
+ ```
+   genesis-tool SYSTEMVER COMMAND
+```
+
+..where `SYSTEMVER` is one of the supported system generations: `byron-legacy`, `byron-pbft` etc.
+
+The supported commands are (as per excerpt from the tool's `--help`):
+
+```
+Available commands:
+  genesis                         Perform genesis.
+  pretty-secret-key-public-hash   Print a hash of secret key's public key (not a secret).
+  migrate-delegate-key-from       Migrate a delegate key from an older version.
+```

--- a/app/genesis-tool/README.md
+++ b/app/genesis-tool/README.md
@@ -14,6 +14,6 @@ The supported commands are (as per excerpt from the tool's `--help`):
 ```
 Available commands:
   genesis                         Perform genesis.
-  pretty-secret-key-public-hash   Print a hash of secret key's public key (not a secret).
+  pretty-secret-key-public        Pretty-print a secret key's public key and its hash (not a secret).
   migrate-delegate-key-from       Migrate a delegate key from an older version.
 ```

--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -120,6 +120,17 @@ runCommand
       -- prettySigningKeyPub = TL.toStrict . Builder.toLazyText . formatFullVerificationKey . toVerification
       prettySigningKeyPub = TL.toStrict . F.format CCr.hashHexF . CC.addressHash . CCr.toVerification
 
+runCommand
+  toKMO
+  (MigrateDelegateKeyFrom
+    fromVer
+    secretPathTo
+    secretPathFrom)
+  =
+  LB.writeFile secretPathTo =<< kmoSerialiseDelegateKey toKMO =<< kmoDeserialiseDelegateKey fromKMO <$> LB.readFile secretPathFrom
+  where
+    fromKMO = decideKeyMaterialOps fromVer
+
 decideKeyMaterialOps :: SystemVersion -> KeyMaterialOps IO
 decideKeyMaterialOps =
   let serialiseSigningKey (SigningKey x) = toLazyByteString $ CCr.toCBORXPrv x

--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -12,25 +12,20 @@
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
 module Run (
-      runCLI
-    ) where
+    decideKeyMaterialOps
+  , runCommand
+  ) where
 
-import           Prelude (error, id)
+import           Prelude (String, error, id)
 
-import qualified Codec.CBOR.Decoding as D
-import qualified Codec.CBOR.Encoding as E
-import           Codec.CBOR.Read (deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
-import           Control.Lens (LensLike, _Left)
 import           Control.Monad
-import qualified Data.Binary as Binary
-import           Data.Coerce
 import           Data.Semigroup ((<>))
 import           Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as LB
 import           System.Posix.Files (ownerReadMode, setFileMode)
 import           System.Directory (createDirectory, doesPathExist)
+import           Text.Printf (printf)
 
 import qualified Text.JSON.Canonical as CanonicalJSON
 
@@ -38,14 +33,103 @@ import qualified Crypto.SCRAPE as Scrape
 
 import           Cardano.Prelude hiding (option)
 
-import qualified Cardano.Crypto.Wallet as CC
 import           Cardano.Crypto.Random (runSecureRandom)
-import           Cardano.Crypto.Signing
-  (keyGen, SigningKey(..), toCBORXPrv)
+import           Cardano.Crypto.Signing (SigningKey(..), toCBORXPrv)
 
 import           Cardano.Chain.Genesis
 
+import qualified Byron.Legacy as Legacy
 import           CLI
+
+runCommand :: KeyMaterialOps IO -> Command -> IO ()
+runCommand
+  KeyMaterialOps{..}
+  (Genesis
+    outDir
+    startTime
+    protocolParametersFile
+    blockCount
+    protocolMagic
+    giTestBalance
+    giFakeAvvmBalance
+    giAvvmBalanceFactor
+    giSeed)
+  = do
+
+    exists <- doesPathExist outDir
+    if exists
+      then error $ "Genesis output directory must not already exist: " <> outDir
+      else createDirectory outDir
+
+    protoParamsRaw <- LB.readFile protocolParametersFile
+    let protocolParameters = either (error . show) id $ canonicalDecPre protoParamsRaw
+
+    -- We're relying on the generator to fake AVVM and delegation.
+    mGenesisDelegation <- runExceptT $ mkGenesisDelegation []
+    let genesisDelegation   = either (error . show) id mGenesisDelegation
+        genesisAvvmBalances = GenesisAvvmBalances mempty
+
+    let mGenesisSpec =
+          mkGenesisSpec
+          genesisAvvmBalances -- :: !GenesisAvvmBalances
+          genesisDelegation   -- :: !GenesisDelegation
+          protocolParameters  -- :: !ProtocolParameters
+          blockCount          -- :: !BlockCount
+          protocolMagic       -- :: !ProtocolMagic
+          genesisInitializer  -- :: !GenesisInitializer
+        genesisInitializer =
+          GenesisInitializer
+          giTestBalance       -- :: !TestnetBalanceOptions
+          giFakeAvvmBalance   -- :: !FakeAvvmOptions
+          giAvvmBalanceFactor -- :: !LovelacePortion
+          giUseHeavyDlg       -- :: !Bool
+          giSeed              -- :: !Integer
+        giUseHeavyDlg =
+          True                -- Not using delegate keys unsupported.
+
+    let genesisSpec = either (error . show) id mGenesisSpec
+
+    -- Generate (mostly)
+    res <- runExceptT $ generateGenesisData startTime genesisSpec
+    let (genesisData, GeneratedSecrets{..}) = either (error . show) id res
+
+    -- Write out (mostly)
+    let genesisJSONFile = outDir <> "/genesis.json"
+    LB.writeFile genesisJSONFile =<< kmoSerialiseGenesis genesisData
+
+    writeSecrets outDir "genesis-keys"  "key"  kmoSerialiseGenesisKey   gsDlgIssuersSecrets
+    writeSecrets outDir "delegate-keys" "key"  kmoSerialiseDelegateKey  gsRichSecrets
+    writeSecrets outDir "poor-keys"     "key"  kmoSerialisePoorKey      gsPoorSecrets
+    writeSecrets outDir "avvm-seed"     "seed" (pure . LB.fromStrict)   gsFakeAvvmSeeds
+
+decideKeyMaterialOps :: SystemVersion -> KeyMaterialOps IO
+decideKeyMaterialOps =
+  let serialiseSigningKey (SigningKey x) = toLazyByteString $ toCBORXPrv x
+  in \case
+  ByronLegacy ->
+    KeyMaterialOps
+    { kmoSerialiseGenesisKey  = pure . serialiseSigningKey
+    , kmoSerialiseDelegateKey = \sk->
+        toLazyByteString . Legacy.encodeLegacyDelegateKey . Legacy.LegacyDelegateKey sk
+        <$> runSecureRandom Scrape.keyPairGenerate
+    , kmoSerialisePoorKey     = pure . serialiseSigningKey . poorSecretToKey
+    , kmoSerialiseGenesis     = pure . canonicalEncPre
+    }
+  ByronPBFT ->
+    KeyMaterialOps
+    { kmoSerialiseGenesisKey  = pure . serialiseSigningKey
+    , kmoSerialiseDelegateKey = pure . serialiseSigningKey
+    , kmoSerialisePoorKey     = pure . serialiseSigningKey . poorSecretToKey
+    , kmoSerialiseGenesis     = pure . canonicalEncPre
+    }
+
+writeSecrets :: FilePath -> String -> String -> (a -> IO LB.ByteString) -> [a] -> IO ()
+writeSecrets outDir prefix suffix secretOp xs =
+  forM_ (zip xs $ [0::Int ..]) $
+  \(secret, nr)-> do
+    let filename = outDir <> "/" <> prefix <> "." <> printf "%03d" nr <> "." <> suffix
+    secretOp secret >>= LB.writeFile filename
+    setFileMode                      filename ownerReadMode
 
 -- Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
 canonicalEncPre
@@ -67,159 +151,3 @@ canonicalDecPre
 canonicalDecPre bs = do
   eVal <- first toS (CanonicalJSON.parseCanonicalJSON bs)
   first show (CanonicalJSON.fromJSON eVal :: Either SchemaError a)
-
--- LegacyRichmenKey is a subset of the UserSecret's from the legacy codebase:
--- 1. the VSS keypair must be present
--- 2. the signing key must be present
--- 3. the rest must be absent (Nothing)
---
--- Legacy reference: https://github.com/input-output-hk/cardano-sl/blob/release/3.0.1/lib/src/Pos/Util/UserSecret.hs#L189
-data LegacyRichmenKey
-  =  LegacyRichmenKey
-  { lrkSigningKey :: SigningKey
-  , lrkVSSKeyPair :: Scrape.KeyPair
-  }
-
--- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
-encodeBinary :: Binary.Binary a => a -> E.Encoding
-encodeBinary = E.encodeBytes . LB.toStrict . Binary.encode
-
--- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
-decodeBinary :: Binary.Binary a => D.Decoder s a
-decodeBinary = do
-    x <- D.decodeBytesCanonical
-    toCborError $ case Binary.decodeOrFail (LB.fromStrict x) of
-        Left (_, _, err) -> Left (T.pack err)
-        Right (bs, _, res)
-            | LB.null bs -> Right res
-            | otherwise  -> Left "decodeBinary: unconsumed input"
-
-encodeXPrv :: CC.XPrv -> E.Encoding
-encodeXPrv a = E.encodeBytes $ CC.unXPrv a
-
-decodeXPrv :: D.Decoder s CC.XPrv
-decodeXPrv = toCborError . over _Left T.pack . CC.xprv =<< D.decodeBytesCanonical
-  where over :: LensLike Identity s t a b -> (a -> b) -> s -> t
-        over = coerce
-
--- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
--- | Enforces that the input size is the same as the decoded one, failing in
--- case it's not.
-enforceSize :: Text -> Int -> D.Decoder s ()
-enforceSize lbl requestedSize = D.decodeListLenCanonical >>= matchSize requestedSize lbl
-
--- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
--- | Compare two sizes, failing if they are not equal.
-matchSize :: Int -> Text -> Int -> D.Decoder s ()
-matchSize requestedSize lbl actualSize =
-  when (actualSize /= requestedSize) $
-    cborError (lbl <> " failed the size check. Expected " <> show requestedSize <> ", found " <> show actualSize)
-
--- Reverse-engineered from cardano-sl legacy codebase.
-encodeLegacyRichmenKey :: LegacyRichmenKey -> E.Encoding
-encodeLegacyRichmenKey LegacyRichmenKey{lrkSigningKey=(SigningKey sk),..}
-  =  E.encodeListLen 4
-  <> E.encodeListLen 1 <> encodeBinary lrkVSSKeyPair
-  <> E.encodeListLen 1 <> encodeXPrv sk
-  <> E.encodeListLenIndef <> E.encodeBreak
-  <> E.encodeListLen 0
-
--- Reverse-engineered from cardano-sl legacy codebase.
-decodeLegacyRichmenKey :: D.Decoder s LegacyRichmenKey
-decodeLegacyRichmenKey = do
-    enforceSize "UserSecret" 4
-    vss  <- do
-      enforceSize "vss" 1
-      decodeBinary
-    pkey <- do
-      enforceSize "pkey" 1
-      SigningKey <$> decodeXPrv
-    _    <- do
-      D.decodeListLenIndef
-      D.decodeSequenceLenIndef (flip (:)) [] reverse D.decodeNull
-    _    <- do
-      enforceSize "wallet" 0
-    pure $ LegacyRichmenKey pkey vss
-
-runCLI :: CLI -> IO ()
-runCLI CLI{..} = do
-    -- If the user asked to submit a transaction, we don't have to spin up a
-    -- full node, we simply transmit it and exit.
-    case command of
-      KeyGen sigPath vrfPath -> do
-        (vrf, SigningKey sig) <- runSecureRandom $ keyGen
-        -- Write private key as raw CBOR, public as JSON.
-        LB.writeFile (fromVerificationPath vrfPath) $ canonicalEncPre vrf
-        LB.writeFile (fromSigningPath      sigPath) $ toLazyByteString $ toCBORXPrv sig
-
-      RtByronLegacyRichmanKey src dst -> do
-        bytes <- LB.readFile src
-        let (,) _ key = either (error . show) id $ deserialiseFromBytes decodeLegacyRichmenKey bytes
-        LB.writeFile dst $ toLazyByteString $ encodeLegacyRichmenKey key
-
-      FullByronGenesis
-        outDir
-        startTime
-        protocolParametersFile
-        blockCount
-        protocolMagic
-        giTestBalance
-        giFakeAvvmBalance
-        giAvvmBalanceFactor
-        giSeed
-        -> do
-
-        exists <- doesPathExist outDir
-        if exists
-          then error $ "Genesis output directory must not already exist: " <> outDir
-          else createDirectory outDir
-
-        protoParamsRaw <- LB.readFile protocolParametersFile
-        let protocolParameters = either (error . show) id $ canonicalDecPre protoParamsRaw
-
-        -- We're relying on the generator to fake AVVM and delegation.
-        mGenesisDelegation <- runExceptT $ mkGenesisDelegation []
-        let genesisDelegation   = either (error . show) id mGenesisDelegation
-            genesisAvvmBalances = GenesisAvvmBalances mempty
-
-        let mGenesisSpec =
-              mkGenesisSpec
-              genesisAvvmBalances -- :: !GenesisAvvmBalances
-              genesisDelegation   -- :: !GenesisDelegation
-              protocolParameters  -- :: !ProtocolParameters
-              blockCount          -- :: !BlockCount
-              protocolMagic       -- :: !ProtocolMagic
-              genesisInitializer  -- :: !GenesisInitializer
-            genesisInitializer =
-              GenesisInitializer
-              giTestBalance       -- :: !TestnetBalanceOptions
-              giFakeAvvmBalance   -- :: !FakeAvvmOptions
-              giAvvmBalanceFactor -- :: !LovelacePortion
-              giUseHeavyDlg       -- :: !Bool
-              giSeed              -- :: !Integer
-            giUseHeavyDlg =
-              True
-
-        let genesisSpec = either (error . show) id mGenesisSpec
-
-        res <- runExceptT $ generateGenesisData startTime genesisSpec
-        let (gd, GeneratedSecrets{..}) = either (error . show) id res
-
-        richmenSecrets <- zipWith LegacyRichmenKey gsRichSecrets
-                       <$> (runSecureRandom $ flip replicateM Scrape.keyPairGenerate
-                                            $ length gsRichSecrets)
-
-        let outJSONFile = outDir <> "/genesis.json"
-            serialiseSigningKey (SigningKey x) = toLazyByteString $ toCBORXPrv x
-            writeSecrets :: FilePath -> [a] -> (a -> LB.ByteString) -> IO ()
-            writeSecrets prefix xs f =
-              forM_ (zip xs $ [0::Int ..]) $
-              \(key, nr)-> do
-                let filename = outDir <> "/" <> prefix <> "." <> show nr <> ".key"
-                LB.writeFile   filename (f key)
-                setFileMode filename ownerReadMode
-        LB.writeFile outJSONFile $ canonicalEncPre gd
-        writeSecrets "dlg-issuer"  gsDlgIssuersSecrets $ serialiseSigningKey
-        writeSecrets "rich-secret" richmenSecrets      $ toLazyByteString . encodeLegacyRichmenKey
-        writeSecrets "poor-secret" gsPoorSecrets       $ serialiseSigningKey . poorSecretToKey
-        writeSecrets "avvm-seed"   gsFakeAvvmSeeds     $ LB.fromStrict

--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+
+module Run (
+      runCLI
+    ) where
+
+import           Prelude (error)
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding)
+import           Codec.CBOR.Write (toLazyByteString)
+import qualified Codec.Serialise as Serialise (encode, decode)
+import           Control.Exception
+import           Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import           Control.Monad
+import           Control.Tracer
+import           Crypto.Random
+import           Data.Functor.Contravariant (contramap)
+import qualified Data.Map.Strict as M
+import           Data.Maybe
+import           Data.Semigroup ((<>))
+import           Data.ByteString.Lazy (ByteString)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy as LB
+import           System.IO.Error (isDoesNotExistError)
+import           System.Directory (removeFile)
+
+import qualified Data.Aeson.Encode.Pretty as AE
+  (Config(..), Indent(..), NumberFormat(..), encodePretty', keyOrder)
+
+import qualified Text.JSON.Canonical as CanonicalJSON
+
+import           Cardano.Prelude hiding (option)
+
+import           Cardano.Crypto.Random (runSecureRandom)
+import           Cardano.Crypto.Signing
+  (keyGen, SigningKey(..), fromCBORXPrv, toCBORXPrv, toVerification)
+
+import           Cardano.BM.Data.Tracer (ToLogObject (..))
+import           Cardano.BM.Trace (Trace, appendName)
+
+import           Cardano.Chain.Genesis
+import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
+
+import           CLI
+
+-- Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
+canonicalEncPre
+  :: forall a . CanonicalJSON.ToJSON Identity a => a -> LB.ByteString
+canonicalEncPre x =
+  LB.fromStrict
+    . encodeUtf8
+    . toS
+    $ CanonicalJSON.prettyCanonicalJSON
+    $ runIdentity
+    $ CanonicalJSON.toJSON x
+
+-- Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
+canonicalDecPre
+  :: forall a
+   . CanonicalJSON.FromJSON (Either SchemaError) a
+  => LB.ByteString
+  -> Either Text a
+canonicalDecPre bs = do
+  eVal <- first toS (CanonicalJSON.parseCanonicalJSON bs)
+  first show (CanonicalJSON.fromJSON eVal :: Either SchemaError a)
+
+runCLI :: CLI -> IO ()
+runCLI cli@CLI{..} = do
+    -- If the user asked to submit a transaction, we don't have to spin up a
+    -- full node, we simply transmit it and exit.
+    case command of
+      DummyGenesis out -> do
+        putStrLn ("Dummy genesis requested" :: Text)
+        let genesisDataJSON = canonicalEncPre Dummy.dummyGenesisData
+        -- genesisDataJSON <- toJSON dummy
+
+        putStrLn $ genesisDataJSON
+
+      RTByronGenesis input -> do
+        bs <- LB.readFile input
+        let gd :: Either Text GenesisData = canonicalDecPre bs
+            genesisDataJSON = case gd of
+                                Left err -> error $ T.unpack err
+                                Right x  -> canonicalEncPre x
+        putStrLn $ genesisDataJSON
+
+      FullByronGenesis -> do
+        putStrLn ("Full Byron genesis requested -- not implemented yet." :: Text)
+
+      KeyGen sigPath vrfPath -> do
+        (vrf, SigningKey sig) <- runSecureRandom $ keyGen
+        -- Write private key as raw CBOR, public as JSON.
+        LB.writeFile (fromVerificationPath vrfPath) $ canonicalEncPre vrfBs
+        LB.writeFile (fromSigningPath      sigPath) $ toLazyByteString $ toCBORXPrv sig

--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE NumericUnderscores  #-}
@@ -13,31 +14,15 @@ module Run (
       runCLI
     ) where
 
-import           Prelude (error)
+import           Prelude (error, id)
 
-import           Codec.CBOR.Decoding (Decoder)
-import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.Write (toLazyByteString)
-import qualified Codec.Serialise as Serialise (encode, decode)
-import           Control.Exception
-import           Control.Concurrent (threadDelay)
-import qualified Control.Concurrent.Async as Async
 import           Control.Monad
-import           Control.Tracer
-import           Crypto.Random
-import           Data.Functor.Contravariant (contramap)
-import qualified Data.Map.Strict as M
-import           Data.Maybe
 import           Data.Semigroup ((<>))
-import           Data.ByteString.Lazy (ByteString)
 import           Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as LB
-import           System.IO.Error (isDoesNotExistError)
-import           System.Directory (removeFile)
-
-import qualified Data.Aeson.Encode.Pretty as AE
-  (Config(..), Indent(..), NumberFormat(..), encodePretty', keyOrder)
+import           System.Posix.Files (ownerReadMode, setFileMode)
+import           System.Directory (createDirectory, doesPathExist)
 
 import qualified Text.JSON.Canonical as CanonicalJSON
 
@@ -45,13 +30,9 @@ import           Cardano.Prelude hiding (option)
 
 import           Cardano.Crypto.Random (runSecureRandom)
 import           Cardano.Crypto.Signing
-  (keyGen, SigningKey(..), fromCBORXPrv, toCBORXPrv, toVerification)
-
-import           Cardano.BM.Data.Tracer (ToLogObject (..))
-import           Cardano.BM.Trace (Trace, appendName)
+  (keyGen, SigningKey(..), toCBORXPrv)
 
 import           Cardano.Chain.Genesis
-import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
 import           CLI
 
@@ -77,30 +58,75 @@ canonicalDecPre bs = do
   first show (CanonicalJSON.fromJSON eVal :: Either SchemaError a)
 
 runCLI :: CLI -> IO ()
-runCLI cli@CLI{..} = do
+runCLI CLI{..} = do
     -- If the user asked to submit a transaction, we don't have to spin up a
     -- full node, we simply transmit it and exit.
     case command of
-      DummyGenesis out -> do
-        putStrLn ("Dummy genesis requested" :: Text)
-        let genesisDataJSON = canonicalEncPre Dummy.dummyGenesisData
-        -- genesisDataJSON <- toJSON dummy
-
-        putStrLn $ genesisDataJSON
-
-      RTByronGenesis input -> do
-        bs <- LB.readFile input
-        let gd :: Either Text GenesisData = canonicalDecPre bs
-            genesisDataJSON = case gd of
-                                Left err -> error $ T.unpack err
-                                Right x  -> canonicalEncPre x
-        putStrLn $ genesisDataJSON
-
-      FullByronGenesis -> do
-        putStrLn ("Full Byron genesis requested -- not implemented yet." :: Text)
-
       KeyGen sigPath vrfPath -> do
         (vrf, SigningKey sig) <- runSecureRandom $ keyGen
         -- Write private key as raw CBOR, public as JSON.
-        LB.writeFile (fromVerificationPath vrfPath) $ canonicalEncPre vrfBs
+        LB.writeFile (fromVerificationPath vrfPath) $ canonicalEncPre vrf
         LB.writeFile (fromSigningPath      sigPath) $ toLazyByteString $ toCBORXPrv sig
+
+      FullByronGenesis
+        outDir
+        startTime
+        protocolParametersFile
+        blockCount
+        protocolMagic
+        giTestBalance
+        giFakeAvvmBalance
+        giAvvmBalanceFactor
+        giSeed
+        -> do
+
+        exists <- doesPathExist outDir
+        if exists
+          then error $ "Genesis output directory must not already exist: " <> outDir
+          else createDirectory outDir
+
+        protoParamsRaw <- LB.readFile protocolParametersFile
+        let protocolParameters = either (error . show) id $ canonicalDecPre protoParamsRaw
+
+        -- We're relying on the generator to fake AVVM and delegation.
+        mGenesisDelegation <- runExceptT $ mkGenesisDelegation []
+        let genesisDelegation   = either (error . show) id mGenesisDelegation
+            genesisAvvmBalances = GenesisAvvmBalances mempty
+
+        let mGenesisSpec =
+              mkGenesisSpec
+              genesisAvvmBalances -- :: !GenesisAvvmBalances
+              genesisDelegation   -- :: !GenesisDelegation
+              protocolParameters  -- :: !ProtocolParameters
+              blockCount          -- :: !BlockCount
+              protocolMagic       -- :: !ProtocolMagic
+              genesisInitializer  -- :: !GenesisInitializer
+            genesisInitializer =
+              GenesisInitializer
+              giTestBalance       -- :: !TestnetBalanceOptions
+              giFakeAvvmBalance   -- :: !FakeAvvmOptions
+              giAvvmBalanceFactor -- :: !LovelacePortion
+              giUseHeavyDlg       -- :: !Bool
+              giSeed              -- :: !Integer
+            giUseHeavyDlg =
+              True
+
+        let genesisSpec = either (error . show) id mGenesisSpec
+
+        res <- runExceptT $ generateGenesisData startTime genesisSpec
+        let (gd, GeneratedSecrets{..}) = either (error . show) id res
+
+        let outJSONFile = outDir <> "/genesis.json"
+            serialiseSigningKey (SigningKey x) = toLazyByteString $ toCBORXPrv x
+            writeSecrets :: FilePath -> [a] -> (a -> LB.ByteString) -> IO ()
+            writeSecrets prefix xs f =
+              forM_ (zip xs $ [0::Int ..]) $
+              \(key, nr)-> do
+                let filename = outDir <> "/" <> prefix <> "." <> show nr <> ".key"
+                LB.writeFile   filename (f key)
+                setFileMode filename ownerReadMode
+        LB.writeFile outJSONFile $ canonicalEncPre gd
+        writeSecrets "dlg-issuer"  gsDlgIssuersSecrets $ serialiseSigningKey
+        writeSecrets "rich-secret" gsRichSecrets       $ serialiseSigningKey
+        writeSecrets "poor-secret" gsPoorSecrets       $ serialiseSigningKey . poorSecretToKey
+        writeSecrets "avvm-seed"   gsFakeAvvmSeeds     $ LB.fromStrict

--- a/app/genesis-tool/Run.hs
+++ b/app/genesis-tool/Run.hs
@@ -31,8 +31,6 @@ import           System.Posix.Files (ownerReadMode, setFileMode)
 import           System.Directory (createDirectory, doesPathExist)
 import           Text.Printf (printf)
 
-import qualified Text.JSON.Canonical as CanonicalJSON
-
 import qualified Crypto.SCRAPE as Scrape
 
 import           Cardano.Prelude hiding (option)
@@ -44,6 +42,8 @@ import qualified Cardano.Crypto.Signing as CCr
 import           Cardano.Crypto (SigningKey(..))
 
 import           Cardano.Chain.Genesis
+
+import           Cardano.Node.CanonicalJSON
 
 import qualified Byron.Legacy as Legacy
 import           CLI
@@ -161,24 +161,3 @@ writeSecrets outDir prefix suffix secretOp xs =
     let filename = outDir <> "/" <> prefix <> "." <> printf "%03d" nr <> "." <> suffix
     secretOp secret >>= LB.writeFile filename
     setFileMode                      filename ownerReadMode
-
--- Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
-canonicalEncPre
-  :: forall a . CanonicalJSON.ToJSON Identity a => a -> LB.ByteString
-canonicalEncPre x =
-  LB.fromStrict
-    . encodeUtf8
-    . toS
-    $ CanonicalJSON.prettyCanonicalJSON
-    $ runIdentity
-    $ CanonicalJSON.toJSON x
-
--- Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
-canonicalDecPre
-  :: forall a
-   . CanonicalJSON.FromJSON (Either SchemaError) a
-  => LB.ByteString
-  -> Either Text a
-canonicalDecPre bs = do
-  eVal <- first toS (CanonicalJSON.parseCanonicalJSON bs)
-  first show (CanonicalJSON.fromJSON eVal :: Either SchemaError a)

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -135,6 +135,49 @@ executable wallet-client
   else
      build-depends:    unix
 
+executable genesis-tool
+  hs-source-dirs:      app/genesis-tool
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  ghc-options:         -threaded
+                       -Wall
+                       -O2
+                       "-with-rtsopts=-T"
+                       -fno-warn-unticked-promoted-constructors
+  other-modules:       CLI
+                     , Run
+  build-depends:       base
+                     , cardano-crypto-wrapper
+                     , cardano-ledger
+                     , cardano-ledger-test
+                     , cardano-node
+                     , cardano-prelude
+                     , contra-tracer
+                     , iohk-monitoring
+
+                     , aeson
+                     , aeson-pretty
+                     , async
+                     , bytestring
+                     , canonical-json
+                     , cborg
+                     , containers
+                     , cryptonite
+                     , directory
+                     , formatting
+                     , mtl
+                     , network
+                     , optparse-applicative
+                     , serialise
+                     , stm
+                     , string-conv
+                     , text
+                     , typed-protocols
+  if os(windows)
+     build-depends:    Win32
+  else
+     build-depends:    unix
+
 test-suite cardano-node-test
   hs-source-dirs:       test
   main-is:              Spec.hs

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -85,6 +85,7 @@ executable cardano-node
                      , cryptonite
                      , directory
                      , formatting
+                     , lens
                      , mtl
                      , network
                      , optparse-applicative
@@ -149,6 +150,7 @@ executable genesis-tool
                      , Run
   build-depends:       base
                      , cardano-binary
+                     , cardano-crypto
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-test
@@ -156,10 +158,12 @@ executable genesis-tool
                      , cardano-prelude
                      , contra-tracer
                      , iohk-monitoring
+                     , pvss
 
                      , aeson
                      , aeson-pretty
                      , async
+                     , binary
                      , bytestring
                      , canonical-json
                      , cborg

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -13,6 +13,7 @@ extra-source-files: README.md, ChangeLog.md
 library
   hs-source-dirs:      cardano-node
 
+  exposed-modules:     Cardano.Node.CanonicalJSON
   exposed-modules:     Cardano.Node.CLI
 
   other-modules:
@@ -20,16 +21,19 @@ library
 
   build-depends:
                        base >=4.12 && <5
+                     , bytestring
+                     , canonical-json
                      , optparse-applicative
+                     , time
 
+                     , cardano-binary
+                     , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-test
                      , cardano-prelude
                      , cardano-shell
                      , ouroboros-consensus
                      , ouroboros-network
-
-                     , optparse-applicative
 
   default-language:    Haskell2010
   default-extensions:
@@ -172,6 +176,7 @@ executable genesis-tool
                      , cryptonite
                      , directory
                      , formatting
+                     , lens
                      , mtl
                      , network
                      , optparse-applicative
@@ -179,6 +184,7 @@ executable genesis-tool
                      , stm
                      , string-conv
                      , text
+                     , time
                      , typed-protocols
   if os(windows)
      build-depends:    Win32

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -148,6 +148,7 @@ executable genesis-tool
                        -fno-warn-unticked-promoted-constructors
   other-modules:       CLI
                      , Run
+                     , Byron.Legacy
   build-depends:       base
                      , cardano-binary
                      , cardano-crypto

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -29,10 +29,13 @@ library
                      , ouroboros-consensus
                      , ouroboros-network
 
+                     , optparse-applicative
+
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
+  default-extensions:
 
   ghc-options:         -Weverything
+                       -Wno-implicit-prelude
                        -fno-warn-safe
                        -fno-warn-unsafe
                        -fno-warn-missing-import-lists

--- a/cardano-node.cabal
+++ b/cardano-node.cabal
@@ -92,6 +92,7 @@ executable cardano-node
                      , stm
                      , string-conv
                      , text
+                     , time
                      , typed-protocols
   if os(windows)
      build-depends:    Win32
@@ -147,6 +148,7 @@ executable genesis-tool
   other-modules:       CLI
                      , Run
   build-depends:       base
+                     , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-test

--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -13,9 +13,7 @@ module Cardano.Node.CLI (
   , parseNodeId
   , parseCoreNodeId
   , parseNumCoreNodes
-<<<<<<< HEAD
   , parseViewMode
-=======
   , parseTestnetBalanceOptions
   , parseLovelace
   , parseLovelacePortion
@@ -26,7 +24,6 @@ module Cardano.Node.CLI (
   , parseIntegral
   , parseFlag
   , parseUTCTime
->>>>>>> genesis-tool:  move more things to NodeLib
   -- * Generic
   , command'
   ) where
@@ -45,10 +42,10 @@ import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Util
 
-import           Cardano.Binary (Annotated(..))
-import           Cardano.Crypto.ProtocolMagic
+import           Cardano.Binary (Annotated (..))
 import           Cardano.Chain.Common
 import           Cardano.Chain.Genesis
+import           Cardano.Crypto.ProtocolMagic
 
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 

--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -14,6 +14,8 @@ module Cardano.Node.CLI (
   , parseCoreNodeId
   , parseNumCoreNodes
   , parseViewMode
+  -- * Generic
+  , command'
   ) where
 
 import           Prelude
@@ -146,3 +148,13 @@ parseViewMode =
         [ long "live-view"
         , help "Live view with TUI."
         ]
+
+{-------------------------------------------------------------------------------
+  optparse-applicative auxiliary
+-------------------------------------------------------------------------------}
+
+command' :: String -> String -> Parser a -> Mod CommandFields a
+command' c descr p =
+    command c $ info (p <**> helper) $ mconcat [
+        progDesc descr
+      ]

--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -13,7 +13,20 @@ module Cardano.Node.CLI (
   , parseNodeId
   , parseCoreNodeId
   , parseNumCoreNodes
+<<<<<<< HEAD
   , parseViewMode
+=======
+  , parseTestnetBalanceOptions
+  , parseLovelace
+  , parseLovelacePortion
+  , parseFakeAvvmOptions
+  , parseK
+  , parseProtocolMagic
+  , parseFilePath
+  , parseIntegral
+  , parseFlag
+  , parseUTCTime
+>>>>>>> genesis-tool:  move more things to NodeLib
   -- * Generic
   , command'
   ) where
@@ -22,6 +35,8 @@ import           Prelude
 
 import           Data.Foldable (asum)
 import           Data.Semigroup ((<>))
+import           Data.Time (UTCTime)
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Options.Applicative
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -29,6 +44,11 @@ import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Util
+
+import           Cardano.Binary (Annotated(..))
+import           Cardano.Crypto.ProtocolMagic
+import           Cardano.Chain.Common
+import           Cardano.Chain.Genesis
 
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
@@ -148,6 +168,72 @@ parseViewMode =
         [ long "live-view"
         , help "Live view with TUI."
         ]
+
+parseTestnetBalanceOptions :: Parser TestnetBalanceOptions
+parseTestnetBalanceOptions =
+  TestnetBalanceOptions
+  <$> parseIntegral        "n-poor-addresses"         "Number of poor nodes (with small balance)."
+  <*> parseIntegral        "n-delegate-addresses"     "Number of delegate nodes (with huge balance)."
+  <*> parseLovelace        "total-balance"            "Total balance owned by these nodes."
+  <*> parseLovelacePortion "delegate-share"           "Portion of stake owned by all delegates together."
+  <*> parseFlag            "use-hd-addresses"         "Whether generate plain addresses or with hd payload."
+
+parseLovelace :: String -> String -> Parser Lovelace
+parseLovelace optname desc =
+  either (error . show) id . mkLovelace
+  <$> parseIntegral optname desc
+
+parseLovelacePortion :: String -> String -> Parser LovelacePortion
+parseLovelacePortion optname desc =
+  either (error . show) id . mkLovelacePortion
+  <$> parseIntegral optname desc
+
+parseFakeAvvmOptions :: Parser FakeAvvmOptions
+parseFakeAvvmOptions =
+  FakeAvvmOptions
+  <$> parseIntegral        "avvm-entry-count"         "Number of AVVM addresses."
+  <*> parseLovelace        "avvm-entry-balance"       "AVVM address."
+
+parseK :: Parser BlockCount
+parseK =
+  BlockCount
+  <$> parseIntegral        "k"                        "The security parameter of the Ouroboros protocol."
+
+parseProtocolMagic :: Parser ProtocolMagic
+parseProtocolMagic =
+  flip AProtocolMagic RequiresMagic . flip Annotated () . ProtocolMagicId
+  <$> parseIntegral        "protocol-magic"           "The magic number unique to any instance of Cardano."
+
+parseFilePath :: String -> String -> Parser FilePath
+parseFilePath optname desc =
+    strOption (
+            long optname
+         <> metavar "FILEPATH"
+         <> help desc
+    )
+
+parseIntegral :: Integral a => String -> String -> Parser a
+parseIntegral optname desc =
+    option (fromInteger <$> auto) (
+            long optname
+         <> metavar "INT"
+         <> help desc
+    )
+
+parseFlag :: String -> String -> Parser Bool
+parseFlag optname desc =
+    flag False True (
+            long optname
+         <> help desc
+    )
+
+parseUTCTime :: String -> String -> Parser UTCTime
+parseUTCTime optname desc =
+    option (posixSecondsToUTCTime . fromInteger <$> auto) (
+            long optname
+         <> metavar "POSIXSECONDS"
+         <> help desc
+    )
 
 {-------------------------------------------------------------------------------
   optparse-applicative auxiliary

--- a/cardano-node/Cardano/Node/CanonicalJSON.hs
+++ b/cardano-node/Cardano/Node/CanonicalJSON.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Node.CanonicalJSON
+    ( canonicalEncPre, canonicalDecPre
+    ) where
+
+import qualified Data.ByteString.Lazy as LB
+import qualified Text.JSON.Canonical as CanonicalJSON
+
+import           Cardano.Prelude
+
+{-------------------------------------------------------------------------------
+  Stolen from: cardano-prelude/test/Test/Cardano/Prelude/Tripping.hs
+-------------------------------------------------------------------------------}
+canonicalEncPre
+  :: forall a . CanonicalJSON.ToJSON Identity a => a -> LB.ByteString
+canonicalEncPre x =
+  LB.fromStrict
+    . encodeUtf8
+    . toS
+    $ CanonicalJSON.prettyCanonicalJSON
+    $ runIdentity
+    $ CanonicalJSON.toJSON x
+
+canonicalDecPre
+  :: forall a
+   . CanonicalJSON.FromJSON (Either SchemaError) a => LB.ByteString -> Either Text a
+canonicalDecPre bs = do
+  eVal <- first toS (CanonicalJSON.parseCanonicalJSON bs)
+  first show (CanonicalJSON.fromJSON eVal :: Either SchemaError a)

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -99,6 +99,7 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.cardano-binary)
+            (hsPkgs.cardano-crypto)
             (hsPkgs.cardano-crypto-wrapper)
             (hsPkgs.cardano-ledger)
             (hsPkgs.cardano-ledger-test)
@@ -110,6 +111,7 @@
             (hsPkgs.aeson)
             (hsPkgs.aeson-pretty)
             (hsPkgs.async)
+            (hsPkgs.binary)
             (hsPkgs.bytestring)
             (hsPkgs.canonical-json)
             (hsPkgs.cborg)
@@ -117,6 +119,7 @@
             (hsPkgs.cryptonite)
             (hsPkgs.directory)
             (hsPkgs.formatting)
+            (hsPkgs.lens)
             (hsPkgs.mtl)
             (hsPkgs.network)
             (hsPkgs.optparse-applicative)

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -18,14 +18,18 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.bytestring)
+          (hsPkgs.canonical-json)
           (hsPkgs.optparse-applicative)
+          (hsPkgs.time)
+          (hsPkgs.cardano-binary)
+          (hsPkgs.cardano-crypto-wrapper)
           (hsPkgs.cardano-ledger)
           (hsPkgs.cardano-ledger-test)
           (hsPkgs.cardano-prelude)
           (hsPkgs.cardano-shell)
           (hsPkgs.ouroboros-consensus)
           (hsPkgs.ouroboros-network)
-          (hsPkgs.optparse-applicative)
           ] ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);
@@ -57,6 +61,7 @@
             (hsPkgs.cryptonite)
             (hsPkgs.directory)
             (hsPkgs.formatting)
+            (hsPkgs.lens)
             (hsPkgs.mtl)
             (hsPkgs.network)
             (hsPkgs.optparse-applicative)
@@ -127,6 +132,7 @@
             (hsPkgs.stm)
             (hsPkgs.string-conv)
             (hsPkgs.text)
+            (hsPkgs.time)
             (hsPkgs.typed-protocols)
             ] ++ (if system.isWindows
             then [ (hsPkgs.Win32) ]

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -93,6 +93,31 @@
             then [ (hsPkgs.Win32) ]
             else [ (hsPkgs.unix) ]);
           };
+        "genesis-tool" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.aeson)
+            (hsPkgs.async)
+            (hsPkgs.bytestring)
+            (hsPkgs.cborg)
+            (hsPkgs.containers)
+            (hsPkgs.cryptonite)
+            (hsPkgs.directory)
+            (hsPkgs.formatting)
+            (hsPkgs.mtl)
+            (hsPkgs.network)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.serialise)
+            (hsPkgs.stm)
+            (hsPkgs.string-conv)
+            (hsPkgs.text)
+            (hsPkgs.typed-protocols)
+            ] ++ (if system.isWindows
+            then [ (hsPkgs.Win32) ]
+            else [ (hsPkgs.unix) ]);
+          };
         };
       tests = {
         "cardano-node-test" = {

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -25,6 +25,7 @@
           (hsPkgs.cardano-shell)
           (hsPkgs.ouroboros-consensus)
           (hsPkgs.ouroboros-network)
+          (hsPkgs.optparse-applicative)
           ] ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);
@@ -63,6 +64,7 @@
             (hsPkgs.stm)
             (hsPkgs.string-conv)
             (hsPkgs.text)
+            (hsPkgs.time)
             (hsPkgs.typed-protocols)
             ] ++ (if system.isWindows
             then [ (hsPkgs.Win32) ]
@@ -96,11 +98,20 @@
         "genesis-tool" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.cardano-binary)
             (hsPkgs.cardano-crypto-wrapper)
             (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-ledger-test)
+            (hsPkgs.cardano-node)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.contra-tracer)
+            (hsPkgs.iohk-monitoring)
+            (hsPkgs.pvss)
             (hsPkgs.aeson)
+            (hsPkgs.aeson-pretty)
             (hsPkgs.async)
             (hsPkgs.bytestring)
+            (hsPkgs.canonical-json)
             (hsPkgs.cborg)
             (hsPkgs.containers)
             (hsPkgs.cryptonite)

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,6 +5,7 @@
         "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
         "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
         "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
+        "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+start_future_offset="15 minutes"
+start_time="$(date -d "now + ${start_future_offset}" +%s)"
+protocol_params="$(dirname $0)/protocol-params.json"
+
+protocol_magic=633343912
+n_poor=128
+n_rich=7
+total_balance=80000000000000
+richmen_share=2
+avvm_entries=128
+avvm_entry_balance=10000000000
+not_so_secret=2718281828
+
+set -xeu
+
+cabal new-run --                                      \
+      genesis-tool                                    \
+      full-byron-genesis                              \
+      --start-time "${start_time}"                    \
+      --protocol-parameters-file "${protocol_params}" \
+      --k 2160                                        \
+      --protocol-magic ${protocol_magic}              \
+      --n-poor-addresses ${n_poor}                    \
+      --n-richmen-addresses ${n_rich}                 \
+      --total-balance ${total_balance}                \
+      --richmen-share ${richmen_share}                \
+      --use-hd-addresses                              \
+      --avvm-entry-count ${avvm_entries}              \
+      --avvm-entry-balance ${avvm_entry_balance}      \
+      --secret-seed ${not_so_secret}                  \
+      --genesis-output-dir ./genesis.out

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -4,30 +4,34 @@ start_future_offset="15 minutes"
 start_time="$(date -d "now + ${start_future_offset}" +%s)"
 protocol_params="$(dirname $0)/protocol-params.json"
 
-protocol_magic=633343912
+protocol_magic=633343913
 n_poor=128
-n_rich=7
+n_delegate=7
 total_balance=80000000000000
-richmen_share=2
+delegate_share=2
 avvm_entries=128
 avvm_entry_balance=10000000000
 not_so_secret=2718281828
 
-set -xeu
+systemVersion="$1"; shift || true
+case "$systemVersion" in
+        --byron-legacy | --byron-pbft | --help ) systemVersionPretty=$(echo $systemVersion | cut -c3-);;
+        * ) echo "Usage:  $(basename $0) --byron-{legacy,pbft} [GENESIS-TOOL-ARG..]" >&2; exit 1;; esac
 
+set -xe
 cabal new-run --                                      \
-      genesis-tool                                    \
-      full-byron-genesis                              \
+      genesis-tool ${systemVersion} genesis           \
+      --genesis-output-dir ./genesis.${systemVersionPretty} \
       --start-time "${start_time}"                    \
       --protocol-parameters-file "${protocol_params}" \
       --k 2160                                        \
       --protocol-magic ${protocol_magic}              \
       --n-poor-addresses ${n_poor}                    \
-      --n-richmen-addresses ${n_rich}                 \
+      --n-delegate-addresses ${n_delegate}            \
       --total-balance ${total_balance}                \
-      --richmen-share ${richmen_share}                \
+      --delegate-share ${delegate_share}              \
       --use-hd-addresses                              \
       --avvm-entry-count ${avvm_entries}              \
       --avvm-entry-balance ${avvm_entry_balance}      \
       --secret-seed ${not_so_secret}                  \
-      --genesis-output-dir ./genesis.out
+      "$@"

--- a/scripts/protocol-params.json
+++ b/scripts/protocol-params.json
@@ -1,0 +1,23 @@
+{
+    "heavyDelThd": "300000000000",
+    "maxBlockSize": "2000000",
+    "maxHeaderSize": "2000000",
+    "maxProposalSize": "700",
+    "maxTxSize": "4096",
+    "mpcThd": "20000000000000",
+    "scriptVersion": 0,
+    "slotDuration": "20000",
+    "softforkRule": {
+        "initThd": "900000000000000",
+        "minThd": "600000000000000",
+        "thdDecrement": "50000000000000"
+    },
+    "txFeePolicy": {
+        "multiplier": "43946000000",
+        "summand": "155381000000000"
+    },
+    "unlockStakeEpoch": "18446744073709551615",
+    "updateImplicit": "10000",
+    "updateProposalThd": "100000000000000",
+    "updateVoteThd": "1000000000000"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,16 @@
-with (import <nixpkgs> {});
-stdenv.mkDerivation {
-  name = "srcEnv";
-  buildInputs = [ tmux
-                ];
+{ withHoogle ? true
+}:
+let
+  default = import ./default.nix {};
+in
+default.nix-tools._raw.shellFor {
+  packages    = ps: with ps; [ cardano-node ];
+  withHoogle  = withHoogle;
+  buildInputs =
+  (with default.nix-tools._raw; [
+    cabal-install.components.exes.cabal
+  ]) ++
+  (with default.nix-tools._raw._config._module.args.pkgs; [
+    tmux
+  ]);
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,6 +33,7 @@ extra-deps:
   - containers-0.5.11.0
   - ekg-prometheus-adapter-0.1.0.4
   - prometheus-2.1.1
+  - pvss-0.2.0
   - time-units-1.0.0
   - libsystemd-journal-1.4.4
   - tasty-hedgehog-1.0.0.1


### PR DESCRIPTION
Issue: https://github.com/input-output-hk/cardano-node/issues/30

# TODO
- [x] Figure out secret key size discrepancy: 130 bytes in this implementation vs. 203 for actual secret keys in `cardano-sl` (**SHOWSTOPPER**).
  - this appears to be due to VSS keys also being there: https://github.com/input-output-hk/cardano-sl/blob/master/tools/src/keygen/Dump.hs#L48
- [x] Key pretty-printing.
- [x] Documentation.
- [x] Key material migration.
- [x] Factor.
- [?] Optional random generation of things meaningfully available to random generation (seed, protocol magic, etc.)