### PR TITLE
Switch demo scripts to use stack

### DIFF
--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -2,12 +2,11 @@
 
 #tmux new-session -s 'Demo' -t demo
 
-#ALGO="--real-pbft"
-ALGO="--bft"
+ALGO="--real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS="--system-start \"${NOW}\" --slot-duration 2 node -t configuration/simple-topology.json ${ALGO}"
 #SCR="./scripts/start-node.sh"
-CMD="cabal new-exec cardano-node --"
+CMD="stack exec cardano-node --"
 HOST="127.0.0.1"
 
 function mklogcfg () {

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -3,7 +3,7 @@
 now=`date "+%Y-%m-%d 00:00:00"`
 
 set -x
-cabal new-run cardano-node -- \
+stack exec cardano-node -- \
     --system-start "$now" --slot-duration 2 \
     --log-config configuration/log-configuration.yaml \
     submit -t configuration/simple-topology.json \


### PR DESCRIPTION
This allows us to have a commit on `master` that we can run the exact demo from 21st June 2019, that we will point to from a wiki page about the demo.