### PR TITLE
Update cardano-ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ dist/
 result*
 launch-*
 .stack-to-nix.cache
+stack.yaml.lock
 /genesis.*

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,6 +15,7 @@ import           Cardano.Shell.Features.Logging (LoggingCLIArguments (..),
                                                  LoggingLayer (..),
                                                  createLoggingFeature,
                                                  loggingParser)
+import           Cardano.Shell.Configuration.Lib (finaliseCardanoConfiguration)
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Presets (mainnetConfiguration)
 import           Cardano.Shell.Types (ApplicationEnvironment (Development),
@@ -49,7 +50,7 @@ opts = info (commandLineParser <**> helper)
 main :: IO ()
 main = do
 
-    let cardanoConfiguration = mainnetConfiguration
+    let Right cardanoConfiguration = finaliseCardanoConfiguration mainnetConfiguration
     cardanoEnvironment  <- initializeCardanoEnvironment
 
     logConfig           <- execParser opts

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -343,7 +343,7 @@ handleSimpleNode p NodeCLIArguments{..} myNodeAddress (TopologyInfo myNodeId top
             myLocalAddr
             Peer
             (\(DictVersion _) -> acceptEq)
-            (muxLocalResponderNetworkApplication <$> networkAppNodeToClient)
+            (localResponderNetworkApplication <$> networkAppNodeToClient)
             wait
 
       -- serve downstream nodes
@@ -355,7 +355,7 @@ handleSimpleNode p NodeCLIArguments{..} myNodeAddress (TopologyInfo myNodeId top
             myAddr
             Peer
             (\(DictVersion _) -> acceptEq)
-            (muxResponderNetworkApplication <$> networkAppNodeToNode)
+            (responderNetworkApplication <$> networkAppNodeToNode)
             wait
 
       -- ip subscription manager
@@ -381,7 +381,7 @@ handleSimpleNode p NodeCLIArguments{..} myNodeAddress (TopologyInfo myNodeId top
             (\(DictVersion codec) -> encodeTerm codec)
             (\(DictVersion codec) -> decodeTerm codec)
             Peer
-            (muxInitiatorNetworkApplication <$> networkAppNodeToNode) sock)
+            (initiatorNetworkApplication <$> networkAppNodeToNode) sock)
           wait
 
       void $ Async.waitAny [localServer, peerServer, subManager]

--- a/app/TxSubmission.hs
+++ b/app/TxSubmission.hs
@@ -46,7 +46,7 @@ import           Ouroboros.Consensus.Util.Condense
 
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Codec.Cbor
-import           Network.Mux.Interface
+import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Block (Point)
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
@@ -143,28 +143,28 @@ submitTx :: RunDemo blk
 submitTx pInfoConfig nodeId tx tracer =
     connectTo
       (,)
-      (muxLocalInitiatorNetworkApplication tracer pInfoConfig tx)
+      (localInitiatorNetworkApplication tracer pInfoConfig tx)
       Nothing
       addr
   where
     addr = localSocketAddrInfo (localSocketFilePath nodeId)
 
-muxLocalInitiatorNetworkApplication
+localInitiatorNetworkApplication
   :: forall blk m peer.
      (RunDemo blk, MonadST m, MonadThrow m, MonadTimer m)
   => Tracer m String
   -> NodeConfig (BlockProtocol blk)
   -> GenTx blk
   -> Versions NodeToClientVersion DictVersion
-              (MuxApplication InitiatorApp peer NodeToClientProtocols
-                              m ByteString () Void)
-muxLocalInitiatorNetworkApplication tracer pInfoConfig tx =
+              (OuroborosApplication InitiatorApp peer NodeToClientProtocols
+                                    m ByteString () Void)
+localInitiatorNetworkApplication tracer pInfoConfig tx =
     simpleSingletonVersions
       NodeToClientV_1
       (NodeToClientVersionData { networkMagic = 0 })
       (DictVersion nodeToClientCodecCBORTerm)
 
-  $ MuxInitiatorApplication $ \peer ptcl -> case ptcl of
+  $ OuroborosInitiatorApplication $ \peer ptcl -> case ptcl of
       LocalTxSubmissionPtcl -> \channel -> do
         traceWith tracer ("Submitting transaction: " {-++ show tx-})
         result <- runPeer

--- a/cabal.project
+++ b/cabal.project
@@ -6,19 +6,19 @@ package cardano-node
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 501d91e426ae84ce0ae056be38bd3db594af9fc2
+  tag: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 501d91e426ae84ce0ae056be38bd3db594af9fc2
+  tag: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 501d91e426ae84ce0ae056be38bd3db594af9fc2
+  tag: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
   subdir: cardano-crypto-class
 
 source-repository-package
@@ -29,94 +29,94 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 5241971fe563c90ea82b20af344116d46d672835
+  tag: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 5241971fe563c90ea82b20af344116d46d672835
+  tag: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 5241971fe563c90ea82b20af344116d46d672835
+  tag: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 5241971fe563c90ea82b20af344116d46d672835
+  tag: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a21f83d9407b2955fbaea4ce8a79b262361112aa
+  tag: 3084f8b8514d93970415e895b241691b80c7b9ee
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a21f83d9407b2955fbaea4ce8a79b262361112aa
+  tag: 3084f8b8514d93970415e895b241691b80c7b9ee
   subdir: test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
-  tag: 71fb36665338491e92d3ef14c20ae38ad6882c94
+  tag: 71a8257bfea837ddef716d8c81e436aa3273345e
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl-x509
-  tag: e8bfc1294e088f90e5ae0b4aedbc82ee46ac5ee4
+  tag: ec96c64c665b741c17b4e38f611315bae9b0b054
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+  tag: ca270835199406a06be590d2391bd87b072e7537
   subdir: io-sim-classes
 
 source-repository-package

--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -86,6 +86,7 @@ type TraceConstraints blk =
     , Show (ApplyTxErr blk)
     , Show (GenTx blk)
     , Show blk
+    , Show (Header blk)
     )
 
 data SomeProtocol where

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "14f9b09920813447a4060b6810bf17fc4ea35840";
-      sha256 = "1m2q9pg6kvhnfz1sgfcf9xq70iq63c7r6ag1zm212gqr0h79d5g5";
+      rev = "6b808ad5506cb097cdf5832e1cd5cad0c83c58d6";
+      sha256 = "1cpn117lnyjxfnc18i0pawzf4cd60my7z9ifmgyjvzg6xaiv8v6a";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "14f9b09920813447a4060b6810bf17fc4ea35840";
-      sha256 = "1m2q9pg6kvhnfz1sgfcf9xq70iq63c7r6ag1zm212gqr0h79d5g5";
+      rev = "6b808ad5506cb097cdf5832e1cd5cad0c83c58d6";
+      sha256 = "1cpn117lnyjxfnc18i0pawzf4cd60my7z9ifmgyjvzg6xaiv8v6a";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -46,8 +46,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "14f9b09920813447a4060b6810bf17fc4ea35840";
-      sha256 = "1m2q9pg6kvhnfz1sgfcf9xq70iq63c7r6ag1zm212gqr0h79d5g5";
+      rev = "6b808ad5506cb097cdf5832e1cd5cad0c83c58d6";
+      sha256 = "1cpn117lnyjxfnc18i0pawzf4cd60my7z9ifmgyjvzg6xaiv8v6a";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "5241971fe563c90ea82b20af344116d46d672835";
-      sha256 = "02z2dvnxwnh94mcnww207nx6i8pnxkyq1dpbic37r70cnsgxs112";
+      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
+      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "5241971fe563c90ea82b20af344116d46d672835";
-      sha256 = "02z2dvnxwnh94mcnww207nx6i8pnxkyq1dpbic37r70cnsgxs112";
+      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
+      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "5241971fe563c90ea82b20af344116d46d672835";
-      sha256 = "02z2dvnxwnh94mcnww207nx6i8pnxkyq1dpbic37r70cnsgxs112";
+      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
+      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -72,6 +72,7 @@
             (hsPkgs.directory)
             (hsPkgs.filepath)
             (hsPkgs.formatting)
+            (hsPkgs.generic-monoid)
             (hsPkgs.hedgehog)
             (hsPkgs.lens)
             (hsPkgs.mtl)
@@ -114,8 +115,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "5241971fe563c90ea82b20af344116d46d672835";
-      sha256 = "02z2dvnxwnh94mcnww207nx6i8pnxkyq1dpbic37r70cnsgxs112";
+      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
+      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "d673b92f2a2d9354d102514d0a0fa74f8248b14a";
-      sha256 = "1zdri9jh1ws3b4jzmv6ywhpic6imcfp8ixgi33hh5rzz7ph76gzn";
+      rev = "3084f8b8514d93970415e895b241691b80c7b9ee";
+      sha256 = "086l78i7xmaryh03rfklgni02vlfsbdk2pwxf0msrc170lk8vzd4";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -69,7 +69,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "d673b92f2a2d9354d102514d0a0fa74f8248b14a";
-      sha256 = "1zdri9jh1ws3b4jzmv6ywhpic6imcfp8ixgi33hh5rzz7ph76gzn";
+      rev = "3084f8b8514d93970415e895b241691b80c7b9ee";
+      sha256 = "086l78i7xmaryh03rfklgni02vlfsbdk2pwxf0msrc170lk8vzd4";
       });
     }

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -37,6 +37,7 @@
           (hsPkgs.stm)
           (hsPkgs.text)
           (hsPkgs.transformers)
+          (hsPkgs.generic-monoid)
           ];
         };
       exes = {
@@ -102,7 +103,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "71fb36665338491e92d3ef14c20ae38ad6882c94";
-      sha256 = "04fca2b170wxj61birq6qb6fn8qnmdkz16rsmrn0x86bsfl0r1vf";
+      rev = "71a8257bfea837ddef716d8c81e436aa3273345e";
+      sha256 = "1yabl5pqlplyx7ifd1w9f3i1l3v5kf6185mdbh5q6b3fklrfsdy3";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b2022cf7f5925e486f9e0a31f6f6d02145d5ebda";
-      sha256 = "0h816f3nh7n6hk42pdy0l56a56vz8b998x0d0ysg3bkj0dc9sh0w";
+      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
+      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,6 +5,7 @@
         "binary" = (((hackage.binary)."0.8.7.0").revisions).default;
         "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
         "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
+        "generic-monoid" = (((hackage.generic-monoid)."0.1.0.0").revisions).default;
         "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
         "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
@@ -14,7 +15,6 @@
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
-        "pretty-show" = (((hackage.pretty-show)."1.8.2").revisions).default;
         "brick" = (((hackage.brick)."0.47").revisions)."4936c50acfdf09620dad5217fb384fc0d59626f75abed8b48250b419ec2ab623";
         "config-ini" = (((hackage.config-ini)."0.2.4.0").revisions)."38a6d484d471c6fac81445de2eac8c4e8c82760962fca5491ae1c3bfca9c4047";
         "data-clist" = (((hackage.data-clist)."0.1.2.2").revisions)."4d70add0a200a178853cd37c6469101bac3c36aebb3aa9c503ff225211b1a8c9";
@@ -49,6 +49,6 @@
       compiler.version = "8.6.5";
       compiler.nix-name = "ghc865";
       };
-  resolver = "lts-13.24";
+  resolver = "lts-13.28";
   compiler = "ghc-8.6.5";
   }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -155,8 +155,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b2022cf7f5925e486f9e0a31f6f6d02145d5ebda";
-      sha256 = "0h816f3nh7n6hk42pdy0l56a56vz8b998x0d0ysg3bkj0dc9sh0w";
+      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
+      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -121,8 +121,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -119,8 +119,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -21,6 +21,7 @@
           (hsPkgs.io-sim-classes)
           (hsPkgs.bytestring)
           (hsPkgs.contra-tracer)
+          (hsPkgs.time)
           ];
         };
       tests = {
@@ -34,6 +35,7 @@
             (hsPkgs.QuickCheck)
             (hsPkgs.tasty)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.time)
             ];
           };
         };
@@ -41,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "0fb0db07e8c3fdd60aa8e22492782f2afcf74788";
-      sha256 = "020j2fmr7s8hsgxj2a6n2sbgq6bqp8kisi4c35fj982kpbshidqm";
+      rev = "ca270835199406a06be590d2391bd87b072e7537";
+      sha256 = "031qv7fiyhypgy4myxcllq0xiqlr6w5wlmspa8rc7n1kpm9gz0nq";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "1d20fe361ec2f1e8de31e78a01b7aab28baf9dcc",
-  "date": "2019-07-12T19:19:34+00:00",
-  "sha256": "11gnzk6flan7ilbbn9xigbfi57cjf1imj5f8bsml4xkfl35ndxfz",
+  "rev": "acf1eb8d13972e78f15fa255a7b5307b8bede948",
+  "date": "2019-07-19T06:50:28+00:00",
+  "sha256": "1m9pkpvj629fzvqn2233vkvz93nf76balfq7333kgb0wj9483d1p",
   "fetchSubmodules": false
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/68648612f916e8adaf6c9ca5fe39bc6712470a6a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3084f8b8514d93970415e895b241691b80c7b9ee/snapshot.yaml
 
 packages:
   - .
@@ -6,7 +6,7 @@ packages:
 extra-deps:
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 5241971fe563c90ea82b20af344116d46d672835
+    commit: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -14,13 +14,13 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: d673b92f2a2d9354d102514d0a0fa74f8248b14a
+    commit: 3084f8b8514d93970415e895b241691b80c7b9ee
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 14f9b09920813447a4060b6810bf17fc4ea35840
+    commit: 6b808ad5506cb097cdf5832e1cd5cad0c83c58d6
     subdirs:
       - binary
       - binary/test
@@ -28,11 +28,12 @@ extra-deps:
 
     # Following deps are for cardano-shell
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 71fb36665338491e92d3ef14c20ae38ad6882c94
+    commit: 71a8257bfea837ddef716d8c81e436aa3273345e
 
   - binary-0.8.7.0
   - containers-0.5.11.0
   - ekg-prometheus-adapter-0.1.0.4
+  - generic-monoid-0.1.0.0
   - prometheus-2.1.1
   - pvss-0.2.0
   - time-units-1.0.0
@@ -40,7 +41,7 @@ extra-deps:
   - tasty-hedgehog-1.0.0.1
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: b2022cf7f5925e486f9e0a31f6f6d02145d5ebda
+    commit: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
     subdirs:
       - contra-tracer
       - iohk-monitoring
@@ -55,7 +56,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 0fb0db07e8c3fdd60aa8e22492782f2afcf74788
+    commit: ca270835199406a06be590d2391bd87b072e7537
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
This bumps a bunch of dependencies, and updates the code to work with cardano-shell again. The way in which this is done involved a partial pattern match - I expect a proper updating to arrive with https://github.com/input-output-hk/cardano-node/pull/60

As a consequence, this fixes the `--real-pbft` demo.