### PR TITLE
LiveView: stop the TUI & node itself.

### DIFF
--- a/app/LiveView.hs
+++ b/app/LiveView.hs
@@ -678,13 +678,14 @@ eventHandler prev (AppEvent lvBackend) = do
     M.continue $ next { lvsColorTheme = lvsColorTheme prev }
 eventHandler lvs  (VtyEvent e)         =
     case e of
-        V.EvKey  (V.KChar 'q') [] -> stopNodeThread >> M.halt lvs
-        V.EvKey  (V.KChar 'Q') [] -> stopNodeThread >> M.halt lvs
-        V.EvKey  (V.KChar 'd') [] -> M.continue $ lvs { lvsColorTheme = DarkTheme }
-        V.EvKey  (V.KChar 'D') [] -> M.continue $ lvs { lvsColorTheme = DarkTheme }
-        V.EvKey  (V.KChar 'l') [] -> M.continue $ lvs { lvsColorTheme = LightTheme }
-        V.EvKey  (V.KChar 'L') [] -> M.continue $ lvs { lvsColorTheme = LightTheme }
-        _                         -> M.continue lvs
+        V.EvKey  (V.KChar 'q') []        -> stopNodeThread >> M.halt lvs
+        V.EvKey  (V.KChar 'Q') []        -> stopNodeThread >> M.halt lvs
+        V.EvKey  (V.KChar 'c') [V.MCtrl] -> stopNodeThread >> M.halt lvs
+        V.EvKey  (V.KChar 'd') []        -> M.continue $ lvs { lvsColorTheme = DarkTheme }
+        V.EvKey  (V.KChar 'D') []        -> M.continue $ lvs { lvsColorTheme = DarkTheme }
+        V.EvKey  (V.KChar 'l') []        -> M.continue $ lvs { lvsColorTheme = LightTheme }
+        V.EvKey  (V.KChar 'L') []        -> M.continue $ lvs { lvsColorTheme = LightTheme }
+        _                                -> M.continue lvs
   where
     stopNodeThread = case lvsNodeThread lvs of
         Nothing -> return ()

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -82,11 +82,11 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol hiding (Protocol)
+import qualified Ouroboros.Consensus.Protocol as Consensus
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.STM
 import           Ouroboros.Consensus.Util.ThreadRegistry
-import qualified Ouroboros.Consensus.Protocol as Consensus
 
 import           Ouroboros.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Storage.ChainDB as ChainDB
@@ -152,6 +152,7 @@ runNode nodeCli@NodeCLIArguments{..} loggingLayer = do
             let lvbe = MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be }
             llAddBackend loggingLayer lvbe "LiveViewBackend"
             setTopology be topology
+            setNodeThread be nodeThread
             captureCounters be tr
 
             void $ Async.waitAny [nodeThread]


### PR DESCRIPTION
Now pressing `q` (in a live view) stops the TUI as well as the node itself.