### PR TITLE
ci/check-dependencies-merged-to-master.sh

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,3 +25,8 @@ steps:
     command: 'nix-shell scripts/buildkite/stack-cabal-sync.nix --run scripts/buildkite/stack-cabal-sync.sh'
     agents:
       system: x86_64-linux
+
+  - label: 'dependencies-at-master'
+    command: 'ci/check-dependencies-merged-to-master.sh'
+    agents:
+      system: x86_64-linux

--- a/ci/check-dependencies-merged-to-master.sh
+++ b/ci/check-dependencies-merged-to-master.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+self=$(basename $PWD)
+
+fmap() {
+        f=$1
+        read line
+        while test -n "$line"
+        do ${f} "$line"
+           read line; done
+}
+
+## Compute a case pattern that would match local cabal package names.
+local_packages="$(find . -name '*.cabal' | grep -v dist-newstyle | fmap basename | sed 's/.cabal//' | xargs echo)"
+match_local_packages_case_pattern="$(echo $local_packages | sed 's/ / | /g')"
+
+stack_to_nix_pins=nix/.stack.nix/*.nix
+ls ${stack_to_nix_pins} >/dev/null || {
+        echo "ERROR: stack-to-nix pins not found: ${stack_to_nix_pins}"
+        exit 1
+}
+
+for x in ${stack_to_nix_pins}
+do
+        name=$(basename -s .nix $x)
+        eval "case '$name' in 'default' | ${match_local_packages_case_pattern} ) continue; esac"
+        url=$(grep 'url =' $x | cut -d'"' -f2 | xargs echo | sed s'/^http:/https:/')
+        rev=$(grep 'rev =' $x | cut -d'"' -f2)
+        query="${url}/branch_commits/${rev}"
+        echo -n "${name}: "
+        if ! curl --silent "${query}" |
+                fgrep '<li class="branch">' |
+                cut -d'>' -f3 |
+                cut -d'<' -f1 | grep 'master'
+         then
+                cat <<EOF
+${name} ${rev} not on master of ${url}
+check:
+curl --silent ${query}
+EOF
+                exit 1
+        fi
+done


### PR DESCRIPTION
This adds a new required Buildkite CI check -- as can be seen below, there's now a new entry -- `buildkite/cardano-node/dependencies-at-master`: https://buildkite.com/input-output-hk/cardano-node/builds/1494#d91bcbbd-8b4a-49ee-912e-0abec8926b25

When it fails, it provides output of the following kind:
```
bimap: master
cardano-binary: master
cardano-binary-test: master
cardano-crypto-class: cardano-crypto-class 0e26a4f00324100b4c34f2a9c7606ae03e94d7a1 not on master of https://github.com/input-output-hk/cardano-base
check:
curl --silent https://github.com/input-output-hk/cardano-base/branch_commits/0e26a4f00324100b4c34f2a9c7606ae03e94d7a1
```

# Implementation
- a _mish-mash-of-bash_ is not the prettiest way to do it, can certainly be improved -- but it's a start