### PR TITLE
use cardano-shell rev with proper mainnet conf

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -64,7 +64,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
-  tag: 33e4d04fafbfe094422a45203dda0900be109439
+  tag: 2044172cd8856e927860e9b5c731a4343462206e
 
 source-repository-package
   type: git

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -2,7 +2,7 @@
   {
     flags = {};
     package = {
-      specVersion = "1.10";
+      specVersion = "2.2";
       identifier = { name = "cardano-shell"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "2018 IOHK";
@@ -35,6 +35,7 @@
           (hsPkgs.QuickCheck)
           (hsPkgs.safe-exceptions)
           (hsPkgs.stm)
+          (hsPkgs.async)
           (hsPkgs.text)
           (hsPkgs.transformers)
           (hsPkgs.generic-monoid)
@@ -59,6 +60,16 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.optparse-applicative)
             (hsPkgs.safe-exceptions)
+            ];
+          };
+        "daedalus-ipc" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.cardano-shell)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.safe-exceptions)
+            (hsPkgs.iohk-monitoring)
             ];
           };
         "cardano-launcher" = {
@@ -87,6 +98,7 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.dhall)
             (hsPkgs.safe-exceptions)
+            (hsPkgs.process)
             (hsPkgs.QuickCheck)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.tree-diff)
@@ -97,13 +109,16 @@
             (hsPkgs.dejafu)
             (hsPkgs.hunit-dejafu)
             ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-shell or (pkgs.buildPackages.cardano-shell))
+            ];
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "33e4d04fafbfe094422a45203dda0900be109439";
-      sha256 = "0ma4qrv2zfbwqy2vw6abwn74f32vm059z2k35ma4hwn2m0r2ivd9";
+      rev = "2044172cd8856e927860e9b5c731a4343462206e";
+      sha256 = "1ij6cpj7lg26ka90dg5q5n0976kqy2np912zdk4w4hwl9vqy4z4j";
       });
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
 
     # Following deps are for cardano-shell
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 33e4d04fafbfe094422a45203dda0900be109439
+    commit: 2044172cd8856e927860e9b5c731a4343462206e
 
   - binary-0.8.7.0
   - containers-0.5.11.0


### PR DESCRIPTION
Fixes a bug in which mainnet ledger is invalid at the first transaction,
because the genesis UTxO is all messed up due to improper network magic
(mainnet requires no magic).