### PR TITLE
Update after ouroboros-network#903

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -86,37 +86,37 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 2b0f6312ed162759616e99f21804f14cecab6b47
   subdir: io-sim-classes
 
 source-repository-package

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -26,6 +26,7 @@
           (hsPkgs.contra-tracer)
           (hsPkgs.cardano-ledger-test)
           (hsPkgs.base16-bytestring)
+          (hsPkgs.bifunctors)
           (hsPkgs.bimap)
           (hsPkgs.bytestring)
           (hsPkgs.cardano-binary)
@@ -146,8 +147,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -122,8 +122,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "2b0f6312ed162759616e99f21804f14cecab6b47";
+      sha256 = "0jjd79ix5ndkm4lxkrsbc9xn5y9fgvc0imj7gxaxzd20i5zj95yd";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,7 +56,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 49fde639a21a13c55795075b5d967bb966f1a923
+    commit: 2b0f6312ed162759616e99f21804f14cecab6b47
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
The point of #903 is to trace the progress of the ledger initialisation. Some pointers on how to do this:
* Note the new line: `LedgerDB.ReplayedBlock {} -> ignore`
* See the new `ChainDB.TraceEvent.TraceLedgerReplayEvent` constructor: https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-f1834e0128e7b50336516db371f62579R302
* See https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-1b6e41536e4311c26facb6a658fdb160R388
* The above `TraceReplayEvent` is decorated with more info here: https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-da0a5a3d801a2f66b948bf6b372a6d82R272
  This includes:
  - The point and epoch of the replayed block
  - The slot of the first block in the epoch of the replayed block. If the block's `pointSlot` equals this slot, it is the first block in the epoch (note that the EBB has the same slot as the first block in the epoch)
  - The point and epoch of the last block that has to be replayed (the tip of the ImmutableDB).
  Using this information, it should be possible to trace  user-friendly progress of the ledger initialisation process. Note that showing progress per epoch might be too slow, progress per 500 blocks/slots or so seems reasonable.
