### PR TITLE
Fix the plumbing of the PBFT sig threshold param

### DIFF
--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -238,7 +238,7 @@ data CommonCLI = CommonCLI
   , cliGenesisHash                :: !(Last Text)
   , cliStaticKeySigningKeyFile    :: !(Last FilePath)
   , cliStaticKeyDlgCertFile       :: !(Last FilePath)
-  --TODO cliPBftSigThd            :: !(Last Double)
+  , cliPBftSigThd                 :: !(Last Double)
   --TODO cliUpdate                :: !PartialUpdate
   }
 
@@ -265,7 +265,11 @@ parseCommonCLI =
           <> metavar "FILEPATH"
           <> help "Path to the delegation certificate."
            )
-
+    <*> lastDoubleOption
+           ( long "pbft-signature-threshold"
+          <> metavar "DOUBLE"
+          <> help "The PBFT signature threshold."
+           )
 
 {-------------------------------------------------------------------------------
   Configuration merging
@@ -291,6 +295,7 @@ mergeConfiguration pcc cli =
                    , cliGenesisHash
                    , cliStaticKeySigningKeyFile
                    , cliStaticKeyDlgCertFile
+                   , cliPBftSigThd
                    } =
       mempty {
         pccCore = mempty {
@@ -298,7 +303,8 @@ mergeConfiguration pcc cli =
         , pcoGenesisHash             = cliGenesisHash
         , pcoStaticKeySigningKeyFile = cliStaticKeySigningKeyFile
         , pcoStaticKeyDlgCertFile    = cliStaticKeyDlgCertFile
-       -- TODO: cliPBftSigThd, cliUpdate
+        , pcoPBftSigThd              = cliPBftSigThd
+       -- TODO: cliUpdate
         }
       }
 

--- a/cardano-node/Cardano/Node/CLI.hs
+++ b/cardano-node/Cardano/Node/CLI.hs
@@ -152,6 +152,7 @@ fromProtocol _ MockPBFT =
 fromProtocol CardanoConfiguration{ccCore} RealPBFT = do
     let Core{ coGenesisFile
             , coGenesisHash
+            , coPBftSigThd
             } = ccCore
         genHash = either (throw . ConfigurationError) id $
                   decodeAbstractHash coGenesisHash
@@ -171,9 +172,12 @@ fromProtocol CardanoConfiguration{ccCore} RealPBFT = do
         -- These defaults are good for mainnet.
         defSoftVer  = Update.SoftwareVersion (Update.ApplicationName "cardano-sl") 1
         defProtoVer = Update.ProtocolVersion 0 2 0
+        -- TODO: The plumbing here to make the PBFT options from the
+        -- CardanoConfiguration is subtle, it should have its own function
+        -- to do this, along with other config conversion plumbing:
         p = ProtocolRealPBFT
               gc
-              Nothing
+              (fmap PBftSignatureThreshold coPBftSigThd)
               defProtoVer
               defSoftVer
               optionalLeaderCredentials

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -16,6 +16,7 @@ NETARGS=(
         --slot-duration 2
         --genesis-file "configuration/Test.Cardano.Chain.Genesis.Dummy.dummyConfig.configGenesisData.json"
         --genesis-hash "fc32ebdf3c9bfa2ebf6bdcac98649f610601ddb266a2a2743e787dc9952a1aeb"
+        --pbft-signature-threshold 0.7
         node
         --topology "configuration/simple-topology.json"
         ${ALGO}

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -12,6 +12,7 @@ NETARGS=(
         --slot-duration 2
         --genesis-file "configuration/Test.Cardano.Chain.Genesis.Dummy.dummyConfig.configGenesisData.json"
         --genesis-hash "fc32ebdf3c9bfa2ebf6bdcac98649f610601ddb266a2a2743e787dc9952a1aeb"
+        --pbft-signature-threshold 0.7
         node
         --topology "configuration/simple-topology.json"
         ${ALGO}


### PR DESCRIPTION
The coPBftSigThd needs to be passed through.

This allows overriding the threshold from the config or CLI. This is needed to adjust the threshold for clusters with short k. The default is tuned for the mainnet value of k.