### PR TITLE
improve the bash completion for `--log-config`

### DIFF
--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -31,6 +31,7 @@ loggingParser = LoggingCLIArguments
         ( long "log-config"
        <> metavar "LOGCONFIG"
        <> help "Configuration file for logging"
+       <> completer (bashCompleter "file")
         )
 
 parseProtocol :: Parser Protocol


### PR DESCRIPTION
this allows you do to things like `source <(cardano-explorer-db-node --bash-completion-script `type -p cardano-explorer-db-node`)` and then tab-completion can complete all args, and knows that `--log-config` takes a file