### PR TITLE
[#115] textual representation of log messages - for readability in debugging

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -75,13 +75,13 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: 695374d78ebb9806343b86049eb5e06d1afd52f7
+  tag: 4ad81798402ce05655b37b31b0b67f444a2f0b91
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: 695374d78ebb9806343b86049eb5e06d1afd52f7
+  tag: 4ad81798402ce05655b37b31b0b67f444a2f0b91
 
 source-repository-package
   type: git

--- a/cardano-node/src/Cardano/Node/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracers.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
 
 module Cardano.Node.Tracers
   ( ConsensusTraceOptions
@@ -13,8 +17,9 @@ module Cardano.Node.Tracers
   , mkTracers
   , withTip
   ) where
+
 import           Cardano.Prelude hiding (atomically, show)
-import           Prelude (String, show)
+import           Prelude (String, show, id)
 
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad.Class.MonadSTM
@@ -24,14 +29,15 @@ import           Data.Functor.Contravariant (contramap)
 import           Data.Text (Text, pack)
 
 import           Cardano.BM.Data.Aggregated (Measurable (PureI))
-import           Cardano.BM.Data.LogItem (LOContent (LogValue), LogObject (..),
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..),
                                           PrivacyAnnotation (Confidential),
                                           mkLOMeta)
-import           Cardano.BM.Data.Severity (Severity (..))
-import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity(..))
-import           Cardano.BM.Trace (appendName, traceNamedObject)
+import           Cardano.BM.Tracing
+import           Cardano.BM.Trace (traceNamedObject)
+import           Cardano.BM.Data.Tracer (trStructured)
 
 
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block (Header)
@@ -44,13 +50,13 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 
 import           Cardano.Node.ToObjectOrphans
 
 
 data Tracers peer blk = Tracers {
-      -- | Trace the ChainDB. By default we use 'readableChainDB' tracer but a
-      -- more verbose one can be enabled.
+      -- | Trace the ChainDB (flag '--trace-chain-db' will turn on textual output)
       chainDBTracer         :: Tracer IO (WithTip blk (ChainDB.TraceEvent blk))
 
       -- | Consensus-specific tracers.
@@ -105,6 +111,117 @@ data TraceOptions = TraceOptions
 type ConsensusTraceOptions = Consensus.Tracers' () ()    (Const Bool)
 type ProtocolTraceOptions  = ProtocolTracers'   () () () (Const Bool)
 
+-- | tracing to LogObject, either structural or textual
+--
+
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
+            => Transformable Text IO (WithTip blk (ChainDB.TraceEvent blk)) where
+    -- structure required, will call 'toObject'
+    trTransformer StructuredLogging verb tr = trStructured verb tr
+    -- textual output based on the readable ChainDB tracer
+    trTransformer TextualRepresentation _verb tr = readableChainDBTracer $ Tracer $ \s ->
+        traceWith tr =<<
+            LogObject <$> pure ""
+                      <*> (mkLOMeta Debug Public)
+                      <*> pure (LogMessage $ pack s)
+    -- user defined formatting of log output
+    trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+-- | tracer transformer to text messages for TraceEvents
+
+-- Converts the trace events from the ChainDB that we're interested in into
+-- human-readable trace messages.
+readableChainDBTracer
+    :: forall m blk.
+       (Monad m, Condense (HeaderHash blk), ProtocolLedgerView blk)
+    => Tracer m String
+    -> Tracer m (WithTip blk (ChainDB.TraceEvent blk))
+readableChainDBTracer tracer = Tracer $ \case
+    WithTip tip (ChainDB.TraceAddBlockEvent ev) -> case ev of
+        ChainDB.StoreButDontChange   pt -> tr $ WithTip tip $
+          "Ignoring block: " <> condense pt
+        ChainDB.TryAddToCurrentChain pt -> tr $ WithTip tip $
+          "Block fits onto the current chain: " <> condense pt
+        ChainDB.TrySwitchToAFork pt _   -> tr $ WithTip tip $
+          "Block fits onto some fork: " <> condense pt
+        ChainDB.SwitchedToChain _ c     -> tr $ WithTip tip $
+          "Chain changed, new tip: " <> condense (AF.headPoint c)
+        ChainDB.AddBlockValidation ev' -> case ev' of
+            ChainDB.InvalidBlock err pt -> tr $ WithTip tip $
+              "Invalid block " <> condense pt <> ": " <> show err
+            ChainDB.InvalidCandidate c err -> tr $ WithTip tip $
+              "Invalid candidate " <> condense (AF.headPoint c) <> ": " <> show err
+            ChainDB.ValidCandidate c -> tr $ WithTip tip $
+              "Valid candidate " <> condense (AF.headPoint c)
+        ChainDB.AddedBlockToVolDB pt     -> tr $ WithTip tip $
+          "Chain added block " <> condense pt
+        ChainDB.ChainChangedInBg c1 c2     -> tr $ WithTip tip $
+          "Chain changed in bg, from " <> condense (AF.headPoint c1) <> " to "  <> condense (AF.headPoint c2)
+    WithTip tip (ChainDB.TraceLedgerReplayEvent ev) -> case ev of
+        LedgerDB.ReplayFromGenesis _replayTo -> tr $ WithTip tip $
+          "Replaying ledger from genesis"
+        LedgerDB.ReplayFromSnapshot snap tip' _replayTo -> tr $ WithTip tip $
+          "Replaying ledger from snapshot " <> show snap <> " at " <>
+          condense tip'
+        LedgerDB.ReplayedBlock {} -> pure ()
+    WithTip tip (ChainDB.TraceLedgerEvent ev) -> case ev of
+        LedgerDB.TookSnapshot snap pt -> tr $ WithTip tip $
+          "Took ledger snapshot " <> show snap <> " at " <> condense pt
+        LedgerDB.DeletedSnapshot snap -> tr $ WithTip tip $
+          "Deleted old snapshot " <> show snap
+        LedgerDB.InvalidSnapshot snap failure -> tr $ WithTip tip $
+          "Invalid snapshot " <> show snap <> show failure
+    WithTip tip (ChainDB.TraceCopyToImmDBEvent ev) -> case ev of
+        ChainDB.CopiedBlockToImmDB pt -> tr $ WithTip tip $
+          "Copied block " <> condense pt <> " to the ImmutableDB"
+        ChainDB.NoBlocksToCopyToImmDB -> tr $ WithTip tip $
+          "There are no blocks to copy to the ImmutableDB"
+    WithTip tip (ChainDB.TraceGCEvent ev) -> case ev of
+        ChainDB.PerformedGC slot        -> tr $ WithTip tip $
+          "Performed a garbage collection for " <> condense slot
+        ChainDB.ScheduledGC slot _difft -> tr $ WithTip tip $
+          "Scheduled a garbage collection for " <> condense slot
+    WithTip tip (ChainDB.TraceOpenEvent ev) -> case ev of
+        ChainDB.OpenedDB immTip tip' -> tr $ WithTip tip $
+          "Opened db with immutable tip at " <> condense immTip <>
+          " and tip " <> condense tip'
+        ChainDB.ClosedDB immTip tip' -> tr $ WithTip tip $
+          "Closed db with immutable tip at " <> condense immTip <>
+          " and tip " <> condense tip'
+        ChainDB.ReopenedDB immTip tip' -> tr $ WithTip tip $
+          "Reopened db with immutable tip at " <> condense immTip <>
+          " and tip " <> condense tip'
+        ChainDB.OpenedImmDB immTip epoch -> tr $ WithTip tip $
+          "Opened imm db with immutable tip at " <> condense immTip <>
+          " and epoch " <> show epoch
+        ChainDB.OpenedVolDB -> tr $ WithTip tip $
+          "Opened vol db"
+        ChainDB.OpenedLgrDB -> tr $ WithTip tip $
+          "Opened lgr db"
+    WithTip tip (ChainDB.TraceReaderEvent ev) -> case ev of
+        ChainDB.NewReader readerid -> tr $ WithTip tip $
+          "New reader with id: " <> condense readerid
+        ChainDB.ReaderNoLongerInMem _ -> tr $ WithTip tip $
+          "ReaderNoLongerInMem"
+        ChainDB.ReaderSwitchToMem _ _ -> tr $ WithTip tip $
+          "ReaderSwitchToMem"
+        ChainDB.ReaderNewImmIterator _ _ -> tr $ WithTip tip $
+          "ReaderNewImmIterator"
+    WithTip tip (ChainDB.TraceInitChainSelEvent ev) -> case ev of
+        ChainDB.InitChainSelValidation _ -> tr $ WithTip tip $
+          "InitChainSelValidation"
+    WithTip tip (ChainDB.TraceIteratorEvent ev) -> case ev of
+        ChainDB.StreamFromVolDB _ _ _ -> tr $ WithTip tip $
+          "StreamFromVolDB"
+        _ -> pure ()  -- TODO add more iterator events
+    WithTip tip (ChainDB.TraceImmDBEvent _ev) -> tr $ WithTip tip $
+        "TraceImmDBEvent"
+
+  where
+    tr :: WithTip blk String -> m ()
+    tr = traceWith (contramap (showWithTip id) tracer)
+
+
 -- | Smart constructor of 'NodeTraces'.
 --
 mkTracers :: forall peer blk.
@@ -118,8 +235,9 @@ mkTracers :: forall peer blk.
 mkTracers traceOptions tracer = Tracers
     { chainDBTracer
         = if traceChainDB traceOptions
-          then contramap show tracer'
-          else toLogObject' (traceVerbosity traceOptions) tracer
+          -- then contramap show tracer'
+          then toLogObject' TextualRepresentation (traceVerbosity traceOptions) tracer
+          else toLogObject' StructuredLogging (traceVerbosity traceOptions) tracer
     , consensusTracers
         = mkConsensusTracers
     , protocolTracers
@@ -135,9 +253,6 @@ mkTracers traceOptions tracer = Tracers
         $ withName "DnsResolver" tracer
     }
   where
-    tracer' :: Tracer IO String
-    tracer' = contramap pack $ toLogObject' (traceVerbosity traceOptions) tracer
-
     enableTracer
       :: Show a
       => Bool

--- a/cardano-node/src/Cardano/Node/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracers.hs
@@ -235,7 +235,6 @@ mkTracers :: forall peer blk.
 mkTracers traceOptions tracer = Tracers
     { chainDBTracer
         = if traceChainDB traceOptions
-          -- then contramap show tracer'
           then toLogObject' TextualRepresentation (traceVerbosity traceOptions) tracer
           else toLogObject' StructuredLogging (traceVerbosity traceOptions) tracer
     , consensusTracers

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "695374d78ebb9806343b86049eb5e06d1afd52f7";
-      sha256 = "09x1ig3r2iafnp2cgdj712gj1hxf3ki6r6gg56732bnjrh388f6j";
+      rev = "4ad81798402ce05655b37b31b0b67f444a2f0b91";
+      sha256 = "130k6msxrxr0dai0gk2r9ca2bjpwqpklk7rxqf1yrn2plivkqqlm";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -156,8 +156,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "695374d78ebb9806343b86049eb5e06d1afd52f7";
-      sha256 = "09x1ig3r2iafnp2cgdj712gj1hxf3ki6r6gg56732bnjrh388f6j";
+      rev = "4ad81798402ce05655b37b31b0b67f444a2f0b91";
+      sha256 = "130k6msxrxr0dai0gk2r9ca2bjpwqpklk7rxqf1yrn2plivkqqlm";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,7 @@ extra-deps:
   - tasty-hedgehog-1.0.0.1
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 695374d78ebb9806343b86049eb5e06d1afd52f7
+    commit: 4ad81798402ce05655b37b31b0b67f444a2f0b91
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
add the flag `--trace-chain-db` to turn on textual representation of logged messages.
(-> in shelley-testnet.sh, variable SPECIAL)