### PR TITLE
cardano-cli refactoring & submit-tx subcommand

### DIFF
--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -2,19 +2,26 @@
 module Main (main) where
 
 import           Cardano.Prelude hiding (option)
-import           Prelude (String)
+import           Prelude (String, error, id)
+
+import           Options.Applicative
+
+import           Control.Exception.Safe (catchIO)
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import           Data.Time (UTCTime)
+import           System.Exit (ExitCode(..), exitWith)
 
 import           Cardano.Binary (Annotated (..))
 import           Cardano.Chain.Common
-import qualified Cardano.Chain.Genesis as Genesis
-import           Cardano.Chain.Slotting (EpochNumber(..))
-import           Cardano.CLI.Run (ClientCommand(..), SystemVersion(..), decideKeyMaterialOps, runCommand)
-import           Cardano.Common.CommonCLI (command')
+import           Cardano.Chain.Genesis
+import           Cardano.Chain.Slotting
 import           Cardano.Crypto (AProtocolMagic(..), ProtocolMagic, ProtocolMagicId(..), RequiresNetworkMagic(..))
 
-import           Options.Applicative
-import           Control.Exception.Safe (catchIO)
-import           System.Exit (ExitCode(..), exitWith)
+import           Cardano.Common.CommonCLI
+import           Cardano.Common.Protocol
+import           Cardano.Node.Parsers
+import           Cardano.CLI.Ops (decideCLIOps)
+import           Cardano.CLI.Run (ClientCommand(..), runCommand)
 
 main :: IO ()
 main = do
@@ -41,3 +48,163 @@ parseClient :: Parser CLI
 parseClient = CLI
     <$> parseProtocolAsCommand
     <*> parseClientCommand
+
+parseClientCommand :: Parser ClientCommand
+parseClientCommand =
+  subparser
+  (mconcat
+    [ commandGroup "Genesis"
+    , command' "genesis"                        "Perform genesis." $
+      Genesis
+      <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
+      <*> parseUTCTime     "start-time"               "Start time of the new cluster to be enshrined in the new genesis."
+      <*> parseFilePath    "protocol-parameters-file" "JSON file with protocol parameters."
+      <*> parseK
+      <*> parseProtocolMagic
+      <*> parseTestnetBalanceOptions
+      <*> parseFakeAvvmOptions
+      <*> (LovelacePortion . fromInteger . fromMaybe 1 <$>
+           (optional $
+             parseIntegral  "avvm-balance-factor"      "AVVM balances will be multiplied by this factor (defaults to 1)."))
+      <*> optional (parseIntegral    "secret-seed"              "Optionally specify the seed of generation.")
+    , command' "dump-hardcoded-genesis"         "Write out a hard-coded genesis." $
+      DumpHardcodedGenesis
+      <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
+    , command' "print-genesis-hash"             "Compute hash of a genesis file." $
+      PrintGenesisHash
+      <$> parseFilePath    "genesis-json"             "Genesis JSON file to hash."
+    ])
+  <|> subparser
+  (mconcat
+    [ commandGroup "Keys"
+    , command' "keygen"                         "Generate a signing key." $
+      Keygen
+      <$> parseFilePath    "secret"                   "Non-existent file to write the secret key to."
+      <*> parseFlag        "no-password"              "Disable password protection."
+    , command' "to-verification"                "Extract a verification key in its base64 form." $
+      ToVerification
+      <$> parseFilePath    "secret"                   "Secret key file to extract from."
+      <*> parseFilePath    "to"                       "Non-existent file to write the base64-formatted verification key to."
+    , command' "signing-key-public"             "Pretty-print a signing key's verification key (not a secret)." $
+      PrettySigningKeyPublic
+      <$> parseFilePath    "secret"                   "File name of the secret key to pretty-print."
+    , command' "signing-key-address"            "Print address of a signing key." $
+      PrintSigningKeyAddress
+      <$> parseNetworkMagic
+      <*> parseFilePath    "secret"                   "Secret key, whose address is to be printed."
+    , command' "migrate-delegate-key-from"      "Migrate a delegate key from an older version." $
+      MigrateDelegateKeyFrom
+      <$> parseProtocol
+      <*> parseFilePath    "to"                       "Output secret key file."
+      <*> parseFilePath    "from"                     "Secret key file to migrate."
+    ])
+  <|> subparser
+  (mconcat
+    [ commandGroup "Delegation"
+    , command' "redelegate"                     "Redelegate genesis authority to a different verification key." $
+      Redelegate
+      <$> parseProtocolMagicId "protocol-magic"
+      <*> (EpochNumber <$>
+            parseIntegral   "since-epoch"              "First epoch of effective delegation.")
+      <*> parseFilePath    "secret"                   "The genesis key to redelegate from."
+      <*> parseFilePath    "delegate-key"             "The operation verification key to delegate to."
+      <*> parseFilePath    "certificate"              "Non-existent file to write the certificate to."
+    , command' "check-delegation"               "Verify that a given certificate constitutes a valid delegation relationship betwen keys." $
+      CheckDelegation
+      <$> parseProtocolMagicId "protocol-magic"
+      <*> parseFilePath    "certificate"              "The certificate embodying delegation to verify."
+      <*> parseFilePath    "issuer-key"               "The genesis key that supposedly delegates."
+      <*> parseFilePath    "delegate-key"             "The operation verification key supposedly delegated to."
+    ])
+  <|> subparser
+  (mconcat
+    [ commandGroup "Transactions"
+    , command' "submit-tx"                      "Submit a raw, signed transaction, in its on-wire representation." $
+      SubmitTx
+      <$> parseTopologyInfo "PBFT node ID to submit Tx to."
+      <*> parseFilePath    "tx"                       "File containing the raw transaction."
+      <*> parseCommonCLI
+    ])
+
+parseTestnetBalanceOptions :: Parser TestnetBalanceOptions
+parseTestnetBalanceOptions =
+  TestnetBalanceOptions
+  <$> parseIntegral        "n-poor-addresses"         "Number of poor nodes (with small balance)."
+  <*> parseIntegral        "n-delegate-addresses"     "Number of delegate nodes (with huge balance)."
+  <*> parseLovelace        "total-balance"            "Total balance owned by these nodes."
+  <*> parseLovelacePortion "delegate-share"           "Portion of stake owned by all delegates together."
+  <*> parseFlag            "use-hd-addresses"         "Whether generate plain addresses or with hd payload."
+
+parseLovelace :: String -> String -> Parser Lovelace
+parseLovelace optname desc =
+  either (error . show) id . mkLovelace
+  <$> parseIntegral optname desc
+
+parseLovelacePortion :: String -> String -> Parser LovelacePortion
+parseLovelacePortion optname desc =
+  either (error . show) id . mkLovelacePortion
+  <$> parseIntegral optname desc
+
+parseFakeAvvmOptions :: Parser FakeAvvmOptions
+parseFakeAvvmOptions =
+  FakeAvvmOptions
+  <$> parseIntegral        "avvm-entry-count"         "Number of AVVM addresses."
+  <*> parseLovelace        "avvm-entry-balance"       "AVVM address."
+
+parseK :: Parser BlockCount
+parseK =
+  BlockCount
+  <$> parseIntegral        "k"                        "The security parameter of the Ouroboros protocol."
+
+parseNetworkMagic :: Parser NetworkMagic
+parseNetworkMagic = asum
+    [ flag' NetworkMainOrStage $ mconcat [
+          long "main-or-staging"
+        , help ""
+        ]
+    , option (fmap NetworkTestnet auto) (
+          long "testnet-magic"
+       <> metavar "MAGIC"
+       <> help "The testnet network magic, decibal"
+        )
+    ]
+
+parseProtocolMagicId :: String -> Parser ProtocolMagicId
+parseProtocolMagicId arg =
+  ProtocolMagicId
+  <$> parseIntegral        arg                        "The magic number unique to any instance of Cardano."
+
+parseProtocolMagic :: Parser ProtocolMagic
+parseProtocolMagic =
+  flip AProtocolMagic RequiresMagic . flip Annotated ()
+  <$> parseProtocolMagicId "protocol-magic"
+
+parseUTCTime :: String -> String -> Parser UTCTime
+parseUTCTime optname desc =
+    option (posixSecondsToUTCTime . fromInteger <$> auto) (
+            long optname
+         <> metavar "POSIXSECONDS"
+         <> help desc
+    )
+
+parseFilePath :: String -> String -> Parser FilePath
+parseFilePath optname desc =
+    strOption (
+            long optname
+         <> metavar "FILEPATH"
+         <> help desc
+    )
+parseIntegral :: Integral a => String -> String -> Parser a
+parseIntegral optname desc =
+    option (fromInteger <$> auto) (
+            long optname
+         <> metavar "INT"
+         <> help desc
+    )
+
+parseFlag :: String -> String -> Parser Bool
+parseFlag optname desc =
+    flag False True (
+            long optname
+         <> help desc
+    )

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
+module Main (main) where
 
 import           Cardano.Prelude hiding (option)
-import           Prelude (String, error, id)
+import           Prelude (String)
 
 import           Cardano.Binary (Annotated (..))
 import           Cardano.Chain.Common
@@ -11,21 +12,19 @@ import           Cardano.CLI.Run (ClientCommand(..), SystemVersion(..), decideKe
 import           Cardano.Common.CommonCLI (command')
 import           Cardano.Crypto (AProtocolMagic(..), ProtocolMagic, ProtocolMagicId(..), RequiresNetworkMagic(..))
 
-import           Data.Time (UTCTime)
-import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Options.Applicative
 import           Control.Exception.Safe (catchIO)
 import           System.Exit (ExitCode(..), exitWith)
 
 main :: IO ()
 main = do
-  CLI{mainCommand, systemVersion} <- execParser opts
-  catchIO (runCommand (decideKeyMaterialOps systemVersion) mainCommand) $
+  CLI{mainCommand, protocol} <- execParser opts
+  ops <- decideCLIOps protocol
+  catchIO (runCommand ops mainCommand) $
     \err-> do
       hPutStrLn stderr ("Error:\n" <> show err :: String)
       exitWith $ ExitFailure 1
 
--- | Top level parser with info.
 opts :: ParserInfo CLI
 opts = info (parseClient <**> helper)
   ( fullDesc
@@ -33,176 +32,12 @@ opts = info (parseClient <**> helper)
     <> header "Cardano genesis tool."
   )
 
-{-------------------------------------------------------------------------------
-  CLI parsers & Types
--------------------------------------------------------------------------------}
-
 data CLI = CLI
-  { systemVersion :: SystemVersion
-  , mainCommand   :: ClientCommand
+  { protocol    :: Protocol
+  , mainCommand :: ClientCommand
   }
 
 parseClient :: Parser CLI
 parseClient = CLI
-    <$> parseSystemVersion
+    <$> parseProtocolAsCommand
     <*> parseClientCommand
-
-parseSystemVersion :: Parser SystemVersion
-parseSystemVersion = subparser $ mconcat
-  [ commandGroup "System version"
-  , metavar "SYSTEMVER"
-  , command' "byron-legacy" "Byron Legacy mode" $ pure ByronLegacy
-  , command' "byron-pbft"   "Byron PBFT mode"   $ pure ByronPBFT
-  ]
-
-parseClientCommand :: Parser ClientCommand
-parseClientCommand =
-  subparser
-  (mconcat
-    [ commandGroup "Genesis"
-    , command' "genesis"                        "Perform genesis." $
-      Genesis
-      <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
-      <*> parseUTCTime     "start-time"               "Start time of the new cluster to be enshrined in the new genesis."
-      <*> parseFilePath    "protocol-parameters-file" "JSON file with protocol parameters."
-      <*> parseK
-      <*> parseProtocolMagic
-      <*> parseTestnetBalanceOptions
-      <*> parseFakeAvvmOptions
-      <*> (LovelacePortion . fromInteger . fromMaybe 1 <$>
-           (optional $
-             parseIntegral  "avvm-balance-factor"      "AVVM balances will be multiplied by this factor (defaults to 1)."))
-      <*> optional (parseIntegral    "secret-seed"              "Optionally specify the seed of generation.")
-    , command' "dump-hardcoded-genesis"         "Write out a hard-coded genesis." $
-      DumpHardcodedGenesis
-      <$> parseFilePath    "genesis-output-dir"       "A yet-absent directory where genesis JSON file along with secrets shall be placed."
-    , command' "print-genesis-hash"             "Compute hash of a genesis file." $
-      PrintGenesisHash
-      <$> parseFilePath    "genesis-json"             "Genesis JSON file to hash."
-    ])
-  <|> subparser
-  (mconcat
-    [ commandGroup "Keys"
-    , command' "keygen"                         "Generate a signing key." $
-      Keygen
-      <$> parseFilePath    "secret"                   "Non-existent file to write the secret key to."
-      <*> parseFlag        "no-password"              "Disable password protection."
-    , command' "to-verification"                "Extract a verification key in its base64 form." $
-      ToVerification
-      <$> parseFilePath    "secret"                   "Secret key file to extract from."
-      <*> parseFilePath    "to"                       "Non-existent file to write the base64-formatted verification key to."
-    , command' "signing-key-public"             "Pretty-print a signing key's verification key (not a secret)." $
-      PrettySigningKeyPublic
-      <$> parseFilePath    "secret"                   "File name of the secret key to pretty-print."
-    , command' "signing-key-address"            "Print address of a signing key." $
-      PrintSigningKeyAddress
-      <$> parseNetworkMagic
-      <*> parseFilePath    "secret"                   "Secret key, whose address is to be printed."
-    , command' "migrate-delegate-key-from"      "Migrate a delegate key from an older version." $
-      MigrateDelegateKeyFrom
-      <$> parseSystemVersion
-      <*> parseFilePath    "to"                       "Output secret key file."
-      <*> parseFilePath    "from"                     "Secret key file to migrate."
-    ])
-  <|> subparser
-  (mconcat
-    [ commandGroup "Delegation"
-    , command' "redelegate"                     "Redelegate genesis authority to a different verification key." $
-      Redelegate
-      <$> parseProtocolMagicId "protocol-magic"
-      <*> (EpochNumber <$>
-            parseIntegral   "since-epoch"              "First epoch of effective delegation.")
-      <*> parseFilePath    "secret"                   "The genesis key to redelegate from."
-      <*> parseFilePath    "delegate-key"             "The operation verification key to delegate to."
-      <*> parseFilePath    "certificate"              "Non-existent file to write the certificate to."
-    , command' "check-delegation"               "Verify that a given certificate constitutes a valid delegation relationship betwen keys." $
-      CheckDelegation
-      <$> parseProtocolMagicId "protocol-magic"
-      <*> parseFilePath    "certificate"              "The certificate embodying delegation to verify."
-      <*> parseFilePath    "issuer-key"               "The genesis key that supposedly delegates."
-      <*> parseFilePath    "delegate-key"             "The operation verification key supposedly delegated to."
-    ])
-
-parseTestnetBalanceOptions :: Parser Genesis.TestnetBalanceOptions
-parseTestnetBalanceOptions =
-  Genesis.TestnetBalanceOptions
-  <$> parseIntegral        "n-poor-addresses"         "Number of poor nodes (with small balance)."
-  <*> parseIntegral        "n-delegate-addresses"     "Number of delegate nodes (with huge balance)."
-  <*> parseLovelace        "total-balance"            "Total balance owned by these nodes."
-  <*> parseLovelacePortion "delegate-share"           "Portion of stake owned by all delegates together."
-  <*> parseFlag            "use-hd-addresses"         "Whether generate plain addresses or with hd payload."
-
-parseLovelace :: String -> String -> Parser Lovelace
-parseLovelace optname desc =
-  either (error . show) id . mkLovelace
-  <$> parseIntegral optname desc
-
-parseLovelacePortion :: String -> String -> Parser LovelacePortion
-parseLovelacePortion optname desc =
-  either (error . show) id . mkLovelacePortion
-  <$> parseIntegral optname desc
-
-parseFakeAvvmOptions :: Parser Genesis.FakeAvvmOptions
-parseFakeAvvmOptions =
-  Genesis.FakeAvvmOptions
-  <$> parseIntegral        "avvm-entry-count"         "Number of AVVM addresses."
-  <*> parseLovelace        "avvm-entry-balance"       "AVVM address."
-
-parseK :: Parser BlockCount
-parseK =
-  BlockCount
-  <$> parseIntegral        "k"                        "The security parameter of the Ouroboros protocol."
-
-parseProtocolMagicId :: String -> Parser ProtocolMagicId
-parseProtocolMagicId arg =
-  ProtocolMagicId
-  <$> parseIntegral        arg                        "The magic number unique to any instance of Cardano."
-
-parseProtocolMagic :: Parser ProtocolMagic
-parseProtocolMagic =
-  flip AProtocolMagic RequiresMagic . flip Annotated ()
-  <$> parseProtocolMagicId "protocol-magic"
-
-parseNetworkMagic :: Parser NetworkMagic
-parseNetworkMagic = asum
-    [ flag' NetworkMainOrStage $ mconcat [
-          long "main-or-staging"
-        , help ""
-        ]
-    , option (fmap NetworkTestnet auto) (
-          long "testnet-magic"
-       <> metavar "MAGIC"
-       <> help "The testnet network magic, decibal"
-        )
-    ]
-
-parseFilePath :: String -> String -> Parser FilePath
-parseFilePath optname desc =
-    strOption (
-            long optname
-         <> metavar "FILEPATH"
-         <> help desc
-    )
-
-parseIntegral :: Integral a => String -> String -> Parser a
-parseIntegral optname desc =
-    option (fromInteger <$> auto) (
-            long optname
-         <> metavar "INT"
-         <> help desc
-    )
-
-parseFlag :: String -> String -> Parser Bool
-parseFlag optname desc =
-    flag False True (
-            long optname
-         <> help desc
-    )
-
-parseUTCTime :: String -> String -> Parser UTCTime
-parseUTCTime optname desc =
-    option (posixSecondsToUTCTime . fromInteger <$> auto) (
-            long optname
-         <> metavar "POSIXSECONDS"
-         <> help desc
-    )

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -30,8 +30,8 @@ import           Ouroboros.Consensus.BlockchainTime (SlotLength(..), slotLengthF
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
-import           Cardano.Common.CommonCLI (command', mergeConfiguration, parseCommonCLI)
-import           Cardano.Node.Parsers (loggingParser, parseProtocol)
+import           Cardano.Common.CommonCLI
+import           Cardano.Node.Parsers
 import           Cardano.Node.Run
 import           Cardano.Node.Topology (NodeAddress (..))
 import           Cardano.Node.Tracers (ConsensusTraceOptions,  ProtocolTraceOptions, TraceOptions(..))

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -3,17 +3,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 
+module Main (main) where
 
 import           Prelude (read)
 
 import           Data.Semigroup ((<>))
 import qualified Data.IP as IP
-import qualified Data.Set as Set
 import           Network.Socket (PortNumber)
 import           Options.Applicative
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
-import           Cardano.Node.Configuration.Partial (PartialCardanoConfiguration (..), finaliseCardanoConfiguration)
+import           Cardano.Node.Configuration.Partial (PartialCardanoConfiguration (..))
 import           Cardano.Node.Configuration.Presets (mainnetConfiguration)
 import           Cardano.Node.Configuration.Types (CardanoConfiguration (..),
                                                    CardanoEnvironment (..))
@@ -22,21 +22,18 @@ import           Cardano.Node.Features.Logging (LoggingCLIArguments (..),
                                                 createLoggingFeature
                                                 )
 import           Cardano.Prelude hiding (option)
-import           Cardano.Shell.Lib (GeneralException (..),
-                                    runCardanoApplicationWithFeatures)
+import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..),
                                       CardanoFeatureInit (..))
 import           Ouroboros.Consensus.BlockchainTime (SlotLength(..), slotLengthFromMillisec)
-import qualified Ouroboros.Consensus.Ledger.Mock as Mock
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
-import           Ouroboros.Consensus.NodeId (NodeId (..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
 import           Cardano.Common.CommonCLI (command', mergeConfiguration, parseCommonCLI)
 import           Cardano.Node.Parsers (loggingParser, parseProtocol)
 import           Cardano.Node.Run
-import           Cardano.Node.Topology (NodeAddress (..), TopologyInfo (..))
+import           Cardano.Node.Topology (NodeAddress (..))
 import           Cardano.Node.Tracers (ConsensusTraceOptions,  ProtocolTraceOptions, TraceOptions(..))
 
 
@@ -57,11 +54,7 @@ main = do
 
 initializeAllFeatures :: CLIArguments -> PartialCardanoConfiguration -> CardanoEnvironment -> IO ([CardanoFeature], NodeLayer)
 initializeAllFeatures (CLIArguments logCli nodeCli) partialConfig cardanoEnvironment = do
-    finalConfig <- case finaliseCardanoConfiguration $
-                          mergeConfiguration partialConfig (commonCLI nodeCli)
-                   of
-      Left err -> throwIO $ ConfigurationError err
-      Right x  -> pure x
+    finalConfig <- mkConfiguration partialConfig (commonCLI nodeCli)
 
     (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment finalConfig logCli
     (nodeLayer   , nodeFeature)    <- createNodeFeature loggingLayer nodeCli cardanoEnvironment finalConfig
@@ -184,67 +177,14 @@ parseNodeCommand :: Parser NodeCommand
 parseNodeCommand = subparser $ mconcat [
     command' "node" "Run a node." $
       SimpleNode
-        <$> parseTopologyInfo
+        <$> parseTopologyInfo "PBFT node ID to assume."
         <*> parseNodeAddress
         <*> parseProtocol
         <*> parseViewMode
         <*> parseTraceOptions
-  , command' "submit" "Submit a transaction." $
-      TxSubmitter <$> parseTopologyInfo <*> parseMockTx <*> parseProtocol
   , command' "trace-acceptor" "Spawn an acceptor." $
       pure TraceAcceptor
   ]
-
-parseTopologyInfo :: Parser TopologyInfo
-parseTopologyInfo = TopologyInfo <$> parseNodeId <*> parseTopologyFile
-
-parseNodeId :: Parser NodeId
-parseNodeId =
-    option (fmap CoreId auto) (
-            long "node-id"
-         <> short 'n'
-         <> metavar "NODE-ID"
-         <> help "The ID for this node"
-    )
-
-parseMockTx :: Parser Mock.Tx
-parseMockTx = mkTx
-    <$> many parseMockTxIn
-    <*> many parseMockTxOut
-  where
-    mkTx :: [Mock.TxIn] -> [Mock.TxOut] -> Mock.Tx
-    mkTx ins = Mock.Tx (Set.fromList ins)
-
-parseMockTxIn :: Parser Mock.TxIn
-parseMockTxIn = (,)
-    <$> strOption (mconcat [
-            long "txin"
-          , help "Hash of the input transaction. Single hex char."
-          ])
-    <*> option auto (mconcat [
-            long "txix"
-          , help "Index of the output in the specified transaction"
-          ])
-
-parseMockTxOut :: Parser Mock.TxOut
-parseMockTxOut = (,)
-    <$> strOption (mconcat [
-            long "address"
-          , help "Address to transfer to"
-          ])
-    <*> option auto (mconcat [
-            long "amount"
-          , help "Amount to transfer"
-          ])
-
-parseTopologyFile :: Parser FilePath
-parseTopologyFile =
-    strOption (
-            long "topology"
-         <> short 't'
-         <> metavar "FILEPATH"
-         <> help "The path to a file describing the topology."
-    )
 
 parseNodeAddress :: Parser NodeAddress
 parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort

--- a/cardano-node/app/chairman.hs
+++ b/cardano-node/app/chairman.hs
@@ -9,8 +9,6 @@ import           Control.Concurrent.Async
 import           Options.Applicative
 
 import           Cardano.Node.Configuration.Presets (mainnetConfiguration)
-import           Cardano.Node.Configuration.Partial (finaliseCardanoConfiguration)
-import           Cardano.Shell.Lib (GeneralException (ConfigurationError))
 
 import           Control.Tracer (stdoutTracer)
 
@@ -36,12 +34,8 @@ main = do
                  } <- execParser opts
 
     SomeProtocol p
-      <- case finaliseCardanoConfiguration $
-                mergeConfiguration
-                  mainnetConfiguration
-                  caCommonCLI of
-        Left err -> throwIO (ConfigurationError err)
-        Right cc -> fromProtocol cc caProtocol
+      <- do cc <- mkConfiguration mainnetConfiguration caCommonCLI
+            fromProtocol cc caProtocol
 
     let run = runChairman p caCoreNodeIds
                           (NumCoreNodes $ length caCoreNodeIds)

--- a/cardano-node/app/chairman.hs
+++ b/cardano-node/app/chairman.hs
@@ -17,7 +17,7 @@ import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 
-import           Cardano.Common.CommonCLI (CommonCLI, mergeConfiguration, parseCommonCLI)
+import           Cardano.Common.CommonCLI
 import           Cardano.Common.Protocol (Protocol, SomeProtocol(..), fromProtocol)
 import           Cardano.Node.Parsers (parseCoreNodeId, parseProtocol)
 

--- a/cardano-node/app/wallet-client.hs
+++ b/cardano-node/app/wallet-client.hs
@@ -15,9 +15,7 @@ import           Cardano.Node.Features.Logging (LoggingCLIArguments (..),
                                                 createLoggingFeature
                                                 )
 import           Cardano.Node.Parsers (loggingParser, parseCoreNodeId)
-import           Cardano.Prelude (throwIO)
-import           Cardano.Shell.Lib (GeneralException (..),
-                                    runCardanoApplicationWithFeatures)
+import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..),
                                       CardanoFeatureInit (..))
@@ -86,15 +84,7 @@ main = do
 
 initializeAllFeatures :: ArgParser -> PartialCardanoConfiguration -> CardanoEnvironment -> IO ([CardanoFeature], NodeLayer)
 initializeAllFeatures (ArgParser logCli cli) partialConfig cardanoEnvironment = do
-    finalConfig <- case finaliseCardanoConfiguration $
-                        mergeConfiguration partialConfig (cliCommon cli)
-                   of
-      Left err -> throwIO $ ConfigurationError err
-      --TODO: if we're using exceptions for this, then we should use a local
-      -- excption type, local to this app, that enumerates all the ones we
-      -- are reporting, and has proper formatting of the result.
-      -- It would also require catching at the top level and printing.
-      Right x  -> pure x
+    finalConfig <- mkConfiguration partialConfig (cliCommon cli)
 
     (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment finalConfig logCli
     (nodeLayer   , nodeFeature)    <- createNodeFeature loggingLayer cli cardanoEnvironment finalConfig

--- a/cardano-node/app/wallet-client.hs
+++ b/cardano-node/app/wallet-client.hs
@@ -14,7 +14,7 @@ import           Cardano.Node.Features.Logging (LoggingCLIArguments (..),
                                                 LoggingLayer (..),
                                                 createLoggingFeature
                                                 )
-import           Cardano.Node.Parsers (loggingParser, parseCoreNodeId, parseProtocol)
+import           Cardano.Node.Parsers (loggingParser, parseCoreNodeId)
 import           Cardano.Prelude (throwIO)
 import           Cardano.Shell.Lib (GeneralException (..),
                                     runCardanoApplicationWithFeatures)

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -30,6 +30,7 @@ library
                        Cardano.Node.Features.Logging
                        Cardano.Node.GitRev
                        Cardano.Node.GitRevFromGit
+                       Cardano.Node.Orphans
                        Cardano.Node.Parsers
                        Cardano.Node.Run
                        Cardano.Node.Topology

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -15,9 +15,10 @@ library
   hs-source-dirs:      src
 
   exposed-modules:     Cardano.Chairman
+                       Cardano.CLI.Ops
+                       Cardano.CLI.Run
                        Cardano.Common.CommonCLI
                        Cardano.Common.Protocol
-                       Cardano.CLI.Run
                        Cardano.Legacy.Byron
                        Cardano.Node.CanonicalJSON
                        -- Conversion

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -30,9 +30,9 @@ import qualified Cardano.Crypto.Signing as CCr
 import           Cardano.Chain.Genesis
 import qualified Crypto.SCRAPE as Scrape
 
+import           Cardano.Common.Protocol
 import qualified Cardano.Legacy.Byron as Legacy
 import           Cardano.Node.CanonicalJSON
-import           Cardano.Node.CLI
 
 
 -- | Generic operations for a specific system era.

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Cardano.CLI.Ops
+  ( CLIOps(..)
+  , decideCLIOps
+  , CliError(..)
+  ) where
+
+import           Prelude (String)
+import qualified Prelude as Prelude
+import           Cardano.Prelude hiding (option)
+
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text as T
+import           Options.Applicative
+
+import           Cardano.Binary (Annotated(..), serialize')
+import           Cardano.Chain.Common
+import qualified Cardano.Chain.Common as CC
+import           Cardano.Chain.Delegation hiding (epoch)
+import           Cardano.Chain.Slotting (EpochNumber)
+import           Cardano.Crypto (SigningKey (..), ProtocolMagic, ProtocolMagicId)
+import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import           Codec.CBOR.Write (toLazyByteString)
+import qualified Cardano.Crypto.Random as CCr
+import qualified Cardano.Crypto.Hashing as CCr
+import qualified Cardano.Crypto.Signing as CCr
+import           Cardano.Chain.Genesis
+import qualified Crypto.SCRAPE as Scrape
+
+import qualified Cardano.Legacy.Byron as Legacy
+import           Cardano.Node.CanonicalJSON
+import           Cardano.Node.CLI
+
+
+-- | Generic operations for a specific system era.
+data CLIOps m
+  = CLIOps
+  { coSerialiseGenesisKey       :: SigningKey    -> m LB.ByteString
+  , coSerialiseDelegateKey      :: SigningKey    -> m LB.ByteString
+  , coSerialisePoorKey          :: PoorSecret    -> m LB.ByteString
+  , coSerialiseGenesis          :: GenesisData   -> m LB.ByteString
+  , coSerialiseDelegationCert   :: Certificate   -> m LB.ByteString
+  , coDeserialiseDelegateKey    :: FilePath
+                                -> LB.ByteString -> m SigningKey
+  , coProtocol                  :: Protocol
+  }
+
+decideCLIOps :: Protocol -> IO (CLIOps IO)
+decideCLIOps coProtocol =
+  let serialiseSigningKey (SigningKey x) = toLazyByteString $ CCr.toCBORXPrv x
+  in case coProtocol of
+    ByronLegacy ->
+      pure CLIOps
+      { coSerialiseGenesisKey          = pure . serialiseSigningKey
+      , coSerialiseDelegateKey         = \sk->
+          toLazyByteString . Legacy.encodeLegacyDelegateKey . Legacy.LegacyDelegateKey sk
+          <$> CCr.runSecureRandom Scrape.keyPairGenerate
+      , coSerialisePoorKey             = pure . serialiseSigningKey . poorSecretToKey
+      , coSerialiseGenesis             = pure . canonicalEncPre
+      , coSerialiseDelegationCert      = pure . canonicalEncPre
+      , coDeserialiseDelegateKey       = \f ->
+          flip (.) (deserialiseFromBytes Legacy.decodeLegacyDelegateKey) $
+          \case Left  e -> throwIO $ SigningKeyDeserialisationFailed f e
+                Right x -> pure . Legacy.lrkSigningKey . snd $ x
+      , coProtocol = coProtocol
+      }
+    RealPBFT ->
+      pure CLIOps
+      { coSerialiseGenesisKey          = pure . serialiseSigningKey
+      , coSerialiseDelegateKey         = pure . serialiseSigningKey
+      , coSerialisePoorKey             = pure . serialiseSigningKey . poorSecretToKey
+      , coSerialiseGenesis             = pure . canonicalEncPre
+      , coSerialiseDelegationCert      = pure . canonicalEncPre
+      , coDeserialiseDelegateKey       = \f ->
+          flip (.) (deserialiseFromBytes CCr.fromCBORXPrv) $
+          \case Left  e -> throwIO $ SigningKeyDeserialisationFailed f e
+                Right x -> pure . SigningKey . snd $ x
+      , coProtocol = coProtocol
+      }
+    x ->
+      throwIO $ ProtocolNotSupported x
+
+data CliError
+  -- Basic user errors
+  = OutputMustNotAlreadyExist FilePath
+  | ProtocolNotSupported Protocol
+  -- Validation errors
+  | CertificateValidationErrors FilePath [Text]
+  -- Serialization errors
+  | ProtocolParametersParseFailed FilePath Text
+  | GenesisReadError FilePath GenesisDataError
+  | SigningKeyDeserialisationFailed FilePath DeserialiseFailure
+  | VerificationKeyDeserialisationFailed FilePath Text
+  | DlgCertificateDeserialisationFailed FilePath Text
+  | TxDeserialisationFailed FilePath DeserialiseFailure
+  -- TODO:  sadly, VerificationKeyParseError isn't exported from Cardano.Crypto.Signing/*
+  -- Inconsistencies
+  | DelegationError GenesisDelegationError
+  | GenesisSpecError Text
+  | GenesisGenerationError GenesisDataGenerationError
+  -- Invariants/assertions -- does it belong here?
+  | NoGenesisDelegationForKey Text
+
+instance Show CliError where
+  show (OutputMustNotAlreadyExist fp)
+    = "Output file/directory must not already exist: " <> fp
+  show (ProtocolNotSupported proto)
+    = "Unsupported protocol "<> show proto
+  show (CertificateValidationErrors fp errs)
+    = Prelude.unlines $
+      "Errors while validating certificate '" <> fp <> "':":
+      (("  " <>) . T.unpack <$> errs)
+  show (ProtocolParametersParseFailed fp err)
+    = "Protocol parameters file '" <> fp <> "' read failure: "<> T.unpack err
+  show (GenesisReadError fp err)
+    = "Genesis file '" <> fp <> "' read failure: "<> show err
+  show (SigningKeyDeserialisationFailed fp err)
+    = "Signing key '" <> fp <> "' read failure: "<> show err
+  show (VerificationKeyDeserialisationFailed fp err)
+    = "Verification key '" <> fp <> "' read failure: "<> T.unpack err
+  show (DlgCertificateDeserialisationFailed fp err)
+    = "Delegation certificate '" <> fp <> "' read failure: "<> T.unpack err
+  show (TxDeserialisationFailed fp err)
+    = "Transaction file '" <> fp <> "' read failure: "<> show err
+  show (DelegationError err)
+    = "Error while issuing delegation: " <> show err
+  show (GenesisSpecError err)
+    = "Error in genesis specification: " <> T.unpack err
+  show (GenesisGenerationError err)
+    = "Genesis generation failed: " <> show err
+  show (NoGenesisDelegationForKey key)
+    = "Newly-generated genesis doesn't delegate to operational key: " <> T.unpack key
+
+instance Exception CliError

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -7,30 +7,25 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.CLI.Ops
   ( CLIOps(..)
   , decideCLIOps
   , CliError(..)
   ) where
 
-import           Prelude (String)
 import qualified Prelude as Prelude
 import           Cardano.Prelude hiding (option)
 
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
-import           Options.Applicative
 
-import           Cardano.Binary (Annotated(..), serialize')
-import           Cardano.Chain.Common
-import qualified Cardano.Chain.Common as CC
 import           Cardano.Chain.Delegation hiding (epoch)
-import           Cardano.Chain.Slotting (EpochNumber)
-import           Cardano.Crypto (SigningKey (..), ProtocolMagic, ProtocolMagicId)
+import           Cardano.Crypto (SigningKey (..))
 import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
 import qualified Cardano.Crypto.Random as CCr
-import qualified Cardano.Crypto.Hashing as CCr
 import qualified Cardano.Crypto.Signing as CCr
 import           Cardano.Chain.Genesis
 import qualified Crypto.SCRAPE as Scrape

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -31,6 +31,7 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 
 import           Network.Mux.Types (MuxError)
@@ -347,6 +348,7 @@ localInitiatorNetworkApplication
      , Condense (HeaderHash blk)
      , MonadAsync m
      , MonadST    m
+     , MonadTimer m
      , MonadThrow m
      , MonadThrow (STM m)
      )

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -7,8 +7,9 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-
 {-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Chairman (runChairman) where
 
@@ -30,7 +31,6 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 
 import           Network.Mux.Types (MuxError)
@@ -349,7 +349,6 @@ localInitiatorNetworkApplication
      , MonadST    m
      , MonadThrow m
      , MonadThrow (STM m)
-     , MonadTimer m
      )
   => CoreNodeId
   -> ChainsVar m blk
@@ -366,7 +365,7 @@ localInitiatorNetworkApplication
   -- in 'ouroboros-network' package).
   -> NodeConfig (BlockProtocol blk)
   -> Versions NodeToClientVersion DictVersion
-              (OuroborosApplication InitiatorApp peer NodeToClientProtocols
+              (OuroborosApplication 'InitiatorApp peer NodeToClientProtocols
                                     m ByteString () Void)
 localInitiatorNetworkApplication coreNodeId chainsVar securityParam maxBlockNo chairmanTracer chainSyncTracer localTxSubmissionTracer pInfoConfig =
     simpleSingletonVersions

--- a/cardano-node/src/Cardano/Node/Configuration/Partial.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Partial.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE RecordWildCards    #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Node.Configuration.Partial
     ( PartialCardanoConfiguration (..)
     , PartialCore (..)

--- a/cardano-node/src/Cardano/Node/Features/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Features/Logging.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Node.Features.Logging
     ( LoggingLayer (..)
     , createLoggingFeature
@@ -21,7 +23,6 @@ module Cardano.Node.Features.Logging
 import           Cardano.Prelude hiding (trace)
 import           Control.Exception.Safe (MonadCatch)
 import qualified Control.Monad.STM as STM
-import           Options.Applicative
 
 import qualified Cardano.BM.Backend.Switchboard as Switchboard
 import           Cardano.BM.Configuration (Configuration)

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Node.Orphans
+  ()
+where
+
+import           Codec.Serialise (Serialise(..))
+import           Control.Exception
+import           GHC.Generics
+
+import qualified Cardano.Chain.Genesis as Genesis
+import           Ouroboros.Consensus.Ledger.Byron
+import           Ouroboros.Consensus.Ledger.Byron.Config
+
+-- TODO: consider not throwing this, or wrap it in a local error type here
+-- that has proper error messages.
+instance Exception Genesis.ConfigurationError
+
+deriving instance Generic (GenTx (ByronBlockOrEBB ByronConfig))
+instance Serialise (GenTx (ByronBlockOrEBB ByronConfig)) where
+  decode = decodeByronGenTx
+  encode = encodeByronGenTx

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Node.Parsers
   ( loggingParser
   , parseCoreNodeId

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -59,7 +59,6 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Subscription.Dns
 
 import           Ouroboros.Consensus.BlockchainTime (SlotLength(..))
-import qualified Ouroboros.Consensus.Ledger.Mock as Mock
 import           Ouroboros.Consensus.Node (NodeKernel (getChainDB),
                                            RunNetworkArgs (..),
                                            RunNode (nodeStartTime))
@@ -101,7 +100,6 @@ data NodeCLIArguments = NodeCLIArguments {
 
 data NodeCommand =
     SimpleNode  TopologyInfo NodeAddress Protocol ViewMode TraceOptions
-  | TxSubmitter TopologyInfo Mock.Tx     Protocol
   | TraceAcceptor
 
 -- Node can be run in two modes.

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -115,12 +115,6 @@ runNode nodeCli@NodeCLIArguments{..} loggingLayer cc = do
     -- full node, we simply transmit it and exit.
     case command of
 
-      TxSubmitter topology tx protocol -> do
-        let trace'      = appendName (pack (show (node topology))) tr
-        let tracer      = contramap pack $ toLogObject trace'
-        SomeProtocol p  <- fromProtocol cc protocol
-        handleTxSubmission p topology tx tracer
-
       TraceAcceptor -> do
         let trace'      = appendName "acceptor" tr
         let tracer      = contramap pack $ toLogObject trace'

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 #if !defined(mingw32_HOST_OS)
 #define UNIX

--- a/cardano-node/src/Cardano/Node/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Node/ToObjectOrphans.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE UndecidableInstances  #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Node.ToObjectOrphans
   (

--- a/cardano-node/src/Cardano/Node/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Topology.hs
@@ -2,9 +2,22 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Node.Topology where
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
+module Cardano.Node.Topology
+  ( TopologyInfo(..)
+  , NodeAddress(..)
+  , nodeAddressToSockAddr
+  , nodeAddressInfo
+  , RemoteAddress(..)
+  , remoteAddressToNodeAddress
+  , NodeSetup(..)
+  , NetworkTopology(..)
+  , readTopologyFile
+  )
+where
 
 import           Cardano.Prelude hiding (toS)
 import           Prelude (String, read)

--- a/cardano-node/src/Cardano/Node/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracers.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Node.Tracers
   ( ConsensusTraceOptions
   , ProtocolTraceOptions

--- a/cardano-node/src/Cardano/Node/TxSubmission.hs
+++ b/cardano-node/src/Cardano/Node/TxSubmission.hs
@@ -19,7 +19,6 @@ import           Prelude (String)
 import           Data.Void (Void)
 import           Data.ByteString.Lazy (ByteString)
 
-import qualified Codec.Serialise as Serialise
 import           Network.Socket as Socket
 
 import           Control.Monad (fail)
@@ -47,7 +46,7 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 import           Ouroboros.Network.Protocol.ChainSync.Client
-                   (ChainSyncClient(..), chainSyncClientPeer)
+                   (chainSyncClientPeer)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.NodeToClient
@@ -83,10 +82,6 @@ handleTxSubmission ptcl tinfo tx tracer = do
           protocolInfo (NumCoreNodes (length nodeSetups))
                        (CoreNodeId nid)
                        ptcl
-
-    -- TODO:  generalised Tx hash
-    -- traceWith tracer $
-    --   "The Id for this transaction is: " <> condense (H.hash @ShortHash tx)
 
     submitTx pInfoConfig (node tinfo) tx tracer
 

--- a/cardano-node/src/Cardano/Node/TxSubmission.hs
+++ b/cardano-node/src/Cardano/Node/TxSubmission.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Node.TxSubmission (
       handleTxSubmission
     , localSocketFilePath
@@ -16,10 +18,6 @@ import           Prelude (String)
 
 import           Data.Void (Void)
 import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Set as Set
-import           Options.Applicative
-import           Data.Proxy
 
 import qualified Codec.Serialise as Serialise
 import           Network.Socket as Socket
@@ -30,19 +28,14 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 
-import           Cardano.Crypto.Hash (ShortHash)
-import qualified Cardano.Crypto.Hash as H
-
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Demo.Run
-import qualified Ouroboros.Consensus.Ledger.Byron as Byron
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.NodeId
 import qualified Ouroboros.Consensus.Protocol as Consensus
 import           Ouroboros.Consensus.Protocol hiding (Protocol)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
-import           Ouroboros.Consensus.Util.Condense
 
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Codec.Cbor
@@ -54,7 +47,7 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 import           Ouroboros.Network.Protocol.ChainSync.Client
-                   (chainSyncClientPeer)
+                   (ChainSyncClient(..), chainSyncClientPeer)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.NodeToClient
@@ -128,7 +121,7 @@ localInitiatorNetworkApplication
   -> NodeConfig (BlockProtocol blk)
   -> GenTx blk
   -> Versions NodeToClientVersion DictVersion
-              (OuroborosApplication InitiatorApp peer NodeToClientProtocols
+              (OuroborosApplication 'InitiatorApp peer NodeToClientProtocols
                                     m ByteString () Void)
 localInitiatorNetworkApplication tracer pInfoConfig tx =
     simpleSingletonVersions

--- a/cardano-node/src/Cardano/Node/TxSubmission.hs
+++ b/cardano-node/src/Cardano/Node/TxSubmission.hs
@@ -16,7 +16,12 @@ import           Prelude (String)
 
 import           Data.Void (Void)
 import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Set as Set
+import           Options.Applicative
+import           Data.Proxy
 
+import qualified Codec.Serialise as Serialise
 import           Network.Socket as Socket
 
 import           Control.Monad (fail)
@@ -30,7 +35,7 @@ import qualified Cardano.Crypto.Hash as H
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Demo.Run
-import qualified Ouroboros.Consensus.Ledger.Mock as Mock
+import qualified Ouroboros.Consensus.Ledger.Byron as Byron
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.NodeId
 import qualified Ouroboros.Consensus.Protocol as Consensus
@@ -67,10 +72,10 @@ handleTxSubmission :: forall blk.
                       )
                    => Consensus.Protocol blk
                    -> TopologyInfo
-                   -> Mock.Tx
+                   -> GenTx blk
                    -> Tracer IO String
                    -> IO ()
-handleTxSubmission ptcl tinfo mocktx tracer = do
+handleTxSubmission ptcl tinfo tx tracer = do
     topoE <- readTopologyFile (topologyFile tinfo)
     NetworkTopology nodeSetups <-
       case topoE of
@@ -86,11 +91,9 @@ handleTxSubmission ptcl tinfo mocktx tracer = do
                        (CoreNodeId nid)
                        ptcl
 
-        tx :: GenTx blk
-        tx = demoMockTx pInfoConfig mocktx
-
-    traceWith tracer $
-      "The Id for this transaction is: " <> condense (H.hash @ShortHash mocktx)
+    -- TODO:  generalised Tx hash
+    -- traceWith tracer $
+    --   "The Id for this transaction is: " <> condense (H.hash @ShortHash tx)
 
     submitTx pInfoConfig (node tinfo) tx tracer
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE RankNTypes           #-}
+
+module Cardano.Node.Types
+  ( Protocol(..)
+  , parseProtocol
+  , parseProtocolAsCommand
+  )
+where
+
+import Prelude
+import Data.Foldable
+import Options.Applicative
+
+data Protocol
+  = ByronLegacy
+  | BFT
+  | Praos
+  | MockPBFT
+  | RealPBFT
+  deriving (Show)
+
+

--- a/cardano-node/src/Cardano/Wallet/Client.hs
+++ b/cardano-node/src/Cardano/Wallet/Client.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.Wallet.Client
   (runWalletClient)
 where
@@ -104,7 +106,7 @@ localInitiatorNetworkApplication
   -- in 'ouroboros-network' package).
   -> NodeConfig (BlockProtocol blk)
   -> Versions NodeToClientVersion DictVersion
-              (OuroborosApplication InitiatorApp peer NodeToClientProtocols
+              (OuroborosApplication 'InitiatorApp peer NodeToClientProtocols
                                     m ByteString Void Void)
 localInitiatorNetworkApplication Proxy chainSyncTracer localTxSubmissionTracer pInfoConfig =
     simpleSingletonVersions

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -44,10 +44,11 @@ args=(
 
 set -xe
 RUNNER=${RUNNER:-cabal new-run --}
+
 ${RUNNER} cardano-cli byron-pbft genesis "${args[@]}" "$@"
 
 # move new genesis to configuration
-GENHASH=`${RUNNER} cardano-cli byron-pbft print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1`
+GENHASH=`${RUNNER} cardano-cli real-pbft print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1`
 TARGETDIR="${CONFIGDIR}/${GENHASH:0:5}"
 mkdir -vp "${TARGETDIR}"
 cp -iav ${tmpdir}/genesis.json ${TARGETDIR}/
@@ -59,4 +60,3 @@ set -
 echo $GENHASH > ${TARGETDIR}/GENHASH
 echo "genesis created with hash = ${GENHASH}"
 echo "  in directory ${TARGETDIR}"
-

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
 
+test -z "$1" -o ! -f "$1" -o ! -r "$1" && {
+        cat >&1 <<EOF
+Usage:  $(basename $0) TX-FILE
+EOF
+        exit 1
+}
+TX="$1"
+shift
+
 #CMD="stack exec --nix cardano-node -- "
-CMD="cabal new-exec cardano-node -- "
+CMD="cabal new-exec cardano-cli -- "
 
 ALGO="--real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS=(
-        --slot-duration 2
+        ${ALGO}
+        submit-tx
         --genesis-file "configuration/Test.Cardano.Chain.Genesis.Dummy.dummyConfig.configGenesisData.json"
         --genesis-hash "fc32ebdf3c9bfa2ebf6bdcac98649f610601ddb266a2a2743e787dc9952a1aeb"
-        submit
-        --topology "configuration/simple-topology.json"
-        ${ALGO}
+        --topology     "configuration/simple-topology.json"
+        --node-id      "0"
+        --tx           "$TX"
 )
 
 function mkdlgkey () {
@@ -23,8 +33,5 @@ function mkdlgcert () {
 
 set -x
 ${CMD} \
-    --log-config configuration/log-configuration.yaml \
-    $(mkdlgkey 0) \
-    $(mkdlgcert 0) \
     ${NETARGS[*]} \
            $@


### PR DESCRIPTION
0. New `submit-tx` subcommand. 
0. Drop `SystemVersion` in favor of `Protocol`.
0. Move some command parsers to `Cardano.Node.Parsers`.
0. Rename and segregate `CLIOps` (ex-`KeyMaterialOps`)
0. Add `ByronLegacy` to the `Protocol` type
0. Remove `submit` subcommand from `cardano-node`
0. Factor orphans.
0. Factor `mkConfiguration`
0. Eliminate all warnings.
0. Documentation & updated the `scripts/submit-tx.sh` script.

# TODO

- [ ] Separate the first megacommit ?
- [ ] Testing -- this requires a way to create transactions. WIP