### PR TITLE
nix scripts: adds custom proxy override

### DIFF
--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "db7f09b0809551228cbceecca61992b486cef498",
-  "date": "2019-08-21T13:49:57+00:00",
-  "sha256": "128qjdzj8wbzlspb7ix68mah9r21pmx6xbbqrf2xz6dwjx3lwyf4",
+  "rev": "02ea28007cd0fdda9e713d64bacb31e4d496acbc",
+  "date": "2019-08-23T17:57:41+00:00",
+  "sha256": "1fdv7yn4l9yzrvqgzfv0rjkryv5q5qpxh8sfqgvibqgqva0yv4n6",
   "fetchSubmodules": false
 }

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -17,12 +17,19 @@ let
       stateDir = "./";
       # defaults to proxy if env has no relays
       edgeHost = "127.0.0.1";
-      edgePort = 7777;
+      edgePort = 3001;
+      useProxy = false;
+      proxyPort = "7777";
+      proxyHost = "127.0.0.1";
       loggingConfig = ../configuration/log-configuration.yaml;
     };
     config = defaultConfig // envConfig // customConfig;
-    topologyFile = config.topologyFile or commonLib.mkEdgeTopology {
-      inherit (config) hostAddr port nodeId edgeHost edgePort;
+    topologyFile = let
+      edgePort = if config.useProxy then config.proxyPort else config.edgePort;
+      edgeHost = if config.useProxy then config.proxyHost else config.edgeHost;
+    in config.topologyFile or commonLib.mkEdgeTopology {
+      inherit (config) hostAddr port nodeId;
+      inherit edgeHost edgePort;
     };
     serviceConfig = {
       inherit (config)
@@ -36,6 +43,7 @@ let
         hostAddr
         port
         nodeId;
+      dbPrefix = "db-${envConfig.name}";
       logger.configFile = config.loggingConfig;
       topology = topologyFile;
     };


### PR DESCRIPTION
* adds useProxy, proxyHost and proxyPort parameters
* fixes name of db directory to contain correct environment

This changes default to use a public node in the topology obtained from cardanoLib (iohk-nix). A new attribute has been added called `useProxy` that can be passed with customConfig. 

Example usage: `nix-build -A scripts.mainnet.node -o launch_mainnet_node_proxy_topology --arg customConfig '{ useProxy = true; proxyHost = "1.2.3.4"; proxyPort = 1234; }'`

If proxyHost and proxyPort are not set they default to 127.0.0.1 and 7777;