### PR TITLE
Non-genesis UTxO expenditure

### DIFF
--- a/cardano-node/README.md
+++ b/cardano-node/README.md
@@ -206,14 +206,22 @@ transaction, in its raw wire format (see GenTx for Byron transactions).
 The canned `scripts/submit-tx.sh` script will submit the supplied transaction to a testnet
 launched by `scripts/shelley-testnet*.sh` family of scripts.
 
-### Issuing genesis UTxO expenditure Tx
+### Issuing UTxO expenditure (genesis and regular)
 
-To make a transaction spending genesis UTxO, you can either use the `issue-genesis-utxo-expenditure`
-subcommand directly, or, again use a canned script that will make a transaction tailored
-for the aforementioned testnet cluster -- `scripts/issue-genesis-utxo-expenditure.sh`.
+To make a transaction spending UTxO, you can either use the:
 
-The script requires the target file name to write the transaction to, and optionally
-allows specifying the target address and lovelace value to send.
+  - `issue-genesis-utxo-expenditure`, for genesis UTxO
+  - `issue-utxo-expenditure`, for normal UTxO
+  
+subcommands directly, or, again use canned scripts that will make transactions tailored
+for the aforementioned testnet cluster:
+
+  - `scripts/issue-genesis-utxo-expenditure.sh`.
+  - `scripts/issue-utxo-expenditure.sh`.
+
+The script requires the target file name to write the transaction to, input TxId
+(for normal UTxO), and optionally allows specifying the source txin output index,
+source and target signing keys and lovelace value to send.
 
 The target address defaults to the 1-st richman key (`configuration/delegate-keys.001.key`)
 of the testnet, and lovelace amount is almost the entirety of its funds.

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -208,6 +208,7 @@ executable cardano-cli
                      , optparse-applicative
                      , ouroboros-consensus
                      , safe-exceptions
+                     , text
                      , time
   default-extensions:  NoImplicitPrelude
 

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -143,6 +143,7 @@
             (hsPkgs.optparse-applicative)
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.safe-exceptions)
+            (hsPkgs.text)
             (hsPkgs.time)
             ];
           };

--- a/scripts/get-default-key-address.sh
+++ b/scripts/get-default-key-address.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+RUNNER=${RUNNER:-cabal new-run -v0 --}
+
+genesis="33873"
+genesis_root="configuration/${genesis}"
+genesis_file="${genesis_root}/genesis.json"
+proto_magic="$(jq '.protocolConsts | .protocolMagic' "${genesis_file}")"
+
+key="$1"
+test -r "${key}" || {
+        cat <<EOF
+Usage:  $(basename $0) SIGNING-KEY-FILE"
+
+Print the default, non-HD address of a signing key.
+EOF
+}
+
+${RUNNER} cardano-cli real-pbft signing-key-address  \
+          --testnet-magic ${proto_magic}             \
+          --secret ${key}                            \
+        | head -n1 | xargs echo -n

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -8,32 +8,38 @@ genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 genesis_hash="$(${RUNNER} cardano-cli real-pbft print-genesis-hash --genesis-json ${genesis_file})"
-from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
-from_key="${genesis_root}/delegate-keys.000.key"
-default_to_key="${genesis_root}/delegate-keys.001.key"
+default_from_key="${genesis_root}/delegate-keys.001.key"
+default_to_key="${genesis_root}/delegate-keys.002.key"
 
 ## rob the bank
-default_lovelace="863000000000000"
+default_lovelace="862000000000000"
 
 case $# in
-        1 ) tx="$1"
-            proto_magic="$(jq '.protocolConsts | .protocolMagic' "${genesis_file}")"
-            addr="$(scripts/get-default-key-address.sh ${default_to_key})"
+        2 ) tx="$1"
+            txid="$2"
+            outindex="0"
+            from_key="${default_from_key}"
+            to_key="${default_to_key}"
             lovelace=${default_lovelace};;
-        3 ) tx="$1";
-            addr="$2";
-            lovelace="$3";;
+        6 ) tx="$1"
+            txid="$2"
+            outindex="$3"
+            from_key="$4"
+            to_key="$5"
+            lovelace="$6";;
         * ) cat >&2 <<EOF
-Usage:  $(basename $0) TX-FILE TO-ADDR LOVELACE
+Usage:  $(basename $0) TX-FILE IN-TXID IN-INDEX FROM-KEY-FILE TO-KEY-FILE LOVELACE
 EOF
             exit 1;; esac
+
+addr=$(scripts/get-default-key-address.sh ${to_key})
 
 args=" --genesis-file        ${genesis_file}
        --genesis-hash        ${genesis_hash}
        --tx                  ${tx}
        --wallet-key          ${from_key}
-       --rich-addr-from    \"${from_addr}\"
+       --txin             (\"${txid}\",${outindex})
        --txout            (\"${addr}\",${lovelace})
 "
 set -x
-${RUNNER} cardano-cli real-pbft issue-genesis-utxo-expenditure ${args}
+${RUNNER} cardano-cli real-pbft issue-utxo-expenditure ${args}


### PR DESCRIPTION
1. Adds `issue-utxo-expenditure` subcommand to `cardano-cli`, with `scripts/issue-utxo-expenditure.sh`
2. Factors a couple of immediately related things:
  - `withRealPBFT`
  - `signTxId`
  - `genesisUTxOTxIn`
