### PR TITLE
cardano-cli:  improve the help facilities and the README

### DIFF
--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -65,7 +65,7 @@ data CLI
 parseClient :: Parser CLI
 parseClient =
   CLI
-    <$> parseProtocolAsCommand
+    <$> parseProtocolActual
     <*> parseClientCommand
 
 parseClientCommand :: Parser ClientCommand

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -6,6 +6,7 @@ module Cardano.Common.Parsers
   ( loggingParser
   , parseCoreNodeId
   , parseProtocol
+  , parseProtocolActual
   , parseProtocolAsCommand
   , parseTopologyInfo
   ) where
@@ -43,26 +44,36 @@ parseNodeId desc =
          <> help desc
     )
 
+-- | Flag parser, that returns its argument on success.
+fl :: a -> String -> String -> Parser a
+fl val opt desc = flag' val $ mconcat [long opt, help desc]
+
 parseProtocol :: Parser Protocol
 parseProtocol = asum
   [ fl ByronLegacy "byron-legacy"
-    "Use the Byron/Ouroboros Classic suite of algorithms"
+    "Byron/Ouroboros Classic suite of algorithms"
 
   , fl BFT "bft"
-    "Use the BFT consensus algorithm"
+    "BFT consensus"
 
   , fl Praos "praos"
-    "Use the Praos consensus algorithm"
+    "Praos consensus"
 
   , fl MockPBFT "mock-pbft"
-    "Use the Permissive BFT consensus algorithm using a mock ledger"
+    "Permissive BFT consensus with a mock ledger"
 
   , fl RealPBFT "real-pbft"
-    "Use the Permissive BFT consensus algorithm using the real ledger"
+    "Permissive BFT consensus with a real ledger"
   ]
-  where
-    fl :: forall a. a -> String -> String -> Parser a
-    fl x l h = flag' x $ mconcat [long l, help h]
+
+parseProtocolActual :: Parser Protocol
+parseProtocolActual = asum
+  [ fl ByronLegacy "byron-legacy"
+    "Byron/Ouroboros Classic suite of algorithms"
+
+  , fl RealPBFT "real-pbft"
+    "Permissive BFT consensus with a real ledger"
+  ]
 
 parseProtocolAsCommand :: Parser Protocol
 parseProtocolAsCommand = subparser $ mconcat

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -9,7 +9,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-exec -- cardano-cli real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-exec -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 CMD=`find dist-newstyle/ -type f -name "cardano-node"`
 test -n "${CMD}" || {

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -45,10 +45,10 @@ args=(
 set -xe
 RUNNER=${RUNNER:-cabal new-run --}
 
-${RUNNER} cardano-cli real-pbft genesis "${args[@]}" "$@"
+${RUNNER} cardano-cli --real-pbft genesis "${args[@]}" "$@"
 
 # move new genesis to configuration
-GENHASH=`${RUNNER} cardano-cli real-pbft print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1`
+GENHASH=`${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1`
 TARGETDIR="${CONFIGDIR}/${GENHASH:0:5}"
 mkdir -vp "${TARGETDIR}"
 cp -iav ${tmpdir}/genesis.json ${TARGETDIR}/

--- a/scripts/get-default-key-address.sh
+++ b/scripts/get-default-key-address.sh
@@ -16,7 +16,7 @@ Print the default, non-HD address of a signing key.
 EOF
 }
 
-${RUNNER} cardano-cli real-pbft signing-key-address  \
+${RUNNER} cardano-cli --real-pbft signing-key-address  \
           --testnet-magic ${proto_magic}             \
           --secret ${key}                            \
         | head -n1 | xargs echo -n

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
 from_key="${genesis_root}/delegate-keys.000.key"
 default_to_key="${genesis_root}/delegate-keys.001.key"
@@ -36,4 +36,4 @@ args=" --genesis-file        ${genesis_file}
        --txout            (\"${addr}\",${lovelace})
 "
 set -x
-${RUNNER} cardano-cli real-pbft issue-genesis-utxo-expenditure ${args}
+${RUNNER} cardano-cli --real-pbft issue-genesis-utxo-expenditure ${args}

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 default_from_key="${genesis_root}/delegate-keys.001.key"
 default_to_key="${genesis_root}/delegate-keys.002.key"
 
@@ -42,4 +42,4 @@ args=" --genesis-file        ${genesis_file}
        --txout            (\"${addr}\",${lovelace})
 "
 set -x
-${RUNNER} cardano-cli real-pbft issue-utxo-expenditure ${args}
+${RUNNER} cardano-cli --real-pbft issue-utxo-expenditure ${args}

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -15,7 +15,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-exec -- cardano-cli real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-exec -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="--real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -17,12 +17,12 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${CMD} real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${CMD} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS=(
-        ${ALGO}
+        --${ALGO}
         submit-tx
         --genesis-file "${genesis_file}"
         --genesis-hash "${genesis_hash}"


### PR DESCRIPTION
1. Arg parsing: make the mode less opaque by switching to an option, hide currently unused system versions.  Update scripts to the changes.
2. Improve the README.