### PR TITLE
Use cabal new-run instead of new-exec in scripts

### DIFF
--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -9,7 +9,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-exec -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run exe:cardano-cli -- --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 CMD=`find dist-newstyle/ -type f -name "cardano-node"`
 test -n "${CMD}" || {
@@ -21,7 +21,7 @@ test -n "${CMD}" || {
 }
 
 
-exec cabal new-exec chairman -- --real-pbft \
+exec cabal new-run exe:chairman -- --real-pbft \
                                 -n 0 -n 1 -n 2 \
                                 -k 10 -s 250 \
                                 -t 1000 \

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-exec --}
+RUNNER=${RUNNER:-cabal new-run exe:cardano-cli --}
 
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
 from_key="${genesis_root}/delegate-keys.000.key"
 default_to_key="${genesis_root}/delegate-keys.001.key"

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-exec --}
+RUNNER=${RUNNER:-cabal new-run exe:cardano-cli --}
 
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 default_from_key="${genesis_root}/delegate-keys.001.key"
 default_to_key="${genesis_root}/delegate-keys.002.key"
 

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-run -- cardano-node}
+RUNNER=${RUNNER:-cabal new-run exe:cardano-node --}
 TOPOLOGY=${TOPOLOGY:-"configuration/topology-proxy-follower.json"}
 
 ARGS=(

--- a/scripts/shelley-testnet-dns.sh
+++ b/scripts/shelley-testnet-dns.sh
@@ -26,7 +26,7 @@ NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS="--slot-duration 2 node -t configuration/simple-topology-dns.json ${ALGO}"
 #SCR="./scripts/start-node.sh"
 #CMD="stack exec --nix cardano-node --"
-CMD="cabal new-exec cardano-node --"
+CMD="cabal new-run exe:cardano-node --"
 HOST="127.0.0.1"
 HOST6="::1"
 

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -26,7 +26,7 @@ NETARGS=(
 
 # SCR="./scripts/start-node.sh"
 # CMD="stack exec --nix cardano-node --"
-CMD="cabal new-exec cardano-node --"
+CMD="cabal new-run exe:cardano-node --"
 
 # SPECIAL=""
 SPECIAL="--live-view"

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -36,14 +36,7 @@ ACCARGS=(
 )
 # SCR="./scripts/start-node.sh"
 # CMD="stack exec --nix cardano-node --"
-CMD=`find dist-newstyle/ -type f -name "cardano-node"`
-test -n "${CMD}" || {
-        cabal new-build exe:cardano-node || {
-                echo "ERROR: couldn't find or cabal new-build exe:cardano-node" >&2
-                exit 1
-        }
-        CMD=`find dist-newstyle/ -type f -name "cardano-node"`
-}
+CMD="cabal new-run exe:cardano-node --"
 # SPECIAL=""
 SPECIAL="--live-view"
 HOST="127.0.0.1"

--- a/scripts/start-node.sh
+++ b/scripts/start-node.sh
@@ -3,7 +3,7 @@
 now=`date "+%Y-%m-%d 00:00:00"`
 
 set -x
-cabal new-run cardano-node -- \
+cabal new-run exe:cardano-node -- \
     --slot-duration 2 \
     --log-config configuration/log-configuration.yaml \
     node -t configuration/simple-topology.json \

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -10,7 +10,7 @@ TX="$1"
 shift
 
 #CMD="stack exec --nix cardano-node -- "
-CMD="cabal new-exec cardano-cli -- "
+CMD="cabal new-run exe:cardano-cli -- "
 
 genesis="33873"
 genesis_root="configuration/${genesis}"

--- a/scripts/trace-acceptor.sh
+++ b/scripts/trace-acceptor.sh
@@ -5,7 +5,7 @@ GENHASH="33873aeaf8a47fefc7c2ea3f72e98a04459e07ec3edfb63c9ca709f540f69503"
 
 # CMD="stack exec cardano-node -- "
 # CMD="./cardano-node.exe -- "
-CMD="cabal new-exec cardano-node -- "
+CMD="cabal new-run exe:cardano-node -- "
 
 NETARGS=(
         --slot-duration 2


### PR DESCRIPTION
`cabal new-run` rebuilds the binary if needed, this is much better
default than `new-exec`.