### PR TITLE
Fix `readFile` in `Cardano.Node.Configuration.Topology`

### DIFF
--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -1,30 +1,31 @@
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Node.Configuration.Topology
   ( TopologyInfo(..)
-  , NodeAddress(..)
-  , nodeAddressToSockAddr
-  , nodeAddressInfo
-  , RemoteAddress(..)
-  , remoteAddressToNodeAddress
-  , NodeSetup(..)
   , NetworkTopology(..)
+  , NodeAddress(..)
+  , NodeSetup(..)
+  , RemoteAddress(..)
+  , nodeAddressInfo
+  , nodeAddressToSockAddr
   , readTopologyFile
+  , remoteAddressToNodeAddress
   )
 where
 
 import           Cardano.Prelude hiding (toS)
 import           Prelude (String, read)
 
+import           Control.Exception (IOException)
+import qualified Control.Exception as Exception
 import           Data.Aeson
 import           Data.Aeson.TH
-import qualified Data.ByteString as B
+import qualified Data.ByteString as BS
 import qualified Data.IP as IP
 import           Data.String.Conv (toS)
 import           Text.Read (readMaybe)
@@ -35,98 +36,91 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 -- | A data structure bundling together a node identifier and the path to
 -- the topology file.
-data TopologyInfo = TopologyInfo {
-    node         :: NodeId
+data TopologyInfo = TopologyInfo
+  { node :: NodeId
   , topologyFile :: FilePath
   }
 
 -- | IPv4 address with a port number.
---
-data NodeAddress = NodeAddress {
-      naHostAddress :: !IP.IP
-    , naPort        :: !PortNumber
-    }
-  deriving (Eq, Ord, Show)
+data NodeAddress = NodeAddress
+  { naHostAddress :: !IP.IP
+  , naPort :: !PortNumber
+  } deriving (Eq, Ord, Show)
 
 instance Condense NodeAddress where
-    condense NodeAddress {naHostAddress, naPort}
-      = show naHostAddress ++ ":" ++ show naPort
+  condense (NodeAddress addr port) = show addr ++ ":" ++ show port
 
 instance FromJSON NodeAddress where
-    parseJSON = withObject "NodeAddress" $ \v -> do
-      NodeAddress
+  parseJSON = withObject "NodeAddress" $ \v -> do
+    NodeAddress
       <$> (read <$> v .: "addr")
       <*> ((fromIntegral :: Int -> PortNumber) <$> v .: "port")
 
-nodeAddressToSockAddr
-    :: NodeAddress
-    -> SockAddr
-nodeAddressToSockAddr NodeAddress {naHostAddress, naPort} = case naHostAddress of
-    IP.IPv4 ipv4 -> SockAddrInet  naPort   (IP.toHostAddress  ipv4)
-    IP.IPv6 ipv6 -> SockAddrInet6 naPort 0 (IP.toHostAddress6 ipv6) 0
+nodeAddressToSockAddr :: NodeAddress -> SockAddr
+nodeAddressToSockAddr (NodeAddress addr port) =
+  case addr of
+    IP.IPv4 ipv4 -> SockAddrInet port $ IP.toHostAddress ipv4
+    IP.IPv6 ipv6 -> SockAddrInet6 port 0 (IP.toHostAddress6 ipv6) 0
 
 nodeAddressInfo :: NodeAddress -> AddrInfo
-nodeAddressInfo na@NodeAddress {naHostAddress}
-    = AddrInfo {
-        addrFlags      = addrFlags defaultHints
-      , addrFamily     = case naHostAddress of
-                          IP.IPv4{} -> AF_INET
-                          IP.IPv6{} -> AF_INET6
-      , addrSocketType = Stream
-      , addrProtocol   = addrProtocol defaultHints
-      , addrAddress    = nodeAddressToSockAddr na
-      , addrCanonName  = Nothing
+nodeAddressInfo na@(NodeAddress hostAddr _) =
+  AddrInfo
+    { addrFlags = addrFlags defaultHints
+    , addrFamily = case hostAddr of
+                     IP.IPv4 _ -> AF_INET
+                     IP.IPv6 _ -> AF_INET6
+    , addrSocketType = Stream
+    , addrProtocol = addrProtocol defaultHints
+    , addrAddress = nodeAddressToSockAddr na
+    , addrCanonName = Nothing
     }
 
 -- | Domain name with port number
 --
-data RemoteAddress = RemoteAddress {
-    raAddress :: !String
+data RemoteAddress = RemoteAddress
+  { raAddress :: !String
   -- ^ either a dns address or ip address
-  , raPort    :: !PortNumber
+  , raPort :: !PortNumber
   -- ^ port number of the destination
   , raValency :: !Int
-  -- ^ if a dns address is given valency governs to how many resolved ip addresses
+  -- ^ if a dns address is given valency governs
+  -- to how many resolved ip addresses
   -- should we maintain acctive (hot) connection;
-  -- if an ip address is given valency is used as a boolean value, @0@ means to
-  -- ignore the address;
-  }
-  deriving (Eq, Ord, Show)
+  -- if an ip address is given valency is used as
+  -- a boolean value, @0@ means to ignore the address;
+  } deriving (Eq, Ord, Show)
 
 
 -- | Parse 'raAddress' field as an IP address; if it parses and the valency is
 -- non zero return corresponding NodeAddress.
 --
-remoteAddressToNodeAddress
-  :: RemoteAddress
-  -> Maybe NodeAddress
-remoteAddressToNodeAddress RemoteAddress {raAddress, raPort, raValency} =
-    case readMaybe raAddress of
-      Nothing -> Nothing
-      Just naHostAddress | raValency /= 0 -> Just (NodeAddress {
-                                                      naHostAddress
-                                                    , naPort = raPort
-                                                    })
-                         | otherwise      -> Nothing
+remoteAddressToNodeAddress:: RemoteAddress-> Maybe NodeAddress
+remoteAddressToNodeAddress (RemoteAddress addrStr port val) =
+  case readMaybe addrStr of
+    Nothing -> Nothing
+    Just addr -> if val /= 0
+                 then Just $ NodeAddress addr port
+                 else Nothing
 
 
 instance Condense RemoteAddress where
-    condense RemoteAddress {raAddress, raPort, raValency} = raAddress ++ ":" ++ show raPort ++ " (" ++ show raValency ++ ")"
+  condense (RemoteAddress addr port val) =
+    addr ++ ":" ++ show port ++ " (" ++ show val ++ ")"
 
 instance FromJSON RemoteAddress where
-    parseJSON = withObject "RemoteAddress" $ \v -> RemoteAddress
+  parseJSON = withObject "RemoteAddress" $ \v ->
+    RemoteAddress
       <$> v .: "addr"
       <*> ((fromIntegral :: Int -> PortNumber) <$> v .: "port")
       <*> (v .: "valency")
 
-data NodeSetup = NodeSetup {
-    nodeAddress :: !NodeAddress
-  , producers   :: ![RemoteAddress]
-  }
-  deriving Show
+data NodeSetup = NodeSetup
+  { nodeAddress :: !NodeAddress
+  , producers :: ![RemoteAddress]
+  } deriving Show
 
 instance FromJSON NodeId where
-    parseJSON v = CoreId <$> parseJSON v
+  parseJSON v = CoreId <$> parseJSON v
 
 deriveFromJSON defaultOptions ''NodeSetup
 
@@ -137,4 +131,11 @@ deriveFromJSON defaultOptions ''NetworkTopology
 
 readTopologyFile :: FilePath -> IO (Either String NetworkTopology)
 readTopologyFile topo = do
-    eitherDecode . toS <$> B.readFile topo
+  eBs <- Exception.try $ BS.readFile topo
+  case eBs of
+    Left e -> pure . Left $ handler e
+    Right bs -> pure . eitherDecode $ toS bs
+ where
+  handler :: IOException -> String
+  handler e = "Cardano.Node.Configuration.Topology.readTopologyFile: "
+              ++ displayException e


### PR DESCRIPTION
1. We should catch and render `IOException`s that may be thrown from the use of `readFile`. There are other `readFile`s in the repo that I will get to when I start removing exception throwing.
2. Style changes.