### PR TITLE
Update `scripts/shelley-testnet.sh`

### DIFF
--- a/cardano-node/src/Cardano/CLI/Tx/Submission.hs
+++ b/cardano-node/src/Cardano/CLI/Tx/Submission.hs
@@ -17,7 +17,6 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Void (Void)
 
 import           System.Directory (canonicalizePath, makeAbsolute)
-import           System.FilePath ((</>))
 
 import           Control.Monad (fail)
 import           Control.Monad.Class.MonadST (MonadST)
@@ -99,14 +98,14 @@ submitTx :: ( RunDemo blk
          -> GenTx blk
          -> Tracer IO String
          -> IO ()
-submitTx cc protoInfoConfig nodeId tx tracer = do
-    socketDir <- canonicalizePath =<< makeAbsolute (ccSocketPath cc)
+submitTx cc protoInfoConfig _nodeId tx tracer = do
+    socketPath <- canonicalizePath =<< makeAbsolute (ccSocketPath cc)
     NodeToClient.connectTo
       nullTracer
       (,)
       (localInitiatorNetworkApplication tracer protoInfoConfig tx)
       Nothing
-      (localSocketAddrInfo (socketDir </> localSocketFilePath nodeId))
+      (localSocketAddrInfo socketPath)
 
 localInitiatorNetworkApplication
   :: forall blk m peer.

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -9,7 +9,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-run exe:cardano-cli -- --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run -v0 exe:cardano-cli -- --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 CMD=`find dist-newstyle/ -type f -name "cardano-node"`
 test -n "${CMD}" || {

--- a/scripts/genesis.sh
+++ b/scripts/genesis.sh
@@ -43,7 +43,7 @@ args=(
 )
 
 set -xe
-RUNNER=${RUNNER:-cabal new-run --}
+RUNNER=${RUNNER:-cabal new-run -v0 --}
 
 ${RUNNER} cardano-cli --real-pbft genesis "${args[@]}" "$@"
 

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-run exe:cardano-cli --}
+RUNNER=${RUNNER:-cabal new-run -v0 --}
 
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
 from_key="${genesis_root}/delegate-keys.000.key"
 default_to_key="${genesis_root}/delegate-keys.001.key"
@@ -34,6 +34,7 @@ args=" --genesis-file        ${genesis_file}
        --wallet-key          ${from_key}
        --rich-addr-from    \"${from_addr}\"
        --txout            (\"${addr}\",${lovelace})
+       --socket-path         /dev/null
 "
 set -x
 ${RUNNER} cardano-cli --real-pbft issue-genesis-utxo-expenditure ${args}

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-run exe:cardano-cli --}
+RUNNER=${RUNNER:-cabal new-run -v0 --}
 
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 default_from_key="${genesis_root}/delegate-keys.001.key"
 default_to_key="${genesis_root}/delegate-keys.002.key"
 
@@ -40,6 +40,7 @@ args=" --genesis-file        ${genesis_file}
        --wallet-key          ${from_key}
        --txin             (\"${txid}\",${outindex})
        --txout            (\"${addr}\",${lovelace})
+       --socket-path         /dev/null
 "
 set -x
 ${RUNNER} cardano-cli --real-pbft issue-utxo-expenditure ${args}

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-RUNNER=${RUNNER:-cabal new-run exe:cardano-node --}
+RUNNER=${RUNNER:-cabal new-run --}
 TOPOLOGY=${TOPOLOGY:-"configuration/topology-proxy-follower.json"}
 
 ARGS=(
@@ -15,4 +15,4 @@ ARGS=(
         --real-pbft
 )
 
-${RUNNER} "${ARGS[@]}"
+${RUNNER} cardano-node "${ARGS[@]}"

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -8,8 +8,6 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-RUNNER=${RUNNER:-cabal new-run -v0 --}
-
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
@@ -17,7 +15,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run -v0 -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="--real-pbft"
 ACCARGS=(

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -8,6 +8,8 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
+RUNNER=${RUNNER:-cabal new-run -v0 --}
+
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
@@ -15,10 +17,9 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-exec -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="--real-pbft"
-NOW=`date "+%Y-%m-%d 00:00:00"`
 ACCARGS=(
         --slot-duration 2
         --socket-path "socket/node4.socket"
@@ -48,7 +49,7 @@ function mknetargs () {
                printf -- "--genesis-hash ${genesis_hash} "
                printf -- "--pbft-signature-threshold 0.7 "
                printf -- "--require-network-magic "
-               printf -- "--database-path "db" "
+               printf -- "--database-path db "
                printf -- "--socket-path $1 "
                printf -- "node "
                printf -- "--topology configuration/simple-topology.json "

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -10,14 +10,14 @@ TX="$1"
 shift
 
 #CMD="stack exec --nix cardano-node -- "
-CMD="cabal new-run exe:cardano-cli -- "
+CMD="cabal new-run"
 
 genesis="33873"
 genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${CMD} --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${CMD} -v0 -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
@@ -29,6 +29,7 @@ NETARGS=(
         --topology     "configuration/simple-topology.json"
         --node-id      "0"
         --tx           "$TX"
+        --socket-path  socket/node1.socket
 )
 
 function mkdlgkey () {
@@ -39,6 +40,4 @@ function mkdlgcert () {
 }
 
 set -x
-${CMD} \
-    ${NETARGS[*]} \
-           $@
+${CMD} -- cardano-cli ${NETARGS[*]} "$@"


### PR DESCRIPTION
1. Update  `scripts/shelley-testnet.sh` to use the now mandatory socket path.
2. Use `cabal new-run` in `scripts/shelley-testnet2.sh`.