### PR TITLE
Refactor `runCommand` with `ExceptT`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,12 +58,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: b83730dccab14111d62144b048084eec7900d091
+  tag: 56fadcea03417771f4b3666fd1dfc9bad8df1484
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: b83730dccab14111d62144b048084eec7900d091
+  tag: 56fadcea03417771f4b3666fd1dfc9bad8df1484
   subdir: test
 
 source-repository-package

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -86,6 +86,8 @@ library
                      , template-haskell
                      , text
                      , time
+                     , transformers
+                     , transformers-except
                      , typed-protocols
                      , typed-protocols-cbor
                      , utf8-string
@@ -154,6 +156,7 @@ executable cardano-node
                      , stm
                      , text
                      , time
+
   if os(windows)
      build-depends:    Win32
   else
@@ -213,6 +216,9 @@ executable cardano-cli
                      , safe-exceptions
                      , text
                      , time
+                     , transformers-except
+                     , transformers
+
   default-extensions:  NoImplicitPrelude
 
 executable chairman

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -109,6 +109,14 @@ data CliError
   | GenesisGenerationError !Genesis.GenesisDataGenerationError
   -- Invariants/assertions -- does it belong here?
   | NoGenesisDelegationForKey !Text
+  -- File reading errors
+  | ReadVerificationKeyFailure !FilePath !Text
+  -- ^ An exception was encountered while trying to read
+  -- the verification key file.
+  | ReadSigningKeyFailure !FilePath !Text
+  -- ^ An exception was encountered while trying to read
+  -- the signing key file.
+
 
 instance Show CliError where
   show (OutputMustNotAlreadyExist fp)
@@ -143,5 +151,10 @@ instance Show CliError where
     = "Genesis generation failed: " <> show err
   show (NoGenesisDelegationForKey key)
     = "Newly-generated genesis doesn't delegate to operational key: " <> T.unpack key
-
+  show (ReadVerificationKeyFailure fp expt)
+    = "Exception encountered while trying to read the verification key file at: " <> fp
+       <> "Exception: " <> T.unpack expt
+  show (ReadSigningKeyFailure fp expt)
+    = "Exception encountered while trying to read the signing key file at: " <> fp
+       <> "Exception: " <> T.unpack expt
 instance Exception CliError

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -62,6 +62,8 @@
           (hsPkgs.template-haskell)
           (hsPkgs.text)
           (hsPkgs.time)
+          (hsPkgs.transformers)
+          (hsPkgs.transformers-except)
           (hsPkgs.typed-protocols)
           (hsPkgs.typed-protocols-cbor)
           (hsPkgs.utf8-string)
@@ -145,6 +147,8 @@
             (hsPkgs.safe-exceptions)
             (hsPkgs.text)
             (hsPkgs.time)
+            (hsPkgs.transformers-except)
+            (hsPkgs.transformers)
             ];
           };
         "chairman" = {

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,7 +42,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "b83730dccab14111d62144b048084eec7900d091";
+      rev = "56fadcea03417771f4b3666fd1dfc9bad8df1484";
       sha256 = "00vnsl521bc2qbv4v3j00afprx8d58n8gfgcbhs2xpp8dywrfa5i";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -43,7 +43,7 @@
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
       rev = "56fadcea03417771f4b3666fd1dfc9bad8df1484";
-      sha256 = "00vnsl521bc2qbv4v3j00afprx8d58n8gfgcbhs2xpp8dywrfa5i";
+      sha256 = "1dljg11kpdd24lq7jdkqr2h7wnm1vxgnr2dwiw2wgxdf6m5i5vzr";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -69,7 +69,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "b83730dccab14111d62144b048084eec7900d091";
+      rev = "56fadcea03417771f4b3666fd1dfc9bad8df1484";
       sha256 = "00vnsl521bc2qbv4v3j00afprx8d58n8gfgcbhs2xpp8dywrfa5i";
       });
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -70,6 +70,6 @@
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
       rev = "56fadcea03417771f4b3666fd1dfc9bad8df1484";
-      sha256 = "00vnsl521bc2qbv4v3j00afprx8d58n8gfgcbhs2xpp8dywrfa5i";
+      sha256 = "1dljg11kpdd24lq7jdkqr2h7wnm1vxgnr2dwiw2wgxdf6m5i5vzr";
       });
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -11,6 +11,7 @@
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
+        "transformers-except" = (((hackage.transformers-except)."0.1.1").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/b83730dccab14111d62144b048084eec7900d091/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/56fadcea03417771f4b3666fd1dfc9bad8df1484/snapshot.yaml
 
 packages:
   - cardano-config
@@ -19,7 +19,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: b83730dccab14111d62144b048084eec7900d091
+    commit: 56fadcea03417771f4b3666fd1dfc9bad8df1484
     subdirs:
       - .
       - test
@@ -44,6 +44,7 @@ extra-deps:
   - time-units-1.0.0
   - libsystemd-journal-1.4.4
   - tasty-hedgehog-1.0.0.1
+  - transformers-except-0.1.1
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
     commit: c85d57a95d919336afea7e0eff00e834bd6b4b58


### PR DESCRIPTION
 Why `ExceptT`?
- When refactoring the code that throws exceptions, exception handling can be accidentally refactored out.
- We should be using `Either` or `ExceptT` instead of throwing exceptions in plain IO. This is more explicit. 