### PR TITLE
update consensus for access to chain sync tracers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -91,37 +91,37 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+  tag: c14774c532a84df1c010350ed07669dbce8770a2
   subdir: io-sim-classes
 
 source-repository-package

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -193,7 +193,8 @@ parseTraceChainDB =
 parseConsensusTraceOptions :: Parser ConsensusTraceOptions
 parseConsensusTraceOptions = Consensus.Tracers
   <$> (Const <$> parseTraceChainSyncClient)
-  <*> (Const <$> parseTraceChainSyncServer)
+  <*> (Const <$> parseTraceChainSyncHeaderServer)
+  <*> (Const <$> parseTraceChainSyncBlockServer)
   <*> (Const <$> parseTraceBlockFetchDecisions)
   <*> (Const <$> parseTraceBlockFetchClient)
   <*> (Const <$> parseTraceBlockFetchServer)
@@ -217,11 +218,18 @@ parseTraceChainSyncClient  =
       <> help "Trace ChainSync client."
     )
 
-parseTraceChainSyncServer :: Parser Bool
-parseTraceChainSyncServer  =
+parseTraceChainSyncBlockServer :: Parser Bool
+parseTraceChainSyncBlockServer  =
     switch (
-         long "trace-chain-sync-server"
-      <> help "Trace ChainSync server."
+         long "trace-chain-sync-block-server"
+      <> help "Trace ChainSync server (blocks)."
+    )
+
+parseTraceChainSyncHeaderServer :: Parser Bool
+parseTraceChainSyncHeaderServer  =
+    switch (
+         long "trace-chain-sync-header-server"
+      <> help "Trace ChainSync server (headers)."
     )
 
 parseTraceTxInbound :: Parser Bool

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -202,10 +202,14 @@ mkTracers traceOptions tracer = Tracers
         = annotateSeverity $ filterSeverity (pure . const Info)  -- filter out everything below this level
           $ toLogObject' (tracingFormatting $ hasConsensusTraceFlag Consensus.chainSyncClientTracer) tracingVerbosity
           $ addName "ChainSyncClient" tracer
-      , Consensus.chainSyncServerTracer
+      , Consensus.chainSyncServerHeaderTracer
         = annotateSeverity $ filterSeverity (pure . const Info)  -- filter out everything below this level
-          $ toLogObject' (tracingFormatting $ hasConsensusTraceFlag Consensus.chainSyncServerTracer) tracingVerbosity
-          $ addName "ChainSyncServer" tracer
+          $ toLogObject' (tracingFormatting $ hasConsensusTraceFlag Consensus.chainSyncServerHeaderTracer) tracingVerbosity
+          $ addName "ChainSyncHeaderServer" tracer
+      , Consensus.chainSyncServerBlockTracer
+        = annotateSeverity $ filterSeverity (pure . const Info)  -- filter out everything below this level
+          $ toLogObject' (tracingFormatting $ hasConsensusTraceFlag Consensus.chainSyncServerBlockTracer) tracingVerbosity
+          $ addName "ChainSyncBlockServer" tracer
       , Consensus.blockFetchDecisionTracer
         = annotateSeverity $ filterSeverity (pure . const Info)  -- filter out everything below this level
           $ toLogObject' (tracingFormatting $ hasConsensusTraceFlag Consensus.blockFetchDecisionTracer) tracingVerbosity

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -159,8 +159,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -122,8 +122,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "2ad7dced59caece77b6a5e06914aa37d8a3bba23";
-      sha256 = "0f0wq8fd6f38nqr936xp9lxjk57cm9d8l1ngv5w8q7ikwah175cq";
+      rev = "c14774c532a84df1c010350ed07669dbce8770a2";
+      sha256 = "1gp03pbc5hv8fj6738s22d9m58b0ii0l079lfja4x9f6mvyrqk45";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -62,7 +62,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
+    commit: c14774c532a84df1c010350ed07669dbce8770a2
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
the tracing of chain sync structures depends on a newer version of the consensus layer, and had a recursive call to itself in the rendering.

the rendering was wrong: `toObject verb ev = toObject verb ev` will obviously loop
(sorry for that! :-) )

----
the rendering of the server events depends on this PR: https://github.com/input-output-hk/ouroboros-network/pull/1032
(if this is fast we can include it here)
