### PR TITLE
Make `--host-addr` optional

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,19 +11,19 @@ package cardano-node
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: cardano-crypto-class
 
 source-repository-package
@@ -58,12 +58,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: eee27bd6697d5ab1b943ee9c50ee638bde009c81
+  tag: 161c2e248f79427a3f7456cc9de9436669bd236b
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: eee27bd6697d5ab1b943ee9c50ee638bde009c81
+  tag: 161c2e248f79427a3f7456cc9de9436669bd236b
   subdir: test
 
 source-repository-package
@@ -122,37 +122,37 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+  tag: f0ee20c41c242bf26587b94d941e3d1afbca0bad
   subdir: io-sim-classes
 
 source-repository-package

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -10,7 +10,7 @@ import qualified Data.IP as IP
 import           Data.Semigroup ((<>))
 import           Network.Socket (PortNumber)
 import           Options.Applicative ( Parser, auto, flag, help, long
-                                     , metavar, option, str
+                                     , metavar, option, str, value
                                      )
 import qualified Options.Applicative as Opt
 
@@ -155,12 +155,13 @@ parseNodeArgs =
 parseNodeAddress :: Parser NodeAddress
 parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort
 
-parseHostAddr :: Parser IP.IP
+parseHostAddr :: Parser (Maybe IP.IP)
 parseHostAddr =
-    option (read <$> str) (
+    option (Just <$> read <$> str) (
           long "host-addr"
        <> metavar "HOST-NAME"
-       <> help "The ipv6 or ipv4 address"
+       <> help "Optionally limit node to one ipv6 or ipv4 address"
+       <> value Nothing
     )
 
 parsePort :: Parser PortNumber

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -160,11 +160,13 @@ handleSimpleNode
           Just ps -> ps
           Nothing -> error $ "handleSimpleNode: own address "
                           <> show myNodeAddress
+                          <> ", Node Id "
+                          <> show nid
                           <> " not found in topology"
 
     traceWith tracer $ unlines
       [ "**************************************"
-      , "I am Node "        <> show myNodeAddress
+      , "I am Node "        <> show myNodeAddress <> " Id: " <> show nid
       , "My producers are " <> show producers'
       , "**************************************"
       ]

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -151,8 +151,8 @@ handleSimpleNode
     traceWith tracer $
       "System started at " <> show (nodeStartTime (Proxy @blk) cfg)
 
-    let producers' = case List.lookup myNodeAddress $
-                          map (\ns -> (nodeAddress ns, producers ns)) nodeSetups of
+    let producers' = case List.lookup nid $
+                          map (\ns -> (nodeId ns, producers ns)) nodeSetups of
           Just ps -> ps
           Nothing -> error $ "handleSimpleNode: own address "
                           <> show myNodeAddress
@@ -168,6 +168,7 @@ handleSimpleNode
     -- Socket directory
     myLocalAddr <- localSocketAddrInfo myNodeId (ccSocketDir cc) MkdirIfMissing
 
+    addrs <- nodeAddressInfo myNodeAddress
     let ipProducerAddrs  :: [NodeAddress]
         dnsProducerAddrs :: [RemoteAddress]
         (ipProducerAddrs, dnsProducerAddrs) = partitionEithers
@@ -188,7 +189,7 @@ handleSimpleNode
           , rnaMuxTracer             = muxTracer             nodeTracers
           , rnaMuxLocalTracer        = nullTracer
           , rnaMkPeer                = Peer
-          , rnaMyAddr                = nodeAddressInfo myNodeAddress
+          , rnaMyAddrs               = addrs
           , rnaMyLocalAddr           = myLocalAddr
           , rnaIpProducers           = ipProducers
           , rnaDnsProducers          = dnsProducers

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -83,6 +83,10 @@ data Peer = Peer { localAddr  :: SockAddr
 instance Condense Peer where
     condense (Peer localA remoteA) = (show localA) ++ (show remoteA)
 
+instance NoUnexpectedThunks Peer where
+    showTypeOf _ = "Peer"
+    whnfNoUnexpectedThunks _ctxt _act = return NoUnexpectedThunks
+
 data NodeArgs = NodeArgs !TopologyInfo !NodeAddress !Protocol !ViewMode
 
 -- Node can be run in two modes.

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -240,6 +240,7 @@ instance DefineSeverity (ChainDB.TraceEvent blk) where
 instance DefinePrivacyAnnotation (TraceChainSyncClientEvent blk tip)
 instance DefineSeverity (TraceChainSyncClientEvent blk tip) where
   defineSeverity (TraceDownloadedHeader _) = Info
+  defineSeverity (TraceFoundIntersection _ _ _) = Info
   defineSeverity (TraceRolledBack _) = Notice
   defineSeverity (TraceException _) = Warning
 
@@ -654,7 +655,8 @@ instance (Condense (HeaderHash blk), ProtocolLedgerView blk, SupportedBlock blk,
     TraceException exc ->
       mkObject [ "kind" .= String "ChainSyncClientEvent.TraceException"
                , "exception" .= String (pack $ show exc) ]
-
+    TraceFoundIntersection _ _ _ ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceFoundIntersection" ]
 
 instance ToObject (TraceChainSyncServerEvent blk b) where
     toObject _ _ev = mkObject [ "kind" .= String "ChainSyncServerEvent" ]

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7";
-      sha256 = "1yly8v8plaiyfz3p74vsq2qnq3pjb1vizyacfsdijw41mnqynmaa";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7";
-      sha256 = "1yly8v8plaiyfz3p74vsq2qnq3pjb1vizyacfsdijw41mnqynmaa";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7";
-      sha256 = "1yly8v8plaiyfz3p74vsq2qnq3pjb1vizyacfsdijw41mnqynmaa";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "eee27bd6697d5ab1b943ee9c50ee638bde009c81";
-      sha256 = "1q99rjjmpcwscmixy607695d0x3rzbwinb11wdsbi91822w6rriy";
+      rev = "161c2e248f79427a3f7456cc9de9436669bd236b";
+      sha256 = "0n75252npkp49p5czf0w0vwprcq5d7rrbgjnjcirq8306c9yi3np";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -71,7 +71,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "eee27bd6697d5ab1b943ee9c50ee638bde009c81";
-      sha256 = "1q99rjjmpcwscmixy607695d0x3rzbwinb11wdsbi91822w6rriy";
+      rev = "161c2e248f79427a3f7456cc9de9436669bd236b";
+      sha256 = "0n75252npkp49p5czf0w0vwprcq5d7rrbgjnjcirq8306c9yi3np";
       });
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { checktvarinvariant = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-consensus"; version = "0.1.0.0"; };
@@ -103,6 +103,7 @@
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
             (hsPkgs.cryptonite)
+            (hsPkgs.deepseq)
             (hsPkgs.fgl)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)
@@ -139,6 +140,7 @@
             (hsPkgs.cereal)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
+            (hsPkgs.deepseq)
             (hsPkgs.directory)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)
@@ -164,8 +166,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -132,8 +132,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "04336ee89d74c9ef839ad54ab9cd2f3e07a39696";
-      sha256 = "0vxa5jj00pmldwg9drxljijphj48vjh5nc8jkfc6bzv987ddjxrm";
+      rev = "f0ee20c41c242bf26587b94d941e3d1afbca0bad";
+      sha256 = "11ch7msjlm57a2kbxn1gnps4q58lj9dpfszynbnfnxz2y0hb3xvg";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/nixos/cardano-cluster-service.nix
+++ b/nix/nixos/cardano-cluster-service.nix
@@ -27,7 +27,7 @@ let
         nodeAddress = { inherit addr port; };
         producers = map mkPeer (remove port ports);
       };
-    in toFile "topology.yaml" (toJSON (imap mkNodeTopo ports));
+    in toFile "topology.yaml" (toJSON (imap0 mkNodeTopo ports));
 
   ## Note how some values are literal strings, and some integral.
   ## This is an important detail.

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,13 +34,13 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: eee27bd6697d5ab1b943ee9c50ee638bde009c81
+    commit: 161c2e248f79427a3f7456cc9de9436669bd236b
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: d8da018e13e4d7a9b5372a00926dcdc48c5ad2c7
+    commit: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
     subdirs:
       - binary
       - binary/test
@@ -71,7 +71,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 04336ee89d74c9ef839ad54ab9cd2f3e07a39696
+    commit: f0ee20c41c242bf26587b94d941e3d1afbca0bad
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
By making host-addr optional we make it possible to run a node with both IPv4 and IPv6 addresses.