### PR TITLE
Logging disablement changes & script fixes

### DIFF
--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -6,15 +6,14 @@
 
 import           Prelude (String, read)
 
-import           Data.Semigroup ((<>))
 import qualified Data.IP as IP
+import           Data.Semigroup ((<>))
 import           Network.Socket (PortNumber)
-import           Options.Applicative ( Parser, auto, flag, flag', help, long
-                                     , metavar, option, str, switch
+import           Options.Applicative ( Parser, auto, flag, help, long
+                                     , metavar, option, str
                                      )
 import qualified Options.Applicative as Opt
 
-import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import           Cardano.Config.Partial (PartialCardanoConfiguration (..))
 import           Cardano.Config.Types (CardanoEnvironment (..))
 import           Cardano.Config.Presets (mainnetConfiguration)
@@ -26,15 +25,13 @@ import           Cardano.Prelude hiding (option)
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..),)
-import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
-import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
 import           Cardano.Config.CommonCLI
 import           Cardano.Common.Help
 import           Cardano.Common.Parsers
 import           Cardano.Node.Run
 import           Cardano.Node.Configuration.Topology (NodeAddress (..))
-import           Cardano.Tracing.Tracers (ConsensusTraceOptions,  ProtocolTraceOptions, TraceOptions(..))
+import           Cardano.Tracing.Tracers
 
 main :: IO ()
 main = do
@@ -92,13 +89,13 @@ initializeAllFeatures
   -> PartialCardanoConfiguration
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
-initializeAllFeatures (CLI (CLIMain nodeCLI logCLI commonCLI) traceCLI commonCLIAdv)
+initializeAllFeatures (CLI (CLIMain nodeCLI logCLI commonCLI) traceOpts commonCLIAdv)
                       partialConfig cardanoEnvironment = do
     -- TODO: we have to execute on our decision to implement the
     -- generalised options monoid (GOM), to serve the purposes of composition
     -- of the three config layers:  presets, config files and CLI.
     -- Currently we have a mish-mash (see createNodeFeature accepting both
-    -- 'finalConfig' and nodeCli/traceCLI/advancedCLI. Yuck!
+    -- 'finalConfig' and nodeCli/traceCLI/advancedCLI). Yuck!
     --
     -- Considerations:
     -- 1. the CLI parser data structures must be grouped to accomodate help sectioning.
@@ -112,7 +109,11 @@ initializeAllFeatures (CLI (CLIMain nodeCLI logCLI commonCLI) traceCLI commonCLI
       Right x -> pure x
 
     (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment finalConfig logCLI
-    (nodeLayer   , nodeFeature)    <- createNodeFeature loggingLayer nodeCLI traceCLI cardanoEnvironment finalConfig
+    (nodeLayer   , nodeFeature)    <-
+      createNodeFeature
+        loggingLayer nodeCLI
+        traceOpts
+        cardanoEnvironment finalConfig
 
     pure ([ loggingFeature
           , nodeFeature
@@ -134,14 +135,14 @@ cliParser = CLI
   <*> cliTracingParser
   <*> parseCommonCLIAdvanced
 
+cliTracingParser :: Parser TraceOptions
+cliTracingParser = parseTraceOptions Opt.hidden
+
 cliParserMain :: Parser CLIMain
 cliParserMain = CLIMain
   <$> parseNodeArgs
   <*> loggingParser
   <*> parseCommonCLI
-
-cliTracingParser :: Parser TraceOptions
-cliTracingParser = parseTraceOptions Opt.hidden
 
 parseNodeArgs :: Parser NodeArgs
 parseNodeArgs =
@@ -150,22 +151,6 @@ parseNodeArgs =
     <*> parseNodeAddress
     <*> parseProtocol
     <*> parseViewMode
-
-parseTraceBlockFetchClient :: MParser Bool
-parseTraceBlockFetchClient m =
-    switch (
-         long "trace-block-fetch-client"
-      <> help "Trace BlockFetch client."
-      <> m
-    )
-
-parseTraceBlockFetchServer :: MParser Bool
-parseTraceBlockFetchServer m =
-    switch (
-         long "trace-block-fetch-server"
-      <> help "Trace BlockFetch server."
-      <> m
-    )
 
 parseNodeAddress :: Parser NodeAddress
 parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort
@@ -184,220 +169,6 @@ parsePort =
           long "port"
        <> metavar "PORT"
        <> help "The port number"
-    )
-
-parseTraceOptions :: MParser TraceOptions
-parseTraceOptions m = TraceOptions
-  <$> parseTracingGlobal m
-  <*> parseTracingVerbosity m
-  <*> parseTraceChainDB m
-  <*> parseConsensusTraceOptions m
-  <*> parseProtocolTraceOptions m
-  <*> parseTraceIpSubscription m
-  <*> parseTraceDnsSubscription m
-  <*> parseTraceDnsResolver m
-  <*> parseTraceMux m
-
-parseTracingGlobal :: MParser Bool
-parseTracingGlobal m =
-  switch ( long "tracing-off"
-           <> help "Tracing globally turned off."
-           <> m
-         )
-
-parseTracingVerbosity :: MParser TracingVerbosity
-parseTracingVerbosity m = asum [
-  flag' MinimalVerbosity (
-      long "tracing-verbosity-minimal"
-        <> help "Minimal level of the rendering of captured items"
-        <> m)
-    <|>
-  flag' MaximalVerbosity ( 
-      long "tracing-verbosity-maximal"
-        <> help "Maximal level of the rendering of captured items"
-        <> m)
-    <|>
-  flag NormalVerbosity NormalVerbosity (
-      long "tracing-verbosity-normal"
-        <> help "the default level of the rendering of captured items"
-        <> m)
-  ]
-
-parseTraceChainDB :: MParser Bool
-parseTraceChainDB m =
-    switch (
-         long "trace-chain-db"
-      <> help "Verbose tracer of ChainDB."
-      <> m
-    )
-
-parseConsensusTraceOptions :: (forall a b. Opt.Mod a b) -> Parser ConsensusTraceOptions
-parseConsensusTraceOptions m = Consensus.Tracers
-  <$> (Const <$> parseTraceChainSyncClient m)
-  <*> (Const <$> parseTraceChainSyncHeaderServer m)
-  <*> (Const <$> parseTraceChainSyncBlockServer m)
-  <*> (Const <$> parseTraceBlockFetchDecisions m)
-  <*> (Const <$> parseTraceBlockFetchClient m)
-  <*> (Const <$> parseTraceBlockFetchServer m)
-  <*> (Const <$> parseTraceTxInbound m)
-  <*> (Const <$> parseTraceTxOutbound m)
-  <*> (Const <$> parseTraceLocalTxSubmissionServer m)
-  <*> (Const <$> parseTraceMempool m)
-  <*> (Const <$> parseTraceForge m)
-
-type MParser a = (forall b c. Opt.Mod b c) -> Parser a
-
-parseTraceBlockFetchDecisions :: MParser Bool
-parseTraceBlockFetchDecisions m =
-    switch (
-         long "trace-block-fetch-decisions"
-      <> help "Trace BlockFetch decisions made by the BlockFetch client."
-      <> m
-    )
-
-parseTraceChainSyncClient :: MParser Bool
-parseTraceChainSyncClient m =
-    switch (
-         long "trace-chain-sync-client"
-      <> help "Trace ChainSync client."
-      <> m
-    )
-
-parseTraceChainSyncBlockServer :: MParser Bool
-parseTraceChainSyncBlockServer m =
-    switch (
-         long "trace-chain-sync-block-server"
-      <> help "Trace ChainSync server (blocks)."
-      <> m
-    )
-
-parseTraceChainSyncHeaderServer :: MParser Bool
-parseTraceChainSyncHeaderServer m =
-    switch (
-         long "trace-chain-sync-header-server"
-      <> help "Trace ChainSync server (headers)."
-      <> m
-    )
-
-parseTraceTxInbound :: MParser Bool
-parseTraceTxInbound m =
-    switch (
-         long "trace-tx-inbound"
-      <> help "Trace TxSubmission server (inbound transactions)."
-      <> m
-    )
-
-parseTraceTxOutbound :: MParser Bool
-parseTraceTxOutbound m =
-    switch (
-         long "trace-tx-outbound"
-      <> help "Trace TxSubmission client (outbound transactions)."
-      <> m
-    )
-
-parseTraceLocalTxSubmissionServer :: MParser Bool
-parseTraceLocalTxSubmissionServer m =
-    switch (
-         long "trace-local-tx-submission-server"
-      <> help "Trace local TxSubmission server."
-      <> m
-    )
-
-parseTraceMempool :: MParser Bool
-parseTraceMempool m =
-    switch (
-         long "trace-mempool"
-      <> help "Trace mempool."
-      <> m
-    )
-
-parseTraceForge :: MParser Bool
-parseTraceForge m =
-    switch (
-         long "trace-forge"
-      <> help "Trace block forging."
-      <> m
-    )
-
-parseTraceChainSyncProtocol :: MParser Bool
-parseTraceChainSyncProtocol m =
-    switch (
-         long "trace-chain-sync-protocol"
-      <> help "Trace ChainSync protocol messages."
-      <> m
-    )
-
-parseTraceBlockFetchProtocol :: MParser Bool
-parseTraceBlockFetchProtocol m =
-    switch (
-         long "trace-block-fetch-protocol"
-      <> help "Trace BlockFetch protocol messages."
-      <> m
-    )
-
-parseTraceTxSubmissionProtocol :: MParser Bool
-parseTraceTxSubmissionProtocol m =
-    switch (
-         long "trace-tx-submission-protocol"
-      <> help "Trace TxSubmission protocol messages."
-      <> m
-    )
-
-parseTraceLocalChainSyncProtocol :: MParser Bool
-parseTraceLocalChainSyncProtocol m =
-    switch (
-         long "trace-local-chain-sync-protocol"
-      <> help "Trace local ChainSync protocol messages."
-      <> m
-    )
-
-parseTraceLocalTxSubmissionProtocol :: MParser Bool
-parseTraceLocalTxSubmissionProtocol m =
-    switch (
-         long "trace-local-tx-submission-protocol"
-      <> help "Trace local TxSubmission protocol messages."
-      <> m
-    )
-
-
-parseProtocolTraceOptions :: MParser ProtocolTraceOptions
-parseProtocolTraceOptions m = ProtocolTracers
-  <$> (Const <$> parseTraceChainSyncProtocol m)
-  <*> (Const <$> parseTraceBlockFetchProtocol m)
-  <*> (Const <$> parseTraceTxSubmissionProtocol m)
-  <*> (Const <$> parseTraceLocalChainSyncProtocol m)
-  <*> (Const <$> parseTraceLocalTxSubmissionProtocol m)
-
-parseTraceIpSubscription :: MParser Bool
-parseTraceIpSubscription m =
-    switch (
-         long "trace-ip-subscription"
-      <> help "Trace IP Subscription messages."
-      <> m
-    )
-
-parseTraceDnsSubscription :: MParser Bool
-parseTraceDnsSubscription m =
-    switch (
-         long "trace-dns-subscription"
-      <> help "Trace DNS Subscription messages."
-      <> m
-    )
-
-parseTraceDnsResolver :: MParser Bool
-parseTraceDnsResolver m =
-    switch (
-         long "trace-dns-resolver"
-      <> help "Trace DNS Resolver messages."
-      <> m
-    )
-
-parseTraceMux :: MParser Bool
-parseTraceMux m =
-    switch (
-         long "trace-mux"
-      <> help "Trace Mux Events"
-      <> m
     )
 
 -- Optional flag for live view (with TUI graphics).

--- a/cardano-node/src/Cardano/CLI/Tx/BenchmarkingTxSubmission.hs
+++ b/cardano-node/src/Cardano/CLI/Tx/BenchmarkingTxSubmission.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
 module Cardano.CLI.Tx.BenchmarkingTxSubmission
   ( ROEnv(..)
   , RPCTxSubmission(..)

--- a/cardano-node/src/Cardano/CLI/Tx/Generation.hs
+++ b/cardano-node/src/Cardano/CLI/Tx/Generation.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+{-# OPTIONS_GHC -Wno-missed-specialisations #-}
+
 module Cardano.CLI.Tx.Generation
   ( NumberOfTxs(..)
   , NumberOfOutputsPerTx(..)

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -9,19 +9,25 @@ module Cardano.Common.Parsers
   , parseProtocolActual
   , parseProtocolAsCommand
   , parseTopologyInfo
+  , parseTraceOptions
   ) where
 
 
-import           Prelude (String)
+import           Prelude (String, error)
 
 import           Cardano.Prelude hiding (option)
 
 import           Options.Applicative
+import qualified Options.Applicative as Opt
 
+import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import           Cardano.Config.Logging (LoggingCLIArguments(..))
 import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
+import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
 import qualified Cardano.BM.Data.Severity as Log
+import           Cardano.Config.Logging
 import           Cardano.Common.Protocol
 import           Cardano.Node.Configuration.Topology
 
@@ -100,23 +106,280 @@ parseTopologyFile =
          <> help "The path to a file describing the topology."
     )
 
--- | The parser for the logging specific arguments.
+-- | A parser that requires either:
+--   --tracing-off, or
+--   --log-config FILEPATH
+--   The idea is that we either supply tracing configuration,
+--   or explicitly disable tracing -- no shaky middle ground.
 loggingParser :: Parser LoggingCLIArguments
-loggingParser = LoggingCLIArguments
-    <$> strOption
-        ( long "log-config"
-       <> metavar "LOGCONFIG"
-       <> help "Configuration file for logging"
-       <> completer (bashCompleter "file")
-        )
-    <*> option auto
-        ( long "log-min-severity"
-       <> metavar "SEVERITY"
-       <> help "Limit logging to items with severity at least this severity"
-       <> value Log.Info
-       <> showDefault
-        )
-    <*> switch
-        ( long "log-metrics"
-       <> help "Log a number of metrics about this node"
-        )
+loggingParser = decide
+  <$> ((Left <$>
+        switch
+        ( long "tracing-off"
+          <> help "Tracing globally turned off."))
+       <|>
+       (Right <$>
+        parseLoggingCLIArgumentsInternal))
+  where
+    decide :: Either Bool LoggingCLIArguments -> LoggingCLIArguments
+    -- This branch should never trigger, because:
+    -- 1. 'switch' can only parse to 'False', if the flag is not supplied,
+    -- 2. if the flag is not supplied, we'll never get a Left, because
+    --    that parser's branch wouldn't be triggered -- instead,
+    --    the '<|>' operator above  would make 'optparse-applicative' insist
+    --    on having a 'Right'.
+    decide (Left False) = error "If this happens, report a bug in 'optparse-applicative'."
+    decide (Left True) = muteLoggingCLIArguments
+    decide (Right lca) = lca
+
+    -- This one isn't exposed, because we want to preserve the invariant,
+    -- that --tracing-off makes other options unavailable.
+    parseLoggingCLIArgumentsInternal :: Parser LoggingCLIArguments
+    parseLoggingCLIArgumentsInternal =
+      LoggingCLIArguments
+        <$> (Just
+             <$> strOption
+              ( long "log-config"
+                <> metavar "LOGCONFIG"
+                <> help "Configuration file for logging"
+                <> completer (bashCompleter "file")))
+        <*> option auto
+         ( long "log-min-severity"
+           <> metavar "SEVERITY"
+           <> help "Limit logging to items with severity at least this severity"
+           <> value Log.Info
+           <> showDefault)
+        <*> switch
+         ( long "log-metrics"
+           <> help "Log a number of metrics about this node")
+
+    -- This is the value returned by the parser, when --tracing-off is supplied.
+    muteLoggingCLIArguments :: LoggingCLIArguments
+    muteLoggingCLIArguments =
+      LoggingCLIArguments
+      Nothing
+      Log.Emergency
+      False
+
+-- | The parser for the logging specific arguments.
+parseTraceOptions :: MParser TraceOptions
+parseTraceOptions m = TraceOptions
+  <$> parseTracingVerbosity m
+  <*> parseTraceChainDB m
+  <*> parseConsensusTraceOptions m
+  <*> parseProtocolTraceOptions m
+  <*> parseTraceIpSubscription m
+  <*> parseTraceDnsSubscription m
+  <*> parseTraceDnsResolver m
+  <*> parseTraceMux m
+
+parseTraceBlockFetchClient :: MParser Bool
+parseTraceBlockFetchClient m =
+    switch (
+         long "trace-block-fetch-client"
+      <> help "Trace BlockFetch client."
+      <> m
+    )
+
+parseTraceBlockFetchServer :: MParser Bool
+parseTraceBlockFetchServer m =
+    switch (
+         long "trace-block-fetch-server"
+      <> help "Trace BlockFetch server."
+      <> m
+    )
+
+parseTracingVerbosity :: MParser TracingVerbosity
+parseTracingVerbosity m = asum [
+  flag' MinimalVerbosity (
+      long "tracing-verbosity-minimal"
+        <> help "Minimal level of the rendering of captured items"
+        <> m)
+    <|>
+  flag' MaximalVerbosity ( 
+      long "tracing-verbosity-maximal"
+        <> help "Maximal level of the rendering of captured items"
+        <> m)
+    <|>
+  flag NormalVerbosity NormalVerbosity (
+      long "tracing-verbosity-normal"
+        <> help "the default level of the rendering of captured items"
+        <> m)
+  ]
+
+parseTraceChainDB :: MParser Bool
+parseTraceChainDB m =
+    switch (
+         long "trace-chain-db"
+      <> help "Verbose tracer of ChainDB."
+      <> m
+    )
+
+parseConsensusTraceOptions :: (forall a b. Opt.Mod a b) -> Parser ConsensusTraceOptions
+parseConsensusTraceOptions m = Consensus.Tracers
+  <$> (Const <$> parseTraceChainSyncClient m)
+  <*> (Const <$> parseTraceChainSyncHeaderServer m)
+  <*> (Const <$> parseTraceChainSyncBlockServer m)
+  <*> (Const <$> parseTraceBlockFetchDecisions m)
+  <*> (Const <$> parseTraceBlockFetchClient m)
+  <*> (Const <$> parseTraceBlockFetchServer m)
+  <*> (Const <$> parseTraceTxInbound m)
+  <*> (Const <$> parseTraceTxOutbound m)
+  <*> (Const <$> parseTraceLocalTxSubmissionServer m)
+  <*> (Const <$> parseTraceMempool m)
+  <*> (Const <$> parseTraceForge m)
+
+type MParser a = (forall b c. Opt.Mod b c) -> Parser a
+
+parseTraceBlockFetchDecisions :: MParser Bool
+parseTraceBlockFetchDecisions m =
+    switch (
+         long "trace-block-fetch-decisions"
+      <> help "Trace BlockFetch decisions made by the BlockFetch client."
+      <> m
+    )
+
+parseTraceChainSyncClient :: MParser Bool
+parseTraceChainSyncClient m =
+    switch (
+         long "trace-chain-sync-client"
+      <> help "Trace ChainSync client."
+      <> m
+    )
+
+parseTraceChainSyncBlockServer :: MParser Bool
+parseTraceChainSyncBlockServer m =
+    switch (
+         long "trace-chain-sync-block-server"
+      <> help "Trace ChainSync server (blocks)."
+      <> m
+    )
+
+parseTraceChainSyncHeaderServer :: MParser Bool
+parseTraceChainSyncHeaderServer m =
+    switch (
+         long "trace-chain-sync-header-server"
+      <> help "Trace ChainSync server (headers)."
+      <> m
+    )
+
+parseTraceTxInbound :: MParser Bool
+parseTraceTxInbound m =
+    switch (
+         long "trace-tx-inbound"
+      <> help "Trace TxSubmission server (inbound transactions)."
+      <> m
+    )
+
+parseTraceTxOutbound :: MParser Bool
+parseTraceTxOutbound m =
+    switch (
+         long "trace-tx-outbound"
+      <> help "Trace TxSubmission client (outbound transactions)."
+      <> m
+    )
+
+parseTraceLocalTxSubmissionServer :: MParser Bool
+parseTraceLocalTxSubmissionServer m =
+    switch (
+         long "trace-local-tx-submission-server"
+      <> help "Trace local TxSubmission server."
+      <> m
+    )
+
+parseTraceMempool :: MParser Bool
+parseTraceMempool m =
+    switch (
+         long "trace-mempool"
+      <> help "Trace mempool."
+      <> m
+    )
+
+parseTraceForge :: MParser Bool
+parseTraceForge m =
+    switch (
+         long "trace-forge"
+      <> help "Trace block forging."
+      <> m
+    )
+
+parseTraceChainSyncProtocol :: MParser Bool
+parseTraceChainSyncProtocol m =
+    switch (
+         long "trace-chain-sync-protocol"
+      <> help "Trace ChainSync protocol messages."
+      <> m
+    )
+
+parseTraceBlockFetchProtocol :: MParser Bool
+parseTraceBlockFetchProtocol m =
+    switch (
+         long "trace-block-fetch-protocol"
+      <> help "Trace BlockFetch protocol messages."
+      <> m
+    )
+
+parseTraceTxSubmissionProtocol :: MParser Bool
+parseTraceTxSubmissionProtocol m =
+    switch (
+         long "trace-tx-submission-protocol"
+      <> help "Trace TxSubmission protocol messages."
+      <> m
+    )
+
+parseTraceLocalChainSyncProtocol :: MParser Bool
+parseTraceLocalChainSyncProtocol m =
+    switch (
+         long "trace-local-chain-sync-protocol"
+      <> help "Trace local ChainSync protocol messages."
+      <> m
+    )
+
+parseTraceLocalTxSubmissionProtocol :: MParser Bool
+parseTraceLocalTxSubmissionProtocol m =
+    switch (
+         long "trace-local-tx-submission-protocol"
+      <> help "Trace local TxSubmission protocol messages."
+      <> m
+    )
+
+
+parseProtocolTraceOptions :: MParser ProtocolTraceOptions
+parseProtocolTraceOptions m = ProtocolTracers
+  <$> (Const <$> parseTraceChainSyncProtocol m)
+  <*> (Const <$> parseTraceBlockFetchProtocol m)
+  <*> (Const <$> parseTraceTxSubmissionProtocol m)
+  <*> (Const <$> parseTraceLocalChainSyncProtocol m)
+  <*> (Const <$> parseTraceLocalTxSubmissionProtocol m)
+
+parseTraceIpSubscription :: MParser Bool
+parseTraceIpSubscription m =
+    switch (
+         long "trace-ip-subscription"
+      <> help "Trace IP Subscription messages."
+      <> m
+    )
+
+parseTraceDnsSubscription :: MParser Bool
+parseTraceDnsSubscription m =
+    switch (
+         long "trace-dns-subscription"
+      <> help "Trace DNS Subscription messages."
+      <> m
+    )
+
+parseTraceDnsResolver :: MParser Bool
+parseTraceDnsResolver m =
+    switch (
+         long "trace-dns-resolver"
+      <> help "Trace DNS Resolver messages."
+      <> m
+    )
+
+parseTraceMux :: MParser Bool
+parseTraceMux m =
+    switch (
+         long "trace-mux"
+      <> help "Trace Mux Events"
+      <> m
+    )

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -13,7 +13,7 @@ import           Cardano.Config.Types (CardanoConfiguration (..),
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
-import           Cardano.Tracing.Tracers (TraceOptions(..))
+import           Cardano.Tracing.Tracers
 
 
 -------------------------------------------------------------------------------
@@ -61,6 +61,14 @@ createNodeFeature loggingLayer nodeCLI traceOptions cardanoEnvironment cardanoCo
 
     pure (nodeLayer, cardanoFeature)
   where
-    createNodeLayer :: CardanoEnvironment -> LoggingLayer -> CardanoConfiguration -> NodeArgs -> TraceOptions -> IO NodeLayer
-    createNodeLayer _ logLayer cc nodeArgs traceCLI = do
-        pure $ NodeLayer {nlRunNode = liftIO $ runNode nodeArgs logLayer traceCLI cc}
+    createNodeLayer
+      :: CardanoEnvironment
+      -> LoggingLayer
+      -> CardanoConfiguration
+      -> NodeArgs
+      -> TraceOptions
+      -> IO NodeLayer
+    createNodeLayer _ logLayer cc nodeArgs traceOpts = do
+        pure $ NodeLayer
+          { nlRunNode = liftIO $ runNode nodeArgs logLayer traceOpts cc
+          }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -102,9 +102,9 @@ runNode (NodeArgs topology myNodeAddress protocol viewMode) loggingLayer traceOp
                              MinimalVerbosity -> "minimal"
                              MaximalVerbosity -> "maximal"
     SomeProtocol p  <- fromProtocol cc protocol
-    let tracers     = if tracingGlobalOff traceOptions
-                        then nullTracers
-                        else mkTracers traceOptions trace'
+
+    let tracers     = mkTracers traceOptions trace'
+
     case viewMode of
       SimpleView -> handleSimpleNode p myNodeAddress topology trace' tracers cc
       LiveView   -> do

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -60,8 +60,8 @@ import           Ouroboros.Network.Subscription
 
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 
+import           Cardano.Config.Logging
 import           Cardano.Tracing.ToObjectOrphans
-
 
 data Tracers peer blk = Tracers {
       -- | Trace the ChainDB (flag '--trace-chain-db' will turn on textual output)
@@ -104,25 +104,6 @@ type TraceConstraints blk =
   , Show blk
   , Show (Header blk)
   )
-
--- | Tracing options. Each option enables a tracer which adds verbosity to the
--- log output.
-data TraceOptions = TraceOptions
-  { tracingGlobalOff     :: !Bool
-  , traceVerbosity       :: !TracingVerbosity
-  , traceChainDB         :: !Bool
-    -- ^ By default we use 'readableChainDB' tracer, if on this it will use
-    -- more verbose tracer
-  , traceConsensus       :: ConsensusTraceOptions
-  , traceProtocols       :: ProtocolTraceOptions
-  , traceIpSubscription  :: !Bool
-  , traceDnsSubscription :: !Bool
-  , traceDnsResolver     :: !Bool
-  , traceMux             :: !Bool
-  }
-
-type ConsensusTraceOptions = Consensus.Tracers' () ()    () (Const Bool)
-type ProtocolTraceOptions  = ProtocolTracers'   () () ()    (Const Bool)
 
 nullTracers :: Tracers peer blk
 nullTracers = Tracers {

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -76,6 +76,9 @@ options:
     cardano.node.metrics:
       - kind: UserDefinedBK
         name: LiveViewBackend
-    cardano.node.CoreId 0.mempool:
+    'cardano.node.CoreId 0.mempool':
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    'cardano.node.CoreId 0.slotNum.ChainDB':
       - kind: UserDefinedBK
         name: LiveViewBackend

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -76,6 +76,10 @@ options:
     cardano.node.metrics:
       - kind: UserDefinedBK
         name: LiveViewBackend
-    cardano.node.CoreId 1.mempool:
+    'cardano.node.CoreId 1.mempool':
       - kind: UserDefinedBK
         name: LiveViewBackend
+    'cardano.node.CoreId 1.slotNum.ChainDB':
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -81,6 +81,10 @@ options:
     cardano.node.metrics:
       - kind: UserDefinedBK
         name: LiveViewBackend
-    cardano.node.CoreId 2.mempool:
+    'cardano.node.CoreId 2.mempool':
       - kind: UserDefinedBK
         name: LiveViewBackend
+    'cardano.node.CoreId 2.slotNum.ChainDB':
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -9,7 +9,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-run -v0 exe:cardano-cli -- --real-pbft --log-config configuration/log-configuration.yaml print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run -v0 exe:cardano-cli -- --real-pbft --tracing-off print-genesis-hash --genesis-json ${genesis_file})"
 
 CMD=`find dist-newstyle/ -type f -name "cardano-node"`
 test -n "${CMD}" || {

--- a/scripts/get-default-key-address.sh
+++ b/scripts/get-default-key-address.sh
@@ -16,7 +16,7 @@ Print the default, non-HD address of a signing key.
 EOF
 }
 ${RUNNER} cardano-cli \
-          --log-config configuration/log-configuration.yaml \
+          --tracing-off \
           --real-pbft \
           signing-key-address \
           --testnet-magic ${proto_magic} \

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --log-config configuration/log-configuration.yaml --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
 from_key="${genesis_root}/delegate-keys.000.key"
 default_to_key="${genesis_root}/delegate-keys.001.key"
@@ -28,12 +28,15 @@ Usage:  $(basename $0) TX-FILE TO-ADDR LOVELACE
 EOF
             exit 1;; esac
 
-args=" --genesis-file        ${genesis_file}
+args=" --tracing-off
+       --real-pbft
+       --genesis-file        ${genesis_file}
        --genesis-hash        ${genesis_hash}
+       issue-genesis-utxo-expenditure
        --tx                  ${tx}
        --wallet-key          ${from_key}
        --rich-addr-from    \"${from_addr}\"
        --txout            (\"${addr}\",${lovelace})
 "
 set -x
-${RUNNER} cardano-cli --log-config configuration/log-configuration.yaml --real-pbft issue-genesis-utxo-expenditure ${args}
+${RUNNER} cardano-cli ${args}

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --log-config configuration/log-configuration.yaml --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 default_from_key="${genesis_root}/delegate-keys.001.key"
 default_to_key="${genesis_root}/delegate-keys.002.key"
 
@@ -34,12 +34,15 @@ EOF
 
 addr=$(scripts/get-default-key-address.sh ${to_key})
 
-args=" --genesis-file        ${genesis_file}
+args=" --tracing-off
+       --real-pbft
+       --genesis-file        ${genesis_file}
        --genesis-hash        ${genesis_hash}
+       issue-utxo-expenditure
        --tx                  ${tx}
        --wallet-key          ${from_key}
        --txin             (\"${txid}\",${outindex})
        --txout            (\"${addr}\",${lovelace})
 "
 set -x
-${RUNNER} cardano-cli --real-pbft --log-config configuration/log-configuration.yaml issue-utxo-expenditure ${args}
+${RUNNER} cardano-cli ${args}

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -1,0 +1,44 @@
+set -x
+genesis="33873"
+genesis_root="configuration/${genesis}"
+genesis_file="${genesis_root}/genesis.json"
+if test ! -f "${genesis_file}"
+then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
+genesis_hash="$(cabal new-run -v0 -- cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+
+function logcfg () {
+        printf -- "--log-config configuration/log-config-${1}.yaml "
+}
+function dlgkey () {
+        printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key " "$1"
+}
+function dlgcert () {
+        printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json " "$1"
+}
+function commonargs() {
+        printf -- "--slot-duration 2 "
+}
+
+function acceptorargs() {
+        commonargs
+        logcfg acceptor
+        dlgkey 0
+        dlgcert 0
+}
+
+function nodeargs () {
+        local extra="$2"
+        commonargs
+        logcfg $1
+        dlgkey $1
+        dlgcert $1
+        printf -- "--node-id $1 "
+        printf -- "--port 300$1 "
+        printf -- "--genesis-file ${genesis_file} "
+        printf -- "--genesis-hash ${genesis_hash} "
+        printf -- "--pbft-signature-threshold 0.7 "
+        printf -- "--require-network-magic "
+        printf -- "--database-path db "
+        printf -- "--topology configuration/simple-topology.json "
+        printf -- "${extra} "
+}

--- a/scripts/shelley-testnet-dns.sh
+++ b/scripts/shelley-testnet-dns.sh
@@ -23,7 +23,7 @@
 
 ALGO="--real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
-NETARGS="--slot-duration 2 node -t configuration/simple-topology-dns.json ${ALGO}"
+NETARGS="--slot-duration 2 --topology configuration/simple-topology-dns.json ${ALGO}"
 #SCR="./scripts/start-node.sh"
 #CMD="stack exec --nix cardano-node --"
 CMD="cabal new-run exe:cardano-node --"

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -10,76 +10,56 @@ set -e
 # tmux new-session -s 'Demo' -t demo
 
 # then run this script
-RUNNER=${RUNNER:-cabal new-run -v0 --}
+# CMD="stack exec --nix --"
+CMD="cabal new-run --"
 
-genesis="33873"
-genesis_root="configuration/${genesis}"
-genesis_file="${genesis_root}/genesis.json"
-if test ! -f "${genesis_file}"
-then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
+. $(dirname $0)/lib-node.sh
 
-genesis_hash="$(${RUNNER} cardano-cli --log-config configuration/log-configuration.yaml --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
-
-ALGO="--real-pbft"
-# SCR="./scripts/start-node.sh"
-# CMD="stack exec --nix cardano-node --"
-CMD="cabal new-run exe:cardano-node --"
-
-# SPECIAL=""
-SPECIAL="--live-view"
 # VERBOSITY="--tracing-verbosity-minimal"
 # VERBOSITY="--tracing-verbosity-normal"
 VERBOSITY="--tracing-verbosity-maximal"
 HOST="127.0.0.1"
 HOST6="::1"
+ALGO="--real-pbft"
 
-function mklogcfg () {
-  echo "--log-config configuration/log-config-${1}.yaml"
-}
-function mkdlgkey () {
-  printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key" "$1"
-}
-function mkdlgcert () {
-  printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json" "$1"
-}
+# EXTRA=""
+EXTRA="
+  --live-view
+  --trace-block-fetch-decisions
+  --trace-block-fetch-client
+  --trace-block-fetch-server
+  --trace-tx-inbound
+  --trace-tx-outbound
+  --trace-local-tx-submission-server
+  --trace-mempool
+  --trace-forge
+  --trace-chain-sync-protocol
+  --trace-block-fetch-protocol
+  --trace-tx-submission-protocol
+  --trace-local-chain-sync-protocol
+  --trace-local-tx-submission-protocol
+"
 
-function mknetargs () {
-               printf -- "--slot-duration 2 "
-               printf -- "--genesis-file ${genesis_file} "
-               printf -- "--genesis-hash ${genesis_hash} "
-               printf -- "--pbft-signature-threshold 0.7 "
-               printf -- "--require-network-magic "
-               printf -- "--database-path db "
-               printf -- "--topology configuration/simple-topology.json "
-               printf -- "--trace-block-fetch-decisions "
-               printf -- "--trace-block-fetch-client "
-               printf -- "--trace-block-fetch-server "
-               printf -- "--trace-tx-inbound "
-               printf -- "--trace-tx-outbound "
-               printf -- "--trace-local-tx-submission-server "
-               printf -- "--trace-mempool "
-               printf -- "--trace-forge "
-               printf -- "--trace-chain-sync-protocol "
-               printf -- "--trace-block-fetch-protocol "
-               printf -- "--trace-tx-submission-protocol "
-               printf -- "--trace-local-chain-sync-protocol "
-               printf -- "--trace-local-tx-submission-protocol "
-               printf -- "${ALGO}"
-}
+. $(dirname $0)/lib-node.sh
 
 # for acceptor logs:
 mkdir -p logs/
 
 PWD=$(pwd)
 
+tmux split-window -v
+tmux select-pane -t 0
 tmux split-window -h
 tmux split-window -v
 tmux select-pane -t 0
 tmux split-window -v
 
+tmux select-pane -t 4
+tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
+sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 0) $(mkdlgkey 0) $(mkdlgcert 0) $(mknetargs) --node-id 0 --host-addr ${HOST6} --port 3000 ${VERBOSITY}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})") --host-addr ${HOST6}" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 1) $(mkdlgkey 1) $(mkdlgcert 1) $(mknetargs) --node-id 1 --host-addr ${HOST}  --port 3001 ${VERBOSITY}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})") --host-addr ${HOST} " C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 2) $(mkdlgkey 2) $(mkdlgcert 2) $(mknetargs) --node-id 2 --host-addr ${HOST6} --port 3002 ${VERBOSITY}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})") --host-addr ${HOST6}" C-m

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -8,49 +8,15 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-genesis="33873"
-genesis_root="configuration/${genesis}"
-genesis_file="${genesis_root}/genesis.json"
-if test ! -f "${genesis_file}"
-then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-
-cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-run -v0 -- cardano-cli --real-pbft --log-config configuration/log-configuration.yaml print-genesis-hash --genesis-json ${genesis_file})"
-
 ALGO="--real-pbft"
-ACCARGS=(
-        --slot-duration 2
-        trace-acceptor
-)
-# SCR="./scripts/start-node.sh"
 # CMD="stack exec --nix cardano-node --"
-CMD="cabal new-run exe:cardano-node --"
-# SPECIAL=""
-SPECIAL="--live-view"
+CMD="cabal new-run --"
 HOST="127.0.0.1"
 HOST6="::1"
+# EXTRA="--live-view"
+EXTRA=""
 
-function mklogcfg () {
-  echo "--log-config configuration/log-config-${1}.yaml"
-}
-function mkdlgkey () {
-  printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key" "$1"
-}
-function mkdlgcert () {
-  printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json" "$1"
-}
-
-function mknetargs () {
-               printf -- "--slot-duration 2 "
-               printf -- "--genesis-file ${genesis_file} "
-               printf -- "--genesis-hash ${genesis_hash} "
-               printf -- "--pbft-signature-threshold 0.7 "
-               printf -- "--require-network-magic "
-               printf -- "--database-path db "
-               printf -- "node "
-               printf -- "--topology configuration/simple-topology.json "
-               printf -- "${ALGO} "
-}
+. $(dirname $0)/lib-node.sh
 
 # for acceptor logs:
 mkdir -p logs/
@@ -65,11 +31,11 @@ tmux select-pane -t 0
 tmux split-window -v
 
 tmux select-pane -t 4
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg acceptor) $(mkdlgkey 0) $(mkdlgcert 0) ${ACCARGS[*]}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 0) $(mkdlgkey 0) $(mkdlgcert 0) $(mknetargs) -n 0 --host-addr ${HOST6} --port 3000 ${SPECIAL}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} ${EXTRA}") --host-addr ${HOST6}" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 1) $(mkdlgkey 1) $(mkdlgcert 1) $(mknetargs) -n 1 --host-addr ${HOST}  --port 3001 ${SPECIAL}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} ${EXTRA}") --host-addr ${HOST} " C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} $(mklogcfg 2) $(mkdlgkey 2) $(mkdlgcert 2) $(mknetargs) -n 2 --host-addr ${HOST6} --port 3002 ${SPECIAL}" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} ${EXTRA}") --host-addr ${HOST6}" C-m

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -17,15 +17,15 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${CMD} -v0 -- cardano-cli --log-config configuration/log-configuration.yaml --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${CMD} -v0 -- cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS=(
         --${ALGO}
-        submit-tx
         --genesis-file "${genesis_file}"
         --genesis-hash "${genesis_hash}"
+        submit-tx
         --topology     "configuration/simple-topology.json"
         --node-id      "0"
         --tx           "$TX"

--- a/scripts/trace-acceptor.sh
+++ b/scripts/trace-acceptor.sh
@@ -1,29 +1,10 @@
 #!/usr/bin/env bash
 
-NOW=`date "+%Y-%m-%d 00:00:00"`
-GENHASH="33873aeaf8a47fefc7c2ea3f72e98a04459e07ec3edfb63c9ca709f540f69503"
-
 # CMD="stack exec trace-acceptor-node -- "
 # CMD="./trace-acceptor.exe -- "
 CMD="cabal new-run exe:trace-acceptor -- "
 
-NETARGS=(
-        --slot-duration 2
-        --genesis-file "configuration/${GENHASH:0:5}/genesis.json"
-        --genesis-hash "${GENHASH}"
-)
-
-function mkdlgkey () {
-  printf -- "--signing-key configuration/${GENHASH:0:5}/delegate-keys.%03d.key" "$1"
-}
-function mkdlgcert () {
-  printf -- "--delegation-certificate configuration/${GENHASH:0:5}/delegation-cert.%03d.json" "$1"
-}
-
 set -x
 ${CMD} \
     --log-config configuration/log-config-acceptor.yaml \
-    $(mkdlgkey 0) \
-    $(mkdlgcert 0) \
-    ${NETARGS[*]} \
-           $@
+    $@


### PR DESCRIPTION
0. Restore the IPv6 topology in the testnet scripts
0. Refactor & update scripts to CLI changes (they break oh so often..)
0. `--tracing-off` and `--log-config` are now mutually exclusive -- one important implication is that `--log-config` is no longer a mandatory option.
0. All logging users now respect `--tracing-off` -- i.e. it is no longer specific to `cardano-node`
0. Some code shuffling for better locality

# Discussion

0. Perhaps, we might want a third option, that supplies some kind of non-disabled default for the tracing infrastructure. Maybe @CodiePP has some suggestions for how we can get this.