### PR TITLE
`cardano-cli`: drop `--tracing-off` & improve error printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 \#*
 \.#*
 *.swp
+.dir-locals.el
 result*
 launch-*
 .stack-to-nix.cache

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -55,7 +55,7 @@ main = do
     (runCommand ops finalConfig loggingLayer (mainCommand co) :: ExceptT CliError IO ())
   case cmdRes of
     Right _ -> pure ()
-    Left err -> do print $ renderCliError err
+    Left err -> do putStrLn $ renderCliError err
                    exitFailure
   where
     pref :: ParserPrefs

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -9,7 +9,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 cabal new-build "exe:cardano-cli"
-genesis_hash="$(cabal new-run -v0 exe:cardano-cli -- --real-pbft --tracing-off print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run -v0 exe:cardano-cli -- --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 CMD=`find dist-newstyle/ -type f -name "cardano-node"`
 test -n "${CMD}" || {

--- a/scripts/get-default-key-address.sh
+++ b/scripts/get-default-key-address.sh
@@ -16,7 +16,6 @@ Print the default, non-HD address of a signing key.
 EOF
 }
 ${RUNNER} cardano-cli \
-          --tracing-off \
           --real-pbft \
           signing-key-address \
           --testnet-magic ${proto_magic} \

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 from_addr="2cWKMJemoBahGYHvphuM3cmwhgWZmRzPSRX5xdx11A1aJ168wLgRpD7naamfWk4dfQ28c"
 from_key="${genesis_root}/delegate-keys.000.key"
 default_to_key="${genesis_root}/delegate-keys.001.key"
@@ -28,8 +28,7 @@ Usage:  $(basename $0) TX-FILE TO-ADDR LOVELACE
 EOF
             exit 1;; esac
 
-args=" --tracing-off
-       --real-pbft
+args=" --real-pbft
        --genesis-file        ${genesis_file}
        --genesis-hash        ${genesis_hash}
        issue-genesis-utxo-expenditure

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -7,7 +7,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${RUNNER} cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${RUNNER} cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 default_from_key="${genesis_root}/delegate-keys.001.key"
 default_to_key="${genesis_root}/delegate-keys.002.key"
 
@@ -34,8 +34,7 @@ EOF
 
 addr=$(scripts/get-default-key-address.sh ${to_key})
 
-args=" --tracing-off
-       --real-pbft
+args=" --real-pbft
        --genesis-file        ${genesis_file}
        --genesis-hash        ${genesis_hash}
        issue-utxo-expenditure

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -4,7 +4,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(cabal new-run -v0 -- cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(cabal new-run -v0 -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 function logcfg () {
         printf -- "--log-config configuration/log-config-${1}.yaml "

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -17,7 +17,7 @@ genesis_root="configuration/${genesis}"
 genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
-genesis_hash="$(${CMD} -v0 -- cardano-cli --tracing-off --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
+genesis_hash="$(${CMD} -v0 -- cardano-cli --real-pbft print-genesis-hash --genesis-json ${genesis_file})"
 
 ALGO="real-pbft"
 NOW=`date "+%Y-%m-%d 00:00:00"`


### PR DESCRIPTION
`cardano-cli`:

1. Drop `--tracing-off` -- it was implemented with a hard-to-fix bug.
2. Fix error printing -- it was over-quoting.