### PR TITLE
Tx generator: fix target node IP-address.

### DIFF
--- a/cardano-node/src/Cardano/CLI/Tx/Generation.hs
+++ b/cardano-node/src/Cardano/CLI/Tx/Generation.hs
@@ -646,7 +646,9 @@ runBenchmark benchTracer
   let localAddr :: Maybe Network.Socket.AddrInfo
       localAddr = Nothing
 
-  let targetNodeHost = show $ naHostAddress targetNodeAddress
+  let targetNodeHost = maybe (panic "Target node's IP-address is undefined!")
+                             show
+                             $ naHostAddress targetNodeAddress
       targetNodePort = show $ naPort targetNodeAddress
 
   let hints :: AddrInfo


### PR DESCRIPTION
Previously `naHostAddress` was `IP`, but now its `Maybe IP`, so we have to check it.