### PR TITLE
Reduce severity of slot number and implement `TraceChainSyncServerEvent`'s `ToObject` instance

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -183,7 +183,7 @@ mkTracers traceOptions tracer = Tracers
                                              logValue :: LOContent a
                                              logValue = LogValue "slotNum" . PureI $ sNum
                                          -- phash = fst tippair
-                                         meta <- mkLOMeta Critical Confidential
+                                         meta <- mkLOMeta Debug Confidential
                                          let tr' = appendName "slotNum" tr
                                          traceNamedObject tr' (meta, logValue)
                   _ -> pure ()


### PR DESCRIPTION
This PR changes the following

- Slot number was being reported as `Critical` severity and is now reduced to `Debug`
- Implements `TraceChainSyncServerEvent`'s `ToObject` instance #233 