### PR TITLE
Restore log config file `minSeverity` functionality

### DIFF
--- a/benchmarking/chain-sync_mainnet.sh
+++ b/benchmarking/chain-sync_mainnet.sh
@@ -12,7 +12,6 @@ exec ${NODE} \
   --genesis-file ${BASEDIR}/../configuration/mainnet-genesis.json \
   --genesis-hash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
   --log-config ${BASEDIR}/launch_mainnet.d/log-configuration.yaml \
-  --log-min-severity Notice \
   --log-metrics \
   --database-path .//db-mainnet \
   --socket-dir socket \

--- a/benchmarking/launch_mainnet.d/log-configuration.yaml
+++ b/benchmarking/launch_mainnet.d/log-configuration.yaml
@@ -1,5 +1,5 @@
 # global filter; messages must have at least this severity to pass:
-minSeverity: Debug
+minSeverity: Notice
 
 # global file rotation settings:
 rotation:
@@ -90,4 +90,3 @@ options:
     cardano.node.metrics:
       - kind: UserDefinedBK
         name: LiveViewBackend
-

--- a/benchmarking/trace-acceptor.sh
+++ b/benchmarking/trace-acceptor.sh
@@ -10,5 +10,4 @@ CMD="cabal new-run exe:trace-acceptor -- "
 set -x
 ${CMD} \
     --log-config ${BASEDIR}/launch_mainnet.d/log-config-acceptor.yaml \
-    --log-min-severity Debug \
            $@

--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -140,7 +140,6 @@ type LoggingCardanoFeature = CardanoFeatureInit
 -- | CLI specific data structure.
 data LoggingCLIArguments = LoggingCLIArguments
   { logConfigFile :: !(Maybe FilePath)
-  , minSeverity :: !Severity
   , captureMetrics :: !Bool
   }
 
@@ -163,7 +162,6 @@ loggingCLIConfiguration lca@LoggingCLIArguments{logConfigFile = Just fp} = do
     throwIO $ FileNotFoundException fp
 
   config <- Config.setup fp
-  Config.setMinSeverity config (minSeverity lca)
   pure (LoggingEnabled, LoggingConfiguration config (captureMetrics lca))
 
 createLoggingFeature

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
-import qualified Cardano.BM.Data.Severity as Log
 import           Cardano.Config.Logging
 import           Cardano.Common.Protocol
 import           Cardano.Node.Configuration.Topology
@@ -121,12 +120,6 @@ loggingParser =
                 <> metavar "LOGCONFIG"
                 <> help "Configuration file for logging"
                 <> completer (bashCompleter "file")))
-        <*> option auto
-         ( long "log-min-severity"
-           <> metavar "SEVERITY"
-           <> help "Limit logging to items with severity at least this severity"
-           <> value Log.Info
-           <> showDefault)
         <*> switch
          ( long "log-metrics"
            <> help "Log a number of metrics about this node")
@@ -136,7 +129,6 @@ loggingParser =
     muteLoggingCLIArguments =
       LoggingCLIArguments
       Nothing
-      Log.Emergency
       False
 
 -- | The parser for the logging specific arguments.
@@ -174,7 +166,7 @@ parseTracingVerbosity m = asum [
         <> help "Minimal level of the rendering of captured items"
         <> m)
     <|>
-  flag' MaximalVerbosity ( 
+  flag' MaximalVerbosity (
       long "tracing-verbosity-maximal"
         <> help "Maximal level of the rendering of captured items"
         <> m)

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -673,7 +673,7 @@ instance ToObject (TraceChainSyncServerEvent blk b) where
 
 instance Show peer => ToObject [TraceLabelPeer peer
                         (FetchDecision [Point header])] where
-  toObject MinimalVerbosity lbls = toObject NormalVerbosity lbls
+  toObject MinimalVerbosity _ = emptyObject
   toObject NormalVerbosity lbls = mkObject [ "kind" .= String "TraceLabelPeer"
                                            , "length" .= String (pack $ show $ length lbls) ]
   toObject MaximalVerbosity [] = emptyObject

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -76,4 +76,3 @@ options:
       - AggregationBK
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
-


### PR DESCRIPTION
Changing `minSeverity` in the log configuration `.yaml` file was being overridden by a command line parser. We should be aiming for one source of configuration truth i.e the log configuration `.yaml` file.