### PR TITLE
Recover Partial Options Monoid design pattern in `cardano-node.hs`

### DIFF
--- a/cardano-node/app/trace-acceptor.hs
+++ b/cardano-node/app/trace-acceptor.hs
@@ -32,7 +32,7 @@ main = do
 
   let cardanoApplication =
         CardanoApplication . liftIO $ runTraceAcceptor loggingLayer
-        
+
   runCardanoApplicationWithFeatures [loggingFeature] cardanoApplication
   where
     pcc :: PartialCardanoConfiguration
@@ -46,7 +46,7 @@ main = do
 
     opts :: Opt.ParserInfo (CommonCLI, CommonCLIAdvanced, LoggingCLIArguments)
     opts =
-      Opt.info (cliParser <**> Opt.helper)
+      Opt.info (nodeCliParser <**> Opt.helper)
         ( Opt.fullDesc
           <> Opt.header
           "trace-acceptor - utility to support a variety of key\
@@ -54,8 +54,8 @@ main = do
           \ pretty-printing..) for different system generations."
         )
 
-    cliParser :: Parser (CommonCLI, CommonCLIAdvanced, LoggingCLIArguments)
-    cliParser = (,,)
+    nodeCliParser :: Parser (CommonCLI, CommonCLIAdvanced, LoggingCLIArguments)
+    nodeCliParser = (,,)
       <$> parseCommonCLI
       <*> parseCommonCLIAdvanced
       <*> loggingParser

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -8,9 +8,11 @@ module Cardano.Node.Features.Node
 
 import           Cardano.Prelude
 
+import           Cardano.Common.Protocol (Protocol)
 import           Cardano.Config.Types (CardanoConfiguration (..),
                                        CardanoEnvironment (..))
 import           Cardano.Config.Logging (LoggingLayer (..),)
+import           Cardano.Node.Configuration.Topology (NodeAddress, TopologyInfo)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
 import           Cardano.Tracing.Tracers
@@ -31,12 +33,16 @@ data NodeLayer = NodeLayer
 
 createNodeFeature
   :: LoggingLayer
-  -> NodeArgs
+  -> TopologyInfo
+  -> NodeAddress
+  -> Protocol
+  -> ViewMode
   -> TraceOptions
   -> CardanoEnvironment
   -> CardanoConfiguration
   -> IO (NodeLayer, CardanoFeature)
-createNodeFeature loggingLayer nodeCLI traceOptions cardanoEnvironment cardanoConfiguration = do
+createNodeFeature loggingLayer topInfo nAddr protocol vMode traceOptions
+                  cardanoEnvironment cardanoConfiguration = do
     -- we parse any additional configuration if there is any
     -- We don't know where the user wants to fetch the additional
     -- configuration from, it could be from the filesystem, so
@@ -47,7 +53,10 @@ createNodeFeature loggingLayer nodeCLI traceOptions cardanoEnvironment cardanoCo
                    cardanoEnvironment
                    loggingLayer
                    cardanoConfiguration
-                   nodeCLI
+                   topInfo
+                   nAddr
+                   protocol
+                   vMode
                    traceOptions
 
     -- Construct the cardano feature
@@ -65,10 +74,14 @@ createNodeFeature loggingLayer nodeCLI traceOptions cardanoEnvironment cardanoCo
       :: CardanoEnvironment
       -> LoggingLayer
       -> CardanoConfiguration
-      -> NodeArgs
+      -> TopologyInfo
+      -> NodeAddress
+      -> Protocol
+      -> ViewMode
       -> TraceOptions
       -> IO NodeLayer
-    createNodeLayer _ logLayer cc nodeArgs traceOpts = do
+    createNodeLayer _ logLayer cc topologyInfo nodeAddr ptcl viewMode traceOpts = do
         pure $ NodeLayer
-          { nlRunNode = liftIO $ runNode nodeArgs logLayer traceOpts cc
+          { nlRunNode = liftIO $ runNode topologyInfo nodeAddr ptcl
+                                         viewMode logLayer traceOpts cc
           }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -16,7 +16,6 @@
 
 module Cardano.Node.Run
   ( runNode
-  , NodeArgs(..)
   , ViewMode(..)
   )
 where
@@ -87,15 +86,22 @@ instance NoUnexpectedThunks Peer where
     showTypeOf _ = "Peer"
     whnfNoUnexpectedThunks _ctxt _act = return NoUnexpectedThunks
 
-data NodeArgs = NodeArgs !TopologyInfo !NodeAddress !Protocol !ViewMode
 
 -- Node can be run in two modes.
 data ViewMode =
     LiveView    -- Live mode with TUI
   | SimpleView  -- Simple mode, just output text.
 
-runNode :: NodeArgs -> LoggingLayer -> TraceOptions -> CardanoConfiguration -> IO ()
-runNode (NodeArgs topology myNodeAddress protocol viewMode) loggingLayer traceOptions cc = do
+runNode
+  :: TopologyInfo
+  -> NodeAddress
+  -> Protocol
+  -> ViewMode
+  -> LoggingLayer
+  -> TraceOptions
+  -> CardanoConfiguration
+  -> IO ()
+runNode topology myNodeAddress protocol viewMode loggingLayer traceOptions cc = do
     let !tr = llAppendName loggingLayer "node" (llBasicTrace loggingLayer)
     let trace'      = appendName (pack $ show $ node topology) tr
     let tracer      = contramap pack $ toLogObject trace'


### PR DESCRIPTION
We have deviated from the Partial Options Monoid pattern as described here: https://medium.com/@jonathangfischoff/the-partial-options-monoid-pattern-31914a71fc67

This PR gets us closer to the original design pattern in `cardano-node.hs` only. If approved future PRs will target the rest of the `cardano-node` repo.