### PR TITLE
Remove `CLIOps` datatype

### DIFF
--- a/cardano-node/src/Cardano/CLI/Genesis.hs
+++ b/cardano-node/src/Cardano/CLI/Genesis.hs
@@ -141,8 +141,8 @@ dumpGenesis ptcl (NewDirectory outDir) genesisData gs = do
 
   dlgCerts <- mapM findDelegateCert $ gsRichSecrets gs
 
-  liftIO $ wOut "genesis-keys" "key" (pure . serialiseSigningKey' ptcl) (gsDlgIssuersSecrets gs)
-  liftIO $ wOut "delegate-keys" "key" (serialiseDelegateKey ptcl) (gsRichSecrets gs)
+  liftIO $ wOut "genesis-keys" "key" (pure . serialiseSigningKey ptcl) (gsDlgIssuersSecrets gs)
+  liftIO $ wOut "delegate-keys" "key" (pure . serialiseDelegateKey ptcl) (gsRichSecrets gs)
   liftIO $ wOut "poor-keys" "key" (pure . serialisePoorKey ptcl) (gsPoorSecrets gs)
   liftIO $ wOut "delegation-cert" "json" (pure . serialiseDelegationCert ptcl) dlgCerts
   liftIO $ wOut "avvm-seed" "seed" (pure . (Right <$> LB.fromStrict)) (gsFakeAvvmSeeds gs)

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -163,12 +163,12 @@ data ClientCommand
     [SigningKeyFile]
 
 runCommand :: CLIOps IO -> CardanoConfiguration -> LoggingLayer -> ClientCommand -> ExceptT CliError IO ()
-runCommand co _ _ (Genesis outDir params) = do
+runCommand _ cc _ (Genesis outDir params) = do
   gen <- mkGenesis params
-  dumpGenesis co outDir `uncurry` gen
+  dumpGenesis (ccProtocol cc) outDir `uncurry` gen
 
-runCommand co _ _ (DumpHardcodedGenesis dir) =
-  dumpGenesis co dir (Genesis.configGenesisData Dummy.dummyConfig) Dummy.dummyGeneratedSecrets
+runCommand _ cc _ (DumpHardcodedGenesis dir) =
+  dumpGenesis (ccProtocol cc) dir (Genesis.configGenesisData Dummy.dummyConfig) Dummy.dummyGeneratedSecrets
 
 runCommand co _ _ (PrettySigningKeyPublic skF) = do
   sK <- readSigningKey co skF

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -42,7 +42,7 @@ import           Cardano.Prelude hiding (option, trace)
 
 import           Codec.Serialise (serialise)
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (hoistEither, newExceptT)
+import           Control.Monad.Trans.Except.Extra (hoistEither)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Semigroup ((<>))
 import qualified Data.Text as T
@@ -177,7 +177,7 @@ runCommand cc _ (PrettySigningKeyPublic skF) = do
 
 runCommand cc _ (MigrateDelegateKeyFrom _ (NewSigningKeyFile newKey) oldKey) = do
   sk <- readSigningKey (ccProtocol cc) oldKey
-  sDk <- newExceptT $ serialiseDelegateKey (ccProtocol cc) sk
+  sDk <- hoistEither $ serialiseDelegateKey (ccProtocol cc) sk
   liftIO $ ensureNewFileLBS newKey sDk
 
 runCommand _ _ (PrintGenesisHash genFp) = do
@@ -196,7 +196,7 @@ runCommand cc _ (PrintSigningKeyAddress netMagic skF) = do
 runCommand cc _ (Keygen (NewSigningKeyFile skF) passReq) = do
   pPhrase <- liftIO $ getPassphrase ("Enter password to encrypt '" <> skF <> "': ") passReq
   sK <- liftIO $ keygen pPhrase
-  serDk <- newExceptT $ serialiseDelegateKey (ccProtocol cc) sK
+  serDk <- hoistEither $ serialiseDelegateKey (ccProtocol cc) sK
   liftIO $ ensureNewFileLBS skF serDk
 
 runCommand cc _ (ToVerification skFp (NewVerificationKeyFile vkFp)) = do

--- a/cardano-node/src/Cardano/CLI/Tx.hs
+++ b/cardano-node/src/Cardano/CLI/Tx.hs
@@ -133,17 +133,16 @@ genesisUTxOTxIn gc vk genAddr =
 -- | Perform an action that expects ProtocolInfo for Byron/PBFT,
 --   with attendant configuration.
 withRealPBFT
-  :: CLIOps IO
-  -> CardanoConfiguration
+  :: CardanoConfiguration
   -> (Demo.RunDemo (ByronBlockOrEBB ByronConfig)
       => Consensus.Protocol (ByronBlockOrEBB ByronConfig)
       -> IO a)
   -> IO a
-withRealPBFT co cc action = do
-  SomeProtocol p <- fromProtocol cc (coProtocol co)
+withRealPBFT cc action = do
+  SomeProtocol p <- fromProtocol cc (ccProtocol cc)
   case p of
     proto@Consensus.ProtocolRealPBFT{} -> action proto
-    _ -> throwIO $ ProtocolNotSupported (coProtocol co)
+    _ -> throwIO $ ProtocolNotSupported (ccProtocol cc)
 
 -- | Generate a transaction spending genesis UTxO at a given address,
 --   to given outputs, signed by the given key.
@@ -169,14 +168,13 @@ txSpendGenesisUTxOByronPBFT gc sk genAddr outs =
 -- | Generate a transaction spending genesis UTxO at a given address,
 --   to given outputs, signed by the given key.
 issueGenesisUTxOExpenditure
-  :: CLIOps IO
-  -> Address
+  :: Address
   -> NonEmpty TxOut
   -> CardanoConfiguration
   -> Crypto.SigningKey
   -> IO (GenTx (ByronBlockOrEBB ByronConfig))
-issueGenesisUTxOExpenditure co genRichAddr outs cc sk = do
-  withRealPBFT co cc $
+issueGenesisUTxOExpenditure genRichAddr outs cc sk = do
+  withRealPBFT cc $
     \(Consensus.ProtocolRealPBFT gc _ _ _ _)-> do
       let tx = txSpendGenesisUTxOByronPBFT gc sk genRichAddr outs
       putStrLn $ "genesis protocol magic:  " <> show (configProtocolMagicId gc)
@@ -204,14 +202,13 @@ txSpendUTxOByronPBFT gc sk ins outs =
 -- | Generate a transaction from given Tx inputs to outputs,
 --   signed by the given key.
 issueUTxOExpenditure
-  :: CLIOps IO
-  -> NonEmpty TxIn
+  :: NonEmpty TxIn
   -> NonEmpty TxOut
   -> CardanoConfiguration
   -> Crypto.SigningKey
   -> IO (GenTx (ByronBlockOrEBB ByronConfig))
-issueUTxOExpenditure co ins outs cc key = do
-  withRealPBFT co cc $
+issueUTxOExpenditure ins outs cc key = do
+  withRealPBFT cc $
     \(Consensus.ProtocolRealPBFT gc _ _ _ _)-> do
       let tx = txSpendUTxOByronPBFT gc key ins outs
       putStrLn $ "genesis protocol magic:  " <> show (configProtocolMagicId gc)
@@ -220,13 +217,12 @@ issueUTxOExpenditure co ins outs cc key = do
 
 -- | Submit a transaction to a node specified by topology info.
 nodeSubmitTx
-  :: CLIOps IO
-  -> TopologyInfo
+  :: TopologyInfo
   -> CardanoConfiguration
   -> GenTx (ByronBlockOrEBB ByronConfig)
   -> IO ()
-nodeSubmitTx co topology cc tx =
-  withRealPBFT co cc $
+nodeSubmitTx topology cc tx =
+  withRealPBFT cc $
     \p@Consensus.ProtocolRealPBFT{} -> do
       putStrLn $ "transaction hash (TxId): " <> show (txId tx)
       handleTxSubmission cc p topology tx stdoutTracer


### PR DESCRIPTION
Having several modular pure functions is preferable to the larger "swiss army knife" style `CLIOps m`.