### PR TITLE
add node id as hostname in federated logging

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -104,43 +104,43 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/scribe-systemd
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-aggregation
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-editor
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-ekg
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-monitoring
-  tag: bea0e079fc32ed316ce352d17d14199a680e3f6c
+  tag: a71addb2c45a8e116c2a57385b67812d51352a7a
 
 -- dependencies of iohk-monitoring
 source-repository-package

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -67,6 +67,7 @@ library
                      , file-embed
                      , filepath
                      , formatting
+                     , hostname
                      , io-sim-classes
                      , iohk-monitoring
                      , iproute

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -20,8 +20,7 @@ module Cardano.Node.Run
   )
 where
 
-import           Cardano.Prelude hiding (ByteString, atomically, throwIO, trace,
-                                  wait)
+import           Cardano.Prelude hiding (ByteString, atomically, trace)
 import           Prelude (error, id, unlines)
 
 import qualified Control.Concurrent.Async as Async
@@ -43,7 +42,7 @@ import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.BackendKind (BackendKind (TraceForwarderBK))
 import           Cardano.BM.Data.LogItem (LogObject (..))
 import           Cardano.BM.Data.Tracer (ToLogObject (..),
-                                         TracingVerbosity (..))
+                     TracingVerbosity (..), setHostname)
 import           Cardano.Config.Logging (LoggingLayer (..))
 import           Cardano.Config.Types (CardanoConfiguration (..), ViewMode (..))
 
@@ -51,8 +50,8 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Subscription.Dns
 
 import           Ouroboros.Consensus.Node (NodeKernel (getChainDB),
-                                           RunNetworkArgs (..),
-                                           RunNode (nodeNetworkMagic, nodeStartTime))
+                     RunNetworkArgs (..),
+                     RunNode (nodeNetworkMagic, nodeStartTime))
 import qualified Ouroboros.Consensus.Node as Node (run)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -91,8 +90,9 @@ runNode
   -> CardanoConfiguration
   -> IO ()
 runNode loggingLayer cc = do
-    let !trace = llAppendName loggingLayer "node" (llBasicTrace loggingLayer)
-    let tracer      = contramap pack $ toLogObject trace
+    let !trace = setHostname (pack $ show $ node $ ccTopologyInfo cc) $
+                 llAppendName loggingLayer "node" (llBasicTrace loggingLayer)
+    let tracer = contramap pack $ toLogObject trace
 
     traceWith tracer $ "tracing verbosity = " ++
                          case traceVerbosity $ ccTraceOptions cc of

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -41,6 +41,7 @@
           (hsPkgs.file-embed)
           (hsPkgs.filepath)
           (hsPkgs.formatting)
+          (hsPkgs.hostname)
           (hsPkgs.io-sim-classes)
           (hsPkgs.iohk-monitoring)
           (hsPkgs.iproute)

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -93,8 +93,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -37,8 +37,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-editor.nix
+++ b/nix/.stack.nix/lobemo-backend-editor.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/plugins/backend-editor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -37,8 +37,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -72,8 +72,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-scribe-systemd.nix
+++ b/nix/.stack.nix/lobemo-scribe-systemd.nix
@@ -36,8 +36,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bea0e079fc32ed316ce352d17d14199a680e3f6c";
-      sha256 = "1hcshwmfsm34l1j65xcrk5ab6qh93yihf7163n85wva5z71l1rgj";
+      rev = "a71addb2c45a8e116c2a57385b67812d51352a7a";
+      sha256 = "1a2ma0nkwb78pivc6s5xjnpsxdy569ql02psxns7r9p2g5xpfd9a";
       });
     postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -69,7 +69,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: bea0e079fc32ed316ce352d17d14199a680e3f6c
+    commit: a71addb2c45a8e116c2a57385b67812d51352a7a
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
the node id is removed from the context naming.
we can nevertheless indicate the source of the tracer with setting the hostname to the node id in federated logging.

- [x] depends on upstream PR https://github.com/input-output-hk/iohk-monitoring-framework/pull/448