### PR TITLE
Update version and changelog

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,3 +1,15 @@
 # Changelog for cardano-node
 
 ## Unreleased changes
+
+## cardano-node 1.0.0
+
+- Complete rewrite compared to previous cardano-sl series.
+
+- New modular design. The cardano-node is the top level for the node and
+  aggregates the other components from other packages: consensus, ledger and
+  networking, with configuration, CLI, logging and monitoring.
+
+- The node no longer incorporates wallet or explorer functionality. The wallet
+  backend and explorer backend are separate components that run in separate
+  external processes that communicate with the node via local IPC.

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-node
-version:               3.0.1.87
+version:               1.0.0
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -3,7 +3,7 @@
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-node"; version = "3.0.1.87"; };
+      identifier = { name = "cardano-node"; version = "1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";


### PR DESCRIPTION
~Bump version to 4.0.0.0, a major version bump since cardano-sl 3.x~

Set version to 1.0.0 because this is a new component, not a continuation of cardano-sl.