### PR TITLE
Update logging configuration

### DIFF
--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -11,8 +11,6 @@ rotation:
 setupBackends:
   - AggregationBK
   - KatipBK
-  # - EditorBK
-  # - EKGViewBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -71,11 +69,24 @@ options:
       subtrace: NoTrace
     '#messagecounters.switchboard':
       subtrace: NoTrace
+    '#messagecounters.katip':
+      subtrace: NoTrace
+    '#messagecounters.monitoring':
+      subtrace: NoTrace
   mapBackends:
-    cardano.epoch-validation.benchmark:
-      - AggregationBK
-    '#aggregation.cardano.epoch-validation.benchmark':
+    cardano.node.metrics.ChainDB:
       - EKGViewBK
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.metrics:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.BlockFetchDecision:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.peers.BlockFetchDecision:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
 
 ##########################################################
 ############### Cardano Node Configuration ###############

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -24,6 +24,7 @@ let
           "${lib.optionalString (cfg.pbftThreshold != null) "--pbft-signature-threshold ${cfg.pbftThreshold}"}"
           "${lib.optionalString (cfg.signingKey != null) "--signing-key ${cfg.signingKey}"}"
           "${lib.optionalString (cfg.delegationCertificate != null) "--delegation-certificate ${cfg.delegationCertificate}"}"
+          "${lib.optionalString (cfg.logger.extras != null) "${cfg.logger.extras}"}"
         ];
     in ''
         echo "Starting ${exec}: '' + concatStringsSep "\"\n   echo \"" cmd + ''"
@@ -188,6 +189,13 @@ in {
         default = ../../configuration/log-configuration.yaml;
         description = ''
           Logger configuration file
+        '';
+      };
+      logger.extras = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Logging extra arguments
         '';
       };
     };

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -27,6 +27,7 @@ let
       proxyPort = 7777;
       proxyHost = "127.0.0.1";
       loggingConfig = ../configuration/log-configuration.yaml;
+      loggingExtras = null;
     };
     config = defaultConfig // envConfig // customConfig;
     topologyFile = let
@@ -51,6 +52,7 @@ let
       runtimeDir = null;
       dbPrefix = "db-${envConfig.name}";
       logger.configFile = config.loggingConfig;
+      logger.extras = config.loggingExtras;
       topology = topologyFile;
     };
     nodeConf = { config.services.cardano-node = serviceConfig; };


### PR DESCRIPTION
the logging configuration does not output the captured metrics in the logs anymore.
and, the nix build can accept optional logging parameters:

```
nix-build -A scripts.mainnet.node -o mainnet-node-local --arg customConfig '{ useProxy = true; loggingExtras = "--live-view --trace-mempool --trace-chain-sync-protocol"; }'
```