### PR TITLE
fix: enable logging if logging config passed in

### DIFF
--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -133,7 +133,7 @@ loggingCLIConfiguration mfp captureMetrics' =
       Nothing ->
         fmap (LoggingDisabled,) $ LoggingConfiguration <$> Config.empty <*> pure captureMetrics'
       Just fp -> do
-        fmap (LoggingDisabled,) $ LoggingConfiguration <$> readConfig fp <*> pure captureMetrics'
+        fmap (LoggingEnabled,) $ LoggingConfiguration <$> readConfig fp <*> pure captureMetrics'
   where
     readConfig :: FilePath -> IO Configuration
     readConfig fp =


### PR DESCRIPTION
a previous PR left logging disabled even if a configuration file was passed in as an argument.
(https://github.com/input-output-hk/cardano-node/pull/282)

reported by @oneEdoubleD