### PR TITLE
Derive all logging and node configuration from a single yaml file

### DIFF
--- a/benchmarking/chain-sync_mainnet.sh
+++ b/benchmarking/chain-sync_mainnet.sh
@@ -10,17 +10,12 @@ NODE="cabal new-run exe:cardano-node -- "
 
 exec ${NODE} \
   --genesis-file ${BASEDIR}/../configuration/mainnet-genesis.json \
-  --genesis-hash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
-  --log-config ${BASEDIR}/launch_mainnet.d/log-configuration.yaml \
-  --log-metrics \
+  --config ${BASEDIR}/launch_mainnet.d/log-configuration.yaml \
   --database-path .//db-mainnet \
   --socket-dir socket \
   --topology ${BASEDIR}/launch_mainnet.d/topology-local.yaml \
-  --real-pbft \
-  --node-id 0 \
   --host-addr 127.0.0.1 \
-  --port 3001 \
-  --live-view \
+  --port 7777 \
   --tracing-verbosity-maximal \
   --trace-mempool \
   --trace-forge \

--- a/benchmarking/launch_mainnet.d/log-config-acceptor.yaml
+++ b/benchmarking/launch_mainnet.d/log-config-acceptor.yaml
@@ -88,3 +88,81 @@ options:
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
 
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 4
+Protocol: RealPBFT
+GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold: 0.5
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/benchmarking/launch_mainnet.d/log-configuration.yaml
+++ b/benchmarking/launch_mainnet.d/log-configuration.yaml
@@ -95,3 +95,80 @@ options:
     cardano.node.metrics:
       - kind: UserDefinedBK
         name: LiveViewBackend
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 0
+Protocol: RealPBFT
+GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold: 0.5
+TurnOnLogging: True
+ViewMode: LiveView
+TurnOnLogMetrics: True
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/benchmarking/trace-acceptor.sh
+++ b/benchmarking/trace-acceptor.sh
@@ -9,5 +9,10 @@ CMD="cabal new-run exe:trace-acceptor -- "
 
 set -x
 ${CMD} \
-    --log-config ${BASEDIR}/launch_mainnet.d/log-config-acceptor.yaml \
+    --config ${BASEDIR}/launch_mainnet.d/log-config-acceptor.yaml \
+    --topology "./configuration/simple-topology.json" \
+    --database-path "./db/" \
+    --genesis-file "configuration/mainnet-genesis.json" \
+    --socket-dir "./socket" \
+    --port 1234 \
            $@

--- a/cardano-config/src/Cardano/Config/CommonCLI.hs
+++ b/cardano-config/src/Cardano/Config/CommonCLI.hs
@@ -22,15 +22,20 @@ module Cardano.Config.CommonCLI
   , lastStrOption
   , lastStrOptionM
   , lastFlag
-  , parseDbPath
-  , parseDelegationeCert
-  , parseGenesisHash
+  , parseDbPathLast
+  , parseDelegationCert
+  , parseDelegationCertLast
+  , parseGenesisHashLast
   , parseGenesisPath
-  , parsePbftSigThreshold
-  , parseRequireNetworkMagic
+  , parseGenesisPathLast
+  , parsePbftSigThresholdLast
+  , parseRequireNetworkMagicLast
   , parseSigningKey
-  , parseSlotLength
+  , parseSlotLengthLast
   , parseSocketDir
+  , parseSocketDirLast
+  -- Last Parsers
+  , parseSigningKeyLast
 
   ) where
 
@@ -67,46 +72,79 @@ data CommonCLIAdvanced = CommonCLIAdvanced
   Common CLI
 -------------------------------------------------------------------------------}
 
-parseDbPath :: Parser (Last FilePath)
-parseDbPath =
+parseDbPathLast :: Parser (Last FilePath)
+parseDbPathLast =
   lastStrOption
     ( long "database-path"
         <> metavar "FILEPATH"
         <> help "Directory where the state is stored."
     )
-parseGenesisPath :: Parser (Last FilePath)
+parseGenesisPath :: Parser FilePath
 parseGenesisPath =
+  strOption
+    ( long "genesis-file"
+        <> metavar "FILEPATH"
+        <> help "The filepath to the genesis file."
+    )
+
+parseGenesisPathLast :: Parser (Last FilePath)
+parseGenesisPathLast =
   lastStrOption
     ( long "genesis-file"
         <> metavar "FILEPATH"
         <> help "The filepath to the genesis file."
     )
 
-parseGenesisHash :: Parser (Last Text)
-parseGenesisHash =
+parseGenesisHashLast :: Parser (Last Text)
+parseGenesisHashLast =
   lastStrOption
     ( long "genesis-hash"
         <> metavar "GENESIS-HASH"
         <> help "The genesis hash value."
     )
-parseDelegationeCert :: Parser (Last FilePath)
-parseDelegationeCert =
+parseDelegationCert :: Parser FilePath
+parseDelegationCert =
+  strOption
+    ( long "delegation-certificate"
+        <> metavar "FILEPATH"
+        <> help "Path to the delegation certificate."
+    )
+
+parseDelegationCertLast :: Parser (Last FilePath)
+parseDelegationCertLast =
   lastStrOption
     ( long "delegation-certificate"
         <> metavar "FILEPATH"
         <> help "Path to the delegation certificate."
     )
 
-parseSigningKey :: Parser (Last FilePath)
-parseSigningKey =
+parseSigningKeyLast :: Parser (Last FilePath)
+parseSigningKeyLast =
   lastStrOption
     ( long "signing-key"
         <> metavar "FILEPATH"
         <> help "Path to the signing key."
     )
 
-parseSocketDir :: Parser (Last FilePath)
+parseSigningKey :: Parser FilePath
+parseSigningKey =
+  strOption
+    ( long "signing-key"
+        <> metavar "FILEPATH"
+        <> help "Path to the signing key."
+    )
+
+parseSocketDir :: Parser FilePath
 parseSocketDir =
+  strOption
+    ( long "socket-dir"
+        <> metavar "FILEPATH"
+        <> help "Directory with local sockets:\
+                \  ${dir}/node-{core,relay}-${node-id}.socket"
+    )
+
+parseSocketDirLast :: Parser (Last FilePath)
+parseSocketDirLast =
   lastStrOption
     ( long "socket-dir"
         <> metavar "FILEPATH"
@@ -149,23 +187,23 @@ parseCommonCLI =
          <> help "Directory with local sockets:  ${dir}/node-{core,relay}-${node-id}.socket"
         )
 
-parsePbftSigThreshold :: Parser (Last Double)
-parsePbftSigThreshold =
+parsePbftSigThresholdLast :: Parser (Last Double)
+parsePbftSigThresholdLast =
   lastDoubleOption
     ( long "pbft-signature-threshold"
         <> metavar "DOUBLE"
         <> help "The PBFT signature threshold."
         <> hidden
     )
-parseRequireNetworkMagic :: Parser (Last RequireNetworkMagic)
-parseRequireNetworkMagic =
+parseRequireNetworkMagicLast :: Parser (Last RequireNetworkMagic)
+parseRequireNetworkMagicLast =
   lastFlag NoRequireNetworkMagic RequireNetworkMagic
     ( long "require-network-magic"
         <> help "Require network magic in transactions."
         <> hidden
     )
-parseSlotLength :: Parser (Last Consensus.SlotLength)
-parseSlotLength = do
+parseSlotLengthLast :: Parser (Last Consensus.SlotLength)
+parseSlotLengthLast = do
   slotDurInteger <- lastAutoOption
                       ( long "slot-duration"
                           <> metavar "SECONDS"

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -125,6 +125,7 @@ data CardanoConfiguration = CardanoConfiguration
 
 data NodeCLI = NodeCLI
     { mscFp :: !MiscellaneousFilepaths
+    , nodeAddr :: !NodeAddress
     , configFp :: !ConfigYamlFilePath
     , traceOpts :: !TraceOptions
     } deriving Show
@@ -173,7 +174,6 @@ data NodeConfiguration =
     NodeConfiguration
       { ncProtocol :: Protocol
       , ncNodeId :: NodeId
-      , ncNodeAddress :: NodeAddress
       , ncGenesisHash :: Text
       , ncNumCoreNodes :: Maybe Int
       , ncReqNetworkMagic :: RequiresNetworkMagic
@@ -194,8 +194,6 @@ data NodeConfiguration =
 instance FromJSON NodeConfiguration where
     parseJSON = withObject "NodeConfiguration" $ \v -> do
                   nId <- v .: "NodeId"
-                  nodeHostAddr <- v .: "NodeHostAddress"
-                  nodePort <- v .: "NodePort"
                   ptcl <- v .: "Protocol"
                   genesisHash <- v .: "GenesisHash"
                   numCoreNode <- v .:? "NumCoreNodes"
@@ -260,7 +258,6 @@ instance FromJSON NodeConfiguration where
                   pure $ NodeConfiguration
                            ptcl
                            nId
-                           (NodeAddress nodeHostAddr nodePort)
                            genesisHash
                            numCoreNode
                            rNetworkMagic

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -187,7 +187,6 @@ data NodeConfiguration =
       , ncDLG :: DLG
       , ncBlock :: Block
       , ncNode :: Node
-      , ncTLS :: TLS
       , ncWallet :: Wallet
       } deriving (Show)
 
@@ -236,20 +235,6 @@ instance FromJSON NodeConfiguration where
                   netConnTimeout <- v .: "NetworkConnectionTimeout"
                   handshakeTimeout <- v .: "HandshakeTimeout"
 
-                  -- Certificates
-                  caPrg <- v .: "CA-Organization"
-                  caCommonName <- v .: "CA-CommonName"
-                  caExpDays <- v .: "CA-ExpiryDays"
-                  caAltDns <- v .: "CA-AltDNS"
-                  serverPrg <- v .: "Server-Organization"
-                  serverCommonName <- v .: "Server-CommonName"
-                  serverExpDays <- v .: "Server-ExpiryDays"
-                  serverAltDns <- v .: "Server-AltDNS"
-                  walletPrg <- v .: "Wallet-Organization"
-                  walletCommonName <- v .: "Wallet-CommonName"
-                  walletExpDays <- v .: "Wallet-ExpiryDays"
-                  walletAltDns <- v .: "Wallet-AltDNS"
-
                   -- Wallet
                   throttleEnabled <- v .: "Enabled"
                   throttleRate <- v .: "Rate"
@@ -278,11 +263,6 @@ instance FromJSON NodeConfiguration where
                            (Node (slotLengthFromMillisec slotLength)
                                   netConnTimeout
                                   handshakeTimeout
-                           )
-                           (TLS
-                              (Certificate caPrg caCommonName caExpDays caAltDns)
-                              (Certificate serverPrg serverCommonName serverExpDays serverAltDns)
-                              (Certificate walletPrg walletCommonName walletExpDays walletAltDns)
                            )
                            (Wallet throttleEnabled throttleRate throttlePeriod throttleBurst)
 

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -303,8 +303,7 @@ parseTxRelatedValues =
         "submit-tx"
         "Submit a raw, signed transaction, in its on-wire representation."
         $ SubmitTx
-            <$> parseTopologyInfo "PBFT node ID to submit Tx to."
-            <*> parseTxFile "tx"
+            <$> parseTxFile "tx"
             <*> nodeCliParser
     , command'
         "issue-genesis-utxo-expenditure"
@@ -335,9 +334,7 @@ parseTxRelatedValues =
         "generate-txs"
         "Launch transactions generator."
         $ GenerateTxs
-            <$> parseTopologyInfo
-                  "PBFT node ID to submit generated Txs to."
-            <*> parseNumberOfTxs
+            <$> parseNumberOfTxs
                   "num-of-txs"
                   "Number of transactions generator will create."
             <*> parseNumberOfInputsPerTx

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -78,7 +78,7 @@ initializeAllFeatures
   :: NodeCLI
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
-initializeAllFeatures nCli@(NodeCLI _ ncFp _)
+initializeAllFeatures nCli@(NodeCLI _ _ ncFp _)
                        cardanoEnvironment = do
 
     (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment nCli

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -6,47 +5,33 @@
 {-# LANGUAGE RankNTypes #-}
 
 import           Cardano.Prelude hiding (option)
-import           Prelude (String, read)
+import           Prelude (String)
 
 import           Data.Semigroup ((<>))
-import           Network.Socket (PortNumber)
-import           Options.Applicative ( Parser, auto, flag, help, long
-                                     , metavar, option, str, value)
+import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..),)
-import qualified Ouroboros.Consensus.BlockchainTime as Consensus
 
 import           Cardano.Common.Help
 import           Cardano.Common.Parsers
-import           Cardano.Config.Protocol
-import           Cardano.Config.CommonCLI
+import           Cardano.Config.CommonCLI (parseCommonCLIAdvanced)
 import           Cardano.Config.Logging (createLoggingFeature)
-import           Cardano.Config.Partial (PartialCardanoConfiguration (..),
-                                         PartialCore (..), PartialNode (..),
-                                         mkCardanoConfiguration)
-import           Cardano.Config.Presets (mainnetConfiguration)
-import           Cardano.Config.Types (CardanoEnvironment (..), RequireNetworkMagic,
-                                       parseNodeConfiguration)
-import           Cardano.Config.Topology (NodeAddress (..), NodeHostAddress(..), TopologyInfo)
+import           Cardano.Config.Types (CardanoEnvironment (..), ConfigYamlFilePath(..),
+                                       NodeCLI(..), parseNodeConfiguration)
 import           Cardano.Node.Features.Node
-import           Cardano.Node.Run
-import           Cardano.Tracing.Tracers
 
 main :: IO ()
 main = do
     cli <- Opt.execParser opts
 
-    (features, nodeLayer) <- initializeAllFeatures cli pcc env
+    (features, nodeLayer) <- initializeAllFeatures cli env
 
     runCardanoApplicationWithFeatures features (cardanoApplication nodeLayer)
 
     where
-      pcc :: PartialCardanoConfiguration
-      pcc = mainnetConfiguration
-
       env :: CardanoEnvironment
       env = NoEnvironment
 
@@ -56,9 +41,11 @@ main = do
       opts :: Opt.ParserInfo NodeCLI
       opts =
         Opt.info (nodeCliParser
-                  <**> helperBrief "help" "Show this help text" nodeCliHelpMain
-                  <**> helperBrief "help-tracing" "Show help for tracing options" cliHelpTracing
-                  <**> helperBrief "help-advanced" "Show help for advanced options" cliHelpAdvanced)
+                    <**> helperBrief "help" "Show this help text" nodeCliHelpMain
+                    <**> helperBrief "help-tracing" "Show help for tracing options" cliHelpTracing
+                    <**> helperBrief "help-advanced" "Show help for advanced options" cliHelpAdvanced
+                 )
+
           ( Opt.fullDesc <>
             Opt.progDesc "Start node of the Cardano blockchain."
           )
@@ -86,163 +73,25 @@ main = do
         <$$> ""
         <$$> parserHelpOptions parseCommonCLIAdvanced
 
+
 initializeAllFeatures
   :: NodeCLI
-  -> PartialCardanoConfiguration
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
-initializeAllFeatures (NodeCLI parsedPcc (ConfigYamlFilePath ncFp))
-                      partialConfigPreset cardanoEnvironment = do
+initializeAllFeatures nCli@(NodeCLI _ ncFp _)
+                       cardanoEnvironment = do
 
-    -- `partialConfigPreset` and `parsedPcc` are merged then checked here using
-    -- the partial options monoid approach.
-    -- https://medium.com/@jonathangfischoff/the-partial-options-monoid-pattern-31914a71fc67
-    finalConfig <- case mkCardanoConfiguration $ partialConfigPreset <> parsedPcc of
-                     Left e -> throwIO e
-                     Right x -> pure x
+    (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment nCli
 
-    (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment finalConfig
-
-    nodeConfig <- parseNodeConfiguration ncFp
+    nodeConfig <- parseNodeConfiguration $ unConfigPath ncFp
     (nodeLayer   , nodeFeature)    <-
       createNodeFeature
         loggingLayer
         cardanoEnvironment
-        finalConfig
         nodeConfig
+        nCli
 
     pure ([ loggingFeature
           , nodeFeature
           ] :: [CardanoFeature]
          , nodeLayer)
-
--------------------------------------------------------------------------------
--- Parsers & Types
--------------------------------------------------------------------------------
-
-data NodeCLI = NodeCLI !PartialCardanoConfiguration  !ConfigYamlFilePath
-
--- | Filepath of the configuration yaml file. This file determines
--- all the configuration settings required for the cardano node
--- (logging, tracing, protocol, slot length etc)
-newtype ConfigYamlFilePath = ConfigYamlFilePath FilePath
-
--- | The product parser for all the CLI arguments.
-nodeCliParser :: Parser NodeCLI
-nodeCliParser = do
-  topInfo <- lastOption $ parseTopologyInfo "PBFT node ID to assume."
-  nAddr <- lastOption parseNodeAddress
-  ptcl <- ( parseProtocolBFT
-          <|> parseProtocolByron
-          <|> parseProtocolMockPBFT
-          <|> parseProtocolPraos
-          <|> parseProtocolRealPBFT
-          )
-  vMode <- parseViewMode
-  logConfigFp <- lastOption parseLogConfigFile
-  logMetrics <- parseLogMetrics
-  dbPath <- parseDbPath
-  genPath <- parseGenesisPath
-  genHash <- parseGenesisHash
-  delCert <- parseDelegationeCert
-  sKey <- parseSigningKey
-  socketDir <- parseSocketDir
-  traceOptions <- cliTracingParser
-  pbftSigThresh <- parsePbftSigThreshold
-  reqNetMagic <- parseRequireNetworkMagic
-  slotLength <- parseSlotLength
-
-  nodeConfigFp <- parseConfigFile
-
-  pure $ NodeCLI
-         (createPcc dbPath socketDir topInfo nAddr ptcl logConfigFp vMode
-                    logMetrics genPath genHash delCert sKey pbftSigThresh
-                    reqNetMagic traceOptions slotLength)
-         (ConfigYamlFilePath $ fromMaybe (panic "No configuration yaml filepath supplied") (getLast nodeConfigFp))
- where
-  -- This merges the command line parsed values into one `PartialCardanoconfiguration`.
-  createPcc
-    :: Last FilePath
-    -> Last FilePath
-    -> Last TopologyInfo
-    -> Last NodeAddress
-    -> Last Protocol
-    -> Last FilePath
-    -> Last ViewMode
-    -> Last Bool
-    -> Last FilePath
-    -> Last Text
-    -> Last FilePath
-    -> Last FilePath
-    -> Last Double
-    -> Last RequireNetworkMagic
-    -> Last TraceOptions
-    -> Last Consensus.SlotLength
-    -> PartialCardanoConfiguration
-  createPcc
-    dbPath
-    socketDir
-    topInfo
-    nAddr
-    ptcl
-    logConfigFp
-    vMode
-    logMetrics
-    genPath
-    genHash
-    delCert
-    sKey
-    pbftSigThresh
-    reqNetMagic
-    traceOptions
-    slotLength = mempty { pccDBPath = dbPath
-                        , pccNodeAddress = nAddr
-                        , pccSocketDir = socketDir
-                        , pccTopologyInfo = topInfo
-                        , pccProtocol = ptcl
-                        , pccViewMode = vMode
-                        , pccLogConfig = logConfigFp
-                        , pccLogMetrics = logMetrics
-                        , pccCore = mempty { pcoGenesisFile = genPath
-                                           , pcoGenesisHash = genHash
-                                           , pcoStaticKeyDlgCertFile = delCert
-                                           , pcoStaticKeySigningKeyFile = sKey
-                                           , pcoPBftSigThd = pbftSigThresh
-                                           , pcoRequiresNetworkMagic = reqNetMagic
-                                           }
-                        , pccNode = mempty { pnoSlotLength = slotLength }
-                        , pccTraceOptions = traceOptions
-                        }
-
-
-
-cliTracingParser :: Parser (Last TraceOptions)
-cliTracingParser = Last . Just <$> parseTraceOptions Opt.hidden
-
-parseNodeAddress :: Parser NodeAddress
-parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort
-
-parseHostAddr :: Parser NodeHostAddress
-parseHostAddr =
-    option (NodeHostAddress . Just <$> read <$> str) (
-          long "host-addr"
-       <> metavar "HOST-NAME"
-       <> help "Optionally limit node to one ipv6 or ipv4 address"
-       <> (value $ NodeHostAddress Nothing)
-    )
-
-parsePort :: Parser PortNumber
-parsePort =
-    option ((fromIntegral :: Int -> PortNumber) <$> auto) (
-          long "port"
-       <> metavar "PORT"
-       <> help "The port number"
-    )
-
--- Optional flag for live view (with TUI graphics).
-parseViewMode :: Parser (Last ViewMode)
-parseViewMode =
-    flag (Last $ Just SimpleView) (Last $ Just LiveView) $ mconcat
-        [ long "live-view"
-        , help "Live view with TUI."
-        ]

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -266,6 +266,7 @@ executable chairman
                      , async
                      , bytestring
                      , cardano-config
+                     , cardano-prelude
                      , containers
                      , contra-tracer
                      , cardano-node
@@ -280,6 +281,8 @@ executable chairman
                      , text
                      , typed-protocols
                      , typed-protocols-cbor
+
+  default-extensions:   NoImplicitPrelude
 
   if os(windows)
      build-depends:    Win32

--- a/cardano-node/src/Cardano/CLI/Genesis.hs
+++ b/cardano-node/src/Cardano/CLI/Genesis.hs
@@ -5,7 +5,6 @@
 
 module Cardano.CLI.Genesis
   ( NewDirectory(..)
-  , GenesisFile(..)
   , GenesisParameters(..)
   , mkGenesis
   , readGenesis
@@ -44,14 +43,11 @@ import qualified Cardano.Crypto as Crypto
 
 import           Cardano.CLI.Key
 import           Cardano.CLI.Ops
+import           Cardano.Config.Types (GenesisFile(..))
 
 
 newtype NewDirectory =
   NewDirectory FilePath
-  deriving (Eq, Ord, Show, IsString)
-
-newtype GenesisFile =
-  GenesisFile FilePath
   deriving (Eq, Ord, Show, IsString)
 
 -- | Parameters required for generation of new genesis.
@@ -64,7 +60,7 @@ data GenesisParameters = GenesisParameters
   , gpFakeAvvmOptions :: !Genesis.FakeAvvmOptions
   , gpAvvmBalanceFactor :: !Common.LovelacePortion
   , gpSeed :: !(Maybe Integer)
-  }
+  } deriving Show
 
 mkGenesisSpec :: GenesisParameters -> ExceptT CliError IO Genesis.GenesisSpec
 mkGenesisSpec gp = do

--- a/cardano-node/src/Cardano/CLI/Key.hs
+++ b/cardano-node/src/Cardano/CLI/Key.hs
@@ -10,9 +10,8 @@
 
 module Cardano.CLI.Key
   ( -- * Keys
-    SigningKeyFile(..)
+    VerificationKeyFile(..)
   , NewSigningKeyFile(..)
-  , VerificationKeyFile(..)
   , NewVerificationKeyFile(..)
   , prettyPublicKey
   , readSigningKey
@@ -44,16 +43,13 @@ import           System.IO (hSetEcho, hFlush, stdout, stdin)
 
 import qualified Cardano.Chain.Common as Common
 import           Cardano.Config.Protocol
+import           Cardano.Config.Types (SigningKeyFile(..))
 import           Cardano.Crypto (SigningKey(..))
 import qualified Cardano.Crypto.Random as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
 import           Cardano.CLI.Ops
 
-
-newtype SigningKeyFile =
-  SigningKeyFile FilePath
-  deriving (Eq, Ord, Show, IsString)
 
 newtype NewSigningKeyFile =
   NewSigningKeyFile FilePath

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -110,7 +110,6 @@ data CliError
   -- the signing key file.
   | InvariantViolation !Prelude.String
 
-
 instance Show CliError where
   show (OutputMustNotAlreadyExist fp)
     = "Output file/directory must not already exist: " <> fp

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -28,6 +28,7 @@ import           Prelude (String)
 
 import           Cardano.Prelude hiding (option)
 
+import           Network.Socket (PortNumber)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
@@ -63,6 +64,8 @@ nodeCliParser = do
   sKeyFp <- optional parseSigningKey
   socketFp <- parseSocketDir
 
+  -- Node Address
+  nAddress <- parseNodeAddress
   -- NodeConfiguration filepath
   nodeConfigFp <- parseConfigFile
 
@@ -79,6 +82,7 @@ nodeCliParser = do
               (SigningKeyFile <$> sKeyFp)
               (SocketFile socketFp)
             )
+           nAddress
            (ConfigYamlFilePath nodeConfigFp)
            (fromMaybe (panic "Cardano.Common.Parsers: Trace Options were not specified") $ getLast traceOptions)
 
@@ -113,6 +117,26 @@ parseNodeId desc =
             long "node-id"
          <> metavar "NODE-ID"
          <> help desc
+    )
+
+parseNodeAddress :: Parser NodeAddress
+parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort
+
+parseHostAddr :: Parser NodeHostAddress
+parseHostAddr =
+    option (NodeHostAddress . readMaybe <$> str) (
+          long "host-addr"
+       <> metavar "HOST-NAME"
+       <> help "Optionally limit node to one ipv6 or ipv4 address"
+       <> (value $ NodeHostAddress Nothing)
+    )
+
+parsePort :: Parser PortNumber
+parsePort =
+    option ((fromIntegral :: Int -> PortNumber) <$> auto) (
+          long "port"
+       <> metavar "PORT"
+       <> help "The port number"
     )
 
 -- | Flag parser, that returns its argument on success.

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Common.Parsers
   ( loggingParser
+  , parseConfigFile
   , parseCoreNodeId
   , parseLogConfigFile
   , parseLogMetrics
@@ -37,6 +38,15 @@ import           Cardano.Config.Topology
 import           Cardano.Config.Types (TraceOptions(..))
 
 -- Common command line parsers
+
+parseConfigFile :: Parser (Last FilePath)
+parseConfigFile =
+  (Last . Just) <$> strOption
+    ( long "config"
+    <> metavar "NODE-CONFIGURATION"
+    <> help "Configuration file for the cardano-node"
+    <> completer (bashCompleter "file")
+    )
 
 parseCoreNodeId :: Parser CoreNodeId
 parseCoreNodeId =

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -8,9 +8,8 @@ module Cardano.Node.Features.Node
 
 import           Cardano.Prelude
 
-import           Cardano.Config.Types (CardanoConfiguration (..),
-                                       CardanoEnvironment (..),
-                                       NodeConfiguration)
+import           Cardano.Config.Types (CardanoEnvironment (..),
+                                       NodeConfiguration, NodeCLI(..))
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
@@ -31,10 +30,10 @@ data NodeLayer = NodeLayer
 createNodeFeature
   :: LoggingLayer
   -> CardanoEnvironment
-  -> CardanoConfiguration
   -> NodeConfiguration
+  -> NodeCLI
   -> IO (NodeLayer, CardanoFeature)
-createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfiguration = do
+createNodeFeature loggingLayer cardanoEnvironment nodeConfiguration nCli = do
     -- we parse any additional configuration if there is any
     -- We don't know where the user wants to fetch the additional
     -- configuration from, it could be from the filesystem, so
@@ -44,8 +43,8 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfi
     nodeLayer <- createNodeLayer
                    cardanoEnvironment
                    loggingLayer
-                   cardanoConfiguration
                    nodeConfiguration
+                   nCli
 
     -- Construct the cardano feature
     let cardanoFeature :: CardanoFeature
@@ -61,10 +60,10 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfi
     createNodeLayer
       :: CardanoEnvironment
       -> LoggingLayer
-      -> CardanoConfiguration
       -> NodeConfiguration
+      -> NodeCLI
       -> IO NodeLayer
-    createNodeLayer _ logLayer cc nc = do
+    createNodeLayer _ logLayer nc nCli' = do
         pure $ NodeLayer
-          { nlRunNode = liftIO $ runNode logLayer cc nc
+          { nlRunNode = liftIO $ runNode logLayer nc nCli'
           }

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -9,7 +9,8 @@ module Cardano.Node.Features.Node
 import           Cardano.Prelude
 
 import           Cardano.Config.Types (CardanoConfiguration (..),
-                                       CardanoEnvironment (..))
+                                       CardanoEnvironment (..),
+                                       NodeConfiguration)
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
@@ -31,8 +32,9 @@ createNodeFeature
   :: LoggingLayer
   -> CardanoEnvironment
   -> CardanoConfiguration
+  -> NodeConfiguration
   -> IO (NodeLayer, CardanoFeature)
-createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
+createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfiguration = do
     -- we parse any additional configuration if there is any
     -- We don't know where the user wants to fetch the additional
     -- configuration from, it could be from the filesystem, so
@@ -43,6 +45,7 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
                    cardanoEnvironment
                    loggingLayer
                    cardanoConfiguration
+                   nodeConfiguration
 
     -- Construct the cardano feature
     let cardanoFeature :: CardanoFeature
@@ -59,8 +62,9 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
       :: CardanoEnvironment
       -> LoggingLayer
       -> CardanoConfiguration
+      -> NodeConfiguration
       -> IO NodeLayer
-    createNodeLayer _ logLayer cc = do
+    createNodeLayer _ logLayer cc nc = do
         pure $ NodeLayer
-          { nlRunNode = liftIO $ runNode logLayer cc
+          { nlRunNode = liftIO $ runNode logLayer cc nc
           }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -161,14 +161,14 @@ handleSimpleNode p trace nodeTracers nCli nc = do
                           map (\ns -> (nodeId ns, producers ns)) nodeSetups of
           Just ps -> ps
           Nothing -> error $ "handleSimpleNode: own address "
-                          <> show (ncNodeAddress nc)
+                          <> show (nodeAddr nCli)
                           <> ", Node Id "
                           <> show nid
                           <> " not found in topology"
 
     traceWith tracer $ unlines
       [ "**************************************"
-      , "I am Node "        <> show (ncNodeAddress nc) <> " Id: " <> show nid
+      , "I am Node "        <> show (nodeAddr nCli) <> " Id: " <> show nid
       , "My producers are " <> show producers'
       , "**************************************"
       ]
@@ -179,7 +179,7 @@ handleSimpleNode p trace nodeTracers nCli nc = do
                      (unSocket . socketFile $ mscFp nCli)
                      MkdirIfMissing
 
-    addrs <- nodeAddressInfo $ ncNodeAddress nc
+    addrs <- nodeAddressInfo $ nodeAddr nCli
     let ipProducerAddrs  :: [NodeAddress]
         dnsProducerAddrs :: [RemoteAddress]
         (ipProducerAddrs, dnsProducerAddrs) = partitionEithers

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -45,7 +45,7 @@ import           Cardano.BM.Data.LogItem (LogObject (..))
 import           Cardano.BM.Data.Tracer (ToLogObject (..),
                      TracingVerbosity (..), setHostname)
 import           Cardano.Config.Logging (LoggingLayer (..))
-import           Cardano.Config.Types (CardanoConfiguration (..), ViewMode (..))
+import           Cardano.Config.Types (NodeConfiguration (..), ViewMode (..))
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Subscription.Dns
@@ -66,6 +66,7 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Cardano.Common.LocalSocket
 import           Cardano.Config.Protocol (SomeProtocol(..), fromProtocol)
 import           Cardano.Config.Topology
+import           Cardano.Config.Types (CardanoConfiguration(..))
 import           Cardano.Tracing.Tracers
 #ifdef UNIX
 import           Cardano.Node.TUI.LiveView
@@ -89,6 +90,7 @@ instance NoUnexpectedThunks Peer where
 runNode
   :: LoggingLayer
   -> CardanoConfiguration
+  -> NodeConfiguration
   -> IO ()
 runNode loggingLayer cc = do
     hn <- hostname
@@ -101,12 +103,12 @@ runNode loggingLayer cc = do
                              NormalVerbosity -> "normal"
                              MinimalVerbosity -> "minimal"
                              MaximalVerbosity -> "maximal"
-    SomeProtocol p  <- fromProtocol cc $ ccProtocol cc
+    SomeProtocol p  <- fromProtocol cc $ ncProtocol nc
 
     let tracers     = mkTracers (ccTraceOptions cc) trace
 
     case ccViewMode cc of
-      SimpleView -> handleSimpleNode p trace tracers cc
+      SimpleView -> handleSimpleNode p trace tracers cc nc
       LiveView   -> do
 #ifdef UNIX
         let c = llConfiguration loggingLayer
@@ -114,7 +116,7 @@ runNode loggingLayer cc = do
         -- turn off logging to the console, only forward it through a pipe to a central logging process
         CM.setDefaultBackends c [TraceForwarderBK, UserDefinedBK "LiveViewBackend"]
         -- User will see a terminal graphics and will be able to interact with it.
-        nodeThread <- Async.async $ handleSimpleNode p trace tracers cc
+        nodeThread <- Async.async $ handleSimpleNode p trace tracers cc nc
 
         be :: LiveViewBackend Text <- realize c
         let lvbe = MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be }
@@ -125,7 +127,7 @@ runNode loggingLayer cc = do
 
         void $ Async.waitAny [nodeThread]
 #else
-        handleSimpleNode p trace tracers cc
+        handleSimpleNode p trace tracers nc
 #endif
   where
     hostname = do
@@ -140,8 +142,9 @@ handleSimpleNode :: forall blk. RunNode blk
                  -> Tracer IO (LogObject Text)
                  -> Tracers Peer blk
                  -> CardanoConfiguration
+                 -> NodeConfiguration
                  -> IO ()
-handleSimpleNode p trace nodeTracers cc = do
+handleSimpleNode p trace nodeTracers cc nc = do
     NetworkTopology nodeSetups <-
       either error id <$> readTopologyFile (topologyFile $ ccTopologyInfo cc)
 
@@ -156,14 +159,14 @@ handleSimpleNode p trace nodeTracers cc = do
                           map (\ns -> (nodeId ns, producers ns)) nodeSetups of
           Just ps -> ps
           Nothing -> error $ "handleSimpleNode: own address "
-                          <> show (ccNodeAddress cc)
+                          <> show (ncNodeAddress nc)
                           <> ", Node Id "
                           <> show nid
                           <> " not found in topology"
 
     traceWith tracer $ unlines
       [ "**************************************"
-      , "I am Node "        <> show (ccNodeAddress cc) <> " Id: " <> show nid
+      , "I am Node "        <> show (ncNodeAddress nc) <> " Id: " <> show nid
       , "My producers are " <> show producers'
       , "**************************************"
       ]
@@ -171,7 +174,7 @@ handleSimpleNode p trace nodeTracers cc = do
     -- Socket directory
     myLocalAddr <- localSocketAddrInfo (node $ ccTopologyInfo cc) (ccSocketDir cc) MkdirIfMissing
 
-    addrs <- nodeAddressInfo $ ccNodeAddress cc
+    addrs <- nodeAddressInfo $ ncNodeAddress nc
     let ipProducerAddrs  :: [NodeAddress]
         dnsProducerAddrs :: [RemoteAddress]
         (ipProducerAddrs, dnsProducerAddrs) = partitionEithers

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -63,7 +63,6 @@ import           Cardano.BM.Trace
 import           Cardano.Node.TUI.GitRev (gitRev)
 import           Ouroboros.Consensus.NodeId
 import           Paths_cardano_node (version)
-import           Cardano.Config.Topology
 
 -- constants, to be evaluated from host system
 
@@ -335,8 +334,8 @@ initLiveViewState = do
                 , lvsColorTheme          = DarkTheme
                 }
 
-setTopology :: LiveViewBackend a -> TopologyInfo -> IO ()
-setTopology lvbe (TopologyInfo nodeid _) =
+setTopology :: LiveViewBackend a -> NodeId -> IO ()
+setTopology lvbe nodeid =
     modifyMVar_ (getbe lvbe) $ \lvs ->
         return $ lvs { lvsNodeId = namenum }
   where

--- a/configuration/default-node-config.nix
+++ b/configuration/default-node-config.nix
@@ -1,0 +1,137 @@
+{ cfg
+}:
+{
+  minSeverity = "Debug";
+  rotation = {
+    rpLogLimitBytes = 5000000;
+    rpKeepFilesNum = 10;
+    rpMaxAgeHours = 24;
+  };
+  setupBackends = [
+    "KatipBK"
+  ];
+  defaultBackends = [
+    "KatipBK"
+  ];
+  setupScribes = [
+    { scKind = "StdoutSK";
+      scName = "stdout";
+      scFormat = "ScText";
+      scRotation = null;
+    }
+  ];
+  defaultScribes = [
+    [ "StdoutSK"
+      "stdout"
+    ]
+  ];
+  options = {
+    cfokey.value = "Release-1.0.0";
+    mapSubtrace = {
+      "#ekgview" = {
+        contents = [
+          [ { tag = "Contains";
+              contents = "cardano.epoch-validation.benchmark"; }
+            [ { tag = "Contains";
+                contents = ".monoclock.basic."; }
+            ]
+          ]
+          [ { tag = "Contains";
+              contents = "cardano.epoch-validation.benchmark";
+            }
+            [ { tag = "Contains";
+                contents = "diff.RTS.cpuNs.timed."; }
+            ]
+          ]
+          [ { tag = "StartsWith";
+              contents = "#ekgview.#aggregation.cardano.epoch-validation.benchmark";
+            }
+            [ { tag = "Contains";
+                contents = "diff.RTS.gcNum.timed."; }
+            ]
+          ]
+        ];
+        subtrace = "FilterTrace";
+      };
+      "cardano.epoch-validation.utxo-stats"  = { subtrace = "NoTrace"; };
+      "cardano.#messagecounters.aggregation" = { subtrace = "NoTrace"; };
+      "cardano.#messagecounters.ekgview"     = { subtrace = "NoTrace"; };
+      "cardano.#messagecounters.switchboard" = { subtrace = "NoTrace"; };
+      "cardano.#messagecounters.katip"       = { subtrace = "NoTrace"; };
+      "cardano.#messagecounters.monitoring"  = { subtrace = "NoTrace"; };
+    };
+    mapBackends = {
+      "cardano.node.metrics.ChainDB" = [
+        "EKGViewBK"
+        { kind = "UserDefinedBK"; name = "LiveViewBackend"; }
+      ];
+      "cardano.node.metrics" = [
+        { kind = "UserDefinedBK"; name = "LiveViewBackend"; }
+      ];
+      "cardano.node.BlockFetchDecision" = [
+        { kind = "UserDefinedBK"; name = "LiveViewBackend"; }
+      ];
+      "cardano.node.peers.BlockFetchDecision" = [
+        { kind = "UserDefinedBK"; name = "LiveViewBackend"; }
+      ];
+    };
+  };
+  NodeId = 0;
+  Protocol = "RealPBFT";
+  GenesisHash = cfg.genesisHash;
+  NumCoreNodes = 1;
+  RequiresNetworkMagic = "RequiresMagic";
+  PBftSignatureThreshold = 0.7;
+  TurnOnLogging = true;
+  ViewMode = "SimpleView";
+  TurnOnLogMetrics = false;
+  ResponseTimeout = 30000000;
+  PollDelay = 1800000000;
+  Servers = [
+    "0.pool.ntp.org"
+    "2.pool.ntp.org"
+    "3.pool.ntp.org"
+  ];
+  ApplicationName = "cardano-sl";
+  ApplicationVersion = 1;
+  LastKnownBlockVersion-Major = 0;
+  LastKnownBlockVersion-Minor = 2;
+  LastKnownBlockVersion-Alt = 0;
+  MemPoolLimitTx = 200;
+  AssetLockedSrcAddress = [];
+  CacheParameter = 500;
+  MessageCacheTimeout = 30;
+  NetworkDiameter = 18;
+  RecoveryHeadersMessage = 2200;
+  StreamWindow = 2048;
+  NonCriticalCQBootstrap = 0.95;
+  NonCriticalCQ = 0.8;
+  CriticalCQBootstrap = 0.8888;
+  CriticalCQ = 0.654321;
+  CriticalForkThreshold = 3;
+  FixedTimeCQ = 3600;
+  SlotLength = 20000;
+  NetworkConnectionTimeout = 15000;
+  HandshakeTimeout = 30000;
+  CA-Organization = "Input Output HK";
+  CA-CommonName = "Cardano SL Self-Signed Root CA";
+  CA-ExpiryDays = 3600;
+  CA-AltDNS = [];
+  Server-Organization = "Input Output HK";
+  Server-CommonName = "Cardano SL Server";
+  Server-ExpiryDays = 3600;
+  Server-AltDNS = [
+    "localhost"
+    "localhost.localdomain"
+    "127.0.0.1"
+    "::1"
+  ];
+  Wallet-Organization = "Input Output HK";
+  Wallet-CommonName = "Daedalus Wallet";
+  Wallet-ExpiryDays = 3600;
+  Wallet-AltDNS = [];
+  Enabled = false;
+  Rate = 0;
+  Period = "";
+  Burst = 0;
+}

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -86,3 +86,86 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 0
+NodeHostAddress: ''
+NodePort: 3000
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -138,28 +138,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -92,8 +92,6 @@ options:
 
 
 NodeId: 0
-NodeHostAddress: ''
-NodePort: 3000
 Protocol: RealPBFT
 GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -86,9 +86,6 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
-
-
-
 ##########################################################
 ############### Cardano Node Configuration ###############
 ##########################################################
@@ -98,7 +95,7 @@ NodeId: 0
 NodeHostAddress: ''
 NodePort: 3000
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -86,3 +86,85 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 1
+NodeHostAddress: ''
+NodePort: 3001
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -140,28 +140,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -97,7 +97,7 @@ NodeId: 1
 NodeHostAddress: ''
 NodePort: 3001
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -94,8 +94,6 @@ options:
 
 
 NodeId: 1
-NodeHostAddress: ''
-NodePort: 3001
 Protocol: RealPBFT
 GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -91,3 +91,86 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 2
+NodeHostAddress: ''
+NodePort: 3002
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -144,28 +144,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -98,8 +98,6 @@ options:
 
 
 NodeId: 2
-NodeHostAddress: ''
-NodePort: 3002
 Protocol: RealPBFT
 GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -92,8 +92,6 @@ options:
       - kind: UserDefinedBK
         name: LiveViewBackend
 
-
-
 ##########################################################
 ############### Cardano Node Configuration ###############
 ##########################################################
@@ -103,7 +101,7 @@ NodeId: 2
 NodeHostAddress: ''
 NodePort: 3002
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-acceptor.yaml
+++ b/configuration/log-config-acceptor.yaml
@@ -110,8 +110,6 @@ options:
 
 
 NodeId: 4
-NodeHostAddress: ''
-NodePort: 7000
 Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1

--- a/configuration/log-config-acceptor.yaml
+++ b/configuration/log-config-acceptor.yaml
@@ -156,28 +156,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/log-config-acceptor.yaml
+++ b/configuration/log-config-acceptor.yaml
@@ -104,3 +104,83 @@ options:
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
 
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 4
+NodeHostAddress: ''
+NodePort: 7000
+Protocol: RealPBFT
+GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold: 0.5
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -94,8 +94,6 @@ options:
 
 
 NodeId: 0
-NodeHostAddress: ''
-NodePort: 7000
 Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -96,7 +96,7 @@ options:
 NodeId: 0
 NodeHostAddress: ''
 NodePort: 7000
-Protocol: ByronLegacy
+Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -139,28 +139,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/mainnet-proxy-follower.yaml
+++ b/configuration/mainnet-proxy-follower.yaml
@@ -83,8 +83,6 @@ options:
 
 
 NodeId: 0
-NodeHostAddress: ''
-NodePort: 7776
 Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1

--- a/configuration/mainnet-proxy-follower.yaml
+++ b/configuration/mainnet-proxy-follower.yaml
@@ -128,28 +128,6 @@ SlotLength: 20000
 NetworkConnectionTimeout: 15000
 HandshakeTimeout: 30000
 
-#####       Certificates       #####
-
-
-CA-Organization: "Input Output HK"
-CA-CommonName: "Cardano SL Self-Signed Root CA"
-CA-ExpiryDays: 3600
-CA-AltDNS: []
-
-Server-Organization: "Input Output HK"
-Server-CommonName: "Cardano SL Server"
-Server-ExpiryDays: 3600
-Server-AltDNS: [ "localhost"
-               , "localhost.localdomain"
-               , "127.0.0.1"
-               , "::1"
-               ]
-
-Wallet-Organization: "Input Output HK"
-Wallet-CommonName: "Daedalus Wallet"
-Wallet-ExpiryDays: 3600
-Wallet-AltDNS: []
-
 Enabled: False
 Rate: 0
 Period: ''

--- a/configuration/mainnet-proxy-follower.yaml
+++ b/configuration/mainnet-proxy-follower.yaml
@@ -11,6 +11,8 @@ rotation:
 setupBackends:
   - AggregationBK
   - KatipBK
+  # - EditorBK
+  # - EKGViewBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -69,24 +71,11 @@ options:
       subtrace: NoTrace
     '#messagecounters.switchboard':
       subtrace: NoTrace
-    '#messagecounters.katip':
-      subtrace: NoTrace
-    '#messagecounters.monitoring':
-      subtrace: NoTrace
   mapBackends:
-    cardano.node.metrics.ChainDB:
+    cardano.epoch-validation.benchmark:
+      - AggregationBK
+    '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.metrics:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.BlockFetchDecision:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.peers.BlockFetchDecision:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
 
 ##########################################################
 ############### Cardano Node Configuration ###############
@@ -95,12 +84,12 @@ options:
 
 NodeId: 0
 NodeHostAddress: ''
-NodePort: 7000
+NodePort: 7776
 Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1
-RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True

--- a/configuration/simple-topology.json
+++ b/configuration/simple-topology.json
@@ -1,7 +1,7 @@
 [
     { "nodeId": 0
     , "nodeAddress":
-      { "addr": "::1"
+      { "addr": "127.0.0.1"
       , "port": 3000
       }
     , "producers":
@@ -9,7 +9,7 @@
         , "port": 3001
 	, "valency": 1
         }
-      , { "addr": "::1"
+      , { "addr": "127.0.0.1"
         , "port": 3002
 	, "valency": 1
         }
@@ -21,11 +21,11 @@
       , "port": 3001
       }
     , "producers":
-      [ { "addr": "::1"
+      [ { "addr": "127.0.0.1"
         , "port": 3000
 	, "valency": 1
         }
-      , { "addr": "::1"
+      , { "addr": "127.0.0.1"
         , "port": 3002
 	, "valency": 1
         }
@@ -33,11 +33,11 @@
     },
     { "nodeId": 2
     , "nodeAddress":
-      { "addr": "::1"
+      { "addr": "127.0.0.1"
       , "port": 3002
       }
     , "producers":
-      [ { "addr": "::1"
+      [ { "addr": "127.0.0.1"
         , "port": 3000
 	, "valency": 1
         }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -179,6 +179,7 @@
             (hsPkgs.async)
             (hsPkgs.bytestring)
             (hsPkgs.cardano-config)
+            (hsPkgs.cardano-prelude)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
             (hsPkgs.cardano-node)

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -7,8 +7,8 @@ let
   cfg = config.services.cardano-node;
   envConfig = environments.${cfg.environment};
   systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
-  nodeConfig = (import cfg.configFile) { inherit cfg; };
   configFile = toFile "config.json" (toJSON nodeConfig);
+  nodeConfig = (import cfg.configFile) { inherit cfg; };
   mkScript = cfg:
     let exec = "cardano-node";
         cmd = builtins.filter (x: x != "") [

--- a/nix/nixos/chairman-as-a-service.nix
+++ b/nix/nixos/chairman-as-a-service.nix
@@ -2,16 +2,18 @@
 , lib
 , ... }:
 
-with lib; with builtins;
+with import ../../lib.nix; with lib; with builtins;
 let
   cfg  = config.services.chairman;
   ncfg = config.services.cardano-node;
   ccfg      = config.services.cardano-cluster;
   envConfig = environments.${cfg.environment};
+  configFile = toFile "config.json" (toJSON nodeConfig);
+  nodeConfig = (import ncfg.configFile) { inherit cfg; };
 
   mkChairmanConfig = nodeConfig: chairmanConfig: {
     inherit (nodeConfig) package genesisFile genesisHash stateDir pbftThreshold consensusProtocol;
-    inherit (chairmanConfig) timeout maxBlockNo k node-ids;
+    inherit (chairmanConfig) timeout maxBlockNo k node-ids topology dbPrefix;
   };
   mkScript = cfg:
     let nodeIdArgs = builtins.concatStringsSep " "
@@ -23,12 +25,23 @@ let
           "--${ncfg.consensusProtocol}"
           (nodeIdArgs)
           "--timeout ${toString cfg.timeout}"
+          "--database-path ${cfg.stateDir}/${cfg.dbPrefix}"
           "--max-block-no ${toString cfg.maxBlockNo}"
           "--security-param ${toString cfg.k}"
           "--genesis-file ${cfg.genesisFile}"
           "--genesis-hash ${cfg.genesisHash}"
           "--socket-dir ${ if (ncfg.runtimeDir == null) then "${ncfg.stateDir}/socket" else "/run/${ncfg.runtimeDir}"}"
           "${lib.optionalString (cfg.pbftThreshold != null) "--pbft-signature-threshold ${cfg.pbftThreshold}"}"
+          "--topology ${cfg.topology}"
+          "--port 1234"
+          "--database-path ${cfg.stateDir}/${cfg.dbPrefix}"
+          "--genesis-file ${cfg.genesisFile}"
+          "--socket-dir ${ if (ncfg.runtimeDir == null) then "${ncfg.stateDir}/socket" else "/run/${ncfg.runtimeDir}"}"
+          "--config ${configFile}"
+
+
+
+
         ];
     in ''
         echo "Starting ${exec}: '' + concatStringsSep "\"\n   echo \"" cmd + ''"
@@ -59,6 +72,36 @@ in {
         default = 360;
         description = ''How long to wait for consensus of maxBlockNo blocks.'';
       };
+      topology = mkOption {
+        type = types.path;
+        default = mkEdgeTopology {
+          inherit (cfg) hostAddr nodeId port;
+          edgeHost = envConfig.edgeHost or "127.0.0.1";
+        };
+        description = ''
+          Cluster topology
+        '';
+      };
+      dbPrefix = mkOption {
+        type = types.str;
+        default = "db-${cfg.environment}";
+        description = ''
+          Prefix of database directories inside `stateDir`.
+          (eg. for "db", there will be db-0, etc.).
+        '';
+      };
+      environment = mkOption {
+        type = types.enum (builtins.attrNames environments);
+        default = "testnet";
+        description = ''
+          environment node will connect to
+        '';
+      };
+      configFile = mkOption {
+        type = types.path;
+        default = ../../configuration/default-node-config.nix;
+        description = ''Node's configuration file, as a Nix expression.'';
+      };
       maxBlockNo = mkOption {
         type = int;
         default = 5;
@@ -68,6 +111,13 @@ in {
         type = int;
         default = 2160;
         description = ''Should come from genesis instead.'';
+      };
+      genesisHash = mkOption {
+        type = types.str;
+        default = envConfig.genesisHash;
+        description = ''
+          Hash of the genesis file
+        '';
       };
     };
   };

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -6,6 +6,8 @@ let chairman-runner = chairmanScript {
         k          = 2160;
         timeout    = 300;
         maxBlockNo = 30;
+        topology = commonLib.mkEdgeTopology {};
+
       };
     };
 in {

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -26,6 +26,7 @@ in {
     $machine->waitForOpenPort(3001);
     $machine->waitForOpenPort(3002);
     $machine->waitForOpenPort(3003);
+    $machine->succeed("netstat -pltn | systemd-cat --identifier=netstat --priority=crit");
     $machine->succeed("${chairman-runner} 2>&1 | systemd-cat --identifier=chairman --priority=crit");
   '';
 

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -51,8 +51,6 @@ let
         nodeId;
       runtimeDir = null;
       dbPrefix = "db-${envConfig.name}";
-      logger.configFile = config.loggingConfig;
-      logger.extras = config.loggingExtras;
       topology = topologyFile;
     };
     nodeConf = { config.services.cardano-node = serviceConfig; };

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -18,8 +18,15 @@ exec cabal new-run exe:chairman -- --real-pbft \
                                 --core-node-id 0 --core-node-id 1 --core-node-id 2 \
                                 -k 10 -s 250 \
                                 -t 1000 \
+                                --port 1234 \
                                 --genesis-file "${genesis_file}" \
                                 --genesis-hash "${genesis_hash}" \
+                                --socket-dir "./socket/" \
                                 --pbft-signature-threshold 0.7 \
                                 --require-network-magic \
-                                --database-path "db"
+                                --database-path "db" \
+                                --topology configuration/simple-topology.json \
+                                --database-path ./db/ \
+                                --genesis-file ${genesis_file} \
+                                --socket-dir "./socket/" \
+                                --config "configuration/log-config-0.yaml"

--- a/scripts/generator.sh
+++ b/scripts/generator.sh
@@ -11,6 +11,10 @@ NETARGS=(
         --genesis-hash  "${genesis_hash}"
         generate-txs
         --topology      "configuration/simple-topology.json"
+        --genesis-file  "${genesis_file}"
+        --database-path "./db/"
+        --socket-dir    "./socket/"
+
 )
 TX_GEN_ARGS=(
         --num-of-txs     1000

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -32,6 +32,10 @@ args=" --real-pbft
        --wallet-key          ${from_key}
        --rich-addr-from    \"${from_addr}\"
        --txout            (\"${addr}\",${lovelace})
+       --topology            configuration/simple-topology.json
+       --genesis-file       \"${genesis_file}\"
+       --database-path       ./db/
+       --socket-dir          ./socket/
 "
 set -x
 ${RUNNER} cardano-cli ${args}

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -38,6 +38,10 @@ args=" --real-pbft
        --wallet-key          ${from_key}
        --txin             (\"${txid}\",${outindex})
        --txout            (\"${addr}\",${lovelace})
+       --topology            configuration/simple-topology.json
+       --genesis-file        \"${genesis_file}\"
+       --database-path       ./db/
+       --socket-dir          ./socket/
 "
 set -x
 ${RUNNER} cardano-cli ${args}

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -29,6 +29,7 @@ function acceptorargs() {
         nodecfg acceptor
         dlgkey 0
         dlgcert 0
+        printf -- "--port 1234"
 }
 
 function nodeargs () {
@@ -38,4 +39,5 @@ function nodeargs () {
         dlgkey $1
         dlgcert $1
         printf -- "${extra} "
+        printf -- "--port 300$1 "
 }

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -8,8 +8,8 @@ genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
-function logcfg () {
-        printf -- "--log-config configuration/log-config-${1}.yaml "
+function nodecfg () {
+        printf -- "--config configuration/log-config-${1}.yaml "
 }
 function dlgkey () {
         printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key " "$1"
@@ -18,12 +18,15 @@ function dlgcert () {
         printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json " "$1"
 }
 function commonargs() {
-        printf -- "--slot-duration 2 "
+        printf -- "--topology configuration/simple-topology.json "
+        printf -- "--database-path ./db/ "
+        printf -- "--genesis-file ${genesis_file} "
+        printf -- "--socket-dir ./socket/ "
 }
 
 function acceptorargs() {
         commonargs
-        logcfg acceptor
+        nodecfg acceptor
         dlgkey 0
         dlgcert 0
 }
@@ -31,16 +34,8 @@ function acceptorargs() {
 function nodeargs () {
         local extra="$2"
         commonargs
-        logcfg $1
+        nodecfg $1
         dlgkey $1
         dlgcert $1
-        printf -- "--node-id $1 "
-        printf -- "--port 300$1 "
-        printf -- "--genesis-file ${genesis_file} "
-        printf -- "--genesis-hash ${genesis_hash} "
-        printf -- "--pbft-signature-threshold 0.7 "
-        printf -- "--require-network-magic "
-        printf -- "--database-path db "
-        printf -- "--topology configuration/simple-topology.json "
         printf -- "${extra} "
 }

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -6,14 +6,11 @@ RUNNER=${RUNNER:-cabal new-run --}
 TOPOLOGY=${TOPOLOGY:-"configuration/topology-proxy-follower.json"}
 
 ARGS=(
-        --log-config              "configuration/log-configuration.yaml"
+        --database-path           "./db/"
         --genesis-file            "configuration/mainnet-genesis.json"
-        --genesis-hash            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-        --node-id                 "0"
         --topology                "${TOPOLOGY}"
-        --port                    "7776"
-        --real-pbft
-        --config                  "configuration/log-configuration.yaml"
+        --socket-dir              "./socket/"
+        --config                  "./configuration/mainnet-proxy-follower.yaml"
 )
 
 ${RUNNER} exe:cardano-node "${ARGS[@]}"

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -11,6 +11,7 @@ ARGS=(
         --topology                "${TOPOLOGY}"
         --socket-dir              "./socket/"
         --config                  "./configuration/mainnet-proxy-follower.yaml"
+        --port                    7776
 )
 
 ${RUNNER} exe:cardano-node "${ARGS[@]}"

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -13,6 +13,7 @@ ARGS=(
         --topology                "${TOPOLOGY}"
         --port                    "7776"
         --real-pbft
+        --config                  "configuration/log-configuration.yaml"
 )
 
 ${RUNNER} exe:cardano-node "${ARGS[@]}"

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -20,7 +20,6 @@ ALGO="--real-pbft"
 
 # EXTRA=""
 EXTRA="
-  --live-view
   --trace-block-fetch-decisions
   --trace-block-fetch-client
   --trace-block-fetch-server

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -16,7 +16,6 @@ CMD="cabal new-run --"
 # VERBOSITY="--tracing-verbosity-minimal"
 # VERBOSITY="--tracing-verbosity-normal"
 VERBOSITY="--tracing-verbosity-maximal"
-ALGO="--real-pbft"
 
 # EXTRA=""
 EXTRA="
@@ -55,8 +54,8 @@ tmux select-pane -t 4
 tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 " $(echo -n ${EXTRA})")" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 " $(echo -n ${EXTRA})")" C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 " $(echo -n ${EXTRA})")" C-m

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -8,7 +8,6 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-ALGO="--real-pbft"
 # CMD="stack exec --nix cardano-node --"
 CMD="cabal new-run --"
 # EXTRA="--live-view"
@@ -32,8 +31,8 @@ tmux select-pane -t 4
 tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 " ${EXTRA}")" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 " ${EXTRA}")" C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 " ${EXTRA}")" C-m

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -21,7 +21,10 @@ NETARGS=(
         --genesis-file "${genesis_file}"
         --genesis-hash "${genesis_hash}"
         submit-tx
-        --topology     "configuration/simple-topology.json"
+        --topology      "configuration/simple-topology.json"
+        --genesis-file  "${genesis_file}"
+        --database-path "./db/"
+        --socket-dir    "./socket/"
         --node-id      "0"
         --tx           "$TX"
 )

--- a/scripts/trace-acceptor.sh
+++ b/scripts/trace-acceptor.sh
@@ -3,8 +3,12 @@
 # CMD="stack exec trace-acceptor-node -- "
 # CMD="./trace-acceptor.exe -- "
 CMD="cabal new-run exe:trace-acceptor -- "
-
+#TODO: Confirm if db path is necessary for trace acceptor
 set -x
 ${CMD} \
-    --log-config configuration/log-config-acceptor.yaml \
+    --topology "./configuration/simple-topology.json" \
+    --database-path "./db/" \
+    --genesis-file "configuration/mainnet-genesis.json" \
+    --socket-dir "./socket" \
+    --config "configuration/log-config-acceptor.yaml" \
     $@

--- a/scripts/trace-acceptor.sh
+++ b/scripts/trace-acceptor.sh
@@ -11,4 +11,5 @@ ${CMD} \
     --genesis-file "configuration/mainnet-genesis.json" \
     --socket-dir "./socket" \
     --config "configuration/log-config-acceptor.yaml" \
+    --port 1234 \
     $@


### PR DESCRIPTION
This PR aims to reduce the `cardano-node` cli to the following:
```
Usage: cardano-node --topology FILEPATH --database-path FILEPATH
                    --genesis-file FILEPATH [--delegation-certificate FILEPATH] 
                    [--signing-key FILEPATH] --socket-dir FILEPATH 
                    [--host-addr HOST-NAME] --port PORT
                    --config NODE-CONFIGURATION [--help] [--help-tracing] 
                    [--help-advanced]
  Start node of the Cardano blockchain.
```
The `--config` parameter takes a yaml file that defines the logging and the node configuration but currently not the tracers.

**NB**: 
- In order to keep this PR from being even bigger, I will make a follow up PR to include the ability to turn off and on tracers (and change individual verbosities).
- Futher work needs to be done to rework the `cardano-cli` cli. Current changes made to it are temporary in order to keep this PR from getting larger. 

#275 

