### PR TITLE
Get the RealPBFT protocol and software version from the configuration

### DIFF
--- a/cardano-config/src/Cardano/Config/CommonCLI.hs
+++ b/cardano-config/src/Cardano/Config/CommonCLI.hs
@@ -22,15 +22,20 @@ module Cardano.Config.CommonCLI
   , lastStrOption
   , lastStrOptionM
   , lastFlag
-  , parseDbPath
-  , parseDelegationeCert
-  , parseGenesisHash
+  , parseDbPathLast
+  , parseDelegationCert
+  , parseDelegationCertLast
+  , parseGenesisHashLast
   , parseGenesisPath
-  , parsePbftSigThreshold
-  , parseRequireNetworkMagic
+  , parseGenesisPathLast
+  , parsePbftSigThresholdLast
+  , parseRequireNetworkMagicLast
   , parseSigningKey
-  , parseSlotLength
+  , parseSlotLengthLast
   , parseSocketDir
+  , parseSocketDirLast
+  -- Last Parsers
+  , parseSigningKeyLast
 
   ) where
 
@@ -67,46 +72,79 @@ data CommonCLIAdvanced = CommonCLIAdvanced
   Common CLI
 -------------------------------------------------------------------------------}
 
-parseDbPath :: Parser (Last FilePath)
-parseDbPath =
+parseDbPathLast :: Parser (Last FilePath)
+parseDbPathLast =
   lastStrOption
     ( long "database-path"
         <> metavar "FILEPATH"
         <> help "Directory where the state is stored."
     )
-parseGenesisPath :: Parser (Last FilePath)
+parseGenesisPath :: Parser FilePath
 parseGenesisPath =
+  strOption
+    ( long "genesis-file"
+        <> metavar "FILEPATH"
+        <> help "The filepath to the genesis file."
+    )
+
+parseGenesisPathLast :: Parser (Last FilePath)
+parseGenesisPathLast =
   lastStrOption
     ( long "genesis-file"
         <> metavar "FILEPATH"
         <> help "The filepath to the genesis file."
     )
 
-parseGenesisHash :: Parser (Last Text)
-parseGenesisHash =
+parseGenesisHashLast :: Parser (Last Text)
+parseGenesisHashLast =
   lastStrOption
     ( long "genesis-hash"
         <> metavar "GENESIS-HASH"
         <> help "The genesis hash value."
     )
-parseDelegationeCert :: Parser (Last FilePath)
-parseDelegationeCert =
+parseDelegationCert :: Parser FilePath
+parseDelegationCert =
+  strOption
+    ( long "delegation-certificate"
+        <> metavar "FILEPATH"
+        <> help "Path to the delegation certificate."
+    )
+
+parseDelegationCertLast :: Parser (Last FilePath)
+parseDelegationCertLast =
   lastStrOption
     ( long "delegation-certificate"
         <> metavar "FILEPATH"
         <> help "Path to the delegation certificate."
     )
 
-parseSigningKey :: Parser (Last FilePath)
-parseSigningKey =
+parseSigningKeyLast :: Parser (Last FilePath)
+parseSigningKeyLast =
   lastStrOption
     ( long "signing-key"
         <> metavar "FILEPATH"
         <> help "Path to the signing key."
     )
 
-parseSocketDir :: Parser (Last FilePath)
+parseSigningKey :: Parser FilePath
+parseSigningKey =
+  strOption
+    ( long "signing-key"
+        <> metavar "FILEPATH"
+        <> help "Path to the signing key."
+    )
+
+parseSocketDir :: Parser FilePath
 parseSocketDir =
+  strOption
+    ( long "socket-dir"
+        <> metavar "FILEPATH"
+        <> help "Directory with local sockets:\
+                \  ${dir}/node-{core,relay}-${node-id}.socket"
+    )
+
+parseSocketDirLast :: Parser (Last FilePath)
+parseSocketDirLast =
   lastStrOption
     ( long "socket-dir"
         <> metavar "FILEPATH"
@@ -149,23 +187,23 @@ parseCommonCLI =
          <> help "Directory with local sockets:  ${dir}/node-{core,relay}-${node-id}.socket"
         )
 
-parsePbftSigThreshold :: Parser (Last Double)
-parsePbftSigThreshold =
+parsePbftSigThresholdLast :: Parser (Last Double)
+parsePbftSigThresholdLast =
   lastDoubleOption
     ( long "pbft-signature-threshold"
         <> metavar "DOUBLE"
         <> help "The PBFT signature threshold."
         <> hidden
     )
-parseRequireNetworkMagic :: Parser (Last RequireNetworkMagic)
-parseRequireNetworkMagic =
+parseRequireNetworkMagicLast :: Parser (Last RequireNetworkMagic)
+parseRequireNetworkMagicLast =
   lastFlag NoRequireNetworkMagic RequireNetworkMagic
     ( long "require-network-magic"
         <> help "Require network magic in transactions."
         <> hidden
     )
-parseSlotLength :: Parser (Last Consensus.SlotLength)
-parseSlotLength = do
+parseSlotLengthLast :: Parser (Last Consensus.SlotLength)
+parseSlotLengthLast = do
   slotDurInteger <- lastAutoOption
                       ( long "slot-duration"
                           <> metavar "SECONDS"

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -303,8 +303,7 @@ parseTxRelatedValues =
         "submit-tx"
         "Submit a raw, signed transaction, in its on-wire representation."
         $ SubmitTx
-            <$> parseTopologyInfo "PBFT node ID to submit Tx to."
-            <*> parseTxFile "tx"
+            <$> parseTxFile "tx"
             <*> nodeCliParser
     , command'
         "issue-genesis-utxo-expenditure"
@@ -335,9 +334,7 @@ parseTxRelatedValues =
         "generate-txs"
         "Launch transactions generator."
         $ GenerateTxs
-            <$> parseTopologyInfo
-                  "PBFT node ID to submit generated Txs to."
-            <*> parseNumberOfTxs
+            <$> parseNumberOfTxs
                   "num-of-txs"
                   "Number of transactions generator will create."
             <*> parseNumberOfInputsPerTx

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -6,47 +5,33 @@
 {-# LANGUAGE RankNTypes #-}
 
 import           Cardano.Prelude hiding (option)
-import           Prelude (String, read)
+import           Prelude (String)
 
 import           Data.Semigroup ((<>))
-import           Network.Socket (PortNumber)
-import           Options.Applicative ( Parser, auto, flag, help, long
-                                     , metavar, option, str, value)
+import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..),)
-import qualified Ouroboros.Consensus.BlockchainTime as Consensus
 
 import           Cardano.Common.Help
 import           Cardano.Common.Parsers
-import           Cardano.Config.Protocol
-import           Cardano.Config.CommonCLI
+import           Cardano.Config.CommonCLI (parseCommonCLIAdvanced)
 import           Cardano.Config.Logging (createLoggingFeature)
-import           Cardano.Config.Partial (PartialCardanoConfiguration (..),
-                                         PartialCore (..), PartialNode (..),
-                                         mkCardanoConfiguration)
-import           Cardano.Config.Presets (mainnetConfiguration)
-import           Cardano.Config.Types (CardanoEnvironment (..), RequireNetworkMagic,
-                                       parseNodeConfiguration)
-import           Cardano.Config.Topology (NodeAddress (..), NodeHostAddress(..), TopologyInfo)
+import           Cardano.Config.Types (CardanoEnvironment (..), ConfigYamlFilePath(..),
+                                       NodeCLI(..), parseNodeConfiguration)
 import           Cardano.Node.Features.Node
-import           Cardano.Node.Run
-import           Cardano.Tracing.Tracers
 
 main :: IO ()
 main = do
     cli <- Opt.execParser opts
 
-    (features, nodeLayer) <- initializeAllFeatures cli pcc env
+    (features, nodeLayer) <- initializeAllFeatures cli env
 
     runCardanoApplicationWithFeatures features (cardanoApplication nodeLayer)
 
     where
-      pcc :: PartialCardanoConfiguration
-      pcc = mainnetConfiguration
-
       env :: CardanoEnvironment
       env = NoEnvironment
 
@@ -56,9 +41,11 @@ main = do
       opts :: Opt.ParserInfo NodeCLI
       opts =
         Opt.info (nodeCliParser
-                  <**> helperBrief "help" "Show this help text" nodeCliHelpMain
-                  <**> helperBrief "help-tracing" "Show help for tracing options" cliHelpTracing
-                  <**> helperBrief "help-advanced" "Show help for advanced options" cliHelpAdvanced)
+                    <**> helperBrief "help" "Show this help text" nodeCliHelpMain
+                    <**> helperBrief "help-tracing" "Show help for tracing options" cliHelpTracing
+                    <**> helperBrief "help-advanced" "Show help for advanced options" cliHelpAdvanced
+                 )
+
           ( Opt.fullDesc <>
             Opt.progDesc "Start node of the Cardano blockchain."
           )
@@ -86,163 +73,25 @@ main = do
         <$$> ""
         <$$> parserHelpOptions parseCommonCLIAdvanced
 
+
 initializeAllFeatures
   :: NodeCLI
-  -> PartialCardanoConfiguration
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
-initializeAllFeatures (NodeCLI parsedPcc (ConfigYamlFilePath ncFp))
-                      partialConfigPreset cardanoEnvironment = do
+initializeAllFeatures nCli@(NodeCLI _ ncFp _)
+                       cardanoEnvironment = do
 
-    -- `partialConfigPreset` and `parsedPcc` are merged then checked here using
-    -- the partial options monoid approach.
-    -- https://medium.com/@jonathangfischoff/the-partial-options-monoid-pattern-31914a71fc67
-    finalConfig <- case mkCardanoConfiguration $ partialConfigPreset <> parsedPcc of
-                     Left e -> throwIO e
-                     Right x -> pure x
+    (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment nCli
 
-    (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment finalConfig
-
-    nodeConfig <- parseNodeConfiguration ncFp
+    nodeConfig <- parseNodeConfiguration $ unConfigPath ncFp
     (nodeLayer   , nodeFeature)    <-
       createNodeFeature
         loggingLayer
         cardanoEnvironment
-        finalConfig
         nodeConfig
+        nCli
 
     pure ([ loggingFeature
           , nodeFeature
           ] :: [CardanoFeature]
          , nodeLayer)
-
--------------------------------------------------------------------------------
--- Parsers & Types
--------------------------------------------------------------------------------
-
-data NodeCLI = NodeCLI !PartialCardanoConfiguration  !ConfigYamlFilePath
-
--- | Filepath of the configuration yaml file. This file determines
--- all the configuration settings required for the cardano node
--- (logging, tracing, protocol, slot length etc)
-newtype ConfigYamlFilePath = ConfigYamlFilePath FilePath
-
--- | The product parser for all the CLI arguments.
-nodeCliParser :: Parser NodeCLI
-nodeCliParser = do
-  topInfo <- lastOption $ parseTopologyInfo "PBFT node ID to assume."
-  nAddr <- lastOption parseNodeAddress
-  ptcl <- ( parseProtocolBFT
-          <|> parseProtocolByron
-          <|> parseProtocolMockPBFT
-          <|> parseProtocolPraos
-          <|> parseProtocolRealPBFT
-          )
-  vMode <- parseViewMode
-  logConfigFp <- lastOption parseLogConfigFile
-  logMetrics <- parseLogMetrics
-  dbPath <- parseDbPath
-  genPath <- parseGenesisPath
-  genHash <- parseGenesisHash
-  delCert <- parseDelegationeCert
-  sKey <- parseSigningKey
-  socketDir <- parseSocketDir
-  traceOptions <- cliTracingParser
-  pbftSigThresh <- parsePbftSigThreshold
-  reqNetMagic <- parseRequireNetworkMagic
-  slotLength <- parseSlotLength
-
-  nodeConfigFp <- parseConfigFile
-
-  pure $ NodeCLI
-         (createPcc dbPath socketDir topInfo nAddr ptcl logConfigFp vMode
-                    logMetrics genPath genHash delCert sKey pbftSigThresh
-                    reqNetMagic traceOptions slotLength)
-         (ConfigYamlFilePath $ fromMaybe (panic "No configuration yaml filepath supplied") (getLast nodeConfigFp))
- where
-  -- This merges the command line parsed values into one `PartialCardanoconfiguration`.
-  createPcc
-    :: Last FilePath
-    -> Last FilePath
-    -> Last TopologyInfo
-    -> Last NodeAddress
-    -> Last Protocol
-    -> Last FilePath
-    -> Last ViewMode
-    -> Last Bool
-    -> Last FilePath
-    -> Last Text
-    -> Last FilePath
-    -> Last FilePath
-    -> Last Double
-    -> Last RequireNetworkMagic
-    -> Last TraceOptions
-    -> Last Consensus.SlotLength
-    -> PartialCardanoConfiguration
-  createPcc
-    dbPath
-    socketDir
-    topInfo
-    nAddr
-    ptcl
-    logConfigFp
-    vMode
-    logMetrics
-    genPath
-    genHash
-    delCert
-    sKey
-    pbftSigThresh
-    reqNetMagic
-    traceOptions
-    slotLength = mempty { pccDBPath = dbPath
-                        , pccNodeAddress = nAddr
-                        , pccSocketDir = socketDir
-                        , pccTopologyInfo = topInfo
-                        , pccProtocol = ptcl
-                        , pccViewMode = vMode
-                        , pccLogConfig = logConfigFp
-                        , pccLogMetrics = logMetrics
-                        , pccCore = mempty { pcoGenesisFile = genPath
-                                           , pcoGenesisHash = genHash
-                                           , pcoStaticKeyDlgCertFile = delCert
-                                           , pcoStaticKeySigningKeyFile = sKey
-                                           , pcoPBftSigThd = pbftSigThresh
-                                           , pcoRequiresNetworkMagic = reqNetMagic
-                                           }
-                        , pccNode = mempty { pnoSlotLength = slotLength }
-                        , pccTraceOptions = traceOptions
-                        }
-
-
-
-cliTracingParser :: Parser (Last TraceOptions)
-cliTracingParser = Last . Just <$> parseTraceOptions Opt.hidden
-
-parseNodeAddress :: Parser NodeAddress
-parseNodeAddress = NodeAddress <$> parseHostAddr <*> parsePort
-
-parseHostAddr :: Parser NodeHostAddress
-parseHostAddr =
-    option (NodeHostAddress . Just <$> read <$> str) (
-          long "host-addr"
-       <> metavar "HOST-NAME"
-       <> help "Optionally limit node to one ipv6 or ipv4 address"
-       <> (value $ NodeHostAddress Nothing)
-    )
-
-parsePort :: Parser PortNumber
-parsePort =
-    option ((fromIntegral :: Int -> PortNumber) <$> auto) (
-          long "port"
-       <> metavar "PORT"
-       <> help "The port number"
-    )
-
--- Optional flag for live view (with TUI graphics).
-parseViewMode :: Parser (Last ViewMode)
-parseViewMode =
-    flag (Last $ Just SimpleView) (Last $ Just LiveView) $ mconcat
-        [ long "live-view"
-        , help "Live view with TUI."
-        ]

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -265,6 +265,7 @@ executable chairman
                      , async
                      , bytestring
                      , cardano-config
+                     , cardano-prelude
                      , containers
                      , contra-tracer
                      , cardano-node
@@ -279,6 +280,8 @@ executable chairman
                      , text
                      , typed-protocols
                      , typed-protocols-cbor
+
+  default-extensions:   NoImplicitPrelude
 
   if os(windows)
      build-depends:    Win32

--- a/cardano-node/src/Cardano/CLI/Genesis.hs
+++ b/cardano-node/src/Cardano/CLI/Genesis.hs
@@ -5,7 +5,6 @@
 
 module Cardano.CLI.Genesis
   ( NewDirectory(..)
-  , GenesisFile(..)
   , GenesisParameters(..)
   , mkGenesis
   , readGenesis
@@ -44,14 +43,11 @@ import qualified Cardano.Crypto as Crypto
 
 import           Cardano.CLI.Key
 import           Cardano.CLI.Ops
+import           Cardano.Config.Types (GenesisFile(..))
 
 
 newtype NewDirectory =
   NewDirectory FilePath
-  deriving (Eq, Ord, Show, IsString)
-
-newtype GenesisFile =
-  GenesisFile FilePath
   deriving (Eq, Ord, Show, IsString)
 
 -- | Parameters required for generation of new genesis.
@@ -64,7 +60,7 @@ data GenesisParameters = GenesisParameters
   , gpFakeAvvmOptions :: !Genesis.FakeAvvmOptions
   , gpAvvmBalanceFactor :: !Common.LovelacePortion
   , gpSeed :: !(Maybe Integer)
-  }
+  } deriving Show
 
 mkGenesisSpec :: GenesisParameters -> ExceptT CliError IO Genesis.GenesisSpec
 mkGenesisSpec gp = do

--- a/cardano-node/src/Cardano/CLI/Key.hs
+++ b/cardano-node/src/Cardano/CLI/Key.hs
@@ -10,9 +10,8 @@
 
 module Cardano.CLI.Key
   ( -- * Keys
-    SigningKeyFile(..)
+    VerificationKeyFile(..)
   , NewSigningKeyFile(..)
-  , VerificationKeyFile(..)
   , NewVerificationKeyFile(..)
   , prettyPublicKey
   , readSigningKey
@@ -44,16 +43,13 @@ import           System.IO (hSetEcho, hFlush, stdout, stdin)
 
 import qualified Cardano.Chain.Common as Common
 import           Cardano.Config.Protocol
+import           Cardano.Config.Types (SigningKeyFile(..))
 import           Cardano.Crypto (SigningKey(..))
 import qualified Cardano.Crypto.Random as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
 import           Cardano.CLI.Ops
 
-
-newtype SigningKeyFile =
-  SigningKeyFile FilePath
-  deriving (Eq, Ord, Show, IsString)
 
 newtype NewSigningKeyFile =
   NewSigningKeyFile FilePath

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -110,7 +110,6 @@ data CliError
   -- the signing key file.
   | InvariantViolation !Prelude.String
 
-
 instance Show CliError where
   show (OutputMustNotAlreadyExist fp)
     = "Output file/directory must not already exist: " <> fp

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Common.Parsers
   ( loggingParser
+  , parseConfigFile
   , parseCoreNodeId
   , parseLogConfigFile
   , parseLogMetrics
@@ -37,6 +38,15 @@ import           Cardano.Config.Topology
 import           Cardano.Config.Types (TraceOptions(..))
 
 -- Common command line parsers
+
+parseConfigFile :: Parser (Last FilePath)
+parseConfigFile =
+  (Last . Just) <$> strOption
+    ( long "config-yaml"
+    <> metavar "NODE-CONFIGURATION"
+    <> help "Configuration file for the cardano-node"
+    <> completer (bashCompleter "file")
+    )
 
 parseCoreNodeId :: Parser CoreNodeId
 parseCoreNodeId =

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -1,13 +1,18 @@
-{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Common.Parsers
-  ( loggingParser
+  ( cliTracingParser
+  , loggingParser
+  , nodeCliParser
   , parseConfigFile
   , parseCoreNodeId
-  , parseLogConfigFile
-  , parseLogMetrics
+  , parseDbPath
+  , parseLogConfigFileLast
+  , parseLogMetricsLast
+  , parseLogOutputFile
   , parseProtocol
   , parseProtocolBFT
   , parseProtocolByron
@@ -32,20 +37,66 @@ import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 
+import           Cardano.Config.CommonCLI
 import           Cardano.Config.Orphanage
 import           Cardano.Config.Protocol
 import           Cardano.Config.Topology
-import           Cardano.Config.Types (TraceOptions(..))
+import           Cardano.Config.Types (ConfigYamlFilePath(..), DbFile(..),
+                                       DelegationCertFile(..), GenesisFile (..),
+                                       MiscellaneousFilepaths(..),
+                                       NodeCLI(..), SigningKeyFile(..), SocketFile(..),
+                                       TraceOptions(..), TopologyFile(..))
 
 -- Common command line parsers
 
-parseConfigFile :: Parser (Last FilePath)
+cliTracingParser :: Parser (Last TraceOptions)
+cliTracingParser = Last . Just <$> parseTraceOptions Opt.hidden
+
+-- | The product parser for all the CLI arguments.
+nodeCliParser :: Parser NodeCLI
+nodeCliParser = do
+  -- Filepaths
+  topFp <- parseTopologyFile
+  dbFp <- parseDbPath
+  genFp <- parseGenesisPath
+  delCertFp <- optional parseDelegationCert
+  sKeyFp <- optional parseSigningKey
+  socketFp <- parseSocketDir
+
+  -- NodeConfiguration filepath
+  nodeConfigFp <- parseConfigFile
+
+  -- TraceOptions
+  traceOptions <- cliTracingParser
+
+
+  pure $ NodeCLI
+           (MiscellaneousFilepaths
+              (TopologyFile topFp)
+              (DbFile dbFp)
+              (GenesisFile genFp)
+              (DelegationCertFile <$> delCertFp)
+              (SigningKeyFile <$> sKeyFp)
+              (SocketFile socketFp)
+            )
+           (ConfigYamlFilePath nodeConfigFp)
+           (fromMaybe (panic "Cardano.Common.Parsers: Trace Options were not specified") $ getLast traceOptions)
+
+parseConfigFile :: Parser FilePath
 parseConfigFile =
-  (Last . Just) <$> strOption
+  strOption
     ( long "config-yaml"
     <> metavar "NODE-CONFIGURATION"
     <> help "Configuration file for the cardano-node"
     <> completer (bashCompleter "file")
+    )
+
+parseDbPath :: Parser FilePath
+parseDbPath =
+  strOption
+    ( long "database-path"
+    <> metavar "FILEPATH"
+    <> help "Directory where the state is stored."
     )
 
 parseCoreNodeId :: Parser CoreNodeId
@@ -132,21 +183,30 @@ parseTopologyFile =
          <> metavar "FILEPATH"
          <> help "The path to a file describing the topology."
     )
-parseLogConfigFile :: Parser FilePath
-parseLogConfigFile =
+parseLogOutputFile :: Parser FilePath
+parseLogOutputFile =
   strOption
+    ( long "log-output"
+    <> metavar "FILEPATH"
+    <> help "Logging output file"
+    <> completer (bashCompleter "file")
+    )
+
+parseLogConfigFileLast :: Parser (Last FilePath)
+parseLogConfigFileLast =
+  lastStrOption
     ( long "log-config"
     <> metavar "LOGCONFIG"
     <> help "Configuration file for logging"
     <> completer (bashCompleter "file")
     )
 
-parseLogMetrics :: Parser (Last Bool)
-parseLogMetrics =
-  (Last . Just) <$> switch
-                      ( long "log-metrics"
-                      <> help "Log a number of metrics about this node"
-                      )
+parseLogMetricsLast :: Parser (Last Bool)
+parseLogMetricsLast =
+ Last . Just <$> switch
+   ( long "log-metrics"
+   <> help "Log a number of metrics about this node"
+   )
 
 -- | A parser disables logging if --log-config is not supplied.
 loggingParser :: Parser LoggingCLIArguments

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -8,9 +8,8 @@ module Cardano.Node.Features.Node
 
 import           Cardano.Prelude
 
-import           Cardano.Config.Types (CardanoConfiguration (..),
-                                       CardanoEnvironment (..),
-                                       NodeConfiguration)
+import           Cardano.Config.Types (CardanoEnvironment (..),
+                                       NodeConfiguration, NodeCLI(..))
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
@@ -31,10 +30,10 @@ data NodeLayer = NodeLayer
 createNodeFeature
   :: LoggingLayer
   -> CardanoEnvironment
-  -> CardanoConfiguration
   -> NodeConfiguration
+  -> NodeCLI
   -> IO (NodeLayer, CardanoFeature)
-createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfiguration = do
+createNodeFeature loggingLayer cardanoEnvironment nodeConfiguration nCli = do
     -- we parse any additional configuration if there is any
     -- We don't know where the user wants to fetch the additional
     -- configuration from, it could be from the filesystem, so
@@ -44,8 +43,8 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfi
     nodeLayer <- createNodeLayer
                    cardanoEnvironment
                    loggingLayer
-                   cardanoConfiguration
                    nodeConfiguration
+                   nCli
 
     -- Construct the cardano feature
     let cardanoFeature :: CardanoFeature
@@ -61,10 +60,10 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfi
     createNodeLayer
       :: CardanoEnvironment
       -> LoggingLayer
-      -> CardanoConfiguration
       -> NodeConfiguration
+      -> NodeCLI
       -> IO NodeLayer
-    createNodeLayer _ logLayer cc nc = do
+    createNodeLayer _ logLayer nc nCli' = do
         pure $ NodeLayer
-          { nlRunNode = liftIO $ runNode logLayer cc nc
+          { nlRunNode = liftIO $ runNode logLayer nc nCli'
           }

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -9,7 +9,8 @@ module Cardano.Node.Features.Node
 import           Cardano.Prelude
 
 import           Cardano.Config.Types (CardanoConfiguration (..),
-                                       CardanoEnvironment (..))
+                                       CardanoEnvironment (..),
+                                       NodeConfiguration)
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
@@ -31,8 +32,9 @@ createNodeFeature
   :: LoggingLayer
   -> CardanoEnvironment
   -> CardanoConfiguration
+  -> NodeConfiguration
   -> IO (NodeLayer, CardanoFeature)
-createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
+createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration nodeConfiguration = do
     -- we parse any additional configuration if there is any
     -- We don't know where the user wants to fetch the additional
     -- configuration from, it could be from the filesystem, so
@@ -43,6 +45,7 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
                    cardanoEnvironment
                    loggingLayer
                    cardanoConfiguration
+                   nodeConfiguration
 
     -- Construct the cardano feature
     let cardanoFeature :: CardanoFeature
@@ -59,8 +62,9 @@ createNodeFeature loggingLayer cardanoEnvironment cardanoConfiguration = do
       :: CardanoEnvironment
       -> LoggingLayer
       -> CardanoConfiguration
+      -> NodeConfiguration
       -> IO NodeLayer
-    createNodeLayer _ logLayer cc = do
+    createNodeLayer _ logLayer cc nc = do
         pure $ NodeLayer
-          { nlRunNode = liftIO $ runNode logLayer cc
+          { nlRunNode = liftIO $ runNode logLayer cc nc
           }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -45,7 +45,8 @@ import           Cardano.BM.Data.LogItem (LogObject (..))
 import           Cardano.BM.Data.Tracer (ToLogObject (..),
                                          TracingVerbosity (..))
 import           Cardano.Config.Logging (LoggingLayer (..))
-import           Cardano.Config.Types (NodeConfiguration (..), ViewMode (..))
+import           Cardano.Config.Types (MiscellaneousFilepaths(..),
+                                       NodeConfiguration (..), ViewMode (..))
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Subscription.Dns
@@ -66,7 +67,8 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Cardano.Common.LocalSocket
 import           Cardano.Config.Protocol (SomeProtocol(..), fromProtocol)
 import           Cardano.Config.Topology
-import           Cardano.Config.Types (CardanoConfiguration(..))
+import           Cardano.Config.Types (DbFile(..), NodeCLI(..),
+                                       SocketFile(..), TopologyFile(..))
 import           Cardano.Tracing.Tracers
 #ifdef UNIX
 import           Cardano.Node.TUI.LiveView
@@ -89,24 +91,24 @@ instance NoUnexpectedThunks Peer where
 
 runNode
   :: LoggingLayer
-  -> CardanoConfiguration
   -> NodeConfiguration
+  -> NodeCLI
   -> IO ()
-runNode loggingLayer cc nc = do
+runNode loggingLayer nc nCli = do
     let !trace = llAppendName loggingLayer "node" (llBasicTrace loggingLayer)
     let tracer      = contramap pack $ toLogObject trace
 
     traceWith tracer $ "tracing verbosity = " ++
-                         case traceVerbosity $ ccTraceOptions cc of
+                         case traceVerbosity $ traceOpts nCli of
                              NormalVerbosity -> "normal"
                              MinimalVerbosity -> "minimal"
                              MaximalVerbosity -> "maximal"
-    SomeProtocol p  <- fromProtocol cc $ ncProtocol nc
+    SomeProtocol p  <- fromProtocol nc nCli $ ncProtocol nc
 
-    let tracers     = mkTracers (ccTraceOptions cc) trace
+    let tracers     = mkTracers (traceOpts nCli) trace
 
-    case ccViewMode cc of
-      SimpleView -> handleSimpleNode p trace tracers cc nc
+    case ncViewMode nc of
+      SimpleView -> handleSimpleNode p trace tracers nCli nc
       LiveView   -> do
 #ifdef UNIX
         let c = llConfiguration loggingLayer
@@ -114,18 +116,18 @@ runNode loggingLayer cc nc = do
         -- turn off logging to the console, only forward it through a pipe to a central logging process
         CM.setDefaultBackends c [TraceForwarderBK, UserDefinedBK "LiveViewBackend"]
         -- User will see a terminal graphics and will be able to interact with it.
-        nodeThread <- Async.async $ handleSimpleNode p trace tracers cc nc
+        nodeThread <- Async.async $ handleSimpleNode p trace tracers nCli nc
 
         be :: LiveViewBackend Text <- realize c
         let lvbe = MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be }
         llAddBackend loggingLayer lvbe (UserDefinedBK "LiveViewBackend")
-        setTopology be $ ccTopologyInfo cc
+        setTopology be (ncNodeId nc)
         setNodeThread be nodeThread
         captureCounters be trace
 
         void $ Async.waitAny [nodeThread]
 #else
-        handleSimpleNode p trace tracers nc
+        handleSimpleNode p trace tracers nCli nc
 #endif
 
 -- | Sets up a simple node, which will run the chain sync protocol and block
@@ -135,12 +137,12 @@ handleSimpleNode :: forall blk. RunNode blk
                  => Consensus.Protocol blk
                  -> Tracer IO (LogObject Text)
                  -> Tracers Peer blk
-                 -> CardanoConfiguration
+                 -> NodeCLI
                  -> NodeConfiguration
                  -> IO ()
-handleSimpleNode p trace nodeTracers cc nc = do
+handleSimpleNode p trace nodeTracers nCli nc = do
     NetworkTopology nodeSetups <-
-      either error id <$> readTopologyFile (topologyFile $ ccTopologyInfo cc)
+      either error id <$> readTopologyFile (unTopology . topFile $ mscFp nCli)
 
     let pInfo@ProtocolInfo{ pInfoConfig = cfg } =
           protocolInfo (NumCoreNodes (length nodeSetups)) (CoreNodeId nid) p
@@ -166,7 +168,10 @@ handleSimpleNode p trace nodeTracers cc nc = do
       ]
 
     -- Socket directory
-    myLocalAddr <- localSocketAddrInfo (node $ ccTopologyInfo cc) (ccSocketDir cc) MkdirIfMissing
+    myLocalAddr <- localSocketAddrInfo
+                     (ncNodeId nc)
+                     (unSocket . socketFile $ mscFp nCli)
+                     MkdirIfMissing
 
     addrs <- nodeAddressInfo $ ncNodeAddress nc
     let ipProducerAddrs  :: [NodeAddress]
@@ -206,9 +211,9 @@ handleSimpleNode p trace nodeTracers cc nc = do
           , dstValency = raValency ra
           }
 
-    removeStaleLocalSocket (node $ ccTopologyInfo cc) (ccSocketDir cc)
+    removeStaleLocalSocket (ncNodeId nc) (unSocket . socketFile $ mscFp nCli)
 
-    dbPath <- canonicalizePath =<< makeAbsolute (ccDBPath cc)
+    dbPath <- canonicalizePath =<< makeAbsolute (unDB . dBFile $ mscFp nCli)
 
     varTip <- atomically $ newTVar GenesisPoint
 
@@ -228,6 +233,6 @@ handleSimpleNode p trace nodeTracers cc nc = do
           atomically $ writeTVar varTip tip
   where
       nid :: Int
-      nid = case node $ ccTopologyInfo cc of
+      nid = case ncNodeId nc of
               CoreId  n -> n
               RelayId _ -> error "Non-core nodes currently not supported"

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -63,7 +63,6 @@ import           Cardano.BM.Trace
 import           Cardano.Node.TUI.GitRev (gitRev)
 import           Ouroboros.Consensus.NodeId
 import           Paths_cardano_node (version)
-import           Cardano.Config.Topology
 
 -- constants, to be evaluated from host system
 
@@ -335,8 +334,8 @@ initLiveViewState = do
                 , lvsColorTheme          = DarkTheme
                 }
 
-setTopology :: LiveViewBackend a -> TopologyInfo -> IO ()
-setTopology lvbe (TopologyInfo nodeid _) =
+setTopology :: LiveViewBackend a -> NodeId -> IO ()
+setTopology lvbe nodeid =
     modifyMVar_ (getbe lvbe) $ \lvs ->
         return $ lvs { lvsNodeId = namenum }
   where

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -86,3 +86,86 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 0
+NodeHostAddress: ''
+NodePort: 3000
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -86,9 +86,6 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
-
-
-
 ##########################################################
 ############### Cardano Node Configuration ###############
 ##########################################################
@@ -98,7 +95,7 @@ NodeId: 0
 NodeHostAddress: ''
 NodePort: 3000
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -86,3 +86,85 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 1
+NodeHostAddress: ''
+NodePort: 3001
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -97,7 +97,7 @@ NodeId: 1
 NodeHostAddress: ''
 NodePort: 3001
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -91,3 +91,86 @@ options:
     cardano.node.peers.BlockFetchDecision:
       - kind: UserDefinedBK
         name: LiveViewBackend
+
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 2
+NodeHostAddress: ''
+NodePort: 3002
+Protocol: RealPBFT
+GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -92,8 +92,6 @@ options:
       - kind: UserDefinedBK
         name: LiveViewBackend
 
-
-
 ##########################################################
 ############### Cardano Node Configuration ###############
 ##########################################################
@@ -103,7 +101,7 @@ NodeId: 2
 NodeHostAddress: ''
 NodePort: 3002
 Protocol: RealPBFT
-GenesisHash: b010944818186e0f1e4094d41b0612240f61908a5a262080c0be5d63ebd4766b
+GenesisHash: c0c757817d86660accdc45b9d18c1274d51d6427b92995944d014e0ff056cb3e
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7

--- a/configuration/log-config-acceptor.yaml
+++ b/configuration/log-config-acceptor.yaml
@@ -104,3 +104,83 @@ options:
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
 
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 4
+NodeHostAddress: ''
+NodePort: 7000
+Protocol: RealPBFT
+GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold: 0.5
+TurnOnLogging: True
+ViewMode: SimpleView
+TurnOnLogMetrics: False
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -96,7 +96,7 @@ options:
 NodeId: 0
 NodeHostAddress: ''
 NodePort: 7000
-Protocol: ByronLegacy
+Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic

--- a/configuration/mainnet-proxy-follower.yaml
+++ b/configuration/mainnet-proxy-follower.yaml
@@ -11,6 +11,8 @@ rotation:
 setupBackends:
   - AggregationBK
   - KatipBK
+  # - EditorBK
+  # - EKGViewBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -69,24 +71,11 @@ options:
       subtrace: NoTrace
     '#messagecounters.switchboard':
       subtrace: NoTrace
-    '#messagecounters.katip':
-      subtrace: NoTrace
-    '#messagecounters.monitoring':
-      subtrace: NoTrace
   mapBackends:
-    cardano.node.metrics.ChainDB:
+    cardano.epoch-validation.benchmark:
+      - AggregationBK
+    '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.metrics:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.BlockFetchDecision:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.peers.BlockFetchDecision:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
 
 ##########################################################
 ############### Cardano Node Configuration ###############
@@ -95,14 +84,14 @@ options:
 
 NodeId: 0
 NodeHostAddress: ''
-NodePort: 7000
+NodePort: 7776
 Protocol: RealPBFT
 GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 NumCoreNodes: 1
-RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+RequiresNetworkMagic: RequiresMagic
+PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: SimpleView
+ViewMode
 TurnOnLogMetrics: True
 ##### Network Time Parameters #####
 

--- a/configuration/simple-topology.json
+++ b/configuration/simple-topology.json
@@ -1,7 +1,7 @@
 [
     { "nodeId": 0
     , "nodeAddress":
-      { "addr": "::1"
+      { "addr": "127.0.0.1"
       , "port": 3000
       }
     , "producers":
@@ -9,7 +9,7 @@
         , "port": 3001
 	, "valency": 1
         }
-      , { "addr": "::1"
+      , { "addr": "127.0.0.1"
         , "port": 3002
 	, "valency": 1
         }
@@ -21,11 +21,11 @@
       , "port": 3001
       }
     , "producers":
-      [ { "addr": "::1"
+      [ { "addr": "127.0.0.1"
         , "port": 3000
 	, "valency": 1
         }
-      , { "addr": "::1"
+      , { "addr": "127.0.0.1"
         , "port": 3002
 	, "valency": 1
         }
@@ -33,11 +33,11 @@
     },
     { "nodeId": 2
     , "nodeAddress":
-      { "addr": "::1"
+      { "addr": "127.0.0.1"
       , "port": 3002
       }
     , "producers":
-      [ { "addr": "::1"
+      [ { "addr": "127.0.0.1"
         , "port": 3000
 	, "valency": 1
         }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -178,6 +178,7 @@
             (hsPkgs.async)
             (hsPkgs.bytestring)
             (hsPkgs.cardano-config)
+            (hsPkgs.cardano-prelude)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
             (hsPkgs.cardano-node)

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "02ea28007cd0fdda9e713d64bacb31e4d496acbc",
-  "date": "2019-08-23T17:57:41+00:00",
-  "sha256": "1fdv7yn4l9yzrvqgzfv0rjkryv5q5qpxh8sfqgvibqgqva0yv4n6",
+  "rev": "d708bde14bb6d68204d579ce606415dbfd4d9595",
+  "date": "2019-11-11T16:32:41+00:00",
+  "sha256": "1dfcs1l42373j8k409gp8057xjmi5d6bf42maxfdg4kr1n482xqz",
   "fetchSubmodules": false
 }

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "d708bde14bb6d68204d579ce606415dbfd4d9595",
-  "date": "2019-11-11T16:32:41+00:00",
-  "sha256": "1dfcs1l42373j8k409gp8057xjmi5d6bf42maxfdg4kr1n482xqz",
+  "rev": "ae4232c5e206f2cde44248099c37d6d7dfd4f342",
+  "date": "2019-11-12T01:56:13+00:00",
+  "sha256": "1yjgjvm0jcnrwqsq5dl77mz01c3iwzr2bgadqv4lsmjy7bgbp1bf",
   "fetchSubmodules": false
 }

--- a/nix/nixos/cardano-cluster-service.nix
+++ b/nix/nixos/cardano-cluster-service.nix
@@ -140,7 +140,7 @@ in {
     services.cardano-node = {
       enable = true;
       instanced = true;
-      inherit topology genesisFile genesisHash signingKey delegationCertificate nodeId port;
+      inherit topology genesisFile signingKey delegationCertificate nodeId port;
     };
     systemd.services."cardano-node@" = {
       scriptArgs = "%i ${ncfg.genesisFile}";

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -151,9 +151,9 @@ in {
 
       configFile = mkOption {
         type = types.path;
-        default = ../../configuration/log-configuration.yaml;
+        default = envConfig.configFile;
         description = ''
-          Logger configuration file
+          Configuration file
         '';
       };
     };

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -11,20 +11,13 @@ let
     let exec = "cardano-node";
         cmd = builtins.filter (x: x != "") [
           "${cfg.package}/bin/${exec}"
+          "--config-yaml ${cfg.configFile}"
           "--genesis-file ${cfg.genesisFile}"
-          "--genesis-hash ${cfg.genesisHash}"
-          "--log-config ${cfg.logger.configFile}"
           "--database-path ${cfg.stateDir}/${cfg.dbPrefix}"
           "--socket-dir ${ if (cfg.runtimeDir == null) then "${cfg.stateDir}/socket" else "/run/${cfg.runtimeDir}"}"
           "--topology ${cfg.topology}"
-          "--${cfg.consensusProtocol}"
-          "--node-id ${toString cfg.nodeId}"
-          "--host-addr ${cfg.hostAddr}"
-          "--port ${toString cfg.port}"
-          "${lib.optionalString (cfg.pbftThreshold != null) "--pbft-signature-threshold ${cfg.pbftThreshold}"}"
           "${lib.optionalString (cfg.signingKey != null) "--signing-key ${cfg.signingKey}"}"
           "${lib.optionalString (cfg.delegationCertificate != null) "--delegation-certificate ${cfg.delegationCertificate}"}"
-          "${lib.optionalString (cfg.logger.extras != null) "${cfg.logger.extras}"}"
         ];
     in ''
         echo "Starting ${exec}: '' + concatStringsSep "\"\n   echo \"" cmd + ''"
@@ -80,22 +73,6 @@ in {
         '';
       };
 
-      genesisHash = mkOption {
-        type = types.str;
-        default = envConfig.genesisHash;
-        description = ''
-          Hash of the genesis file
-        '';
-      };
-
-      pbftThreshold = mkOption {
-        type = types.nullOr types.str;
-        default = envConfig.pbftThreshold or null;
-        description = ''
-          PBFT Threshold
-        '';
-      };
-
       signingKey = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -109,18 +86,6 @@ in {
         default = null;
         description = ''
           Delegation certificate
-        '';
-      };
-
-      consensusProtocol = mkOption {
-        default = "real-pbft";
-        type = types.enum ["bft" "praos" "mock-pbft" "real-pbft"];
-        description = ''
-          Consensus initialy used by the node:
-            - bft: BFT consensus algorithm
-            - praos: Praos consensus algorithm
-            - mock-pbft: Permissive BFT consensus algorithm using a mock ledger
-            - real-pbft: Permissive BFT consensus algorithm using the real ledger
         '';
       };
 
@@ -184,18 +149,11 @@ in {
         '';
       };
 
-      logger.configFile = mkOption {
+      configFile = mkOption {
         type = types.path;
         default = ../../configuration/log-configuration.yaml;
         description = ''
           Logger configuration file
-        '';
-      };
-      logger.extras = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = ''
-          Logging extra arguments
         '';
       };
     };

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -12,12 +12,10 @@ let
   };
   mkNodeScript = envConfig: let
     defaultConfig = {
-      consensusProtocol = "real-pbft";
       hostAddr = "127.0.0.1";
       port = 3001;
       signingKey = null;
       delegationCertificate = null;
-      pbftThreshold = null;
       nodeId = 0;
       stateDir = "./";
       # defaults to proxy if env has no relays
@@ -26,8 +24,6 @@ let
       useProxy = false;
       proxyPort = 7777;
       proxyHost = "127.0.0.1";
-      loggingConfig = ../configuration/log-configuration.yaml;
-      loggingExtras = null;
     };
     config = defaultConfig // envConfig // customConfig;
     topologyFile = let
@@ -40,19 +36,15 @@ let
     serviceConfig = {
       inherit (config)
         genesisFile
-        genesisHash
         stateDir
         signingKey
         delegationCertificate
-        consensusProtocol
-        pbftThreshold
         hostAddr
         port
+        configFile
         nodeId;
       runtimeDir = null;
       dbPrefix = "db-${envConfig.name}";
-      logger.configFile = config.loggingConfig;
-      logger.extras = config.loggingExtras;
       topology = topologyFile;
     };
     nodeConf = { config.services.cardano-node = serviceConfig; };

--- a/scripts/chairman.sh
+++ b/scripts/chairman.sh
@@ -20,6 +20,12 @@ exec cabal new-run exe:chairman -- --real-pbft \
                                 -t 1000 \
                                 --genesis-file "${genesis_file}" \
                                 --genesis-hash "${genesis_hash}" \
+                                --socket-dir "./socket/" \
                                 --pbft-signature-threshold 0.7 \
                                 --require-network-magic \
-                                --database-path "db"
+                                --database-path "db" \
+                                --topology configuration/simple-topology.json \
+                                --database-path ./db/ \
+                                --genesis-file ${genesis_file} \
+                                --socket-dir "./socket/" \
+                                --config-yaml "configuration/log-config-0.yaml"

--- a/scripts/generator.sh
+++ b/scripts/generator.sh
@@ -11,6 +11,10 @@ NETARGS=(
         --genesis-hash  "${genesis_hash}"
         generate-txs
         --topology      "configuration/simple-topology.json"
+        --genesis-file  "${genesis_file}"
+        --database-path "./db/"
+        --socket-dir    "./socket/"
+
 )
 TX_GEN_ARGS=(
         --num-of-txs     1000

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -32,6 +32,10 @@ args=" --real-pbft
        --wallet-key          ${from_key}
        --rich-addr-from    \"${from_addr}\"
        --txout            (\"${addr}\",${lovelace})
+       --topology            configuration/simple-topology.json
+       --genesis-file       \"${genesis_file}\"
+       --database-path       ./db/
+       --socket-dir          ./socket/
 "
 set -x
 ${RUNNER} cardano-cli ${args}

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -38,6 +38,10 @@ args=" --real-pbft
        --wallet-key          ${from_key}
        --txin             (\"${txid}\",${outindex})
        --txout            (\"${addr}\",${lovelace})
+       --topology            configuration/simple-topology.json
+       --genesis-file        \"${genesis_file}\"
+       --database-path       ./db/
+       --socket-dir          ./socket/
 "
 set -x
 ${RUNNER} cardano-cli ${args}

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -8,8 +8,8 @@ genesis_file="${genesis_root}/genesis.json"
 if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
-function logcfg () {
-        printf -- "--log-config configuration/log-config-${1}.yaml "
+function nodecfg () {
+        printf -- "--config-yaml configuration/log-config-${1}.yaml "
 }
 function dlgkey () {
         printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key " "$1"
@@ -18,12 +18,15 @@ function dlgcert () {
         printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json " "$1"
 }
 function commonargs() {
-        printf -- "--slot-duration 2 "
+        printf -- "--topology configuration/simple-topology.json "
+        printf -- "--database-path ./db/ "
+        printf -- "--genesis-file ${genesis_file} "
+        printf -- "--socket-dir ./socket/ "
 }
 
 function acceptorargs() {
         commonargs
-        logcfg acceptor
+        nodecfg acceptor
         dlgkey 0
         dlgcert 0
 }
@@ -31,16 +34,8 @@ function acceptorargs() {
 function nodeargs () {
         local extra="$2"
         commonargs
-        logcfg $1
+        nodecfg $1
         dlgkey $1
         dlgcert $1
-        printf -- "--node-id $1 "
-        printf -- "--port 300$1 "
-        printf -- "--genesis-file ${genesis_file} "
-        printf -- "--genesis-hash ${genesis_hash} "
-        printf -- "--pbft-signature-threshold 0.7 "
-        printf -- "--require-network-magic "
-        printf -- "--database-path db "
-        printf -- "--topology configuration/simple-topology.json "
         printf -- "${extra} "
 }

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -13,6 +13,7 @@ ARGS=(
         --topology                "${TOPOLOGY}"
         --port                    "7776"
         --real-pbft
+        --config-yaml             "configuration/log-configuration.yaml"
 )
 
 ${RUNNER} exe:cardano-node "${ARGS[@]}"

--- a/scripts/mainnet-proxy-follower.sh
+++ b/scripts/mainnet-proxy-follower.sh
@@ -6,14 +6,11 @@ RUNNER=${RUNNER:-cabal new-run --}
 TOPOLOGY=${TOPOLOGY:-"configuration/topology-proxy-follower.json"}
 
 ARGS=(
-        --log-config              "configuration/log-configuration.yaml"
+        --database-path           "./db/"
         --genesis-file            "configuration/mainnet-genesis.json"
-        --genesis-hash            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-        --node-id                 "0"
         --topology                "${TOPOLOGY}"
-        --port                    "7776"
-        --real-pbft
-        --config-yaml             "configuration/log-configuration.yaml"
+        --socket-dir              "./socket/"
+        --config-yaml             "./configuration/mainnet-proxy-follower.yaml"
 )
 
 ${RUNNER} exe:cardano-node "${ARGS[@]}"

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -20,7 +20,6 @@ ALGO="--real-pbft"
 
 # EXTRA=""
 EXTRA="
-  --live-view
   --trace-block-fetch-decisions
   --trace-block-fetch-client
   --trace-block-fetch-server

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -16,7 +16,6 @@ CMD="cabal new-run --"
 # VERBOSITY="--tracing-verbosity-minimal"
 # VERBOSITY="--tracing-verbosity-normal"
 VERBOSITY="--tracing-verbosity-maximal"
-ALGO="--real-pbft"
 
 # EXTRA=""
 EXTRA="
@@ -55,8 +54,8 @@ tmux select-pane -t 4
 tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 " $(echo -n ${EXTRA})")" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 " $(echo -n ${EXTRA})")" C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 " $(echo -n ${EXTRA})")" C-m

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -8,7 +8,6 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-ALGO="--real-pbft"
 # CMD="stack exec --nix cardano-node --"
 CMD="cabal new-run --"
 # EXTRA="--live-view"
@@ -32,8 +31,8 @@ tmux select-pane -t 4
 tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 0
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 " ${EXTRA}")" C-m
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 " ${EXTRA}")" C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 " ${EXTRA}")" C-m

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -21,7 +21,10 @@ NETARGS=(
         --genesis-file "${genesis_file}"
         --genesis-hash "${genesis_hash}"
         submit-tx
-        --topology     "configuration/simple-topology.json"
+        --topology      "configuration/simple-topology.json"
+        --genesis-file  "${genesis_file}"
+        --database-path "./db/"
+        --socket-dir    "./socket/"
         --node-id      "0"
         --tx           "$TX"
 )

--- a/scripts/trace-acceptor.sh
+++ b/scripts/trace-acceptor.sh
@@ -3,8 +3,12 @@
 # CMD="stack exec trace-acceptor-node -- "
 # CMD="./trace-acceptor.exe -- "
 CMD="cabal new-run exe:trace-acceptor -- "
-
+#TODO: Confirm if db path is necessary for trace acceptor
 set -x
 ${CMD} \
-    --log-config configuration/log-config-acceptor.yaml \
+    --topology "./configuration/simple-topology.json" \
+    --database-path "./db/" \
+    --genesis-file "configuration/mainnet-genesis.json" \
+    --socket-dir "./socket" \
+    --config-yaml "configuration/log-config-acceptor.yaml" \
     $@


### PR DESCRIPTION
Previously these two were using hard coded constants that are only appropriate for mainnet. But now we can get them from the configuration system properly.

This should allow targeting networks other than mainnet, including testnet and other clusters.

Also fix a related TODO by pulling the conversion out into a proper top level function.

This PR currently targets `jordan/replace-cardano-configuration` because it builds on PR #289 but that PR probably should be merged first, and then this one can be retargeted to master.