### PR TITLE
Transaction generator: specify target nodes without topology.

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -243,6 +243,8 @@ executable cardano-cli
                      , cardano-ledger
                      , cardano-prelude
                      , cardano-node
+                     , iproute
+                     , network
                      , optparse-applicative
                      , ouroboros-consensus
                      , safe-exceptions

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -164,6 +164,8 @@
             (hsPkgs.cardano-ledger)
             (hsPkgs.cardano-prelude)
             (hsPkgs.cardano-node)
+            (hsPkgs.iproute)
+            (hsPkgs.network)
             (hsPkgs.optparse-applicative)
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.safe-exceptions)


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-node/issues/329

Since https://github.com/input-output-hk/cardano-node/pull/318 is going to eliminate `TopologyInfo` type, tx generator has to avoid such a dependency. Currently tx generator uses `--target-node-id`s only for extracting corresponding IPs/ports from topology file, so now it should receive `--target-node` CLI parameter with not `NodeId`, but with explicit IP/port, for example: `--target-node ("127.0.0.1",3002)`.