### PR TITLE
MuxTraceHandshakeClientEnd should be at Info

### DIFF
--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -200,7 +200,7 @@ instance DefineSeverity (WithMuxBearer peer (MuxTrace ptcl)) where
     MuxTraceChannelSendStart {}      -> Debug
     MuxTraceChannelSendEnd {}        -> Debug
     MuxTraceHandshakeStart           -> Debug
-    MuxTraceHandshakeClientEnd {}    -> Debug
+    MuxTraceHandshakeClientEnd {}    -> Info
     MuxTraceHandshakeServerEnd       -> Debug
     MuxTraceHandshakeClientError {}  -> Error
     MuxTraceHandshakeServerError {}  -> Error


### PR DESCRIPTION
Change MuxTraceHandshakeClientEnd to info so that the initial rtt
sample is visible in the logs.