### PR TITLE
Unshare the module list

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -55,11 +55,6 @@ in {
         type = types.str;
         default = mkScript cfg;
       };
-      extraOptions = mkOption {
-        type = types.listOf types.str;
-        default = [];
-        description = "extra command line arguments for cardano-node";
-      };
 
       package = mkOption {
         type = types.package;

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -7,7 +7,7 @@ with lib; with builtins;
 let
   localLib = import ../../lib.nix;
   cfg = config.services.cardano-node;
-  svcLib = (import ../svclib.nix { inherit pkgs cardano-node; });
+  svcLib = (import ../svclib.nix { inherit pkgs; cardano-node = pkgs.cardano-node; });
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   mkScript = cfg:
     let exec = "cardano-node";

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -24,8 +24,7 @@ let
             "--signing-key ${cfg.signingKey}"}"
           "${lib.optionalString (cfg.delegationCertificate != null)
             "--delegation-certificate ${cfg.delegationCertificate}"}"
-          "${cfg.extraArgs}"
-        ];
+        ] ++ cfg.extraArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
         echo "Starting ${exec}: '' + concatStringsSep "\"\n   echo \"" cmd + ''"
@@ -188,7 +187,7 @@ in {
 
       topology = mkOption {
         type = types.path;
-        default = mkEdgeTopology {
+        default = localLib.mkEdgeTopology {
           inherit (cfg) nodeId port;
           inherit (envConfig) edgeNodes;
         };
@@ -210,8 +209,8 @@ in {
       };
 
       extraArgs = mkOption {
-        type = types.str;
-        default = "";
+        type = types.listOf types.str;
+        default = [];
         description = ''Extra CLI args for 'cardano-node'.'';
       };
 

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,6 +1,3 @@
 [
  ./cardano-node-service.nix
- ./cardano-node-legacy-service.nix
- ./cardano-cluster-service.nix
- ./chairman-as-a-service.nix
 ]

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -37,7 +37,10 @@ in {
     machine = { lib, config, pkgs, ... }: {
       imports = [
         (byron-proxy-src + "/nix/nixos")
-        ../.
+        ../cardano-node-service.nix
+        ../cardano-node-legacy-service.nix
+        ../chairman-as-a-service.nix
+        ../cardano-cluster-service.nix
       ];
       virtualisation.memorySize = 2048;
       virtualisation.diskSize   = 2048;


### PR DESCRIPTION
1. Unshares `nix/nixos/module-list.nix` -- leaving it to only be used for deployments.
2. Repairs `extraArgs` to be additive 
3. Drops `extraOptions` -- with apologies to @cleverca22 for me screwing it up