### PR TITLE
Add --validate-db to validate all on-disk database files

### DIFF
--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -128,6 +128,7 @@ data NodeCLI = NodeCLI
     , nodeAddr :: !NodeAddress
     , configFp :: !ConfigYamlFilePath
     , traceOpts :: !TraceOptions
+    , validateDB :: !Bool
     } deriving Show
 
 -- | Filepath of the configuration yaml file. This file determines

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -77,7 +77,7 @@ initializeAllFeatures
   :: NodeCLI
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
-initializeAllFeatures nCli@(NodeCLI _ _ ncFp _)
+initializeAllFeatures nCli@NodeCLI { configFp = ncFp }
                        cardanoEnvironment = do
 
     (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment nCli

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -77,19 +77,22 @@ nodeCliParser = do
   -- TraceOptions
   traceOptions <- cliTracingParser
 
+  validate <- parseValidateDB
 
-  pure $ NodeCLI
-           (MiscellaneousFilepaths
-              (TopologyFile topFp)
-              (DbFile dbFp)
-              (GenesisFile genFp)
-              (DelegationCertFile <$> delCertFp)
-              (SigningKeyFile <$> sKeyFp)
-              (SocketFile socketFp)
-            )
-           nAddress
-           (ConfigYamlFilePath nodeConfigFp)
-           (fromMaybe (panic "Cardano.Common.Parsers: Trace Options were not specified") $ getLast traceOptions)
+  pure NodeCLI
+    { mscFp = MiscellaneousFilepaths
+      { topFile = TopologyFile topFp
+      , dBFile = DbFile dbFp
+      , genesisFile = GenesisFile genFp
+      , delegCertFile = DelegationCertFile <$> delCertFp
+      , signKeyFile = SigningKeyFile <$> sKeyFp
+      , socketFile = SocketFile socketFp
+      }
+    , nodeAddr = nAddress
+    , configFp = ConfigYamlFilePath nodeConfigFp
+    , traceOpts = fromMaybe (panic "Cardano.Common.Parsers: Trace Options were not specified") $ getLast traceOptions
+    , validateDB = validate
+    }
 
 parseConfigFile :: Parser FilePath
 parseConfigFile =
@@ -166,6 +169,13 @@ parsePort =
           long "port"
        <> metavar "PORT"
        <> help "The port number"
+    )
+
+parseValidateDB :: Parser Bool
+parseValidateDB =
+    switch (
+         long "validate-db"
+      <> help "Validate all on-disk database files"
     )
 
 -- | Flag parser, that returns its argument on success.


### PR DESCRIPTION
This optional flag enables validation of all ImmutableDB epoch files, instead of only the most recent one, which is the default.

Note that we can't yet detect all kinds of corruption: we can detect truncation, but not random bitflips. We're working on that, see https://github.com/input-output-hk/ouroboros-network/issues/1253.