### PR TITLE
Updated ouroboros-network dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -151,37 +151,37 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 52677b3c8f2a98d974590b7688281116aaa68ff7
+  tag: bb5ef891587789166e8f292a221e6ba63e0c573e
   subdir: io-sim-classes
 
 source-repository-package

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -65,8 +65,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -42,6 +42,7 @@
           (hsPkgs.filepath)
           (hsPkgs.fingertree)
           (hsPkgs.formatting)
+          (hsPkgs.hashable)
           (hsPkgs.memory)
           (hsPkgs.mmorph)
           (hsPkgs.mtl)
@@ -181,8 +182,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -133,8 +133,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "52677b3c8f2a98d974590b7688281116aaa68ff7";
-      sha256 = "1kkc54knyd07vqi28nmfn6l7f7sf3grcgi7vl252qshd2k5axdgn";
+      rev = "bb5ef891587789166e8f292a221e6ba63e0c573e";
+      sha256 = "07j3n8hlvcymwillcg9jl92jmvm1bmkx3lzh4sy23hp4rl0vg1m2";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -94,7 +94,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 52677b3c8f2a98d974590b7688281116aaa68ff7
+    commit: bb5ef891587789166e8f292a221e6ba63e0c573e
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
Using `Ouroboros.Network.Diffusion` API.

`cabal.project` and `stack.yaml` file needs a git hash from `ouroboros-network` master branch after https://github.com/input-output-hk/ouroboros-network/pull/1308 gets merged.