### PR TITLE
Make public key extraction more robust in the cluster test

### DIFF
--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -188,7 +188,7 @@ let
       signing-key-public
       --secret ${pbftSK}
       )
-      ${cardano-node}/bin/cardano-cli "''${args[@]}" | tail -n -2 | head -n 1 | cut -d: -f2 | xargs echo -n > $out
+      ${cardano-node}/bin/cardano-cli "''${args[@]}" | fgrep 'public key (base64):' | cut -d: -f2 | xargs echo -n > $out
     '';
 
   ## extractDelegateCertificate


### PR DESCRIPTION
This should improve robustness against logging changes in the cluster test.

The root of the problem is the impossibility to completely disable logging in `cardano-node` -- we used to have this mechanism, but at some point it was removed, making any usage of `cardano-cli`'s standard output more fragile.