### PR TITLE
Turn off idle GC for the node

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -126,9 +126,8 @@ executable cardano-node
   ghc-options:         -threaded
                        -Wall
                        -rtsopts
-                       "-with-rtsopts=-T"
+                       "-with-rtsopts=-T -I0"
                        -fno-warn-unticked-promoted-constructors
-                       -rtsopts
 
   build-depends:       base
                      , aeson


### PR DESCRIPTION
Set the `+RTS -I0` flag by default.

From the ghc +RTS -?  help output:
```
-I<sec>  Perform full GC after <sec> idle time (default: 0.3, 0 == off)
```
So what this does is turn off this GHC RTS feature where it will run the GC a short time after the last thread becomes idle. This is a sensible feature in many programs to allow the program to release memory back to the OS.

For server applications like the node however it is a poor choice. The node has relatively frequent activity anyway so it has enough opportunities to return memory to the OS after major GCs. What it does though is to run a major GC much more frequently than it would otherwise due to its inherent allocation rate. The effect is that when the node is otherwise mostly idle (fully synced) it spends a lot of CPU time in GC.

The effect of this change is very noticable in the ekg monitoring output for the rts statistics.