### PR TITLE
nix | svclib:  provide a working default for the `cardano-node` arg

### DIFF
--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -1,4 +1,4 @@
-{ pkgs, cardano-node ? pkgs.cardano-node }:
+{ pkgs, cardano-node ? (import ./nix/nix-tools.nix {}).nix-tools.exes.cardano-node }:
 with builtins; with pkgs.lib;
 let
 


### PR DESCRIPTION
Small fix for `svclib` -- @denisshevchenko might need this.