### PR TITLE
Hide tracing options from default `--help` command

### DIFF
--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -55,8 +55,14 @@ import           Cardano.Config.Types
 
 -- Common command line parsers
 
+-- | Help hidden in order to reduce help output of `cardano-node`.
+cliTracingParserHiddenHelp :: Parser (Last TraceOptions)
+cliTracingParserHiddenHelp = Last . Just <$> parseTraceOptions Opt.internal
+
+-- | Help not hidden
 cliTracingParser :: Parser (Last TraceOptions)
-cliTracingParser = Last . Just <$> parseTraceOptions Opt.hidden
+cliTracingParser = Last . Just <$> parseTraceOptions mempty
+
 
 -- | The product parser for all the CLI arguments.
 nodeCliParser :: Parser NodeCLI
@@ -77,7 +83,7 @@ nodeCliParser = do
   nodeConfigFp <- parseConfigFile
 
   -- TraceOptions
-  traceOptions <- cliTracingParser
+  traceOptions <- cliTracingParserHiddenHelp
 
   validate <- parseValidateDB
 


### PR DESCRIPTION
These options were previously hidden but `Opt.hidden` didn't seem to be working. To access the trace options help, use `--help-tracing`.