### PR TITLE
Revert monitoring update

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,20 +11,26 @@ package cardano-node
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
   subdir: cardano-crypto-class
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
+  subdir: slotting
 
 source-repository-package
   type: git
@@ -76,12 +82,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+  tag: 9352518fd9f957ab5e9611a2e27f495339c597d1
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+  tag: 9352518fd9f957ab5e9611a2e27f495339c597d1
   subdir: test
 
 source-repository-package
@@ -151,37 +157,37 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: typed-protocols-cbor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c785fe64445357b806c847fa438fc7612563b42b
+  tag: 602856e08e0ebe9d63751185d39580d3b22989c1
   subdir: io-sim-classes
 
 source-repository-package

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -26,7 +26,6 @@ import qualified Ouroboros.Consensus.Node.Tracers as ConsensusTracers
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers'(..))
 
 
-deriving instance Eq Consensus.SlotLength
 deriving instance Num Consensus.SlotLength
 
 deriving instance Show TracingVerbosity

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef";
-      sha256 = "13hcbgmcg3zzllii95r6qr9mkch6p4lf9ds04ar5jpnbc2az284q";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef";
-      sha256 = "13hcbgmcg3zzllii95r6qr9mkch6p4lf9ds04ar5jpnbc2az284q";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef";
-      sha256 = "13hcbgmcg3zzllii95r6qr9mkch6p4lf9ds04ar5jpnbc2az284q";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3c40edcf5bdba8721d3430d0aaaeea8770ce9bec";
-      sha256 = "1z77nwjxj0v9gxhs3mlmqfq705mkkcpnwgr0d8shykjvf0iqdkcn";
+      rev = "9352518fd9f957ab5e9611a2e27f495339c597d1";
+      sha256 = "04k3jm27bcbmskrxidyhg6ryb587prl8gayxik8mhv9zi81d36qw";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -25,7 +25,9 @@
           (hsPkgs.canonical-json)
           (hsPkgs.cborg)
           (hsPkgs.containers)
+          (hsPkgs.fingertree)
           (hsPkgs.formatting)
+          (hsPkgs.generic-deriving)
           (hsPkgs.ghc-heap)
           (hsPkgs.ghc-prim)
           (hsPkgs.hashable)
@@ -33,6 +35,7 @@
           (hsPkgs.mtl)
           (hsPkgs.nonempty-containers)
           (hsPkgs.protolude)
+          (hsPkgs.serialise)
           (hsPkgs.tagged)
           (hsPkgs.text)
           (hsPkgs.time)
@@ -71,7 +74,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3c40edcf5bdba8721d3430d0aaaeea8770ce9bec";
-      sha256 = "1z77nwjxj0v9gxhs3mlmqfq705mkkcpnwgr0d8shykjvf0iqdkcn";
+      rev = "9352518fd9f957ab5e9611a2e27f495339c597d1";
+      sha256 = "04k3jm27bcbmskrxidyhg6ryb587prl8gayxik8mhv9zi81d36qw";
       });
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -1,0 +1,39 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { development = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-slotting"; version = "0.1.0.0"; };
+      license = "NONE";
+      copyright = "IOHK";
+      maintainer = "formal.methods@iohk.io";
+      author = "IOHK Formal Methods Team";
+      homepage = "";
+      url = "";
+      synopsis = "Key slotting types for cardano libraries";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.cardano-prelude)
+          (hsPkgs.cardano-binary)
+          (hsPkgs.cborg)
+          (hsPkgs.containers)
+          (hsPkgs.mmorph)
+          (hsPkgs.mtl)
+          (hsPkgs.serialise)
+          (hsPkgs.transformers)
+          ];
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/cardano-base";
+      rev = "80deee31f8d9422b8e090e55b17e1a714153180b";
+      sha256 = "0jzv074hc8kq0r0k47bw8hvziyi16mfyv5gcyngd1d0mbrc0j2k1";
+      });
+    postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -42,6 +42,7 @@
         cardano-binary = ./cardano-binary.nix;
         cardano-binary-test = ./cardano-binary-test.nix;
         cardano-crypto-class = ./cardano-crypto-class.nix;
+        cardano-slotting = ./cardano-slotting.nix;
         cardano-shell = ./cardano-shell.nix;
         goblins = ./goblins.nix;
         contra-tracer = ./contra-tracer.nix;

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -65,8 +65,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -39,6 +39,7 @@
           (hsPkgs.deepseq)
           (hsPkgs.digest)
           (hsPkgs.directory)
+          (hsPkgs.filelock)
           (hsPkgs.filepath)
           (hsPkgs.fingertree)
           (hsPkgs.formatting)
@@ -119,7 +120,9 @@
             (hsPkgs.contra-tracer)
             (hsPkgs.cryptonite)
             (hsPkgs.deepseq)
+            (hsPkgs.directory)
             (hsPkgs.fgl)
+            (hsPkgs.filepath)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)
             (hsPkgs.graphviz)
@@ -130,8 +133,10 @@
             (hsPkgs.random)
             (hsPkgs.serialise)
             (hsPkgs.tasty)
+            (hsPkgs.tasty-golden)
             (hsPkgs.tasty-hunit)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.temporary)
             (hsPkgs.text)
             (hsPkgs.time)
             (hsPkgs.tree-diff)
@@ -183,8 +188,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -28,6 +28,7 @@
           (hsPkgs.bytestring)
           (hsPkgs.cardano-binary)
           (hsPkgs.cardano-prelude)
+          (hsPkgs.cardano-slotting)
           (hsPkgs.cborg)
           (hsPkgs.containers)
           (hsPkgs.dns)
@@ -74,6 +75,7 @@
             (hsPkgs.bytestring)
             (hsPkgs.cardano-binary)
             (hsPkgs.cardano-prelude)
+            (hsPkgs.cardano-slotting)
             (hsPkgs.cborg)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
@@ -109,6 +111,7 @@
             (hsPkgs.bytestring)
             (hsPkgs.cardano-binary)
             (hsPkgs.cardano-prelude)
+            (hsPkgs.cardano-slotting)
             (hsPkgs.cborg)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
@@ -133,8 +136,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "c785fe64445357b806c847fa438fc7612563b42b";
-      sha256 = "015ac7fj10xg5wcgv265qdgi85gdgj14cl03lrnqsmyqxsy1pjpn";
+      rev = "602856e08e0ebe9d63751185d39580d3b22989c1";
+      sha256 = "1frmr2szqipfxnny8d1h18564dwssach5liy9i4vcg1dpjzfdph6";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3c40edcf5bdba8721d3430d0aaaeea8770ce9bec/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/9352518fd9f957ab5e9611a2e27f495339c597d1/snapshot.yaml
 
 packages:
   - cardano-config
@@ -46,17 +46,18 @@ extra-deps:
       - byron/chain/executable-spec
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3c40edcf5bdba8721d3430d0aaaeea8770ce9bec
+    commit: 9352518fd9f957ab5e9611a2e27f495339c597d1
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 468d9b79ae3ac28f5f2cbb3ce52623a69923c4ef
+    commit: 80deee31f8d9422b8e090e55b17e1a714153180b
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
+      - slotting
 
     # Following deps are for cardano-shell
   - git: https://github.com/input-output-hk/cardano-shell
@@ -94,7 +95,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: c785fe64445357b806c847fa438fc7612563b42b
+    commit: 602856e08e0ebe9d63751185d39580d3b22989c1
     subdirs:
         - io-sim-classes
         - network-mux


### PR DESCRIPTION
After the monitoring update (`833045ef9e8527f880bc8a55f84bebd92ffd39dd`), there was strange behaviour in `cardano-cli`.

```
./scripts/genesis.sh                                                                                                                             19-12-17 - 16:27:14
+ RUNNER='cabal v2-run -v0 --'
+ cabal v2-run -v0 -- cardano-cli --log-config /home/jordan/Repos/Work/userepotool/cardano-node/configuration/configuration-silent.yaml --real-pbft genesis --genesis-output-dir /tmp/tmp.0yuukSykpv.d --start-time 1576614498 --protocol-parameters-file ./scripts/protocol-params.json --k 2160 --protocol-magic 459045235 --n-poor-addresses 128 --n-delegate-addresses 7 --total-balance 8000000000000000 --delegate-share 900000000000000 --avvm-entry-count 128 --avvm-entry-balance 10000000000000 --secret-seed 2718281828
warning: redirecting to https://github.com/well-typed/canonical-json/
cardano-cli: ExceptionInLinkedThread ThreadId 14 thread blocked indefinitely in an STM transaction
```
We should revert that until the monitoring team can apply a fix.