### PR TITLE
Tx generator: pure availableFunds.

### DIFF
--- a/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
@@ -1,8 +1,6 @@
 # Explorer DB Node configuration
 
 NetworkName: mainnet
-RequiresNetworkMagic: RequiresNoMagic
-GenesisHash: 5fbffc20a6ee41093a0f6a44e6110b66a69c7cc591c714075a6c537c360e32b6
 EnableLogMetrics: False
 EnableLogging: True
 
@@ -106,3 +104,84 @@ options:
       - AggregationBK
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
+
+
+
+
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId: 0
+NodeHostAddress: ''
+NodePort: 7000
+Protocol: ByronLegacy
+GenesisHash: f556e11e70d071629c84401ea8e18b7158dc045ebe29c40e80c18eca5bab3adb
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold: 0.5
+
+##### Network Time Parameters #####
+
+ResponseTimeout: 30000000
+PollDelay: 1800000000
+Servers: [ "0.pool.ntp.org"
+         , "2.pool.ntp.org"
+         , "3.pool.ntp.org"
+         ]
+
+#####    Update Parameters    #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+MemPoolLimitTx: 200
+AssetLockedSrcAddress: []
+
+CacheParameter: 500
+MessageCacheTimeout: 30
+
+NetworkDiameter: 18
+RecoveryHeadersMessage: 2200
+StreamWindow: 2048
+NonCriticalCQBootstrap: 0.95
+NonCriticalCQ: 0.8
+CriticalCQBootstrap: 0.8888
+CriticalCQ: 0.654321
+CriticalForkThreshold: 3
+FixedTimeCQ: 3600
+
+SlotLength: 20000
+NetworkConnectionTimeout: 15000
+HandshakeTimeout: 30000
+
+#####       Certificates       #####
+
+
+CA-Organization: "Input Output HK"
+CA-CommonName: "Cardano SL Self-Signed Root CA"
+CA-ExpiryDays: 3600
+CA-AltDNS: []
+
+Server-Organization: "Input Output HK"
+Server-CommonName: "Cardano SL Server"
+Server-ExpiryDays: 3600
+Server-AltDNS: [ "localhost"
+               , "localhost.localdomain"
+               , "127.0.0.1"
+               , "::1"
+               ]
+
+Wallet-Organization: "Input Output HK"
+Wallet-CommonName: "Daedalus Wallet"
+Wallet-ExpiryDays: 3600
+Wallet-AltDNS: []
+
+Enabled: False
+Rate: 0
+Period: ''
+Burst: 0


### PR DESCRIPTION
After #359 was done, we saw that `availableFunds` should not be `TVar` actually. Now we have to turn it from the mutable value to a pure one.

This PR fixes `log-config-explorer.yaml` for local cluster as well. 