### PR TITLE
CAD-379 Update `nix/cardano-node-service.nix` with tracing arguments

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -25,6 +25,11 @@ let
             "--signing-key ${cfg.signingKey}"}"
           "${lib.optionalString (cfg.delegationCertificate != null)
             "--delegation-certificate ${cfg.delegationCertificate}"}"
+          "--tracing-verbosity-${cfg.tracingVerbosity}"
+          "--trace-block-fetch-decisions"
+          "--trace-chain-db"
+          "--trace-mempool"
+          "--trace-forge"
         ] ++ cfg.extraArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
@@ -190,6 +195,11 @@ in {
         description = ''
           Cluster topology
         '';
+      };
+
+      tracingVerbosity = mkOption {
+        type = types.enum [ "minimal" "normal" "maximal" ];
+        default = "normal";
       };
 
       nodeConfig = mkOption {

--- a/scripts/shelley-testnet2.sh
+++ b/scripts/shelley-testnet2.sh
@@ -11,7 +11,22 @@ set -e
 # CMD="stack exec --nix cardano-node --"
 CMD="cabal v2-run --"
 # EXTRA="--live-view"
-EXTRA=""
+EXTRA="
+  --trace-block-fetch-decisions
+  --trace-block-fetch-client
+  --trace-block-fetch-server
+  --trace-chain-db
+  --trace-tx-inbound
+  --trace-tx-outbound
+  --trace-local-tx-submission-server
+  --trace-mempool
+  --trace-forge
+  --trace-chain-sync-protocol
+  --trace-block-fetch-protocol
+  --trace-tx-submission-protocol
+  --trace-local-chain-sync-protocol
+  --trace-local-tx-submission-protocol
+"
 
 . $(dirname $0)/lib-node.sh
 
@@ -31,8 +46,8 @@ tmux select-pane -t 4
 tmux send-keys "cd '${PWD}'; ${CMD} trace-acceptor $(acceptorargs)" C-m
 sleep 2
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 " ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 " ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 3
-tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 " ${EXTRA}")" C-m
+tmux send-keys "cd '${PWD}'; ${CMD} exe:cardano-node $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})") " C-m


### PR DESCRIPTION
Previously not specifying a tracer did not turn it off, it just changed its severity. Currently if you do not specify a tracer, that tracer is turned off. Therefore this is a temporary fix until https://github.com/input-output-hk/cardano-node/issues/443 is implemented.