### PR TITLE
Move tracers to `.yaml` files

### DIFF
--- a/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
+++ b/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
@@ -35,32 +35,9 @@ exec ${NODE} \
   --topology ${BASEDIR}/configuration/topology-local.yaml \
   --host-addr 127.0.0.1 \
   --port 7778 \
-  --tracing-verbosity-maximal \
-  --trace-block-fetch-decisions \
-  --trace-mempool \
-  --trace-chain-db \
-  --trace-forge \
    \
  $@
 
 #  --socket-dir ${BASEDIR}/${DATADIR}/socket \
-# this will render the events in textual format
-#  --trace-chain-db \
-
-#  --trace-block-fetch-client \
-#  --trace-chain-sync-protocol \
-#  --trace-block-fetch-protocol \
-#  --trace-block-fetch-decisions \
-#  --trace-block-fetch-server \
-#  --trace-chain-sync-header-server \
-#  --trace-tx-inbound \
-#  --trace-tx-outbound \
-#  --trace-local-tx-submission-server \
-#  --trace-local-chain-sync-protocol \
-#  --trace-tx-submission-protocol \
-#  --trace-local-tx-submission-protocol \
-#  --trace-ip-subscription \
-#  --trace-dns-subscription \
-#  --trace-dns-resolver \
 
 ../analyse-logs.sh

--- a/benchmarking/chain-sync/configuration/log-configuration.yaml
+++ b/benchmarking/chain-sync/configuration/log-configuration.yaml
@@ -107,3 +107,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: MaximalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: False
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False

--- a/benchmarking/cluster3nodes/configuration/log-config-0.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-0.yaml
@@ -93,3 +93,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: True
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/benchmarking/cluster3nodes/configuration/log-config-1.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-1.yaml
@@ -95,3 +95,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: True
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/benchmarking/cluster3nodes/configuration/log-config-2.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-2.yaml
@@ -99,3 +99,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: True
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
@@ -99,3 +99,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: False
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: False
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: False
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False

--- a/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
@@ -67,3 +67,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: False
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: False
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: False
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False

--- a/benchmarking/cluster3nodes/run-3node-cluster.sh
+++ b/benchmarking/cluster3nodes/run-3node-cluster.sh
@@ -19,22 +19,7 @@ CMD="cabal v2-run --"
 # VERBOSITY="--tracing-verbosity-normal"
 VERBOSITY="--tracing-verbosity-maximal"
 
-# EXTRA=""
-EXTRA="
-  --trace-block-fetch-decisions
-  --trace-block-fetch-client
-  --trace-block-fetch-server
-  --trace-tx-inbound
-  --trace-tx-outbound
-  --trace-local-tx-submission-server
-  --trace-mempool
-  --trace-forge
-  --trace-chain-sync-protocol
-  --trace-block-fetch-protocol
-  --trace-tx-submission-protocol
-  --trace-local-chain-sync-protocol
-  --trace-local-tx-submission-protocol
-"
+EXTRA=""
 
 BASEPATH=$(realpath $(dirname $0))
 

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -25,6 +25,15 @@ deriving instance Num Consensus.SlotLength
 
 deriving instance Show TracingVerbosity
 
+instance FromJSON TracingVerbosity where
+  parseJSON (String str) = case str of
+    "MinimalVerbosity" -> pure MinimalVerbosity
+    "MaximalVerbosity" -> pure MaximalVerbosity
+    "NormalVerbosity" -> pure NormalVerbosity
+    err -> panic $ "Parsing of TracingVerbosity failed, "
+                 <> err <> " is not a valid TracingVerbosity"
+  parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
+                             <> "Encountered: " <> (T.pack $ Prelude.show invalid)
 
 instance FromJSON PortNumber where
   parseJSON (Number portNum) = case readMaybe . show $ coefficient portNum of

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -104,7 +104,6 @@ data NodeCLI = NodeCLI
     , genesisHash :: !Text
     , nodeAddr :: !NodeAddress
     , configFp :: !ConfigYamlFilePath
-    , traceOpts :: !TraceOptions
     , validateDB :: !Bool
     } deriving Show
 
@@ -157,6 +156,7 @@ data NodeConfiguration =
       , ncPbftSignatureThresh :: Maybe Double
       , ncLoggingSwitch :: Bool
       , ncLogMetrics :: Bool
+      , ncTraceOptions :: TraceOptions
       , ncViewMode :: ViewMode
       , ncUpdate :: Update
       } deriving (Show)
@@ -179,6 +179,33 @@ instance FromJSON NodeConfiguration where
                   lkBlkVersionMinor <- v .: "LastKnownBlockVersion-Minor"
                   lkBlkVersionAlt <- v .: "LastKnownBlockVersion-Alt"
 
+                  -- Trace Options
+                  tOptions <- TraceOptions
+                                <$> v .: "TracingVerbosity"
+                                <*> v .: "TraceBlockFetchClient"
+                                <*> v .: "TraceBlockFetchDecisions"
+                                <*> v .: "TraceBlockFetchProtocol"
+                                <*> v .: "TraceBlockFetchProtocolSerialised"
+                                <*> v .: "TraceBlockFetchServer"
+                                <*> v .: "TraceChainDb"
+                                <*> v .: "TraceChainSyncClient"
+                                <*> v .: "TraceChainSyncBlockServer"
+                                <*> v .: "TraceChainSyncHeaderServer"
+                                <*> v .: "TraceChainSyncProtocol"
+                                <*> v .: "TraceDNSResolver"
+                                <*> v .: "TraceDNSSubscription"
+                                <*> v .: "TraceErrorPolicy"
+                                <*> v .: "TraceForge"
+                                <*> v .: "TraceIpSubscription"
+                                <*> v .: "TraceLocalChainSyncProtocol"
+                                <*> v .: "TraceLocalTxSubmissionProtocol"
+                                <*> v .: "TraceLocalTxSubmissionServer"
+                                <*> v .: "TraceMempool"
+                                <*> v .: "TraceMux"
+                                <*> v .: "TraceTxInbound"
+                                <*> v .: "TraceTxOutbound"
+                                <*> v .: "TraceTxSubmissionProtocol"
+
                   pure $ NodeConfiguration
                            ptcl
                            nId
@@ -187,6 +214,7 @@ instance FromJSON NodeConfiguration where
                            pbftSignatureThresh
                            loggingSwitch
                            logMetrics
+                           tOptions
                            vMode
                            (Update appName appVersion (LastKnownBlockVersion
                                                          lkBlkVersionMajor

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -352,38 +352,27 @@ instance FromJSON ViewMode where
 --   which verbosity to the log output.
 data TraceOptions = TraceOptions
   { traceVerbosity :: !TracingVerbosity
-  , traceChainDB :: !Bool
-    -- ^ By default we use 'readableChainDB' tracer, if on this it will use
-    -- more verbose tracer
-
-    -- Consensus Tracers --
-  , traceChainSyncClient :: !Bool
-  , traceChainSyncHeaderServer :: !Bool
-  , traceChainSyncBlockServer :: !Bool
-  , traceBlockFetchDecisions :: !Bool
   , traceBlockFetchClient :: !Bool
-  , traceBlockFetchServer :: !Bool
-  , traceTxInbound :: !Bool
-  , traceTxOutbound :: !Bool
-  , traceLocalTxSubmissionServer :: !Bool
-  , traceMempool :: !Bool
-  , traceForge :: !Bool
-    -----------------------
-
-    -- Protocol Tracers --
-  , traceChainSyncProtocol :: !Bool
-    -- There's two variants of the block fetch tracer and for now
-    -- at least we'll set them both together from the same flags.
+  , traceBlockFetchDecisions :: !Bool
   , traceBlockFetchProtocol :: !Bool
   , traceBlockFetchProtocolSerialised :: !Bool
-  , traceTxSubmissionProtocol :: !Bool
+  , traceBlockFetchServer :: !Bool
+  , traceChainDB :: !Bool
+  , traceChainSyncClient :: !Bool
+  , traceChainSyncBlockServer :: !Bool
+  , traceChainSyncHeaderServer :: !Bool
+  , traceChainSyncProtocol :: !Bool
+  , traceDnsResolver :: !Bool
+  , traceDnsSubscription :: !Bool
+  , traceErrorPolicy :: !Bool
+  , traceForge :: !Bool
+  , traceIpSubscription :: !Bool
   , traceLocalChainSyncProtocol :: !Bool
   , traceLocalTxSubmissionProtocol :: !Bool
-  , traceIpSubscription :: !Bool
-    -----------------------
-
-  , traceDnsSubscription :: !Bool
-  , traceDnsResolver :: !Bool
-  , traceErrorPolicy :: !Bool
+  , traceLocalTxSubmissionServer :: !Bool
+  , traceMempool :: !Bool
   , traceMux :: !Bool
+  , traceTxInbound :: !Bool
+  , traceTxOutbound :: !Bool
+  , traceTxSubmissionProtocol :: !Bool
   } deriving (Eq, Show)

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -42,7 +42,6 @@ main = toplevelExceptionHandler $ do
       opts =
         Opt.info (nodeCliParser
                     <**> helperBrief "help" "Show this help text" nodeCliHelpMain
-                    <**> helperBrief "help-tracing" "Show help for tracing options" cliHelpTracing
                  )
 
           ( Opt.fullDesc <>
@@ -59,14 +58,6 @@ main = toplevelExceptionHandler $ do
         parserHelpHeader "cardano-node" nodeCliParser
         <$$> ""
         <$$> parserHelpOptions nodeCliParser
-
-      cliHelpTracing :: String
-      cliHelpTracing = renderHelpDoc 80 $
-        "Additional tracing options:"
-        <$$> ""
-        <$$> parserHelpOptions cliTracingParser
-
-
 
 
 initializeAllFeatures

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -53,10 +53,6 @@ import           Cardano.Config.Types
 
 -- Common command line parsers
 
--- | Help hidden in order to reduce help output of `cardano-node`.
-cliTracingParserHiddenHelp :: Parser (Last TraceOptions)
-cliTracingParserHiddenHelp = Last . Just <$> parseTraceOptions Opt.internal
-
 -- | Help not hidden
 cliTracingParser :: Parser (Last TraceOptions)
 cliTracingParser = Last . Just <$> parseTraceOptions mempty
@@ -77,11 +73,9 @@ nodeCliParser = do
 
   -- Node Address
   nAddress <- parseNodeAddress
+
   -- NodeConfiguration filepath
   nodeConfigFp <- parseConfigFile
-
-  -- TraceOptions
-  traceOptions <- cliTracingParserHiddenHelp
 
   validate <- parseValidateDB
 
@@ -97,7 +91,6 @@ nodeCliParser = do
     , genesisHash = genHash
     , nodeAddr = nAddress
     , configFp = ConfigYamlFilePath nodeConfigFp
-    , traceOpts = fromMaybe (panic "Cardano.Common.Parsers: Trace Options were not specified") $ getLast traceOptions
     , validateDB = validate
     }
 

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -4,8 +4,7 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Common.Parsers
-  ( cliTracingParser
-  , loggingParser
+  ( loggingParser
   , nodeCliParser
   , parseConfigFile
   , parseCoreNodeId
@@ -28,7 +27,6 @@ module Cardano.Common.Parsers
   , parseProtocolRealPBFT
   , parseSocketDir
   , parseTopologyInfo
-  , parseTraceOptions
   ) where
 
 
@@ -38,9 +36,7 @@ import           Cardano.Prelude hiding (option)
 
 import           Network.Socket (PortNumber)
 import           Options.Applicative
-import qualified Options.Applicative as Opt
 
-import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import           Cardano.Config.Logging (LoggingCLIArguments(..))
 import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
 
@@ -52,11 +48,6 @@ import           Cardano.Config.Topology
 import           Cardano.Config.Types
 
 -- Common command line parsers
-
--- | Help not hidden
-cliTracingParser :: Parser (Last TraceOptions)
-cliTracingParser = Last . Just <$> parseTraceOptions mempty
-
 
 -- | The product parser for all the CLI arguments.
 nodeCliParser :: Parser NodeCLI
@@ -308,243 +299,3 @@ loggingParser =
       LoggingCLIArguments
       Nothing
       False
-
--- | The parser for the logging specific arguments.
-parseTraceOptions :: MParser TraceOptions
-parseTraceOptions m = TraceOptions
-  <$> parseTracingVerbosity m
-  <*> parseTraceChainDB m
-
-  -- Consensus Trace Options --
-  <*> parseTraceChainSyncClient m
-  <*> parseTraceChainSyncHeaderServer m
-  <*> parseTraceChainSyncBlockServer m
-  <*> parseTraceBlockFetchDecisions m
-  <*> parseTraceBlockFetchClient m
-  <*> parseTraceBlockFetchServer m
-  <*> parseTraceTxInbound m
-  <*> parseTraceTxOutbound m
-  <*> parseTraceLocalTxSubmissionServer m
-  <*> parseTraceMempool m
-  <*> parseTraceForge m
-  -----------------------------
-
-  -- Protocol Tracing Options --
-  <*> parseTraceChainSyncProtocol m
-  <*> parseTraceBlockFetchProtocol m
-  <*> parseTraceBlockFetchProtocolSerialised m
-  <*> parseTraceTxSubmissionProtocol m
-  <*> parseTraceLocalChainSyncProtocol m
-  <*> parseTraceLocalTxSubmissionProtocol m
-  ------------------------------
-
-  <*> parseTraceIpSubscription m
-  <*> parseTraceDnsSubscription m
-  <*> parseTraceDnsResolver m
-  <*> parseTraceErrorPolicy m
-  <*> parseTraceMux m
-
-parseTraceBlockFetchClient :: MParser Bool
-parseTraceBlockFetchClient m =
-    switch (
-         long "trace-block-fetch-client"
-      <> help "Trace BlockFetch client."
-      <> m
-    )
-
-parseTraceBlockFetchServer :: MParser Bool
-parseTraceBlockFetchServer m =
-    switch (
-         long "trace-block-fetch-server"
-      <> help "Trace BlockFetch server."
-      <> m
-    )
-
-parseTracingVerbosity :: MParser TracingVerbosity
-parseTracingVerbosity m = asum [
-  flag' MinimalVerbosity (
-      long "tracing-verbosity-minimal"
-        <> help "Minimal level of the rendering of captured items"
-        <> m)
-    <|>
-  flag' MaximalVerbosity (
-      long "tracing-verbosity-maximal"
-        <> help "Maximal level of the rendering of captured items"
-        <> m)
-    <|>
-  flag NormalVerbosity NormalVerbosity (
-      long "tracing-verbosity-normal"
-        <> help "the default level of the rendering of captured items"
-        <> m)
-  ]
-
-parseTraceChainDB :: MParser Bool
-parseTraceChainDB m =
-    switch (
-         long "trace-chain-db"
-      <> help "Verbose tracer of ChainDB."
-      <> m
-    )
-
-type MParser a = (forall b c. Opt.Mod b c) -> Parser a
-
-parseTraceBlockFetchDecisions :: MParser Bool
-parseTraceBlockFetchDecisions m =
-    switch (
-         long "trace-block-fetch-decisions"
-      <> help "Trace BlockFetch decisions made by the BlockFetch client."
-      <> m
-    )
-
-parseTraceChainSyncClient :: MParser Bool
-parseTraceChainSyncClient m =
-    switch (
-         long "trace-chain-sync-client"
-      <> help "Trace ChainSync client."
-      <> m
-    )
-
-parseTraceChainSyncBlockServer :: MParser Bool
-parseTraceChainSyncBlockServer m =
-    switch (
-         long "trace-chain-sync-block-server"
-      <> help "Trace ChainSync server (blocks)."
-      <> m
-    )
-
-parseTraceChainSyncHeaderServer :: MParser Bool
-parseTraceChainSyncHeaderServer m =
-    switch (
-         long "trace-chain-sync-header-server"
-      <> help "Trace ChainSync server (headers)."
-      <> m
-    )
-
-parseTraceTxInbound :: MParser Bool
-parseTraceTxInbound m =
-    switch (
-         long "trace-tx-inbound"
-      <> help "Trace TxSubmission server (inbound transactions)."
-      <> m
-    )
-
-parseTraceTxOutbound :: MParser Bool
-parseTraceTxOutbound m =
-    switch (
-         long "trace-tx-outbound"
-      <> help "Trace TxSubmission client (outbound transactions)."
-      <> m
-    )
-
-parseTraceLocalTxSubmissionServer :: MParser Bool
-parseTraceLocalTxSubmissionServer m =
-    switch (
-         long "trace-local-tx-submission-server"
-      <> help "Trace local TxSubmission server."
-      <> m
-    )
-
-parseTraceMempool :: MParser Bool
-parseTraceMempool m =
-    switch (
-         long "trace-mempool"
-      <> help "Trace mempool."
-      <> m
-    )
-
-parseTraceForge :: MParser Bool
-parseTraceForge m =
-    switch (
-         long "trace-forge"
-      <> help "Trace block forging."
-      <> m
-    )
-
-parseTraceChainSyncProtocol :: MParser Bool
-parseTraceChainSyncProtocol m =
-    switch (
-         long "trace-chain-sync-protocol"
-      <> help "Trace ChainSync protocol messages."
-      <> m
-    )
-
-parseTraceBlockFetchProtocol :: MParser Bool
-parseTraceBlockFetchProtocol m =
-    switch (
-         long "trace-block-fetch-protocol"
-      <> help "Trace BlockFetch protocol messages."
-      <> m
-    )
-
-
-parseTraceBlockFetchProtocolSerialised :: MParser Bool
-parseTraceBlockFetchProtocolSerialised m =
-    switch (
-         long "trace-block-fetch-protocol-serialised"
-      <> help "Serialised Trace BlockFetch protocol messages."
-      <> m
-    )
-
-parseTraceTxSubmissionProtocol :: MParser Bool
-parseTraceTxSubmissionProtocol m =
-    switch (
-         long "trace-tx-submission-protocol"
-      <> help "Trace TxSubmission protocol messages."
-      <> m
-    )
-
-parseTraceLocalChainSyncProtocol :: MParser Bool
-parseTraceLocalChainSyncProtocol m =
-    switch (
-         long "trace-local-chain-sync-protocol"
-      <> help "Trace local ChainSync protocol messages."
-      <> m
-    )
-
-parseTraceLocalTxSubmissionProtocol :: MParser Bool
-parseTraceLocalTxSubmissionProtocol m =
-    switch (
-         long "trace-local-tx-submission-protocol"
-      <> help "Trace local TxSubmission protocol messages."
-      <> m
-    )
-
-parseTraceIpSubscription :: MParser Bool
-parseTraceIpSubscription m =
-    switch (
-         long "trace-ip-subscription"
-      <> help "Trace IP Subscription messages."
-      <> m
-    )
-
-parseTraceDnsSubscription :: MParser Bool
-parseTraceDnsSubscription m =
-    switch (
-         long "trace-dns-subscription"
-      <> help "Trace DNS Subscription messages."
-      <> m
-    )
-
-parseTraceDnsResolver :: MParser Bool
-parseTraceDnsResolver m =
-    switch (
-         long "trace-dns-resolver"
-      <> help "Trace DNS Resolver messages."
-      <> m
-    )
-
-parseTraceErrorPolicy :: MParser Bool
-parseTraceErrorPolicy m =
-    switch (
-         long "trace-error-policy"
-      <> help "Trace error policy resolution."
-      <> m
-    )
-
-parseTraceMux :: MParser Bool
-parseTraceMux m =
-    switch (
-         long "trace-mux"
-      <> help "Trace Mux Events"
-      <> m
-    )

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -90,7 +90,7 @@ runNode loggingLayer nc nCli = do
     let tracer = contramap pack $ toLogObject trace
 
     traceWith tracer $ "tracing verbosity = " ++
-                         case traceVerbosity $ traceOpts nCli of
+                         case traceVerbosity $ ncTraceOptions nc of
                              NormalVerbosity -> "normal"
                              MinimalVerbosity -> "minimal"
                              MaximalVerbosity -> "maximal"
@@ -110,7 +110,7 @@ runNode loggingLayer nc nCli = do
                         Left err -> (putTextLn . pack $ show err) >> exitFailure
                         Right (SomeProtocol p) -> pure $ SomeProtocol p
 
-    tracers <- mkTracers (traceOpts nCli) trace
+    tracers <- mkTracers (ncTraceOptions nc) trace
 
     case ncViewMode nc of
       SimpleView -> handleSimpleNode p trace tracers nCli nc

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -73,31 +73,24 @@ import           Cardano.Tracing.MicroBenchmarking
 
 import           Control.Tracer.Transformers
 
-data Tracers peer blk = Tracers {
-      -- | Trace the ChainDB (flag '--trace-chain-db' will turn on textual output)
-      chainDBTracer         :: Tracer IO (WithTip blk (ChainDB.TraceEvent blk))
-
-      -- | Consensus-specific tracers.
-    , consensusTracers      :: Consensus.Tracers IO peer blk
-
-      -- | Tracers for the protocol messages.
-    , protocolTracers       :: ProtocolTracers IO peer blk DeserialiseFailure
-
-      -- | Trace the IP subscription manager (flag '--trace-ip-subscription' will turn on textual output)
-    , ipSubscriptionTracer  :: Tracer IO (WithIPList (SubscriptionTrace Socket.SockAddr))
-
-      -- | Trace the DNS subscription manager (flag '--trace-dns-subscription' will turn on textual output)
-    , dnsSubscriptionTracer :: Tracer IO (WithDomainName (SubscriptionTrace Socket.SockAddr))
-
-      -- | Trace the DNS resolver (flag '--trace-dns-resolver' will turn on textual output)
-    , dnsResolverTracer     :: Tracer IO (WithDomainName DnsTrace)
-
-      -- | Trace error policy resolution (flag '--trace-error-policy' will turn on textual output)
-    , errorPolicyTracer     :: Tracer IO (WithAddr Socket.SockAddr ErrorPolicyTrace)
-
-      -- | Trace the Mux (flag --trace-mux' will turn on textual output)
-    , muxTracer             :: Tracer IO (WithMuxBearer peer (MuxTrace NodeToNodeProtocols))
-    }
+data Tracers peer blk = Tracers
+  { -- | Trace the ChainDB
+    chainDBTracer :: Tracer IO (WithTip blk (ChainDB.TraceEvent blk))
+    -- | Consensus-specific tracers.
+  , consensusTracers :: Consensus.Tracers IO peer blk
+    -- | Tracers for the protocol messages.
+  , protocolTracers :: ProtocolTracers IO peer blk DeserialiseFailure
+    -- | Trace the IP subscription manager
+  , ipSubscriptionTracer :: Tracer IO (WithIPList (SubscriptionTrace Socket.SockAddr))
+    -- | Trace the DNS subscription manager
+  , dnsSubscriptionTracer :: Tracer IO (WithDomainName (SubscriptionTrace Socket.SockAddr))
+    -- | Trace the DNS resolver
+  , dnsResolverTracer :: Tracer IO (WithDomainName DnsTrace)
+    -- | Trace error policy resolution
+  , errorPolicyTracer :: Tracer IO (WithAddr Socket.SockAddr ErrorPolicyTrace)
+    -- | Trace the Mux
+  , muxTracer :: Tracer IO (WithMuxBearer peer (MuxTrace NodeToNodeProtocols))
+  }
 
 data ForgeTracers = ForgeTracers
   { ftForged :: Trace IO Text
@@ -109,16 +102,16 @@ data ForgeTracers = ForgeTracers
   }
 
 nullTracers :: Tracers peer blk
-nullTracers = Tracers {
-      chainDBTracer = nullTracer,
-      consensusTracers = Consensus.nullTracers,
-      protocolTracers = nullProtocolTracers,
-      ipSubscriptionTracer = nullTracer,
-      dnsSubscriptionTracer = nullTracer,
-      dnsResolverTracer = nullTracer,
-      errorPolicyTracer = nullTracer,
-      muxTracer = nullTracer
-    }
+nullTracers = Tracers
+  { chainDBTracer = nullTracer
+  , consensusTracers = Consensus.nullTracers
+  , protocolTracers = nullProtocolTracers
+  , ipSubscriptionTracer = nullTracer
+  , dnsSubscriptionTracer = nullTracer
+  , dnsResolverTracer = nullTracer
+  , errorPolicyTracer = nullTracer
+  , muxTracer = nullTracer
+  }
 
 
 instance ElidingTracer
@@ -142,14 +135,15 @@ instance ElidingTracer
 
 -- | Smart constructor of 'NodeTraces'.
 --
-mkTracers :: forall peer blk.
-              ( ProtocolLedgerView blk
-              , TraceConstraints blk
-              , Show peer
-              )
-           => TraceOptions
-           -> Trace IO Text
-           -> IO (Tracers peer blk)
+mkTracers
+  :: forall peer blk.
+     ( ProtocolLedgerView blk
+     , TraceConstraints blk
+     , Show peer
+     )
+  => TraceOptions
+  -> Trace IO Text
+  -> IO (Tracers peer blk)
 mkTracers traceOptions tracer = do
   -- We probably don't want to pay the extra IO cost per-counter-increment. -- sk
   staticMetaCC <- mkLOMeta Critical Confidential
@@ -430,10 +424,10 @@ mkTracers traceOptions tracer = do
 
 -- | get information about a chain fragment
 
-data ChainInformation = ChainInformation {
-    slots :: Word64,
-    blocks :: Word64,
-    density :: Rational
+data ChainInformation = ChainInformation
+  { slots :: Word64
+  , blocks :: Word64
+  , density :: Rational
     -- ^ the actual number of blocks created over the maximum
     -- expected number of blocks that could be created
   }
@@ -471,18 +465,14 @@ chainInformation frag = ChainInformation
 -- Tracing utils
 --
 
-withName :: String
-         -> Tracer IO (LogObject Text)
-         -> Tracer IO String
+withName :: String -> Tracer IO (LogObject Text) -> Tracer IO String
 withName name tr = contramap pack $ toLogObject $ appendName (pack name) tr
 
 
 -- | A way to satisfy tracer which requires current tip.  The tip is read from
 -- a mutable cell.
 --
-withTip :: TVar IO (Point blk)
-        -> Tracer IO (WithTip blk a)
-        -> Tracer IO a
+withTip :: TVar IO (Point blk) -> Tracer IO (WithTip blk a) -> Tracer IO a
 withTip varTip tr = Tracer $ \msg -> do
     tip <- atomically $ readTVar varTip
     traceWith (contramap (WithTip tip) tr) msg

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -98,3 +98,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: MaximalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Verbose tracer of ChainDB
+TraceChainDb: True
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False

--- a/configuration/configuration-silent.yaml
+++ b/configuration/configuration-silent.yaml
@@ -76,3 +76,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: False
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: False
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: False
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False

--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -104,3 +104,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: True
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -110,3 +110,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-config-1.liveview.yaml
+++ b/configuration/log-config-1.liveview.yaml
@@ -103,3 +103,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: True
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -109,3 +109,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-config-2.liveview.yaml
+++ b/configuration/log-config-2.liveview.yaml
@@ -109,3 +109,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: True
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -115,3 +115,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -99,3 +99,79 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
+
+#####         Tracing         #####
+
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: NormalVerbosity
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: True
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+TraceBlockFetchDecisions: True
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: True
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: False
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: True
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: False
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: False
+
+# Trace error policy resolution.
+TraceErrorPolicy: False
+
+# Trace block forging.
+TraceForge: True
+
+# Trace IP Subscription messages.
+TraceIpSubscription: False
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: True
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: True
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: True
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: True
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: True
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: True
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: True

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -25,11 +25,6 @@ let
             "--signing-key ${cfg.signingKey}"}"
           "${lib.optionalString (cfg.delegationCertificate != null)
             "--delegation-certificate ${cfg.delegationCertificate}"}"
-          "--tracing-verbosity-${cfg.tracingVerbosity}"
-          "--trace-block-fetch-decisions"
-          "--trace-chain-db"
-          "--trace-mempool"
-          "--trace-forge"
         ] ++ cfg.extraArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
@@ -195,11 +190,6 @@ in {
         description = ''
           Cluster topology
         '';
-      };
-
-      tracingVerbosity = mkOption {
-        type = types.enum [ "minimal" "normal" "maximal" ];
-        default = "normal";
       };
 
       nodeConfig = mkOption {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "d651b042b10211b78ba86950f98cd21b5a33e9ea",
-        "sha256": "169z4mgsdy1bgiy954ayjp9ymiid02f7zlp5ifq8xpy7xs8hx0rm",
+        "rev": "e4a53fa76c111393481d5739f0d7d10782f3cfcb",
+        "sha256": "1h5jd10pb8a7n18m5f123imw7nzikpawp3vbqsmhysmfazj61gpb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/d651b042b10211b78ba86950f98cd21b5a33e9ea.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/e4a53fa76c111393481d5739f0d7d10782f3cfcb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/scripts/mainnet.sh
+++ b/scripts/mainnet.sh
@@ -15,20 +15,6 @@ ARGS=(
         --socket-dir              "${root}/socket/"
         --config                  "${configuration}/configuration-mainnet.yaml"
         --port                    7776
-
-        --trace-block-fetch-decisions
-        --trace-block-fetch-client
-        --trace-block-fetch-server
-        --trace-tx-inbound
-        --trace-tx-outbound
-        --trace-local-tx-submission-server
-        --trace-mempool
-        --trace-forge
-        --trace-chain-sync-protocol
-        --trace-block-fetch-protocol
-        --trace-tx-submission-protocol
-        --trace-local-chain-sync-protocol
-        --trace-local-tx-submission-protocol
 )
 
 ${NODE} "${ARGS[@]}"

--- a/scripts/shelley-testnet-live.sh
+++ b/scripts/shelley-testnet-live.sh
@@ -8,22 +8,7 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-EXTRA="
-  --trace-block-fetch-decisions
-  --trace-block-fetch-client
-  --trace-block-fetch-server
-  --trace-chain-db
-  --trace-tx-inbound
-  --trace-tx-outbound
-  --trace-local-tx-submission-server
-  --trace-mempool
-  --trace-forge
-  --trace-chain-sync-protocol
-  --trace-block-fetch-protocol
-  --trace-tx-submission-protocol
-  --trace-local-chain-sync-protocol
-  --trace-local-tx-submission-protocol
-"
+EXTRA=""
 
 . $(dirname $0)/lib-node.sh
 NODE="$(executable_runner cardano-node)"

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -15,22 +15,7 @@ set -e
 # VERBOSITY="--tracing-verbosity-normal"
 VERBOSITY="--tracing-verbosity-maximal"
 
-# EXTRA=""
-EXTRA="
-  --trace-block-fetch-decisions
-  --trace-block-fetch-client
-  --trace-block-fetch-server
-  --trace-tx-inbound
-  --trace-tx-outbound
-  --trace-local-tx-submission-server
-  --trace-mempool
-  --trace-forge
-  --trace-chain-sync-protocol
-  --trace-block-fetch-protocol
-  --trace-tx-submission-protocol
-  --trace-local-chain-sync-protocol
-  --trace-local-tx-submission-protocol
-"
+EXTRA=""
 
 . $(dirname $0)/lib-node.sh
 NODE="$(executable_runner cardano-node)"


### PR DESCRIPTION
Specifying the tracers on the command line is cumbersome and the consensus is to move to them to the configuration `.yaml` files. 

Relevant: #443 