### PR TITLE
CAD-384:  add mempoolBytes metric

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -278,6 +278,9 @@ mkTracers traceOptions tracer = do
             logValue2 :: LOContent a
             logValue2 = LogValue "txsProcessed" $ PureI $ fromIntegral n
 
+            logValue3 :: LOContent a
+            logValue3 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
+
         meta <- mkLOMeta Critical Confidential
 
         traceNamedObject tr (meta, logValue1)
@@ -286,6 +289,8 @@ mkTracers traceOptions tracer = do
         traceNamedObject tr (meta, logValue2)
         traceNamedObject tr' (meta, logValue2)
 
+        traceNamedObject tr (meta, logValue3)
+        traceNamedObject tr' (meta, logValue3)
 
     mempoolTracer :: Tracer IO (TraceEventMempool blk)
     mempoolTracer = Tracer $ \ev -> do


### PR DESCRIPTION
1. Expose the mempool size (in bytes) as a new metric.
2. Add the metric to the TUI LiveView interface
3. A bit more order in the trace hierarchy.