### PR TITLE
CAD-384:  restore non-live-view mode in `scripts/shelley-testnet.sh`

### DIFF
--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -30,17 +30,11 @@ setupScribes:
   - scKind: FileSK
     scName: "logs/node-0.log"
     scFormat: ScText
-  - scKind: StdoutSK
-    scName: stdout
-    scFormat: ScText
-    scRotation: null
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
     - "logs/node-0.log"
-  - - StdoutSK
-    - stdout
 
 # more options which can be passed as key-value pairs:
 options:
@@ -98,7 +92,7 @@ NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: SimpleView
+ViewMode: LiveView
 TurnOnLogMetrics: True
 
 

--- a/configuration/log-config-1.liveview.yaml
+++ b/configuration/log-config-1.liveview.yaml
@@ -19,28 +19,22 @@ defaultBackends:
 #hasGUI: 12871
 
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12781
+hasEKG: 12782
 
 hasPrometheus:
   - "127.0.0.1"
-  - 13788
+  - 13789
 
 # here we set up outputs of logging in 'katip':
 setupScribes:
   - scKind: FileSK
-    scName: "logs/node-0.log"
+    scName: "logs/node-1.log"
     scFormat: ScText
-  - scKind: StdoutSK
-    scName: stdout
-    scFormat: ScText
-    scRotation: null
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
-    - "logs/node-0.log"
-  - - StdoutSK
-    - stdout
+    - "logs/node-1.log"
 
 # more options which can be passed as key-value pairs:
 options:
@@ -91,14 +85,13 @@ options:
 ############### Cardano Node Configuration ###############
 ##########################################################
 
-
-NodeId: 0
+NodeId: 1
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: SimpleView
+ViewMode: LiveView
 TurnOnLogMetrics: True
 
 

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -30,11 +30,17 @@ setupScribes:
   - scKind: FileSK
     scName: "logs/node-1.log"
     scFormat: ScText
+  - scKind: StdoutSK
+    scName: stdout
+    scFormat: ScText
+    scRotation: null
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
     - "logs/node-1.log"
+  - - StdoutSK
+    - stdout
 
 # more options which can be passed as key-value pairs:
 options:
@@ -91,7 +97,7 @@ NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: LiveView
+ViewMode: SimpleView
 TurnOnLogMetrics: True
 
 

--- a/configuration/log-config-2.liveview.yaml
+++ b/configuration/log-config-2.liveview.yaml
@@ -16,37 +16,36 @@ defaultBackends:
   - KatipBK
 
 # if wanted, the GUI is listening on this port:
-#hasGUI: 12871
+#hasGUI: 12872
 
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12781
+hasEKG: 12783
 
 hasPrometheus:
   - "127.0.0.1"
-  - 13788
+  - 13790
 
 # here we set up outputs of logging in 'katip':
 setupScribes:
   - scKind: FileSK
-    scName: "logs/node-0.log"
+    scName: "logs/node-2.log"
     scFormat: ScText
-  - scKind: StdoutSK
-    scName: stdout
-    scFormat: ScText
-    scRotation: null
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
-    - "logs/node-0.log"
-  - - StdoutSK
-    - stdout
+    - "logs/node-2.log"
 
 # more options which can be passed as key-value pairs:
 options:
   cfokey:
     value: "Release-1.0.0"
   mapSubtrace:
+    benchmark:
+      contents:
+        - GhcRtsStats
+        - MonotonicClock
+      subtrace: ObservableTrace
     '#ekgview':
       contents:
       - - tag: Contains
@@ -92,13 +91,13 @@ options:
 ##########################################################
 
 
-NodeId: 0
+NodeId: 2
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: SimpleView
+ViewMode: LiveView
 TurnOnLogMetrics: True
 
 

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -30,11 +30,17 @@ setupScribes:
   - scKind: FileSK
     scName: "logs/node-2.log"
     scFormat: ScText
+  - scKind: StdoutSK
+    scName: stdout
+    scFormat: ScText
+    scRotation: null
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
     - "logs/node-2.log"
+  - - StdoutSK
+    - stdout
 
 # more options which can be passed as key-value pairs:
 options:
@@ -97,7 +103,7 @@ NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
 PBftSignatureThreshold: 0.7
 TurnOnLogging: True
-ViewMode: LiveView
+ViewMode: SimpleView
 TurnOnLogMetrics: True
 
 

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -16,7 +16,7 @@ if test ! -f "${genesis_file}"
 then echo "ERROR: genesis ${genesis_file} does not exist!">&1; exit 1; fi
 
 function nodecfg () {
-        printf -- "--config ${configuration}/log-config-${1}.yaml "
+        printf -- "--config ${configuration}/log-config-${1}${2}.yaml "
 }
 function dlgkey () {
         printf -- "--signing-key            ${genesis_root}/delegate-keys.%03d.key " "$1"
@@ -33,11 +33,13 @@ function commonargs() {
 }
 
 function nodeargs () {
-        local extra="$2"
+        local id="$1"
+        local flavor="$2"
+        local extra="$3"
         commonargs
-        nodecfg $1
-        dlgkey $1
-        dlgcert $1
+        nodecfg $id $flavor
+        dlgkey $id
+        dlgcert $id
         printf -- "${extra} "
         printf -- "--port 300$1 "
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -11,7 +11,7 @@ root="$(realpath $(dirname $0)/..)"
 configuration="${root}/configuration"
 scripts="${root}/scripts"
 
-default_mode='stack'
+default_mode='cabal'
 mode='default'
 while test -n "$1"
 do case "$1" in

--- a/scripts/shelley-testnet-live.sh
+++ b/scripts/shelley-testnet-live.sh
@@ -8,7 +8,6 @@ set -e
 # create tmux session:
 #> tmux new-session -s 'Demo' -t demo
 
-# EXTRA="--live-view"
 EXTRA="
   --trace-block-fetch-decisions
   --trace-block-fetch-client
@@ -42,9 +41,8 @@ tmux select-pane -t 0
 tmux split-window -v
 
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})") " C-m
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 0 '.liveview' "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})") " C-m
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 1 '.liveview' "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 3
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})") " C-m
-
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 2 '.liveview' "${ALGO} $(echo -n ${EXTRA})") " C-m

--- a/scripts/shelley-testnet.sh
+++ b/scripts/shelley-testnet.sh
@@ -50,8 +50,8 @@ tmux select-pane -t 0
 tmux split-window -v
 
 tmux select-pane -t 1
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 0 "${ALGO} $(echo -n ${EXTRA})") " C-m
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 0 '' "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 2
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 1 "${ALGO} $(echo -n ${EXTRA})") " C-m
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 1 '' "${ALGO} $(echo -n ${EXTRA})") " C-m
 tmux select-pane -t 3
-tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 2 "${ALGO} $(echo -n ${EXTRA})") " C-m
+tmux send-keys "cd '${PWD}'; ${NODE} $(nodeargs 2 '' "${ALGO} $(echo -n ${EXTRA})") " C-m


### PR DESCRIPTION
1. restore non-live-view mode in `scripts/shelley-testnet.sh`
2. rename `scripts/shelley-testnet2.sh` to `scripts/shelley-testnet-live.sh`

NOTE:  very unfortunately we can no longer control the live-view mode from the CLI -- which necessitates config file duplication.  I think we should have applied better judgement during the wholesale CLI -> config file move.