### PR TITLE
ToObjectOrphans: Fix typos in some keys

### DIFF
--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -817,11 +817,11 @@ instance ToObject (TraceFetchClientState header) where
   toObject _verb (CompletedBlockFetch {}) =
     mkObject [ "kind" .= String "CompletedBlockFetch" ]
   toObject _verb (CompletedFetchBatch {}) =
-    mkObject [" kind" .= String "CompletedFetchBatch" ]
+    mkObject [ "kind" .= String "CompletedFetchBatch" ]
   toObject _verb (StartedFetchBatch {}) =
-    mkObject [" kind" .= String "StartedFetchBatch" ]
+    mkObject [ "kind" .= String "StartedFetchBatch" ]
   toObject _verb (RejectedFetchBatch {}) =
-    mkObject [" kind" .= String "RejectedFetchBatch" ]
+    mkObject [ "kind" .= String "RejectedFetchBatch" ]
 
 instance ToObject (TraceBlockFetchServerEvent blk) where
   toObject _verb _ =
@@ -867,5 +867,3 @@ instance ProtocolLedgerView blk => ToObject (TraceForgeEvent blk tx) where
         , "slot"    .= toJSON (unSlotNo slotNo)
         , "reason"  .= show invalidBlockReason
         ]
-
-


### PR DESCRIPTION
- Fixes typos in some `toObject` keys

Is there a schema for the `toObject` values? I notice that the `"kind"` object key is used a lot. Also did you consider using generics or TH to reduce boilerplate in these instances?
