### PR TITLE
Set defaults for empty config `.yaml` fields

### DIFF
--- a/benchmarking/chain-sync/configuration/log-configuration.yaml
+++ b/benchmarking/chain-sync/configuration/log-configuration.yaml
@@ -94,7 +94,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: True

--- a/benchmarking/cluster3nodes/configuration/log-config-0.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-0.yaml
@@ -79,7 +79,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: False

--- a/benchmarking/cluster3nodes/configuration/log-config-1.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-1.yaml
@@ -81,7 +81,7 @@ NodeId: 1
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: False

--- a/benchmarking/cluster3nodes/configuration/log-config-2.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-2.yaml
@@ -85,7 +85,7 @@ NodeId: 2
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: False

--- a/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
@@ -97,7 +97,7 @@ Protocol: ByronLegacy
 GenesisHash: f556e11e70d071629c84401ea8e18b7158dc045ebe29c40e80c18eca5bab3adb
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+PBftSignatureThreshold:
 
 ##### Network Time Parameters #####
 

--- a/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
@@ -85,7 +85,7 @@ NodeId: 99
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True

--- a/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
@@ -53,7 +53,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: False
 ViewMode: SimpleView
 TurnOnLogMetrics: False

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -45,6 +45,8 @@ import           Ouroboros.Consensus.NodeId (NodeId(..))
 
 import           Cardano.Config.Topology
 import           Cardano.Config.Orphanage ()
+import           Cardano.Crypto (RequiresNetworkMagic(..))
+
 --------------------------------------------------------------------------------
 -- Cardano Environment
 --------------------------------------------------------------------------------
@@ -164,20 +166,20 @@ data NodeConfiguration =
 instance FromJSON NodeConfiguration where
     parseJSON = withObject "NodeConfiguration" $ \v -> do
                   nId <- v .:? "NodeId"
-                  ptcl <- v .: "Protocol"
+                  ptcl <- v .: "Protocol" .!= RealPBFT
                   numCoreNode <- v .:? "NumCoreNodes"
-                  rNetworkMagic <- v .: "RequiresNetworkMagic"
+                  rNetworkMagic <- v .:? "RequiresNetworkMagic" .!= RequiresNoMagic
                   pbftSignatureThresh <- v .:? "PBftSignatureThreshold"
-                  loggingSwitch <- v .: "TurnOnLogging"
-                  vMode <- v .: "ViewMode"
-                  logMetrics <- v .: "TurnOnLogMetrics"
+                  loggingSwitch <- v .:? "TurnOnLogging" .!= True
+                  vMode <- v .:? "ViewMode" .!= LiveView
+                  logMetrics <- v .:? "TurnOnLogMetrics" .!= True
 
                   -- Update Parameters
-                  appName <- v .: "ApplicationName"
-                  appVersion <- v .: "ApplicationVersion"
-                  lkBlkVersionMajor <- v .: "LastKnownBlockVersion-Major"
-                  lkBlkVersionMinor <- v .: "LastKnownBlockVersion-Minor"
-                  lkBlkVersionAlt <- v .: "LastKnownBlockVersion-Alt"
+                  appName <- v .:? "ApplicationName" .!= Update.ApplicationName "cardano-sl"
+                  appVersion <- v .:? "ApplicationVersion" .!= 1
+                  lkBlkVersionMajor <- v .:? "LastKnownBlockVersion-Major" .!= 0
+                  lkBlkVersionMinor <- v .:? "LastKnownBlockVersion-Minor" .!= 2
+                  lkBlkVersionAlt <- v .:? "LastKnownBlockVersion-Alt" .!= 0
 
                   pure $ NodeConfiguration
                            ptcl

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -85,7 +85,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: True

--- a/configuration/configuration-silent.yaml
+++ b/configuration/configuration-silent.yaml
@@ -63,7 +63,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: False

--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -90,7 +90,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: True

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -96,7 +96,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True

--- a/configuration/log-config-1.liveview.yaml
+++ b/configuration/log-config-1.liveview.yaml
@@ -89,7 +89,7 @@ NodeId: 1
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: True

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -95,7 +95,7 @@ NodeId: 1
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True

--- a/configuration/log-config-2.liveview.yaml
+++ b/configuration/log-config-2.liveview.yaml
@@ -95,7 +95,7 @@ NodeId: 2
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: True

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -101,7 +101,7 @@ NodeId: 2
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold: 0.7
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -86,7 +86,7 @@ NodeId: 0
 Protocol: RealPBFT
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold: 0.5
+PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: True


### PR DESCRIPTION
This PR addresses two items:
1. The correct `PBftSignatureThreshold` is determined in the consensus layer and therefore this PR removes all set values in the config `.yaml` files. You can still set custom values in the config `.yaml` files which will override the [default value](https://github.com/input-output-hk/ouroboros-network/blob/0d6474c160aa994d2840188035a123dc8de9bd62/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs#L112) .  (#452) 

2. Any fields left blank under the `Cardano Node Configuration` heading in the config `.yaml` files will now have defaults. (#453)