### PR TITLE
Break up `ToObjectOrphans.hs`

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -45,10 +45,12 @@ library
 
   other-modules:       Paths_cardano_node
                        Cardano.Tracing.ToObjectOrphans.ChainDBTrace
+                       Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace
                        Cardano.Tracing.ToObjectOrphans.DnsTrace
                        Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace
                        Cardano.Tracing.ToObjectOrphans.MuxTrace
                        Cardano.Tracing.ToObjectOrphans.SubscriptionTrace
+                       Cardano.Tracing.ToObjectOrphans.LabelPeerTrace
                        Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -44,6 +44,8 @@ library
 
 
   other-modules:       Paths_cardano_node
+                       Cardano.Tracing.ToObjectOrphans.ChainDBTrace
+                       Cardano.Tracing.ToObjectOrphans.SubscriptionTrace
                        Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -48,9 +48,11 @@ library
                        Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace
                        Cardano.Tracing.ToObjectOrphans.DnsTrace
                        Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace
+                       Cardano.Tracing.ToObjectOrphans.ForgeEventTrace
+                       Cardano.Tracing.ToObjectOrphans.LabelPeerTrace
                        Cardano.Tracing.ToObjectOrphans.MuxTrace
                        Cardano.Tracing.ToObjectOrphans.SubscriptionTrace
-                       Cardano.Tracing.ToObjectOrphans.LabelPeerTrace
+                       Cardano.Tracing.ToObjectOrphans.TxSubmissionTrace
                        Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -45,6 +45,9 @@ library
 
   other-modules:       Paths_cardano_node
                        Cardano.Tracing.ToObjectOrphans.ChainDBTrace
+                       Cardano.Tracing.ToObjectOrphans.DnsTrace
+                       Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace
+                       Cardano.Tracing.ToObjectOrphans.MuxTrace
                        Cardano.Tracing.ToObjectOrphans.SubscriptionTrace
                        Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -44,8 +44,10 @@ library
 
 
   other-modules:       Paths_cardano_node
+                       Cardano.Tracing.ToObjectOrphans.BlockFetchServerEventTrace
                        Cardano.Tracing.ToObjectOrphans.ChainDBTrace
                        Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace
+                       Cardano.Tracing.ToObjectOrphans.ConsensusToObjectOrphans
                        Cardano.Tracing.ToObjectOrphans.DnsTrace
                        Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace
                        Cardano.Tracing.ToObjectOrphans.ForgeEventTrace
@@ -53,7 +55,6 @@ library
                        Cardano.Tracing.ToObjectOrphans.MuxTrace
                        Cardano.Tracing.ToObjectOrphans.SubscriptionTrace
                        Cardano.Tracing.ToObjectOrphans.TxSubmissionTrace
-                       Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking
 
   build-depends:       aeson

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -21,28 +21,17 @@ import           Prelude (String, show, id)
 import           Data.Aeson (Value (..), toJSON, (.=))
 import           Data.Text (pack)
 
-import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..),
-                   mkLOMeta)
 import           Cardano.BM.Tracing
 import           Cardano.BM.Data.Tracer (trStructured, mkObject)
 
 import           Ouroboros.Consensus.BlockFetchServer
                    (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Mempool.API (GenTx, GenTxId)
-import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
-import           Ouroboros.Consensus.TxSubmission
-                   (TraceLocalTxSubmissionServerEvent (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Point (WithOrigin (..))
-import           Ouroboros.Network.TxSubmission.Inbound
-                   (TraceTxSubmissionInbound)
-import           Ouroboros.Network.TxSubmission.Outbound
-                   (TraceTxSubmissionOutbound)
-
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 
 -- | Tracing wrapper which includes current tip in the logs (thus it requires
@@ -93,59 +82,11 @@ instance DefinePrivacyAnnotation (TraceBlockFetchServerEvent blk)
 instance DefineSeverity (TraceBlockFetchServerEvent blk) where
   defineSeverity _ = Info
 
-instance DefinePrivacyAnnotation (TraceTxSubmissionInbound
-                                  (GenTxId blk) (GenTx blk))
-instance DefineSeverity (TraceTxSubmissionInbound
-                         (GenTxId blk) (GenTx blk)) where
-  defineSeverity _ = Info
-
-instance DefinePrivacyAnnotation (TraceTxSubmissionOutbound
-                                  (GenTxId blk) (GenTx blk))
-instance DefineSeverity (TraceTxSubmissionOutbound
-                         (GenTxId blk) (GenTx blk)) where
-  defineSeverity _ = Info
-
-instance DefinePrivacyAnnotation (TraceLocalTxSubmissionServerEvent blk)
-instance DefineSeverity (TraceLocalTxSubmissionServerEvent blk) where
-  defineSeverity _ = Info
-
-instance DefinePrivacyAnnotation (TraceForgeEvent blk tx)
-instance DefineSeverity (TraceForgeEvent blk tx) where
-  defineSeverity TraceForgedBlock {}            = Info
-  defineSeverity TraceStartLeadershipCheck {}   = Info
-  defineSeverity TraceNodeNotLeader {}          = Info
-  defineSeverity TraceNodeIsLeader {}           = Info
-  defineSeverity TraceNoLedgerState {}          = Warning
-  defineSeverity TraceNoLedgerView {}           = Warning
-  defineSeverity TraceBlockFromFuture {}        = Warning
-  defineSeverity TraceAdoptedBlock {}           = Info
-  defineSeverity TraceDidntAdoptBlock {}        = Warning
-  defineSeverity TraceForgedInvalidBlock {}     = Alert
-
 -- | instances of @Transformable@
 
 -- transform @BlockFetchServerEvent@
 instance Transformable Text IO (TraceBlockFetchServerEvent blk) where
   trTransformer _ verb tr = trStructured verb tr
-
-instance Transformable Text IO (TraceTxSubmissionInbound
-                                (GenTxId blk) (GenTx blk)) where
-  trTransformer _ verb tr = trStructured verb tr
-
-instance Transformable Text IO (TraceTxSubmissionOutbound
-                                (GenTxId blk) (GenTx blk)) where
-  trTransformer _ verb tr = trStructured verb tr
-
-instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
-  trTransformer _ verb tr = trStructured verb tr
-
-instance (Show blk, Show tx, ProtocolLedgerView blk) => Transformable Text IO (TraceForgeEvent blk tx) where
-  trTransformer StructuredLogging verb tr = trStructured verb tr
-  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
-    traceWith tr =<< LogObject <$> pure mempty
-                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-                               <*> pure (LogMessage $ pack $ show s)
-  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
 
 -- | instances of @ToObject@
 instance ToObject SlotNo where
@@ -170,68 +111,3 @@ instance ToObject LedgerDB.DiskSnapshot where
 instance ToObject (TraceBlockFetchServerEvent blk) where
   toObject _verb _ =
     mkObject [ "kind" .= String "TraceBlockFetchServerEvent" ]
-
-instance ToObject (TraceTxSubmissionInbound (GenTxId blk) (GenTx blk)) where
-  toObject _verb _ =
-    mkObject [ "kind" .= String "TraceTxSubmissionInbound" ]
-
-instance ToObject (TraceTxSubmissionOutbound (GenTxId blk) (GenTx blk)) where
-  toObject _verb _ =
-    mkObject [ "kind" .= String "TraceTxSubmissionOutbound" ]
-
-instance ToObject (TraceLocalTxSubmissionServerEvent blk) where
-  toObject _verb _ =
-    mkObject [ "kind" .= String "TraceLocalTxSubmissionServerEvent" ]
-
-instance ProtocolLedgerView blk => ToObject (TraceForgeEvent blk tx) where
-  toObject _verb (TraceAdoptedBlock slotNo _blk _txs) =
-    mkObject
-        [ "kind"    .= String "TraceAdoptedBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceBlockFromFuture currentSlot tip) =
-    mkObject
-        [ "kind" .= String "TraceBlockFromFuture"
-        , "current slot" .= toJSON (unSlotNo currentSlot)
-        , "tip" .= toJSON (unSlotNo tip)
-        ]
-  toObject _verb (TraceDidntAdoptBlock slotNo _) =
-    mkObject
-        [ "kind"    .= String "TraceDidntAdoptBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceForgedBlock slotNo _ _) =
-    mkObject
-        [ "kind"    .= String "TraceForgedBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceForgedInvalidBlock slotNo _ _) =
-    mkObject
-        [ "kind"    .= String "TraceForgedInvalidBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceNodeIsLeader slotNo) =
-    mkObject
-        [ "kind"    .= String "TraceNodeIsLeader"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceNodeNotLeader slotNo) =
-    mkObject
-        [ "kind"    .= String "TraceNodeNotLeader"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceNoLedgerState slotNo _blk) =
-    mkObject
-        [ "kind"    .= String "TraceNoLedgerState"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceNoLedgerView slotNo _) =
-    mkObject
-        [ "kind"    .= String "TraceNoLedgerView"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
-  toObject _verb (TraceStartLeadershipCheck slotNo) =
-    mkObject
-        [ "kind"    .= String "TraceStartLeadershipCheck"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -20,7 +20,6 @@ import           Prelude (String, show, id)
 
 import           Data.Aeson (Value (..), toJSON, (.=))
 import           Data.Text (pack)
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Network.Socket as Socket (SockAddr)
 import           Network.Mux (WithMuxBearer (..), MuxTrace (..))
 
@@ -44,7 +43,6 @@ import           Ouroboros.Consensus.TxSubmission
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
-import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.BlockFetch.ClientState
                    (TraceFetchClientState (..), TraceLabelPeer (..))
@@ -52,16 +50,13 @@ import           Ouroboros.Network.BlockFetch.Decision (FetchDecision)
 import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Network.NodeToNode
                    (WithAddr(..), ErrorPolicyTrace(..))
-import           Ouroboros.Network.Subscription (ConnectResult (..), DnsTrace (..),
-                   SubscriptionTrace (..),
-                   WithDomainName (..), WithIPList (..))
+import           Ouroboros.Network.Subscription (DnsTrace (..),
+                   WithDomainName (..))
 import           Ouroboros.Network.TxSubmission.Inbound
                    (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound
                    (TraceTxSubmissionOutbound)
 
-import qualified Ouroboros.Storage.ChainDB as ChainDB
-import           Ouroboros.Storage.Common (EpochNo (..))
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 
 -- | Tracing wrapper which includes current tip in the logs (thus it requires
@@ -108,53 +103,7 @@ instance ( Show a
 
   show = showWithTip show
 
--- instances of @DefinePrivacyAnnotation@ and @DefineSeverity@
-instance DefinePrivacyAnnotation (WithIPList (SubscriptionTrace Socket.SockAddr))
-instance DefineSeverity (WithIPList (SubscriptionTrace Socket.SockAddr)) where
-  defineSeverity (WithIPList _ _ ev) = case ev of
-    SubscriptionTraceConnectStart _ -> Info
-    SubscriptionTraceConnectEnd _ connectResult -> case connectResult of
-      ConnectSuccess         -> Info
-      ConnectSuccessLast     -> Notice
-      ConnectValencyExceeded -> Warning
-    SubscriptionTraceConnectException {} -> Error
-    SubscriptionTraceSocketAllocationException {} -> Error
-    SubscriptionTraceTryConnectToPeer {} -> Info
-    SubscriptionTraceSkippingPeer {} -> Info
-    SubscriptionTraceSubscriptionRunning -> Debug
-    SubscriptionTraceSubscriptionWaiting {} -> Debug
-    SubscriptionTraceSubscriptionFailed -> Error
-    SubscriptionTraceSubscriptionWaitingNewConnection {} -> Notice
-    SubscriptionTraceStart {} -> Debug
-    SubscriptionTraceRestart {} -> Info
-    SubscriptionTraceConnectionExist {} -> Notice
-    SubscriptionTraceUnsupportedRemoteAddr {} -> Error
-    SubscriptionTraceMissingLocalAddress -> Warning
-    SubscriptionTraceApplicationException {} -> Error
-    SubscriptionTraceAllocateSocket {} -> Debug
-    SubscriptionTraceCloseSocket {} -> Info
 
-instance DefinePrivacyAnnotation (WithDomainName (SubscriptionTrace Socket.SockAddr))
-instance DefineSeverity (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
-  defineSeverity (WithDomainName _ ev) = case ev of
-    SubscriptionTraceConnectStart {} -> Info
-    SubscriptionTraceConnectEnd {} -> Info
-    SubscriptionTraceConnectException {} -> Error
-    SubscriptionTraceSocketAllocationException {} -> Error
-    SubscriptionTraceTryConnectToPeer {} -> Info
-    SubscriptionTraceSkippingPeer {} -> Info
-    SubscriptionTraceSubscriptionRunning -> Debug
-    SubscriptionTraceSubscriptionWaiting {} -> Debug
-    SubscriptionTraceSubscriptionFailed -> Warning
-    SubscriptionTraceSubscriptionWaitingNewConnection {} -> Debug
-    SubscriptionTraceStart {} -> Debug
-    SubscriptionTraceRestart {} -> Debug
-    SubscriptionTraceConnectionExist {} -> Info
-    SubscriptionTraceUnsupportedRemoteAddr {} -> Warning
-    SubscriptionTraceMissingLocalAddress -> Warning
-    SubscriptionTraceApplicationException {} -> Error
-    SubscriptionTraceAllocateSocket {} -> Debug
-    SubscriptionTraceCloseSocket {} -> Debug
 
 instance DefinePrivacyAnnotation (WithDomainName DnsTrace)
 instance DefineSeverity (WithDomainName DnsTrace) where
@@ -207,67 +156,6 @@ instance DefineSeverity (WithMuxBearer peer MuxTrace) where
     MuxTraceRecvDeltaQObservation {} -> Debug
     MuxTraceRecvDeltaQSample {}      -> Info
 
-instance DefinePrivacyAnnotation (WithTip blk (ChainDB.TraceEvent blk))
-instance DefineSeverity (WithTip blk (ChainDB.TraceEvent blk)) where
-  defineSeverity (WithTip _tip ev) = defineSeverity ev
-
-instance DefineSeverity (ChainDB.TraceEvent blk) where
-  defineSeverity (ChainDB.TraceAddBlockEvent ev) = case ev of
-    ChainDB.IgnoreBlockOlderThanK {} -> Info
-    ChainDB.IgnoreBlockAlreadyInVolDB {} -> Info
-    ChainDB.IgnoreInvalidBlock {} -> Info
-    ChainDB.BlockInTheFuture {} -> Info
-    ChainDB.StoreButDontChange {} -> Debug
-    ChainDB.TryAddToCurrentChain {} -> Debug
-    ChainDB.TrySwitchToAFork {} -> Info
-    ChainDB.SwitchedToChain {} -> Notice
-    ChainDB.AddBlockValidation ev' -> case ev' of
-      ChainDB.InvalidBlock {} -> Error
-      ChainDB.InvalidCandidate {} -> Error
-      ChainDB.ValidCandidate {} -> Info
-      ChainDB.CandidateExceedsRollback {} -> Error
-    ChainDB.AddedBlockToVolDB {} -> Debug
-    ChainDB.ChainChangedInBg {} -> Info
-    ChainDB.ScheduledChainSelection {} -> Debug
-    ChainDB.RunningScheduledChainSelection {} -> Debug
-
-  defineSeverity (ChainDB.TraceLedgerReplayEvent ev) = case ev of
-    LedgerDB.ReplayFromGenesis {} -> Info
-    LedgerDB.ReplayFromSnapshot {} -> Info
-    LedgerDB.ReplayedBlock {} -> Info
-
-  defineSeverity (ChainDB.TraceLedgerEvent ev) = case ev of
-    LedgerDB.TookSnapshot {} -> Info
-    LedgerDB.DeletedSnapshot {} -> Debug
-    LedgerDB.InvalidSnapshot {} -> Error
-
-  defineSeverity (ChainDB.TraceCopyToImmDBEvent ev) = case ev of
-    ChainDB.CopiedBlockToImmDB {} -> Notice
-    ChainDB.NoBlocksToCopyToImmDB -> Debug
-
-  defineSeverity (ChainDB.TraceGCEvent ev) = case ev of
-    ChainDB.PerformedGC {} -> Debug
-    ChainDB.ScheduledGC {} -> Debug
-
-  defineSeverity (ChainDB.TraceOpenEvent ev) = case ev of
-    ChainDB.OpenedDB {} -> Info
-    ChainDB.ClosedDB {} -> Info
-    ChainDB.ReopenedDB {} -> Debug
-    ChainDB.OpenedImmDB {} -> Info
-    ChainDB.OpenedVolDB -> Info
-    ChainDB.OpenedLgrDB -> Info
-
-  defineSeverity (ChainDB.TraceReaderEvent ev) = case ev of
-    ChainDB.NewReader {} -> Info
-    ChainDB.ReaderNoLongerInMem {} -> Info
-    ChainDB.ReaderSwitchToMem {} -> Info
-    ChainDB.ReaderNewImmIterator {} -> Info
-  defineSeverity (ChainDB.TraceInitChainSelEvent ev) = case ev of
-    ChainDB.InitChainSelValidation {} -> Debug
-  defineSeverity (ChainDB.TraceIteratorEvent ev) = case ev of
-    ChainDB.StreamFromVolDB {} -> Debug
-    _ -> Debug
-  defineSeverity (ChainDB.TraceImmDBEvent _ev) = Debug
 
 instance DefinePrivacyAnnotation (TraceChainSyncClientEvent blk)
 instance DefineSeverity (TraceChainSyncClientEvent blk) where
@@ -370,23 +258,7 @@ instance (Show blk, Show tx, ProtocolLedgerView blk) => Transformable Text IO (T
                                <*> pure (LogMessage $ pack $ show s)
   trTransformer UserdefinedFormatting verb tr = trStructured verb tr
 
--- transform @SubscriptionTrace@
-instance Transformable Text IO (WithIPList (SubscriptionTrace Socket.SockAddr)) where
-  trTransformer StructuredLogging verb tr = trStructured verb tr
-  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
-    traceWith tr =<< LogObject <$> pure mempty
-                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-                               <*> pure (LogMessage $ pack $ show s)
-  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
 
-
-instance Transformable Text IO (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
-  trTransformer StructuredLogging verb tr = trStructured verb tr
-  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
-    traceWith tr =<< LogObject <$> pure mempty
-                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-                               <*> pure (LogMessage $ pack $ show s)
-  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
 
 -- transform @DnsTrace@
 instance Transformable Text IO (WithDomainName DnsTrace) where
@@ -416,136 +288,7 @@ instance (Show peer)
                                <*> pure (LogMessage $ pack $ show s)
   trTransformer UserdefinedFormatting verb tr = trStructured verb tr
 
--- transform @TraceEvent@
-instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
-            => Transformable Text IO (WithTip blk (ChainDB.TraceEvent blk)) where
-  -- structure required, will call 'toObject'
-  trTransformer StructuredLogging verb tr = trStructured verb tr
-  -- textual output based on the readable ChainDB tracer
-  trTransformer TextualRepresentation _verb tr = readableChainDBTracer $ Tracer $ \s ->
-    traceWith tr =<< LogObject <$> pure mempty
-                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-                               <*> pure (LogMessage $ pack s)
-  -- user defined formatting of log output
-  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
-
--- | tracer transformer to text messages for TraceEvents
--- Converts the trace events from the ChainDB that we're interested in into
--- human-readable trace messages.
-readableChainDBTracer
-  :: forall m blk.
-     (Monad m, Condense (HeaderHash blk), ProtocolLedgerView blk)
-  => Tracer m String
-  -> Tracer m (WithTip blk (ChainDB.TraceEvent blk))
-readableChainDBTracer tracer = Tracer $ \case
-  WithTip tip (ChainDB.TraceAddBlockEvent ev) -> case ev of
-    ChainDB.IgnoreBlockOlderThanK pt -> tr $ WithTip tip $
-      "Ignoring block older than K: " <> condense pt
-    ChainDB.IgnoreBlockAlreadyInVolDB pt -> tr $ WithTip tip $
-      "Ignoring block already in DB: " <> condense pt
-    ChainDB.IgnoreInvalidBlock pt _reason -> tr $ WithTip tip $
-      "Ignoring previously seen invalid block: " <> condense pt
-    ChainDB.BlockInTheFuture pt slot -> tr $ WithTip tip $
-      "Ignoring block from future: " <> condense pt <> ", slot " <> condense slot
-    ChainDB.StoreButDontChange pt   -> tr $ WithTip tip $
-      "Ignoring block: " <> condense pt
-    ChainDB.TryAddToCurrentChain pt -> tr $ WithTip tip $
-      "Block fits onto the current chain: " <> condense pt
-    ChainDB.TrySwitchToAFork pt _   -> tr $ WithTip tip $
-      "Block fits onto some fork: " <> condense pt
-    ChainDB.SwitchedToChain _ c     -> tr $ WithTip tip $
-      "Chain changed, new tip: " <> condense (AF.headPoint c)
-    ChainDB.AddBlockValidation ev' -> case ev' of
-      ChainDB.InvalidBlock err pt -> tr $ WithTip tip $
-        "Invalid block " <> condense pt <> ": " <> show err
-      ChainDB.InvalidCandidate c -> tr $ WithTip tip $
-        "Invalid candidate " <> condense (AF.headPoint c)
-      ChainDB.ValidCandidate c -> tr $ WithTip tip $
-        "Valid candidate " <> condense (AF.headPoint c)
-      ChainDB.CandidateExceedsRollback _ _ c -> tr $ WithTip tip $
-        "Exceeds rollback " <> condense (AF.headPoint c)
-    ChainDB.AddedBlockToVolDB pt _ _ -> tr $ WithTip tip $
-      "Chain added block " <> condense pt
-    ChainDB.ChainChangedInBg c1 c2     -> tr $ WithTip tip $
-      "Chain changed in bg, from " <> condense (AF.headPoint c1) <> " to "  <> condense (AF.headPoint c2)
-    ChainDB.ScheduledChainSelection pt slot _n -> tr $ WithTip tip $
-      "Chain selection scheduled for future: " <> condense pt
-                                  <> ", slot " <> condense slot
-    ChainDB.RunningScheduledChainSelection pts slot _n -> tr $ WithTip tip $
-      "Running scheduled chain selection: " <> condense (NonEmpty.toList pts)
-                               <> ", slot " <> condense slot
-  WithTip tip (ChainDB.TraceLedgerReplayEvent ev) -> case ev of
-    LedgerDB.ReplayFromGenesis _replayTo -> tr $ WithTip tip
-      "Replaying ledger from genesis"
-    LedgerDB.ReplayFromSnapshot snap tip' _replayTo -> tr $ WithTip tip $
-      "Replaying ledger from snapshot " <> show snap <> " at " <>
-        condense tip'
-    LedgerDB.ReplayedBlock _r (epochno, slotno) _replayTo -> tr $ WithTip tip $
-      "Replayed block: " <> show (unSlotNo slotno) <> " in epoch: " <> show (unEpochNo epochno)
-  WithTip tip (ChainDB.TraceLedgerEvent ev) -> case ev of
-    LedgerDB.TookSnapshot snap pt -> tr $ WithTip tip $
-      "Took ledger snapshot " <> show snap <> " at " <> condense pt
-    LedgerDB.DeletedSnapshot snap -> tr $ WithTip tip $
-      "Deleted old snapshot " <> show snap
-    LedgerDB.InvalidSnapshot snap failure -> tr $ WithTip tip $
-      "Invalid snapshot " <> show snap <> show failure
-  WithTip tip (ChainDB.TraceCopyToImmDBEvent ev) -> case ev of
-    ChainDB.CopiedBlockToImmDB pt -> tr $ WithTip tip $
-      "Copied block " <> condense pt <> " to the ImmutableDB"
-    ChainDB.NoBlocksToCopyToImmDB -> tr $ WithTip tip
-      "There are no blocks to copy to the ImmutableDB"
-  WithTip tip (ChainDB.TraceGCEvent ev) -> case ev of
-    ChainDB.PerformedGC slot        -> tr $ WithTip tip $
-      "Performed a garbage collection for " <> condense slot
-    ChainDB.ScheduledGC slot _difft -> tr $ WithTip tip $
-      "Scheduled a garbage collection for " <> condense slot
-  WithTip tip (ChainDB.TraceOpenEvent ev) -> case ev of
-    ChainDB.OpenedDB immTip tip' -> tr $ WithTip tip $
-      "Opened db with immutable tip at " <> condense immTip <>
-      " and tip " <> condense tip'
-    ChainDB.ClosedDB immTip tip' -> tr $ WithTip tip $
-      "Closed db with immutable tip at " <> condense immTip <>
-      " and tip " <> condense tip'
-    ChainDB.ReopenedDB immTip tip' -> tr $ WithTip tip $
-      "Reopened db with immutable tip at " <> condense immTip <>
-      " and tip " <> condense tip'
-    ChainDB.OpenedImmDB immTip epoch -> tr $ WithTip tip $
-      "Opened imm db with immutable tip at " <> condense immTip <>
-      " and epoch " <> show epoch
-    ChainDB.OpenedVolDB -> tr $ WithTip tip "Opened vol db"
-    ChainDB.OpenedLgrDB -> tr $ WithTip tip "Opened lgr db"
-  WithTip tip (ChainDB.TraceReaderEvent ev) -> case ev of
-    ChainDB.NewReader readerid -> tr $ WithTip tip $
-      "New reader with id: " <> condense readerid
-    ChainDB.ReaderNoLongerInMem _ -> tr $ WithTip tip "ReaderNoLongerInMem"
-    ChainDB.ReaderSwitchToMem _ _ -> tr $ WithTip tip "ReaderSwitchToMem"
-    ChainDB.ReaderNewImmIterator _ _ -> tr $ WithTip tip "ReaderNewImmIterator"
-  WithTip tip (ChainDB.TraceInitChainSelEvent ev) -> case ev of
-    ChainDB.InitChainSelValidation _ -> tr $ WithTip tip "InitChainSelValidation"
-  WithTip tip (ChainDB.TraceIteratorEvent ev) -> case ev of
-    ChainDB.StreamFromVolDB _ _ _ -> tr $ WithTip tip "StreamFromVolDB"
-    _ -> pure ()  -- TODO add more iterator events
-  WithTip tip (ChainDB.TraceImmDBEvent _ev) -> tr $ WithTip tip "TraceImmDBEvent"
-
- where
-  tr :: WithTip blk String -> m ()
-  tr = traceWith (contramap (showWithTip id) tracer)
-
-
 -- | instances of @ToObject@
-
-instance ToObject (WithIPList (SubscriptionTrace Socket.SockAddr)) where
-  toObject _verb (WithIPList localAddresses dests ev) =
-    mkObject [ "kind" .= String "WithIPList SubscriptionTrace"
-             , "localAddresses" .= show localAddresses
-             , "dests" .= show dests
-             , "event" .= show ev ]
-
-instance ToObject (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
-  toObject _verb (WithDomainName dom ev) =
-    mkObject [ "kind" .= String "SubscriptionTrace"
-             , "domain" .= show dom
-             , "event" .= show ev ]
 
 instance ToObject (WithDomainName DnsTrace) where
   toObject _verb (WithDomainName dom ev) =
@@ -566,20 +309,6 @@ instance (Show peer)
              , "bearer" .= show b
              , "event" .= show ev ]
 
-instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
-      => ToObject (WithTip blk (ChainDB.TraceEvent blk)) where
-  -- example: turn off any tracing of @TraceEvent@s when minimal verbosity level is set
-  -- toObject MinimalVerbosity _ = emptyObject -- no output
-  toObject verb (WithTip tip ev) =
-    let evobj = toObject verb ev
-    in
-    if evobj == emptyObject
-    then emptyObject
-    else mkObject [ "kind" .= String "TraceEvent"
-                  , "tip" .= showTip MinimalVerbosity tip
-                  , "event" .= evobj
-                  ]
-
 instance ToObject SlotNo where
   toObject _verb slot =
     mkObject [ "kind" .= String "SlotNo"
@@ -591,155 +320,6 @@ instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
   toObject verb p =
     mkObject [ "kind" .= String "Tip"
              , "tip" .= showTip verb p ]
-
-instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
-      => ToObject (ChainDB.TraceEvent blk) where
-  toObject verb (ChainDB.TraceAddBlockEvent ev) = case ev of
-    ChainDB.IgnoreBlockOlderThanK pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockOlderThanK"
-               , "block" .= toObject verb pt ]
-    ChainDB.IgnoreBlockAlreadyInVolDB pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockAlreadyInVolDB"
-               , "block" .= toObject verb pt ]
-    ChainDB.IgnoreInvalidBlock pt reason ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreInvalidBlock"
-               , "block" .= toObject verb pt
-               , "reason" .= show reason ]
-    ChainDB.BlockInTheFuture pt slot ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
-               , "block" .= toObject verb pt
-               , "slot" .= toObject verb slot ]
-    ChainDB.StoreButDontChange pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.StoreButDontChange"
-               , "block" .= toObject verb pt ]
-    ChainDB.TryAddToCurrentChain pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.TryAddToCurrentChain"
-               , "block" .= toObject verb pt ]
-    ChainDB.TrySwitchToAFork pt _ ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.TrySwitchToAFork"
-               , "block" .= toObject verb pt ]
-    ChainDB.SwitchedToChain _ c ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.SwitchedToChain"
-               , "newtip" .= showTip verb (AF.headPoint c) ]
-    ChainDB.AddBlockValidation ev' -> case ev' of
-      ChainDB.InvalidBlock err pt ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidBlock"
-                 , "block" .= toObject verb pt
-                 , "error" .= show err ]
-      ChainDB.InvalidCandidate c ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidCandidate"
-                 , "block" .= showTip verb (AF.headPoint c) ]
-      ChainDB.ValidCandidate c ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.ValidCandidate"
-                 , "block" .= showTip verb (AF.headPoint c) ]
-      ChainDB.CandidateExceedsRollback supported actual c ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateExceedsRollback"
-                 , "block" .= showTip verb (AF.headPoint c)
-                 , "supported" .= show supported
-                 , "actual"    .= show actual ]
-    ChainDB.AddedBlockToVolDB pt (BlockNo bn) _ ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.AddedBlockToVolDB"
-               , "block" .= toObject verb pt
-               , "blockNo" .= show bn ]
-    ChainDB.ChainChangedInBg c1 c2     ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.ChainChangedInBg"
-               , "prev" .= showTip verb (AF.headPoint c1)
-               , "new" .= showTip verb (AF.headPoint c2) ]
-    ChainDB.ScheduledChainSelection pt slot n ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.ScheduledChainSelection"
-               , "block" .= toObject verb pt
-               , "slot" .= toObject verb slot
-               , "scheduled" .= n ]
-    ChainDB.RunningScheduledChainSelection pts slot n ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.RunningScheduledChainSelection"
-               , "blocks" .= map (toObject verb) (NonEmpty.toList pts)
-               , "slot" .= toObject verb slot
-               , "scheduled" .= n ]
-
-  toObject MinimalVerbosity (ChainDB.TraceLedgerReplayEvent _ev) = emptyObject -- no output
-  toObject verb (ChainDB.TraceLedgerReplayEvent ev) = case ev of
-    LedgerDB.ReplayFromGenesis _replayTo ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
-    LedgerDB.ReplayFromSnapshot snap tip' _replayTo ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "tip" .= show tip' ]
-    LedgerDB.ReplayedBlock _ (epochno, slotno) _replayTo ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
-               , "epoch" .= show (unEpochNo epochno)
-               , "slot" .= show (unSlotNo slotno) ]
-
-  toObject MinimalVerbosity (ChainDB.TraceLedgerEvent _ev) = emptyObject -- no output
-  toObject verb (ChainDB.TraceLedgerEvent ev) = case ev of
-    LedgerDB.TookSnapshot snap pt ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.TookSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "tip" .= show pt ]
-    LedgerDB.DeletedSnapshot snap ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.DeletedSnapshot"
-               , "snapshot" .= toObject verb snap ]
-    LedgerDB.InvalidSnapshot snap failure ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.InvalidSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "failure" .= show failure ]
-
-  toObject verb (ChainDB.TraceCopyToImmDBEvent ev) = case ev of
-    ChainDB.CopiedBlockToImmDB pt ->
-      mkObject [ "kind" .= String "TraceCopyToImmDBEvent.CopiedBlockToImmDB"
-               , "slot" .= toObject verb pt ]
-    ChainDB.NoBlocksToCopyToImmDB ->
-      mkObject [ "kind" .= String "TraceCopyToImmDBEvent.NoBlocksToCopyToImmDB" ]
-
-  toObject verb (ChainDB.TraceGCEvent ev) = case ev of
-    ChainDB.PerformedGC slot ->
-      mkObject [ "kind" .= String "TraceGCEvent.PerformedGC"
-               , "slot" .= toObject verb slot ]
-    ChainDB.ScheduledGC slot difft ->
-      mkObject $ [ "kind" .= String "TraceGCEvent.ScheduledGC"
-                 , "slot" .= toObject verb slot ] <>
-                 [ "difft" .= String ((pack . show) difft) | verb >= MaximalVerbosity]
-
-  toObject verb (ChainDB.TraceOpenEvent ev) = case ev of
-    ChainDB.OpenedDB immTip tip' ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedDB"
-               , "immtip" .= toObject verb immTip
-               , "tip" .= toObject verb tip' ]
-    ChainDB.ClosedDB immTip tip' ->
-      mkObject [ "kind" .= String "TraceOpenEvent.ClosedDB"
-               , "immtip" .= toObject verb immTip
-               , "tip" .= toObject verb tip' ]
-    ChainDB.ReopenedDB immTip tip' ->
-      mkObject [ "kind" .= String "TraceOpenEvent.ReopenedDB"
-               , "immtip" .= toObject verb immTip
-               , "tip" .= toObject verb tip' ]
-    ChainDB.OpenedImmDB immTip epoch ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedImmDB"
-               , "immtip" .= toObject verb immTip
-               , "epoch" .= String ((pack . show) epoch) ]
-    ChainDB.OpenedVolDB ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedVolDB" ]
-    ChainDB.OpenedLgrDB ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedLgrDB" ]
-
-  toObject _verb (ChainDB.TraceReaderEvent ev) = case ev of
-    ChainDB.NewReader readerid ->
-      mkObject [ "kind" .= String "TraceGCEvent.PerformedGC"
-               , "readerid" .= String ((pack . condense) readerid) ]
-    ChainDB.ReaderNoLongerInMem _ ->
-      mkObject [ "kind" .= String "ReaderNoLongerInMem" ]
-    ChainDB.ReaderSwitchToMem _ _ ->
-      mkObject [ "kind" .= String "ReaderSwitchToMem" ]
-    ChainDB.ReaderNewImmIterator _ _ ->
-      mkObject [ "kind" .= String "ReaderNewImmIterator" ]
-  toObject _verb (ChainDB.TraceInitChainSelEvent ev) = case ev of
-    ChainDB.InitChainSelValidation _ ->
-      mkObject [ "kind" .= String "InitChainSelValidation" ]
-  toObject _verb (ChainDB.TraceIteratorEvent ev) = case ev of
-    ChainDB.StreamFromVolDB _ _ _ ->
-      mkObject [ "kind" .= String "StreamFromVolDB" ]
-    _ -> emptyObject  -- TODO add more iterator events
-  toObject _verb (ChainDB.TraceImmDBEvent _ev) =
-    mkObject [ "kind" .= String "TraceImmDBEvent" ]
 
 instance ToObject LedgerDB.DiskSnapshot where
   toObject MinimalVerbosity snap = toObject NormalVerbosity snap

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/BlockFetchServerEventTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/BlockFetchServerEventTrace.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.BlockFetchServerEventTrace () where
+
+import           Cardano.Prelude
+
+import           Data.Aeson hiding (Error)
+
+import           Ouroboros.Consensus.BlockFetchServer (TraceBlockFetchServerEvent)
+import           Cardano.BM.Data.Tracer ( mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..),  Transformable(..)
+                                    )
+
+instance DefinePrivacyAnnotation (TraceBlockFetchServerEvent blk)
+instance DefineSeverity (TraceBlockFetchServerEvent blk) where
+  defineSeverity _ = Info
+
+-- transform @BlockFetchServerEvent@
+instance Transformable Text IO (TraceBlockFetchServerEvent blk) where
+  trTransformer _ verb tr = trStructured verb tr
+instance ToObject (TraceBlockFetchServerEvent blk) where
+  toObject _verb _ =
+    mkObject [ "kind" .= String "TraceBlockFetchServerEvent" ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainDBTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainDBTrace.hs
@@ -1,0 +1,387 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-missing-local-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+
+module Cardano.Tracing.ToObjectOrphans.ChainDBTrace () where
+
+import Cardano.Tracing.ToObjectOrphans
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (String, show)
+
+import           Data.Aeson hiding (Error)
+import qualified Data.List.NonEmpty as NonEmpty
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( TracingVerbosity(..), definePrivacyAnnotation
+                                        , emptyObject, mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , contramap, traceWith, mkLOMeta)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (BlockNo(..), HeaderHash, SlotNo(..))
+import qualified Ouroboros.Storage.ChainDB as ChainDB
+import           Ouroboros.Storage.Common (EpochNo (..))
+import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView(..))
+import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
+import           Ouroboros.Consensus.Util.Condense (Condense(..))
+
+
+
+
+
+
+
+instance DefinePrivacyAnnotation (WithTip blk (ChainDB.TraceEvent blk))
+instance DefineSeverity (WithTip blk (ChainDB.TraceEvent blk)) where
+  defineSeverity (WithTip _tip ev) = defineSeverity ev
+
+instance DefineSeverity (ChainDB.TraceEvent blk) where
+  defineSeverity (ChainDB.TraceAddBlockEvent ev) = case ev of
+    ChainDB.IgnoreBlockOlderThanK {} -> Info
+    ChainDB.IgnoreBlockAlreadyInVolDB {} -> Info
+    ChainDB.IgnoreInvalidBlock {} -> Info
+    ChainDB.BlockInTheFuture {} -> Info
+    ChainDB.StoreButDontChange {} -> Debug
+    ChainDB.TryAddToCurrentChain {} -> Debug
+    ChainDB.TrySwitchToAFork {} -> Info
+    ChainDB.SwitchedToChain {} -> Notice
+    ChainDB.AddBlockValidation ev' -> case ev' of
+      ChainDB.InvalidBlock {} -> Error
+      ChainDB.InvalidCandidate {} -> Error
+      ChainDB.ValidCandidate {} -> Info
+      ChainDB.CandidateExceedsRollback {} -> Error
+    ChainDB.AddedBlockToVolDB {} -> Debug
+    ChainDB.ChainChangedInBg {} -> Info
+    ChainDB.ScheduledChainSelection {} -> Debug
+    ChainDB.RunningScheduledChainSelection {} -> Debug
+
+  defineSeverity (ChainDB.TraceLedgerReplayEvent ev) = case ev of
+    LedgerDB.ReplayFromGenesis {} -> Info
+    LedgerDB.ReplayFromSnapshot {} -> Info
+    LedgerDB.ReplayedBlock {} -> Info
+
+  defineSeverity (ChainDB.TraceLedgerEvent ev) = case ev of
+    LedgerDB.TookSnapshot {} -> Info
+    LedgerDB.DeletedSnapshot {} -> Debug
+    LedgerDB.InvalidSnapshot {} -> Error
+
+  defineSeverity (ChainDB.TraceCopyToImmDBEvent ev) = case ev of
+    ChainDB.CopiedBlockToImmDB {} -> Notice
+    ChainDB.NoBlocksToCopyToImmDB -> Debug
+
+  defineSeverity (ChainDB.TraceGCEvent ev) = case ev of
+    ChainDB.PerformedGC {} -> Debug
+    ChainDB.ScheduledGC {} -> Debug
+
+  defineSeverity (ChainDB.TraceOpenEvent ev) = case ev of
+    ChainDB.OpenedDB {} -> Info
+    ChainDB.ClosedDB {} -> Info
+    ChainDB.ReopenedDB {} -> Debug
+    ChainDB.OpenedImmDB {} -> Info
+    ChainDB.OpenedVolDB -> Info
+    ChainDB.OpenedLgrDB -> Info
+
+  defineSeverity (ChainDB.TraceReaderEvent ev) = case ev of
+    ChainDB.NewReader {} -> Info
+    ChainDB.ReaderNoLongerInMem {} -> Info
+    ChainDB.ReaderSwitchToMem {} -> Info
+    ChainDB.ReaderNewImmIterator {} -> Info
+  defineSeverity (ChainDB.TraceInitChainSelEvent ev) = case ev of
+    ChainDB.InitChainSelValidation {} -> Debug
+  defineSeverity (ChainDB.TraceIteratorEvent ev) = case ev of
+    ChainDB.StreamFromVolDB {} -> Debug
+    _ -> Debug
+  defineSeverity (ChainDB.TraceImmDBEvent _ev) = Debug
+
+-- transform @TraceEvent@
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
+            => Transformable Text IO (WithTip blk (ChainDB.TraceEvent blk)) where
+  -- structure required, will call 'toObject'
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  -- textual output based on the readable ChainDB tracer
+  trTransformer TextualRepresentation _verb tr = readableChainDBTracer $ Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage $ toS s)
+  -- user defined formatting of log output
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+-- | tracer transformer to text messages for TraceEvents
+-- Converts the trace events from the ChainDB that we're interested in into
+-- human-readable trace messages.
+readableChainDBTracer
+  :: forall m blk.
+     (Monad m, Condense (HeaderHash blk), ProtocolLedgerView blk)
+  => Tracer m String
+  -> Tracer m (WithTip blk (ChainDB.TraceEvent blk))
+readableChainDBTracer tracer = Tracer $ \case
+  WithTip tip (ChainDB.TraceAddBlockEvent ev) -> case ev of
+    ChainDB.IgnoreBlockOlderThanK pt -> tr $ WithTip tip $
+      "Ignoring block older than K: " <> condense pt
+    ChainDB.IgnoreBlockAlreadyInVolDB pt -> tr $ WithTip tip $
+      "Ignoring block already in DB: " <> condense pt
+    ChainDB.IgnoreInvalidBlock pt _reason -> tr $ WithTip tip $
+      "Ignoring previously seen invalid block: " <> condense pt
+    ChainDB.BlockInTheFuture pt slot -> tr $ WithTip tip $
+      "Ignoring block from future: " <> condense pt <> ", slot " <> condense slot
+    ChainDB.StoreButDontChange pt   -> tr $ WithTip tip $
+      "Ignoring block: " <> condense pt
+    ChainDB.TryAddToCurrentChain pt -> tr $ WithTip tip $
+      "Block fits onto the current chain: " <> condense pt
+    ChainDB.TrySwitchToAFork pt _   -> tr $ WithTip tip $
+      "Block fits onto some fork: " <> condense pt
+    ChainDB.SwitchedToChain _ c     -> tr $ WithTip tip $
+      "Chain changed, new tip: " <> condense (AF.headPoint c)
+    ChainDB.AddBlockValidation ev' -> case ev' of
+      ChainDB.InvalidBlock err pt -> tr $ WithTip tip $
+        "Invalid block " <> condense pt <> ": " <> show err
+      ChainDB.InvalidCandidate c -> tr $ WithTip tip $
+        "Invalid candidate " <> condense (AF.headPoint c)
+      ChainDB.ValidCandidate c -> tr $ WithTip tip $
+        "Valid candidate " <> condense (AF.headPoint c)
+      ChainDB.CandidateExceedsRollback _ _ c -> tr $ WithTip tip $
+        "Exceeds rollback " <> condense (AF.headPoint c)
+    ChainDB.AddedBlockToVolDB pt _ _ -> tr $ WithTip tip $
+      "Chain added block " <> condense pt
+    ChainDB.ChainChangedInBg c1 c2     -> tr $ WithTip tip $
+      "Chain changed in bg, from " <> condense (AF.headPoint c1) <> " to "  <> condense (AF.headPoint c2)
+    ChainDB.ScheduledChainSelection pt slot _n -> tr $ WithTip tip $
+      "Chain selection scheduled for future: " <> condense pt
+                                  <> ", slot " <> condense slot
+    ChainDB.RunningScheduledChainSelection pts slot _n -> tr $ WithTip tip $
+      "Running scheduled chain selection: " <> condense (NonEmpty.toList pts)
+                               <> ", slot " <> condense slot
+  WithTip tip (ChainDB.TraceLedgerReplayEvent ev) -> case ev of
+    LedgerDB.ReplayFromGenesis _replayTo -> tr $ WithTip tip
+      "Replaying ledger from genesis"
+    LedgerDB.ReplayFromSnapshot snap tip' _replayTo -> tr $ WithTip tip $
+      "Replaying ledger from snapshot " <> show snap <> " at " <>
+        condense tip'
+    LedgerDB.ReplayedBlock _r (epochno, slotno) _replayTo -> tr $ WithTip tip $
+      "Replayed block: " <> show (unSlotNo slotno) <> " in epoch: " <> show (unEpochNo epochno)
+  WithTip tip (ChainDB.TraceLedgerEvent ev) -> case ev of
+    LedgerDB.TookSnapshot snap pt -> tr $ WithTip tip $
+      "Took ledger snapshot " <> show snap <> " at " <> condense pt
+    LedgerDB.DeletedSnapshot snap -> tr $ WithTip tip $
+      "Deleted old snapshot " <> show snap
+    LedgerDB.InvalidSnapshot snap failure -> tr $ WithTip tip $
+      "Invalid snapshot " <> show snap <> show failure
+  WithTip tip (ChainDB.TraceCopyToImmDBEvent ev) -> case ev of
+    ChainDB.CopiedBlockToImmDB pt -> tr $ WithTip tip $
+      "Copied block " <> condense pt <> " to the ImmutableDB"
+    ChainDB.NoBlocksToCopyToImmDB -> tr $ WithTip tip
+      "There are no blocks to copy to the ImmutableDB"
+  WithTip tip (ChainDB.TraceGCEvent ev) -> case ev of
+    ChainDB.PerformedGC slot        -> tr $ WithTip tip $
+      "Performed a garbage collection for " <> condense slot
+    ChainDB.ScheduledGC slot _difft -> tr $ WithTip tip $
+      "Scheduled a garbage collection for " <> condense slot
+  WithTip tip (ChainDB.TraceOpenEvent ev) -> case ev of
+    ChainDB.OpenedDB immTip tip' -> tr $ WithTip tip $
+      "Opened db with immutable tip at " <> condense immTip <>
+      " and tip " <> condense tip'
+    ChainDB.ClosedDB immTip tip' -> tr $ WithTip tip $
+      "Closed db with immutable tip at " <> condense immTip <>
+      " and tip " <> condense tip'
+    ChainDB.ReopenedDB immTip tip' -> tr $ WithTip tip $
+      "Reopened db with immutable tip at " <> condense immTip <>
+      " and tip " <> condense tip'
+    ChainDB.OpenedImmDB immTip epoch -> tr $ WithTip tip $
+      "Opened imm db with immutable tip at " <> condense immTip <>
+      " and epoch " <> show epoch
+    ChainDB.OpenedVolDB -> tr $ WithTip tip "Opened vol db"
+    ChainDB.OpenedLgrDB -> tr $ WithTip tip "Opened lgr db"
+  WithTip tip (ChainDB.TraceReaderEvent ev) -> case ev of
+    ChainDB.NewReader readerid -> tr $ WithTip tip $
+      "New reader with id: " <> condense readerid
+    ChainDB.ReaderNoLongerInMem _ -> tr $ WithTip tip "ReaderNoLongerInMem"
+    ChainDB.ReaderSwitchToMem _ _ -> tr $ WithTip tip "ReaderSwitchToMem"
+    ChainDB.ReaderNewImmIterator _ _ -> tr $ WithTip tip "ReaderNewImmIterator"
+  WithTip tip (ChainDB.TraceInitChainSelEvent ev) -> case ev of
+    ChainDB.InitChainSelValidation _ -> tr $ WithTip tip "InitChainSelValidation"
+  WithTip tip (ChainDB.TraceIteratorEvent ev) -> case ev of
+    ChainDB.StreamFromVolDB _ _ _ -> tr $ WithTip tip "StreamFromVolDB"
+    _ -> pure ()  -- TODO add more iterator events
+  WithTip tip (ChainDB.TraceImmDBEvent _ev) -> tr $ WithTip tip "TraceImmDBEvent"
+
+ where
+  tr = traceWith (contramap (showWithTip identity) tracer)
+
+
+--tr :: forall m blk.
+--  (Monad m, Condense (HeaderHash blk), ProtocolLedgerView blk)
+--  => Tracer m String -> WithTip blk String -> m ()
+--tr trcr wTip = traceWith (contramap (showWithTip identity) trcr) wTip
+
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
+      => ToObject (WithTip blk (ChainDB.TraceEvent blk)) where
+  -- example: turn off any tracing of @TraceEvent@s when minimal verbosity level is set
+  -- toObject MinimalVerbosity _ = emptyObject -- no output
+  toObject verb (WithTip tip ev) =
+    let evobj = toObject verb ev
+    in
+    if evobj == emptyObject
+    then emptyObject
+    else mkObject [ "kind" .= String "TraceEvent"
+                  , "tip" .= showTip MinimalVerbosity tip
+                  , "event" .= evobj
+                  ]
+
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
+      => ToObject (ChainDB.TraceEvent blk) where
+  toObject verb (ChainDB.TraceAddBlockEvent ev) = case ev of
+    ChainDB.IgnoreBlockOlderThanK pt ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockOlderThanK"
+               , "block" .= toObject verb pt ]
+    ChainDB.IgnoreBlockAlreadyInVolDB pt ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockAlreadyInVolDB"
+               , "block" .= toObject verb pt ]
+    ChainDB.IgnoreInvalidBlock pt reason ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreInvalidBlock"
+               , "block" .= toObject verb pt
+               , "reason" .= show reason ]
+    ChainDB.BlockInTheFuture pt slot ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
+               , "block" .= toObject verb pt
+               , "slot" .= toObject verb slot ]
+    ChainDB.StoreButDontChange pt ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.StoreButDontChange"
+               , "block" .= toObject verb pt ]
+    ChainDB.TryAddToCurrentChain pt ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.TryAddToCurrentChain"
+               , "block" .= toObject verb pt ]
+    ChainDB.TrySwitchToAFork pt _ ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.TrySwitchToAFork"
+               , "block" .= toObject verb pt ]
+    ChainDB.SwitchedToChain _ c ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.SwitchedToChain"
+               , "newtip" .= showTip verb (AF.headPoint c) ]
+    ChainDB.AddBlockValidation ev' -> case ev' of
+      ChainDB.InvalidBlock err pt ->
+        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidBlock"
+                 , "block" .= toObject verb pt
+                 , "error" .= show err ]
+      ChainDB.InvalidCandidate c ->
+        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidCandidate"
+                 , "block" .= showTip verb (AF.headPoint c) ]
+      ChainDB.ValidCandidate c ->
+        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.ValidCandidate"
+                 , "block" .= showTip verb (AF.headPoint c) ]
+      ChainDB.CandidateExceedsRollback supported actual c ->
+        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateExceedsRollback"
+                 , "block" .= showTip verb (AF.headPoint c)
+                 , "supported" .= show supported
+                 , "actual"    .= show actual ]
+    ChainDB.AddedBlockToVolDB pt (BlockNo bn) _ ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.AddedBlockToVolDB"
+               , "block" .= toObject verb pt
+               , "blockNo" .= show bn ]
+    ChainDB.ChainChangedInBg c1 c2     ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.ChainChangedInBg"
+               , "prev" .= showTip verb (AF.headPoint c1)
+               , "new" .= showTip verb (AF.headPoint c2) ]
+    ChainDB.ScheduledChainSelection pt slot n ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.ScheduledChainSelection"
+               , "block" .= toObject verb pt
+               , "slot" .= toObject verb slot
+               , "scheduled" .= n ]
+    ChainDB.RunningScheduledChainSelection pts slot n ->
+      mkObject [ "kind" .= String "TraceAddBlockEvent.RunningScheduledChainSelection"
+               , "blocks" .= map (toObject verb) (NonEmpty.toList pts)
+               , "slot" .= toObject verb slot
+               , "scheduled" .= n ]
+
+  toObject MinimalVerbosity (ChainDB.TraceLedgerReplayEvent _ev) = emptyObject -- no output
+  toObject verb (ChainDB.TraceLedgerReplayEvent ev) = case ev of
+    LedgerDB.ReplayFromGenesis _replayTo ->
+      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
+    LedgerDB.ReplayFromSnapshot snap tip' _replayTo ->
+      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
+               , "snapshot" .= toObject verb snap
+               , "tip" .= show tip' ]
+    LedgerDB.ReplayedBlock _ (epochno, slotno) _replayTo ->
+      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
+               , "epoch" .= show (unEpochNo epochno)
+               , "slot" .= show (unSlotNo slotno) ]
+
+  toObject MinimalVerbosity (ChainDB.TraceLedgerEvent _ev) = emptyObject -- no output
+  toObject verb (ChainDB.TraceLedgerEvent ev) = case ev of
+    LedgerDB.TookSnapshot snap pt ->
+      mkObject [ "kind" .= String "TraceLedgerEvent.TookSnapshot"
+               , "snapshot" .= toObject verb snap
+               , "tip" .= show pt ]
+    LedgerDB.DeletedSnapshot snap ->
+      mkObject [ "kind" .= String "TraceLedgerEvent.DeletedSnapshot"
+               , "snapshot" .= toObject verb snap ]
+    LedgerDB.InvalidSnapshot snap failure ->
+      mkObject [ "kind" .= String "TraceLedgerEvent.InvalidSnapshot"
+               , "snapshot" .= toObject verb snap
+               , "failure" .= show failure ]
+
+  toObject verb (ChainDB.TraceCopyToImmDBEvent ev) = case ev of
+    ChainDB.CopiedBlockToImmDB pt ->
+      mkObject [ "kind" .= String "TraceCopyToImmDBEvent.CopiedBlockToImmDB"
+               , "slot" .= toObject verb pt ]
+    ChainDB.NoBlocksToCopyToImmDB ->
+      mkObject [ "kind" .= String "TraceCopyToImmDBEvent.NoBlocksToCopyToImmDB" ]
+
+  toObject verb (ChainDB.TraceGCEvent ev) = case ev of
+    ChainDB.PerformedGC slot ->
+      mkObject [ "kind" .= String "TraceGCEvent.PerformedGC"
+               , "slot" .= toObject verb slot ]
+    ChainDB.ScheduledGC slot difft ->
+      mkObject $ [ "kind" .= String "TraceGCEvent.ScheduledGC"
+                 , "slot" .= toObject verb slot ] <>
+                 [ "difft" .= String ((toS . show) difft) | verb >= MaximalVerbosity]
+
+  toObject verb (ChainDB.TraceOpenEvent ev) = case ev of
+    ChainDB.OpenedDB immTip tip' ->
+      mkObject [ "kind" .= String "TraceOpenEvent.OpenedDB"
+               , "immtip" .= toObject verb immTip
+               , "tip" .= toObject verb tip' ]
+    ChainDB.ClosedDB immTip tip' ->
+      mkObject [ "kind" .= String "TraceOpenEvent.ClosedDB"
+               , "immtip" .= toObject verb immTip
+               , "tip" .= toObject verb tip' ]
+    ChainDB.ReopenedDB immTip tip' ->
+      mkObject [ "kind" .= String "TraceOpenEvent.ReopenedDB"
+               , "immtip" .= toObject verb immTip
+               , "tip" .= toObject verb tip' ]
+    ChainDB.OpenedImmDB immTip epoch ->
+      mkObject [ "kind" .= String "TraceOpenEvent.OpenedImmDB"
+               , "immtip" .= toObject verb immTip
+               , "epoch" .= String ((toS . show) epoch) ]
+    ChainDB.OpenedVolDB ->
+      mkObject [ "kind" .= String "TraceOpenEvent.OpenedVolDB" ]
+    ChainDB.OpenedLgrDB ->
+      mkObject [ "kind" .= String "TraceOpenEvent.OpenedLgrDB" ]
+
+  toObject _verb (ChainDB.TraceReaderEvent ev) = case ev of
+    ChainDB.NewReader readerid ->
+      mkObject [ "kind" .= String "TraceGCEvent.PerformedGC"
+               , "readerid" .= String ((toS . condense) readerid) ]
+    ChainDB.ReaderNoLongerInMem _ ->
+      mkObject [ "kind" .= String "ReaderNoLongerInMem" ]
+    ChainDB.ReaderSwitchToMem _ _ ->
+      mkObject [ "kind" .= String "ReaderSwitchToMem" ]
+    ChainDB.ReaderNewImmIterator _ _ ->
+      mkObject [ "kind" .= String "ReaderNewImmIterator" ]
+  toObject _verb (ChainDB.TraceInitChainSelEvent ev) = case ev of
+    ChainDB.InitChainSelValidation _ ->
+      mkObject [ "kind" .= String "InitChainSelValidation" ]
+  toObject _verb (ChainDB.TraceIteratorEvent ev) = case ev of
+    ChainDB.StreamFromVolDB _ _ _ ->
+      mkObject [ "kind" .= String "StreamFromVolDB" ]
+    _ -> emptyObject  -- TODO add more iterator events
+  toObject _verb (ChainDB.TraceImmDBEvent _ev) =
+    mkObject [ "kind" .= String "TraceImmDBEvent" ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainDBTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainDBTrace.hs
@@ -11,13 +11,13 @@
 
 module Cardano.Tracing.ToObjectOrphans.ChainDBTrace () where
 
-import Cardano.Tracing.ToObjectOrphans
-
 import           Cardano.Prelude hiding (show)
 import           Prelude (String, show)
 
 import           Data.Aeson hiding (Error)
 import qualified Data.List.NonEmpty as NonEmpty
+
+import           Cardano.Tracing.ToObjectOrphans.ConsensusToObjectOrphans
 
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
 import           Cardano.BM.Data.Tracer ( TracingVerbosity(..), definePrivacyAnnotation

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainSyncEventTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainSyncEventTrace.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.Tracing.ToObjectOrphans
+
+import           Cardano.BM.Data.Tracer ( mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Transformable(..)
+                                    )
+import           Ouroboros.Consensus.Block (SupportedBlock, headerPoint)
+import           Ouroboros.Consensus.ChainSyncClient (TraceChainSyncClientEvent (..))
+import           Ouroboros.Consensus.ChainSyncServer (TraceChainSyncServerEvent(..))
+import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView(..))
+import           Ouroboros.Consensus.Util.Condense (Condense(..))
+import           Ouroboros.Network.Block (ChainUpdate(..), HeaderHash, tipPoint)
+
+
+instance DefinePrivacyAnnotation (TraceChainSyncClientEvent blk)
+instance DefineSeverity (TraceChainSyncClientEvent blk) where
+  defineSeverity (TraceDownloadedHeader _) = Info
+  defineSeverity (TraceFoundIntersection _ _ _) = Info
+  defineSeverity (TraceRolledBack _) = Notice
+  defineSeverity (TraceException _) = Warning
+
+-- transform @ChainSyncClient@
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk, SupportedBlock blk)
+          => Transformable Text IO (TraceChainSyncClientEvent blk) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance (Condense (HeaderHash blk), ProtocolLedgerView blk, SupportedBlock blk)
+          => ToObject (TraceChainSyncClientEvent blk) where
+  toObject verb ev = case ev of
+    TraceDownloadedHeader pt ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceDownloadedHeader"
+               , "block" .= toObject verb (headerPoint pt) ]
+    TraceRolledBack tip ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceRolledBack"
+               , "tip" .= toObject verb tip ]
+    TraceException exc ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceException"
+               , "exception" .= String (toS $ show exc) ]
+    TraceFoundIntersection _ _ _ ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceFoundIntersection" ]
+
+instance DefinePrivacyAnnotation (TraceChainSyncServerEvent blk b)
+instance DefineSeverity (TraceChainSyncServerEvent blk b) where
+  defineSeverity _ = Info
+
+-- transform @ChainSyncServer@
+instance Condense (HeaderHash blk) => Transformable Text IO (TraceChainSyncServerEvent blk b) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance Condense (HeaderHash blk) => ToObject (TraceChainSyncServerEvent blk b) where
+    toObject verb ev = case ev of
+      TraceChainSyncServerRead tip (AddBlock hdr) ->
+        mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock"
+                 , "tip" .= (String (toS . showTip verb $ tipPoint tip))
+                 , "addedBlock" .= (String (toS $ condense hdr)) ]
+      TraceChainSyncServerRead tip (RollBack pt) ->
+        mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.RollBack"
+                 , "tip" .= (String (toS . showTip verb $ tipPoint tip))
+                 , "rolledBackBlock" .= (String (toS $ showTip verb pt)) ]
+      TraceChainSyncServerReadBlocked tip (AddBlock hdr) ->
+        mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock"
+                 , "tip" .= (String (toS . showTip verb $ tipPoint tip))
+                 , "addedBlock" .= (String (toS $ condense hdr)) ]
+      TraceChainSyncServerReadBlocked tip (RollBack pt) ->
+        mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.RollBack"
+                 , "tip" .= (String (toS . showTip verb $ tipPoint tip))
+                 , "rolledBackBlock" .= (String (toS $ showTip verb pt)) ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainSyncEventTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ChainSyncEventTrace.hs
@@ -11,7 +11,7 @@ import           Prelude (show)
 
 import           Data.Aeson hiding (Error)
 
-import           Cardano.Tracing.ToObjectOrphans
+import           Cardano.Tracing.ToObjectOrphans.ConsensusToObjectOrphans
 
 import           Cardano.BM.Data.Tracer ( mkObject, trStructured)
 import           Cardano.BM.Tracing ( DefinePrivacyAnnotation

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ConsensusToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ConsensusToObjectOrphans.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
-module Cardano.Tracing.ToObjectOrphans
+module Cardano.Tracing.ToObjectOrphans.ConsensusToObjectOrphans
   ( WithTip (..)
   , showTip
   , showWithTip
@@ -22,10 +22,8 @@ import           Data.Aeson (Value (..), toJSON, (.=))
 import           Data.Text (pack)
 
 import           Cardano.BM.Tracing
-import           Cardano.BM.Data.Tracer (trStructured, mkObject)
+import           Cardano.BM.Data.Tracer (mkObject)
 
-import           Ouroboros.Consensus.BlockFetchServer
-                   (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -78,16 +76,6 @@ instance ( Show a
 
   show = showWithTip show
 
-instance DefinePrivacyAnnotation (TraceBlockFetchServerEvent blk)
-instance DefineSeverity (TraceBlockFetchServerEvent blk) where
-  defineSeverity _ = Info
-
--- | instances of @Transformable@
-
--- transform @BlockFetchServerEvent@
-instance Transformable Text IO (TraceBlockFetchServerEvent blk) where
-  trTransformer _ verb tr = trStructured verb tr
-
 -- | instances of @ToObject@
 instance ToObject SlotNo where
   toObject _verb slot =
@@ -107,7 +95,3 @@ instance ToObject LedgerDB.DiskSnapshot where
   toObject MaximalVerbosity snap =
     mkObject [ "kind" .= String "snapshot"
              , "snapshot" .= String (pack $ show snap) ]
-
-instance ToObject (TraceBlockFetchServerEvent blk) where
-  toObject _verb _ =
-    mkObject [ "kind" .= String "TraceBlockFetchServerEvent" ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/DnsTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/DnsTrace.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.DnsTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( definePrivacyAnnotation
+                                        , mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , traceWith, mkLOMeta)
+import           Ouroboros.Network.Subscription (DnsTrace (..), WithDomainName (..))
+
+instance DefinePrivacyAnnotation (WithDomainName DnsTrace)
+instance DefineSeverity (WithDomainName DnsTrace) where
+  defineSeverity (WithDomainName _ ev) = case ev of
+    DnsTraceLookupException {} -> Error
+    DnsTraceLookupAError {} -> Error
+    DnsTraceLookupAAAAError {} -> Error
+    DnsTraceLookupIPv6First -> Info
+    DnsTraceLookupIPv4First -> Info
+    DnsTraceLookupAResult {} -> Debug
+    DnsTraceLookupAAAAResult {} -> Debug
+
+-- transform @DnsTrace@
+instance Transformable Text IO (WithDomainName DnsTrace) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+instance ToObject (WithDomainName DnsTrace) where
+  toObject _verb (WithDomainName dom ev) =
+    mkObject [ "kind" .= String "DnsTrace"
+             , "domain" .= show dom
+             , "event" .= show ev ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ErrorPolicyTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ErrorPolicyTrace.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+import qualified Network.Socket as Socket (SockAddr)
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( definePrivacyAnnotation
+                                        , mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , traceWith, mkLOMeta)
+import           Ouroboros.Network.NodeToNode
+                   (WithAddr(..), ErrorPolicyTrace(..))
+
+instance DefinePrivacyAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace)
+instance DefineSeverity (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  defineSeverity (WithAddr _ ev) = case ev of
+    ErrorPolicySuspendPeer {} -> Warning -- peer misbehaved
+    ErrorPolicySuspendConsumer {} -> Notice -- peer temporarily not useful
+    ErrorPolicyLocalNodeError {} -> Error
+    ErrorPolicyResumePeer {} -> Debug
+    ErrorPolicyKeepSuspended {} -> Debug
+    ErrorPolicyResumeConsumer {} -> Debug
+    ErrorPolicyResumeProducer {} -> Debug
+    ErrorPolicyUnhandledApplicationException {} -> Error
+    ErrorPolicyUnhandledConnectionException {} -> Error
+    ErrorPolicyAcceptException {} -> Error
+
+
+-- transform @ErrorPolicyTrace@
+instance Transformable Text IO (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+
+instance ToObject (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  toObject _verb (WithAddr addr ev) =
+    mkObject [ "kind" .= String "ErrorPolicyTrace"
+             , "address" .= show addr
+             , "event" .= show ev ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ForgeEventTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/ForgeEventTrace.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.ForgeEventTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( definePrivacyAnnotation
+                                        , mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , traceWith, mkLOMeta)
+import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
+import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
+import           Ouroboros.Network.Block (SlotNo (..))
+
+instance DefinePrivacyAnnotation (TraceForgeEvent blk tx)
+instance DefineSeverity (TraceForgeEvent blk tx) where
+  defineSeverity TraceForgedBlock {}            = Info
+  defineSeverity TraceStartLeadershipCheck {}   = Info
+  defineSeverity TraceNodeNotLeader {}          = Info
+  defineSeverity TraceNodeIsLeader {}           = Info
+  defineSeverity TraceNoLedgerState {}          = Warning
+  defineSeverity TraceNoLedgerView {}           = Warning
+  defineSeverity TraceBlockFromFuture {}        = Warning
+  defineSeverity TraceAdoptedBlock {}           = Info
+  defineSeverity TraceDidntAdoptBlock {}        = Warning
+  defineSeverity TraceForgedInvalidBlock {}     = Alert
+
+instance (Show blk, Show tx, ProtocolLedgerView blk) => Transformable Text IO (TraceForgeEvent blk tx) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+instance ProtocolLedgerView blk => ToObject (TraceForgeEvent blk tx) where
+  toObject _verb (TraceAdoptedBlock slotNo _blk _txs) =
+    mkObject
+        [ "kind"    .= String "TraceAdoptedBlock"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceBlockFromFuture currentSlot tip) =
+    mkObject
+        [ "kind" .= String "TraceBlockFromFuture"
+        , "current slot" .= toJSON (unSlotNo currentSlot)
+        , "tip" .= toJSON (unSlotNo tip)
+        ]
+  toObject _verb (TraceDidntAdoptBlock slotNo _) =
+    mkObject
+        [ "kind"    .= String "TraceDidntAdoptBlock"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceForgedBlock slotNo _ _) =
+    mkObject
+        [ "kind"    .= String "TraceForgedBlock"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceForgedInvalidBlock slotNo _ _) =
+    mkObject
+        [ "kind"    .= String "TraceForgedInvalidBlock"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceNodeIsLeader slotNo) =
+    mkObject
+        [ "kind"    .= String "TraceNodeIsLeader"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceNodeNotLeader slotNo) =
+    mkObject
+        [ "kind"    .= String "TraceNodeNotLeader"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceNoLedgerState slotNo _blk) =
+    mkObject
+        [ "kind"    .= String "TraceNoLedgerState"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceNoLedgerView slotNo _) =
+    mkObject
+        [ "kind"    .= String "TraceNoLedgerView"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]
+  toObject _verb (TraceStartLeadershipCheck slotNo) =
+    mkObject
+        [ "kind"    .= String "TraceStartLeadershipCheck"
+        , "slot"    .= toJSON (unSlotNo slotNo)
+        ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/LabelPeerTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/LabelPeerTrace.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.LabelPeerTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.BM.Data.Tracer ( TracingVerbosity(..), emptyObject
+                                        , mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Transformable(..)
+                                    )
+import           Ouroboros.Network.Block (Point)
+import           Ouroboros.Network.BlockFetch.ClientState (TraceFetchClientState (..)
+                                                          , TraceLabelPeer (..))
+import           Ouroboros.Network.BlockFetch.Decision (FetchDecision)
+
+
+instance DefinePrivacyAnnotation [TraceLabelPeer peer
+                                  (FetchDecision [Point header])]
+instance DefineSeverity [TraceLabelPeer peer(FetchDecision [Point header])] where
+  defineSeverity [] = Debug
+  defineSeverity _ = Info
+
+
+instance DefinePrivacyAnnotation (TraceLabelPeer peer
+                                  (TraceFetchClientState header))
+instance DefineSeverity (TraceLabelPeer peer
+                         (TraceFetchClientState header)) where
+  defineSeverity _ = Info
+
+-- transform @BlockFetchDecision@
+instance Show peer => Transformable Text IO [TraceLabelPeer peer
+                                (FetchDecision [Point header])] where
+  trTransformer _ verb tr = trStructured verb tr
+
+-- transform @BlockFetchDecision@
+instance Show peer => Transformable Text IO (TraceLabelPeer peer
+                                (TraceFetchClientState header)) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance Show peer => ToObject [TraceLabelPeer peer
+                        (FetchDecision [Point header])] where
+  toObject MinimalVerbosity _ = emptyObject
+  toObject NormalVerbosity lbls = mkObject [ "kind" .= String "TraceLabelPeer"
+                                           , "length" .= String (toS $ show $ length lbls) ]
+  toObject MaximalVerbosity [] = emptyObject
+  toObject MaximalVerbosity (lbl : r) = toObject MaximalVerbosity lbl <>
+                                        toObject MaximalVerbosity r
+
+instance Show peer => ToObject (TraceLabelPeer peer
+                        (FetchDecision [Point header])) where
+  toObject verb (TraceLabelPeer peerid a) =
+    mkObject [ "kind" .= String "FetchDecision"
+             , "peer" .= show peerid
+             , "decision" .= toObject verb a ]
+
+instance Show peer => ToObject (TraceLabelPeer peer
+                        (TraceFetchClientState header)) where
+  toObject verb (TraceLabelPeer peerid a) =
+    mkObject [ "kind" .= String "TraceFetchClientState"
+             , "peer" .= show peerid
+             , "state" .= toObject verb a ]
+
+instance ToObject (TraceFetchClientState header) where
+  toObject _verb (AddedFetchRequest {}) =
+    mkObject [ "kind" .= String "AddedFetchRequest" ]
+  toObject _verb (AcknowledgedFetchRequest {}) =
+    mkObject [ "kind" .= String "AcknowledgedFetchRequest" ]
+  toObject _verb (CompletedBlockFetch {}) =
+    mkObject [ "kind" .= String "CompletedBlockFetch" ]
+  toObject _verb (CompletedFetchBatch {}) =
+    mkObject [ "kind" .= String "CompletedFetchBatch" ]
+  toObject _verb (StartedFetchBatch {}) =
+    mkObject [ "kind" .= String "StartedFetchBatch" ]
+  toObject _verb (RejectedFetchBatch {}) =
+    mkObject [ "kind" .= String "RejectedFetchBatch" ]
+
+instance ToObject (FetchDecision [Point header]) where
+  toObject _verb (Left decline) =
+    mkObject [ "kind" .= String "FetchDecision declined"
+             , "declined" .= String (toS $ show $ decline) ]
+  toObject _verb (Right results) =
+    mkObject [ "kind" .= String "FetchDecision results"
+             , "length" .= String (toS $ show $ length results) ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/MuxTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/MuxTrace.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+
+module Cardano.Tracing.ToObjectOrphans.MuxTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( definePrivacyAnnotation
+                                        , mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , traceWith, mkLOMeta)
+import           Network.Mux (WithMuxBearer (..), MuxTrace (..))
+
+
+instance DefinePrivacyAnnotation (WithMuxBearer peer MuxTrace)
+instance DefineSeverity (WithMuxBearer peer MuxTrace) where
+  defineSeverity (WithMuxBearer _ ev) = case ev of
+    MuxTraceRecvHeaderStart          -> Debug
+    MuxTraceRecvHeaderEnd {}         -> Debug
+    MuxTraceRecvPayloadStart {}      -> Debug
+    MuxTraceRecvPayloadEnd {}        -> Debug
+    MuxTraceRecvStart {}             -> Debug
+    MuxTraceRecvEnd {}               -> Debug
+    MuxTraceSendStart {}             -> Debug
+    MuxTraceSendEnd                  -> Debug
+    MuxTraceState {}                 -> Info
+    MuxTraceCleanExit {}             -> Info
+    MuxTraceExceptionExit {}         -> Info
+    MuxTraceChannelRecvStart {}      -> Debug
+    MuxTraceChannelRecvEnd {}        -> Debug
+    MuxTraceChannelSendStart {}      -> Debug
+    MuxTraceChannelSendEnd {}        -> Debug
+    MuxTraceHandshakeStart           -> Debug
+    MuxTraceHandshakeClientEnd {}    -> Info
+    MuxTraceHandshakeServerEnd       -> Debug
+    MuxTraceHandshakeClientError {}  -> Error
+    MuxTraceHandshakeServerError {}  -> Error
+    MuxTraceRecvDeltaQObservation {} -> Debug
+    MuxTraceRecvDeltaQSample {}      -> Info
+
+-- transform @MuxTrace@
+instance (Show peer)
+           => Transformable Text IO (WithMuxBearer peer MuxTrace) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+instance (Show peer)
+      => ToObject (WithMuxBearer peer MuxTrace) where
+  toObject _verb (WithMuxBearer b ev) =
+    mkObject [ "kind" .= String "MuxTrace"
+             , "bearer" .= show b
+             , "event" .= show ev ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/SubscriptionTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/SubscriptionTrace.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+
+module Cardano.Tracing.ToObjectOrphans.SubscriptionTrace () where
+
+import           Cardano.Prelude hiding (show)
+import           Prelude (show)
+
+import           Data.Aeson hiding (Error)
+import qualified Network.Socket as Socket (SockAddr)
+
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject(..))
+import           Cardano.BM.Data.Tracer ( definePrivacyAnnotation, trStructured
+                                        , mkObject)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity (..), Tracer(..)
+                                    , TracingFormatting(..), Transformable(..)
+                                    , traceWith, mkLOMeta)
+import           Ouroboros.Network.Subscription ( ConnectResult(..), SubscriptionTrace (..)
+                                                , WithDomainName(..), WithIPList(..))
+
+-- instances of @DefinePrivacyAnnotation@ and @DefineSeverity@
+instance DefinePrivacyAnnotation (WithIPList (SubscriptionTrace Socket.SockAddr))
+instance DefineSeverity (WithIPList (SubscriptionTrace Socket.SockAddr)) where
+  defineSeverity (WithIPList _ _ ev) = case ev of
+    SubscriptionTraceConnectStart _ -> Info
+    SubscriptionTraceConnectEnd _ connectResult -> case connectResult of
+      ConnectSuccess         -> Info
+      ConnectSuccessLast     -> Notice
+      ConnectValencyExceeded -> Warning
+    SubscriptionTraceConnectException {} -> Error
+    SubscriptionTraceSocketAllocationException {} -> Error
+    SubscriptionTraceTryConnectToPeer {} -> Info
+    SubscriptionTraceSkippingPeer {} -> Info
+    SubscriptionTraceSubscriptionRunning -> Debug
+    SubscriptionTraceSubscriptionWaiting {} -> Debug
+    SubscriptionTraceSubscriptionFailed -> Error
+    SubscriptionTraceSubscriptionWaitingNewConnection {} -> Notice
+    SubscriptionTraceStart {} -> Debug
+    SubscriptionTraceRestart {} -> Info
+    SubscriptionTraceConnectionExist {} -> Notice
+    SubscriptionTraceUnsupportedRemoteAddr {} -> Error
+    SubscriptionTraceMissingLocalAddress -> Warning
+    SubscriptionTraceApplicationException {} -> Error
+    SubscriptionTraceAllocateSocket {} -> Debug
+    SubscriptionTraceCloseSocket {} -> Info
+
+instance DefinePrivacyAnnotation (WithDomainName (SubscriptionTrace Socket.SockAddr))
+instance DefineSeverity (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
+  defineSeverity (WithDomainName _ ev) = case ev of
+    SubscriptionTraceConnectStart {} -> Info
+    SubscriptionTraceConnectEnd {} -> Info
+    SubscriptionTraceConnectException {} -> Error
+    SubscriptionTraceSocketAllocationException {} -> Error
+    SubscriptionTraceTryConnectToPeer {} -> Info
+    SubscriptionTraceSkippingPeer {} -> Info
+    SubscriptionTraceSubscriptionRunning -> Debug
+    SubscriptionTraceSubscriptionWaiting {} -> Debug
+    SubscriptionTraceSubscriptionFailed -> Warning
+    SubscriptionTraceSubscriptionWaitingNewConnection {} -> Debug
+    SubscriptionTraceStart {} -> Debug
+    SubscriptionTraceRestart {} -> Debug
+    SubscriptionTraceConnectionExist {} -> Info
+    SubscriptionTraceUnsupportedRemoteAddr {} -> Warning
+    SubscriptionTraceMissingLocalAddress -> Warning
+    SubscriptionTraceApplicationException {} -> Error
+    SubscriptionTraceAllocateSocket {} -> Debug
+    SubscriptionTraceCloseSocket {} -> Debug
+
+-- transform @SubscriptionTrace@
+instance Transformable Text IO (WithIPList (SubscriptionTrace Socket.SockAddr)) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+
+instance Transformable Text IO (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
+  trTransformer StructuredLogging verb tr = trStructured verb tr
+  trTransformer TextualRepresentation _verb tr = Tracer $ \s ->
+    traceWith tr =<< LogObject <$> pure mempty
+                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+                               <*> pure (LogMessage . toS $ show s)
+  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+
+instance ToObject (WithIPList (SubscriptionTrace Socket.SockAddr)) where
+  toObject _verb (WithIPList localAddresses dests ev) =
+    mkObject [ "kind" .= String "WithIPList SubscriptionTrace"
+             , "localAddresses" .= show localAddresses
+             , "dests" .= show dests
+             , "event" .= show ev ]
+
+instance ToObject (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
+  toObject _verb (WithDomainName dom ev) =
+    mkObject [ "kind" .= String "SubscriptionTrace"
+             , "domain" .= show dom
+             , "event" .= show ev ]

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans/TxSubmissionTrace.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans/TxSubmissionTrace.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Tracing.ToObjectOrphans.TxSubmissionTrace () where
+
+import           Cardano.Prelude
+
+import           Data.Aeson hiding (Error)
+
+import           Cardano.BM.Data.Tracer (mkObject, trStructured)
+import           Cardano.BM.Tracing ( DefinePrivacyAnnotation
+                                    , DefineSeverity(..), ToObject(..)
+                                    , Severity(..), Transformable(..)
+                                    )
+import           Ouroboros.Consensus.Mempool.API (GenTx, GenTxId)
+import           Ouroboros.Consensus.TxSubmission (TraceLocalTxSubmissionServerEvent(..))
+import           Ouroboros.Network.TxSubmission.Inbound (TraceTxSubmissionInbound)
+import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound)
+
+instance DefinePrivacyAnnotation (TraceTxSubmissionInbound
+                                  (GenTxId blk) (GenTx blk))
+instance DefineSeverity (TraceTxSubmissionInbound
+                         (GenTxId blk) (GenTx blk)) where
+  defineSeverity _ = Info
+
+instance DefinePrivacyAnnotation (TraceTxSubmissionOutbound
+                                  (GenTxId blk) (GenTx blk))
+instance DefineSeverity (TraceTxSubmissionOutbound
+                         (GenTxId blk) (GenTx blk)) where
+  defineSeverity _ = Info
+
+instance DefinePrivacyAnnotation (TraceLocalTxSubmissionServerEvent blk)
+instance DefineSeverity (TraceLocalTxSubmissionServerEvent blk) where
+  defineSeverity _ = Info
+
+instance Transformable Text IO (TraceTxSubmissionInbound
+                                (GenTxId blk) (GenTx blk)) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance Transformable Text IO (TraceTxSubmissionOutbound
+                                (GenTxId blk) (GenTx blk)) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
+  trTransformer _ verb tr = trStructured verb tr
+
+instance ToObject (TraceTxSubmissionInbound (GenTxId blk) (GenTx blk)) where
+  toObject _verb _ =
+    mkObject [ "kind" .= String "TraceTxSubmissionInbound" ]
+
+instance ToObject (TraceTxSubmissionOutbound (GenTxId blk) (GenTx blk)) where
+  toObject _verb _ =
+    mkObject [ "kind" .= String "TraceTxSubmissionOutbound" ]
+
+instance ToObject (TraceLocalTxSubmissionServerEvent blk) where
+  toObject _verb _ =
+    mkObject [ "kind" .= String "TraceLocalTxSubmissionServerEvent" ]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -68,10 +68,12 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Cardano.Config.Protocol (TraceConstraints)
 import           Cardano.Config.Types
 import           Cardano.Tracing.ToObjectOrphans.ChainDBTrace ()
+import           Cardano.Tracing.ToObjectOrphans.DnsTrace ()
+import           Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace ()
+import           Cardano.Tracing.ToObjectOrphans.MuxTrace ()
 import           Cardano.Tracing.ToObjectOrphans.SubscriptionTrace ()
 import           Cardano.Tracing.ToObjectOrphans
 import           Cardano.Tracing.MicroBenchmarking
-import           Cardano.Tracing.ToObjectOrphans
 
 import           Control.Tracer.Transformers
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -71,9 +71,11 @@ import           Cardano.Tracing.ToObjectOrphans.ChainDBTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace ()
 import           Cardano.Tracing.ToObjectOrphans.DnsTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace ()
+import           Cardano.Tracing.ToObjectOrphans.ForgeEventTrace ()
 import           Cardano.Tracing.ToObjectOrphans.LabelPeerTrace ()
 import           Cardano.Tracing.ToObjectOrphans.MuxTrace ()
 import           Cardano.Tracing.ToObjectOrphans.SubscriptionTrace ()
+import           Cardano.Tracing.ToObjectOrphans.TxSubmissionTrace ()
 import           Cardano.Tracing.ToObjectOrphans
 import           Cardano.Tracing.MicroBenchmarking
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -67,6 +67,9 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 
 import           Cardano.Config.Protocol (TraceConstraints)
 import           Cardano.Config.Types
+import           Cardano.Tracing.ToObjectOrphans.ChainDBTrace ()
+import           Cardano.Tracing.ToObjectOrphans.SubscriptionTrace ()
+import           Cardano.Tracing.ToObjectOrphans
 import           Cardano.Tracing.MicroBenchmarking
 import           Cardano.Tracing.ToObjectOrphans
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -68,8 +68,10 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Cardano.Config.Protocol (TraceConstraints)
 import           Cardano.Config.Types
 import           Cardano.Tracing.ToObjectOrphans.ChainDBTrace ()
+import           Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace ()
 import           Cardano.Tracing.ToObjectOrphans.DnsTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace ()
+import           Cardano.Tracing.ToObjectOrphans.LabelPeerTrace ()
 import           Cardano.Tracing.ToObjectOrphans.MuxTrace ()
 import           Cardano.Tracing.ToObjectOrphans.SubscriptionTrace ()
 import           Cardano.Tracing.ToObjectOrphans

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -67,8 +67,10 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 
 import           Cardano.Config.Protocol (TraceConstraints)
 import           Cardano.Config.Types
+import           Cardano.Tracing.ToObjectOrphans.BlockFetchServerEventTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ChainDBTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ChainSyncEventTrace ()
+import           Cardano.Tracing.ToObjectOrphans.ConsensusToObjectOrphans
 import           Cardano.Tracing.ToObjectOrphans.DnsTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ErrorPolicyTrace ()
 import           Cardano.Tracing.ToObjectOrphans.ForgeEventTrace ()
@@ -76,7 +78,6 @@ import           Cardano.Tracing.ToObjectOrphans.LabelPeerTrace ()
 import           Cardano.Tracing.ToObjectOrphans.MuxTrace ()
 import           Cardano.Tracing.ToObjectOrphans.SubscriptionTrace ()
 import           Cardano.Tracing.ToObjectOrphans.TxSubmissionTrace ()
-import           Cardano.Tracing.ToObjectOrphans
 import           Cardano.Tracing.MicroBenchmarking
 
 import           Control.Tracer.Transformers


### PR DESCRIPTION
This PR breaks up the `ToObjectOrphans.hs` module (which was becoming unwieldy) in to smaller modules defined by the tracer. 