### PR TITLE
[CAD-434] Add time in the block forge and txs creation trace events.

### DIFF
--- a/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
+++ b/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
@@ -28,6 +28,7 @@ import           Control.Monad.Class.MonadTime (DiffTime, Time (..), diffTime,
                                                 getMonotonicTime)
 
 import           Data.Aeson (Value (..), toJSON, (.=))
+import           Data.Time.Clock (diffTimeToPicoseconds)
 
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity (Severity (..))
@@ -64,18 +65,18 @@ instance DefineSeverity (MeasureTxs blk) where
 
 -- TODO(KS): Time will be removed.
 instance ToObject (MeasureTxs blk) where
-  toObject _verb (MeasureTxsTimeStart _txs mempoolNumTxs mempoolNumBytes time) =
+  toObject _verb (MeasureTxsTimeStart _txs mempoolNumTxs mempoolNumBytes (Time time)) =
     mkObject
       [ "kind"              .= String "MeasureTxsTimeStart"
       , "mempoolNumTxs"     .= toJSON mempoolNumTxs
       , "mempoolNumBytes"   .= toJSON mempoolNumBytes
-      , "time"              .= toJSON (show time :: Text)
+      , "time(ps)"          .= toJSON (diffTimeToPicoseconds time)
       ]
-  toObject _verb (MeasureTxsTimeStop slotNo _blk _txs time) =
+  toObject _verb (MeasureTxsTimeStop slotNo _blk _txs (Time time)) =
     mkObject
       [ "kind"              .= String "MeasureTxsTimeStop"
       , "slot"              .= toJSON (unSlotNo slotNo)
-      , "time"              .= toJSON (show time :: Text)
+      , "time(ps)"          .= toJSON (diffTimeToPicoseconds time)
       ]
 
 -- | Transformer for the start of the transaction, when the transaction was added
@@ -186,19 +187,19 @@ instance DefineSeverity (MeasureBlockForging blk) where
   defineSeverity _ = Info
 
 instance ToObject (MeasureBlockForging blk) where
-  toObject _verb (MeasureBlockTimeStart slotNo time) =
+  toObject _verb (MeasureBlockTimeStart slotNo (Time time)) =
     mkObject
       [ "kind"              .= String "MeasureBlockTimeStart"
       , "slot"              .= toJSON (unSlotNo slotNo)
-      , "time"              .= toJSON (show time :: Text)
+      , "time(ps)"          .= toJSON (diffTimeToPicoseconds time)
       ]
-  toObject _verb (MeasureBlockTimeStop slotNo _blk mempoolSize time) =
+  toObject _verb (MeasureBlockTimeStop slotNo _blk mempoolSize (Time time)) =
     mkObject
       [ "kind"              .= String "MeasureBlockTimeStop"
       , "slot"              .= toJSON (unSlotNo slotNo)
       , "mempoolNumTxs"     .= toJSON (msNumTxs mempoolSize)
       , "mempoolNumBytes"   .= toJSON (msNumBytes mempoolSize)
-      , "time"              .= toJSON (show time :: Text)
+      , "time(ps)"          .= toJSON (diffTimeToPicoseconds time)
       ]
 
 -- | Transformer for the start of the block forge, when the current slot is the slot of the

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -166,6 +166,7 @@ mkTracers traceOptions tracer = do
   -- for measuring the time it takes a transaction to get into
   -- a block.
   --txsOutcomeExtractor <- mkOutcomeExtractor @_ @(MeasureTxs blk)
+  --blockForgeOutcomeExtractor <- mkOutcomeExtractor @_ @(MeasureBlockForging blk)
 
   elided <- newstate  -- for eliding messages in ChainDB tracer
 
@@ -367,7 +368,8 @@ mkTracers traceOptions tracer = do
             Consensus.TraceNodeIsLeader slot ->
               LogValue "nodeIsLeader" $ PureI $ fromIntegral $ unSlotNo slot
 
-    mkConsensusTracers :: ForgeTracers -> TraceOptions -> Consensus.Tracers' peer blk (Tracer IO)
+    mkConsensusTracers
+        :: ForgeTracers -> TraceOptions -> Consensus.Tracers' peer blk (Tracer IO)
     mkConsensusTracers forgeTracers traceOpts = Consensus.Tracers
       { Consensus.chainSyncClientTracer
         = tracerOnOff (traceChainSyncClient traceOpts)


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-434

Example from logs:
```
[ksaric-O:cardano.node.Forge:Info:50] [2020-01-21 13:12:43.01 UTC] {"kind":"TraceStartLeadershipCheck","slot":6}
[ksaric-O:cardano.node:Info:50] [2020-01-21 13:12:43.01 UTC] {"time":"Time 27625.795722899s","kind":"MeasureBlockTimeStart","slot":6}
[ksaric-O:cardano.node.Forge:Info:50] [2020-01-21 13:12:43.01 UTC] {"kind":"TraceNodeIsLeader","slot":6}
[ksaric-O:cardano.node:Info:50] [2020-01-21 13:12:43.01 UTC] {"time":"Time 27625.795951114s","kind":"MeasureBlockTimeStop","mempoolNumBytes":0,"slot":6,"mempoolNumTxs":0}
[ksaric-O:cardano.node.Forge:Info:50] [2020-01-21 13:12:43.01 UTC] {"kind":"TraceForgedBlock","slot":6}
[ksaric-O:cardano.node:Info:50] [2020-01-21 13:12:43.01 UTC] {"time":"Time 27625.798213585s","kind":"MeasureTxsTimeStop","slot":6}
[ksaric-O:cardano.node.Forge:Info:50] [2020-01-21 13:12:43.01 UTC] {"kind":"TraceAdoptedBlock","slot":6}
```