### PR TITLE
Optional network and build-tool parameters to Benchmarking scripts

### DIFF
--- a/benchmarking/chain-sync/analyse-logs.sh
+++ b/benchmarking/chain-sync/analyse-logs.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+NETWORK=${1:-mainnet}
+
 # get first block copy time
-LOGFILE=`ls -1 state-node-mainnet/node-0-*.log | head -3`
+LOGFILE=`ls -1 state-node-${NETWORK}/node-0-*.log | head -3`
 FIRSTSLOT=`grep -e '.*:cardano.node.ChainDB:.*TraceCopyToImmDBEvent.CopiedBlockToImmDB.*"tip":"[a-z0-9]*@' $LOGFILE | sed -ne 's/^.* \[\([0-9-]\+\) \([0-9:.]\+\) UTC\] .*"tip":"[a-z0-9]*@\([0-9]\+\)".*/"\1 \2";\3/p; q;'`
 
-LOGFILE=`ls -1r state-node-mainnet/node-0-*.log | head -1`
+LOGFILE=`ls -1r state-node-${NETWORK}/node-0-*.log | head -1`
 LASTSLOT=`grep -e '.*:cardano.node.ChainDB:.*TraceCopyToImmDBEvent.CopiedBlockToImmDB.*"tip":"[a-z0-9]*@' $LOGFILE | sed -ne 's/^.* \[\([0-9-]\+\) \([0-9:.]\+\) UTC\] .*"tip":"[a-z0-9]*@\([0-9]\+\)".*/"\1 \2";\3/p;' | tail -n 1`
 LASTRSS=`grep -e '.*cardano.node-metrics:.*Mem.resident =' $LOGFILE | sed -ne 's/^.* \[\([0-9-]\+\) \([0-9:.]\+\) UTC\] .*Mem.resident = \([0-9]\+\).*/\1 \2\t\3/p;' | { read a b c; while [ -n "$a" ]; do echo "\"$a $b\";$((c*4096))"; read a b c; done; } | tail -n 1`
 

--- a/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
+++ b/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
@@ -25,14 +25,13 @@ date --iso-8601=seconds > STARTTIME
 
 if [[ $1 == 'stack' ]]; then
   NODE="stack --nix exec cardano-node -- "
-  ARGUMENTS=${@:2}
+  shift
 elif [[ $1 == 'cabal' ]]; then
   NODE="cabal v2-run exe:cardano-node -- "
-  ARGUMENTS=${@:2}
+  shift
 else
   # Default to stack
   NODE="stack --nix exec cardano-node -- "
-  ARGUMENTS=$@
 fi
 
 exec ${NODE} \
@@ -45,7 +44,7 @@ exec ${NODE} \
   --host-addr 127.0.0.1 \
   --port 7778 \
    \
-  $ARGUMENTS
+  $@
 
 #  --socket-dir ${BASEDIR}/${DATADIR}/socket \
 

--- a/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
+++ b/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
@@ -23,8 +23,15 @@ ulimit -t $CPU_TIME_LIMIT
 
 date --iso-8601=seconds > STARTTIME
 
-NODE="cabal v2-run exe:cardano-node -- "
-NODE="stack --nix exec cardano-node -- "
+if [[ $1 == 'stack' ]]; then
+  NODE="stack --nix exec cardano-node -- "
+elif [[ $1 == 'cabal' ]]; then
+  NODE="cabal v2-run exe:cardano-node -- "
+else
+  # Default to stack
+  NODE="stack --nix exec cardano-node -- "
+fi
+
 
 exec ${NODE} \
   --genesis-file ${BASEDIR}/../../configuration/mainnet-genesis.json \

--- a/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
+++ b/benchmarking/chain-sync/benchmark-chain-sync-mainnet.sh
@@ -25,13 +25,15 @@ date --iso-8601=seconds > STARTTIME
 
 if [[ $1 == 'stack' ]]; then
   NODE="stack --nix exec cardano-node -- "
+  ARGUMENTS=${@:2}
 elif [[ $1 == 'cabal' ]]; then
   NODE="cabal v2-run exe:cardano-node -- "
+  ARGUMENTS=${@:2}
 else
   # Default to stack
   NODE="stack --nix exec cardano-node -- "
+  ARGUMENTS=$@
 fi
-
 
 exec ${NODE} \
   --genesis-file ${BASEDIR}/../../configuration/mainnet-genesis.json \
@@ -43,7 +45,7 @@ exec ${NODE} \
   --host-addr 127.0.0.1 \
   --port 7778 \
    \
- $@
+  $ARGUMENTS
 
 #  --socket-dir ${BASEDIR}/${DATADIR}/socket \
 

--- a/benchmarking/chain-sync/ci.sh
+++ b/benchmarking/chain-sync/ci.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p yj
 
+if [ $# -lt 1 ]; then
+  echo "call: $0 mainnet|testnet"
+  exit 1
+fi
+
 set -euo pipefail
 
 BASEDIR="$(dirname $0)"


### PR DESCRIPTION
- Optional `network` argument to `analyse-logs.sh` defaulting to `mainnet` if not supplied
- Optional `build-tool` argument to `benchmark-chain-sync-mainnet.sh` defaulting to `stack` if not supplied