### PR TITLE
CAD-430, CAD-429: live peer list & other TUI improvements

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -71,6 +71,7 @@ library
                      , cardano-prelude
                      , cardano-prelude-test
                      , cardano-shell
+                     , cardano-slotting
                      , contra-tracer
                      , cborg >= 0.2.2 && < 0.3
                      , containers

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,7 @@
-let
-  commonLib = import ./lib.nix;
-  lib = commonLib.pkgs.lib;
-in
 { customConfig ? {}
 , target ? builtins.currentSystem
 , interactive ? false
+, profiling ? false
 }:
 #
 # The default.nix file. This will generate targets for all
@@ -35,6 +32,8 @@ in
 # We will need to import the iohk-nix common lib, which includes
 # the nix-tools tooling.
 let
+  commonLib = import ./lib.nix { inherit profiling; };
+  lib = commonLib.pkgs.lib;
   system = if target != "x86_64-windows" then target else builtins.currentSystem;
   crossSystem = if target == "x86_64-windows" then lib.systems.examples.mingwW64 else null;
   nixTools = import ./nix/nix-tools.nix { inherit system crossSystem; };

--- a/lib.nix
+++ b/lib.nix
@@ -1,7 +1,8 @@
+{ ... }@args:
 let
   sources = import ./nix/sources.nix;
   pkgs' = import sources.nixpkgs {};
-  nixTools = import ./nix/nix-tools.nix {};
+  nixTools = import ./nix/nix-tools.nix args;
   haskellNixJson = let
     src = sources."haskell.nix";
   in __toJSON {

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -33,6 +33,7 @@
           (hsPkgs.cardano-prelude)
           (hsPkgs.cardano-prelude-test)
           (hsPkgs.cardano-shell)
+          (hsPkgs.cardano-slotting)
           (hsPkgs.contra-tracer)
           (hsPkgs.cborg)
           (hsPkgs.containers)

--- a/nix/nix-tools.nix
+++ b/nix/nix-tools.nix
@@ -1,6 +1,6 @@
 { ... }@args:
 
 let
-  commonLib = import ../lib.nix;
+  commonLib = import ../lib.nix args;
 
 in commonLib.nix-tools.default-nix ./pkgs.nix args

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -5,7 +5,7 @@
 
 with lib; with builtins;
 let
-  localLib = import ../../lib.nix;
+  localLib = import ../../lib.nix {};
   cfg = config.services.cardano-node;
   svcLib = (import ../svclib.nix { inherit pkgs; cardano-node = pkgs.cardano-node; });
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";

--- a/nix/nixos/chairman-as-a-service.nix
+++ b/nix/nixos/chairman-as-a-service.nix
@@ -3,7 +3,7 @@
 , pkgs
 , ... }:
 
-with import ../../lib.nix; with lib; with builtins;
+with import ../../lib.nix {}; with lib; with builtins;
 let
   cfg  = config.services.chairman;
   ncfg = config.services.cardano-node;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {}
 , iohk-extras ? {}
 , iohk-module ? {}
+, profiling ? false
 , haskell
 , ...
 }:
@@ -40,6 +41,7 @@ let
         packages.ekg.components.library.enableSeparateDataOutput = true;
         packages.cardano-node.configureFlags = [ "--ghc-option=-Werror" ];
         packages.cardano-config.configureFlags = [ "--ghc-option=-Werror" ];
+        enableLibraryProfiling = profiling;
       }
     ];
   };

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -2,7 +2,7 @@
 with commonLib.pkgs.lib;
 let
   pkgs = commonLib.pkgs;
-  localLib = import ../lib.nix;
+  localLib = import ../lib.nix {};
   svcLib = import ./svclib.nix { inherit pkgs; };
   pkgsModule = {
     config._module.args.pkgs = mkDefault pkgs;

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,4 +1,4 @@
-with import ../lib.nix;
+with import ../lib.nix {};
 with pkgs;
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 let
-  commonLib = import ./lib.nix;
+  commonLib = import ./lib.nix {};
   getArchDefault = system: let
     table = {
       x86_64-linux = import ./. { target = "x86_64-linux"; };

--- a/scripts/buildkite/default.nix
+++ b/scripts/buildkite/default.nix
@@ -1,4 +1,4 @@
-with import ../../lib.nix;
+with import ../../lib.nix {};
 with pkgs;
 
 let

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,8 @@ let
       "
     '';
   };
+  haskell-nix-src = builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz;
+  haskell-nix = (import (haskell-nix-src + "/nixpkgs") (import haskell-nix-src)).haskell-nix;
 in
 default.nix-tools._raw.shellFor {
   packages    = ps: with ps; [ cardano-node ];
@@ -31,6 +33,10 @@ default.nix-tools._raw.shellFor {
     ghcid.components.exes.ghcid
   ]) ++
   (with default.nix-tools._raw._config._module.args.pkgs; [
+    (haskell-nix.hackage-package {
+      name = "eventlog2html";
+      version = "0.6.0";
+    }).components.exes.eventlog2html
     tmux
   ]);
 } // { inherit devops; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 { withHoogle ? true
-, localLib ? import ./lib.nix
+, profiling ? false
+, localLib ? import ./lib.nix { inherit profiling; }
 }:
 let
   pkgs = localLib.iohkNix.pkgs;


### PR DESCRIPTION
TUI changes:

1. give the TUI direct access to the `NodeKernel`, to allow easier & richer data queries
1. added a peer list screen, accessible by the 'p' key
1. minor string changes
1. compressed the mempool bars in one line
1. a bunch of minor refactoring

![Screenshot from 2020-01-30 17-01-48](https://user-images.githubusercontent.com/452652/73456064-42939880-4382-11ea-912d-345162bd8158.png)
