### PR TITLE
[CAD-417] Considering NFData instances.

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -11,7 +11,15 @@ build-type:            Simple
 cabal-version:         >= 1.10
 extra-source-files:    README.md, ChangeLog.md
 
+Flag unexpected_thunks
+  Description:   Turn on unexpected thunks checks
+  Default:       False
+
 library
+
+  if flag(unexpected_thunks)
+    cpp-options: -DUNEXPECTED_THUNKS
+
   hs-source-dirs:      src
 
   exposed-modules:     Cardano.Chairman
@@ -51,6 +59,8 @@ library
                      , async
                      , base >=4.12 && <5
                      , bytestring
+                     , deepseq
+                     , strict-concurrency
                      , canonical-json
                      , cardano-binary
                      , cardano-config

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { unexpected_thunks = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-node"; version = "1.4.0"; };
@@ -21,6 +21,8 @@
           (hsPkgs.async)
           (hsPkgs.base)
           (hsPkgs.bytestring)
+          (hsPkgs.deepseq)
+          (hsPkgs.strict-concurrency)
           (hsPkgs.canonical-json)
           (hsPkgs.cardano-binary)
           (hsPkgs.cardano-config)


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-417

If you want to see the checks for unexpected thunks, you should include the appropriate flag.
When using Stack, you can use:
```
stack build --fast -j12 --nix --flag cardano-node:unexpected_thunks
```
It's disabled by default since we don't want heavy checks like these in production.

While it's still not completely clear to me what leaks we had, thinking about it made me simplify my assumptions - _long-running stateful computation has no space for laziness_.
We instead used a strict version of the `MVar` that wraps that state and, voila, no unexpected thunks!
_Is there any reason that the global state should be lazy?_

One of the reasons why I think we had leaks is that we calculated a lot more things than we actually showed, and that, by definition means we had some unevaluated pieces of state that were never forced.