### PR TITLE
disable nightly benchmark against 'testnet'

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -7,12 +7,3 @@ steps:
       - "benchmark-results.log"
     agents:
       system: x86_64-linux
-
-  - label: 'Chain-sync benchmark Testnet'
-    command:
-      - ./benchmarking/chain-sync/ci.sh testnet
-    timeout_in_minutes: 65
-    artifact_paths:
-      - "benchmark-results.log"
-    agents:
-      system: x86_64-linux


### PR DESCRIPTION
this test did not work; results cannot be interpreted.
can be reenabled when we know what the meaning of running this test against 'testnet' and how to interpret its results.