### PR TITLE
CAD-425 logging to journald

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,49 +110,49 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/scribe-systemd
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-aggregation
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-editor
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-ekg
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   plugins/backend-monitoring
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   tracer-transformers
-  tag: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+  tag: c24126944d78e3e015aff21ae78e81408256556f
 
 -- dependencies of iohk-monitoring
 source-repository-package

--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -50,6 +51,9 @@ import           Cardano.BM.Data.SubTrace
 import qualified Cardano.BM.Observer.Monadic as Monadic
 import qualified Cardano.BM.Observer.STM as Stm
 import           Cardano.BM.Plugin (loadPlugin)
+#if defined(linux_HOST_OS)
+import           Cardano.BM.Scribe.Systemd (plugin)
+#endif
 import           Cardano.BM.Setup (setupTrace_, shutdown)
 import           Cardano.BM.Trace (Trace, appendName, traceNamedObject)
 import qualified Cardano.BM.Trace as Trace
@@ -226,6 +230,11 @@ loggingCardanoFeatureInit disabled' conf = do
       >>= loadPlugin switchBoard
   Cardano.BM.Backend.Monitoring.plugin logConfig trace switchBoard
       >>= loadPlugin switchBoard
+
+#if defined(linux_HOST_OS)
+  Cardano.BM.Scribe.Systemd.plugin logConfig trace switchBoard "cardano"
+    >>= loadPlugin switchBoard
+#endif
 
   -- record node metrics
   if recordMetrics conf

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -32,6 +32,9 @@ setupScribes:
 defaultScribes:
   - - StdoutSK
     - stdout
+# for output to 'journald' add this scribe:
+#  - - JournalSK
+#    - cardano
 
 # more options which can be passed as key-value pairs:
 options:

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -95,8 +95,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -37,8 +37,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-editor.nix
+++ b/nix/.stack.nix/lobemo-backend-editor.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/plugins/backend-editor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -37,8 +37,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -72,8 +72,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-scribe-systemd.nix
+++ b/nix/.stack.nix/lobemo-scribe-systemd.nix
@@ -36,8 +36,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/tracer-transformers.nix
+++ b/nix/.stack.nix/tracer-transformers.nix
@@ -45,8 +45,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "096646a3064c6edf2d1e74f9eb5f491ee396ea9d";
-      sha256 = "0lfiffm5xc8g48dqlppa150kdiy9n7m1ssy1gs1kjjgz8qxi0isl";
+      rev = "c24126944d78e3e015aff21ae78e81408256556f";
+      sha256 = "0n8a0lzbb8hk6vlnaf96a0k1yxl8whybwbfl6ciz5pdqdbvpyrid";
       });
     postUnpack = "sourceRoot+=/tracer-transformers; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -71,7 +71,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 096646a3064c6edf2d1e74f9eb5f491ee396ea9d
+    commit: c24126944d78e3e015aff21ae78e81408256556f
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
on Linux logging to `journald` can be enabled with a simple change of the configuration:

```
defaultScribes:
  - - StdoutSK
    - stdout
  - - JournalSK
    - cardano
```

(this PR includes the commit d06ea1d496ad02f7a705e8bc7cbbc71710f150ee by Serge)