### PR TITLE
SRE-16: Add nix dockerTools image, build and push to dockerhub per commit

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -1,0 +1,79 @@
+# This script will load nix-built docker images of cardano-node
+# into the Docker daemon (must be running), and then push to the
+# Docker Hub. Credentials for the hub must already be installed with
+# "docker login".
+#
+# There is a little bit of bash logic to replace the default repo and
+# tag from the nix-build (../nix/docker.nix).
+#
+# 1. The repo (default "inputoutput/cardano-node") is changed to match
+#    the logged in Docker user's credentials.
+#
+# 2. The tag (default "VERSION") is changed to reflect the
+#    branch which is being built under this Buildkite pipeline.
+#
+#    - All commits are tagged with commit hash.
+#    - If the branch is master then master tag is updated
+#    - If there is a tag associated with the commit then that tag is pushed as well
+
+{ nodePackages ?  import ../. {}
+
+# Build system's Nixpkgs. We use this so that we have the same docker
+# version as the docker daemon.
+, hostPkgs ? import <nixpkgs> {}
+
+# Dockerhub repository for image tagging.
+, dockerHubRepoName ? null
+}:
+
+with hostPkgs;
+with hostPkgs.lib;
+
+let
+  images = map impureCreated [
+    nodePackages.dockerImage.base
+    nodePackages.dockerImage.testnet
+    nodePackages.dockerImage.mainnet
+  ];
+
+  # Override Docker image, setting its creation date to the current time rather than the unix epoch.
+  impureCreated = image: image.overrideAttrs (oldAttrs: { created = "now"; }) // { inherit (image) version; };
+
+in
+  writeScript "docker-build-push" (''
+    #!${runtimeShell}
+
+    set -euo pipefail
+
+    export PATH=${lib.makeBinPath [ docker gnused ]}
+
+    ${if dockerHubRepoName == null then ''
+    reponame=cardano-node
+    username="$(docker info | sed '/Username:/!d;s/.* //')"
+    fullrepo="$username/$reponame"
+    '' else ''
+    fullrepo="${dockerHubRepoName}"
+    ''}
+
+  '' + concatMapStringsSep "\n" (image: ''
+    branch="''${BUILDKITE_BRANCH:-}"
+    tag="''${BUILDKITE_TAG:-}"
+    tagged="$fullrepo:$tag"
+    gitrev="${image.imageTag}"
+    echo "Loading $fullrepo:$gitrev"
+    docker load -i ${image}
+    echo "Pushing $fullrepo:$gitrev"
+    docker push "$fullrepo:$gitrev"
+    if [[ "$branch" = master ]]; then
+      echo "Tagging as master"
+      docker tag $fullrepo:$gitrev $fullrepo:$branch
+      echo "Pushing $fullrepo:$branch"
+      docker push "$fullrepo:$branch"
+    fi
+    if [[ "$tag" ]]; then
+      echo "Tagging as ${image.imageTag}"
+      docker tag $fullrepo:$gitrev $fullrepo:$tag
+      echo "Pushing $fullrepo:$tag"
+      docker push "$fullrepo:$tag"
+    fi
+  '') images)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,3 +37,12 @@ steps:
 #    command: 'ci/check-dependencies-merged-to-master.sh'
 #    agents:
 #      system: x86_64-linux
+
+  - label: 'Docker Image'
+    command:
+      - "nix-build .buildkite/docker-build-push.nix --argstr dockerHubRepoName inputoutput/cardano-node -o docker-build-push"
+      - "./docker-build-push"
+    agents:
+      system: x86_64-linux
+    soft_fail:
+      - exit_status: '*'

--- a/default.nix
+++ b/default.nix
@@ -27,8 +27,13 @@ let
     inherit pkgs;
   };
 
+  dockerImage = pkgs.callPackage ./nix/docker.nix {
+    inherit (self) cardano-node;
+    inherit scripts;
+  };
+
   self = {
-    inherit haskellPackages scripts nixosTests environments check-hydra;
+    inherit haskellPackages scripts nixosTests environments check-hydra dockerImage;
 
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,0 +1,119 @@
+############################################################################
+# Docker image builder
+#
+# To test it out, use:
+#
+#   docker load -i $(nix-build -A dockerImage.base --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.latency-tests --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.mainnet --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.mainnet-ci --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.shelley_staging --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.shelley_staging_short --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.staging --no-out-link)
+#   docker load -i $(nix-build -A dockerImage.testnet --no-out-link)
+#
+# For all output except base, run:
+#
+#   docker run inputoutput/cardano-node:<TAG>
+#
+# ie:
+#
+#   docker run inputoutput/cardano-node:6a5b233e5861aa0012287a5557b3a6a08afbf3ca-testnet
+#
+# For base, you will need to provide all variables. ie:
+#
+#   docker run -ti \
+#   --volume $PATH_TO/state-docker:/data \
+#   --volume $PATH_TO/configuration-mainnet.yaml:/config/config.yaml \
+#   --volume $PATH_TO/mainnet-topology.json:/config/topology.json \
+#   --volume $PATH_TO/mainnet-genesis.json:/config/genesis.json \
+#   inputoutput/cardano-node:<GIT_HASH>-custom
+#   --genesis-hash <GENESIS_HASH>
+#
+############################################################################
+
+{ iohkNix
+, commonLib
+, dockerTools
+
+# The main contents of the image.
+, cardano-node
+, scripts
+
+# Get the current commit
+, gitrev ? iohkNix.commitIdFromGitRepoOrZero ../.git
+
+# Other things to include in the image.
+, bashInteractive
+, cacert
+, coreutils
+, curl
+, glibcLocales
+, iana-etc
+, iproute
+, iputils
+, socat
+, utillinux
+
+, repoName ? "inputoutput/cardano-node"
+}:
+
+let
+
+  # Layer of tools which aren't going to change much between versions.
+  baseImage = dockerTools.buildImage {
+    name = "${repoName}-env";
+    contents = [
+      bashInteractive   # Provide the BASH shell
+      cacert            # X.509 certificates of public CA's
+      coreutils         # Basic utilities expected in GNU OS's
+      curl              # CLI tool for transferring files via URLs
+      glibcLocales      # Locale information for the GNU C Library
+      iana-etc          # IANA protocol and port number assignments
+      iproute           # Utilities for controlling TCP/IP networking
+      iputils           # Useful utilities for Linux networking
+      socat             # Utility for bidirectional data transfer
+      utillinux         # System utilities for Linux
+    ];
+    # set up /tmp (override with TMPDIR variable)
+    extraCommands = ''
+      mkdir -m 0777 tmp
+    '';
+  };
+  customImage = dockerTools.buildImage {
+    name = "${repoName}";
+    tag = "${gitrev}-base";
+    fromImage = baseImage;
+    contents = [
+      cardano-node
+    ];
+    created = "now";   # Set creation date to build time. Breaks reproducibility
+    extraCommands = ''
+      mkdir -p data config
+    '';
+    config = {
+      EntryPoint = [
+        "${cardano-node}/bin/cardano-node" "run" "--config"
+        "/config/config.yaml" "--database-path" "/data.db" "--genesis-file"
+        "/config/genesis.json" "--host-addr" "127.0.0.1" "--port" "3001"
+        "--socket-path" "/data/ipc/socket0" "--topology" "/config/topology.json"
+      ];
+      ExposedPorts = {
+        "3001/tcp" = {};  # Cardano node p2p
+      };
+    };
+  };
+  clusterImage = env: dockerTools.buildImage {
+    name = "${repoName}";
+    tag = "${gitrev}-${env.name}";
+    fromImage = customImage;
+    created = "now";   # Set creation date to build time. Breaks reproducibility
+    config = {
+      EntryPoint = [ scripts.${env.name}.node ];
+      ExposedPorts = {
+        "3001/tcp" = {};  # Cardano node p2p
+      };
+    };
+  };
+
+in commonLib.forEnvironments clusterImage // { base = customImage; }

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -33,7 +33,7 @@ let
       tracingVerbosity = "normal";
     } // (builtins.removeAttrs envConfig ["nodeConfig"]);
 
-    nodeConfig = (envConfig.nodeConfig or commonLib.environments.mainnet.nodeConfig)
+    nodeConfig = (envConfig.nodeConfig or environments.mainnet.nodeConfig)
       // (customConfig.nodeConfig or {});
 
     config = defaultConfig

--- a/release.nix
+++ b/release.nix
@@ -60,20 +60,22 @@ let
   in {
     node = getScript "node";
   };
-  # TODO: add docker images
-  #wrapDockerImage = cluster: let
-  #  images = (getArchDefault "x86_64-linux").dockerImages;
-  #  wrapImage = image: pkgs.runCommand "${image.name}-hydra" {} ''
-  #    mkdir -pv $out/nix-support/
-  #    cat <<EOF > $out/nix-support/hydra-build-products
-  #    file dockerimage ${image}
-  #    EOF
-  #  '';
+  wrapDockerImage = cluster: let
+    images = (getArchDefault "x86_64-linux").dockerImage;
+    wrapImage = image: pkgs.runCommand "${image.name}-hydra" {} ''
+      mkdir -pv $out/nix-support/
+      cat <<EOF > $out/nix-support/hydra-build-products
+      file dockerimage-${image.name} ${image}
+      EOF
+    '';
+  in {
+    node = wrapImage images.${cluster};
+  };
   makeRelease = cluster: {
     name = cluster;
     value = {
       scripts = makeScripts cluster;
-      #dockerImage = wrapDockerImage cluster;
+      dockerImage = wrapDockerImage cluster;
     };
   };
   extraBuilds = let


### PR DESCRIPTION
This completes point 1:

1. base image with just the binaries

This PR provides a method to build docker binaries that cane be used with an appropriate set of CLI flags.

Images are tagged using the the commit in which they are built.
