### PR TITLE
Fix accidental change to the socket file names

### DIFF
--- a/cardano-node/src/Cardano/Common/LocalSocket.hs
+++ b/cardano-node/src/Cardano/Common/LocalSocket.hs
@@ -13,7 +13,7 @@ import           System.FilePath ((</>))
 import           System.IO.Error (isDoesNotExistError)
 import           Network.Socket as Socket
 
-import           Ouroboros.Consensus.NodeId (NodeId(..))
+import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
 
 data MkdirIfMissing
   = MkdirIfMissing
@@ -21,8 +21,8 @@ data MkdirIfMissing
   deriving (Eq, Show)
 
 localSocketFilePath :: NodeId -> FilePath
-localSocketFilePath (CoreId  n) = "node-core-" ++ show n ++ ".socket"
-localSocketFilePath (RelayId n) = "node-relay-" ++ show n ++ ".socket"
+localSocketFilePath (CoreId (CoreNodeId n)) = "node-core-"  ++ show (n :: Word64) ++ ".socket"
+localSocketFilePath (RelayId n)             = "node-relay-" ++ show (n :: Word64) ++ ".socket"
 
 -- | Provide an AF_UNIX address for a socket situated in 'socketDir', with its name
 --   derived from the node ID.  When 'mkdir' is 'MkdirIfMissing', the directory is created.


### PR DESCRIPTION
A newtype was introduced that changed the string rendering of the file path from `node-core-0.socket` to `node-core-CoreNodeId 0.socket`.