### PR TITLE
Update `TraceForgeEvent` logging details

### DIFF
--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -36,7 +36,8 @@ import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.BlockchainTime
                    (SlotLength, slotLengthFromSec,
                     SlotLengths, singletonSlotLengths)
-import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId)
+import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId,
+                                                  HasTxId, TxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                                                         PBftLeaderCredentials,
                                                         PBftLeaderCredentialsError,
@@ -73,11 +74,13 @@ type TraceConstraints blk =
     , Condense (Header blk)
     , Condense (HeaderHash blk)
     , Condense (GenTx blk)
+    , HasTxId (GenTx blk)
     , Show (ApplyTxErr blk)
     , Show (GenTx blk)
     , Show (GenTxId blk)
     , Show blk
     , Show (Header blk)
+    , Show (TxId (GenTx blk))
     )
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
- Update tracer `TraceAdoptedBlock` to log the block hash and a list of txids in that block. 

Example output: `[cardano.node.Forge:Info:61] [2020-02-04 18:08:26.00 UTC] {"kind":"TraceAdoptedBlock","slot":6,"tx ids":"[txid: txid:6875a2f9]","block hash":"a6d8325832257989"}`


- Update the following tracers to `Error` severity:
 `TraceNoLedgerState`
 `TraceNoLedgerView`
 `TraceBlockFromFuture`
 `TraceDidntAdoptBlock`
 `TraceForgedInvalidBlock`

Relevant issue: #528 