### PR TITLE
Update iohk-logging dependency.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -128,57 +128,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   plugins/backend-editor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: dd30455144e11efb435619383ba84ce02aee720d
-  --sha256: 1g08bg99fvss99kg27l7pmxm7lh60573xln8l8x2rzvwfvfgk2i5
+  tag: 022ed4261fdeaa84056efdb6010d44f6be1f6952
+  --sha256: 0m84h2gmn54n0rbdhbg2sxj38w0hnmlhi1kc3zc8w1sbm70ym8wv
   subdir:   tracer-transformers
 
 -- dependencies of iohk-monitoring

--- a/stack.yaml
+++ b/stack.yaml
@@ -78,7 +78,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: dd30455144e11efb435619383ba84ce02aee720d
+    commit: 022ed4261fdeaa84056efdb6010d44f6be1f6952
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
Update `iohk-monitoring` dependency, because of the latest changes related to structured logging.