### PR TITLE
Create benchmarking command group & simplify  `cardano-cli` commands

### DIFF
--- a/benchmarking/cluster3nodes/run_tx_generator.sh
+++ b/benchmarking/cluster3nodes/run_tx_generator.sh
@@ -24,9 +24,7 @@ exec ${GENERATOR} \
   --signing-key ${CONFIGDIR}/latest-genesis/delegate-keys.000.key \
   --delegation-certificate ${CONFIGDIR}/latest-genesis/delegation-cert.000.json \
   --genesis-file ${GENESISJSON} \
-  --genesis-hash ${GENESISHASH} \
   --socket-path /tmp/cluster3nodes-socket/0 \
-  --real-pbft \
   --num-of-txs $numtx \
   --add-tx-size $addsizetx \
   --inputs-per-tx $inputstx \

--- a/cardano-node/README.md
+++ b/cardano-node/README.md
@@ -101,7 +101,7 @@ A CLI utility to support a variety of key material operations (genesis, migratio
 
 The general synopsis is as follows:
  ```
-   Usage: cardano-cli (Genesis Related CMDs | Key Related CMDs | Delegation related CMDs | Tx related CMDs)
+   Usage: cardano-cli (Genesis Related CMDs | Key Related CMDs | Delegation related CMDs | Tx related CMDs | Benchmarking related CMDs)
 ```
 
 NOTE: the exact invocation command depends on the environment.  If you have only

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -49,4 +49,5 @@ parseClientCommand =
           <|> parseKeyRelatedValues
           <|> parseDelegationRelatedValues
           <|> parseTxRelatedValues
+          <|> parseBenchmarkingCommands
           )

--- a/cardano-node/src/Cardano/CLI/Parsers.hs
+++ b/cardano-node/src/Cardano/CLI/Parsers.hs
@@ -2,6 +2,7 @@
 
 module Cardano.CLI.Parsers
   ( command'
+  , parseBenchmarkingCommands
   , parseDelegationRelatedValues
   , parseGenesisParameters
   , parseGenesisRelatedValues
@@ -84,6 +85,52 @@ parseAddress :: String -> String -> Parser Address
 parseAddress opt desc =
   option (cliParseBase58Address <$> auto)
     $ long opt <> metavar "ADDR" <> help desc
+
+parseBenchmarkingCommands :: Parser ClientCommand
+parseBenchmarkingCommands =
+  subparser $ mconcat
+    [ commandGroup "Benchmarking related commands"
+    , metavar "Benchmarking related commands"
+    , command'
+        "generate-txs"
+        "Launch transactions generator."
+        $ GenerateTxs
+            <$> parseConfigFile
+            <*> parseSigningKeyFile "signing-key" "Signing key file."
+            <*> (DelegationCertFile <$> parseDelegationCert)
+            <*> (GenesisFile <$> parseGenesisPath)
+            <*> parseSocketPath "Path to a cardano-node socket"
+            <*> (NE.fromList <$> some (
+                  parseTargetNodeAddress
+                    "target-node"
+                    "host and port of the node transactions will be sent to."
+                  )
+                )
+            <*> parseNumberOfTxs
+                  "num-of-txs"
+                  "Number of transactions generator will create."
+            <*> parseNumberOfInputsPerTx
+                  "inputs-per-tx"
+                  "Number of inputs in each of transactions."
+            <*> parseNumberOfOutputsPerTx
+                  "outputs-per-tx"
+                  "Number of outputs in each of transactions."
+            <*> parseFeePerTx
+                  "tx-fee"
+                  "Fee per transaction, in Lovelaces."
+            <*> parseTPSRate
+                  "tps"
+                  "TPS (transaction per second) rate."
+            <*> optional (
+                  parseTxAdditionalSize
+                    "add-tx-size"
+                    "Additional size of transaction, in bytes."
+                )
+            <*> parseSigningKeysFiles
+                  "sig-key"
+                  "Path to signing key file, for genesis UTxO using by generator."
+     ]
+
 
 parseCertificateFile :: String -> String -> Parser CertificateFile
 parseCertificateFile opt desc = CertificateFile <$> parseFilePath opt desc
@@ -428,46 +475,6 @@ parseTxRelatedValues =
                   "Key that has access to all mentioned genesis UTxO inputs."
             <*> (NE.fromList <$> some parseTxIn)
             <*> (NE.fromList <$> some parseTxOut)
-    , command'
-        "generate-txs"
-        "Launch transactions generator."
-        $ GenerateTxs
-            <$> parseConfigFile
-            <*> parseSigningKeyFile "signing-key" "Signing key file."
-            <*> (DelegationCertFile <$> parseDelegationCert)
-            <*> (GenesisFile <$> parseGenesisPath)
-            <*> parseGenesisHash
-            <*> parseSocketPath "Path to a cardano-node socket"
-            <*> parseProtocol
-            <*> (NE.fromList <$> some (
-                  parseTargetNodeAddress
-                    "target-node"
-                    "host and port of the node transactions will be sent to."
-                  )
-                )
-            <*> parseNumberOfTxs
-                  "num-of-txs"
-                  "Number of transactions generator will create."
-            <*> parseNumberOfInputsPerTx
-                  "inputs-per-tx"
-                  "Number of inputs in each of transactions."
-            <*> parseNumberOfOutputsPerTx
-                  "outputs-per-tx"
-                  "Number of outputs in each of transactions."
-            <*> parseFeePerTx
-                  "tx-fee"
-                  "Fee per transaction, in Lovelaces."
-            <*> parseTPSRate
-                  "tps"
-                  "TPS (transaction per second) rate."
-            <*> optional (
-                  parseTxAdditionalSize
-                    "add-tx-size"
-                    "Additional size of transaction, in bytes."
-                )
-            <*> parseSigningKeysFiles
-                  "sig-key"
-                  "Path to signing key file, for genesis UTxO using by generator."
       ]
 
 

--- a/cardano-node/src/Cardano/CLI/Parsers.hs
+++ b/cardano-node/src/Cardano/CLI/Parsers.hs
@@ -444,7 +444,6 @@ parseTxRelatedValues =
             <$> parseTxFile "tx"
             <*> parseProtocol
             <*> (GenesisFile <$> parseGenesisPath)
-            <*> parseGenesisHash
             <*> parseSocketPath "Socket of target node"
     , command'
         "issue-genesis-utxo-expenditure"
@@ -452,7 +451,6 @@ parseTxRelatedValues =
         $ SpendGenesisUTxO
             <$> parseProtocol
             <*> (GenesisFile <$> parseGenesisPath)
-            <*> parseGenesisHash
             <*> parseNewTxFile "tx"
             <*> parseSigningKeyFile
                   "wallet-key"
@@ -468,7 +466,6 @@ parseTxRelatedValues =
         $ SpendUTxO
             <$> parseProtocol
             <*> (GenesisFile <$> parseGenesisPath)
-            <*> parseGenesisHash
             <*> parseNewTxFile "tx"
             <*> parseSigningKeyFile
                   "wallet-key"

--- a/scripts/generator.sh
+++ b/scripts/generator.sh
@@ -30,9 +30,9 @@ function mkdlgcert () {
   printf -- "--delegation-certificate ${genesis_root}/delegation-cert.%03d.json" "$1"
 }
 
-##function targetnode () {
-##      printf -- "--target-node (\"127.0.0.1\",$((3000))) "
-##}
+#function targetnode () {
+#      printf -- "--target-node (\"127.0.0.1\",$((3000))) "
+#}
 
 set -x
 ${CLI} \

--- a/scripts/generator.sh
+++ b/scripts/generator.sh
@@ -5,10 +5,8 @@ CLI="$(executable_quiet_runner cardano-cli)"
 
 NOW=`date "+%Y-%m-%d 00:00:00"`
 NETARGS=(
-        --real-pbft
         --config "configuration/log-configuration.yaml"
         --genesis-file  "${genesis_file}"
-        --genesis-hash  "${genesis_hash}"
         --socket-path    "./socket/0"
 
 )

--- a/scripts/issue-genesis-utxo-expenditure.sh
+++ b/scripts/issue-genesis-utxo-expenditure.sh
@@ -27,7 +27,6 @@ EOF
 args=" issue-genesis-utxo-expenditure
        --real-pbft
        --genesis-file        ${genesis_file}
-       --genesis-hash        ${genesis_hash}
        --tx                  ${tx}
        --wallet-key          ${from_key}
        --rich-addr-from    \"${from_addr}\"

--- a/scripts/issue-utxo-expenditure.sh
+++ b/scripts/issue-utxo-expenditure.sh
@@ -32,7 +32,6 @@ addr=$(${scripts}/get-default-key-address.sh ${to_key})
 args=" issue-utxo-expenditure
        --real-pbft
        --genesis-file        ${genesis_file}
-       --genesis-hash        ${genesis_hash}
        --tx                  ${tx}
        --wallet-key          ${from_key}
        --txin             (\"${txid}\",${outindex})

--- a/scripts/submit-tx.sh
+++ b/scripts/submit-tx.sh
@@ -19,7 +19,6 @@ NETARGS=(
         --tx           "$TX"
         --${ALGO}
         --genesis-file "${genesis_file}"
-        --genesis-hash "${genesis_hash}"
 )
 
 


### PR DESCRIPTION
- Remove `--genesis-hash` from all `cardano-cli` commands as this can be computed from the genesis files
- Create a benchmarking command group for benchmarking related commands
- Remove `--protocol` from `generate-txs` as this can be read from the supplied configuration `.yaml` file