### PR TITLE
CAD-455 log versioning:  make pretty

### DIFF
--- a/benchmarking/chain-sync/configuration/log-config-ci.yaml
+++ b/benchmarking/chain-sync/configuration/log-config-ci.yaml
@@ -28,8 +28,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/chain-sync/configuration/log-configuration.yaml
+++ b/benchmarking/chain-sync/configuration/log-configuration.yaml
@@ -36,8 +36,8 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
+  era:
+    value: "Byron"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/chain-sync/configuration/log-configuration.yaml
+++ b/benchmarking/chain-sync/configuration/log-configuration.yaml
@@ -36,8 +36,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  era:
-    value: "Byron"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-0.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-0.yaml
@@ -34,8 +34,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-2.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-2.yaml
@@ -34,8 +34,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
@@ -49,8 +49,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  era:
-    value: "Byron"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
@@ -49,8 +49,8 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
+  era:
+    value: "Byron"
   mapSubtrace:
     benchmark:
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
@@ -40,8 +40,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-genesis.yaml
@@ -28,8 +28,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapBackends:
     cardano.node.metrics.ChainDB:
       - EKGViewBK

--- a/cabal.project
+++ b/cabal.project
@@ -128,57 +128,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   plugins/backend-editor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 0388b876b63c137839b8a25570c9818a6b53ee47
-  --sha256: 1f47lclsmj0hi87z9jzs2gxwzfqf57qpgmmv1i3syxkksclw6hys
+  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -128,57 +128,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   plugins/backend-editor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
-  --sha256: 1rh96v2hk3crab5ihnj1m84jfszskidxs3gpkv056v184a03hx54
+  tag: e67dcb9a97b688e90aa93481839f2d162ab34b53
+  --sha256: 0m6sa0lrqzfxhq7v5ncimlkd869pnq53khgpkivk0izsy46kfrq6
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -14,6 +14,8 @@ library
   hs-source-dirs:      src
 
   exposed-modules:     Cardano.Config.CommonCLI
+                       Cardano.Config.GitRev
+                       Cardano.Config.GitRevFromGit
                        Cardano.Config.Logging
                        Cardano.Config.Orphanage
                        Cardano.Config.Protocol
@@ -31,6 +33,7 @@ library
                      , cardano-shell
                      , cborg
                      , contra-tracer
+                     , file-embed
                      , generic-monoid
                      , iohk-monitoring
                      , lobemo-backend-aggregation
@@ -42,11 +45,13 @@ library
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-network
+                     , process
                      , iproute
                      , safe-exceptions
                      , scientific
                      , string-conv
                      , stm
+                     , template-haskell
                      , text
                      , transformers
                      , transformers-except

--- a/cardano-config/src/Cardano/Config/GitRev.hs
+++ b/cardano-config/src/Cardano/Config/GitRev.hs
@@ -13,7 +13,7 @@
 
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
-module Cardano.Node.TUI.GitRev (
+module Cardano.Config.GitRev (
       gitRev
     ) where
 import           Cardano.Prelude
@@ -23,7 +23,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding (decodeUtf8)
 
-import           Cardano.Node.TUI.GitRevFromGit (gitRevFromGit)
+import           Cardano.Config.GitRevFromGit (gitRevFromGit)
 
 gitRev :: Text
 gitRev | gitRevEmbed /= zeroRev = gitRevEmbed

--- a/cardano-config/src/Cardano/Config/GitRevFromGit.hs
+++ b/cardano-config/src/Cardano/Config/GitRevFromGit.hs
@@ -13,7 +13,7 @@
 
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
-module Cardano.Node.TUI.GitRevFromGit (
+module Cardano.Config.GitRevFromGit (
       gitRevFromGit
     ) where
 

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -6,10 +6,13 @@
 
 import           Cardano.Prelude hiding (option)
 import           Prelude (String)
+import           Data.Text (pack)
 
 import           Data.Semigroup ((<>))
+import           Data.Version (showVersion)
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
+import           Paths_cardano_node (version)
 
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
@@ -66,7 +69,10 @@ initializeAllFeatures
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
 initializeAllFeatures npm cardanoEnvironment = do
-  (loggingLayer, loggingFeature) <- createLoggingFeature cardanoEnvironment npm
+  (loggingLayer, loggingFeature) <- createLoggingFeature
+                                      (pack $ showVersion version)
+                                      cardanoEnvironment
+                                      npm
   (nodeLayer   , nodeFeature)    <- createNodeFeature
                                       loggingLayer
                                       cardanoEnvironment

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -75,7 +75,6 @@ library
                      , containers
                      , cryptonite
                      , directory
-                     , file-embed
                      , filepath
                      , formatting
                      , hostname
@@ -92,7 +91,6 @@ library
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-network
-                     , process
                      , safe-exceptions
                      , serialise
                      , stm
@@ -147,12 +145,15 @@ executable cardano-node
   else
     ghc-options:         "-with-rtsopts=-T -I0 -N2 -A16m"
 
+  other-modules:       Paths_cardano_node
+
   build-depends:       base >=4.12 && <5
                      , cardano-config
                      , cardano-node
                      , cardano-prelude
                      , cardano-shell
                      , optparse-applicative
+                     , text
 
   if os(windows)
      build-depends:    Win32

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -42,8 +42,6 @@ library
                        Cardano.Node.Features.Node
                        Cardano.Node.Run
                        Cardano.Node.Submission
-                       Cardano.Node.TUI.GitRev
-                       Cardano.Node.TUI.GitRevFromGit
                        Cardano.Node.TxSubClient
                        Cardano.Tracing.Tracers
                        Cardano.Wallet.Client

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -34,9 +34,12 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (hoistEither, firstExceptT)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Semigroup ((<>))
+import           Data.Text (pack)
 import qualified Data.Text.Lazy.IO as TL
 import qualified Data.Text.Lazy.Builder as Builder
+import           Data.Version (showVersion)
 import qualified Formatting as F
+import           Paths_cardano_node (version)
 import           System.Directory (doesPathExist)
 
 import qualified Cardano.Chain.Common as Common
@@ -326,6 +329,7 @@ runCommand (GenerateTxs
 
   -- Logging layer
   (loggingLayer, _) <- liftIO $ createLoggingFeatureCLI
+                                  (pack $ showVersion version)
                                   NoEnvironment
                                   (Just logConfigFp)
                                   (ncLogMetrics nc)

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -78,7 +78,7 @@ import           Cardano.BM.Trace
 
 import           Cardano.Config.Topology
 import           Cardano.Config.Types
-import           Cardano.Node.TUI.GitRev (gitRev)
+import           Cardano.Config.GitRev (gitRev)
 import           Cardano.Slotting.Slot (unSlotNo)
 import qualified Ouroboros.Network.AnchoredFragment as Net
 import qualified Ouroboros.Network.Block as Net

--- a/cardano-node/src/Cardano/Wallet/Logging.hs
+++ b/cardano-node/src/Cardano/Wallet/Logging.hs
@@ -5,6 +5,10 @@ module Cardano.Wallet.Logging
 
 import           Cardano.Prelude
 
+import           Data.Text (pack)
+import           Data.Version (showVersion)
+import           Paths_cardano_node (version)
+
 import           Cardano.Shell.Types (CardanoFeature (..))
 
 import           Cardano.Config.Types ( CardanoEnvironment, ConfigYamlFilePath(..)
@@ -31,7 +35,9 @@ createLoggingFeatureWallet _ wCli = do
                                            (ncLogMetrics nc)
 
     -- we construct the layer
-    (loggingLayer, cleanUpLogging) <- loggingCardanoFeatureInit disabled' loggingConfiguration
+    (loggingLayer, cleanUpLogging) <- loggingCardanoFeatureInit
+                                        (pack $ showVersion version)
+                                        disabled' loggingConfiguration
 
 
     -- we construct the cardano feature

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -34,8 +34,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/configuration/configuration-silent.yaml
+++ b/configuration/configuration-silent.yaml
@@ -37,8 +37,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapBackends:
     cardano.node.metrics.ChainDB:
       - EKGViewBK

--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -30,11 +30,16 @@ setupScribes:
   - scKind: FileSK
     scName: "logs/node-0.log"
     scFormat: ScText
+  - scKind: FileSK
+    scName: "logs/node-0.json"
+    scFormat: ScJson
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
     - "logs/node-0.log"
+  - - FileSK
+    - "logs/node-0.json"
 
 # more options which can be passed as key-value pairs:
 options:

--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -43,8 +43,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -44,8 +44,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/configuration/log-config-1.liveview.yaml
+++ b/configuration/log-config-1.liveview.yaml
@@ -38,8 +38,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -44,8 +44,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     '#ekgview':
       contents:

--- a/configuration/log-config-2.liveview.yaml
+++ b/configuration/log-config-2.liveview.yaml
@@ -38,8 +38,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -44,8 +44,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -38,8 +38,6 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  cfokey:
-    value: "Release-1.0.0"
   mapSubtrace:
     benchmark:
       contents:

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 # It just takes the shell attribute from default.nix.
 { config ? {}
 , sourcesOverride ? {}
-, withHoogle ? false
+, withHoogle ? true
 , pkgs ? import ./nix {
     inherit config sourcesOverride;
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/c40175657bc8134e0561d9b6e6334728c19112e4/snapshot.yaml
+resolver: lts-14.22
 compiler: ghc-8.6.5
 
 packages:
@@ -6,8 +6,8 @@ packages:
   - cardano-node
 
 ghc-options:
-  cardano-config:   -Wall -Werror -fwarn-redundant-constraints
-  cardano-node:     -Wall -Werror -fwarn-redundant-constraints
+  cardano-config:   -Wall -fwarn-redundant-constraints
+  cardano-node:     -Wall -fwarn-redundant-constraints
 
 allow-newer: true
 
@@ -51,7 +51,6 @@ extra-deps:
   - Unique-0.4.7.6
   - word-wrap-0.4.1
   - websockets-0.12.6.1
-  - th-lift-instances-0.1.14
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
@@ -98,7 +97,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 0388b876b63c137839b8a25570c9818a6b53ee47
+    commit: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
     subdirs:
       - contra-tracer
       - iohk-monitoring
@@ -113,6 +112,8 @@ extra-deps:
   - prometheus-2.1.2
   - libsystemd-journal-1.4.4
   - katip-0.8.3.0
+  - git: https://github.com/CodiePP/ekg-prometheus-adapter
+    commit: 1a258b6df7d9807d4c4ff3e99722223d31a2c320
 
     # Extracted from cardano-sl since it's quite useful
   - git: https://github.com/input-output-hk/cardano-sl-x509

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.22
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/c40175657bc8134e0561d9b6e6334728c19112e4/snapshot.yaml
 compiler: ghc-8.6.5
 
 packages:
@@ -6,8 +6,8 @@ packages:
   - cardano-node
 
 ghc-options:
-  cardano-config:   -Wall -fwarn-redundant-constraints
-  cardano-node:     -Wall -fwarn-redundant-constraints
+  cardano-config:   -Wall -Werror -fwarn-redundant-constraints
+  cardano-node:     -Wall -Werror -fwarn-redundant-constraints
 
 allow-newer: true
 
@@ -51,6 +51,7 @@ extra-deps:
   - Unique-0.4.7.6
   - word-wrap-0.4.1
   - websockets-0.12.6.1
+  - th-lift-instances-0.1.14
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
@@ -97,7 +98,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 02c714e56ba0d0704ab4f7bbe6d71661d1c026c9
+    commit: e67dcb9a97b688e90aa93481839f2d162ab34b53
     subdirs:
       - contra-tracer
       - iohk-monitoring
@@ -112,8 +113,6 @@ extra-deps:
   - prometheus-2.1.2
   - libsystemd-journal-1.4.4
   - katip-0.8.3.0
-  - git: https://github.com/CodiePP/ekg-prometheus-adapter
-    commit: 1a258b6df7d9807d4c4ff3e99722223d31a2c320
 
     # Extracted from cardano-sl since it's quite useful
   - git: https://github.com/input-output-hk/cardano-sl-x509


### PR DESCRIPTION
We used to have the following in the structured log:

```
{"at":"2020-02-05T23:39:27.05Z","env": "fromList [(\"value\",String \"Release-1.0.0\")]:0.1.10.1","ns":["cardano","node-metrics"],"data":{},"app":[],"msg":"IO.rchar = 24964 B","...}
```

This makes it more useful -- by tracking node version & commit id in the `env` field:
```
{"at":"2020-02-05T23:39:27.05Z","env":"1.5.0:79a04","ns":["cardano","node-metrics"],"data":{},"app":[],"msg":"IO.rchar = 24964 B","...}
```
# Note

This depends on https://github.com/input-output-hk/iohk-monitoring-framework/pull/514 being merged first.