### PR TITLE
Add CBOR pretty print and validation commands to `cardano-cli`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -127,6 +127,12 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/well-typed/cborg
+  tag: 42a83192749774268337258f4f94c97584b80ca6
+  subdir: cborg
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/goblins
   tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
   --sha256: 17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b

--- a/cabal.project
+++ b/cabal.project
@@ -127,12 +127,6 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/well-typed/cborg
-  tag: 42a83192749774268337258f4f94c97584b80ca6
-  subdir: cborg
-
-source-repository-package
-  type: git
   location: https://github.com/input-output-hk/goblins
   tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
   --sha256: 17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b
@@ -289,6 +283,13 @@ source-repository-package
   location: http://github.com/well-typed/canonical-json
   tag: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f
   --sha256: 02fzn1xskis1lc1pkz0j92v6ipd89ww0k2p3dvwpm3yap5dpnm7k
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/cborg.git
+  tag: 42a83192749774268337258f4f94c97584b80ca6
+  --sha256: 1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04
+  subdir: cborg
 
 constraints:
   ip < 1.5,

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Config.Types
-    ( ConfigYamlFilePath (..)
+    ( CBORObject (..)
+    , ConfigYamlFilePath (..)
     , CardanoEnvironment (..)
     , DbFile (..)
     , DelegationCertFile (..)
@@ -44,6 +45,15 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 import           Cardano.Config.Orphanage ()
 import           Cardano.Crypto (RequiresNetworkMagic(..))
+
+
+-- | Specify what the CBOR file is
+-- i.e a block, a tx, etc
+data CBORObject = CBORBlockByron
+                | CBORDelegationCertificateByron
+                | CBORTxByron
+                | CBORUpdateProposalByron
+                deriving Show
 
 --------------------------------------------------------------------------------
 -- Cardano Environment

--- a/cardano-node/README.md
+++ b/cardano-node/README.md
@@ -302,3 +302,18 @@ Block number: 5
 # Development
 
 run *ghcid* with: `ghcid -c "cabal v2-repl exe:cardano-node --reorder-goals"`
+
+# Debugging
+
+### Pretty printing CBOR encoded files
+
+It may be useful to print the on chain representations of blocks, delegation certificates, txs and update proposals. There are two commands that do this (for any cbor encoded file):
+
+To pretty print as CBOR:
+`cabal exec cardano-cli -- pretty-print-cbor --filepath CBOREncodedFile`
+
+### Validate cbor files
+
+You can validate Byron era blocks, delegation certificates, txs and update proposals with the `validate-cbor` command.
+
+`cabal exec cardano-cli -- validate-cbor --byron-block --filepath CBOREncodedByronBlockFile`

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -52,4 +52,5 @@ parseClientCommand =
           <|> parseTxRelatedValues
           <|> parseLocalNodeQueryValues
           <|> parseBenchmarkingCommands
+          <|> parseMiscellaneous
           )

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -11,9 +11,12 @@
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Cardano.CLI.Ops
-  ( deserialiseDelegateKey
+  ( decodeCBOR
+  , deserialiseDelegateKey
   , getGenesisHash
   , getLocalTip
+  , validateCBOR
+  , readCBOR
   , readGenesis
   , serialiseDelegationCert
   , serialiseDelegateKey
@@ -31,18 +34,26 @@ import           Cardano.Prelude hiding (catch, option, show)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left)
 import           Test.Cardano.Prelude (canonicalEncodePretty)
 
+import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import           Codec.CBOR.Write (toLazyByteString)
+import           Control.Monad.Trans.Except.Extra
+                   (handleIOExceptT, hoistEither, secondExceptT)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
 import qualified Formatting as F
 import qualified Text.JSON.Canonical as CanonicalJSON
 
-import           Cardano.Binary (DecoderError)
+import           Cardano.Binary
+                   (Decoder, DecoderError, decodeFullDecoder, fromCBOR)
+import           Cardano.Chain.Block (fromCBORABlockOrBoundary)
+import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Crypto.Signing as Crypto
+import           Cardano.Chain.Slotting (EpochSlots(..))
+import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.UTxO as UTxO
 import           Cardano.Crypto (RequiresNetworkMagic, SigningKey (..))
 import qualified Cardano.Crypto.Hashing as Crypto
-import qualified Cardano.Crypto.Signing as Crypto
-import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
-import           Codec.CBOR.Write (toLazyByteString)
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer (nullTracer, stdoutTracer, traceWith)
@@ -88,7 +99,20 @@ import           Cardano.Config.Protocol
 import           Cardano.Config.Types
 import qualified Cardano.CLI.Legacy.Byron as Legacy
 
-
+decodeCBOR
+  :: CBORObject
+  -> LByteString
+  -> (forall s. Decoder s a)
+  -> ExceptT CliError IO a
+decodeCBOR cborObject bs decoder = do
+  case cborObject of
+      CBORBlockByron -> toExceptT $ decodeFullDecoder "Byron Block" decoder bs
+      CBORDelegationCertificateByron -> toExceptT $ decodeFullDecoder "Byron Delegation Certificate" decoder bs
+      CBORTxByron -> toExceptT $ decodeFullDecoder "Byron Tx" decoder bs
+      CBORUpdateProposalByron -> toExceptT $ decodeFullDecoder "Byron Update Proposal" decoder bs
+ where
+   toExceptT :: Either DecoderError a -> ExceptT CliError IO a
+   toExceptT = firstExceptT CBORDecodingError . hoistEither
 
 deserialiseDelegateKey :: Protocol -> FilePath -> LB.ByteString -> Either CliError SigningKey
 deserialiseDelegateKey ByronLegacy fp delSkey =
@@ -109,6 +133,35 @@ getGenesisHash genFile = do
 -- | Read genesis from a file.
 readGenesis :: GenesisFile -> ExceptT CliError IO (Genesis.GenesisData, Genesis.GenesisHash)
 readGenesis (GenesisFile fp) = firstExceptT (GenesisReadError fp) $ Genesis.readGenesisData fp
+
+validateCBOR :: CBORObject -> LByteString -> ExceptT CliError IO ()
+validateCBOR cborObject bs =
+  case cborObject of
+    CBORBlockByron -> do
+      secondExceptT (const ())
+        $ decodeCBOR CBORBlockByron bs (fromCBORABlockOrBoundary $ EpochSlots 21600)
+      liftIO $ putTextLn "Valid Byron block."
+
+    CBORDelegationCertificateByron -> do
+      secondExceptT (const ())
+        $ decodeCBOR CBORDelegationCertificateByron bs (fromCBOR :: Decoder s Delegation.Certificate)
+      liftIO $ putTextLn "Valid Byron delegation certificate."
+
+    CBORTxByron -> do
+      secondExceptT (const ())
+        $ decodeCBOR CBORTxByron bs (fromCBOR :: Decoder s UTxO.Tx)
+      liftIO $ putTextLn "Valid Byron Tx."
+
+    CBORUpdateProposalByron -> do
+      secondExceptT (const ())
+        $ decodeCBOR CBORTxByron bs (fromCBOR :: Decoder s Update.Proposal)
+      liftIO $ putTextLn "Valid Byron update proposal."
+
+readCBOR :: FilePath -> ExceptT CliError IO LByteString
+readCBOR fp =
+  handleIOExceptT
+    (ReadCBORFileFailure fp . toS . displayException)
+    (LB.readFile fp)
 
 serialiseDelegationCert :: CanonicalJSON.ToJSON Identity a => Protocol -> a -> Either CliError LB.ByteString
 serialiseDelegationCert ByronLegacy dlgCert = pure $ canonicalEncodePretty dlgCert
@@ -141,7 +194,8 @@ serialiseSigningKey ptcl _ = Left $ ProtocolNotSupported ptcl
 -- | Exception type for all errors thrown by the CLI.
 --   Well, almost all, since we don't rethrow the errors from readFile & such.
 data CliError
-  = CertificateValidationErrors !FilePath ![Text]
+  = CBORDecodingError DecoderError
+  | CertificateValidationErrors !FilePath ![Text]
   | DelegationError !Genesis.GenesisDelegationError
   | DlgCertificateDeserialisationFailed !FilePath !Text
   | GenerateTxsError !RealPBFTError
@@ -157,6 +211,7 @@ data CliError
   | ProtocolError ProtocolInstantiationError
   | ProtocolNotSupported !Protocol
   | ProtocolParametersParseFailed !FilePath !Text
+  | ReadCBORFileFailure !FilePath !Text
   | ReadSigningKeyFailure !FilePath !Text
   | ReadVerificationKeyFailure !FilePath !Text
   | TxDeserialisationFailed !FilePath !DecoderError
@@ -167,54 +222,59 @@ data CliError
 
 
 instance Show CliError where
-  show (OutputMustNotAlreadyExist fp)
-    = "Output file/directory must not already exist: " <> fp
-  show NotEnoughTxInputs
-    = "Transactions must have at least one input."
-  show NotEnoughTxOutputs
-    = "Transactions must have at least one output."
-  show (ProtocolNotSupported proto)
-    = "Unsupported protocol "<> show proto
+  show (CBORDecodingError e)
+    = "Error with CBOR decoding: " <> show e
   show (CertificateValidationErrors fp errs)
     = unlines $
       "Errors while validating certificate '" <> fp <> "':":
       (("  " <>) . T.unpack <$> errs)
-  show (ProtocolError err)
-    = "Protocol Instantiation Error " <> show err
-  show (ProtocolParametersParseFailed fp err)
-    = "Protocol parameters file '" <> fp <> "' read failure: "<> T.unpack err
   show (GenesisReadError fp err)
     = "Genesis file '" <> fp <> "' read failure: "<> show err
-  show (SigningKeyDeserialisationFailed fp err)
-    = "Signing key '" <> fp <> "' read failure: "<> show err
-  show (VerificationKeyDeserialisationFailed fp err)
-    = "Verification key '" <> fp <> "' read failure: "<> T.unpack err
-  show (DlgCertificateDeserialisationFailed fp err)
-    = "Delegation certificate '" <> fp <> "' read failure: "<> T.unpack err
-  show (TxDeserialisationFailed fp err)
-    = "Transaction file '" <> fp <> "' read failure: "<> show err
   show (DelegationError err)
     = "Error while issuing delegation: " <> show err
+  show (DlgCertificateDeserialisationFailed fp err)
+    = "Delegation certificate '" <> fp <> "' read failure: "<> T.unpack err
   show (GenerateTxsError err)
     = "Error in GenerateTxs command: " <> show err
-  show (NodeSubmitTxError err)
-    = "Error in SubmitTx command: " <> show err
-  show (SpendGenesisUTxOError err)
-    = "Error in SpendGenesisUTxO command: " <> show err
-  show (GenesisSpecError err)
-    = "Error in genesis specification: " <> T.unpack err
   show (GenesisGenerationError err)
     = "Genesis generation failed in mkGenesis: " <> show err
+  show (GenesisSpecError err)
+    = "Error in genesis specification: " <> T.unpack err
   show (IssueUtxoError err)
     = "Error SpendUTxO command: " <> show err
+  show (NodeSubmitTxError err)
+    = "Error in SubmitTx command: " <> show err
   show (NoGenesisDelegationForKey key)
     = "Newly-generated genesis doesn't delegate to operational key: " <> T.unpack key
-  show (ReadVerificationKeyFailure fp expt)
-    = "Exception encountered while trying to read the verification key file at: " <> fp
-       <> "Exception: " <> T.unpack expt
+  show NotEnoughTxInputs
+    = "Transactions must have at least one input."
+  show NotEnoughTxOutputs
+    = "Transactions must have at least one output."
+  show (OutputMustNotAlreadyExist fp)
+    = "Output file/directory must not already exist: " <> fp
+  show (ProtocolError err)
+    = "Protocol Instantiation Error " <> show err
+  show (ProtocolNotSupported proto)
+    = "Unsupported protocol "<> show proto
+  show (ProtocolParametersParseFailed fp err)
+    = "Protocol parameters file '" <> fp <> "' read failure: "<> T.unpack err
   show (ReadSigningKeyFailure fp expt)
     = "Exception encountered while trying to read the signing key file at: " <> fp
        <> "Exception: " <> T.unpack expt
+  show (ReadCBORFileFailure fp expt)
+    = "Exception encountered while trying to read the CBOR file at: " <> fp
+       <> "Exception: " <> T.unpack expt
+  show (ReadVerificationKeyFailure fp expt)
+    = "Exception encountered while trying to read the verification key file at: " <> fp
+       <> "Exception: " <> T.unpack expt
+  show (SigningKeyDeserialisationFailed fp err)
+    = "Signing key '" <> fp <> "' read failure: "<> show err
+  show (SpendGenesisUTxOError err)
+    = "Error in SpendGenesisUTxO command: " <> show err
+  show (TxDeserialisationFailed fp err)
+    = "Transaction file '" <> fp <> "' read failure: "<> show err
+  show (VerificationKeyDeserialisationFailed fp err)
+    = "Verification key '" <> fp <> "' read failure: "<> T.unpack err
 
 instance Exception CliError
 

--- a/cardano-node/src/Cardano/CLI/Parsers.hs
+++ b/cardano-node/src/Cardano/CLI/Parsers.hs
@@ -144,13 +144,13 @@ parseBenchmarkingCommands =
 parseCBORObject :: Parser CBORObject
 parseCBORObject = asum
   [ flagParser CBORBlockByron "byron-block"
-    "The CBOR file is a byron era block."
-  , flagParser CBORDelegationCertificateByron "byron-delegation-cert"
-    "The CBOR file is a byron era delegation certificate."
-  , flagParser CBORUpdateProposalByron "byron-update-proposal"
-    "The CBOR file is a byron era update proposal."
+    "The CBOR file is a byron era block"
+  , flagParser CBORDelegationCertificateByron "byron-delegation-certificate"
+    "The CBOR file is a byron era delegation certificate"
   , flagParser CBORTxByron "byron-tx"
     "The CBOR file is a byron era tx"
+  , flagParser CBORUpdateProposalByron "byron-update-proposal"
+    "The CBOR file is a byron era update proposal"
   ]
 
 parseCertificateFile :: String -> String -> Parser CertificateFile
@@ -390,10 +390,15 @@ parseMiscellaneous = subparser $ mconcat
   , metavar "Miscellaneous commands"
   , command'
       "validate-cbor"
-      "Validate a CBOR blockchain object"
+      "Validate a CBOR blockchain object."
       $ ValidateCBOR
           <$> parseCBORObject
-          <*> parseFilePath "filepath" "Filepath of CBOR file"
+          <*> parseFilePath "filepath" "Filepath of CBOR file."
+  , command'
+      "pretty-print-cbor"
+      "Pretty print a CBOR file."
+      $ PrettyPrintCBOR
+          <$> parseFilePath "filepath" "Filepath of CBOR file."
   ]
 
 parseNumberOfInputsPerTx :: String -> String -> Parser NumberOfInputsPerTx

--- a/cardano-node/src/Cardano/CLI/Parsers.hs
+++ b/cardano-node/src/Cardano/CLI/Parsers.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.Parsers
   , parseGenesisRelatedValues
   , parseKeyRelatedValues
   , parseLocalNodeQueryValues
+  , parseMiscellaneous
   , parseRequiresNetworkMagic
   , parseTxRelatedValues
   ) where
@@ -39,8 +40,9 @@ import           Cardano.Chain.Slotting (EpochNumber(..))
 import           Cardano.Chain.UTxO (TxId, TxIn(..), TxOut(..))
 import           Cardano.Config.CommonCLI
 import           Cardano.Config.Types
-                   (ConfigYamlFilePath(..), DelegationCertFile(..), GenesisFile(..)
-                   , NodeAddress(..), NodeHostAddress(..), SigningKeyFile(..))
+                   (CBORObject(..), ConfigYamlFilePath(..), DelegationCertFile(..)
+                   , GenesisFile(..), NodeAddress(..), NodeHostAddress(..)
+                   , SigningKeyFile(..))
 import           Cardano.Crypto (RequiresNetworkMagic(..), decodeHash)
 import           Cardano.Crypto.ProtocolMagic
                    (AProtocolMagic(..), ProtocolMagic
@@ -139,6 +141,17 @@ parseBenchmarkingCommands =
                   "Path to signing key file, for genesis UTxO using by generator."
      ]
 
+parseCBORObject :: Parser CBORObject
+parseCBORObject = asum
+  [ flagParser CBORBlockByron "byron-block"
+    "The CBOR file is a byron era block."
+  , flagParser CBORDelegationCertificateByron "byron-delegation-cert"
+    "The CBOR file is a byron era delegation certificate."
+  , flagParser CBORUpdateProposalByron "byron-update-proposal"
+    "The CBOR file is a byron era update proposal."
+  , flagParser CBORTxByron "byron-tx"
+    "The CBOR file is a byron era tx"
+  ]
 
 parseCertificateFile :: String -> String -> Parser CertificateFile
 parseCertificateFile opt desc = CertificateFile <$> parseFilePath opt desc
@@ -370,6 +383,18 @@ parseNewVerificationKeyFile :: String -> Parser NewVerificationKeyFile
 parseNewVerificationKeyFile opt =
   NewVerificationKeyFile
     <$> parseFilePath opt "Non-existent file to write the verification key to."
+
+parseMiscellaneous :: Parser ClientCommand
+parseMiscellaneous = subparser $ mconcat
+  [ commandGroup "Miscellaneous commands"
+  , metavar "Miscellaneous commands"
+  , command'
+      "validate-cbor"
+      "Validate a CBOR blockchain object"
+      $ ValidateCBOR
+          <$> parseCBORObject
+          <*> parseFilePath "filepath" "Filepath of CBOR file"
+  ]
 
 parseNumberOfInputsPerTx :: String -> String -> Parser NumberOfInputsPerTx
 parseNumberOfInputsPerTx opt desc = NumberOfInputsPerTx <$> parseIntegral opt desc

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -76,11 +76,6 @@ import           Cardano.CLI.Benchmarking.Tx.Generation
 import           Cardano.Config.Protocol
 import           Cardano.Config.Logging (createLoggingFeatureCLI)
 import           Cardano.Config.Types
-                   (CardanoEnvironment(..), ConfigYamlFilePath(..)
-                   , DelegationCertFile(..), GenesisFile(..)
-                   , LastKnownBlockVersion(..), NodeAddress(..)
-                   , NodeConfiguration(..), SigningKeyFile(..)
-                   , SocketPath(..), Update(..), parseNodeConfigurationFP)
 
 -- | Sub-commands of 'cardano-cli'.
 data ClientCommand
@@ -198,6 +193,12 @@ data ClientCommand
     (Maybe TxAdditionalSize)
     (Maybe ExplorerAPIEnpoint)
     [SigningKeyFile]
+    --- Misc Commands ---
+  | ValidateCBOR
+    CBORObject
+    -- ^ Type of the CBOR object
+    FilePath
+
    deriving Show
 
 
@@ -208,6 +209,10 @@ runCommand (Genesis outDir params ptcl) = do
 
 runCommand (GetLocalNodeTip configFp gFile sockPath) = withIOManagerE $ \iocp ->
   liftIO $ getLocalTip configFp gFile iocp sockPath
+
+runCommand (ValidateCBOR cborObject fp) = do
+  bs <- readCBOR fp
+  validateCBOR cborObject bs
 
 runCommand (PrettySigningKeyPublic ptcl skF) = do
   sK <- readSigningKey ptcl skF

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -198,7 +198,8 @@ data ClientCommand
     CBORObject
     -- ^ Type of the CBOR object
     FilePath
-
+  | PrettyPrintCBOR
+    FilePath
    deriving Show
 
 
@@ -213,6 +214,10 @@ runCommand (GetLocalNodeTip configFp gFile sockPath) = withIOManagerE $ \iocp ->
 runCommand (ValidateCBOR cborObject fp) = do
   bs <- readCBOR fp
   validateCBOR cborObject bs
+
+runCommand (PrettyPrintCBOR fp) = do
+  bs <- readCBOR fp
+  pPrintCBOR bs
 
 runCommand (PrettySigningKeyPublic ptcl skF) = do
   sK <- readSigningKey ptcl skF

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -4,7 +4,8 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Common.Parsers
-  ( nodeMockParser
+  ( flagParser
+  , nodeMockParser
   , nodeMockProtocolModeParser
   , nodeProtocolModeParser
   , nodeRealParser

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,6 @@ extra-deps:
   - hedgehog-1.0.2
   - micro-recursion-schemes-5.0.2.2
   - streaming-binary-0.3.0.1
-  - cborg-0.2.2.1
   - canonical-json-0.6.0.0
   - brick-0.47
   - binary-0.8.7.0
@@ -135,5 +134,10 @@ extra-deps:
         - typed-protocols-examples
         - ouroboros-network-framework
 
+    # Includes updated pretty printing function
+  - git: https://github.com/well-typed/cborg.git
+    commit: 42a83192749774268337258f4f94c97584b80ca6
+    subdirs:
+        - cborg
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
Issue
-----------

- #503 

- This PR adds two commands to `cardano-cli`, a `pretty-print-cbor` command which pretty prints a given CBOR encoded file and a `validate-cbor` command which validates the CBOR encoding of a given file. The `validate-cbor` command currently supports Byron era blocks, delegation certificates, txs and update proposals.
       
- Required: https://github.com/input-output-hk/cardano-prelude/pull/97
- Required: https://github.com/well-typed/cborg/pull/223

checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] This PR results in breaking changes to upstream dependencies.
 
- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
