### PR TITLE
add buildkite job to fetch eval errors from hydra API

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,9 @@
 steps:
+  - label: hydra-eval-errors
+    command: 'nix-build ./nix -A iohkNix.hydraEvalErrors && ./result/bin/hydra-eval-errors.py'
+    agents:
+      system: x86_64-linux
+
   - label: 'stack rebuild'
     env:
       STACK_ROOT: "/build/cardano-node.stack"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "8eb95138be415ea7a02c80cc52cbc14edc0a9e05",
-        "sha256": "1p6j5pz023ixyl4rc19ww2njv5wrffyl2f69zx1jazlqllnakbbz",
+        "rev": "6959cc3af94200219f762b36a394ac2c3afecb38",
+        "sha256": "0iyf54k7snvvirfjkn5809prxmp4p60i33w52qjy4klryld7y01l",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/8eb95138be415ea7a02c80cc52cbc14edc0a9e05.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/6959cc3af94200219f762b36a394ac2c3afecb38.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Instead of running hydra-eval-jobs in buildkite which constantly fails this queries hydra API for eval errors.

How it works:
1. wait for jobset to be created for PR (up to an hour)
2. query the jobset for evals
3. wait for jobset to contain an eval with the correct git rev (up to an hour)
4. query jobset for any eval errors and print them out if any exist

Known issues:

every branch without a PR will fail so first commit in a PR will fail as buildkite doesn't know the PR number. This is not a huge deal as long as it's communicated properly as pushing another commit, ammending current commit or merging/trying with bors will all run it correctly.