### PR TITLE
Add gzip to buildTools

### DIFF
--- a/scripts/buildkite/default.nix
+++ b/scripts/buildkite/default.nix
@@ -7,7 +7,7 @@ let
   '';
 
   buildTools =
-    [ git nix gnumake stack gnused gnutar coreutils stack-hpc-coveralls systemd ];
+    [ git nix gnumake stack gnused gnutar coreutils stack-hpc-coveralls systemd gzip ];
 
 in
   writeScript "stack-rebuild-wrapped" ''


### PR DESCRIPTION
Issue
-----------

- Buildkite builds are failing because gzip is missing

checklist
---------
- [X] This PR contains all the work required to resolve the linked issue.

- [] This PR results in breaking changes to upstream dependencies.

- [] The work contained has sufficient documentation to describe what it does and how to do it.

- [X] The work has sufficient tests and/or testing.

- [X] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [X] I have added the appropriate labels to this PR.
