### PR TITLE
node service:  make the socket path spec work in single-service mode as well

### DIFF
--- a/nix/nixos/cardano-cluster-service.nix
+++ b/nix/nixos/cardano-cluster-service.nix
@@ -89,7 +89,9 @@ in let
   node-root-dir         = "/var/lib/cardano-node";
   shelley-state-dir     = "${node-root-dir}/${legacy-name-shexpr}";
   shelley-database-paths = map (i: "${node-root-dir}/db-${i}") shelley-node-ids-str;
+  shelley-socket-paths   = map (i: "${node-root-dir}/node-${i}.socket") shelley-node-ids-str;
   database-path-shexpr  = ''$(choice "$1" ${toString legacy-node-ids-str} ${toString shelley-database-paths})'';
+  socket-path-shexpr    = ''$(choice "$1" ${toString legacy-node-ids-str} ${toString shelley-socket-paths})'';
 
 in let
   ### Secrets
@@ -215,6 +217,7 @@ in {
       runtimeDir            = null;
       nodeConfigFile        = config-shexpr;
       databasePath          = database-path-shexpr;
+      socketPath            = socket-path-shexpr;
       environment           = "mainnet";
       protover-major        = 0;
       protover-minor        = 0;

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -9,16 +9,16 @@ let
   cfg = config.services.cardano-node;
   inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
+  runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg:
     let exec = "cardano-node run";
-        runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
         cmd = builtins.filter (x: x != "") [
           "${cfg.package}/bin/${exec}"
           "--genesis-file ${cfg.genesisFile}"
           "--genesis-hash ${cfg.genesisHash}"
           "--config ${cfg.nodeConfigFile}"
           "--database-path ${cfg.databasePath}"
-          "--socket-path ${runtimeDir}/node-$1.socket"
+          "--socket-path ${cfg.socketPath}"
           "--topology ${cfg.topology}"
           "--host-addr ${cfg.hostAddr}"
           "--port ${toString cfg.port}"
@@ -155,6 +155,12 @@ in {
         type = types.str;
         default = "${cfg.stateDir}/${cfg.dbPrefix}";
         description = ''Node database path.'';
+      };
+
+      socketPath = mkOption {
+        type = types.str;
+        default = "${runtimeDir}/node.socket";
+        description = ''Local communication socket path.'';
       };
 
       dbPrefix = mkOption {


### PR DESCRIPTION
The Nix definition of `cardano-node` service had its socket path spec suffering from the recent adaptation, which was made with only the chairman test in mind.

This makes the socket path work for both the chairman CI test and the normal deploy.

checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [] This PR results in breaking changes to upstream dependencies.

- [] The work contained has sufficient documentation to describe what it does and how to do it.

- [] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
