### PR TITLE
CAD-636:  repair the JournalSK presentation

### DIFF
--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -31,7 +31,7 @@ import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..),
 import           Cardano.BM.Tracing
 import           Cardano.BM.Data.Tracer (trStructured, emptyObject, mkObject)
 
-import           Ouroboros.Consensus.Block (SupportedBlock, headerPoint)
+import           Ouroboros.Consensus.Block (Header, SupportedBlock, headerPoint)
 import           Ouroboros.Consensus.BlockFetchServer
                    (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.ChainSyncClient
@@ -237,6 +237,14 @@ defaultTextTransformer TextualRepresentation _verb tr =
       <*> pure (LogMessage $ pack $ show s)
 defaultTextTransformer _ verb tr =
   trStructured verb tr
+
+instance ( DefinePrivacyAnnotation (ChainDB.TraceAddBlockEvent blk)
+         , DefineSeverity (ChainDB.TraceAddBlockEvent blk)
+         , ProtocolLedgerView blk
+         , Show (Ouroboros.Consensus.Block.Header blk)
+         , ToObject (ChainDB.TraceAddBlockEvent blk))
+ => Transformable Text IO (ChainDB.TraceAddBlockEvent blk) where
+   trTransformer = defaultTextTransformer
 
 instance DefineSeverity (ChainDB.TraceEvent blk) where
   defineSeverity (ChainDB.TraceAddBlockEvent ev) = case ev of

--- a/configuration/log-configuration.yaml
+++ b/configuration/log-configuration.yaml
@@ -27,17 +27,22 @@ setupScribes:
     scName: stdout
     scFormat: ScText
     scRotation: null
+  # for output to 'journald' add this scribe:
+  # - scKind: JournalSK
+  #   scName: "cardano"
+  #   scFormat: ScText
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - StdoutSK
     - stdout
-# for output to 'journald' add this scribe:
-#  - - JournalSK
-#    - cardano
 
 # more options which can be passed as key-value pairs:
 options:
+  # for output to 'journald', map these TextualRepresentation traces:
+  # mapScribes:
+  #   cardano.node.text:
+  #     - JournalSK::cardano
   mapSubtrace:
     benchmark:
       contents:


### PR DESCRIPTION
1. factor the traces a bit
2. duplicate critical `StructuredLogging` traces as `TextualRepresentation` in the `cardano.node.text` namespace
3. provide an example of how to route those to `JournalSK` using `mapScribes`


# Motivation

Currently `StructuredLogging`-based traces are only rendered into `JournalSK` via the `PAYLOAD` field, with the `MESSAGE` field being empty.

Considerations:

1. MESSAGE being empty is very inconvenient for operational reasons, because the default journal view is rendered such that there's nothing to see in the logs.
2. Doing both renderings for all messages always is costly. Devops only really care for a subset of messages:
  - block being adopted
  - tx received
  - creating a block
  - other chain altering states (like update proposals)

# Sample of JournalSK log output

Note that the log configuration is fairly indiscriminate, as per the example, so more events are included than what @disassembler originally requested:

```
setupScribes:
  - scKind: JournalSK
    scName: "cardano"
    scFormat: ScText
...
  mapScribes:
    cardano.node.text:
      - JournalSK::cardano
```
..yields..:

```
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] TraceImmDBEvent
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Opened imm db with immutable tip at Origin and epoch EpochNo {unEpochNo = 0}
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Opened vol db
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Opened lgr db
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Opened db with immutable tip at Origin and tip Origin
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Chain added block (Point 0, 9a5d2b81827dccec)
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Block fits onto the current chain: (Point 0, 9a5d2b81827dccec)
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Valid candidate (Point 0, 9a5d2b81827dccec)
Feb 21 19:42:29 andromedae cardano[6332]: [genesis (origin)] Chain changed, new tip: (Point 0, 9a5d2b81827dccec)
Feb 21 19:42:29 andromedae cardano[6332]: [9a5d2b8@0] New reader was created

Feb 21 19:42:49 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 1})
Feb 21 19:42:49 andromedae cardano[6332]: TraceNodeNotLeader (SlotNo {unSlotNo = 1})
Feb 21 19:42:49 andromedae cardano[6332]: [9a5d2b8@0] Chain added block (Point 1, a5f246f909cd1883)
Feb 21 19:42:49 andromedae cardano[6332]: [9a5d2b8@0] Block fits onto the current chain: (Point 1, a5f246f909cd1883)
Feb 21 19:42:49 andromedae cardano[6332]: [9a5d2b8@0] Valid candidate (Point 1, a5f246f909cd1883)
Feb 21 19:42:49 andromedae cardano[6332]: [9a5d2b8@0] Chain changed, new tip: (Point 1, a5f246f909cd1883)
Feb 21 19:42:49 andromedae cardano[6332]: [a5f246f@1] New reader was created
Feb 21 19:42:50 andromedae systemd[1]: NetworkManager-dispatcher.service: Succeeded.
Feb 21 19:43:09 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 2})
Feb 21 19:43:09 andromedae cardano[6332]: TraceNodeNotLeader (SlotNo {unSlotNo = 2})
Feb 21 19:43:09 andromedae cardano[6332]: [a5f246f@1] Chain added block (Point 2, ebb546bb3880b2e4)
Feb 21 19:43:09 andromedae cardano[6332]: [a5f246f@1] Block fits onto the current chain: (Point 2, ebb546bb3880b2e4)
Feb 21 19:43:09 andromedae cardano[6332]: [a5f246f@1] Valid candidate (Point 2, ebb546bb3880b2e4)
Feb 21 19:43:09 andromedae cardano[6332]: [a5f246f@1] Chain changed, new tip: (Point 2, ebb546bb3880b2e4)
Feb 21 19:43:29 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 3})
Feb 21 19:43:29 andromedae cardano[6332]: TraceNodeNotLeader (SlotNo {unSlotNo = 3})
Feb 21 19:43:49 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 4})
Feb 21 19:43:49 andromedae cardano[6332]: TraceNodeNotLeader (SlotNo {unSlotNo = 4})
Feb 21 19:44:09 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 5})
Feb 21 19:44:09 andromedae cardano[6332]: TraceNodeNotLeader (SlotNo {unSlotNo = 5})
Feb 21 19:44:29 andromedae cardano[6332]: TraceStartLeadershipCheck (SlotNo {unSlotNo = 6})
Feb 21 19:44:29 andromedae cardano[6332]: TraceNodeIsLeader (SlotNo {unSlotNo = 6})
Feb 21 19:44:29 andromedae cardano[6332]: TraceForgedBlock (SlotNo {unSlotNo = 6}) (ByronBlock {byronBlockRaw = ABOBBlock (ABlock {blockHeader = AHeader {aHeaderProtocolMagicId = Annotated {unAnnotated = ProtocolMagicId {unProtocolMagicId = 459045235}, annotation = "\SUB\ESC\\ys"}, aHeaderPrevHash = Annotated {unAnnotated = AbstractHash ebb546bb3880b2e46f0c833bca2a70efb220bf241cd51980cd63d019ecf99d90, annotation = "X \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144"}, aHeaderSlot = Annotated {unAnnotated = SlotNumber {unSlotNumber = 6}, annotation = "\130\NUL\ACK"}, aHeaderDifficulty = Annotated {unAnnotated = ChainDifficulty {unChainDifficulty = 3}, annotation = "\129\ETX"}, headerProtocolVersion = 0.2.0, headerSoftwareVersion = cardano-sl:1, aHeaderProof = Annotated {unAnnotated = Proof {proofUTxO = TxProof {txpNumber = 0, txpRoot = MerkleRoot {getMerkleRoot = AbstractHash 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8}, txpWitnessesHash = AbstractHash afc0da64183bf2664f3d4eec7238d524ba607faeeab24fc100eb861dba69971b}, proofSsc = SscProof, proofDelegation = AbstractHash afc0da64183bf2664f3d4eec7238d524ba607faeeab24fc100eb861dba69971b, proofUpdate = AbstractHash 4e66280cd94d591072349bec0a3090a53aa945562efb6d08d56e53654b0e4098}, annotation = "\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152"}, headerGenesisKey = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ")\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3", xpubChaincode = ChainCode "\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233"}}, headerSignature = ABlockSignature {delegationCertificate = UnsafeACertificate {aEpoch = Annotated {unAnnotated = EpochNumber {getEpochNumber = 0}, annotation = "\NUL"}, issuerVK = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ")\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3", xpubChaincode = ChainCode "\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233"}}, delegateVK = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ">\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H", xpubChaincode = ChainCode "\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^e"}}, signature = Signature (XSignature {unXSignature = "33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETX"}), annotation = "\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETX"}, signature = Signature (XSignature {unXSignature = "b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO"})}, headerAnnotation = "\133\SUB\ESC\\ysX \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152\132\130\NUL\ACKX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233\129\ETX\130\STX\130\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETXX@b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223", headerExtraAnnotation = "\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223"}, blockBody = ABody {bodyTxPayload = ATxPayload {aUnTxPayload = []}, bodySscPayload = SscPayload, bodyDlgPayload = UnsafeAPayload {getPayload = [], getAnnotation = "\159\255"}, bodyUpdatePayload = APayload {payloadProposal = Nothing, payloadVotes = [], payloadAnnotation = "\130\128\159\255"}}, blockAnnotation = "\131\133\SUB\ESC\\ysX \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152\132\130\NUL\ACKX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233\129\ETX\130\STX\130\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETXX@b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223\132\159\255\130\ETX\217\SOH\STX\128\159\255\130\128\159\255\129\160"}), byronBlockSlotNo = SlotNo {unSlotNo = 6}, byronBlockHash = ByronHash {unByronHash = AbstractHash a782b4635f25e604aa4eae235f878efa8a534e00977ad28d8a1511c526140971}}) (MempoolSize {msNumTxs = 0, msNumBytes = 0})
Feb 21 19:44:29 andromedae cardano[6332]: [ebb546b@2] Chain added block (Point 6, a782b4635f25e604)
Feb 21 19:44:29 andromedae cardano[6332]: [ebb546b@2] Block fits onto the current chain: (Point 6, a782b4635f25e604)
Feb 21 19:44:29 andromedae cardano[6332]: [ebb546b@2] Valid candidate (Point 6, a782b4635f25e604)
Feb 21 19:44:29 andromedae cardano[6332]: [ebb546b@2] Chain changed, new tip: (Point 6, a782b4635f25e604)
Feb 21 19:44:29 andromedae cardano[6332]: TraceAdoptedBlock (SlotNo {unSlotNo = 6}) (ByronBlock {byronBlockRaw = ABOBBlock (ABlock {blockHeader = AHeader {aHeaderProtocolMagicId = Annotated {unAnnotated = ProtocolMagicId {unProtocolMagicId = 459045235}, annotation = "\SUB\ESC\\ys"}, aHeaderPrevHash = Annotated {unAnnotated = AbstractHash ebb546bb3880b2e46f0c833bca2a70efb220bf241cd51980cd63d019ecf99d90, annotation = "X \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144"}, aHeaderSlot = Annotated {unAnnotated = SlotNumber {unSlotNumber = 6}, annotation = "\130\NUL\ACK"}, aHeaderDifficulty = Annotated {unAnnotated = ChainDifficulty {unChainDifficulty = 3}, annotation = "\129\ETX"}, headerProtocolVersion = 0.2.0, headerSoftwareVersion = cardano-sl:1, aHeaderProof = Annotated {unAnnotated = Proof {proofUTxO = TxProof {txpNumber = 0, txpRoot = MerkleRoot {getMerkleRoot = AbstractHash 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8}, txpWitnessesHash = AbstractHash afc0da64183bf2664f3d4eec7238d524ba607faeeab24fc100eb861dba69971b}, proofSsc = SscProof, proofDelegation = AbstractHash afc0da64183bf2664f3d4eec7238d524ba607faeeab24fc100eb861dba69971b, proofUpdate = AbstractHash 4e66280cd94d591072349bec0a3090a53aa945562efb6d08d56e53654b0e4098}, annotation = "\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152"}, headerGenesisKey = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ")\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3", xpubChaincode = ChainCode "\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233"}}, headerSignature = ABlockSignature {delegationCertificate = UnsafeACertificate {aEpoch = Annotated {unAnnotated = EpochNumber {getEpochNumber = 0}, annotation = "\NUL"}, issuerVK = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ")\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3", xpubChaincode = ChainCode "\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233"}}, delegateVK = VerificationKey {unVerificationKey = XPub {xpubPublicKey = ">\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H", xpubChaincode = ChainCode "\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^e"}}, signature = Signature (XSignature {unXSignature = "33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETX"}), annotation = "\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETX"}, signature = Signature (XSignature {unXSignature = "b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO"})}, headerAnnotation = "\133\SUB\ESC\\ysX \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152\132\130\NUL\ACKX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233\129\ETX\130\STX\130\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETXX@b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223", headerExtraAnnotation = "\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223"}, blockBody = ABody {bodyTxPayload = ATxPayload {aUnTxPayload = []}, bodySscPayload = SscPayload, bodyDlgPayload = UnsafeAPayload {getPayload = [], getAnnotation = "\159\255"}, bodyUpdatePayload = APayload {payloadProposal = Nothing, payloadVotes = [], payloadAnnotation = "\130\128\159\255"}}, blockAnnotation = "\131\133\SUB\ESC\\ysX \235\181F\187\&8\128\178\228o\f\131;\202*p\239\178 \191$\FS\213\EM\128\205c\208\EM\236\249\157\144\132\131\NULX \SOWQ\192&\229C\178\232\171.\176`\153\218\161\209\229\223Gw\143w\135\250\171E\205\241/\227\168X \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESC\130\ETXX \211j&\EM\166rIF\EOT\225\ESC\180G\203\207R1\233\242\186%\194\SYN\145w\237\201A\189P\173lX \175\192\218d\CAN;\242fO=N\236r8\213$\186`\DEL\174\234\178O\193\NUL\235\134\GS\186i\151\ESCX Nf(\f\217MY\DLEr4\155\236\n0\144\165:\169EV.\251m\b\213nSeK\SO@\152\132\130\NUL\ACKX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233\129\ETX\130\STX\130\132\NULX@)\177\SI\213\194 O\226\DC3\DC4\US\254\138\204Pa?\178\&7D\248\237a\211g\141\224\190\f\188\145\DC3\137\183\223\203\177\253\185\146\156Q5O\192\SYN\197\222\np\DC1~|\US!\253\169\nD\220h\237s\233X@>\201\197N\234\t\186\142'\136{c|\243\166\202\223\158(rwA\202\240\181\134\144\128i\f\DC1H\FS\151\FS\GS\\Cb^\214\\l\199\163\212\234P\247\252XV\NAK\195\ETB]\209\164D\195\163g^eX@33z\238\173\220\232# \CAN\171\147\151\187\231\&0\US\231\165\&3\252W\201\DLE\ENQ\234=\196-\242\169\202>C\157o;i\181Q\213d 5\239\190w\254\SUB\241\STXS\EOTH\231\207guq\177\186\254\249\ETXX@b\ETX\198\v\208\175\228\186\142V+H\179\215\184\136\149eg\US\224w\253A\166\CANgcx~\DC1\150H\224\SOH\210\214\247H\155\&3\215k\179v\148\239q\247\159_\138\227\SYN\EOT\217\181S0\160\189\ETXj\SO\132\131\NUL\STX\NUL\130jcardano-sl\SOH\160X K\169*\163 \198\n\204\154\215\185\166O.\218U\196\210\236(\230\EOT\250\241\134p\139O\fN\142\223\132\159\255\130\ETX\217\SOH\STX\128\159\255\130\128\159\255\129\160"}), byronBlockSlotNo = SlotNo {unSlotNo = 6}, byronBlockHash = ByronHash {unByronHash = AbstractHash a782b4635f25e604aa4eae235f878efa8a534e00977ad28d8a1511c526140971}}) []
```

# Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] This PR results in breaking changes to upstream dependencies.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
