### PR TITLE
Get local node tip information

### DIFF
--- a/cardano-node/README.md
+++ b/cardano-node/README.md
@@ -282,6 +282,23 @@ source and target signing keys and lovelace value to send.
 The target address defaults to the 1-st richman key (`configuration/delegate-keys.001.key`)
 of the testnet, and lovelace amount is almost the entirety of its funds.
 
+# Local node queries
+
+You can query the tip of your local node via the `get-tip` command as follows
+
+1. Open `tmux`
+2. Run `cabal build cardano-node`
+3. Run `./scripts/shelley-testnet-live.sh`
+4. `cabal exec cardano-cli -- get-tip --config configuration/log-config-0.liveview.yaml --genesis-json configuration/genesis/genesis.json --socket-path socket/0`
+
+You will see output from stdout in this format:
+```
+Current tip:
+Block hash: 4ab21a10e1b25e39
+Slot: 6
+Block number: 5
+```
+
 # Development
 
 run *ghcid* with: `ghcid -c "cabal v2-repl exe:cardano-node --reorder-goals"`

--- a/cardano-node/app/cardano-cli.hs
+++ b/cardano-node/app/cardano-cli.hs
@@ -49,5 +49,6 @@ parseClientCommand =
           <|> parseKeyRelatedValues
           <|> parseDelegationRelatedValues
           <|> parseTxRelatedValues
+          <|> parseLocalNodeQueryValues
           <|> parseBenchmarkingCommands
           )

--- a/cardano-node/src/Cardano/CLI/Genesis.hs
+++ b/cardano-node/src/Cardano/CLI/Genesis.hs
@@ -17,7 +17,7 @@ import           Test.Cardano.Prelude (canonicalDecodePretty)
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra
-                   (hoistEither,left, right)
+                   (hoistEither, left, right)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString)

--- a/cardano-node/src/Cardano/CLI/Genesis.hs
+++ b/cardano-node/src/Cardano/CLI/Genesis.hs
@@ -6,9 +6,8 @@
 module Cardano.CLI.Genesis
   ( NewDirectory(..)
   , GenesisParameters(..)
-  , mkGenesis
-  , readGenesis
   , dumpGenesis
+  , mkGenesis
   )
 where
 
@@ -17,8 +16,8 @@ import           Cardano.Prelude hiding (option, show, trace)
 import           Test.Cardano.Prelude (canonicalDecodePretty)
 
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (hoistEither, firstExceptT,
-                                                   left, right)
+import           Control.Monad.Trans.Except.Extra
+                   (hoistEither,left, right)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString)
@@ -43,7 +42,6 @@ import qualified Cardano.Crypto as Crypto
 
 import           Cardano.CLI.Key
 import           Cardano.CLI.Ops
-import           Cardano.Config.Types (GenesisFile(..))
 
 
 newtype NewDirectory =
@@ -113,10 +111,6 @@ mkGenesis gp = do
 
   withExceptT GenesisGenerationError $
     Genesis.generateGenesisData (gpStartTime gp) genesisSpec
-
--- | Read genesis from a file.
-readGenesis :: GenesisFile -> ExceptT CliError IO (Genesis.GenesisData, Genesis.GenesisHash)
-readGenesis (GenesisFile fp) = firstExceptT (GenesisReadError fp) $ Genesis.readGenesisData fp
 
 -- | Write out genesis into a directory that must not yet exist.  An error is
 -- thrown if the directory already exists, or the genesis has delegate keys that

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -366,7 +366,6 @@ localInitiatorNetworkApplication proxy pInfoConfig =
   localTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) DeserialiseFailure m LB.ByteString
   localTxSubmissionCodec = pcLocalTxSubmissionCodec . protocolCodecs pInfoConfig $ mostRecentNetworkProtocolVersion proxy
 
-
 chainSyncClient
   :: forall blk m . (Condense (HeaderHash blk), MonadIO m)
   => ChainSyncClient (Serialised blk) (Tip blk) m ()

--- a/cardano-node/src/Cardano/CLI/Parsers.hs
+++ b/cardano-node/src/Cardano/CLI/Parsers.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Parsers
   , parseGenesisParameters
   , parseGenesisRelatedValues
   , parseKeyRelatedValues
+  , parseLocalNodeQueryValues
   , parseRequiresNetworkMagic
   , parseTxRelatedValues
   ) where
@@ -29,18 +30,21 @@ import           Cardano.CLI.Run
 import           Cardano.Common.Parsers
 
 import           Cardano.Binary (Annotated(..))
-import           Cardano.Chain.Common ( Address(..), BlockCount(..), Lovelace
-                                      , NetworkMagic(..), decodeAddressBase58
-                                      , mkLovelace, rationalToLovelacePortion)
+import           Cardano.Chain.Common
+                   (Address(..), BlockCount(..), Lovelace
+                   , NetworkMagic(..), decodeAddressBase58
+                   , mkLovelace, rationalToLovelacePortion)
 import           Cardano.Chain.Genesis (FakeAvvmOptions(..), TestnetBalanceOptions(..))
 import           Cardano.Chain.Slotting (EpochNumber(..))
 import           Cardano.Chain.UTxO (TxId, TxIn(..), TxOut(..))
 import           Cardano.Config.CommonCLI
-import           Cardano.Config.Types ( DelegationCertFile(..), GenesisFile(..)
-                                      , NodeAddress(..), NodeHostAddress(..), SigningKeyFile(..))
+import           Cardano.Config.Types
+                   (ConfigYamlFilePath(..), DelegationCertFile(..), GenesisFile(..)
+                   , NodeAddress(..), NodeHostAddress(..), SigningKeyFile(..))
 import           Cardano.Crypto (RequiresNetworkMagic(..), decodeHash)
-import           Cardano.Crypto.ProtocolMagic ( AProtocolMagic(..), ProtocolMagic
-                                              , ProtocolMagicId(..))
+import           Cardano.Crypto.ProtocolMagic
+                   (AProtocolMagic(..), ProtocolMagic
+                   , ProtocolMagicId(..))
 
 
 -- | See the rationale for cliParseBase58Address.
@@ -289,6 +293,17 @@ parseKeyRelatedValues =
                 <*> parseSigningKeyFile "from" "Signing key file to migrate."
                 <*> parseProtocol -- New protocol
                 <*> parseNewSigningKeyFile "to"
+        ]
+parseLocalNodeQueryValues :: Parser ClientCommand
+parseLocalNodeQueryValues =
+  subparser $ mconcat
+        [ commandGroup "Local node related commands"
+        , metavar "Local node related commands"
+        , command' "get-tip" "Get the tip of your local node's blockchain"
+            $ GetLocalNodeTip
+                <$> (ConfigYamlFilePath <$> parseConfigFile)
+                <*> parseGenesisFile "genesis-json"
+                <*> parseSocketPath "Socket of target node"
         ]
 
 parseLovelace :: String -> String -> Parser Lovelace

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -190,6 +190,7 @@ data ClientCommand
     (Maybe ExplorerAPIEnpoint)
     [SigningKeyFile]
    deriving Show
+
 runCommand :: ClientCommand -> ExceptT CliError IO ()
 runCommand (Genesis outDir params ptcl) = do
   gen <- mkGenesis params
@@ -375,8 +376,3 @@ ensureNewFile writer outFile blob = do
 
 ensureNewFileLBS :: FilePath -> LB.ByteString -> IO ()
 ensureNewFileLBS = ensureNewFile LB.writeFile
-
-getGenesisHash :: GenesisFile -> ExceptT CliError IO Text
-getGenesisHash genFile = do
-  (_, Genesis.GenesisHash gHash) <- readGenesis genFile
-  return $ F.sformat Crypto.hashHexF gHash

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -61,22 +61,19 @@ import           Cardano.CLI.Key
 import           Cardano.CLI.Ops
 import           Cardano.CLI.Tx
 import           Cardano.CLI.Benchmarking.Tx.Generation
-                   ( ExplorerAPIEnpoint (..)
-                   , NumberOfTxs (..)
-                   , NumberOfInputsPerTx (..)
-                   , NumberOfOutputsPerTx (..)
-                   , FeePerTx (..), TPSRate (..)
-                   , TxAdditionalSize (..)
-                   , genesisBenchmarkRunner
-                   )
+                   (ExplorerAPIEnpoint (..), NumberOfTxs (..)
+                   , NumberOfInputsPerTx (..), NumberOfOutputsPerTx (..)
+                   , FeePerTx (..), TPSRate (..), TxAdditionalSize (..)
+                   , genesisBenchmarkRunner)
 import           Cardano.Common.Orphans ()
 import           Cardano.Config.Protocol
 import           Cardano.Config.Logging (createLoggingFeatureCLI)
-import           Cardano.Config.Types ( CardanoEnvironment(..), DelegationCertFile(..)
-                                      , GenesisFile(..), LastKnownBlockVersion(..)
-                                      , NodeAddress(..), NodeConfiguration(..)
-                                      , SigningKeyFile(..), SocketPath(..), Update(..)
-                                      , parseNodeConfigurationFP)
+import           Cardano.Config.Types
+                   (CardanoEnvironment(..), ConfigYamlFilePath(..)
+                   , DelegationCertFile(..), GenesisFile(..)
+                   , LastKnownBlockVersion(..), NodeAddress(..)
+                   , NodeConfiguration(..), SigningKeyFile(..)
+                   , SocketPath(..), Update(..), parseNodeConfigurationFP)
 
 -- | Sub-commands of 'cardano-cli'.
 data ClientCommand
@@ -138,6 +135,11 @@ data ClientCommand
     VerificationKeyFile
     VerificationKeyFile
 
+  | GetLocalNodeTip
+    ConfigYamlFilePath
+    GenesisFile
+    SocketPath
+
     -----------------------------------
 
   | SubmitTx
@@ -196,9 +198,13 @@ runCommand (Genesis outDir params ptcl) = do
   gen <- mkGenesis params
   dumpGenesis ptcl outDir `uncurry` gen
 
+runCommand (GetLocalNodeTip configFp gFile sockPath) = do
+  liftIO $ getLocalTip configFp gFile sockPath
+
 runCommand (PrettySigningKeyPublic ptcl skF) = do
   sK <- readSigningKey ptcl skF
   liftIO . putTextLn . prettyPublicKey $ Crypto.toVerification sK
+
 runCommand (MigrateDelegateKeyFrom oldPtcl oldKey newPtcl (NewSigningKeyFile newKey)) = do
   sk <- readSigningKey oldPtcl oldKey
   sDk <- hoistEither $ serialiseDelegateKey newPtcl sk


### PR DESCRIPTION
Issue
-----------

- #541 
- This PR adds a `get-tip` command to `cardano-cli` that retrieves the tip from your local node  (via its socket) and prints to stdout in the following format: e.g

```
Current tip:
Blockhash: 4ab21a1
Slot: 6
Block number: 5
```

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] This PR results in breaking changes to upstream dependencies.

- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
