### PR TITLE
CAD-328 context name in Trace; adaptations to upstream changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -128,57 +128,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   plugins/backend-editor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 479c1718ab85761ae72d13c559b12227c8837748
-  --sha256: 090r44w11lapsvbll4diak7zmim1rcy16yjf6mc30fy92185mr4r
+  tag: 53388e73eb4421df3896deedd51056a3aa880b3b
+  --sha256: 1y8a8zcxc50g640bnlpagi0z6gjf5dd60d89f3w93ch95v70hyci
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cardano-node/app/wallet-client.hs
+++ b/cardano-node/app/wallet-client.hs
@@ -5,10 +5,9 @@
 
 import           Cardano.Prelude hiding (option)
 
-import           Control.Tracer
 import           Options.Applicative
 
-import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Trace
 import           Cardano.Shell.Lib (runCardanoApplicationWithFeatures)
 import           Cardano.Shell.Types (CardanoApplication (..),
                                       CardanoFeature (..))
@@ -101,6 +100,6 @@ createNodeFeature loggingLayer cli cardanoEnvironment = do
   where
     featureStart' :: CardanoEnvironment -> LoggingLayer -> WalletCLI -> IO NodeLayer
     featureStart' _ loggingLayer' walletCli = do
-        let tr :: MonadIO m => Tracer m (Cardano.BM.Data.LogItem.LogObject Text)
+        let tr :: MonadIO m => Trace m Text
             tr = llAppendName loggingLayer "wallet" (llBasicTrace loggingLayer')
         pure $ NodeLayer {nlRunNode = liftIO $ runClient walletCli tr}

--- a/cardano-node/src/Cardano/CLI/Benchmarking/Tx/NodeToNode.hs
+++ b/cardano-node/src/Cardano/CLI/Benchmarking/Tx/NodeToNode.hs
@@ -177,11 +177,8 @@ instance Transformable Text IO (SendRecvTxSubmission ByronBlock) where
             -- Add a timestamp in 'ToObject'-representation.
             HM.insert "time" (String (T.pack . show $ currentTime)) obj
       tracer = if obj == emptyObject then nullTracer else tr
-    traceWith tracer =<<
-      LogObject
-        <$> pure mempty
-        <*> mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg)
-        <*> pure (LogStructured updatedObj)
+    meta <- mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg)
+    traceWith tracer (mempty, LogObject mempty meta (LogStructured updatedObj))
   trTransformer _ _verb _tr = nullTracer
 
 --------------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -46,9 +46,10 @@ import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.BackendKind (BackendKind (..))
 #endif
-import           Cardano.BM.Data.LogItem (LogObject (..))
 import           Cardano.BM.Data.Tracer (ToLogObject (..),
-                     TracingVerbosity (..), setHostname)
+                     TracingVerbosity (..))
+import           Cardano.BM.Data.Transformers (setHostname)
+import           Cardano.BM.Trace
 import           Cardano.Config.Logging (LoggingLayer (..))
 import           Cardano.Config.Types (MiscellaneousFilepaths(..),
                                        NodeConfiguration (..), ViewMode (..))
@@ -155,7 +156,7 @@ runNode loggingLayer npm = do
 handleSimpleNode
   :: forall blk. RunNode blk
   => Consensus.Protocol blk
-  -> Tracer IO (LogObject Text)
+  -> Trace IO Text
   -> Tracers ConnectionId blk
   -> NodeProtocolMode
   -> (NodeKernel IO ConnectionId blk -> IO ())

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -257,7 +257,7 @@ instance IsEffectuator (LiveViewBackend blk) Text where
         checkForUnexpectedThunks ["IsEffectuator LiveViewBackend"] lvbe
 
         case item of
-            LogObject ["cardano","node","metrics"] meta content -> do
+            LogObject "cardano.node.metrics" meta content -> do
                 case content of
                     LogValue "Mem.resident" (PureI pages) ->
                         let !mbytes     = fromIntegral (pages * pagesize) / 1024 / 1024 :: Float

--- a/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
+++ b/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
@@ -30,8 +30,8 @@ import           Control.Monad.Class.MonadTime (DiffTime, Time (..), diffTime,
 import           Data.Aeson (Value (..), toJSON, (.=))
 import           Data.Time.Clock (diffTimeToPicoseconds)
 
-import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity (Severity (..))
+import           Cardano.BM.Data.Trace
 import           Cardano.BM.Data.Tracer
 
 import           Control.Tracer.Transformers.ObserveOutcome
@@ -81,7 +81,7 @@ instance ToObject (MeasureTxs blk) where
 
 -- | Transformer for the start of the transaction, when the transaction was added
 -- to the mempool.
-measureTxsStart :: forall blk. Tracer IO (LogObject Text) -> Tracer IO (TraceEventMempool blk)
+measureTxsStart :: forall blk. Trace IO Text -> Tracer IO (TraceEventMempool blk)
 measureTxsStart tracer = measureTxsStartInter $ toLogObject tracer
   where
     measureTxsStartInter :: Tracer IO (MeasureTxs blk) -> Tracer IO (TraceEventMempool blk)
@@ -102,7 +102,7 @@ measureTxsStart tracer = measureTxsStartInter $ toLogObject tracer
 
 -- | Transformer for the end of the transaction, when the transaction was added to the
 -- block and the block was forged.
-measureTxsEnd :: forall blk. Tracer IO (LogObject Text) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
+measureTxsEnd :: forall blk. Trace IO Text -> Tracer IO (TraceForgeEvent blk (GenTx blk))
 measureTxsEnd tracer = measureTxsEndInter $ toLogObject tracer
   where
     measureTxsEndInter :: Tracer IO (MeasureTxs blk) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
@@ -205,7 +205,7 @@ instance ToObject (MeasureBlockForging blk) where
 
 -- | Transformer for the start of the block forge, when the current slot is the slot of the
 -- node and the protocol starts.
-measureBlockForgeStart :: Tracer IO (LogObject Text) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
+measureBlockForgeStart :: Trace IO Text -> Tracer IO (TraceForgeEvent blk (GenTx blk))
 measureBlockForgeStart tracer = measureBlockForgeStartInter $ toLogObject tracer
   where
     measureBlockForgeStartInter :: Tracer IO (MeasureBlockForging blk) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
@@ -215,7 +215,7 @@ measureBlockForgeStart tracer = measureBlockForgeStartInter $ toLogObject tracer
         _ -> pure ()
 
 -- | Transformer for the end of the block forge, when the block was created/forged.
-measureBlockForgeEnd :: Tracer IO (LogObject Text) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
+measureBlockForgeEnd :: Trace IO Text -> Tracer IO (TraceForgeEvent blk (GenTx blk))
 measureBlockForgeEnd tracer = measureTxsEndInter $ toLogObject tracer
   where
     measureTxsEndInter :: Tracer IO (MeasureBlockForging blk) -> Tracer IO (TraceForgeEvent blk (GenTx blk))

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -449,10 +449,9 @@ instance (Condense (HeaderHash blk), ProtocolLedgerView blk)
   -- structure required, will call 'toObject'
   trTransformer StructuredLogging verb tr = trStructured verb tr
   -- textual output based on the readable ChainDB tracer
-  trTransformer TextualRepresentation _verb tr = readableChainDBTracer $ Tracer $ \s ->
-    traceWith tr =<< LogObject <$> pure mempty
-                               <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-                               <*> pure (LogMessage $ pack s)
+  trTransformer TextualRepresentation _verb tr = readableChainDBTracer $ Tracer $ \s -> do
+    meta <- mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+    traceWith tr (mempty, LogObject mempty meta (LogMessage $ pack s))
   -- user defined formatting of log output
   trTransformer UserdefinedFormatting verb tr = trStructured verb tr
   -- trTransformer _ verb tr = trStructured verb tr

--- a/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-node/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -229,12 +229,9 @@ defaultTextTransformer
   -> Trace m Text
   -> Tracer m b
 defaultTextTransformer TextualRepresentation _verb tr =
-  Tracer $ \s ->
-    traceWith tr =<<
-    LogObject
-      <$> pure mempty
-      <*> mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
-      <*> pure (LogMessage $ pack $ show s)
+  Tracer $ \s -> do
+    meta <- mkLOMeta (defineSeverity s) (definePrivacyAnnotation s)
+    traceWith tr (mempty, LogObject mempty meta (LogMessage $ pack $ show s))
 defaultTextTransformer _ verb tr =
   trStructured verb tr
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -98,7 +98,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 479c1718ab85761ae72d13c559b12227c8837748
+    commit: 53388e73eb4421df3896deedd51056a3aa880b3b
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION

Issue
-----------

- adaptations to upstream changes in iohk-monitoring fw; context name is kept in 'Trace'

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
