### PR TITLE
Add conditional build for chairman and wallet-client

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -424,6 +424,10 @@ that this is vague so use your discretion.
 Cabal file formatting
 ---------------------
 
+### Flags
+
+All Cabal `Flags` should use `lowercase_separated_by_underscores` naming convention.
+
 ### Modules & libraries
 
 Modules and libraries should go in alphabetical order inside corresponding

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -15,6 +15,16 @@ Flag unexpected_thunks
   Description:   Turn on unexpected thunks checks
   Default:       False
 
+Flag with_wallet_client
+  Description:   Turn on wallet-client build
+  Default:       True
+  Manual:        True
+
+Flag with_chairman
+  Description:   Turn on chairman build
+  Default:       True
+  Manual:        True
+
 library
 
   if flag(unexpected_thunks)
@@ -161,7 +171,27 @@ executable cardano-node
   else
      build-depends:    unix
 
+executable cardano-cli
+  hs-source-dirs:      app
+  main-is:             cardano-cli.hs
+  default-language:    Haskell2010
+  ghc-options:         -threaded
+                       -Wall
+                       -rtsopts
+                       "-with-rtsopts=-T"
+  build-depends:       base >=4.12 && <5
+                     , cardano-prelude
+                     , cardano-node
+                     , optparse-applicative
+                     , transformers-except
+
+  default-extensions:  NoImplicitPrelude
+
 executable wallet-client
+  if flag(with_wallet_client)
+    buildable: True
+  else
+    buildable: False
   hs-source-dirs:      app
   main-is:             wallet-client.hs
   default-language:    Haskell2010
@@ -192,23 +222,11 @@ executable wallet-client
   else
      build-depends:    unix
 
-executable cardano-cli
-  hs-source-dirs:      app
-  main-is:             cardano-cli.hs
-  default-language:    Haskell2010
-  ghc-options:         -threaded
-                       -Wall
-                       -rtsopts
-                       "-with-rtsopts=-T"
-  build-depends:       base >=4.12 && <5
-                     , cardano-prelude
-                     , cardano-node
-                     , optparse-applicative
-                     , transformers-except
-
-  default-extensions:  NoImplicitPrelude
-
 executable chairman
+  if flag(with_chairman)
+    buildable: True
+  else
+    buildable: False
   hs-source-dirs:      app
   main-is:             chairman.hs
   default-language:    Haskell2010


### PR DESCRIPTION
- Add Cabal flags `with_wallet_client`, `with_chairman` and default to `True` so any existing workflows won't break

Issue
-----------

- Not linked to existing GH issue

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [X] This PR contains all the work required to resolve the linked issue.

- [X] The work has sufficient tests and/or testing.
- [X] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.
- [ ] The work contained has sufficient documentation to describe what it does and how to do it.



- [ ] I have added the appropriate labels to this PR.

Notes
---------
The documentation for introduced build features will be part of updated `README.md`, which will follow in later PR, it's main focus will be on a `build` & `install` process where the use of introduced Cabal flags will be exampled using Haskell Stack build workflow.

```
stack install \
      --flag cardano-node:-with_wallet_client \
      --flag cardano-node:-with_chairman \
      --local-bin-path=/usr/local/bin
```

Feature works as expected:
```
(haskell-stack)[root@b1d8ceb78368 /usr/src/cardano-node]$ stack install \
>       --flag cardano-node:-with_wallet_client \
>       --flag cardano-node:-with_chairman \
>       --local-bin-path=/usr/local/bin
Copying from /usr/src/cardano-node/.stack-work/install/x86_64-linux-tinfo6/52f54515c28b861e71eecbd2833614d279f5c277005e7e1fb11b6911d7cda8d2/8.6.5/bin/cardano-cli to /usr/lo
cal/bin/cardano-cli
Copying from /usr/src/cardano-node/.stack-work/install/x86_64-linux-tinfo6/52f54515c28b861e71eecbd2833614d279f5c277005e7e1fb11b6911d7cda8d2/8.6.5/bin/cardano-node to /usr/l
ocal/bin/cardano-node

Copied executables to /usr/local/bin:
- cardano-cli
- cardano-node
(haskell-stack)[root@b1d8ceb78368 /usr/src/cardano-node]$
```