### PR TITLE
dockerImage: better UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ logs/
 /benchmarking/chain-sync/state-node-mainnet/
 
 tags
+/config
+/data

--- a/default.nix
+++ b/default.nix
@@ -27,9 +27,16 @@ let
     inherit pkgs;
   };
 
-  dockerImage = pkgs.callPackage ./nix/docker.nix {
+  dockerImage = let
+    defaultConfig = rec {
+      stateDir = "/data";
+      dbPrefix = "db";
+      socketPath = stateDir + "/node.socket";
+    };
+    customConfig' = defaultConfig // customConfig;
+  in pkgs.callPackage ./nix/docker.nix {
     inherit (self) cardano-node;
-    inherit scripts;
+    scripts = callPackage ./nix/scripts.nix { customConfig = customConfig'; };
   };
 
   self = {

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -21,7 +21,7 @@ let
       signingKey = null;
       delegationCertificate = null;
       nodeId = 0;
-      stateDir = "./";
+      stateDir = "state-node-${envConfig.name}";
       # defaults to proxy if env has no relays
       edgeHost = "127.0.0.1";
       edgeNodes = [];
@@ -31,6 +31,7 @@ let
       proxyHost = "127.0.0.1";
       loggingExtras = null;
       tracingVerbosity = "normal";
+      dbPrefix = "db-${envConfig.name}";
     } // (builtins.removeAttrs envConfig ["nodeConfig"]);
 
     nodeConfig = (envConfig.nodeConfig or environments.mainnet.nodeConfig)
@@ -60,9 +61,9 @@ let
         port
         nodeConfig
         nodeId
+        dbPrefix
         tracingVerbosity;
       runtimeDir = null;
-      dbPrefix = "db-${envConfig.name}";
       topology = topologyFile;
       nodeConfigFile = "${__toFile "config-${toString config.nodeId}.json" (__toJSON (svcLib.mkNodeConfig config config.nodeId))}";
     };
@@ -79,8 +80,7 @@ let
   in pkgs.writeScript "cardano-node-${envConfig.name}" ''
     #!${pkgs.runtimeShell}
     set -euo pipefail
-    mkdir -p "state-node-${envConfig.name}"
-    cd "state-node-${envConfig.name}"
+    mkdir -p "${config.stateDir}"
     ${nodeScript} $@
   '';
   scripts = forEnvironments (environment:


### PR DESCRIPTION
* creates a single docker image with a wrapper script
* supports mainnet/testnet or a custom config from same image
* alters nix/scripts to not need to cd into the state directory

To launch mainnet and keep state in a persistent docker volume run:
  `docker run -v /data -e ENV=mainnet inputoutput/cardano-node:<TAG>`

To launch testnet and keep no state between launches run:
  `docker run -e ENV=testnet inputoutput/cardano-node:<TAG>`

To launch with a custom config, volume mount `/config` and `/data`
  `docker run -v $PATH_TO/config:/config -v $PATH_TO/data:/data inputoutput/cardano-node:<TAG> --genesis-hash <GENESIS_HASH>`

`/config` must contain `config.json`, `genesis.json` and `topology.json`



Issue
-----------

- The UX design for how images are pushed is horrible. You have to pull a new image for every environment you want to run. You can't override any parameters to that environment if you want to build your own custom image. Also, you have to know what gitrev to run as the only image pushed for master is a blank image you have to provide your own custom config to. This design is much more elegant, and resulted in a 33 MB decrease in image size (605 MB -> 575 MB). It also means users only have to pull a single image. It also unifies the paths where DB/socket are in all images instead of having env names as part of the paths.

- This PR results in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
