### PR TITLE
dockerImage: rename docker env

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,25 +1,22 @@
 ############################################################################
 # Docker image builder
 #
-# To test it out, use:
+# To build and load into the Docker engine:
 #
 #   docker load -i $(nix-build -A dockerImage --no-out-link)
 #
-# To launch mainnet and keep state in a persistent docker volume run:
+# To launch with provided mainnet configuration and persist state in a docker volume run:
 #
 #   docker run -v /data -e ENV=mainnet inputoutput/cardano-node:<TAG>
-
-# To launch testnet and keep no state between launches run:
+#
+# To launch with provided testnet configuration without persisting state run:
 #
 #   docker run -e ENV=testnet inputoutput/cardano-node:<TAG>
 #
-# To launch with a custom config, volume mount /config and /data
+# To launch with custom config, mount a dir containing config.json, genesis.json, and topology,json into /config
 #
-#   docker run -v $PATH_TO/config:/config -v $PATH_TO/data:/data \
-#     inputoutput/cardano-node:<TAG> --genesis-hash <GENESIS_HASH>
-#
-# /config must contain config.json, genesis.json and topology.json
-#
+#   docker run -v $PATH_TO/config:/config \
+#     inputoutput/cardano-node:<TAG>
 #
 ############################################################################
 
@@ -95,8 +92,8 @@ let
           --topology /config/topology.json $@
       ${clusterStatements}
       else
-        echo "Please set ENV variable to one of: mainnet/testnet"
-        echo "Or add a /config volume with the config files: config.json, topology.json and genesis.json"
+        echo "Please set a ENV environment variable to one of: mainnet/testnet"
+        echo "Or mount a /config volume containing: config.json, topology.json and genesis.json"
       fi
     '';
   in dockerTools.buildImage {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -7,11 +7,11 @@
 #
 # To launch with provided mainnet configuration and persist state in a docker volume run:
 #
-#   docker run -v /data -e ENV=mainnet inputoutput/cardano-node:<TAG>
+#   docker run -v /data -e NETWORK=mainnet inputoutput/cardano-node:<TAG>
 #
 # To launch with provided testnet configuration without persisting state run:
 #
-#   docker run -e ENV=testnet inputoutput/cardano-node:<TAG>
+#   docker run -e NETWORK=testnet inputoutput/cardano-node:<TAG>
 #
 # To launch with custom config, mount a dir containing config.json, genesis.json, and topology,json into /config
 #
@@ -71,16 +71,16 @@ let
       mkdir -m 0777 tmp
     '';
   };
-  # Image with all environment configs or utilizes a config volume mount
-  # To choose an environment, use `-e ENV testnet`
+  # Image with all network configs or utilizes a config volume mount
+  # To choose a network, use `-e NETWORK testnet`
     clusterStatements = lib.concatStringsSep "\n" (lib.mapAttrsToList (_: value: value) (commonLib.forEnvironments (env: ''
-      elif [[ "$ENV" == "${env.name}" ]]; then
+      elif [[ "$NETWORK" == "${env.name}" ]]; then
         exec ${scripts.${env.name}.node}
     '')));
   nodeDockerImage = let
     entry-point = writeScriptBin "entry-point" ''
       #!${runtimeShell}
-      echo $ENV
+      echo $NETWORK
       if [[ -d /config ]]; then
         exec ${cardano-node}/bin/cardano-node run \
           --config /config/config.json \
@@ -92,7 +92,7 @@ let
           --topology /config/topology.json $@
       ${clusterStatements}
       else
-        echo "Please set a ENV environment variable to one of: mainnet/testnet"
+        echo "Please set a NETWORK environment variable to one of: mainnet/testnet"
         echo "Or mount a /config volume containing: config.json, topology.json and genesis.json"
       fi
     '';


### PR DESCRIPTION
Renames the network environment variable from `ENV` to `NETWORK`, and improves the inline documentation

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
