### PR TITLE
CAD-640: TraceForgedInvalidBlock trace: dump the why -- the InvalidBlockReason

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -48,6 +48,7 @@ library
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
+                     , ouroboros-consensus-mock
                      , ouroboros-network
                      , process
                      , iproute
@@ -59,6 +60,7 @@ library
                      , text
                      , transformers
                      , transformers-except
+                     , typed-protocols
                      , yaml
 
   default-language:    Haskell2010

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -21,6 +21,7 @@ library
                        Cardano.Config.Protocol
                        Cardano.Config.Topology
                        Cardano.Config.Types
+                       Cardano.Tracing.ToObjectOrphans
 
   build-depends:       base >=4.12 && <5
                      , aeson
@@ -42,6 +43,7 @@ library
                      , lobemo-backend-monitoring
                      , lobemo-scribe-systemd
                      , network
+                     , network-mux
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-byron

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE NamedFieldPuns    #-}
@@ -25,10 +24,12 @@ import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT,
                                                    hoistEither, left)
 import qualified Data.ByteString.Lazy as LB
 
+import           Cardano.BM.Tracing (ToObject)
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Crypto (RequiresNetworkMagic, decodeHash)
 import qualified Cardano.Crypto.Signing as Signing
+import           Cardano.Tracing.ToObjectOrphans ()
 
 import           Ouroboros.Consensus.Block (Header, BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime (SlotLength, SlotLengths,
@@ -36,6 +37,7 @@ import           Ouroboros.Consensus.BlockchainTime (SlotLength, SlotLengths,
                                                      slotLengthFromSec)
 import           Ouroboros.Consensus.Cardano hiding (Protocol)
 import qualified Ouroboros.Consensus.Cardano as Consensus
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId,
                                                   HasTxId, TxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
@@ -43,7 +45,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
-import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..), ValidationErr(..))
 import           Ouroboros.Consensus.Util (Dict (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Network.Block (HeaderHash)
@@ -76,6 +78,8 @@ type TraceConstraints blk =
     , Show blk
     , Show (Header blk)
     , Show (TxId (GenTx blk))
+    , ToObject (LedgerError blk)
+    , ToObject (ValidationErr (BlockProtocol blk))
     )
 
 {-------------------------------------------------------------------------------

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -106,9 +106,9 @@ showTip :: Condense (HeaderHash blk)
 showTip verb = showPoint verb . getTipPoint
 
 showPoint :: Condense (HeaderHash blk)
-             => TracingVerbosity
-             -> Point blk
-             -> String
+          => TracingVerbosity
+          -> Point blk
+          -> String
 showPoint verb pt =
   case pt of
     GenesisPoint -> "genesis (origin)"
@@ -117,7 +117,7 @@ showPoint verb pt =
   trim :: [a] -> [a]
   trim = case verb of
     MinimalVerbosity -> take 7
-    NormalVerbosity  -> take 7
+    NormalVerbosity -> take 7
     MaximalVerbosity -> id
 
 instance ( Show a
@@ -132,8 +132,8 @@ instance DefineSeverity (WithIPList (SubscriptionTrace Socket.SockAddr)) where
   defineSeverity (WithIPList _ _ ev) = case ev of
     SubscriptionTraceConnectStart _ -> Info
     SubscriptionTraceConnectEnd _ connectResult -> case connectResult of
-      ConnectSuccess         -> Info
-      ConnectSuccessLast     -> Notice
+      ConnectSuccess -> Info
+      ConnectSuccessLast -> Notice
       ConnectValencyExceeded -> Warning
     SubscriptionTraceConnectException {} -> Error
     SubscriptionTraceSocketAllocationException {} -> Error
@@ -202,28 +202,28 @@ instance DefineSeverity (WithAddr Socket.SockAddr ErrorPolicyTrace) where
 instance DefinePrivacyAnnotation (WithMuxBearer peer MuxTrace)
 instance DefineSeverity (WithMuxBearer peer MuxTrace) where
   defineSeverity (WithMuxBearer _ ev) = case ev of
-    MuxTraceRecvHeaderStart          -> Debug
-    MuxTraceRecvHeaderEnd {}         -> Debug
-    MuxTraceRecvPayloadStart {}      -> Debug
-    MuxTraceRecvPayloadEnd {}        -> Debug
-    MuxTraceRecvStart {}             -> Debug
-    MuxTraceRecvEnd {}               -> Debug
-    MuxTraceSendStart {}             -> Debug
-    MuxTraceSendEnd                  -> Debug
-    MuxTraceState {}                 -> Info
-    MuxTraceCleanExit {}             -> Info
-    MuxTraceExceptionExit {}         -> Info
-    MuxTraceChannelRecvStart {}      -> Debug
-    MuxTraceChannelRecvEnd {}        -> Debug
-    MuxTraceChannelSendStart {}      -> Debug
-    MuxTraceChannelSendEnd {}        -> Debug
-    MuxTraceHandshakeStart           -> Debug
-    MuxTraceHandshakeClientEnd {}    -> Info
-    MuxTraceHandshakeServerEnd       -> Debug
-    MuxTraceHandshakeClientError {}  -> Error
-    MuxTraceHandshakeServerError {}  -> Error
+    MuxTraceRecvHeaderStart -> Debug
+    MuxTraceRecvHeaderEnd {} -> Debug
+    MuxTraceRecvPayloadStart {} -> Debug
+    MuxTraceRecvPayloadEnd {} -> Debug
+    MuxTraceRecvStart {} -> Debug
+    MuxTraceRecvEnd {} -> Debug
+    MuxTraceSendStart {} -> Debug
+    MuxTraceSendEnd -> Debug
+    MuxTraceState {} -> Info
+    MuxTraceCleanExit {} -> Info
+    MuxTraceExceptionExit {} -> Info
+    MuxTraceChannelRecvStart {} -> Debug
+    MuxTraceChannelRecvEnd {} -> Debug
+    MuxTraceChannelSendStart {} -> Debug
+    MuxTraceChannelSendEnd {} -> Debug
+    MuxTraceHandshakeStart -> Debug
+    MuxTraceHandshakeClientEnd {} -> Info
+    MuxTraceHandshakeServerEnd -> Debug
+    MuxTraceHandshakeClientError {} -> Error
+    MuxTraceHandshakeServerError {} -> Error
     MuxTraceRecvDeltaQObservation {} -> Debug
-    MuxTraceRecvDeltaQSample {}      -> Info
+    MuxTraceRecvDeltaQSample {} -> Info
 
 instance DefinePrivacyAnnotation (WithTip blk (ChainDB.TraceEvent blk))
 instance DefineSeverity (WithTip blk (ChainDB.TraceEvent blk)) where
@@ -427,8 +427,6 @@ instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
 instance ( Condense (HeaderHash blk)
          , HasTxId tx
          , LedgerSupportsProtocol blk
-         , Show blk
-         , Show tx
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (ValidationErr (BlockProtocol blk)))
@@ -491,11 +489,11 @@ readableChainDBTracer tracer = Tracer $ \case
       "Ignoring previously seen invalid block: " <> condense pt
     ChainDB.BlockInTheFuture pt slot -> tr $ WithTip tip $
       "Ignoring block from future: " <> condense pt <> ", slot " <> condense slot
-    ChainDB.StoreButDontChange pt   -> tr $ WithTip tip $
+    ChainDB.StoreButDontChange pt -> tr $ WithTip tip $
       "Ignoring block: " <> condense pt
     ChainDB.TryAddToCurrentChain pt -> tr $ WithTip tip $
       "Block fits onto the current chain: " <> condense pt
-    ChainDB.TrySwitchToAFork pt _   -> tr $ WithTip tip $
+    ChainDB.TrySwitchToAFork pt _ -> tr $ WithTip tip $
       "Block fits onto some fork: " <> condense pt
     ChainDB.AddedToCurrentChain _ _ c -> tr $ WithTip tip $
       "Chain extended, new tip: " <> condense (AF.headPoint c)
@@ -512,7 +510,7 @@ readableChainDBTracer tracer = Tracer $ \case
         "Exceeds rollback " <> condense (AF.headPoint c)
     ChainDB.AddedBlockToVolDB pt _ _ -> tr $ WithTip tip $
       "Chain added block " <> condense pt
-    ChainDB.ChainChangedInBg c1 c2     -> tr $ WithTip tip $
+    ChainDB.ChainChangedInBg c1 c2 -> tr $ WithTip tip $
       "Chain changed in bg, from " <> condense (AF.headPoint c1) <> " to "  <> condense (AF.headPoint c2)
     ChainDB.ScheduledChainSelection pt slot _n -> tr $ WithTip tip $
       "Chain selection scheduled for future: " <> condense pt
@@ -541,7 +539,7 @@ readableChainDBTracer tracer = Tracer $ \case
     ChainDB.NoBlocksToCopyToImmDB -> tr $ WithTip tip
       "There are no blocks to copy to the ImmutableDB"
   WithTip tip (ChainDB.TraceGCEvent ev) -> case ev of
-    ChainDB.PerformedGC slot        -> tr $ WithTip tip $
+    ChainDB.PerformedGC slot -> tr $ WithTip tip $
       "Performed a garbage collection for " <> condense slot
     ChainDB.ScheduledGC slot _difft -> tr $ WithTip tip $
       "Scheduled a garbage collection for " <> condense slot
@@ -685,12 +683,12 @@ instance (Condense (HeaderHash blk), LedgerSupportsProtocol blk)
         mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateExceedsRollback"
                  , "block" .= showPoint verb (AF.headPoint c)
                  , "supported" .= show supported
-                 , "actual"    .= show actual ]
+                 , "actual" .= show actual ]
     ChainDB.AddedBlockToVolDB pt (BlockNo bn) _ ->
       mkObject [ "kind" .= String "TraceAddBlockEvent.AddedBlockToVolDB"
                , "block" .= toObject verb pt
                , "blockNo" .= show bn ]
-    ChainDB.ChainChangedInBg c1 c2     ->
+    ChainDB.ChainChangedInBg c1 c2 ->
       mkObject [ "kind" .= String "TraceAddBlockEvent.ChainChangedInBg"
                , "prev" .= showPoint verb (AF.headPoint c1)
                , "new" .= showPoint verb (AF.headPoint c2) ]
@@ -837,7 +835,7 @@ instance Show peer => ToObject [TraceLabelPeer peer
                         (FetchDecision [Point header])] where
   toObject MinimalVerbosity _ = emptyObject
   toObject NormalVerbosity lbls = mkObject [ "kind" .= String "TraceLabelPeer"
-                                           , "length" .= String (pack $ show $ length lbls) ]
+                                         , "length" .= String (pack $ show $ length lbls) ]
   toObject MaximalVerbosity [] = emptyObject
   toObject MaximalVerbosity (lbl : r) = toObject MaximalVerbosity lbl <>
                                         toObject MaximalVerbosity r
@@ -862,48 +860,48 @@ instance (Show peer, Show txid, Show tx)
          (TraceSendRecv (TxSubmission txid tx))) where
   toObject verb (TraceLabelPeer peerid (TraceSendMsg (AnyMessage msg))) =
     mkObject
-        [ "kind" .= String "TraceSendMsg"
-        , "peer" .= show peerid
-        , "message" .= toObject verb msg
-        ]
+      [ "kind" .= String "TraceSendMsg"
+      , "peer" .= show peerid
+      , "message" .= toObject verb msg
+      ]
   toObject verb (TraceLabelPeer peerid (TraceRecvMsg (AnyMessage msg))) =
     mkObject
-        [ "kind" .= String "TraceRecvMsg"
-        , "peer" .= show peerid
-        , "message" .= toObject verb msg
-        ]
+      [ "kind" .= String "TraceRecvMsg"
+      , "peer" .= show peerid
+      , "message" .= toObject verb msg
+      ]
 
 instance (Show txid, Show tx) => ToObject (Message
                                    (TxSubmission txid tx) from to) where
   toObject _verb (MsgRequestTxs txids) =
     mkObject
-        [ "kind" .= String "MsgRequestTxs"
-        , "txIds" .= String (pack $ show $ txids)
-        ]
+      [ "kind" .= String "MsgRequestTxs"
+      , "txIds" .= String (pack $ show $ txids)
+      ]
   toObject _verb (MsgReplyTxs txs) =
     mkObject
-        [ "kind" .= String "MsgReplyTxs"
-        , "txs" .= String (pack $ show $ txs)
-        ]
+      [ "kind" .= String "MsgReplyTxs"
+      , "txs" .= String (pack $ show $ txs)
+      ]
   toObject _verb (MsgRequestTxIds _ _ _) =
     mkObject
-        [ "kind" .= String "MsgRequestTxIds"
-        ]
+      [ "kind" .= String "MsgRequestTxIds"
+      ]
   toObject _verb (MsgReplyTxIds _) =
     mkObject
-        [ "kind" .= String "MsgReplyTxIds"
-        ]
+      [ "kind" .= String "MsgReplyTxIds"
+      ]
   toObject _verb MsgDone =
     mkObject
-        [ "kind" .= String "MsgDone"
-        ]
+      [ "kind" .= String "MsgDone"
+      ]
 
 instance Show peer => ToObject (TraceLabelPeer peer
                         (TraceFetchClientState header)) where
   toObject verb (TraceLabelPeer peerid a) =
     mkObject [ "kind" .= String "TraceFetchClientState"
-             , "peer" .= show peerid
-             , "state" .= toObject verb a ]
+           , "peer" .= show peerid
+           , "state" .= toObject verb a ]
 
 instance ToObject (TraceFetchClientState header) where
   toObject _verb (AddedFetchRequest {}) =
@@ -941,118 +939,119 @@ instance ( Condense (HeaderHash blk)
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (ValidationErr (BlockProtocol blk)))
-           => ToObject (TraceForgeEvent blk tx) where
+    => ToObject (TraceForgeEvent blk tx) where
   toObject MaximalVerbosity (TraceAdoptedBlock slotNo blk txs) =
     mkObject
-        [ "kind"    .= String "TraceAdoptedBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        , "block hash" .=  (condense $ blockHash blk)
-        , "tx ids" .= (show $ map txId txs)
-        ]
+      [ "kind" .= String "TraceAdoptedBlock"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      , "block hash" .=  (condense $ blockHash blk)
+      , "tx ids" .= (show $ map txId txs)
+      ]
   toObject _verb (TraceAdoptedBlock slotNo blk _txs) =
     mkObject
-        [ "kind"    .= String "TraceAdoptedBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        , "block hash" .=  (condense $ blockHash blk)
-        ]
+      [ "kind" .= String "TraceAdoptedBlock"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      , "block hash" .=  (condense $ blockHash blk)
+      ]
   toObject _verb (TraceBlockFromFuture currentSlot tip) =
     mkObject
-        [ "kind" .= String "TraceBlockFromFuture"
-        , "current slot" .= toJSON (unSlotNo currentSlot)
-        , "tip" .= toJSON (unSlotNo tip)
-        ]
+      [ "kind" .= String "TraceBlockFromFuture"
+      , "current slot" .= toJSON (unSlotNo currentSlot)
+      , "tip" .= toJSON (unSlotNo tip)
+      ]
   toObject verb (TraceSlotIsImmutable slotNo tipPoint tipBlkNo) =
     mkObject
-        [ "kind" .= String "TraceSlotIsImmutable"
-        , "slot" .= toJSON (unSlotNo slotNo)
-        , "tip" .= showPoint verb tipPoint
-        , "tipBlockNo" .= toJSON (unBlockNo tipBlkNo)
-        ]
+      [ "kind" .= String "TraceSlotIsImmutable"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      , "tip" .= showPoint verb tipPoint
+      , "tipBlockNo" .= toJSON (unBlockNo tipBlkNo)
+      ]
   toObject _verb (TraceDidntAdoptBlock slotNo _) =
     mkObject
-        [ "kind"    .= String "TraceDidntAdoptBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceDidntAdoptBlock"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject _verb (TraceForgedBlock slotNo _ _) =
     mkObject
-        [ "kind"    .= String "TraceForgedBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceForgedBlock"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject verb (TraceForgedInvalidBlock slotNo _ reason) =
     mkObject
-        [ "kind"    .= String "TraceForgedInvalidBlock"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        , "reason"  .= toObject verb reason
-        ]
+      [ "kind" .= String "TraceForgedInvalidBlock"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      , "reason" .= toObject verb reason
+      ]
   toObject _verb (TraceNodeIsLeader slotNo) =
     mkObject
-        [ "kind"    .= String "TraceNodeIsLeader"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceNodeIsLeader"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject _verb (TraceNodeNotLeader slotNo) =
     mkObject
-        [ "kind"    .= String "TraceNodeNotLeader"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceNodeNotLeader"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject _verb (TraceNoLedgerState slotNo _blk) =
     mkObject
-        [ "kind"    .= String "TraceNoLedgerState"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceNoLedgerState"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject _verb (TraceNoLedgerView slotNo _) =
     mkObject
-        [ "kind"    .= String "TraceNoLedgerView"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceNoLedgerView"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
   toObject _verb (TraceStartLeadershipCheck slotNo) =
     mkObject
-        [ "kind"    .= String "TraceStartLeadershipCheck"
-        , "slot"    .= toJSON (unSlotNo slotNo)
-        ]
+      [ "kind" .= String "TraceStartLeadershipCheck"
+      , "slot" .= toJSON (unSlotNo slotNo)
+      ]
 
 instance (Show (GenTx blk), Show (GenTxId blk))
       => ToObject (TraceEventMempool blk) where
   toObject _verb (TraceMempoolAddedTx tx _mpSzBefore mpSzAfter) =
     mkObject
-        [ "kind" .= String "TraceMempoolAddedTx"
-        , "txAdded" .= String (pack $ show $ tx)
-        , "mempoolSize" .= String (pack $ show $ mpSzAfter)
-        ]
+      [ "kind" .= String "TraceMempoolAddedTx"
+      , "txAdded" .= String (pack $ show $ tx)
+      , "mempoolSize" .= String (pack $ show $ mpSzAfter)
+      ]
   toObject _verb (TraceMempoolRejectedTx txAndErrs _mpSzBefore mpSzAfter) =
     mkObject
-        [ "kind" .= String "TraceMempoolRejectedTxs"
-        , "txRejected" .= String (pack $ show $ txAndErrs)
-        , "mempoolSize" .= String (pack $ show $ mpSzAfter)
-        ]
+      [ "kind" .= String "TraceMempoolRejectedTxs"
+      , "txRejected" .= String (pack $ show $ txAndErrs)
+      , "mempoolSize" .= String (pack $ show $ mpSzAfter)
+      ]
   toObject _verb (TraceMempoolRemoveTxs txs mpSz) =
     mkObject
-        [ "kind" .= String "TraceMempoolRemoveTxs"
-        , "txsRemoved" .= String (pack $ show $ txs)
-        , "mempoolSize" .= String (pack $ show $ mpSz)
-        ]
+      [ "kind" .= String "TraceMempoolRemoveTxs"
+      , "txsRemoved" .= String (pack $ show $ txs)
+      , "mempoolSize" .= String (pack $ show $ mpSz)
+      ]
   toObject _verb (TraceMempoolManuallyRemovedTxs txs0 txs1 mpSz) =
     mkObject
-        [ "kind" .= String "TraceMempoolManuallyRemovedTxs"
-        , "txsManuallyRemoved" .= String (pack $ show $ txs0)
-        , "txsNoLongerValidRemoved" .= String (pack $ show $ txs1)
-        , "mempoolSize" .= String (pack $ show $ mpSz)
-        ]
+      [ "kind" .= String "TraceMempoolManuallyRemovedTxs"
+      , "txsManuallyRemoved" .= String (pack $ show $ txs0)
+      , "txsNoLongerValidRemoved" .= String (pack $ show $ txs1)
+      , "mempoolSize" .= String (pack $ show $ mpSz)
+      ]
 
-instance ( StandardHash blk
+instance ( Condense (HeaderHash blk)
+         , StandardHash blk
          , ToObject (LedgerError blk)
          , ToObject (ValidationErr (BlockProtocol blk)))
-      => ToObject (ChainDB.InvalidBlockReason blk) where
+        => ToObject (ChainDB.InvalidBlockReason blk) where
   toObject verb (ChainDB.ValidationError extvalerr) =
     mkObject
-        [ "kind"  .= String "ValidationError"
-        , "error" .= toObject verb extvalerr
-        ]
+      [ "kind" .= String "ValidationError"
+      , "error" .= toObject verb extvalerr
+      ]
   toObject verb (ChainDB.InChainAfterInvalidBlock point extvalerr) =
     mkObject
-        [ "kind"  .= String "InChainAfterInvalidBlock"
-        , "point" .= String (pack $ show point)
-        , "error" .= toObject verb extvalerr
-        ]
+      [ "kind" .= String "InChainAfterInvalidBlock"
+      , "point" .= String (pack $ showPoint verb point)
+      , "error" .= toObject verb extvalerr
+      ]
 
 instance ( StandardHash blk
          , ToObject (LedgerError blk)
@@ -1067,175 +1066,175 @@ instance ( StandardHash blk
       => ToObject (HeaderError blk) where
   toObject verb (HeaderProtocolError err) =
     mkObject
-        [ "kind"  .= String "HeaderProtocolError"
-        , "error" .= toObject verb err
-        ]
+      [ "kind" .= String "HeaderProtocolError"
+      , "error" .= toObject verb err
+      ]
   toObject verb (HeaderEnvelopeError err) =
     mkObject
-        [ "kind"  .= String "HeaderEnvelopeError"
-        , "error" .= toObject verb err
-        ]
+      [ "kind" .= String "HeaderEnvelopeError"
+      , "error" .= toObject verb err
+      ]
 
 instance (StandardHash blk)
  => ToObject (HeaderEnvelopeError blk) where
   toObject _verb (UnexpectedBlockNo expect act) =
     mkObject
-        [ "kind"     .= String "UnexpectedBlockNo"
-        , "expected" .= condense expect
-        , "actual"   .= condense act
-        ]
+      [ "kind" .= String "UnexpectedBlockNo"
+      , "expected" .= condense expect
+      , "actual" .= condense act
+      ]
   toObject _verb (UnexpectedSlotNo expect act) =
     mkObject
-        [ "kind"  .= String "UnexpectedSlotNo"
-        , "expected" .= condense expect
-        , "actual"   .= condense act
-        ]
+      [ "kind" .= String "UnexpectedSlotNo"
+      , "expected" .= condense expect
+      , "actual" .= condense act
+      ]
   toObject _verb (UnexpectedPrevHash expect act) =
     mkObject
-        [ "kind"  .= String "UnexpectedPrevHash"
-        , "expected" .= String (pack $ show expect)
-        , "actual"   .= String (pack $ show act)
-        ]
+      [ "kind" .= String "UnexpectedPrevHash"
+      , "expected" .= String (pack $ show expect)
+      , "actual" .= String (pack $ show act)
+      ]
   toObject _verb (OtherEnvelopeError text) =
     mkObject
-        [ "kind"  .= String "OtherEnvelopeError"
-        , "error" .= String text
-        ]
+      [ "kind" .= String "OtherEnvelopeError"
+      , "error" .= String text
+      ]
 
 instance StandardHash blk => ToObject (Mock.MockError blk) where
   toObject _verb (Mock.MockUtxoError e) =
     mkObject
-        [ "kind"  .= String "MockUtxoError"
-        , "error" .= String (pack $ show e)
-        ]
+      [ "kind" .= String "MockUtxoError"
+      , "error" .= String (pack $ show e)
+      ]
   toObject _verb (Mock.MockInvalidHash expect act) =
     mkObject
-        [ "kind"  .= String "MockInvalidHash"
-        , "expected" .= String (pack $ show expect)
-        , "actual"   .= String (pack $ show act)
-        ]
+      [ "kind" .= String "MockInvalidHash"
+      , "expected" .= String (pack $ show expect)
+      , "actual" .= String (pack $ show act)
+      ]
 
 instance (Show (PBFT.PBftVerKeyHash c))
  => ToObject (PBFT.PBftValidationErr c) where
   toObject _verb (PBFT.PBftInvalidSignature text) =
     mkObject
-        [ "kind"  .= String "PBftInvalidSignature"
-        , "error" .= String text
-        ]
+      [ "kind" .= String "PBftInvalidSignature"
+      , "error" .= String text
+      ]
   toObject _verb (PBFT.PBftNotGenesisDelegate vkhash _ledgerView) =
     mkObject
-        [ "kind"  .= String "PBftNotGenesisDelegate"
-        , "vk"    .= String (pack $ show vkhash)
-        ]
+      [ "kind" .= String "PBftNotGenesisDelegate"
+      , "vk" .= String (pack $ show vkhash)
+      ]
   toObject _verb (PBFT.PBftExceededSignThreshold vkhash n) =
     mkObject
-        [ "kind"  .= String "PBftExceededSignThreshold"
-        , "vk"    .= String (pack $ show vkhash)
-        , "n"     .= String (pack $ show n)
-        ]
+      [ "kind" .= String "PBftExceededSignThreshold"
+      , "vk" .= String (pack $ show vkhash)
+      , "n" .= String (pack $ show n)
+      ]
   toObject _verb PBFT.PBftInvalidSlot =
     mkObject
-        [ "kind"  .= String "PBftInvalidSlot"
-        ]
+      [ "kind" .= String "PBftInvalidSlot"
+      ]
 
 instance ToObject BFT.BftValidationErr where
   toObject _verb (BFT.BftInvalidSignature err) =
     mkObject
-        [ "kind"  .= String "BftInvalidSignature"
-        , "error" .= String (pack err)
-        ]
+      [ "kind" .= String "BftInvalidSignature"
+      , "error" .= String (pack err)
+      ]
 
 instance ToObject (Praos.PraosValidationError c) where
   toObject _verb (Praos.PraosInvalidSlot expect act) =
     mkObject
-        [ "kind"  .= String "PraosInvalidSlot"
-        , "expected" .= String (pack $ show expect)
-        , "actual"   .= String (pack $ show act)
-        ]
+      [ "kind" .= String "PraosInvalidSlot"
+      , "expected" .= String (pack $ show expect)
+      , "actual" .= String (pack $ show act)
+      ]
   toObject _verb (Praos.PraosUnknownCoreId cid) =
     mkObject
-        [ "kind"  .= String "PraosUnknownCoreId"
-        , "error" .= String (pack $ show cid)
-        ]
+      [ "kind" .= String "PraosUnknownCoreId"
+      , "error" .= String (pack $ show cid)
+      ]
   toObject _verb (Praos.PraosInvalidSig str _ _ _) =
     mkObject
-        [ "kind"  .= String "PraosInvalidSig"
-        , "error" .= String (pack str)
-        ]
+      [ "kind" .= String "PraosInvalidSig"
+      , "error" .= String (pack str)
+      ]
   toObject _verb (Praos.PraosInvalidCert _vkvrf y nat _vrf) =
     mkObject
-        [ "kind"  .= String "PraosInvalidCert"
-        , "y"     .= String (pack $ show y)
-        , "nat"   .= String (pack $ show nat)
-        ]
+      [ "kind" .= String "PraosInvalidCert"
+      , "y" .= String (pack $ show y)
+      , "nat" .= String (pack $ show nat)
+      ]
   toObject _verb (Praos.PraosInsufficientStake t y) =
     mkObject
-        [ "kind"  .= String "PraosInsufficientStake"
-        , "t"     .= String (pack $ show t)
-        , "y"     .= String (pack $ show y)
-        ]
+      [ "kind" .= String "PraosInsufficientStake"
+      , "t" .= String (pack $ show t)
+      , "y" .= String (pack $ show y)
+      ]
 
 instance ToObject Block.ChainValidationError where
   toObject _verb Block.ChainValidationBoundaryTooLarge =
     mkObject
-        [ "kind"  .= String "ChainValidationBoundaryTooLarge" ]
+      [ "kind" .= String "ChainValidationBoundaryTooLarge" ]
   toObject _verb Block.ChainValidationBlockAttributesTooLarge =
     mkObject
-        [ "kind"  .= String "ChainValidationBlockAttributesTooLarge" ]
+      [ "kind" .= String "ChainValidationBlockAttributesTooLarge" ]
   toObject _verb (Block.ChainValidationBlockTooLarge _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationBlockTooLarge" ]
+      [ "kind" .= String "ChainValidationBlockTooLarge" ]
   toObject _verb Block.ChainValidationHeaderAttributesTooLarge =
     mkObject
-        [ "kind"  .= String "ChainValidationHeaderAttributesTooLarge" ]
+      [ "kind" .= String "ChainValidationHeaderAttributesTooLarge" ]
   toObject _verb (Block.ChainValidationHeaderTooLarge _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationHeaderTooLarge" ]
+      [ "kind" .= String "ChainValidationHeaderTooLarge" ]
   toObject _verb (Block.ChainValidationDelegationPayloadError err) =
     mkObject
-        [ "kind"  .= String err ]
+      [ "kind" .= String err ]
   toObject _verb (Block.ChainValidationInvalidDelegation _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationInvalidDelegation" ]
+      [ "kind" .= String "ChainValidationInvalidDelegation" ]
   toObject _verb (Block.ChainValidationGenesisHashMismatch _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationGenesisHashMismatch" ]
+      [ "kind" .= String "ChainValidationGenesisHashMismatch" ]
   toObject _verb (Block.ChainValidationExpectedGenesisHash _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationExpectedGenesisHash" ]
+      [ "kind" .= String "ChainValidationExpectedGenesisHash" ]
   toObject _verb (Block.ChainValidationExpectedHeaderHash _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationExpectedHeaderHash" ]
+      [ "kind" .= String "ChainValidationExpectedHeaderHash" ]
   toObject _verb (Block.ChainValidationInvalidHash _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationInvalidHash" ]
+      [ "kind" .= String "ChainValidationInvalidHash" ]
   toObject _verb (Block.ChainValidationMissingHash _) =
     mkObject
-        [ "kind"  .= String "ChainValidationMissingHash" ]
+      [ "kind" .= String "ChainValidationMissingHash" ]
   toObject _verb (Block.ChainValidationUnexpectedGenesisHash _) =
     mkObject
-        [ "kind"  .= String "ChainValidationUnexpectedGenesisHash" ]
+      [ "kind" .= String "ChainValidationUnexpectedGenesisHash" ]
   toObject _verb (Block.ChainValidationInvalidSignature _) =
     mkObject
-        [ "kind"  .= String "ChainValidationInvalidSignature" ]
+      [ "kind" .= String "ChainValidationInvalidSignature" ]
   toObject _verb (Block.ChainValidationDelegationSchedulingError _) =
     mkObject
-        [ "kind"  .= String "ChainValidationDelegationSchedulingError" ]
+      [ "kind" .= String "ChainValidationDelegationSchedulingError" ]
   toObject _verb (Block.ChainValidationProtocolMagicMismatch _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationProtocolMagicMismatch" ]
+      [ "kind" .= String "ChainValidationProtocolMagicMismatch" ]
   toObject _verb Block.ChainValidationSignatureLight =
     mkObject
-        [ "kind"  .= String "ChainValidationSignatureLight" ]
+      [ "kind" .= String "ChainValidationSignatureLight" ]
   toObject _verb (Block.ChainValidationTooManyDelegations _) =
     mkObject
-        [ "kind"  .= String "ChainValidationTooManyDelegations" ]
+      [ "kind" .= String "ChainValidationTooManyDelegations" ]
   toObject _verb (Block.ChainValidationUpdateError _ _) =
     mkObject
-        [ "kind"  .= String "ChainValidationUpdateError" ]
+      [ "kind" .= String "ChainValidationUpdateError" ]
   toObject _verb (Block.ChainValidationUTxOValidationError _) =
     mkObject
-        [ "kind"  .= String "ChainValidationUTxOValidationError" ]
+      [ "kind" .= String "ChainValidationUTxOValidationError" ]
   toObject _verb (Block.ChainValidationProofValidationError _) =
     mkObject
-        [ "kind"  .= String "ChainValidationProofValidationError" ]
+      [ "kind" .= String "ChainValidationProofValidationError" ]

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -49,7 +49,6 @@ library
 
 
   other-modules:       Paths_cardano_node
-                       Cardano.Tracing.ToObjectOrphans
                        Cardano.Tracing.MicroBenchmarking
 
   build-depends:       aeson


### PR DESCRIPTION
Re-submission of https://github.com/input-output-hk/cardano-node/pull/585 -- which was irreversibly closed by Github due to its base having been merged.

1. Move `ToObjectOrphans` to `cardano-config`, because the instances are now needed in earlier code.
2. Factor `defaultTextTransformer` to reduce boilerplate in `ToObjectOrphans`
3. Add a small bunch of `ToObject` instances to detail the error coming from `TraceForgedInvalidBlock`.
4. Add a humaniser for the structured `TraceForgeEvent`
5. Reindent `ToObjectOrphans.hs`

Issue: https://github.com/input-output-hk/cardano-node/issues/579

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
