### PR TITLE
Update scripts.nix

### DIFF
--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -81,6 +81,7 @@ let
     #!${pkgs.runtimeShell}
     set -euo pipefail
     mkdir -p "${config.stateDir}"
+    cd "${config.stateDir}"
     ${nodeScript} $@
   '';
   scripts = forEnvironments (environment:


### PR DESCRIPTION
Issue
-----------

- the script should change its path in to the state directory (e.g. state-node-mainnet) as logs files are placed in the current directory and scripts that analyse those expect them to find in the state dir.

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
