### PR TITLE
nix shell:  eliminate the need to build ouroboros-{consensus,network}

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,15 @@ steps:
     agents:
       system: x86_64-linux
 
+# newParallelJobControl: not a sensible number of jobs: 0
+# CallStack (from HasCallStack):
+#   error, called at ./Distribution/Client/JobControl.hs:101:3 in main:Distribution.Client.JobControl
+## This check triggers the above error in Cabal -- re-enable once resolved.
+#   - label: 'Check Cabal Configure'
+#     command: 'nix-shell --run "cabal v2-update && cabal v2-configure || true"'
+#     agents:
+#       system: x86_64-linux
+
 # FIXME:
 #  - label: 'dependencies-at-master'
 #    command: 'ci/check-dependencies-merged-to-master.sh'

--- a/shell.nix
+++ b/shell.nix
@@ -19,12 +19,6 @@ let
     packages = ps: with ps; [
        ps.cardano-node
        ps.cardano-config
-       # in theory we should only have the above two packages (or better, they should be auto-detected),
-       # but due to source-repository-package declarations being considered as local packages by cabal, we need the following packages as well.
-       # cf. https://github.com/haskell/cabal/issues/6249 and https://github.com/haskell/cabal/issues/5444
-       ps.cardano-sl-x509
-       ps.ouroboros-consensus
-       ps.ouroboros-network
     ];
 
     # These programs will be available inside the nix-shell.


### PR DESCRIPTION
The status quo of the `nix-shell` is that one needs to remove the three lines this PR removes, to avoid re-building the packages they mention.

The underlying cause is that `haskell.nix`'s version of `shellFor` does not supply the packages mentioned on the list, even if they are dependencies of _other_ such packages.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
