### PR TITLE
Update of cardano-node on top of coot/mini-protocol-limits

### DIFF
--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -602,7 +602,7 @@ readableForgeEventTracer tracer = Tracer $ \case
     "Forged for immutable slot " <> show (unSlotNo slotNo) <> ", tip: " <> showPoint MaximalVerbosity tipPoint <> ", block no: " <> show (unBlockNo tipBlkNo)
   TraceDidntAdoptBlock slotNo _ -> tr $
     "Didn't adopt forged block at slot " <> show (unSlotNo slotNo)
-  TraceForgedBlock slotNo _ _ -> tr $
+  TraceForgedBlock slotNo _ _ _ -> tr $
     "Forged block for slot " <> show (unSlotNo slotNo)
   TraceForgedInvalidBlock slotNo _ reason -> tr $
     "Forged invalid block for slot " <> show (unSlotNo slotNo) <> ", reason: " <> show reason
@@ -1045,7 +1045,7 @@ instance ( Condense (HeaderHash blk)
       [ "kind" .= String "TraceDidntAdoptBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
-  toObject _verb (TraceForgedBlock slotNo _ _) =
+  toObject _verb (TraceForgedBlock slotNo _ _ _) =
     mkObject
       [ "kind" .= String "TraceForgedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)

--- a/cardano-node/src/Cardano/CLI/Benchmarking/Tx/NodeToNode.hs
+++ b/cardano-node/src/Cardano/CLI/Benchmarking/Tx/NodeToNode.hs
@@ -232,6 +232,7 @@ benchmarkConnectTxSubmit iocp trs cfg localAddr remoteAddr myTxSubClient = do
       (NtN.NodeToNodeVersionData { NtN.networkMagic = nodeNetworkMagic (Proxy @blk) cfg})
       (NtN.DictVersion NtN.nodeToNodeCodecCBORTerm) $ \_ ->
       NtN.nodeToNodeProtocols
+          NtN.defaultMiniProtocolParameters
           (InitiatorProtocolOnly $
              MuxPeer
                nullTracer

--- a/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
+++ b/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
@@ -219,7 +219,7 @@ measureBlockForgeEnd tracer = measureTxsEndInter $ toLogObject tracer
   where
     measureTxsEndInter :: Tracer IO (MeasureBlockForging blk) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
     measureTxsEndInter tracer' = Tracer $ \case
-        TraceForgedBlock slotNo blk mempoolSize
+        TraceForgedBlock slotNo _point blk mempoolSize
             -> traceWith tracer' =<< (MeasureBlockTimeStop slotNo blk mempoolSize <$> getMonotonicTime)
         _   -> pure ()
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -391,7 +391,7 @@ mkTracers traceOptions tracer = do
         meta <- mkLOMeta Critical Confidential
         traceNamedObject (appendName "metrics" tr) . (meta,) $
           case ev of
-            Consensus.TraceForgedBlock   slot _ _ ->
+            Consensus.TraceForgedBlock   slot _ _ _ ->
               LogValue "forgedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
             Consensus.TraceStartLeadershipCheck slot ->
               LogValue "aboutToLeadSlotLast" $ PureI $ fromIntegral $ unSlotNo slot


### PR DESCRIPTION
Mini protocol limits add a protaction to the ingress queue.  This patch
updates cardano-node to
https://github.com/input-output-hk/ouroboros-network/pull/1740
Which as of the moment is not merged to master.

Note: the git hashes are not updated in this patch as it was used from
`cardano-haskell` repo.


Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
