### PR TITLE
CAD-508 ouroboros-network:  bump to master

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -183,92 +183,92 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 685aff740212b45b7fe5eec4b469eea71b209385
-  --sha256: 1irz63lvq51lnsbdcl75wgwh3bn8f8011whyv8r8afxhpajf1br4
+  tag: 57a482f92c6909148ce71813737bf47aa401668f
+  --sha256: 1p70f3mwc80yrlj7qvwjrvbd2ywrb01zlqlm53szimz5s1lh5ry8
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -36,11 +36,11 @@ import           Ouroboros.Consensus.Block
                    (Header, headerPoint,
                     RealPoint, realPointSlot, realPointHash)
 import           Ouroboros.Network.Point (withOrigin)
-import           Ouroboros.Consensus.BlockFetchServer
+import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
                    (TraceBlockFetchServerEvent)
-import           Ouroboros.Consensus.ChainSyncClient
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                    (TraceChainSyncClientEvent (..))
-import           Ouroboros.Consensus.ChainSyncServer
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
                    (TraceChainSyncServerEvent(..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                    (LedgerSupportsProtocol)
@@ -55,7 +55,7 @@ import qualified Ouroboros.Consensus.Mock.Ledger as Mock
 import qualified Ouroboros.Consensus.Mock.Protocol.Praos as Praos
 import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.TxSubmission
+import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                    (TraceLocalTxSubmissionServerEvent (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -602,7 +602,7 @@ readableForgeEventTracer tracer = Tracer $ \case
     "Forged for immutable slot " <> show (unSlotNo slotNo) <> ", tip: " <> showPoint MaximalVerbosity tipPoint <> ", block no: " <> show (unBlockNo tipBlkNo)
   TraceDidntAdoptBlock slotNo _ -> tr $
     "Didn't adopt forged block at slot " <> show (unSlotNo slotNo)
-  TraceForgedBlock slotNo _ _ -> tr $
+  TraceForgedBlock slotNo _ _ _ -> tr $
     "Forged block for slot " <> show (unSlotNo slotNo)
   TraceForgedInvalidBlock slotNo _ reason -> tr $
     "Forged invalid block for slot " <> show (unSlotNo slotNo) <> ", reason: " <> show reason
@@ -1045,7 +1045,7 @@ instance ( Condense (HeaderHash blk)
       [ "kind" .= String "TraceDidntAdoptBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
-  toObject _verb (TraceForgedBlock slotNo _ _) =
+  toObject _verb (TraceForgedBlock slotNo _ _ _) =
     mkObject
       [ "kind" .= String "TraceForgedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)

--- a/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
+++ b/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
@@ -219,7 +219,7 @@ measureBlockForgeEnd tracer = measureTxsEndInter $ toLogObject tracer
   where
     measureTxsEndInter :: Tracer IO (MeasureBlockForging blk) -> Tracer IO (TraceForgeEvent blk (GenTx blk))
     measureTxsEndInter tracer' = Tracer $ \case
-        TraceForgedBlock slotNo blk mempoolSize
+        TraceForgedBlock slotNo _ blk mempoolSize
             -> traceWith tracer' =<< (MeasureBlockTimeStop slotNo blk mempoolSize <$> getMonotonicTime)
         _   -> pure ()
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -391,7 +391,7 @@ mkTracers traceOptions tracer = do
         meta <- mkLOMeta Critical Confidential
         traceNamedObject (appendName "metrics" tr) . (meta,) $
           case ev of
-            Consensus.TraceForgedBlock   slot _ _ ->
+            Consensus.TraceForgedBlock slot _ _ _ ->
               LogValue "forgedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
             Consensus.TraceStartLeadershipCheck slot ->
               LogValue "aboutToLeadSlotLast" $ PureI $ fromIntegral $ unSlotNo slot

--- a/stack.yaml
+++ b/stack.yaml
@@ -119,7 +119,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 685aff740212b45b7fe5eec4b469eea71b209385
+    commit: 57a482f92c6909148ce71813737bf47aa401668f
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
1. Bump `ouroboros-network` to its current `master`.
2. Adapt to the API changes.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
