### PR TITLE
Use http-client from git master so that it builds with Win32-2.8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -284,6 +284,13 @@ source-repository-package
   --sha256: 1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04
   subdir: cborg
 
+source-repository-package
+  type: git
+  location: https://github.com/snoyberg/http-client.git
+  tag: 1a75bdfca014723dd5d40760fad854b3f0f37156
+  --sha256: 0537bjhk9bzhvl76haswsv7xkkyzrmv5xfph3fydcd953q08hqdb
+  subdir: http-client
+
 constraints:
   ip < 1.5,
   hedgehog >= 1.0,

--- a/stack.yaml
+++ b/stack.yaml
@@ -140,5 +140,12 @@ extra-deps:
     commit: 42a83192749774268337258f4f94c97584b80ca6
     subdirs:
         - cborg
+
+    # Includes a windows build fix (https://github.com/snoyberg/http-client/pull/430)
+  - git: https://github.com/snoyberg/http-client.git
+    commit: 1a75bdfca014723dd5d40760fad854b3f0f37156
+    subdirs:
+        - http-client
+
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
This fixes an error in the Windows build.

* [Hydra job - master](https://hydra.iohk.io/job/Cardano/cardano-node/x86_64-w64-mingw32.cardano-node.x86_64-linux)
* [Hydra job - PR #646](https://hydra.iohk.io/job/Cardano/cardano-node-pr-646/x86_64-w64-mingw32.cardano-node.x86_64-linux)

See: snoyberg/http-client#430
