### PR TITLE
Fix submitTx: swap args in NodeToClient.

### DIFF
--- a/cardano-node/src/Cardano/Node/Submission.hs
+++ b/cardano-node/src/Cardano/Node/Submission.hs
@@ -144,6 +144,11 @@ localInitiatorNetworkApplication tracer cfg tx =
 
     NodeToClient.nodeToClientProtocols
       (InitiatorProtocolOnly $
+         MuxPeer
+           nullTracer
+           (localChainSyncCodec @blk cfg)
+           (chainSyncClientPeer NodeToClient.chainSyncClientNull))
+      (InitiatorProtocolOnly $
          MuxPeerRaw $ \channel -> do
             traceWith tracer TraceLowLevelSubmitting
             result <- runPeer
@@ -155,12 +160,6 @@ localInitiatorNetworkApplication tracer cfg tx =
             case result of
               Nothing  -> traceWith tracer TraceLowLevelAccepted
               Just msg -> traceWith tracer (TraceLowLevelRejected $ show msg))
-
-      (InitiatorProtocolOnly $
-         MuxPeer
-           nullTracer
-           (localChainSyncCodec @blk cfg)
-           (chainSyncClientPeer NodeToClient.chainSyncClientNull))
 
 -- | A 'LocalTxSubmissionClient' that submits exactly one transaction, and then
 -- disconnects, returning the confirmation or rejection.


### PR DESCRIPTION
Issue
-----------

- Fix `submitTx` function: swap arguments in `NodeToClient` to prevent an error: `MuxBearerClosed "<socket: 13> closed when reading data, waiting on next header True" `. This fixes both local tx submission and tx generator (because they use the same function).

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
