### PR TITLE
CAD-722 correct context name of internal metrics

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -322,14 +322,8 @@ mkTracers traceOptions tracer = do
             logValue3 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
 
         meta <- mkLOMeta Critical Confidential
-
-        traceNamedObject tr (meta, logValue1)
         traceNamedObject tr' (meta, logValue1)
-
-        traceNamedObject tr (meta, logValue2)
         traceNamedObject tr' (meta, logValue2)
-
-        traceNamedObject tr (meta, logValue3)
         traceNamedObject tr' (meta, logValue3)
 
     mempoolTracer :: Tracer IO (TraceEventMempool blk)


### PR DESCRIPTION
Issue
-----------

- correct the context name of internal metrics that they are routed to the right backends and do not appear in the logs.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
