### PR TITLE
CAD-721 expand TraceLabelPeer messages

### DIFF
--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -891,10 +891,8 @@ instance Condense (HeaderHash blk) => ToObject (TraceChainSyncServerEvent blk b)
 instance Show peer => ToObject [TraceLabelPeer peer
                         (FetchDecision [Point header])] where
   toObject MinimalVerbosity _ = emptyObject
-  toObject NormalVerbosity lbls = mkObject [ "kind" .= String "TraceLabelPeer"
-                                         , "length" .= String (pack $ show $ length lbls) ]
-  toObject MaximalVerbosity [] = emptyObject
-  toObject MaximalVerbosity (lbl : r) = toObject MaximalVerbosity lbl <>
+  toObject _ [] = emptyObject
+  toObject _ (lbl : r) = toObject MaximalVerbosity lbl <>
                                         toObject MaximalVerbosity r
 
 instance Show peer => ToObject (TraceLabelPeer peer


### PR DESCRIPTION

Issue
-----------

- `TraceLabelPeer` messages were abbreviated at level "NormalVerbosity". Now, they are fully shown in the logs.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
