### PR TITLE
CAD-508: update traces for Tx throughput benchmarking

### DIFF
--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -42,7 +42,7 @@ import           Ouroboros.Consensus.Cardano hiding (Protocol)
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId,
-                                                  HasTxId, TxId)
+                                                  HasTxId, HasTxs, TxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -74,6 +74,8 @@ type TraceConstraints blk =
     , Condense (Header blk)
     , Condense (HeaderHash blk)
     , Condense (GenTx blk)
+    , Condense (TxId (GenTx blk))
+    , HasTxs blk
     , HasTxId (GenTx blk)
     , Show (ApplyTxErr blk)
     , Show (GenTx blk)

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -438,11 +438,6 @@ instance ( Condense (HeaderHash blk)
   -- user defined formatting of log output
   trTransformer _ verb tr = trStructured verb tr
 
-instance (Transformable Text IO a)
- => Transformable Text IO (TraceLabelPeer peer a) where
-  trTransformer f v t = Tracer $ \(TraceLabelPeer _peer a) ->
-    traceWith (trTransformer f v t) a
-
 instance Show peer
  => Transformable Text IO [TraceLabelPeer peer (FetchDecision [Point header])] where
   trTransformer _ verb tr = trStructured verb tr
@@ -461,8 +456,9 @@ instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
 instance ( Show blk
          , StandardHash blk
          , ToObject (AnyMessage (BlockFetch blk)))
- => Transformable Text IO (TraceSendRecv (BlockFetch blk)) where
-  trTransformer = defaultTextTransformer
+ => Transformable Text IO (TraceLabelPeer peer (TraceSendRecv (BlockFetch blk))) where
+  trTransformer f v =
+    contramap (\(TraceLabelPeer _peer a) -> a) . defaultTextTransformer f v
 
 instance Transformable Text IO (TraceTxSubmissionInbound (GenTxId blk) (GenTx blk)) where
   trTransformer = defaultTextTransformer

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -62,7 +62,6 @@ import           Ouroboros.Network.BlockFetch.Decision (FetchDecision)
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 import qualified Ouroboros.Network.NodeToNode as NtN
-import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace, WithAddr)
 import           Ouroboros.Network.Point (fromWithOrigin)
 import           Ouroboros.Network.Subscription
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -47,8 +47,8 @@ import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), TraceBlockchainTimeEvent (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
-import           Ouroboros.Consensus.Mempool.API (GenTx, MempoolSize (..),
-                                                  TraceEventMempool (..))
+import           Ouroboros.Consensus.Mempool.API
+                   (GenTx, MempoolSize (..), TraceEventMempool (..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers,
                                                   ProtocolTracers' (..),
@@ -56,12 +56,13 @@ import           Ouroboros.Consensus.NodeNetwork (ProtocolTracers,
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (Point, BlockNo(..),
+import           Ouroboros.Network.Block (Point, BlockNo(..), HasHeader(..),
                                           blockNo, unBlockNo, unSlotNo)
 import           Ouroboros.Network.BlockFetch.Decision (FetchDecision)
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 import qualified Ouroboros.Network.NodeToNode as NtN
+import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace, WithAddr)
 import           Ouroboros.Network.Point (fromWithOrigin)
 import           Ouroboros.Network.Subscription
 
@@ -480,7 +481,8 @@ mkTracers traceOptions tracer = do
         TraceStartTimeInTheFuture (SystemStart start) toWait ->
           "Waiting " <> show toWait <> " until genesis start time at " <> show start
 
-    mkProtocolTracers :: TraceOptions -> ProtocolTracers' peer localPeer blk DeserialiseFailure (Tracer IO)
+    mkProtocolTracers
+      :: TraceOptions -> ProtocolTracers' peer localPeer blk DeserialiseFailure (Tracer IO)
     mkProtocolTracers traceOpts = ProtocolTracers
       { ptChainSyncTracer
         = tracerOnOff (traceChainSyncProtocol traceOpts)
@@ -490,7 +492,8 @@ mkTracers traceOptions tracer = do
         $ showTracing $ withName "ChainSyncProtocol" tracer
       , ptBlockFetchTracer
         = tracerOnOff (traceBlockFetchProtocol traceOpts)
-        $ showTracing $ withName "BlockFetchProtocol" tracer
+        $ toLogObject' StructuredLogging tracingVerbosity
+        $ appendName "BlockFetchProtocol" tracer
       , ptBlockFetchSerialisedTracer
         = tracerOnOff (traceBlockFetchProtocolSerialised traceOpts)
         $ showTracing $ withName "BlockFetchProtocolSerialised" tracer


### PR DESCRIPTION
1. trace txid lists in the blockfetch protocol's `AddBlock` message
1. establish order among the `ToObjectOrphans`'s instances -- all now sorted alphabetically, keyed by the unqualified name of their outermost type.
1. a dependency for https://github.com/input-output-hk/cardano-benchmarking/pull/2


Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
