### PR TITLE
 Make the chairman test more robust 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,29 +57,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 722d1dccfc60d2a42b8a6e32d61c29f36587c1bc
-  --sha256: 0kxhmhgzdn0pvzm23ar9bwb9jk4b8lgvx0c26ajfpncz1zvs9f6j
+  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
+  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 722d1dccfc60d2a42b8a6e32d61c29f36587c1bc
-  --sha256: 0kxhmhgzdn0pvzm23ar9bwb9jk4b8lgvx0c26ajfpncz1zvs9f6j
+  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
+  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 722d1dccfc60d2a42b8a6e32d61c29f36587c1bc
-  --sha256: 0kxhmhgzdn0pvzm23ar9bwb9jk4b8lgvx0c26ajfpncz1zvs9f6j
+  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
+  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 722d1dccfc60d2a42b8a6e32d61c29f36587c1bc
-  --sha256: 0kxhmhgzdn0pvzm23ar9bwb9jk4b8lgvx0c26ajfpncz1zvs9f6j
+  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
+  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
   subdir: crypto/test
 
 source-repository-package

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -13,18 +13,17 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
-module Cardano.Chairman (runChairman) where
+module Cardano.Chairman (chairmanTest) where
 
 import           Cardano.Prelude hiding (ByteString, STM, atomically, catch, option, show)
 import           Prelude (String, error, show)
 
-import           Control.Concurrent.Async (mapConcurrently)
+import           Control.Concurrent.Async (forConcurrently_)
 import           Control.Monad (void)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
 import           Data.Void (Void)
 import           Data.Coerce (coerce)
-import           Data.Typeable (Typeable)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
@@ -32,24 +31,29 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime (DiffTime)
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 
 import           Network.Mux (MuxError)
 
 import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
-import           Ouroboros.Consensus.Config (TopLevelConfig)
+import           Ouroboros.Consensus.BlockchainTime.SlotLength
+import           Ouroboros.Consensus.BlockchainTime.SlotLengths
+import           Ouroboros.Consensus.Config
+                   ( TopLevelConfig, configConsensus, configBlock )
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Cardano
-import           Ouroboros.Consensus.Util.Condense
 
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Mux
-import           Ouroboros.Network.Block (BlockNo, HasHeader, HeaderHash, Point, Tip)
+import           Ouroboros.Network.Block (BlockNo, HasHeader, Point, Tip)
 import qualified Ouroboros.Network.Block as Block
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import           Ouroboros.Network.Point (WithOrigin(..), fromWithOrigin)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment, Anchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Client hiding (SendMsgDone)
@@ -61,45 +65,266 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.NodeToClient
 
 import           Cardano.Config.Types (SocketPath(..))
-import           Cardano.Tracing.Tracers (TraceConstraints)
 
--- | Run chairman: connect with all the core nodes.  Chairman will store the
--- forks from a common prefix.  If any of them is longer than the security
--- parameter it will throw an exception.
+
+-- | The chairman checks for consensus and progress.
+--
+-- The chairman test is an integration test. It monitors a set of nodes and
+-- checks that all the nodes agree on the chain, within a margin. It also
+-- checks that enough blocks have been made.
+--
+-- Specifically in this case consensus is defined as follows: for all pairs
+-- of chains, the intersection of each pair is within K blocks of each tip.
+-- Progress is defined simply as each chain being at least of a certain length.
+--
+-- The consensus condition is checked incrementally as well as at the end, so
+-- that failures can be detected as early as possible. The progress condition
+-- is only checked at the end.
 --
 -- It is also possible to specify how many blocks should be validated.
 --
-runChairman :: forall blk.
-               ( RunNode blk
-               , TraceConstraints blk
-               )
-            => AssociateWithIOCP
-            -> Protocol blk (BlockProtocol blk)
+chairmanTest :: RunNode blk
+             => Tracer IO String
+             -> Protocol blk (BlockProtocol blk)
+             -> Maybe BlockNo
+             -> Maybe DiffTime
+             -> [SocketPath]
+             -> IO ()
+chairmanTest tracer ptcl maxBlockNo maxRunTime socketPaths = do
+
+    -- The chairman runs until we hit the max block no, or max run time,
+    -- or if both are @Nothing@ it runs indefinately, and the remaining
+    -- checks are never performed.
+    traceWith tracer ("Will run until block number " ++ show maxBlockNo')
+    traceWith tracer ("Will run until timeout "      ++ show maxRunTime')
+
+    -- Run the chairman and get the final snapshot of the chain from each node.
+    chainsSnapshot <- runChairman
+                        tracer
+                        cfg securityParam
+                        maxBlockNo' maxRunTime'
+                        socketPaths
+
+    traceWith tracer ("================== chairman results ==================")
+
+    -- Test if we achieved consensus
+    consensusSuccess <- either throwIO return $
+                          consensusCondition securityParam chainsSnapshot
+
+    traceWith tracer (show consensusSuccess)
+
+    -- Test if we made adequate progress
+    progressSuccess <- either throwIO return $
+                         progressCondition progressThreshold consensusSuccess
+
+    traceWith tracer (show progressSuccess)
+    traceWith tracer ("================== chairman results ==================")
+
+  where
+    ProtocolInfo { pInfoConfig = cfg } = protocolInfo ptcl
+    securityParam = protocolSecurityParam (configConsensus cfg)
+    slotLength    = currentSlotLength (knownSlotLengths (configBlock cfg))
+
+    (maxBlockNo', maxRunTime') = deriveRunLimits slotLength (maxBlockNo, maxRunTime)
+
+    progressThreshold = fromMaybe 0 maxBlockNo'
+
+
+-- | We can specify how long to run the chairman either by specifying the
+-- number of blocks to run for, or the time, or both, or neither. If only
+-- one is given, the other is derived.
+deriveRunLimits :: SlotLength
+                -> (Maybe BlockNo, Maybe DiffTime)
+                -> (Maybe BlockNo, Maybe DiffTime)
+
+-- If only the block number is specified, derive the timeout
+deriveRunLimits slotLength (Just maxBlockNo, Nothing) =
+    (Just maxBlockNo, Just maxRunTime)
+  where
+    maxRunTime = fromIntegral (Block.unBlockNo maxBlockNo)
+               * getSlotLengthDiffTime slotLength
+
+-- If only the timeout is specified, derive the block number
+deriveRunLimits slotLength (Nothing, Just maxRunTime) =
+    (Just maxBlockNo, Just maxRunTime)
+  where
+    maxBlockNo = Block.BlockNo $
+                   floor (maxRunTime / getSlotLengthDiffTime slotLength)
+
+-- Otherwise if both or none specified, leave them
+deriveRunLimits _ x = x
+
+getSlotLengthDiffTime :: SlotLength -> DiffTime
+getSlotLengthDiffTime = realToFrac . getSlotLength
+
+type ChainsSnapshot blk = Map PeerId (AnchoredFragment (Header blk))
+
+type PeerId = SocketPath
+
+data ConsensusSuccess blk =
+     ConsensusSuccess
+       -- Minimum of the maximum intersection points
+       (Anchor (Header blk))
+       -- Chain tip for each chain
+       [(PeerId, Tip (Header blk))]
+  deriving Show
+
+data ConsensusFailure blk =
+     ConsensusFailure
+       -- Tip of two peer's chains that do not intersect within K blocks
+       (PeerId, Tip (Header blk))
+       (PeerId, Tip (Header blk))
+       -- The tntersection point of two chains
+       (Anchor (Header blk))
+       SecurityParam
+  deriving Show
+
+instance HasHeader blk => Exception (ConsensusFailure blk) where
+  displayException (ConsensusFailure (peerid1, tip1)
+                                     (peerid2, tip2)
+                                     intersection
+                                     (SecurityParam securityParam)) =
+    concat
+      [ "consensus failure:\n"
+      , "node at ", show peerid1, " has chain tip ", show tip1, "\n"
+      , "node at ", show peerid2, " has chain tip ", show tip2, "\n"
+      , "but their chain intersection is at ", show intersection, "\n"
+      , "which is further back than the security param K ", show securityParam
+      ]
+
+-- | For this test we define consensus as follows: for all pairs of chains,
+-- the intersection of each pair is within K blocks of each tip.
+--
+consensusCondition :: HasHeader (Header blk)
+                   => SecurityParam
+                   -> ChainsSnapshot blk
+                   -> Either (ConsensusFailure blk)
+                             (ConsensusSuccess blk)
+consensusCondition (SecurityParam securityParam) chains =
+    -- The (forkTooLong . chainForkPoints) predicate is not transitive.
+    -- As a consequence, we need to check it between all the pairs of chains:
+    let forks = [ ((peerid1, peerid2), chainForkPoints chain1 chain2)
+                | (peerid1, chain1) <- Map.toList chains
+                , (peerid2, chain2) <- Map.toList chains
+                ]
+     in case find (forkTooLong . snd) forks of
+          Just ((peerid1, peerid2), (intersection, tip1, tip2)) ->
+            Left $
+              ConsensusFailure
+                (peerid1, AF.anchorToTip tip1)
+                (peerid2, AF.anchorToTip tip2)
+                intersection
+                (SecurityParam securityParam)
+          Nothing ->
+            Right $
+              ConsensusSuccess
+                -- the minimum intersection point:
+                (minimumBy (comparing AF.anchorToBlockNo)
+                           [ intersection | (_,(intersection,_,_)) <- forks ])
+                -- all the chain tips:
+                [ (peerid, AF.anchorToTip (AF.headAnchor chain))
+                | (peerid, chain) <- Map.toList chains ]
+  where
+    chainForkPoints :: HasHeader (Header blk)
+                    => AnchoredFragment (Header blk)
+                    -> AnchoredFragment (Header blk)
+                    -> (Anchor (Header blk), -- intersection
+                        Anchor (Header blk), -- tip of c1
+                        Anchor (Header blk)) -- tip of c2
+    chainForkPoints chain1 chain2 =
+      case AF.intersect chain1 chain2 of
+        -- chains are anochored at the genesis, so their intersection is never
+        -- empty
+        Nothing -> error "chainChains: invariant violation"
+
+        Just (_, _, extension1, extension2) ->
+          (AF.anchor     extension1,
+           AF.headAnchor extension1,
+           AF.headAnchor extension2)
+
+    forkTooLong :: (Anchor (Header blk), -- intersection
+                    Anchor (Header blk), -- tip of chain1
+                    Anchor (Header blk)) -- tip of chain2
+                -> Bool
+    forkTooLong (intersection, tip1, tip2) =
+        -- If only one of len1, len2 is longer than the securityParam then it is
+        -- still ok. That node can still recover by receiving a valid rollback
+        -- instruction, but if both are longer, then we have a failure.
+        forkLen tip1 > securityParam &&
+        forkLen tip2 > securityParam
+      where
+        forkLen :: Anchor (Header blk) -> Word64
+        forkLen tip =
+          Block.unBlockNo $
+            fromWithOrigin 0 (AF.anchorToBlockNo tip)
+          - fromWithOrigin 0 (AF.anchorToBlockNo intersection)
+
+
+data ProgressSuccess =
+     ProgressSuccess
+       BlockNo
+  deriving Show
+
+data ProgressFailure blk =
+     ProgressFailure
+       BlockNo -- minimum expected
+       PeerId
+       (Tip (Header blk))
+  deriving Show
+
+instance HasHeader blk => Exception (ProgressFailure blk) where
+  displayException (ProgressFailure minBlockNo peerid tip) =
+    concat
+      [ "progress failure:\n"
+      , "the node at ", show peerid, " has chain tip ", show tip, "\n"
+      , "while the mininum expected block number is ", show minBlockNo
+      ]
+
+-- | Progress is defined as each chain being at least of a certain length.
+--
+progressCondition :: BlockNo
+                  -> ConsensusSuccess blk
+                  -> Either (ProgressFailure blk) ProgressSuccess
+progressCondition minBlockNo (ConsensusSuccess _ tips) =
+    case find (\(_,tip) -> Block.getTipBlockNo tip < At minBlockNo) tips of
+      Just (peerid, tip) -> Left (ProgressFailure minBlockNo peerid tip)
+      Nothing            -> Right (ProgressSuccess minBlockNo)
+
+
+runChairman :: RunNode blk
+            => Tracer IO String
+            -> TopLevelConfig blk
             -> SecurityParam
             -- ^ security parameter, if a fork is deeper than it 'runChairman'
             -- will throw an exception.
             -> Maybe BlockNo
-            -- ^ finish after that many blocks, if 'Nothing' run continuously.
+            -- ^ finish after this many blocks, if 'Nothing' run continuously.
+            -> Maybe DiffTime
+            -- ^ finish after this much time, if 'Nothing' run continuously.
             -> [SocketPath]
             -- ^ local socket dir
-            -> Tracer IO String
-            -> IO ()
-runChairman iocp ptcl securityParam maxBlockNo socketPaths tracer = do
+            -> IO (ChainsSnapshot blk)
+runChairman tracer cfg securityParam
+            maxBlockNo maxRunTime
+            socketPaths = do
 
-    (chainsVar :: ChainsVar IO blk) <- newTVarM
-      (Map.fromList $ map (\socketPath -> (socketPath, AF.Empty AF.AnchorGenesis)) socketPaths)
+    let initialChains = Map.fromList [ (socketPath, AF.Empty AF.AnchorGenesis)
+                                     | socketPath <- socketPaths]
+    chainsVar <- newTVarM initialChains
 
-    void $ flip mapConcurrently socketPaths $ \sockPath ->
-        let ProtocolInfo { pInfoConfig = cfg } = protocolInfo ptcl
+    void $ timeout (fromMaybe (-1) maxRunTime) $
+      withIOManager $ \iomgr ->
+        forConcurrently_ socketPaths $ \sockPath ->
+          createConnection
+            tracer
+            iomgr
+            cfg
+            securityParam
+            maxBlockNo
+            chainsVar
+            sockPath
 
-        in createConnection
-             chainsVar
-             securityParam
-             maxBlockNo
-             tracer
-             cfg
-             iocp
-             sockPath
+    atomically (readTVar chainsVar)
 
 -- catch 'MuxError'; it will be thrown if a node shuts down closing the
 -- connection.
@@ -115,26 +340,22 @@ handleMuxError tracer chainsVar socketPath err = do
 
 createConnection
   :: forall blk.
-     ( RunNode blk
-     , Condense blk
-     , Condense (Header blk)
-     , Condense (HeaderHash blk)
-     )
-  => ChainsVar IO blk
+     RunNode blk
+  => Tracer IO String
+  -> AssociateWithIOCP
+  -> TopLevelConfig blk
   -> SecurityParam
   -> Maybe BlockNo
-  -> Tracer IO String
-  -> TopLevelConfig blk
-  -> AssociateWithIOCP
+  -> ChainsVar IO blk
   -> SocketPath
   -> IO ()
 createConnection
-  chainsVar
+  tracer
+  iomgr
+  cfg
   securityParam
   maxBlockNo
-  tracer
-  cfg
-  iomgr
+  chainsVar
   socketPath@(SocketFile path) =
       connectTo
         (localSnocket iomgr path)
@@ -153,18 +374,6 @@ createConnection
             cfg)
         path
         `catch` handleMuxError tracer chainsVar socketPath
-
-data ChairmanTrace blk
-  = WitnessedConsensus [Point (Header blk)]
-  -- ^ witness consensus at a given point.  The list is a list of tip points of
-  -- each chain.
-
-instance (Condense blk, Condense (HeaderHash blk)) => Show (ChairmanTrace blk) where
-    show (WitnessedConsensus tips)
-      = mconcat
-      [ "witnessed consensus "
-      , condense tips
-      ]
 
 
 --
@@ -192,69 +401,6 @@ addBlock
     -> STM m ()
 addBlock sockPath chainsVar blk =
     modifyTVar chainsVar (Map.adjust (AF.addBlock (getHeader blk)) sockPath)
-
-
-data ChairmanError blk =
-    NodeMisconduct [Point blk]
-    -- ^ Nodes did not agree on a chain: we witnessed a fork longer than
-    -- 'SecurityParam'.  The given points are tips of the chains when the fork
-    -- was encountered.
-
-instance (Condense blk, Condense (HeaderHash blk))
-    => Show (ChairmanError blk) where
-    show (NodeMisconduct blks) = "NodeMisconduct " ++ condense blks
-
-instance ( Condense blk
-         , Condense (HeaderHash blk)
-         , Typeable blk
-         ) => Exception (ChairmanError blk)
-
-
--- | Check if there is no illegitimate long fork.
---
-checkConsensus
-    :: forall blk m.
-       ( MonadSTM m
-       , MonadThrow (STM m)
-       , HasHeader (Header blk)
-       , Condense (Header blk)
-       , Condense (HeaderHash (Header blk))
-       )
-    => ChainsVar m blk
-    -> SecurityParam
-    -> STM m (ChairmanTrace blk)
-checkConsensus chainsVar (SecurityParam securityParam) = do
-    chains <- readTVar chainsVar
-    let tips = AF.headPoint `map` Map.elems chains
-    case checkChains (Map.elems chains) of
-      True  -> pure (WitnessedConsensus tips)
-      False -> throwM (NodeMisconduct tips)
-  where
-    -- This property is not transitive (e.g. fr0 and fr1 are not long forks,
-    -- and fr1 and fr2 are not long forks, but fr0 and fr2 are long forks).
-    -- As a consequence, we need to check it between all the pairs of chains.
-    longFork :: AnchoredFragment (Header blk)
-             -> AnchoredFragment (Header blk)
-             -> Bool
-    longFork fr0 fr1 = case AF.intersect fr0 fr1 of
-      -- chains are anochored at the genesis, so their intersection is never
-      -- empty
-      Nothing -> error "chainChains: invariant violation"
-      Just (_, _, s0, s1) ->
-        let s0len = fromIntegral (AF.length s0)
-            s1len = fromIntegral (AF.length s1)
-        in if s0len > securityParam && s1len > securityParam
-             then True
-             -- if only one of 's0len', 's1len` is greater than 'securityParam'
-             -- then it is still ok. That node can still recover by receiving
-             -- a valid rollback instruction.
-             else False
-
-    checkChains :: [AnchoredFragment (Header blk)]
-                -> Bool
-    checkChains chains =
-      all (not . (uncurry longFork))
-          [ (fr0, fr1)  | fr0 <- chains, fr1 <- chains ]
 
 
 -- | Rollback a single block.  If the rollback point is not found, we simply
@@ -285,6 +431,8 @@ rollback sockPath chainsVar p =
 -- Chain-Sync client
 --
 
+type ChairmanTrace blk = ConsensusSuccess blk
+
 -- | 'ChainSyncClient' which build chain fragment; on every roll forward it will
 -- check if there is consensus on immutable chain.
 --
@@ -296,8 +444,6 @@ chainSyncClient
      , GetHeader blk
      , HasHeader blk
      , HasHeader (Header blk)
-     , Condense (Header blk)
-     , Condense (HeaderHash (Header blk))
      )
   => Tracer m (ChairmanTrace blk)
   -> SocketPath
@@ -346,6 +492,23 @@ chainSyncClient tracer sockPath chainsVar securityParam maxBlockNo = ChainSyncCl
           pure $ clientStIdle Nothing
       }
 
+-- | Check that all nodes agree with each other, within the security parameter.
+--
+checkConsensus
+    :: forall blk m.
+       ( MonadSTM m
+       , MonadThrow (STM m)
+       , HasHeader blk
+       , HasHeader (Header blk)
+       )
+    => ChainsVar m blk
+    -> SecurityParam
+    -> STM m (ConsensusSuccess blk)
+checkConsensus chainsVar securityParam = do
+    chainsSnapshot <- readTVar chainsVar
+    either throwM return $ consensusCondition securityParam chainsSnapshot
+
+
 --
 -- Client Application
 --
@@ -353,8 +516,6 @@ chainSyncClient tracer sockPath chainsVar securityParam maxBlockNo = ChainSyncCl
 localInitiatorNetworkApplication
   :: forall blk m peer.
      ( RunNode blk
-     , Condense (Header blk)
-     , Condense (HeaderHash blk)
      , MonadAsync m
      , MonadST    m
      , MonadTimer m

--- a/nix/nixos/cardano-cluster-service.nix
+++ b/nix/nixos/cardano-cluster-service.nix
@@ -47,28 +47,28 @@ in let
   ### Names and topologies
   legacy-topology       = svcLib.mkLegacyTopology
     { c-a-1 = { port = 3001;
-                static-routes = [ [ "c-a-2" ] [ "c-b-1" ] [ "c-b-2" ] ];
+                static-routes = [ [ "proxy" ] [ "c-a-2" ] [ "c-b-1" ] ];
               };
       c-a-2 = { port = 3002;
-                static-routes = [ [ "c-b-1" ] [ "c-b-2" ] [ "c-a-1" ] [ "proxy" ] ];
+                static-routes = [ [ "c-a-1" ] [ "c-b-1" ] [ "c-b-2" ] ];
               };
       c-b-1 = { port = 3003;
-                static-routes = [ [ "c-b-2" ] [ "c-a-1" ] [ "c-a-2" ] ];
+                static-routes = [ [ "c-a-1" ] [ "c-a-2" ] [ "c-b-2" ] ];
               };
       c-b-2 = { port = 3004;
-                static-routes = [ [ "c-a-1" ] [ "c-a-2" ] [ "c-b-1" ] ];
+                static-routes = [ [ "c-a-2" ] [ "c-b-1" ] [ "c-a-1" ] ];
               };
       c-c-1 = { port = 3005;
-                static-routes = [ [ "c-d-1" "c-a-1" ] [ "c-c-2" ] [ "proxy" ] ];
+                static-routes = [ [ "c-a-1" ] [ "c-b-1" ] [ "c-b-2" ] ];
               };
       c-c-2 = { port = 3006;
-                static-routes = [ [ "c-b-2" "c-b-1" ] [ "c-c-1" ] [ "proxy" ] ];
+                static-routes = [ [ "c-b-1" ] [ "c-b-2" ] [ "c-c-1" ] ];
               };
       c-d-1 = { port = 3007;
-                static-routes = [ [ "c-a-1" "c-a-2" ] [ "c-b-1" "c-b-2" ] [ "c-c-1" "c-c-2" ] [ "proxy" ] ];
+                static-routes = [ [ "c-b-2" ] [ "c-c-1" ] [ "c-c-2" ] ];
               };
       proxy = { port = 5555;
-                static-routes = [ [ "c-a-2" ] ];
+                static-routes = [ [ "c-a-1" ] ];
                 type = "relay";
               };
     };

--- a/nix/nixos/cardano-cluster-service.nix
+++ b/nix/nixos/cardano-cluster-service.nix
@@ -202,7 +202,6 @@ in {
       node-ids              = shelley-node-ids;
       inherit (ccfg) slot-length;
       nodeConfigFile        = builtins.elemAt shelley-configs 0;
-      timeoutIsSuccess      = true;
     };
     services.cardano-node = {
       enable                = shelley-enabled;

--- a/nix/nixos/chairman-as-a-service.nix
+++ b/nix/nixos/chairman-as-a-service.nix
@@ -12,7 +12,7 @@ let
   envConfig = environments.${cfg.environment};
   mkChairmanConfig = nodeConfig: chairmanConfig: {
     inherit (nodeConfig) package genesisFile genesisHash genesisHashPath stateDir pbftThreshold consensusProtocol;
-    inherit (chairmanConfig) timeout maxBlockNo k slot-length node-ids nodeConfigFile nodeConfig timeoutIsSuccess;
+    inherit (chairmanConfig) timeout k slot-length node-ids nodeConfigFile nodeConfig;
   };
   mkScript = cfg:
     let runtimeDir = if ncfg.runtimeDir == null then ncfg.stateDir else "/run/${ncfg.runtimeDir}";
@@ -24,10 +24,7 @@ let
           "${chairman}/bin/chairman"
           (socketArgs)
           "--timeout ${toString cfg.timeout}"
-          "--max-block-no ${toString cfg.maxBlockNo}"
-          "--security-param ${toString cfg.k}"
           "--config ${cfg.nodeConfigFile}"
-          "${optionalString cfg.timeoutIsSuccess "--timeout-is-success"}"
         ];
     in ''
         GENESIS_HASH=${if (cfg.genesisHash == null) then "$(cat ${cfg.genesisHashPath})" else cfg.genesisHash}
@@ -61,7 +58,7 @@ in {
       timeout = mkOption {
         type = int;
         default = 360;
-        description = ''How long to wait for consensus of maxBlockNo blocks.'';
+        description = ''How long to wait for consensus.'';
       };
       environment = mkOption {
         type = types.enum (builtins.attrNames environments);
@@ -69,11 +66,6 @@ in {
         description = ''
           environment node will connect to
         '';
-      };
-      timeoutIsSuccess = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''Consider timing out as success.'';
       };
       nodeConfig = mkOption {
         type = types.attrs;
@@ -84,16 +76,6 @@ in {
         type = types.str;
         default = "${toFile "config-0.json" (toJSON (svcLib.mkNodeConfig cfg 0))}";
         description = ''Actual configuration file (shell expression).'';
-      };
-      maxBlockNo = mkOption {
-        type = int;
-        default = 5;
-        description = ''How many blocks of consensus should we require before succeeding.'';
-      };
-      k = mkOption {
-        type = int;
-        default = 2160;
-        description = ''Should come from genesis instead.'';
       };
       genesisHash = mkOption {
         type = types.str;

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -28,7 +28,6 @@ let
     inherit cardano-cluster-config;
     chairman-config = {
       timeout    = 450;
-      maxBlockNo = 20;
     };
   };
 in {

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -94,7 +94,7 @@ in {
     $machine->succeed("cat /etc/resolv.conf        | systemd-cat --identifier=resolv");
     $machine->succeed("netstat -pltn | grep LISTEN | systemd-cat --identifier=netstat");
     $machine->succeed("ls -l /var/lib/cardano-node/*.socket | systemd-cat --identifier=sockets");
-    $machine->succeed("bash -c 'set -o pipefail; { ${chairman-runner} 2>&1; status=\$?; echo END-OF-CHAIRMAN-OUTPUT-MARKER; sleep 3; exit \$status; } | systemd-cat --identifier=chairman --priority=crit'");
+    $machine->succeed("bash -c 'set -o pipefail; { ${chairman-runner} 2>&1; status=\$?; echo END-OF-CHAIRMAN-OUTPUT-MARKER; sleep 1; exit \$status; } | systemd-cat --identifier=chairman --priority=crit'");
   '' + optionalString interactive
   ''
     $machine->waitUntilSucceeds("netstat -ptn | grep ESTABLISHED | systemd-cat --identifier=netstat --priority=crit; sleep 9s; false");

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-byron-proxy",
-        "rev": "9bae138919c31b5aeac8f7244e2b28e5f31d9f4f",
-        "sha256": "0drl4hhmph729g5s2bds0j9sg71jzw3b2cai4cm439dn2xymwc9x",
+        "rev": "5538821647728516d5702cbfd9fb3000fcf41082",
+        "sha256": "10s3ivzv6hb7mb32imi2dga02vlaibsx8z1m2h7ns8cfkj4yng30",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-byron-proxy/archive/9bae138919c31b5aeac8f7244e2b28e5f31d9f4f.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-byron-proxy/archive/5538821647728516d5702cbfd9fb3000fcf41082.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-sl": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "cardano-sl",
-        "rev": "d0cc2e6336e3c57771c775cafe831bc83db303d3",
-        "sha256": "1l0af54ivqs26ibsl4nih8800b99f99r1y33wcrnby28mjsph8s2",
+        "rev": "5b35df50cce1ba65da49848f9888c6324796f10f",
+        "sha256": "1slr4lkqpaypwmpydabzlg5qlqpc296z0rpw7y1cns4nm0fb7plv",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-sl/archive/d0cc2e6336e3c57771c775cafe831bc83db303d3.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-sl/archive/5b35df50cce1ba65da49848f9888c6324796f10f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -68,7 +68,8 @@ let
       shelley-ids = range                      node-id-base (node-id-base + node-count - 1);
       mkPeer = id: { inherit valency; port = port-base + id; addr = addr-fn id; };
       mkShelleyNode = {
-        Producers = map (mkPeer) (remove id shelley-ids);
+        Producers = (map (mkPeer) (remove id shelley-ids))
+                    ++ [{ valency = 1; port = proxy-port; addr = proxy-addr; }];
       };
       topology = mkShelleyNode;
     in toFile "topology.yaml" (toJSON topology);

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,7 +56,7 @@ extra-deps:
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 722d1dccfc60d2a42b8a6e32d61c29f36587c1bc
+    commit: 2f6a649662aa93fc8427dcf6706ee63167f4205d
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
It is now structured in a much simpler way: we run the experiment and get a result. Then we inspect that result for two conditions that establish positive evidence of success. If either fails, we fail.

This way it is very clear that we are really testing for a positive condition. Previously it could fail to discover a consensus failure, and nevertheless exit with a successful exit code. This did not establish
positive evidence, and so could fail to detect certain classes of integration mistakes (like inability to connect to the nodes at all).

Also change the number of legacy / new node split from 4 : 3 to 1 : 6. This should help a bit with debugging problems with communication between the old and new nodes.

