### PR TITLE
CAD-742: update deps to fix EBB serialisation mismatch with `cardano-sl`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,29 +57,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 1368966fd6d806d8eb65cd1ba193548c402355f6
-  --sha256: 0mrgby1sw2yawfhkj20zg8wl7k3v9jkcv43prfxxlakikpdkjzhp
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 1368966fd6d806d8eb65cd1ba193548c402355f6
-  --sha256: 0mrgby1sw2yawfhkj20zg8wl7k3v9jkcv43prfxxlakikpdkjzhp
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 1368966fd6d806d8eb65cd1ba193548c402355f6
-  --sha256: 0mrgby1sw2yawfhkj20zg8wl7k3v9jkcv43prfxxlakikpdkjzhp
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 1368966fd6d806d8eb65cd1ba193548c402355f6
-  --sha256: 0mrgby1sw2yawfhkj20zg8wl7k3v9jkcv43prfxxlakikpdkjzhp
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: crypto/test
 
 source-repository-package
@@ -187,92 +187,92 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a85bd4751ca5c81c0507482848358980814e9ca3
-  --sha256: 1fhv6p1rkim6acp5m7gfkzmv9hxmpmg07qc4k03y0sxm1zgwbcjk
+  tag: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
+  --sha256: 0hxl4mg68pifpjk06ayi15af7c1s2xxxxd79zr35fyvh9hxg3h1p
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -870,6 +870,12 @@ instance StandardHash blk
       , "expected" .= String (pack $ show expect)
       , "actual" .= String (pack $ show act)
       ]
+  toObject _verb (Mock.MockExpired expired fail) =
+    mkObject
+      [ "kind" .= String "MockExpired"
+      , "expiration" .= toJSON (unSlotNo expired)
+      , "failure" .= toJSON (unSlotNo fail)
+      ]
 
 instance (Show (PBFT.PBftVerKeyHash c))
  => ToObject (PBFT.PBftValidationErr c) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,7 +56,7 @@ extra-deps:
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 1368966fd6d806d8eb65cd1ba193548c402355f6
+    commit: d00fdb3407c5d13aa57f2ead79490a81854879a4
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -121,7 +121,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: a85bd4751ca5c81c0507482848358980814e9ca3
+    commit: a7ea22d8c1d1ebe358f9425eaa25d1182295c88c
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
- bump `cardano-ledger` to the tip of `dcoutts/ebb-body-proof`
- bump `ouroboros-network` to `origin/cad-742-ledger-for-body-proof-and-abob-fix`

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
