### PR TITLE
cardano-config: Drop use of cardano-prelude-test package

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -27,11 +27,11 @@ library
                      , aeson
                      , async
                      , bytestring
+                     , canonical-json
                      , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-prelude
-                     , cardano-prelude-test
                      , cardano-shell
                      , cborg
                      , contra-tracer


### PR DESCRIPTION
A non test package should never depend on a test package.
