### PR TITLE
Add win32-2.6.2.0 to stack.yaml

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -300,7 +300,7 @@ constraints:
   hedgehog >= 1.0,
   bimap >= 0.4.0,
   brick >= 0.47,
-  libsystemd-journal >= 1.4.4
+  libsystemd-journal >= 1.4.4,
   old-time installed
 
 allow-newer: katip:Win32

--- a/cabal.project
+++ b/cabal.project
@@ -301,6 +301,7 @@ constraints:
   bimap >= 0.4.0,
   brick >= 0.47,
   libsystemd-journal >= 1.4.4
+  old-time installed
 
 allow-newer: katip:Win32
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,6 +53,8 @@ extra-deps:
   - word-wrap-0.4.1
   - websockets-0.12.6.1
   - th-lift-instances-0.1.14
+  - Win32-2.6.2.0
+
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,8 +11,6 @@ ghc-options:
   cardano-node:         -Wall -Werror -fwarn-redundant-constraints
   cardano-tx-generator: -Wall -Werror -fwarn-redundant-constraints
 
-allow-newer: true
-
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-crypto
     commit: 2547ad1e80aeabca2899951601079408becbc92c
@@ -114,7 +112,11 @@ extra-deps:
     # dependencies of iohk-monitoring
   - prometheus-2.1.2
   - libsystemd-journal-1.4.4
-  - katip-0.8.3.0
+
+  - git: https://github.com/Soostone/katip
+    commit: 0d735decdba435ab66bd3891392693d0720925a5
+    subdirs:
+        - katip
 
     # Extracted from cardano-sl since it's quite useful
   - git: https://github.com/input-output-hk/cardano-sl-x509


### PR DESCRIPTION
This PR allows the node to build on Windows 10 using `stack build` by adding `win32-2.6.2.0` to `stack.yaml`.