### PR TITLE
CAD-746 closed all listening ports by default

### DIFF
--- a/benchmarking/chain-sync/configuration/log-config-byron-proxy.yaml
+++ b/benchmarking/chain-sync/configuration/log-config-byron-proxy.yaml
@@ -10,16 +10,13 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-# hasGUI: 18321
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12789
+#hasEKG: 12789
 
 # if wanted, the Prometheus interface is using this port:
-hasPrometheus:
-  - "localhost"
-  - 12799
+#hasPrometheus:
+#  - "localhost"
+#  - 12799
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/benchmarking/chain-sync/configuration/log-configuration.yaml
+++ b/benchmarking/chain-sync/configuration/log-configuration.yaml
@@ -15,13 +15,14 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, Prometheus "metrics" are presented on http://localhost:13789/metrics
-hasPrometheus:
-  - "127.0.0.1"
-  - 13789
+# if wanted, the EKG interface is listening on http://localhost:13788
+#hasEKG: 13788
 
-# if wanted, the EKG interface is listening on this port:
-hasEKG: 13788
+# if wanted, EKG "metrics" are presented on http://localhost:13789/metrics
+# for Prometheus
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13789
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/benchmarking/cluster3nodes/configuration/log-config-0.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-0.yaml
@@ -15,9 +15,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
 

--- a/benchmarking/cluster3nodes/configuration/log-config-1.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-1.yaml
@@ -15,9 +15,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12872
-
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12782
 

--- a/benchmarking/cluster3nodes/configuration/log-config-2.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-2.yaml
@@ -15,9 +15,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
 

--- a/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-explorer.yaml
@@ -24,9 +24,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-# hasGUI: 12787
-
 # if wanted, the EKG interface is listening on this port:
 # hasEKG: 12788
 

--- a/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
+++ b/benchmarking/cluster3nodes/configuration/log-config-generator.yaml
@@ -15,9 +15,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
 

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -15,9 +15,6 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-# hasGUI: 12787
-
 # if wanted, the EKG interface is listening on this port:
 # hasEKG: 12788
 

--- a/configuration/log-config-0.liveview.yaml
+++ b/configuration/log-config-0.liveview.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12781
+#hasEKG: 12781
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13788
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13788
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/configuration/log-config-0.yaml
+++ b/configuration/log-config-0.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12781
+#hasEKG: 12781
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13788
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13788
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/configuration/log-config-1.liveview.yaml
+++ b/configuration/log-config-1.liveview.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12782
+#hasEKG: 12782
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13789
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13789
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/configuration/log-config-1.yaml
+++ b/configuration/log-config-1.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12871
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12782
+#hasEKG: 12782
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13789
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13789
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/configuration/log-config-2.liveview.yaml
+++ b/configuration/log-config-2.liveview.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12872
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12783
+#hasEKG: 12783
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13790
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13790
 
 # here we set up outputs of logging in 'katip':
 setupScribes:

--- a/configuration/log-config-2.yaml
+++ b/configuration/log-config-2.yaml
@@ -15,15 +15,12 @@ setupBackends:
 defaultBackends:
   - KatipBK
 
-# if wanted, the GUI is listening on this port:
-#hasGUI: 12872
-
 # if wanted, the EKG interface is listening on this port:
-hasEKG: 12783
+#hasEKG: 12783
 
-hasPrometheus:
-  - "127.0.0.1"
-  - 13790
+#hasPrometheus:
+#  - "127.0.0.1"
+#  - 13790
 
 # here we set up outputs of logging in 'katip':
 setupScribes:


### PR DESCRIPTION

Issue
-----------

- by default: closed all listening ports except the node-to-node protocol needed to exchange tx and blocks.

- This PR **does result** in breaking changes to upstream dependencies: DevOps please check the nix build process as this closes EKG/Prometheus interfaces and these need to be reenabled in your configurations.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
