### PR TITLE
Use the new DNS pool for mainnet relays

### DIFF
--- a/configuration/mainnet-topology.json
+++ b/configuration/mainnet-topology.json
@@ -1,22 +1,7 @@
 {
    "Producers": [
      {
-       "addr": "3.125.75.199",
-       "port": 3001,
-       "valency": 1
-     },
-     {
-       "addr": "18.177.103.105",
-       "port": 3001,
-       "valency": 1
-     },
-     {
-       "addr": "18.141.0.112",
-       "port": 3001,
-       "valency": 1
-     },
-     {
-       "addr": "52.14.58.121",
+       "addr": "relays-new.cardano-mainnet.iohk.io",
        "port": 3001,
        "valency": 1
      }


### PR DESCRIPTION
The new mainnet relays now have a DSN pool name for them. This pool will be scaled up with more hosts as demand rises.