### PR TITLE
Update to latest dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,35 +17,38 @@ package cardano-tx-generator
 package ouroboros-consensus-byron
   tests: False
 
+package ouroboros-consensus-shelley
+  tests: False
+
 package ouroboros-consensus-mock
   tests: False
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
+  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
+  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
+  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
+  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
   subdir: slotting
 
 source-repository-package
@@ -57,63 +60,77 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
-  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
+  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
+  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
-  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
+  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
+  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
-  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
+  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
+  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 2f6a649662aa93fc8427dcf6706ee63167f4205d
-  --sha256: 07dqa08cjrsljws6z7b1mx9g8gajzqifdbzh9ph98hf8p45yg8h1
+  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
+  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: afacc7969445e4db5427936489f5a49a8a3a8f99
-  --sha256: 0j5c669x7lr5fi7s9lm4jrzhprq8vz8q5z0pb1mrbp5fv4ja352c
+  tag: 28b4381461252b523473972c85b003301a5deadc
+  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: afacc7969445e4db5427936489f5a49a8a3a8f99
-  --sha256: 0j5c669x7lr5fi7s9lm4jrzhprq8vz8q5z0pb1mrbp5fv4ja352c
+  tag: 28b4381461252b523473972c85b003301a5deadc
+  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: afacc7969445e4db5427936489f5a49a8a3a8f99
-  --sha256: 0j5c669x7lr5fi7s9lm4jrzhprq8vz8q5z0pb1mrbp5fv4ja352c
+  tag: 28b4381461252b523473972c85b003301a5deadc
+  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 15329855d4eadbee5f5f486104c7b04b50e05f7b
-  --sha256: 078vvhxsg0w2syg0vwawi6w8n66iq0n1nqhjnfn89h98las8zv7g
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 28b4381461252b523473972c85b003301a5deadc
+  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  subdir: shelley/chain-and-ledger/dependencies/non-integer
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 28b4381461252b523473972c85b003301a5deadc
+  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 15329855d4eadbee5f5f486104c7b04b50e05f7b
-  --sha256: 078vvhxsg0w2syg0vwawi6w8n66iq0n1nqhjnfn89h98las8zv7g
+  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-prelude
+  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
   subdir: test
 
 source-repository-package
@@ -187,92 +204,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  subdir: ouroboros-consensus-shelley
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
-  --sha256: 0r9rxr45iwvcj0k6pqh99zzj8xmgvbxq09wfzhfvs6xb06y2lw33
+  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
+  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-node/src/Cardano/CLI/Ops.hs
+++ b/cardano-node/src/Cardano/CLI/Ops.hs
@@ -80,7 +80,7 @@ import           Ouroboros.Network.Mux
                    (AppType(InitiatorApp), OuroborosApplication(..),
                     MuxPeer(..), RunMiniProtocol(..))
 import           Ouroboros.Network.NodeToClient
-                   (AssociateWithIOCP, NetworkConnectTracers(..), NodeToClientProtocols(..),
+                   (IOManager, NetworkConnectTracers(..), NodeToClientProtocols(..),
                     nodeToClientProtocols, NodeToClientVersionData(..),
                     NodeToClientVersion(NodeToClientV_1),
                     connectTo, localSnocket,
@@ -340,7 +340,7 @@ withRealPBFT _ genFile nMagic sigThresh delCertFp sKeyFp update ptcl action = do
 getLocalTip
   :: ConfigYamlFilePath
   -> Maybe CLISocketPath
-  -> AssociateWithIOCP
+  -> IOManager
   -> IO ()
 getLocalTip configFp mSockPath iocp = do
   nc <- parseNodeConfigurationFP configFp
@@ -370,7 +370,7 @@ createNodeConnection
   :: forall blk . (Condense (HeaderHash blk), RunNode blk)
   => Proxy blk
   -> Consensus.Protocol blk (BlockProtocol blk)
-  -> AssociateWithIOCP
+  -> IOManager
   -> SocketPath
   -> IO ()
 createNodeConnection proxy ptcl iocp (SocketFile path) =

--- a/cardano-node/src/Cardano/CLI/Run.hs
+++ b/cardano-node/src/Cardano/CLI/Run.hs
@@ -28,7 +28,7 @@ module Cardano.CLI.Run (
   , ExplorerAPIEnpoint(..)
 
   -- * re-exports from Ouroboros-Network
-  , AssociateWithIOCP
+  , IOManager
   , withIOManager
   ) where
 
@@ -57,7 +57,7 @@ import           Cardano.Crypto (RequiresNetworkMagic(..))
 import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
-import           Ouroboros.Network.NodeToClient ( AssociateWithIOCP
+import           Ouroboros.Network.NodeToClient ( IOManager
                                                 , withIOManager
                                                 )
 
@@ -420,5 +420,5 @@ ensureNewFile writer outFile blob = do
 ensureNewFileLBS :: FilePath -> LB.ByteString -> ExceptT CliError IO ()
 ensureNewFileLBS = ensureNewFile LB.writeFile
 
-withIOManagerE :: (AssociateWithIOCP -> ExceptT e IO a) -> ExceptT e IO a
+withIOManagerE :: (IOManager -> ExceptT e IO a) -> ExceptT e IO a
 withIOManagerE k = ExceptT $ withIOManager (runExceptT . k)

--- a/cardano-node/src/Cardano/CLI/Tx.hs
+++ b/cardano-node/src/Cardano/CLI/Tx.hs
@@ -49,7 +49,7 @@ import           Cardano.Crypto (SigningKey(..), ProtocolMagicId, RequiresNetwor
 import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
-import           Ouroboros.Network.NodeToClient (AssociateWithIOCP)
+import           Ouroboros.Network.NodeToClient (IOManager)
 
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Byron.Ledger (GenTx(..), ByronBlock)
@@ -249,7 +249,7 @@ issueUTxOExpenditure
 
 -- | Submit a transaction to a node specified by topology info.
 nodeSubmitTx
-  :: AssociateWithIOCP
+  :: IOManager
   -> Text
   -- ^ Genesis hash.
   -> Maybe Int

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -323,7 +323,7 @@ createConnection
   :: forall blk.
      RunNode blk
   => Tracer IO String
-  -> AssociateWithIOCP
+  -> IOManager
   -> TopLevelConfig blk
   -> SecurityParam
   -> ChainsVar IO blk

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -137,7 +137,7 @@ deriveProgressThreshold _ _ (Just progressThreshold) = progressThreshold
 
 -- If only the progress threshold is not specified, derive it from the running time
 deriveProgressThreshold slotLength runningTime Nothing =
-    Block.BlockNo (floor (runningTime / getSlotLengthDiffTime slotLength))
+    Block.BlockNo (floor (runningTime / getSlotLengthDiffTime slotLength) - 1)
 
 
 getSlotLengthDiffTime :: SlotLength -> DiffTime

--- a/cardano-node/src/Cardano/Node/Submission.hs
+++ b/cardano-node/src/Cardano/Node/Submission.hs
@@ -47,7 +47,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Client (chainSyncClientPee
 import           Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSync)
 import           Ouroboros.Network.Protocol.Handshake.Version ( Versions
                                                               , simpleSingletonVersions)
-import           Ouroboros.Network.NodeToClient ( AssociateWithIOCP
+import           Ouroboros.Network.NodeToClient ( IOManager
                                                 , NetworkConnectTracers (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 
@@ -101,7 +101,7 @@ instance (MonadIO m) => Transformable Text m TraceLowLevelSubmit where
 submitTx :: ( RunNode blk
             , Show (ApplyTxErr blk)
             )
-         => AssociateWithIOCP
+         => IOManager
          -> SocketPath
          -> TopLevelConfig blk
          -> GenTx blk

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -86,7 +86,7 @@ import           Cardano.Benchmarking.GeneratorTx.Tx (toCborTxAux, txSpendGenesi
 
 import           Control.Tracer (Tracer, traceWith)
 
-import           Ouroboros.Network.NodeToClient (AssociateWithIOCP)
+import           Ouroboros.Network.NodeToClient (IOManager)
 
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
@@ -146,7 +146,7 @@ newtype ExplorerAPIEnpoint =
 -----------------------------------------------------------------------------------------
 genesisBenchmarkRunner
   :: LoggingLayer
-  -> AssociateWithIOCP
+  -> IOManager
   -> SocketPath
   -> Consensus.Protocol ByronBlock Consensus.ProtocolRealPBFT
   -> NonEmpty NodeAddress
@@ -396,7 +396,7 @@ extractGenesisFunds genesisConfig signingKeys =
 prepareInitialFunds
   :: Tracer IO (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock))
   -> Tracer IO TraceLowLevelSubmit
-  -> AssociateWithIOCP 
+  -> IOManager 
   -> SocketPath
   -> CC.Genesis.Config
   -> TopLevelConfig ByronBlock
@@ -642,7 +642,7 @@ runBenchmark
   -> Tracer IO SendRecvConnect
   -> Tracer IO (SendRecvTxSubmission ByronBlock)
   -> Tracer IO TraceLowLevelSubmit
-  -> AssociateWithIOCP
+  -> IOManager
   -> SocketPath
   -> TopLevelConfig ByronBlock
   -> Crypto.SigningKey
@@ -837,7 +837,7 @@ postTx benchTracer initialRequest serializedTx = do
 createMoreFundCoins
   :: Tracer IO (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock))
   -> Tracer IO TraceLowLevelSubmit
-  -> AssociateWithIOCP
+  -> IOManager
   -> SocketPath
   -> TopLevelConfig ByronBlock
   -> Crypto.SigningKey
@@ -1175,7 +1175,7 @@ launchTxPeer
   -- tracer for lower level connection and details of
   -- protocol interactisn, intended for debugging
   -- associated issues.
-  -> AssociateWithIOCP
+  -> IOManager
   -- ^ associate a file descriptor with IO completion port
   -> MSTM.TVar IO Bool
   -- a "global" stop variable, set to True to force shutdown

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Run.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Trans.Except.Extra
 
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Network.NodeToClient
-                    ( AssociateWithIOCP
+                    ( IOManager
                     , withIOManager
                     )
 
@@ -119,5 +119,5 @@ runCommand (GenerateTxs logConfigFp
 
 ----------------------------------------------------------------------------
 
-withIOManagerE :: (AssociateWithIOCP -> ExceptT e IO a) -> ExceptT e IO a
+withIOManagerE :: (IOManager -> ExceptT e IO a) -> ExceptT e IO a
 withIOManagerE k = ExceptT $ withIOManager (runExceptT . k)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -52,7 +52,7 @@ import           Ouroboros.Network.NodeToNode (NetworkConnectTracers (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 -- TODO: #1685 (ouroboros-network) IO manager terms and types should be exported
 -- from NodeToNode module as well.
-import           Ouroboros.Network.NodeToClient (AssociateWithIOCP)
+import           Ouroboros.Network.NodeToClient (IOManager)
 import           Ouroboros.Network.Protocol.BlockFetch.Client (BlockFetchClient(..), blockFetchClientPeer)
 import           Ouroboros.Network.Protocol.ChainSync.Client (chainSyncClientNull, chainSyncClientPeer)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
@@ -193,7 +193,7 @@ data BenchmarkTxSubmitTracers m blk = BenchmarkTracers
 
 benchmarkConnectTxSubmit
   :: forall m blk . (RunNode blk, m ~ IO)
-  => AssociateWithIOCP
+  => IOManager
   -> BenchmarkTxSubmitTracers m blk
   -- ^ For tracing the send/receive actions
   -> TopLevelConfig blk

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -87,7 +87,7 @@ import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle(..
                                                                  TxSubmissionClient(..))
 import           Ouroboros.Network.Protocol.TxSubmission.Type (BlockingReplyList(..),
                                                                TokBlockingStyle(..))
-import           Ouroboros.Network.NodeToClient ( AssociateWithIOCP
+import           Ouroboros.Network.NodeToClient ( IOManager
                                                 , NetworkConnectTracers (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 
@@ -529,7 +529,7 @@ instance (MonadIO m) => Transformable Text m TraceLowLevelSubmit where
 submitTx :: ( RunNode blk
             , Show (ApplyTxErr blk)
             )
-         => AssociateWithIOCP
+         => IOManager
          -> SocketPath
          -> TopLevelConfig blk
          -> GenTx blk

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/15329855d4eadbee5f5f486104c7b04b50e05f7b/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3/snapshot.yaml
 compiler: ghc-8.6.5
 
 packages:
@@ -56,7 +56,7 @@ extra-deps:
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 2f6a649662aa93fc8427dcf6706ee63167f4205d
+    commit: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -64,7 +64,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: afacc7969445e4db5427936489f5a49a8a3a8f99
+    commit: 28b4381461252b523473972c85b003301a5deadc
     subdirs:
       # small-steps
       - byron/semantics/executable-spec
@@ -72,15 +72,18 @@ extra-deps:
       - byron/ledger/executable-spec
       # cs-blockchain
       - byron/chain/executable-spec
+      - shelley/chain-and-ledger/dependencies/non-integer
+      - shelley/chain-and-ledger/executable-spec
+      - shelley/chain-and-ledger/executable-spec/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 15329855d4eadbee5f5f486104c7b04b50e05f7b
+    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: f869bee9b08ba1044b1476737c9d65083e1c6c7f
+    commit: 1222078176fe74d5ce17f2a8343c6588233a49a3
     subdirs:
       - binary
       - binary/test
@@ -121,7 +124,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: ee2d69a973e0990b723d00fe8f2fec331c9d6b56
+    commit: e71aa72adc7e876cda4ff19b5cc0900167fa9804
     subdirs:
         - io-sim
         - io-sim-classes
@@ -131,6 +134,7 @@ extra-deps:
         - ouroboros-consensus-byron
         - ouroboros-consensus/ouroboros-consensus-mock
         - ouroboros-consensus-cardano
+        - ouroboros-consensus-shelley
         - typed-protocols
         - typed-protocols-examples
         - ouroboros-network-testing


### PR DESCRIPTION
Most updates in the `ouroboros-network` repo.
No code changes in the node itself. This should be quite close to the final 1.9.0 tag release.