### PR TITLE
CAD-704 nightly CI job chain-sync not active anymore

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,9 +1,0 @@
-steps:
-  - label: 'Chain-sync benchmark Mainnet'
-    command:
-      - ./benchmarking/chain-sync/ci.sh mainnet
-    timeout_in_minutes: 65
-    artifact_paths:
-      - "benchmark-results.log"
-    agents:
-      system: x86_64-linux


### PR DESCRIPTION

Issue
-----------

- this PR disables the nightly "chain-sync" job as it is not run on dedicated hardware and will be moved to cardano-benchmarking repo anyway.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
