### PR TITLE
Improve the rendering of mempool trace messages

### DIFF
--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -26,6 +26,7 @@ import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT,
                                                    hoistEither, left)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
+import           Data.Aeson (ToJSON)
 
 import           Cardano.BM.Tracing (ToObject)
 import qualified Cardano.Chain.Genesis as Genesis
@@ -82,6 +83,8 @@ type TraceConstraints blk =
     , Show blk
     , Show (Header blk)
     , Show (TxId (GenTx blk))
+    , ToObject (GenTx blk)
+    , ToJSON   (TxId (GenTx blk))
     , ToObject (LedgerError blk)
     , ToObject (ValidationErr (BlockProtocol blk))
     )


### PR DESCRIPTION
Crucially, include the `ApplyTxErr` rejection reason in the `TraceMempoolRejectedTx` case.