### PR TITLE
Improve some network related tracing

### DIFF
--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -131,16 +131,13 @@ TraceChainSyncHeaderServer: False
 TraceChainSyncProtocol: False
 
 # Trace DNS Resolver messages.
-TraceDNSResolver: False
+TraceDNSResolver: True
 
 # Trace DNS Subscription messages.
-TraceDNSSubscription: False
+TraceDNSSubscription: True
 
 # Trace error policy resolution.
 TraceErrorPolicy: False
-
-# Trace local error policy resolution.
-TraceLocalErrorPolicy: True
 
 # Trace local error policy resolution.
 TraceLocalErrorPolicy: True
@@ -152,7 +149,7 @@ TraceForge: True
 TraceHandshake: False
 
 # Trace IP Subscription messages.
-TraceIpSubscription: False
+TraceIpSubscription: True
 
 # Trace local ChainSync protocol messages.
 TraceLocalChainSyncProtocol: False


### PR DESCRIPTION
Enable subscription tracing and DNS lookup tracing.
When running at Notice level only a few lines related to startup will be
logged.
Events that causes the mux bearer to be torn down and re-established are
also logged.

Issue
-----------
#636 
-

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
