### PR TITLE
Various tweaks to the default mainnet configuration for logging output 

### DIFF
--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -204,7 +204,7 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     LedgerDB.InvalidSnapshot {} -> Error
 
   getSeverityAnnotation (ChainDB.TraceCopyToImmDBEvent ev) = case ev of
-    ChainDB.CopiedBlockToImmDB {} -> Notice
+    ChainDB.CopiedBlockToImmDB {} -> Debug
     ChainDB.NoBlocksToCopyToImmDB -> Debug
 
   getSeverityAnnotation (ChainDB.TraceGCEvent ev) = case ev of

--- a/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
+++ b/cardano-config/src/Cardano/Tracing/ToObjectOrphans.hs
@@ -384,19 +384,19 @@ instance HasSeverityAnnotation (WithIPList (SubscriptionTrace Socket.SockAddr)) 
 instance HasPrivacyAnnotation (Identity (SubscriptionTrace LocalAddress))
 instance HasSeverityAnnotation (Identity (SubscriptionTrace LocalAddress)) where
   getSeverityAnnotation (Identity ev) = case ev of
-    SubscriptionTraceConnectStart {} -> Info
-    SubscriptionTraceConnectEnd {} -> Info
+    SubscriptionTraceConnectStart {} -> Notice
+    SubscriptionTraceConnectEnd {} -> Notice
     SubscriptionTraceConnectException {} -> Error
     SubscriptionTraceSocketAllocationException {} -> Error
-    SubscriptionTraceTryConnectToPeer {} -> Info
+    SubscriptionTraceTryConnectToPeer {} -> Notice
     SubscriptionTraceSkippingPeer {} -> Info
-    SubscriptionTraceSubscriptionRunning -> Debug
+    SubscriptionTraceSubscriptionRunning -> Notice
     SubscriptionTraceSubscriptionWaiting {} -> Debug
     SubscriptionTraceSubscriptionFailed -> Warning
     SubscriptionTraceSubscriptionWaitingNewConnection {} -> Debug
-    SubscriptionTraceStart {} -> Debug
-    SubscriptionTraceRestart {} -> Debug
-    SubscriptionTraceConnectionExist {} -> Info
+    SubscriptionTraceStart {} -> Notice
+    SubscriptionTraceRestart {} -> Notice
+    SubscriptionTraceConnectionExist {} -> Debug
     SubscriptionTraceUnsupportedRemoteAddr {} -> Warning
     SubscriptionTraceMissingLocalAddress -> Warning
     SubscriptionTraceApplicationException {} -> Error

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -29,7 +29,7 @@ ApplicationVersion: 1
 
 ##### Logging configuration #####
 
-ViewMode: LiveView
+ViewMode: SimpleView
 TurnOnLogging: True
 TurnOnLogMetrics: True
 
@@ -58,10 +58,18 @@ setupScribes:
     scName: "logs/mainnet.log"
     scFormat: ScText
 
+  - scKind: StdoutSK
+    scName: stdout
+    scFormat: ScText
+    scRotation: null
+
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
   - - FileSK
     - "logs/mainnet.log"
+
+  - - StdoutSK
+    - stdout
 
 # global file rotation settings:
 rotation:
@@ -159,14 +167,7 @@ options:
   mapBackends:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
-      - kind: UserDefinedBK
-        name: LiveViewBackend
     cardano.node.metrics:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.BlockFetchDecision.peers:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
 
   mapSubtrace:
     benchmark:

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -6,11 +6,11 @@
 GenesisFile: configuration/mainnet-genesis.json
 SocketPath:
 
+
+##### Core protocol parameters #####
+
 Protocol: RealPBFT
-NumCoreNodes: 1
-NodeId:
 RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold:
 
 
 ##### Update Parameters #####

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -117,7 +117,7 @@ TraceDNSResolver: True
 TraceDNSSubscription: True
 
 # Trace error policy resolution.
-TraceErrorPolicy: False
+TraceErrorPolicy: True
 
 # Trace local error policy resolution.
 TraceLocalErrorPolicy: True

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -3,6 +3,8 @@
 ##########################################################
 
 
+##### Locations #####
+
 GenesisFile: configuration/mainnet-genesis.json
 SocketPath: db/node.socket
 
@@ -13,46 +15,82 @@ SocketPath: db/node.socket
 
 ##### Core protocol parameters #####
 
+# This is the instance of the Ouroboros family that we are running.
+# The node also supports various test and mock instances.
+# "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
+# is what we use on mainnet in Byron era.
 Protocol: RealPBFT
+
+# The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresNoMagic
 
 
-##### Update Parameters #####
+##### Update system parameters #####
 
+# This protocol version number gets used by by block producing nodes as part
+# part of the system for agreeing on and synchronising protocol updates.
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
+# In the Byron era some software versions are also published on the chain.
+# We do this only for Byron compatibility now.
 ApplicationName: cardano-sl
 ApplicationVersion: 1
 
 
 ##### Logging configuration #####
 
+# The node can run in either the SimpleView or LiveView. The SimpleView just
+# uses standard output, optionally with log output. The LiveView is a text
+# console with a live view of various node metrics.
 ViewMode: SimpleView
+
+# Enble or disable logging overall
 TurnOnLogging: True
+
+# Enable the collection of various OS metrics such as memory and CPU use.
+# These metrics can be directed to the logs or monitoring backends.
 TurnOnLogMetrics: True
 
-# global filter; messages must have at least this severity to pass:
+# Global logging severity filter. Messages must have at least this severity to
+# pass. Typical values would be Warning, Notice, Info or Debug.
 minSeverity: Notice
 
-# MinimalVerbosity: Minimal level of the rendering of captured items
-# MaximalVerbosity: Maximal level of the rendering of captured items
-# NormalVerbosity: the default level of the rendering of captured items
+# Log items can be rendered with more or less verbose detail.
+# The verbosity can be: MinimalVerbosity, NormalVerbosity
 TracingVerbosity: MaximalVerbosity
 
-# these backends are initialized:
+# The system supports a number of backends for logging and monitoring.
+# This setting lists the the backends that will be available to use in the
+# configuration below. The logging backend is called Katip. Also enable the EKG
+# backend if you want to use the EKG or Prometheus monitoring interfaces.
 setupBackends:
   - KatipBK
+# - EKGViewBK
 
-# if not indicated otherwise, then messages are passed to these backends:
+# This specifies the default backends that trace output is sent to if it
+# is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
 
-# if wanted, the EKG interface is listening on this port:
+# EKG is a simple metrics monitoring system. Uncomment the following to listen
+# on the given local port and point your web browser to http://localhost:12788/
+# for a live view. The same URL can also serve JSON output.
 # hasEKG: 12788
 
-# here we set up outputs of logging in 'katip':
+# The Prometheus monitoring system can also be used. Uncomment the following
+# to listen on the given port
+# hasPrometheus: 12789
+
+# For the Katip logging backend we must set up outputs (called scribes)
+# The available types of scribe are:
+#   FileSK for files
+#   StdoutSK/StdoutSK for stdout/stderr
+#   JournalSK for systemd's journal system
+#   DevNullSK
+# The scribe output format can be ScText or ScJson. Log rotation settings can
+# be specified in the defaults below or overidden on a per-scribe basis here.
 setupScribes:
   - scKind: FileSK
     scName: "logs/mainnet.log"
@@ -63,7 +101,8 @@ setupScribes:
     scFormat: ScText
     scRotation: null
 
-# if not indicated otherwise, then log output is directed to this:
+# For the Katip logging backend this specifies the default scribes that trace
+# output is sent to if it is not configured to be sent to other scribes.
 defaultScribes:
   - - FileSK
     - "logs/mainnet.log"
@@ -71,7 +110,8 @@ defaultScribes:
   - - StdoutSK
     - stdout
 
-# global file rotation settings:
+# The default file rotation settings for katip scribes, unless overridden
+# in the setupScribes above for specific scribes.
 rotation:
   rpLogLimitBytes: 5000000
   rpKeepFilesNum:  3
@@ -79,6 +119,10 @@ rotation:
 
 
 ##### Coarse grained logging control #####
+
+# Trace output from whole subsystems can be enabled/disabled using the following
+# settings. This provides fairly coarse grained control, but it is relatively
+# efficient at filtering out unwanted trace output.
 
 # Trace BlockFetch client.
 TraceBlockFetchClient: False
@@ -161,9 +205,17 @@ TraceTxSubmissionProtocol: False
 
 ##### Fine grained logging control #####
 
-# more options which can be passed as key-value pairs:
+# It is also possible to have more fine grained control over filtering of
+# trace output, and to match and route trace output to particular backends.
+# This is less efficient than the coarse trace filters above but provides
+# much more precise control.
+
 options:
 
+  # This routes metrics matching specific names to particular backends.
+  # This overrides the defaultBackends listed above. And note that it is
+  # and override and not an extension so anything matched here will not
+  # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
@@ -172,6 +224,7 @@ options:
     cardano.node-metrics:
       - EKGViewBK
 
+  # This section is more expressive still, and needs to be properly documented.
   mapSubtrace:
     benchmark:
       contents:

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -59,7 +59,7 @@ minSeverity: Notice
 
 # Log items can be rendered with more or less verbose detail.
 # The verbosity can be: MinimalVerbosity, NormalVerbosity
-TracingVerbosity: MaximalVerbosity
+TracingVerbosity: NormalVerbosity
 
 # The system supports a number of backends for logging and monitoring.
 # This setting lists the the backends that will be available to use in the

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -4,8 +4,12 @@
 
 
 GenesisFile: configuration/mainnet-genesis.json
-SocketPath:
+SocketPath: db/node.socket
 
+#TODO: These parameters cannot yet be used in the config file, only on the CLI:
+#DatabasePath: db/
+#Topology: configuration/mainnet-topology.json
+#Port 7776
 
 ##### Core protocol parameters #####
 

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -168,6 +168,9 @@ options:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
     cardano.node.metrics:
+      - EKGViewBK
+    cardano.node-metrics:
+      - EKGViewBK
 
   mapSubtrace:
     benchmark:

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -128,7 +128,7 @@ rotation:
 TraceBlockFetchClient: False
 
 # Trace BlockFetch decisions made by the BlockFetch client.
-TraceBlockFetchDecisions: True
+TraceBlockFetchDecisions: False
 
 # Trace BlockFetch protocol messages.
 TraceBlockFetchProtocol: False

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -1,3 +1,31 @@
+##########################################################
+############### Cardano Node Configuration ###############
+##########################################################
+
+
+NodeId:
+Protocol: RealPBFT
+GenesisFile: configuration/mainnet-genesis.json
+NumCoreNodes: 1
+RequiresNetworkMagic: RequiresNoMagic
+PBftSignatureThreshold:
+TurnOnLogging: True
+ViewMode: LiveView
+TurnOnLogMetrics: True
+SocketPath:
+
+
+##### Update Parameters #####
+
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+
+##### Logging configuration #####
+
 # global filter; messages must have at least this severity to pass:
 minSeverity: Notice
 
@@ -29,71 +57,8 @@ defaultScribes:
   - - FileSK
     - "logs/mainnet.log"
 
-# more options which can be passed as key-value pairs:
-options:
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
-  mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.metrics:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.BlockFetchDecision.peers:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
 
-##########################################################
-############### Cardano Node Configuration ###############
-##########################################################
-
-
-NodeId:
-Protocol: RealPBFT
-GenesisFile: configuration/mainnet-genesis.json
-NumCoreNodes: 1
-RequiresNetworkMagic: RequiresNoMagic
-PBftSignatureThreshold:
-TurnOnLogging: True
-ViewMode: LiveView
-TurnOnLogMetrics: True
-SocketPath:
-
-
-#####    Update Parameters    #####
-
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-LastKnownBlockVersion-Major: 0
-LastKnownBlockVersion-Minor: 2
-LastKnownBlockVersion-Alt: 0
-
-#####         Tracing         #####
+##### Coarse grained logging control #####
 
 # MinimalVerbosity: Minimal level of the rendering of captured items
 # MaximalVerbosity: Maximal level of the rendering of captured items
@@ -177,3 +142,46 @@ TraceTxOutbound: False
 
 # Trace TxSubmission protocol messages.
 TraceTxSubmissionProtocol: False
+
+
+##### Fine grained logging control #####
+
+# more options which can be passed as key-value pairs:
+options:
+  mapSubtrace:
+    benchmark:
+      contents:
+        - GhcRtsStats
+        - MonotonicClock
+      subtrace: ObservableTrace
+    '#ekgview':
+      contents:
+      - - tag: Contains
+          contents: 'cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: .monoclock.basic.
+      - - tag: Contains
+          contents: 'cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: diff.RTS.cpuNs.timed.
+      - - tag: StartsWith
+          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: diff.RTS.gcNum.timed.
+      subtrace: FilterTrace
+    'cardano.epoch-validation.utxo-stats':
+      # Change the `subtrace` value to `Neutral` in order to log
+      # `UTxO`-related messages during epoch validation.
+      subtrace: NoTrace
+  mapBackends:
+    cardano.node.ChainDB.metrics:
+      - EKGViewBK
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.metrics:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.BlockFetchDecision.peers:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+

--- a/configuration/configuration-mainnet.yaml
+++ b/configuration/configuration-mainnet.yaml
@@ -3,37 +3,39 @@
 ##########################################################
 
 
-NodeId:
-Protocol: RealPBFT
 GenesisFile: configuration/mainnet-genesis.json
+SocketPath:
+
+Protocol: RealPBFT
 NumCoreNodes: 1
+NodeId:
 RequiresNetworkMagic: RequiresNoMagic
 PBftSignatureThreshold:
-TurnOnLogging: True
-ViewMode: LiveView
-TurnOnLogMetrics: True
-SocketPath:
 
 
 ##### Update Parameters #####
 
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+
 
 ##### Logging configuration #####
+
+ViewMode: LiveView
+TurnOnLogging: True
+TurnOnLogMetrics: True
 
 # global filter; messages must have at least this severity to pass:
 minSeverity: Notice
 
-# global file rotation settings:
-rotation:
-  rpLogLimitBytes: 5000000
-  rpKeepFilesNum:  3
-  rpMaxAgeHours:   24
+# MinimalVerbosity: Minimal level of the rendering of captured items
+# MaximalVerbosity: Maximal level of the rendering of captured items
+# NormalVerbosity: the default level of the rendering of captured items
+TracingVerbosity: MaximalVerbosity
 
 # these backends are initialized:
 setupBackends:
@@ -57,13 +59,14 @@ defaultScribes:
   - - FileSK
     - "logs/mainnet.log"
 
+# global file rotation settings:
+rotation:
+  rpLogLimitBytes: 5000000
+  rpKeepFilesNum:  3
+  rpMaxAgeHours:   24
+
 
 ##### Coarse grained logging control #####
-
-# MinimalVerbosity: Minimal level of the rendering of captured items
-# MaximalVerbosity: Maximal level of the rendering of captured items
-# NormalVerbosity: the default level of the rendering of captured items
-TracingVerbosity: MaximalVerbosity
 
 # Trace BlockFetch client.
 TraceBlockFetchClient: False
@@ -148,6 +151,19 @@ TraceTxSubmissionProtocol: False
 
 # more options which can be passed as key-value pairs:
 options:
+
+  mapBackends:
+    cardano.node.ChainDB.metrics:
+      - EKGViewBK
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.metrics:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.BlockFetchDecision.peers:
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+
   mapSubtrace:
     benchmark:
       contents:
@@ -173,15 +189,3 @@ options:
       # Change the `subtrace` value to `Neutral` in order to log
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
-  mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.metrics:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-    cardano.node.BlockFetchDecision.peers:
-      - kind: UserDefinedBK
-        name: LiveViewBackend
-


### PR DESCRIPTION
These are mostly changes to the `configuration/configuration-mainnet.yaml` which is used by developers and as a reasonably sensible template for other production use cases. The goal is to get closer to having a sensible level of logging output at the default log severity level.

With this PR, the log output is still very high during syncing. To reduce the output during syncing needs a better form of eliding, and is not included in this PR.

This PR includes:
 * Rearranging the config file in a more logical order
 * Removing irrelevant options (e.g. things only needed for mock protocols)
 * Switch to stdout logging
 * Sending OS metrics to the metrics backends, not the logs
 * Documentation of all the major options in the config file
 * Tweaks to the severities of a few common trace options
 * Adjusting which tracers are enabled/disabled by default
 * Using normal verbosity by default, not maximal.