### PR TITLE
Bump version to 1.9.2 and update changelog

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,19 @@
 # Changelog for cardano-node
 
+## 1.9.2 -- March 2020
+
+### node changes
+- None.
+
+### consensus changes
+- None.
+
+### ledger changes
+- Fix off-by-one mismatch in the minimum transaction fee (#756, #757)
+
+### network changes
+- None.
+
 ## 1.9.1 -- March 2020
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-node
-version:               1.9.1
+version:               1.9.2
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io


### PR DESCRIPTION
Just a single bugfix for the off-by-one error in the ledger minimum fee calculation.