### PR TITLE
CAD-666 Activate TraceForwarder plugin if needed.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -195,6 +195,13 @@ source-repository-package
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
   --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  subdir:   plugins/backend-trace-forwarder
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
+  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -43,6 +43,7 @@ library
                      , lobemo-backend-aggregation
                      , lobemo-backend-ekg
                      , lobemo-backend-monitoring
+                     , lobemo-backend-trace-forwarder
                      , lobemo-scribe-systemd
                      , network
                      , network-mux

--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -34,6 +34,7 @@ import           Control.Monad.Trans.Except.Extra (catchIOExceptT)
 import           Cardano.BM.Backend.Aggregation (plugin)
 import           Cardano.BM.Backend.EKGView (plugin)
 import           Cardano.BM.Backend.Monitoring (plugin)
+import           Cardano.BM.Backend.TraceForwarder (plugin)
 import qualified Cardano.BM.Backend.Switchboard as Switchboard
 import           Cardano.BM.Configuration (Configuration)
 import qualified Cardano.BM.Configuration as Config
@@ -222,6 +223,11 @@ loggingCardanoFeatureInit ver disabled' conf = do
       when (p > 0) $
           Cardano.BM.Backend.EKGView.plugin logConfig trace switchBoard
               >>= loadPlugin switchBoard
+
+  Config.getForwardTo logConfig >>= \forwardTo ->
+    when (isJust forwardTo) $
+      Cardano.BM.Backend.TraceForwarder.plugin logConfig trace switchBoard
+        >>= loadPlugin switchBoard
 
   Cardano.BM.Backend.Aggregation.plugin logConfig trace switchBoard
       >>= loadPlugin switchBoard

--- a/stack.yaml
+++ b/stack.yaml
@@ -107,6 +107,7 @@ extra-deps:
       - plugins/backend-aggregation
       - plugins/backend-ekg
       - plugins/backend-monitoring
+      - plugins/backend-trace-forwarder
       - plugins/scribe-systemd
       - tracer-transformers
 


### PR DESCRIPTION
Issue
-----------

- Currently `TraceForwarder` plugin won't be activated even if corresponding setting is presented in the config.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
