### PR TITLE
Fixed a typo in a chairman description

### DIFF
--- a/cardano-node/app/chairman.hs
+++ b/cardano-node/app/chairman.hs
@@ -105,6 +105,8 @@ parseChairmanArgs =
 opts :: ParserInfo ChairmanArgs
 opts = info (parseChairmanArgs <**> helper)
   ( fullDesc
-  <> progDesc "Chairman Shelly application checks if Shelly nodes find consensus."
-  <> header "Chairman sits in a room full of Shelley nodes, and checks if they are all behaving ...")
+  <> progDesc "Chairman Shelley application is a CI tool which checks \
+              \if Shelly nodes find consensus and do expected progress."
+  <> header "Chairman sits in a room full of Shelley nodes, and checks \
+            \if they are all behaving ...")
 


### PR DESCRIPTION
Issue
-----------

This patch fixes a typo mentioned in #697, and rewords the description of chairman application.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
