### PR TITLE
Cross-platform clean shutdown mechanism

### DIFF
--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -203,8 +204,8 @@ createLoggingFeature ver _ nodeProtocolMode = do
     pure (loggingLayer, cardanoFeature)
  where
   getConfigYaml :: NodeProtocolMode -> ConfigYamlFilePath
-  getConfigYaml (RealProtocolMode (NodeCLI _ _ rConfigFp _ )) = rConfigFp
-  getConfigYaml (MockProtocolMode (NodeMockCLI _ _ mConfigFp _)) = mConfigFp
+  getConfigYaml (RealProtocolMode NodeCLI{configFp}) = configFp
+  getConfigYaml (MockProtocolMode NodeMockCLI{mockConfigFp}) = mockConfigFp
 
 -- | Initialize `LoggingCardanoFeature`
 loggingCardanoFeatureInit :: Text -> LoggingFlag -> LoggingConfiguration -> IO (LoggingLayer, LoggingLayer -> IO ())

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -27,6 +27,7 @@ module Cardano.Config.Types
     , Update (..)
     , ViewMode (..)
     , YamlSocketPath (..)
+    , Fd (..)
     , parseNodeConfiguration
     , parseNodeConfigurationFP
     ) where
@@ -40,6 +41,7 @@ import qualified Data.Text as T
 import           Data.Yaml (decodeFileThrow)
 import           Network.Socket (PortNumber)
 import           System.FilePath ((</>), takeDirectory)
+import           System.Posix.Types (Fd(Fd))
 
 import qualified Cardano.Chain.Update as Update
 import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
@@ -84,6 +86,7 @@ data NodeCLI = NodeCLI
   , nodeAddr :: !NodeAddress
   , configFp :: !ConfigYamlFilePath
   , validateDB :: !Bool
+  , shutdownIPC :: !(Maybe Fd)
   }
 
 data NodeMockCLI = NodeMockCLI

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Config.Types
     ( CardanoEnvironment (..)
@@ -97,6 +97,15 @@ data NodeMockCLI = NodeMockCLI
 -- Therefore we distinguish this at the top level on the command line.
 data NodeProtocolMode = MockProtocolMode NodeMockCLI
                       | RealProtocolMode NodeCLI
+
+-- TODO: these types above are currently structured such that we cannot share
+-- anything. Sharing nothing is too little. There are things that are the same
+-- that we can and should share. The code is littered with example where we
+-- select the same bits from both sides.
+--
+-- At the same time, we are not yet taking advantage of the ability to have
+-- different fields for the real vs mock. For example the MiscellaneousFilepaths
+-- is used for both, but mock protocols do not use delegCertFile or signKeyFile.
 
 -- | Filepath of the configuration yaml file. This file determines
 -- all the configuration settings required for the cardano node
@@ -254,8 +263,11 @@ parseNodeConfigurationFP (ConfigYamlFilePath fp) = do
 parseNodeConfiguration :: NodeProtocolMode -> IO NodeConfiguration
 parseNodeConfiguration npm =
   case npm of
-    MockProtocolMode (NodeMockCLI _ _ cy _) -> parseNodeConfigurationFP cy
-    RealProtocolMode (NodeCLI _ _ cy _) -> parseNodeConfigurationFP cy
+    MockProtocolMode NodeMockCLI{mockConfigFp} ->
+      parseNodeConfigurationFP mockConfigFp
+
+    RealProtocolMode NodeCLI{configFp} ->
+      parseNodeConfigurationFP configFp
 
 -- TODO:  we don't want ByronLegacy in Protocol.  Let's wrap Protocol with another
 -- sum type for cases where it's required.

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
@@ -124,6 +125,7 @@ nodeRealParser = do
   nodeConfigFp <- parseConfigFile
 
   validate <- parseValidateDB
+  shutdownIPC <- parseShutdownIPC
 
   pure NodeCLI
     { mscFp = MiscellaneousFilepaths
@@ -136,6 +138,7 @@ nodeRealParser = do
     , nodeAddr = nAddress
     , configFp = ConfigYamlFilePath nodeConfigFp
     , validateDB = validate
+    , shutdownIPC
     }
 
 parseCLISocketPath :: Text -> Parser (Maybe CLISocketPath)
@@ -247,6 +250,15 @@ parseValidateDB =
     switch (
          long "validate-db"
       <> help "Validate all on-disk database files"
+    )
+
+parseShutdownIPC :: Parser (Maybe Fd)
+parseShutdownIPC =
+    optional $ option (Fd <$> auto) (
+         long "shutdown-ipc"
+      <> metavar "FD"
+      <> help "Shut down the process when this inherited FD reaches EOF"
+      <> hidden
     )
 
 -- | Flag parser, that returns its argument on success.

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -50,7 +50,8 @@ import           Cardano.BM.Data.BackendKind (BackendKind (..))
 import           Cardano.BM.Data.LogItem (LOContent (..),
                      PrivacyAnnotation (..), mkLOMeta)
 import           Cardano.BM.Data.Tracer (ToLogObject (..),
-                     TracingVerbosity (..))
+                     TracingVerbosity (..), TracingFormatting (..),
+                     severityNotice, trTransformer)
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
 
@@ -205,7 +206,7 @@ handleSimpleNode p trace nodeTracers npm onKernel = do
     Left err   -> (putTextLn $ show err) >> exitFailure
     Right addr -> return addr
 
-  withShutdownHandler npm tracer $
+  withShutdownHandler npm trace $
    Node.run
     (consensusTracers nodeTracers)
     (protocolTracers nodeTracers)
@@ -332,9 +333,9 @@ handleSimpleNode p trace nodeTracers npm onKernel = do
 -- either deliberatly by the parent process or automatically because the parent
 -- process itself terminated, then we initiate a clean shutdown.
 --
-withShutdownHandler :: NodeProtocolMode -> Tracer IO String -> IO () -> IO ()
+withShutdownHandler :: NodeProtocolMode -> Trace IO Text -> IO () -> IO ()
 withShutdownHandler (RealProtocolMode NodeCLI{shutdownIPC = Just (Fd fd)})
-                    tracer action =
+                    trace action =
     Async.race_ (wrapUninterruptableIO waitForEOF) action
   where
     waitForEOF :: IO ()
@@ -342,11 +343,16 @@ withShutdownHandler (RealProtocolMode NodeCLI{shutdownIPC = Just (Fd fd)})
       hnd <- IO.fdToHandle fd
       r   <- try $ IO.hGetChar hnd
       case r of
-        Left e | IO.isEOFError e -> traceWith tracer "received shutdown request"
-               | otherwise       -> throwIO e
+        Left e
+          | IO.isEOFError e -> traceWith tracer "received shutdown request"
+          | otherwise       -> throwIO e
 
         Right _  ->
           throwIO $ IO.userError "--shutdown-ipc FD does not expect input"
+
+    tracer :: Tracer IO Text
+    tracer = trTransformer TextualRepresentation MaximalVerbosity
+                           (severityNotice trace)
 
 withShutdownHandler _ _ action = action
 

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE DeriveTraversable     #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
 
@@ -546,9 +547,9 @@ initLiveViewState = do
                 }
 
 setTopology :: NFData a => LiveViewBackend blk a -> NodeProtocolMode -> IO ()
-setTopology lvbe (RealProtocolMode (NodeCLI _ nAddress _ _)) =
+setTopology lvbe (RealProtocolMode NodeCLI{nodeAddr}) =
   modifyMVar_ (getbe lvbe) $ \lvs ->
-    return $ lvs { lvsNodeId = pack $ "Port: " <> (show $ naPort nAddress) }
+    return lvs { lvsNodeId = pack $ "Port: " <> show (naPort nodeAddr) }
 setTopology lvbe npm = do
   nc <- parseNodeConfiguration npm
   modifyMVar_ (getbe lvbe) $ \lvs ->


### PR DESCRIPTION
Cross-platform clean shutdown support with `--shutdown-ipc FD` flag

Fixes #726

On Windows there is no standard reliable mechanism to politely ask a process to stop. There is only the brutal TerminateProcess. Using that by default is not great since it means the node always has to revalidate its chain DB on startup.

This adds an ad-hoc mechainsim that Daedalus can use to reliably shut down the node process. The `--shutdown-ipc` flag takes the FD of the read end of an inherited pipe. If provided, the node will monitor that pipe when when the write end of the pipe is closed then the node will initiate a clean shutdown. So Daedalus can explicitly terminate the node by closing the write end of the pipe. If Daedalus terminates uncleanly then the pipe will also be closed and the node will also shut down.

Although this mechanism is needed for Windows, it is also cross-platform so it can be used by Daedalus across all platforms.

