### PR TITLE
CAD-812: sync-and-exit mode

### DIFF
--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -48,6 +48,7 @@ import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)
 import           Ouroboros.Consensus.NodeId (NodeId(..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Network.Block (MaxSlotNo(..))
 
 import           Cardano.Config.Orphanage ()
 import           Cardano.Crypto (RequiresNetworkMagic(..))
@@ -87,6 +88,7 @@ data NodeCLI = NodeCLI
   , configFp :: !ConfigYamlFilePath
   , validateDB :: !Bool
   , shutdownIPC :: !(Maybe Fd)
+  , shutdownOnSlotSynced :: !MaxSlotNo
   }
 
 data NodeMockCLI = NodeMockCLI

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -82,6 +82,7 @@ library
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
                      , ouroboros-network
+                     , process
                      , serialise
                      , stm
                      , strict-concurrency

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -41,6 +41,7 @@ import           Network.Socket (PortNumber)
 import           Options.Applicative
 
 import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
+import           Ouroboros.Network.Block (MaxSlotNo(..), SlotNo(..))
 import           Cardano.Chain.Common (Lovelace, mkLovelace)
 
 import           Cardano.Config.CommonCLI
@@ -127,6 +128,8 @@ nodeRealParser = do
   validate <- parseValidateDB
   shutdownIPC <- parseShutdownIPC
 
+  shutdownOnSlotSynced <- parseShutdownOnSlotSynced
+
   pure NodeCLI
     { mscFp = MiscellaneousFilepaths
       { topFile = TopologyFile topFp
@@ -139,6 +142,7 @@ nodeRealParser = do
     , configFp = ConfigYamlFilePath nodeConfigFp
     , validateDB = validate
     , shutdownIPC
+    , shutdownOnSlotSynced
     }
 
 parseCLISocketPath :: Text -> Parser (Maybe CLISocketPath)
@@ -258,6 +262,16 @@ parseShutdownIPC =
          long "shutdown-ipc"
       <> metavar "FD"
       <> help "Shut down the process when this inherited FD reaches EOF"
+      <> hidden
+    )
+
+parseShutdownOnSlotSynced :: Parser MaxSlotNo
+parseShutdownOnSlotSynced =
+    fmap (fromMaybe NoMaxSlotNo) $
+    optional $ option (MaxSlotNo . SlotNo <$> auto) (
+         long "shutdown-on-slot-synced"
+      <> metavar "SLOT"
+      <> help "Shut down the process after ChainDB is synced up to the specified slot"
       <> hidden
     )
 


### PR DESCRIPTION
1. Factor `ShutdownFDs` as an internal API for the shutdown FD doorbell machinery.
1. Provide a restricted run mode, where the node exits after syncing the chain to a specified slot no -- enabled by `--shutdown-on-slot-synced SLOTNO` option.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
