### PR TITLE
Isolate node socket in Docker image

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ let
     defaultConfig = rec {
       stateDir = "/data";
       dbPrefix = "db";
-      socketPath = stateDir + "/node.socket";
+      socketPath = "/ipc/node.socket";
     };
     customConfig' = defaultConfig // customConfig;
   in pkgs.callPackage ./nix/docker.nix {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -18,6 +18,10 @@
 #   docker run -v $PATH_TO/configuration:/configuration \
 #     inputoutput/cardano-node:<TAG>
 #
+# Mount a volume into /ipc for establishing cross-container communication via node.socket
+#
+#   docker run -v node-ipc:/ipc inputoutput/cardano-node:<TAG>
+#   docker run -v node-ipc:/ipc inputoutput/some-node-client
 ############################################################################
 
 { iohkNix
@@ -87,7 +91,7 @@ let
           --database-path /data/db \
           --host-addr 127.0.0.1 \
           --port 3001 \
-          --socket-path /data/node.socket \
+          --socket-path /ipc/node.socket \
           --topology /configuration/topology.json $@
       ${clusterStatements}
       else

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -14,7 +14,7 @@ let
     users = mkOption {};
   };
   mkNodeScript = envConfig: let
-    defaultConfig = {
+    defaultConfig = rec {
       consensusProtocol = "real-pbft";
       hostAddr = "127.0.0.1";
       port = 3001;
@@ -22,6 +22,7 @@ let
       delegationCertificate = null;
       nodeId = 0;
       stateDir = "state-node-${envConfig.name}";
+      socketPath = "${stateDir}/node.socket";
       # defaults to proxy if env has no relays
       edgeHost = "127.0.0.1";
       edgeNodes = [];
@@ -57,6 +58,7 @@ let
     serviceConfig = {
       inherit (config)
         stateDir
+        socketPath
         signingKey
         delegationCertificate
         consensusProtocol


### PR DESCRIPTION
Issue
-----------
The existing design for cross-container IPC requires mounting a single `data` volume, including the node db. 

This PR isolates the node socket to allow independent volume management so that the `ipc` volume can be accessed by clients, without giving them access to the database.

@disassembler This is WIP to show the intended interface. The image still results in the node creating the socket in `data/node.socket`, but I'm not sure where that is defined.

- This PR **results** in a breaking change to the Docker run interface

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
