### PR TITLE
Release 1.10.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -210,99 +210,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea83018839359742ce048e624dc34bd97154172e
-  --sha256: 18skdnhpa85589cxmk1b956vhl7lqbjd4dwmgvfbd614x6vcypmw
+  tag: 3d89fa475bc740473e5ffe947572c19f9b91d26d
+  --sha256: 0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,37 @@
 # Changelog for cardano-node
 
+## 1.10.0 -- April 2020
+
+### node changes
+- Change interpretation of relative paths in the config file (#750)
+- Fix activation of the TraceForwarder logging system plugin (#743)
+- Added a cross-platform clean shutdown mechanism (#767)
+- Log node version on startup (#757)
+- Minor simplifications of tracing output and internals (#763, #768)
+- Improved docs for building and running (#718, #752)
+
+### consensus changes
+- Performance improvement in sync from improved hash representation (#1887)
+- Chain DB locking improvements for better concurrent performance (#1816, #1866, #1907, #1919)
+- Further test coverage for recovery from chain DB corruption (#1628, #1839)
+- Disable support for rewinding system clock to simplify hard fork support (#1908)
+- Improved tests for hard fork history support (#1888, #1898)
+- Refactoring of time support in preparation for hard fork support (#1918)
+- Internal simplifications in the chain DB (#1890)
+- Improved tracing (#1861, #1895)
+- Label consensus threads for more useful performance profile output (#1916)
+
+### ledger changes
+- Fix mismatch with specs with update proposal version numbers (#759, #766)
+- Performance improvement in validation from improved hash representation (#760)
+
+### network changes
+- Improved Windows IO mangager exception handling (#1897)
+- Handle DNS server changes due to switching network connection (#1891)
+- Numerous small memory-use reductions in low level network code (#1902)
+- Label network threads for more useful performance profile output (#1900)
+- Extensions to a simplified library interface for node clients (#1894)
+
 ## 1.9.3 -- March 2020
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-node
-version:               1.9.3
+version:               1.10.0
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/stack.yaml
+++ b/stack.yaml
@@ -123,7 +123,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: ea83018839359742ce048e624dc34bd97154172e
+    commit: 3d89fa475bc740473e5ffe947572c19f9b91d26d
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
Bump to 1.10.0 and update changelog.

Also include the last couple network & consensus PRs, including the fix for handling DNS lookups after a change in network connection that changes the system DNS servers.