### PR TITLE
fix ifd-pins

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -124,8 +124,8 @@ let
     ifd-pins = mkPins {
       inherit (sources) iohk-nix "haskell.nix";
       inherit (import "${sources.iohk-nix}/nix/sources.nix" {}) nixpkgs;
-      hackageSrc = (import pkgs.path (import sources."haskell.nix")).haskell-nix.hackageSrc;
-      stackageSrc = (import pkgs.path (import sources."haskell.nix")).haskell-nix.stackageSrc;
+      #hackageSrc = (import pkgs.path (import sources."haskell.nix")).haskell-nix.hackageSrc;
+      #stackageSrc = (import pkgs.path (import sources."haskell.nix")).haskell-nix.stackageSrc;
     };
   } // extraBuilds // (mkRequiredJob (
       collectTests jobs.native.checks ++


### PR DESCRIPTION
Issue
```
in job ‘ifd-pins’:
anonymous function at /nix/store/w23pbihk4l1lp12s6p1qbjmdzii3z6k6-source/pkgs/top-level/default.nix:20:1 called with unexpected argument '__functor', at /nix/store/w23pbihk4l1lp12s6p1qbjmdzii3z6k6-source/pkgs/top-level/impure.nix:84:1
```
this is a short-term fix, that just disables the 2 problematic lines, so ifd-pins will cache some things

the long-term fix is to figure out what haskell.nix changed to break things


-

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
