### PR TITLE
CAD-828:  hotfix for tmux & graceful Nix build failure handling

### DIFF
--- a/scripts/lib-cluster.sh
+++ b/scripts/lib-cluster.sh
@@ -8,10 +8,9 @@ run_3node_cluster() {
         setup_genesis_for_config "${config}"
         prebuild 'cardano-node'
 
-        self=$(basename "$0")
         tmux new-session \
           -E \
-          -s "${self%.sh}" \
+          -s "3node-cluster-${config}" \
           -n 'Main' \
           "${scripts}/shelley-testnet.tmux0.sh '${config}' '${topo}' '${delegate}'"
 }

--- a/scripts/lib-nix.sh
+++ b/scripts/lib-nix.sh
@@ -21,7 +21,7 @@ fill_nix_executable_cache_entry() {
         vprint "filling the Nix executable cache for \"$1\".."
         NIX_BUILD=(
                 nix-build
-                "${root}/default.nix"
+                "${__COMMON_SRCROOT}/default.nix"
                 --no-out-link
                 ${extra}
                 ${defaultnix_args}

--- a/scripts/lib-nix.sh
+++ b/scripts/lib-nix.sh
@@ -17,6 +17,7 @@ run_nix_executable() {
 
 fill_nix_executable_cache_entry() {
         local name="$1" extra="$2"
+        local nixattr='haskellPackages.cardano-node.components.exes.'${name}
         vprint "filling the Nix executable cache for \"$1\".."
         NIX_BUILD=(
                 nix-build
@@ -24,14 +25,21 @@ fill_nix_executable_cache_entry() {
                 --no-out-link
                 ${extra}
                 ${defaultnix_args}
-                -A 'haskellPackages.cardano-node.components.exes.'${name}
+                -A "${nixattr}"
         )
         dprint "${NIX_BUILD[*]}"
-        local out=$("${NIX_BUILD[@]}")/bin/${name}
+        local out=$("${NIX_BUILD[@]}")
+        if test -z "${out}"
+        then fprint "failed to build ${nixattr}, rerun with --verbose"
+             local __QUOTED="${NIX_BUILD[*]@Q}"
+             local __FILTERED=${__QUOTED/" '--no-build-output'"}
+             fprint "or:  ${__FILTERED/\" '--quiet'\"}"
+             exit 1
+        fi
         local cache_var=nix_executable_cache_${name/-/_}
         eval export ${cache_var}
         declare -n nix_cache_write_ref=${cache_var}
-        nix_cache_write_ref=${out}
+        nix_cache_write_ref=${out}/bin/${name}
         vprint "cached ${name} = ${!cache_var}"
         dprint "new cache:  ${!nix_executable_cache_@}"
 }

--- a/scripts/lib-node.sh
+++ b/scripts/lib-node.sh
@@ -104,8 +104,8 @@ _run_node() {
         state_id="${state_id:-$config_id}"
 
         local NODE_ARGS=(
-          --database-path    "${root}/db/${state_id}/"
-          --socket-path      "${root}/socket/${state_id}-socket"
+          --database-path    "${__COMMON_SRCROOT}/db/${state_id}/"
+          --socket-path      "${__COMMON_SRCROOT}/socket/${state_id}-socket"
           --port             "${port}"
           "$@"
         )

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -28,10 +28,10 @@ dprint() {
 }
 export -f dprint
 
-oprint() {
-        echo "-- $*" >&2
+fprint() {
+        echo "-- FATAL:  $*" >&2
 }
-export -f oprint
+export -f fprint
 
 prebuild() {
         vprint "prebuilding the \"$1\" executable in \"${mode}\" mode.."

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -62,14 +62,12 @@ run_quiet()
         do case "$1" in
            --build-extra )    bld_extra=$2; shift;;
            * ) break;; esac; shift; done
-        local new_bld_extra=$(
-                case ${mode} in
-                        nix )               echo -n '--no-build-output --quiet';;
-                        cabal )             echo -n '-v0';;
-                        stack | stack-nix ) echo -n '--silent';; esac;
-                echo -n " ${bld_extra}";)
+        case ${mode} in
+                nix )               bld_extra="--no-build-output --quiet ${bld_extra}";;
+                cabal )             bld_extra="-v0 ${bld_extra}";;
+                stack | stack-nix ) bld_extra="--silent ${bld_extra}";; esac;
 
-        actually_run --build-extra "${new_bld_extra}" "$@"
+        actually_run --build-extra "${bld_extra}" "$@"
 }
 export -f run_quiet
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1090,SC2034,SC2154,SC2039,SC1007,SC2207,SC2145,SC2155,SC2206
-## Don't import this file directly,
-## unless you provide it the path to 'scripts/' as first argument.
+## Don't import this file directly.
 
-#set -e
+## TODO:  debug the spectacular failure this causes..
+# set -e
 
-. "$1"/lib-nix.sh
+. "${__COMMON_SRCROOT}/scripts/lib-nix.sh"
 
 ##
 ## This depends on the setup done by scripts/common.sh

--- a/scripts/shelley-testnet.tmux1.sh
+++ b/scripts/shelley-testnet.tmux1.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2154
+# shellcheck disable=SC2154,SC2046
 
+__COMMON_SRCROOT="$(realpath $(dirname "$0")/..)"
 ###
 ### INTERNAL PLUMBING, DO NOT RUN DIRECTLY
 ###
 
-dprint "tmux1: $*"
 conf="$1"
 topo="$2"
 delegate="$3"
@@ -50,9 +50,14 @@ tmux split-window -v
 for i in 0 1 2
 do tmux select-pane -t ${i}
    tmux send-keys \
-     ". ${scripts}/lib.sh ${scripts};
-      . ${scripts}/lib-cli.sh;
-      . ${scripts}/lib-node.sh;
+     "__COMMON_SRCROOT=${__COMMON_SRCROOT};
+      DEFAULT_DEBUG=${DEFAULT_DEBUG};
+      DEFAULT_VERBOSE=${DEFAULT_VERBOSE};
+      DEFAULT_TRACE=${DEFAULT_TRACE};
+
+      . ${__COMMON_SRCROOT}/scripts/common.sh;
+      . ${__COMMON_SRCROOT}/lib-cli.sh;
+      . ${__COMMON_SRCROOT}/lib-node.sh;
 
       run_node $(run_node_args ${i})" \
      C-m


### PR DESCRIPTION
1. work around some odd instances of `tmux` losing environment.
2. gracefully handle `nix-build` failures
3. add a compatibility fix for older `bash` 3.2 on OS X.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
