### PR TITLE
Node top level protocol plumbing cleanups in preparation for shelley

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -20,6 +20,7 @@ library
                        Cardano.Config.Orphanage
                        Cardano.Config.Protocol
                        Cardano.Config.Protocol.Mock
+                       Cardano.Config.Protocol.Byron
                        Cardano.Config.Topology
                        Cardano.Config.Types
                        Cardano.Tracing.Constraints

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -19,6 +19,7 @@ library
                        Cardano.Config.Logging
                        Cardano.Config.Orphanage
                        Cardano.Config.Protocol
+                       Cardano.Config.Protocol.Mock
                        Cardano.Config.Topology
                        Cardano.Config.Types
                        Cardano.Tracing.Constraints

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -20,33 +20,23 @@ module Cardano.Config.Protocol
 
 import           Cardano.Prelude
 
-import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT,
-                                                   hoistEither, left)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Text as T
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
-import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.Update as Update
-import qualified Cardano.Crypto.Signing as Signing
 import           Cardano.Tracing.ToObjectOrphans ()
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
-import           Ouroboros.Consensus.Cardano hiding (Protocol)
 import qualified Ouroboros.Consensus.Cardano as Consensus
 
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 import           Cardano.Config.Types
                    (NodeConfiguration(..), Protocol (..),
-                    MiscellaneousFilepaths(..), GenesisFile (..),
-                    DelegationCertFile (..), SigningKeyFile (..),
-                    Update (..), LastKnownBlockVersion (..))
+                    MiscellaneousFilepaths(..))
 import           Cardano.Tracing.Constraints (TraceConstraints)
 
 import           Cardano.Config.Protocol.Mock
+import           Cardano.Config.Protocol.Byron
 
 
 ------------------------------------------------------------------------------
@@ -76,107 +66,9 @@ mkConsensusProtocol config@NodeConfiguration{ncProtocol} files =
                     SomeConsensusProtocol <$> mkConsensusProtocolPraos config
 
       -- Real protocols
-      RealPBFT -> mkConsensusProtocolRealPBFT config files
+      RealPBFT -> firstExceptT ByronProtocolInstantiationError $
+                    SomeConsensusProtocol <$> mkConsensusProtocolRealPBFT config files
 
-
-------------------------------------------------------------------------------
--- Real protocols
---
-
-mkConsensusProtocolRealPBFT
-  :: NodeConfiguration
-  -> Maybe MiscellaneousFilepaths
-  -> ExceptT ProtocolInstantiationError IO SomeConsensusProtocol
-mkConsensusProtocolRealPBFT NodeConfiguration {
-                              ncGenesisFile,
-                              ncReqNetworkMagic,
-                              ncPbftSignatureThresh,
-                              ncUpdate
-                            }
-                            files = do
-    let genFile@(GenesisFile gFp) = ncGenesisFile
-
-    (_, genHash) <- readGenesis genFile
-
-    gc <- firstExceptT (GenesisConfigurationError gFp) $ Genesis.mkConfigFromFile
-             ncReqNetworkMagic
-             gFp
-             (Genesis.unGenesisHash genHash)
-
-    optionalLeaderCredentials <-
-      case files of
-        Just MiscellaneousFilepaths {
-               delegCertFile,
-               signKeyFile
-             }  -> readLeaderCredentials gc delegCertFile signKeyFile
-        Nothing -> return Nothing
-
-    let p = protocolConfigRealPbft ncUpdate ncPbftSignatureThresh
-                                   gc optionalLeaderCredentials
-
-    return $ SomeConsensusProtocol p
-
-
--- | The plumbing to select and convert the appropriate configuration subset
--- for the 'RealPBFT' protocol.
---
-protocolConfigRealPbft :: Update
-                       -> Maybe Double
-                       -> Genesis.Config
-                       -> Maybe PBftLeaderCredentials
-                       -> Consensus.Protocol ByronBlock ProtocolRealPBFT
-protocolConfigRealPbft (Update appName appVer lastKnownBlockVersion)
-                       pbftSignatureThresh
-                       genesis leaderCredentials =
-    Consensus.ProtocolRealPBFT
-      genesis
-      (PBftSignatureThreshold <$> pbftSignatureThresh)
-      (convertProtocolVersion lastKnownBlockVersion)
-      (Update.SoftwareVersion appName appVer)
-      leaderCredentials
-  where
-    convertProtocolVersion
-      LastKnownBlockVersion {lkbvMajor, lkbvMinor, lkbvAlt} =
-      Update.ProtocolVersion lkbvMajor lkbvMinor lkbvAlt
-
-readGenesis
-  :: GenesisFile
-  -> ExceptT ProtocolInstantiationError IO (Genesis.GenesisData, Genesis.GenesisHash)
-readGenesis (GenesisFile fp) = firstExceptT (GenesisReadError fp) $ Genesis.readGenesisData fp
-
-readLeaderCredentials :: Genesis.Config
-                      -> Maybe DelegationCertFile
-                      -> Maybe SigningKeyFile
-                      -> ExceptT ProtocolInstantiationError IO (Maybe PBftLeaderCredentials)
-readLeaderCredentials gc mDelCertFp mSKeyFp =
-  case (mDelCertFp, mSKeyFp) of
-    (Nothing, Nothing) -> pure Nothing
-    (Just _, Nothing) -> left SigningKeyFilepathNotSpecified
-    (Nothing, Just _) -> left DelegationCertificateFilepathNotSpecified
-    (Just delegCertFile, Just signingKeyFile) -> do
-
-         let delegCertFp = unDelegationCert delegCertFile
-         let signKeyFp = unSigningKey signingKeyFile
-
-         signingKeyFileBytes <- liftIO $ LB.readFile signKeyFp
-         delegCertFileBytes <- liftIO $ LB.readFile delegCertFp
-         signingKey <- firstExceptT (SigningKeyDeserialiseFailure signKeyFp)
-                         . hoistEither
-                         $ deserialiseSigningKey signingKeyFileBytes
-         delegCert  <- firstExceptT (CanonicalDecodeFailure delegCertFp)
-                         . hoistEither
-                         $ canonicalDecodePretty delegCertFileBytes
-
-         bimapExceptT PbftError Just
-           . hoistEither
-           $ mkPBftLeaderCredentials gc signingKey delegCert
-
-  where
-    deserialiseSigningKey :: LB.ByteString
-                          -> Either DeserialiseFailure Signing.SigningKey
-    deserialiseSigningKey =
-        fmap (Signing.SigningKey . snd)
-      . deserialiseFromBytes Signing.fromCBORXPrv
 
 
 ------------------------------------------------------------------------------
@@ -184,13 +76,7 @@ readLeaderCredentials gc mDelCertFp mSKeyFp =
 --
 
 data ProtocolInstantiationError =
-    CanonicalDecodeFailure !FilePath !Text
-  | DelegationCertificateFilepathNotSpecified
-  | GenesisConfigurationError !FilePath !Genesis.ConfigurationError
-  | GenesisReadError !FilePath !Genesis.GenesisDataError
-  | PbftError !PBftLeaderCredentialsError
-  | SigningKeyDeserialiseFailure !FilePath !DeserialiseFailure
-  | SigningKeyFilepathNotSpecified
+    ByronProtocolInstantiationError ByronProtocolInstantiationError
   | MockProtocolInstantiationError MockProtocolInstantiationError
   deriving Show
 
@@ -198,19 +84,8 @@ data ProtocolInstantiationError =
 renderProtocolInstantiationError :: ProtocolInstantiationError -> Text
 renderProtocolInstantiationError pie =
   case pie of
-    CanonicalDecodeFailure fp failure -> "Canonical decode failure in " <> toS fp
-                                         <> " Canonical failure: " <> failure
-    DelegationCertificateFilepathNotSpecified -> "Delegation certificate filepath not specified"
-    --TODO: Implement configuration error render function in cardano-ledger
-    GenesisConfigurationError fp genesisConfigError -> "Genesis configuration error in: " <> toS fp
-                                                       <> " Error: " <> (T.pack $ show genesisConfigError)
-    GenesisReadError fp err ->  "There was an error parsing the genesis file: " <> toS fp
-                                <> " Error: " <> (T.pack $ show err)
-    -- TODO: Implement PBftLeaderCredentialsError render function in ouroboros-network
-    PbftError pbftLeaderCredentialsError -> "PBFT leader credentials error: " <> (T.pack $ show pbftLeaderCredentialsError)
-    SigningKeyDeserialiseFailure fp deserialiseFailure -> "Signing key deserialisation error in: " <> toS fp
-                                                           <> " Error: " <> (T.pack $ show deserialiseFailure)
-    SigningKeyFilepathNotSpecified -> "Signing key filepath not specified"
+    ByronProtocolInstantiationError bpie ->
+      renderByronProtocolInstantiationError bpie
 
     MockProtocolInstantiationError mpie ->
       renderMockProtocolInstantiationError mpie

--- a/cardano-config/src/Cardano/Config/Protocol/Byron.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Byron.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Config.Protocol.Byron
+  ( mkConsensusProtocolRealPBFT
+  , ByronProtocolInstantiationError(..)
+  , renderByronProtocolInstantiationError
+  ) where
+
+import           Cardano.Prelude
+
+import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT,
+                                                   hoistEither, left)
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text as T
+
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Crypto.Signing as Signing
+
+import           Ouroboros.Consensus.Cardano hiding (Protocol)
+import qualified Ouroboros.Consensus.Cardano as Consensus
+
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
+
+import           Cardano.Config.Types
+                   (NodeConfiguration(..),
+                    MiscellaneousFilepaths(..), GenesisFile (..),
+                    DelegationCertFile (..), SigningKeyFile (..),
+                    Update (..), LastKnownBlockVersion (..))
+
+
+------------------------------------------------------------------------------
+-- Real Byron protocol
+--
+
+mkConsensusProtocolRealPBFT
+  :: NodeConfiguration
+  -> Maybe MiscellaneousFilepaths
+  -> ExceptT ByronProtocolInstantiationError IO
+             (Consensus.Protocol ByronBlock ProtocolRealPBFT)
+mkConsensusProtocolRealPBFT NodeConfiguration {
+                              ncGenesisFile,
+                              ncReqNetworkMagic,
+                              ncPbftSignatureThresh,
+                              ncUpdate
+                            }
+                            files = do
+    let genFile@(GenesisFile gFp) = ncGenesisFile
+
+    (_, genHash) <- readGenesis genFile
+
+    gc <- firstExceptT (GenesisConfigurationError gFp) $ Genesis.mkConfigFromFile
+             ncReqNetworkMagic
+             gFp
+             (Genesis.unGenesisHash genHash)
+
+    optionalLeaderCredentials <-
+      case files of
+        Just MiscellaneousFilepaths {
+               delegCertFile,
+               signKeyFile
+             }  -> readLeaderCredentials gc delegCertFile signKeyFile
+        Nothing -> return Nothing
+
+    let p = protocolConfigRealPbft ncUpdate ncPbftSignatureThresh
+                                   gc optionalLeaderCredentials
+
+    return p
+
+
+-- | The plumbing to select and convert the appropriate configuration subset
+-- for the 'RealPBFT' protocol.
+--
+protocolConfigRealPbft :: Update
+                       -> Maybe Double
+                       -> Genesis.Config
+                       -> Maybe PBftLeaderCredentials
+                       -> Consensus.Protocol ByronBlock ProtocolRealPBFT
+protocolConfigRealPbft (Update appName appVer lastKnownBlockVersion)
+                       pbftSignatureThresh
+                       genesis leaderCredentials =
+    Consensus.ProtocolRealPBFT
+      genesis
+      (PBftSignatureThreshold <$> pbftSignatureThresh)
+      (convertProtocolVersion lastKnownBlockVersion)
+      (Update.SoftwareVersion appName appVer)
+      leaderCredentials
+  where
+    convertProtocolVersion
+      LastKnownBlockVersion {lkbvMajor, lkbvMinor, lkbvAlt} =
+      Update.ProtocolVersion lkbvMajor lkbvMinor lkbvAlt
+
+readGenesis
+  :: GenesisFile
+  -> ExceptT ByronProtocolInstantiationError IO
+             (Genesis.GenesisData, Genesis.GenesisHash)
+readGenesis (GenesisFile fp) = firstExceptT (GenesisReadError fp) $ Genesis.readGenesisData fp
+
+readLeaderCredentials :: Genesis.Config
+                      -> Maybe DelegationCertFile
+                      -> Maybe SigningKeyFile
+                      -> ExceptT ByronProtocolInstantiationError IO
+                                 (Maybe PBftLeaderCredentials)
+readLeaderCredentials gc mDelCertFp mSKeyFp =
+  case (mDelCertFp, mSKeyFp) of
+    (Nothing, Nothing) -> pure Nothing
+    (Just _, Nothing) -> left SigningKeyFilepathNotSpecified
+    (Nothing, Just _) -> left DelegationCertificateFilepathNotSpecified
+    (Just delegCertFile, Just signingKeyFile) -> do
+
+         let delegCertFp = unDelegationCert delegCertFile
+         let signKeyFp = unSigningKey signingKeyFile
+
+         signingKeyFileBytes <- liftIO $ LB.readFile signKeyFp
+         delegCertFileBytes <- liftIO $ LB.readFile delegCertFp
+         signingKey <- firstExceptT (SigningKeyDeserialiseFailure signKeyFp)
+                         . hoistEither
+                         $ deserialiseSigningKey signingKeyFileBytes
+         delegCert  <- firstExceptT (CanonicalDecodeFailure delegCertFp)
+                         . hoistEither
+                         $ canonicalDecodePretty delegCertFileBytes
+
+         bimapExceptT PbftError Just
+           . hoistEither
+           $ mkPBftLeaderCredentials gc signingKey delegCert
+
+  where
+    deserialiseSigningKey :: LB.ByteString
+                          -> Either DeserialiseFailure Signing.SigningKey
+    deserialiseSigningKey =
+        fmap (Signing.SigningKey . snd)
+      . deserialiseFromBytes Signing.fromCBORXPrv
+
+
+------------------------------------------------------------------------------
+-- Errors
+--
+
+data ByronProtocolInstantiationError =
+    CanonicalDecodeFailure !FilePath !Text
+  | DelegationCertificateFilepathNotSpecified
+  | GenesisConfigurationError !FilePath !Genesis.ConfigurationError
+  | GenesisReadError !FilePath !Genesis.GenesisDataError
+  | PbftError !PBftLeaderCredentialsError
+  | SigningKeyDeserialiseFailure !FilePath !DeserialiseFailure
+  | SigningKeyFilepathNotSpecified
+  deriving Show
+
+
+renderByronProtocolInstantiationError :: ByronProtocolInstantiationError -> Text
+renderByronProtocolInstantiationError pie =
+  case pie of
+    CanonicalDecodeFailure fp failure -> "Canonical decode failure in " <> toS fp
+                                         <> " Canonical failure: " <> failure
+    DelegationCertificateFilepathNotSpecified -> "Delegation certificate filepath not specified"
+    --TODO: Implement configuration error render function in cardano-ledger
+    GenesisConfigurationError fp genesisConfigError -> "Genesis configuration error in: " <> toS fp
+                                                       <> " Error: " <> (T.pack $ show genesisConfigError)
+    GenesisReadError fp err ->  "There was an error parsing the genesis file: " <> toS fp
+                                <> " Error: " <> (T.pack $ show err)
+    -- TODO: Implement PBftLeaderCredentialsError render function in ouroboros-network
+    PbftError pbftLeaderCredentialsError -> "PBFT leader credentials error: " <> (T.pack $ show pbftLeaderCredentialsError)
+    SigningKeyDeserialiseFailure fp deserialiseFailure -> "Signing key deserialisation error in: " <> toS fp
+                                                           <> " Error: " <> (T.pack $ show deserialiseFailure)
+    SigningKeyFilepathNotSpecified -> "Signing key filepath not specified"
+

--- a/cardano-config/src/Cardano/Config/Protocol/Mock.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Mock.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Config.Protocol.Mock
+  ( mkConsensusProtocolBFT
+  , mkConsensusProtocolPBFT
+  , mkConsensusProtocolPraos
+  , MockProtocolInstantiationError(..)
+  , renderMockProtocolInstantiationError
+  ) where
+
+import           Cardano.Prelude
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (hoistEither)
+
+import           Ouroboros.Consensus.BlockchainTime (SlotLength, slotLengthFromSec)
+import           Ouroboros.Consensus.Cardano hiding (Protocol)
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import           Ouroboros.Consensus.Mock.Ledger.Block
+import           Ouroboros.Consensus.Mock.Ledger.Block.BFT
+import           Ouroboros.Consensus.Mock.Ledger.Block.Praos
+import           Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
+
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+
+import           Cardano.Config.Types (NodeConfiguration(..))
+
+
+------------------------------------------------------------------------------
+-- Mock/testing protocols
+--
+
+type BftBlock =
+       SimpleBlock SimpleMockCrypto
+                   (SimpleBftExt SimpleMockCrypto BftMockCrypto)
+
+mkConsensusProtocolBFT
+  :: NodeConfiguration
+  -> ExceptT MockProtocolInstantiationError IO
+             (Consensus.Protocol BftBlock (Bft BftMockCrypto))
+mkConsensusProtocolBFT NodeConfiguration {
+                         ncNodeId,
+                         ncNumCoreNodes
+                       } =
+  hoistEither $ do
+    (nodeId, numCoreNodes) <- checkProtocolParams ncNodeId ncNumCoreNodes
+
+    return $ Consensus.ProtocolMockBFT
+               numCoreNodes
+               nodeId
+               mockSecurityParam
+               (defaultSimpleBlockConfig mockSecurityParam mockSlotLength)
+
+
+type PBFTBlock =
+       SimpleBlock SimpleMockCrypto
+                   (SimplePBftExt SimpleMockCrypto PBftMockCrypto)
+
+mkConsensusProtocolPBFT
+  :: NodeConfiguration
+  -> ExceptT MockProtocolInstantiationError IO
+             (Consensus.Protocol PBFTBlock (PBft PBftMockCrypto))
+mkConsensusProtocolPBFT NodeConfiguration {
+                              ncNodeId,
+                              ncNumCoreNodes
+                            } =
+  hoistEither $ do
+    (nodeId, numCoreNodes) <- checkProtocolParams ncNodeId ncNumCoreNodes
+    let (NumCoreNodes numNodes) = numCoreNodes
+
+    return $ Consensus.ProtocolMockPBFT
+               PBftParams {
+                 pbftSecurityParam      = mockSecurityParam
+               , pbftNumNodes           = numCoreNodes
+               , pbftSignatureThreshold = (1.0 / fromIntegral numNodes) + 0.1
+               }
+               (defaultSimpleBlockConfig mockSecurityParam mockSlotLength)
+               nodeId
+
+
+type PraosBlock =
+       SimpleBlock SimpleMockCrypto
+                   (SimplePraosExt SimpleMockCrypto PraosMockCrypto)
+
+mkConsensusProtocolPraos
+  :: NodeConfiguration
+  -> ExceptT MockProtocolInstantiationError IO
+             (Consensus.Protocol PraosBlock (Praos PraosMockCrypto))
+mkConsensusProtocolPraos NodeConfiguration {
+                           ncNodeId,
+                           ncNumCoreNodes
+                         } =
+  hoistEither $ do
+    (nodeId, numCoreNodes) <- checkProtocolParams ncNodeId ncNumCoreNodes
+
+    return $ Consensus.ProtocolMockPraos
+               numCoreNodes
+               nodeId
+               PraosParams {
+                   praosSecurityParam = mockSecurityParam
+                 , praosSlotsPerEpoch = 3
+                 , praosLeaderF       = 0.5
+                 , praosLifetimeKES   = 1000000
+                 }
+               (defaultSimpleBlockConfig mockSecurityParam (slotLengthFromSec 2))
+
+
+mockSecurityParam :: SecurityParam
+mockSecurityParam = SecurityParam 5
+
+mockSlotLength :: SlotLength
+mockSlotLength = slotLengthFromSec 20
+
+
+-- | Helper for creating a 'Consensus.Protocol' for a mock protocol that
+-- needs the 'CoreNodeId' and NumCoreNodes'. If one of them is missing from the
+-- 'CardanoConfiguration', a 'MockProtocolInstantiationError' exception is thrown.
+checkProtocolParams
+  :: Maybe NodeId
+  -> Maybe Word64
+  -> Either MockProtocolInstantiationError (CoreNodeId, NumCoreNodes)
+checkProtocolParams nId mNumCoreNodes = do
+
+    nodeId <- case nId of
+                Just (CoreId nodeId) -> pure nodeId
+                _                        -> Left MissingCoreNodeId
+    numCoreNodes <- maybe (Left MissingNumCoreNodes) Right mNumCoreNodes
+
+    return (nodeId, NumCoreNodes numCoreNodes)
+
+
+------------------------------------------------------------------------------
+-- Errors
+--
+
+data MockProtocolInstantiationError =
+    MissingCoreNodeId
+  | MissingNumCoreNodes
+  deriving Show
+
+
+renderMockProtocolInstantiationError :: MockProtocolInstantiationError -> Text
+renderMockProtocolInstantiationError pie =
+  case pie of
+    MissingCoreNodeId   -> "Missing core node id"
+    MissingNumCoreNodes -> "NumCoreNodes: not specified in configuration yaml file."
+


### PR DESCRIPTION
Move mock and Byron protocol construction to their own modules. This will make things clearer when we add support for Shelley.

These glue modules involve importing a lot of things, and these will be different for mock, Byron and Shelley, so it is simpler if they are in their own modules. It provides a simpler context for each one.

Also slightly tidy up things as we go.