### PR TITLE
Readme changes - Remove stack, fix Windows pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,6 @@ by the node shell to the other packages.
 
 ## How to build
 
-### Stack
-Use [Haskell Stack - Version 2.1.3](https://haskellstack.org/) to build this project:
-
-```
-$ cd cardano-node
-$ stack build
-```
-
 ## Cabal
 
 Use [Cabal - Version 3.0](https://www.haskell.org/cabal/) to build this project:
@@ -58,7 +50,7 @@ You can download [here](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-n
 The download includes cardano-node.exe and a .dll. To run the node with cardano-node run you need to reference a few files and directories as arguments. These can be copied from the cardano-node repo into the executables directory. The command to run the node on mainnet looks like this:
 
 ```
-cardano-node.exe run --topology ./mainnet-topology.json --database-path ./state --port 3001 --config ./configuration-mainnet.yaml --socket-path ./socket/mainnet-socket
+cardano-node.exe run --topology ./mainnet-topology.json --database-path ./state --port 3001 --config ./configuration-mainnet.yaml --socket-path \\.\pipe\cardano-node
 ```
 
 # `cardano-node`


### PR DESCRIPTION
I made two changes to the readme. First, I remove Stack from the build instructions as it's currently not working. Second, I changed the name of the pipe passed as an argument when running the node as an execuable on Windows. 