### PR TITLE
make stack build work again

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -51,6 +51,7 @@ extra-deps:
   - word-wrap-0.4.1
   - websockets-0.12.6.1
   - th-lift-instances-0.1.14
+  - quiet-0.2
 
     # Cardano-ledger dependencies
   - git: https://github.com/input-output-hk/cardano-ledger


### PR DESCRIPTION
Issue
-----------

- `stack build` worked until `1.10.0`. now `stack.yaml` needs the fix in this PR (the fix was tested with both to `master` and `1.10.1` 

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
