### PR TITLE
nix: Build fixes for musl64 fully static build

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -421,7 +421,8 @@ constraints:
   hedgehog >= 1.0,
   bimap >= 0.4.0,
   brick >= 0.47,
-  libsystemd-journal >= 1.4.4
+  libsystemd-journal >= 1.4.4,
+  pretty-show == 1.9.5
 
 package comonad
   flags: -test-doctests

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -116,9 +116,12 @@ let
 
         # systemd can't be statically linked - disable lobemo-scribe-journal
         packages.cardano-config.flags.systemd = false;
+ 
+        # segfaults in Setup.hs
+        # packages.pretty-show.package.buildType = lib.mkForce "Simple";
 
         # Haddock not working and not needed for cross builds
-        packages.doHaddock = false;
+        doHaddock = false;
       }))
     ];
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -117,8 +117,8 @@ let
         # systemd can't be statically linked - disable lobemo-scribe-journal
         packages.cardano-config.flags.systemd = false;
 
-        # Remove haddock build-tool dependency (suitable version will be available as part of the ghc derivation)
-        packages.time.components.library.build-tools = lib.mkForce [];
+        # Haddock not working and not needed for cross builds
+        packages.doHaddock = false;
       }))
     ];
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -112,6 +112,8 @@ let
         packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
         packages.cardano-node.components.exes.chairman = fullyStaticOptions;
         packages.ouroboros-consensus-byron.components.exes.db-converter = fullyStaticOptions;
+        # systemd can't be statically linked - disable lobemo-scribe-journal
+        packages.cardano-config.flags.systemd = false;
       }))
     ];
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -110,10 +110,15 @@ let
       in {
         # Apply fully static options to our Haskell executables
         packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
+        packages.cardano-node.components.all = fullyStaticOptions;
         packages.cardano-node.components.exes.chairman = fullyStaticOptions;
         packages.ouroboros-consensus-byron.components.exes.db-converter = fullyStaticOptions;
+
         # systemd can't be statically linked - disable lobemo-scribe-journal
         packages.cardano-config.flags.systemd = false;
+
+        # Remove haddock build-tool dependency (suitable version will be available as part of the ghc derivation)
+        packages.time.components.library.build-tools = lib.mkForce [];
       }))
     ];
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -103,8 +103,8 @@ let
 
         # Module options which adds GHC flags and libraries for a fully static build
         fullyStaticOptions = {
-          enableShared = false;
-          enableStatic = true;
+          enableShared = lib.mkForce false;
+          enableStatic = lib.mkForce true;
           configureFlags = map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs;
         };
       in {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ded93b38ff656d3bf1b90f926bbf0ecea3fab723",
-        "sha256": "12pw3ykv2wp6kj0vj8y499p4khmzyx9r9il15l8p2wr2i7cpjxnc",
+        "rev": "2d1d4ccaf84810442ad54837d89583cb62cb2480",
+        "sha256": "0waxa9fgbnf03fqbfc2m357ir4dwar8bg5ah7x7867vrq92qswm9",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/ded93b38ff656d3bf1b90f926bbf0ecea3fab723.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/2d1d4ccaf84810442ad54837d89583cb62cb2480.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/release.nix
+++ b/release.nix
@@ -111,8 +111,7 @@ let
     };
     native = mapTestOn (__trace (__toJSON (packagePlatforms project)) (packagePlatforms project));
     "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross (filterJobsCross project));
-    # TODO: fix broken evals
-    #musl64 = mapTestOnCross musl64 (packagePlatformsCross (filterJobsCross project));
+    musl64 = mapTestOnCross musl64 (packagePlatformsCross (filterJobsCross project));
     ifd-pins = mkPins {
       inherit (sources) iohk-nix "haskell.nix";
       inherit nixpkgs;


### PR DESCRIPTION
cardano-wallet is getting build failures on musl64 due to the dependency of its tests on cardano-node.

See input-output-hk/cardano-wallet#1566

This is a start on [SRE-83](https://jira.iohk.io/projects/SRE/issues/SRE-83) and should hopefully fix the errors on the cardano-wallet side...

[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-node-pr-800#tabs-jobs)