### PR TITLE
CAD-830:  refactor log/trace configuration

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -23,6 +23,7 @@ library
                        Cardano.Config.Protocol.Byron
                        Cardano.Config.ShelleyGenesis
                        Cardano.Config.Topology
+                       Cardano.Config.TraceConfig
                        Cardano.Config.Types
                        Cardano.Tracing.Constraints
                        Cardano.Tracing.ToObjectOrphans

--- a/cardano-config/src/Cardano/Config/TraceConfig.hs
+++ b/cardano-config/src/Cardano/Config/TraceConfig.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+
+module Cardano.Config.TraceConfig
+  (
+    TraceConfig
+  , traceConfigEnabled
+  , traceConfigVerbosity
+  , traceConfigMute
+  , traceConfigParser
+
+  , TraceId
+  , traceEnabled
+
+  -- Per-trace toggles, alpha-sorted.
+  -- Note, the TraceConfig' type itself MUST not be exported.
+  -- The explanation is provided at its declaration site.
+  , traceAcceptPolicy
+  , traceBlockFetchClient
+  , traceBlockFetchDecisions
+  , traceBlockFetchProtocol
+  , traceBlockFetchProtocolSerialised
+  , traceBlockFetchServer
+  , traceChainDB
+  , traceChainSyncClient
+  , traceChainSyncBlockServer
+  , traceChainSyncHeaderServer
+  , traceChainSyncProtocol
+  , traceDnsResolver
+  , traceDnsSubscription
+  , traceErrorPolicy
+  , traceForge
+  , traceHandshake
+  , traceIpSubscription
+  , traceLocalChainSyncProtocol
+  , traceLocalErrorPolicy
+  , traceLocalHandshake
+  , traceLocalTxSubmissionProtocol
+  , traceLocalTxSubmissionServer
+  , traceLocalStateQueryProtocol
+  , traceMempool
+  , traceMux
+  , traceTxInbound
+  , traceTxOutbound
+  , traceTxSubmissionProtocol
+  )
+where
+
+import           Prelude (Show(..))
+import           Cardano.Prelude hiding (show)
+
+import           Data.Aeson
+import           Data.Aeson.Types (Parser)
+
+import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
+
+import           Cardano.Config.Orphanage ()
+
+
+newtype TraceConfig = TraceConfig TraceConfig'
+
+instance Show TraceConfig where
+  show (TraceConfig tr) = show tr
+
+type TraceId = TraceConfig' -> Bool
+
+-- | Tracing configuration -- either disabled completely,
+--   or carries verbosity + fine-grained toggles.
+--
+--   Note, how this type has exported partial accessors,
+--   but also, how these cannot be used outside the module,
+--   because this type itself is not exported.
+--   This, therefore confines the partiality to the module.
+--
+--   The tradeoff, is that instead of exporting accessors as tags,
+--   we'd need to declare an ADT to enumerate the tracers,
+--   and that enumeration would also have had to be maintained
+--   -- thereby severely reducing benefits of totalisation.
+--
+--   Finally -- this type must not be exported.
+--   If it is not clear why, please re-read the above.
+data TraceConfig'
+
+  -- | Intended to mirror Configuration with TurnOnLogging: False.
+  = TracingDisabled
+
+  -- | Detailed tracing options.  Except for verbosity, eaach option controls
+  --   a particular tracer.
+  | TraceOptions
+  -- Common part.
+  { traceVerbosity :: !TracingVerbosity
+
+  -- Per-trace toggles, alpha-sorted.
+  , traceAcceptPolicy :: !Bool
+  , traceBlockFetchClient :: !Bool
+  , traceBlockFetchDecisions :: !Bool
+  , traceBlockFetchProtocol :: !Bool
+  , traceBlockFetchProtocolSerialised :: !Bool
+  , traceBlockFetchServer :: !Bool
+  , traceChainDB :: !Bool
+  , traceChainSyncClient :: !Bool
+  , traceChainSyncBlockServer :: !Bool
+  , traceChainSyncHeaderServer :: !Bool
+  , traceChainSyncProtocol :: !Bool
+  , traceDnsResolver :: !Bool
+  , traceDnsSubscription :: !Bool
+  , traceErrorPolicy :: !Bool
+  , traceForge :: !Bool
+  , traceHandshake :: !Bool
+  , traceIpSubscription :: !Bool
+  , traceLocalChainSyncProtocol :: !Bool
+  , traceLocalErrorPolicy :: !Bool
+  , traceLocalHandshake :: !Bool
+  , traceLocalTxSubmissionProtocol :: !Bool
+  , traceLocalTxSubmissionServer :: !Bool
+  , traceLocalStateQueryProtocol :: !Bool
+  , traceMempool :: !Bool
+  , traceMux :: !Bool
+  , traceTxInbound :: !Bool
+  , traceTxOutbound :: !Bool
+  , traceTxSubmissionProtocol :: !Bool
+  } deriving (Eq, Show)
+
+traceConfigMute :: TraceConfig
+traceConfigMute = TraceConfig TracingDisabled
+
+traceConfigParser :: Object -> Parser TraceConfig
+traceConfigParser v =
+  fmap TraceConfig $
+   TraceOptions
+     <$> v .:? "TracingVerbosity" .!= NormalVerbosity
+     -- Per-trace toggles, alpha-sorted.
+     <*> v .:? "TraceAcceptPolicy" .!= False
+     <*> v .:? "TraceBlockFetchClient" .!= False
+     <*> v .:? "TraceBlockFetchDecisions" .!= True
+     <*> v .:? "TraceBlockFetchProtocol" .!= False
+     <*> v .:? "TraceBlockFetchProtocolSerialised" .!= False
+     <*> v .:? "TraceBlockFetchServer" .!= False
+     <*> v .:? "TraceChainDb" .!= True
+     <*> v .:? "TraceChainSyncClient" .!= True
+     <*> v .:? "TraceChainSyncBlockServer" .!= False
+     <*> v .:? "TraceChainSyncHeaderServer" .!= False
+     <*> v .:? "TraceChainSyncProtocol" .!= False
+     <*> v .:? "TraceDNSResolver" .!= False
+     <*> v .:? "TraceDNSSubscription" .!= True
+     <*> v .:? "TraceErrorPolicy" .!= True
+     <*> v .:? "TraceForge" .!= True
+     <*> v .:? "TraceHandshake" .!= False
+     <*> v .:? "TraceIpSubscription" .!= True
+     <*> v .:? "TraceLocalChainSyncProtocol" .!= False
+     <*> v .:? "TraceLocalErrorPolicy" .!= True
+     <*> v .:? "TraceLocalHandshake" .!= False
+     <*> v .:? "TraceLocalTxSubmissionProtocol" .!= False
+     <*> v .:? "TraceLocalTxSubmissionServer" .!= False
+     <*> v .:? "TraceLocalStateQueryProtocol" .!= False
+     <*> v .:? "TraceMempool" .!= True
+     <*> v .:? "TraceMux" .!= True
+     <*> v .:? "TraceTxInbound" .!= False
+     <*> v .:? "TraceTxOutbound" .!= False
+     <*> v .:? "TraceTxSubmissionProtocol" .!= False
+
+-- | Is tracing enabled at all?
+traceConfigEnabled :: TraceConfig -> Bool
+traceConfigEnabled = \case
+  TraceConfig TracingDisabled -> False
+  TraceConfig TraceOptions{} -> True
+
+-- | Is a particular trace enabled in the config?
+traceEnabled :: TraceConfig -> TraceId -> Bool
+traceEnabled (TraceConfig TracingDisabled) _ = False
+traceEnabled (TraceConfig topts@TraceOptions{}) proj = proj topts
+{-# INLINE traceEnabled #-}
+
+traceConfigVerbosity :: TraceConfig -> TracingVerbosity
+traceConfigVerbosity = \case
+  TraceConfig TracingDisabled -> MinimalVerbosity
+  TraceConfig TraceOptions{traceVerbosity} -> traceVerbosity

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -56,6 +56,7 @@ import           Cardano.BM.Trace
 
 import           Cardano.Config.GitRev (gitRev)
 import           Cardano.Config.Logging (LoggingLayer (..), Severity (..))
+import           Cardano.Config.TraceConfig (traceConfigVerbosity)
 import           Cardano.Config.Types (MiscellaneousFilepaths(..),
                                        NodeConfiguration (..), ViewMode (..))
 
@@ -105,7 +106,7 @@ runNode loggingLayer npm = do
     nc <- parseNodeConfiguration npm
 
     traceWith tracer $ "tracing verbosity = " ++
-                         case traceVerbosity $ ncTraceOptions nc of
+                         case traceConfigVerbosity $ ncTraceConfig nc of
                            NormalVerbosity -> "normal"
                            MinimalVerbosity -> "minimal"
                            MaximalVerbosity -> "maximal"
@@ -116,7 +117,7 @@ runNode loggingLayer npm = do
         Left err -> (putTextLn $ renderProtocolInstantiationError err) >> exitFailure
         Right (SomeConsensusProtocol p) -> pure $ SomeConsensusProtocol p
 
-    tracers <- mkTracers (ncTraceOptions nc) trace
+    tracers <- mkTracers (ncTraceConfig nc) trace
 
     case ncViewMode nc of
       SimpleView -> handleSimpleNode p trace tracers npm (const $ pure ())


### PR DESCRIPTION
- don't enable tracers if logging is disabled
- factor TraceConfig as a single source of logger-side logging enabled-ness
- simplify logging init
- inline LoggingConfiguration
- remove dead code and unused exports in Cardano.Config.Logging


- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
