### PR TITLE
more text view utils

### DIFF
--- a/cardano-api/src/Cardano/Api/View.hs
+++ b/cardano-api/src/Cardano/Api/View.hs
@@ -36,6 +36,7 @@ import           Control.Monad.Trans.Except.Extra (handleIOExceptT, hoistEither,
 
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text.Encoding as Text
 
 
 parseAddressView :: ByteString -> Either ApiError Address
@@ -106,7 +107,18 @@ renderTxUnsignedView tu =
 -- -------------------------------------------------------------------------------------------------
 
 convertTestViewError :: TextViewError -> Either ApiError b
-convertTestViewError = Left . ApiTextView . unTextViewError
+convertTestViewError err =
+  Left $
+    case err of
+      TextViewFormatError msg -> ApiTextView msg
+
+      TextViewTypeError expected actual ->
+        ApiTextView $ mconcat
+          [ "Expected file type ", Text.decodeLatin1 (unTextViewType expected)
+          , ", but got type ", Text.decodeLatin1 (unTextViewType actual)
+          ]
+
+      TextViewDecodeError derr -> ApiErrorCBOR derr
 
 readAddress :: FilePath -> IO (Either ApiError Address)
 readAddress path =

--- a/cardano-config/src/Cardano/Config/TextView.hs
+++ b/cardano-config/src/Cardano/Config/TextView.hs
@@ -1,11 +1,29 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
 module Cardano.Config.TextView
-  ( TextView (..)
+  ( -- * \"TextView\" format
+    TextView (..)
   , TextViewError (..)
+  , TextViewType (..)
+  , TextViewTitle (..)
   , parseTextView
   , renderTextView
+  , expectTextViewOfType
+  , decodeFromTextView
+  , encodeToTextView
 
-  -- Exported for testing.
+    -- * File IO support
+  , TextViewFileError (..)
+  , readTextViewFile
+  , readTextViewFileOfType
+  , readTextViewEncodedFile
+  , writeTextViewFile
+  , writeTextViewEncodedFile
+
+    -- * Exported for testing.
   , rawToMultilineHex
   , unRawToMultilineHex
   ) where
@@ -17,35 +35,173 @@ import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import qualified Data.ByteString.Base16 as Base16
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Char (isSpace)
-
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+import           Cardano.Binary
+import           Control.Monad.Trans.Except.Extra
 
 
-newtype TextViewError
-  = TextViewError { unTextViewError :: Text }
-  deriving (Eq, Show)
+newtype TextViewType
+  = TextViewType { unTextViewType :: ByteString }
+  deriving (Eq, IsString, Show)
 
+newtype TextViewTitle
+  = TextViewTitle { unTextViewTitle :: ByteString }
+  deriving (Eq, IsString, Show)
 
+-- | A 'TextView' is a structured envalope for serialised binary values
+-- with an external format with a semi-readable textual format.
+--
+-- It contains a \"type\" field, e.g. \"PublicKeyByron\" or \"TxSignedShelley\"
+-- to indicate the type of the encoded data. This is used as a sanity check
+-- and to help readers.
+--
+-- It also contains a \"title\" field which is free-form, and could be used
+-- to indicate the role or purpose to a reader.
+--
 data TextView = TextView
-  { tvType :: !ByteString
-  , tvTitle :: !ByteString
+  { tvType :: !TextViewType
+  , tvTitle :: !TextViewTitle
   , tvRawCBOR :: !ByteString
   } deriving (Eq, Show)
 
+-- | The errors that the pure 'TextView' parsing\/decoding functions can return.
+--
+data TextViewError
+  = TextViewFormatError !Text
+  | TextViewTypeError !TextViewType !TextViewType -- ^ expected, actual
+  | TextViewDecodeError !DecoderError
+  deriving (Eq, Show)
+
+-- | Parse a 'TextView' from the external serialised format.
+--
 parseTextView :: ByteString -> Either TextViewError TextView
 parseTextView =
-  first (TextViewError . Text.pack) . Atto.parseOnly pTextView
+  first (TextViewFormatError . Text.pack) . Atto.parseOnly pTextView
 
+
+-- | Render a 'TextView' into the external serialised format.
+--
 renderTextView :: TextView -> ByteString
 renderTextView tv =
   BS.unlines $
-    [ "type: " <> tvType tv
-    , "title: " <> tvTitle tv
+    [ "type: " <> unTextViewType (tvType tv)
+    , "title: " <> unTextViewTitle (tvTitle tv)
     , "cbor-hex:"
     ]
     <> rawToMultilineHex (tvRawCBOR tv)
--- -------------------------------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+
+-- | Check that the \"type\" of the 'TextView' is as expected.
+--
+-- For example, one might check that the type is \"TxSignedShelley\".
+--
+expectTextViewOfType :: TextViewType -> TextView -> Either TextViewError ()
+expectTextViewOfType expectedType tv = do
+    let actualType = tvType tv
+    unless (expectedType == actualType) $
+      throwError (TextViewTypeError expectedType actualType)
+
+
+-- | Decode the body of a 'TextView' with a CBOR 'Decoder'.
+--
+decodeFromTextView :: (forall s . Decoder s a)
+                   -> TextView -> Either TextViewError a
+decodeFromTextView decoder tv =
+    first TextViewDecodeError $
+      decodeFullDecoder errlabel decoder (LBS.fromStrict $ tvRawCBOR tv)
+  where
+    errlabel :: Text
+    errlabel = Text.decodeLatin1 (unTextViewType $ tvType tv)
+
+-- | Encode a value to a 'TextView' using a CBOR encoder. The type and title
+-- fields must also be specified.
+--
+encodeToTextView :: TextViewType -> TextViewTitle -> (a -> Encoding)
+                 -> a -> TextView
+encodeToTextView tvType tvTitle encode a =
+  TextView
+    { tvType
+    , tvTitle
+    , tvRawCBOR = serializeEncoding' (encode a)
+    }
+
+
+-- ----------------------------------------------------------------------------
+
+-- | The errors that the IO 'TextView' reading\/decoding actions can return.
+--
+data TextViewFileError
+  = TextViewFileError !FilePath !TextViewError
+  | TextViewFileIOError !FilePath !IOException
+  deriving (Eq, Show)
+
+
+-- | Read a file in the external serialised format for 'TextView'.
+--
+readTextViewFile :: FilePath -> IO (Either TextViewFileError TextView)
+readTextViewFile path =
+    runExceptT $ do
+      bs <- handleIOExceptT (TextViewFileIOError path) $
+              BS.readFile path
+      firstExceptT (TextViewFileError path) $ hoistEither $
+        parseTextView bs
+
+
+-- | Read a file in the external serialised format for 'TextView', but use
+-- 'expectTextViewOfType' to check that the file is declared to be of the
+-- expected type.
+--
+readTextViewFileOfType :: TextViewType -> FilePath
+                       -> IO (Either TextViewFileError TextView)
+readTextViewFileOfType expectedType path =
+    runExceptT $ do
+      tv <- ExceptT $ readTextViewFile path
+      firstExceptT (TextViewFileError path) $ hoistEither $
+        expectTextViewOfType expectedType tv
+      return tv
+
+
+-- | Read a file in the external serialised format for 'TextView', check
+-- that it's declared to be the expected type, and decode the body.
+--
+readTextViewEncodedFile :: TextViewType -> (forall s . Decoder s a)
+                          -> FilePath -> IO (Either TextViewFileError a)
+readTextViewEncodedFile expectedType decoder path =
+    runExceptT $ do
+      tv <- ExceptT $ readTextViewFileOfType expectedType path
+      firstExceptT (TextViewFileError path) $ hoistEither $
+        decodeFromTextView decoder tv
+
+
+-- | Write a file in the external serialised format for 'TextView'.
+-- Use 'encodeToTextView' to make the value.
+--
+writeTextViewFile :: FilePath -> TextView -> IO (Either TextViewFileError ())
+writeTextViewFile path tv =
+    runExceptT $
+      handleIOExceptT (TextViewFileIOError path) $
+        BS.writeFile path (renderTextView tv)
+
+
+-- | Write a file in the external serialised format for 'TextView'.
+-- Use 'encodeToTextView' to make the value.
+--
+writeTextViewEncodedFile :: TextViewType -> TextViewTitle -> (a -> Encoding)
+                         -> FilePath -> a -> IO (Either TextViewFileError ())
+writeTextViewEncodedFile tvType tvTitle encode path a =
+    runExceptT $
+      handleIOExceptT (TextViewFileIOError path) $
+        BS.writeFile path (renderTextView tv)
+  where
+    tv = encodeToTextView tvType tvTitle encode a
+
+
+-- ----------------------------------------------------------------------------
 
 chunksOf :: ByteString -> [ByteString]
 chunksOf bs =
@@ -59,7 +215,7 @@ pTextView = do
   title <- Atto.string "title: " *> Atto.takeWhile (/= '\n') <* Atto.endOfLine
   hex <- Atto.string "cbor-hex:\n" *> Atto.takeByteString <* Atto.endOfInput
   case Base16.decode . BS.concat . map (BS.dropWhile isSpace) $ BS.lines hex of
-    (raw, "") -> pure $ TextView typ title raw
+    (raw, "") -> pure $ TextView (TextViewType typ) (TextViewTitle title) raw
     (_, err) -> panic $ "pTextView: Base16.deocde failed on " <> textShow err
 
 -- | Convert a raw ByteString to hexadecimal and then line wrap
@@ -74,4 +230,4 @@ unRawToMultilineHex :: ByteString -> Either TextViewError ByteString
 unRawToMultilineHex bs =
   case Base16.decode $ BS.concat (map (BS.dropWhile isSpace) $ BS.lines bs) of
     (raw, "") -> Right raw
-    (_, err) -> Left $ TextViewError ("unRawToMultilineHex: Unable to decode " <> textShow err)
+    (_, err) -> Left $ TextViewFormatError ("unRawToMultilineHex: Unable to decode " <> textShow err)

--- a/cardano-config/test/Test/Cardano/Config/Gen.hs
+++ b/cardano-config/test/Test/Cardano/Config/Gen.hs
@@ -99,8 +99,8 @@ genSeed5 =
 genTextView :: Gen TextView
 genTextView =
   TextView
-    <$> Gen.utf8 (Range.linear 1 20) Gen.alpha
-    <*> Gen.utf8 (Range.linear 1 80) (Gen.filter (/= '\n') Gen.ascii)
+    <$> fmap TextViewType (Gen.utf8 (Range.linear 1 20) Gen.alpha)
+    <*> fmap TextViewTitle (Gen.utf8 (Range.linear 1 80) (Gen.filter (/= '\n') Gen.ascii))
     <*> Gen.bytes (Range.linear 0 500)
 
 -- -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds more to Erik's TextView format utils.

It now covers:
 * parsing/rendering TextView format (as before)
 * checking the expected file type
 * CBOR encoding/decoding
 * reading/writing from files
 * all of the above included in structured errors
 * haddock docs