### PR TITLE
Configurable protocol versions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -103,29 +103,29 @@ package cardano-ledger
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f950ed079b257ee7318c095b2c0363f28843f964
-  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
+  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
+  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f950ed079b257ee7318c095b2c0363f28843f964
-  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
+  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
+  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f950ed079b257ee7318c095b2c0363f28843f964
-  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
+  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
+  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f950ed079b257ee7318c095b2c0363f28843f964
-  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
+  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
+  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
   subdir: slotting
 
 source-repository-package
@@ -207,14 +207,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 91f357abae16099858193b999807323ca9a7c63c
-  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
+  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 91f357abae16099858193b999807323ca9a7c63c
-  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
+  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
   subdir: test
 
 source-repository-package
@@ -295,99 +295,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
-  --sha256: 0dbh2054izih4q2c53n0cyglgv88nbcn57kbakj503622m5hh7sw
+  tag: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
+  --sha256: 0k0mh3wsvgc5sxd7gs1c73vq4g4s9mxbp5gs04qkzz48mks8kbrj
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-api/src/Cardano/Api/Types.hs
+++ b/cardano-api/src/Cardano/Api/Types.hs
@@ -36,7 +36,7 @@ import           Shelley.Spec.Ledger.Keys (KeyDiscriminator, SKey, VKey, VKeyGen
 data Address
   = AddressByron !Byron.Address
   | AddressShelley
-  deriving (Eq, Generic , NFData, Show)  -- Byron.Address' needs NFData
+  deriving (Eq, Generic, Show)
   deriving NoUnexpectedThunks via UseIsNormalForm Address
 
 data KeyPair
@@ -45,23 +45,23 @@ data KeyPair
   -- Byron address derivation scheme.
   = KeyPairByron !Crypto.VerificationKey !Crypto.SigningKey
   | KeyPairShelley !ShelleyVerificationKey !(SKey TPraosStandardCrypto)
-  deriving (Generic, NFData, Show)
+  deriving (Generic, Show)
   deriving anyclass NoUnexpectedThunks
 
 newtype ShelleyKeyDiscriminator = ShelleyKeyDiscriminator KeyDiscriminator
   deriving (Generic, Show)
-  deriving newtype (NFData, NoUnexpectedThunks)
+  deriving newtype NoUnexpectedThunks
 
 data ShelleyVerificationKey
   = GenesisShelleyVerificationKey !(VKeyGenesis TPraosStandardCrypto)
   | RegularShelleyVerificationKey !(VKey TPraosStandardCrypto)
-  deriving (Generic, NFData, Show)
+  deriving (Generic, Show)
   deriving anyclass NoUnexpectedThunks
 
 data PublicKey
   = PubKeyByron !Network !Crypto.VerificationKey
   | PubKeyShelley !Network !ShelleyVerificationKey
-  deriving (Generic, NFData, Show)
+  deriving (Generic, Show)
   deriving anyclass NoUnexpectedThunks
 
 -- The cardano-sl codebase (and cardano-ledger) has something a little like
@@ -69,23 +69,23 @@ data PublicKey
 data Network
   = Mainnet
   | Testnet !Crypto.ProtocolMagicId
-  deriving (Eq, Generic, NFData, Show)
+  deriving (Eq, Generic, Show)
   deriving anyclass NoUnexpectedThunks
 
 data TxSigned
   = TxSignedByron !Byron.Tx !ByteString !(Crypto.Hash Byron.Tx) !(Vector Byron.TxInWitness)
   | TxSignedShelley
-  deriving (Eq, Generic, NFData, Show)
+  deriving (Eq, Generic, Show)
   deriving NoUnexpectedThunks via UseIsNormalForm TxSigned
 
 data TxUnsigned
   = TxUnsignedByron !Byron.Tx !ByteString !(Crypto.Hash Byron.Tx)
   | TxUnsignedShelley
-  deriving (Eq, Generic, NFData, Show)
+  deriving (Eq, Generic, Show)
   deriving NoUnexpectedThunks via UseIsNormalForm TxUnsigned
 
 data TxWitness
   = TxWitByron !Byron.TxInWitness
   | TxWitShelley
-  deriving (Generic, NFData)
+  deriving (Generic)
   deriving NoUnexpectedThunks via UseIsNormalForm TxWitness

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -58,7 +58,7 @@ mkConsensusProtocol config@NodeConfiguration{ncProtocol} files =
                     mkConsensusProtocolRealPBFT config files
 
       TPraos   -> firstExceptT ShelleyProtocolInstantiationError $
-                    SomeConsensusProtocol <$> mkConsensusProtocolTPraos config files
+                    mkConsensusProtocolTPraos config files
 
 
 ------------------------------------------------------------------------------

--- a/cardano-config/src/Cardano/Config/Protocol/Byron.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Byron.hs
@@ -52,7 +52,9 @@ mkConsensusProtocolRealPBFT NodeConfiguration {
                               ncGenesisFile = GenesisFile genesisFile,
                               ncReqNetworkMagic,
                               ncPbftSignatureThresh,
-                              ncUpdate
+                              ncUpdate,
+                              ncByronNodeToNodeVersions,
+                              ncByronNodeToClientVersions
                             }
                             files = do
     (genesisData, genesisHash) <-
@@ -88,7 +90,9 @@ mkConsensusProtocolRealPBFT NodeConfiguration {
             genesisConfig
             optionalLeaderCredentials
 
-    return (SomeConsensusProtocol consensusProtocol)
+    return (SomeConsensusProtocol consensusProtocol
+                                  ncByronNodeToNodeVersions
+                                  ncByronNodeToClientVersions)
 
 
 -- | The plumbing to select and convert the appropriate configuration subset

--- a/cardano-config/src/Cardano/Config/Protocol/Mock.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Mock.hs
@@ -24,6 +24,7 @@ import           Ouroboros.Consensus.Mock.Ledger.Block.BFT
 import           Ouroboros.Consensus.Mock.Ledger.Block.Praos
 import           Ouroboros.Consensus.Mock.Ledger.Block.PBFT
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (HasNetworkProtocolVersion (..))
 
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
@@ -59,7 +60,14 @@ mkConsensusProtocolBFT NodeConfiguration {
             mockSecurityParam
             (defaultSimpleBlockConfig mockSecurityParam mockSlotLength)
 
-    return (SomeConsensusProtocol consensusProtocol)
+        proxy :: Proxy
+                  (SimpleBlock SimpleMockCrypto
+                    (SimpleBftExt SimpleMockCrypto BftMockCrypto))
+        proxy = Proxy 
+
+    return (SomeConsensusProtocol consensusProtocol
+                                  (supportedNodeToNodeVersions proxy)
+                                  (supportedNodeToClientVersions proxy))
 
 
 mkConsensusProtocolPBFT
@@ -88,7 +96,13 @@ mkConsensusProtocolPBFT NodeConfiguration {
             (defaultSimpleBlockConfig mockSecurityParam mockSlotLength)
             nodeId
 
-    return (SomeConsensusProtocol consensusProtocol)
+        proxy :: Proxy (SimpleBlock SimpleMockCrypto
+                         (SimplePBftExt SimpleMockCrypto PBftMockCrypto))
+        proxy = Proxy
+
+    return (SomeConsensusProtocol consensusProtocol
+                                  (supportedNodeToNodeVersions proxy)
+                                  (supportedNodeToClientVersions proxy))
 
 
 mkConsensusProtocolPraos
@@ -118,7 +132,14 @@ mkConsensusProtocolPraos NodeConfiguration {
               }
             (defaultSimpleBlockConfig mockSecurityParam (slotLengthFromSec 2))
 
-    return (SomeConsensusProtocol consensusProtocol)
+        proxy :: Proxy
+                  (SimpleBlock SimpleMockCrypto
+                    (SimplePraosExt SimpleMockCrypto PraosMockCrypto))
+        proxy = Proxy
+
+    return (SomeConsensusProtocol consensusProtocol
+                                  (supportedNodeToNodeVersions proxy)
+                                  (supportedNodeToClientVersions proxy))
 
 
 mockSecurityParam :: SecurityParam

--- a/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
@@ -21,8 +21,8 @@ import qualified Data.Text as T
 
 import qualified Data.Aeson as Aeson
 
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (HasNetworkProtocolVersion (..))
 import           Ouroboros.Consensus.Cardano hiding (Protocol)
-import qualified Ouroboros.Consensus.Cardano as Consensus
 
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
@@ -34,6 +34,7 @@ import           Cardano.Config.Types
                     MiscellaneousFilepaths(..), GenesisFile (..),
                     Update (..), LastKnownBlockVersion (..))
 import           Cardano.Config.Shelley.Genesis ()
+import           Cardano.Config.Protocol.Types (SomeConsensusProtocol (..))
 import           Cardano.TracingOrphanInstances.Shelley ()
 
 
@@ -45,8 +46,7 @@ mkConsensusProtocolTPraos
   :: NodeConfiguration
   -> Maybe MiscellaneousFilepaths
   -> ExceptT ShelleyProtocolInstantiationError IO
-             (Consensus.Protocol (ShelleyBlock TPraosStandardCrypto)
-                                 ProtocolRealTPraos)
+             SomeConsensusProtocol
 mkConsensusProtocolTPraos NodeConfiguration {
                               ncGenesisFile,
                               ncUpdate
@@ -64,7 +64,12 @@ mkConsensusProtocolTPraos NodeConfiguration {
             protocolVersion
             optionalLeaderCredentials
 
-    return consensusProtocol
+        proxy :: Proxy (ShelleyBlock TPraosStandardCrypto)
+        proxy = Proxy
+
+    return $ SomeConsensusProtocol consensusProtocol
+                                   (supportedNodeToNodeVersions proxy)
+                                   (supportedNodeToClientVersions proxy)
 
 
 readShelleyGenesis :: GenesisFile

--- a/cardano-config/src/Cardano/Config/Protocol/Types.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Types.hs
@@ -9,6 +9,7 @@ module Cardano.Config.Protocol.Types
 
 import           Prelude (Show)
 
+import           Data.List.NonEmpty (NonEmpty)
 import           Data.Aeson (ToJSON)
 
 import           Ouroboros.Network.Block
@@ -23,14 +24,21 @@ import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import qualified Ouroboros.Consensus.Cardano as Consensus (Protocol)
 import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (HasNetworkProtocolVersion (..))
 
 import           Cardano.BM.Tracing (ToObject)
 
 
+-- | 'SomeConsensusProtocol' is a en existential product type which holds
+-- 'Consensus.Protocol' together with network versions: 'NodeToNodeVersion' and
+-- 'NodeToClientVersion' for some block type @blk@.
+--
 data SomeConsensusProtocol where
 
      SomeConsensusProtocol :: (RunNode blk, TraceConstraints blk)
                            => Consensus.Protocol blk (BlockProtocol blk)
+                           -> NonEmpty (NodeToNodeVersion blk)
+                           -> NonEmpty (NodeToClientVersion blk)
                            -> SomeConsensusProtocol
 
 

--- a/cardano-node/app/chairman.hs
+++ b/cardano-node/app/chairman.hs
@@ -34,14 +34,19 @@ main = do
     nc <- liftIO $ parseNodeConfigurationFP caConfigYaml
     frmPtclRes <- runExceptT $ mkConsensusProtocol nc Nothing
 
-    SomeConsensusProtocol p <- case frmPtclRes of
-                        Right p  -> pure p
-                        Left err -> do putTextLn $ renderPtclInstantiationErr err
-                                       exitFailure
+    SomeConsensusProtocol
+      p
+      _nodeToNodeVersions
+      nodeToClientVersions
+        <- case frmPtclRes of
+             Right p  -> pure p
+             Left err -> putTextLn (renderPtclInstantiationErr err)
+                      >> exitFailure
 
     chairmanTest
       stdoutTracer
       p
+      nodeToClientVersions
       caRunningTime
       caMinProgress
       caSocketPaths

--- a/configuration/defaults/mainnet/configuration.yaml
+++ b/configuration/defaults/mainnet/configuration.yaml
@@ -21,6 +21,14 @@ SocketPath: db/node.socket
 # is what we use on mainnet in Byron era.
 Protocol: RealPBFT
 
+# By default all supported versions are enabled (the two lists below might not
+# be exhaustive)
+# ByronNodeToClientVersions:
+#   - ByronNodeToClientVersion1
+#   - ByronNodeToClientVersion2
+# ByronNodeToNodeVersions:
+#   - ByronNodeToNodeVersion1
+
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresNoMagic
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/91f357abae16099858193b999807323ca9a7c63c/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3/snapshot.yaml
 compiler: ghc-8.6.5
 
 packages:
@@ -78,13 +78,13 @@ extra-deps:
       - shelley/chain-and-ledger/executable-spec/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 91f357abae16099858193b999807323ca9a7c63c
+    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: f950ed079b257ee7318c095b2c0363f28843f964
+    commit: 5035c9ed95e9d47f050314a7d96b1b2043288f61
     subdirs:
       - binary
       - binary/test
@@ -126,7 +126,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: a5ca95890f3d4a0c37ea017b5a96f309e6f3b4da
+    commit: fcd1a4fc30e08133bc39e446ba9b0c76e6482088
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
Issue
-----------

- Fixes https://github.com/input-output-hk/ouroboros-network/issues/1971
- Makes network protocol versions configurable: can be specified in
  configuration.yaml file.  The default option is to use all supported protocols.
- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [x] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing (in ouroboros-network).

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
