### PR TITLE
CAD-792:  bump monitoring for non-API-breaking efficiency improvements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -239,57 +239,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   plugins/backend-trace-forwarder
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
-  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
+  tag: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
+  --sha256: 12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -177,7 +177,7 @@ createLoggingFeature ver _ nodeProtocolMode = do
 
      Config.getForwardTo logConfig >>= \forwardTo ->
        when (isJust forwardTo) $
-         Cardano.BM.Backend.TraceForwarder.plugin logConfig trace switchBoard
+         Cardano.BM.Backend.TraceForwarder.plugin logConfig trace switchBoard "forwarderMinSeverity"
            >>= loadPlugin switchBoard
 
      Cardano.BM.Backend.Aggregation.plugin logConfig trace switchBoard

--- a/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
@@ -115,9 +115,9 @@ instance HasSeverityAnnotation a => HasSeverityAnnotation (TraceLabelPeer peer a
 
 instance HasPrivacyAnnotation [TraceLabelPeer peer (FetchDecision [Point header])]
 instance HasSeverityAnnotation [TraceLabelPeer peer (FetchDecision [Point header])] where
-  getSeverityAnnotation =
-      maximum
-    . map (\(TraceLabelPeer _ a) -> fetchDecisionSeverity a)
+  getSeverityAnnotation [] = Debug
+  getSeverityAnnotation xs =
+      maximum $ map (\(TraceLabelPeer _ a) -> fetchDecisionSeverity a) xs
     where
       fetchDecisionSeverity :: FetchDecision a -> Severity
       fetchDecisionSeverity fd =

--- a/stack.yaml
+++ b/stack.yaml
@@ -103,7 +103,7 @@ extra-deps:
 
     # iohk-monitoring-framework currently not pinned to a release
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: eb340f88c0d52b973c0e80bf98a8152097a056c0
+    commit: 8f7d2a4ba4288e528fea62946b525f493c26ae7a
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
1. The new `iohk-monitoring` preserves more laziness, see: https://github.com/input-output-hk/iohk-monitoring-framework/pull/550
   - The performance impact is described in CAD-792 -- roughly a 10% reduction in wallclock for a locally-served chainsync benchmark.

1. Some minor API sync.
1. More improvements coming soon in a subsequent PR.. API breaking, though.

#### TODO
- [x] merge https://github.com/input-output-hk/iohk-monitoring-framework/pull/550

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
