### PR TITLE
Plumbing for loading Shelley node leader credentials

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -96,9 +96,9 @@ createUpdateProposal
   -> InstallerHash
   -> [ParametersToUpdate]
   -> ExceptT CliError IO Proposal
-createUpdateProposal configFile sKey pVer sVer sysTag inshash paramsToUpdate = do
+createUpdateProposal yamlConfigFile sKey pVer sVer sysTag inshash paramsToUpdate = do
 
-  nc <- liftIO $ parseNodeConfigurationFP configFile
+  nc <- liftIO $ parseNodeConfigurationFP yamlConfigFile
   (genData, _) <- readGenesis $ ncGenesisFile nc
 
   let metaData :: M.Map SystemTag InstallerHash

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -13,7 +13,7 @@ extra-source-files:    README.md
 library
   hs-source-dirs:      src
 
-  exposed-modules:     Cardano.Config.CommonCLI
+  exposed-modules:     Cardano.Config.Byron.Parsers
                        Cardano.Config.GitRev
                        Cardano.Config.GitRevFromGit
                        Cardano.Config.Logging
@@ -26,6 +26,7 @@ library
                        Cardano.Config.Shelley.Genesis
                        Cardano.Config.Shelley.KES
                        Cardano.Config.Shelley.OCert
+                       Cardano.Config.Shelley.Parsers
                        Cardano.Config.Shelley.VRF
                        Cardano.Config.TextView
                        Cardano.Config.Topology

--- a/cardano-config/src/Cardano/Config/Byron/Parsers.hs
+++ b/cardano-config/src/Cardano/Config/Byron/Parsers.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
-{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
-
-module Cardano.Config.CommonCLI
+module Cardano.Config.Byron.Parsers
   ( parseDelegationCert
-  , parseGenesisPath
   , parseSigningKey
   ) where
 
@@ -12,18 +7,6 @@ import           Cardano.Prelude hiding (option)
 
 import           Options.Applicative hiding (command)
 
-
-{-------------------------------------------------------------------------------
-  Common CLI
--------------------------------------------------------------------------------}
-
-parseGenesisPath :: Parser FilePath
-parseGenesisPath =
-  strOption
-    ( long "genesis-file"
-        <> metavar "FILEPATH"
-        <> help "The filepath to the genesis file."
-    )
 
 parseDelegationCert :: Parser FilePath
 parseDelegationCert =

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -25,7 +25,7 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 import           Cardano.Config.Types
                    (NodeConfiguration(..), Protocol (..),
-                    MiscellaneousFilepaths(..))
+                    ProtocolFilepaths(..))
 
 import           Cardano.Config.Protocol.Types
 import           Cardano.Config.Protocol.Mock
@@ -39,7 +39,7 @@ import           Cardano.Config.Protocol.Shelley
 
 mkConsensusProtocol
   :: NodeConfiguration
-  -> Maybe MiscellaneousFilepaths
+  -> Maybe ProtocolFilepaths
   -> ExceptT ProtocolInstantiationError IO SomeConsensusProtocol
 mkConsensusProtocol config@NodeConfiguration{ncProtocol} files =
     case ncProtocol of

--- a/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
@@ -25,14 +25,21 @@ import           Ouroboros.Consensus.Cardano hiding (Protocol)
 import qualified Ouroboros.Consensus.Cardano as Consensus
 
 import           Ouroboros.Consensus.Shelley.Ledger
-import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Shelley.Protocol
+                   (TPraosStandardCrypto, TPraosIsCoreNode(..))
+import           Ouroboros.Consensus.Shelley.Node
+                   (TPraosLeaderCredentials(..))
 
 import           Shelley.Spec.Ledger.PParams (ProtVer(..))
+import           Shelley.Spec.Ledger.Keys (DiscVKey(..))
 
 import           Cardano.Config.Types
                    (NodeConfiguration(..), ProtocolFilepaths(..),
                     GenesisFile (..), Update (..), LastKnownBlockVersion (..))
 import           Cardano.Config.Shelley.Genesis ()
+import           Cardano.Config.Shelley.OCert
+import           Cardano.Config.Shelley.VRF
+import           Cardano.Config.Shelley.KES
 import           Cardano.TracingOrphanInstances.Shelley ()
 
 
@@ -87,11 +94,46 @@ toShelleyProtocolVersion (Update _appName _appVer lastKnownBlockVersion) =
       {lkbvMajor, lkbvMinor, lkbvAlt = _unused} = lastKnownBlockVersion
 
 
--- TODO: support reading leader credentials
 readLeaderCredentials :: Maybe ProtocolFilepaths
                       -> ExceptT ShelleyProtocolInstantiationError IO
                                  (Maybe (TPraosLeaderCredentials TPraosStandardCrypto))
-readLeaderCredentials _files = return Nothing
+
+-- It's ok to supply none of the files
+readLeaderCredentials Nothing = return Nothing
+readLeaderCredentials (Just ProtocolFilepaths {
+                              shelleyCertFile = Nothing,
+                              shelleyVRFFile  = Nothing,
+                              shelleyKESFile  = Nothing
+                            }) = return Nothing
+
+-- Or to supply all of the files
+readLeaderCredentials (Just ProtocolFilepaths {
+                              shelleyCertFile = Just certFile,
+                              shelleyVRFFile  = Just vrfFile,
+                              shelleyKESFile  = Just kesFile
+                            }) = do
+
+    (opcert, vkey) <- firstExceptT OCertError $ readOperationalCert certFile
+    vrfKey <- firstExceptT VRFError $ readVRFSigningKey vrfFile
+    kesKey <- firstExceptT KESError $ readKESSigningKey kesFile
+
+    return $ Just TPraosLeaderCredentials {
+               tpraosLeaderCredentialsIsCoreNode =
+                 TPraosIsCoreNode {
+                   tpraosIsCoreNodeOpCert     = opcert,
+                   tpraosIsCoreNodeColdVerKey = DiscVKey vkey,
+                   tpraosIsCoreNodeSignKeyVRF = vrfKey
+                 },
+               tpraosLeaderCredentialsSignKey = kesKey
+             }
+
+-- But not ok to supply some of the files without the others.
+readLeaderCredentials (Just ProtocolFilepaths {shelleyCertFile = Nothing}) =
+    throwError OCertNotSpecified
+readLeaderCredentials (Just ProtocolFilepaths {shelleyVRFFile = Nothing}) =
+    throwError VRFKeyNotSpecified
+readLeaderCredentials (Just ProtocolFilepaths {shelleyKESFile = Nothing}) =
+    throwError KESKeyNotSpecified
 
 
 ------------------------------------------------------------------------------
@@ -99,7 +141,14 @@ readLeaderCredentials _files = return Nothing
 --
 
 data ShelleyProtocolInstantiationError =
-    GenesisReadError !FilePath !String
+       GenesisReadError !FilePath !String
+     | OCertError OperationalCertError
+     | VRFError VRFError
+     | KESError KESError
+
+     | OCertNotSpecified
+     | VRFKeyNotSpecified
+     | KESKeyNotSpecified
   deriving Show
 
 
@@ -110,3 +159,15 @@ renderShelleyProtocolInstantiationError pie =
     GenesisReadError fp err ->
         "There was an error parsing the genesis file: "
      <> toS fp <> " Error: " <> (T.pack $ show err)
+
+    KESError   err -> T.pack $ renderKESError err
+    VRFError   err -> T.pack $ renderVRFError err
+    OCertError err -> T.pack $ show err --TODO: renderOperationalCertError
+
+    OCertNotSpecified  -> missingFlagMessage "shelley-operational-certificate"
+    VRFKeyNotSpecified -> missingFlagMessage "shelley-vrf-key"
+    KESKeyNotSpecified -> missingFlagMessage "shelley-kes-key"
+  where
+    missingFlagMessage flag =
+      "To create blocks, the --" <> flag <> " must also be specified"
+

--- a/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
@@ -30,9 +30,8 @@ import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
 import           Shelley.Spec.Ledger.PParams (ProtVer(..))
 
 import           Cardano.Config.Types
-                   (NodeConfiguration(..),
-                    MiscellaneousFilepaths(..), GenesisFile (..),
-                    Update (..), LastKnownBlockVersion (..))
+                   (NodeConfiguration(..), ProtocolFilepaths(..),
+                    GenesisFile (..), Update (..), LastKnownBlockVersion (..))
 import           Cardano.Config.Shelley.Genesis ()
 import           Cardano.TracingOrphanInstances.Shelley ()
 
@@ -43,7 +42,7 @@ import           Cardano.TracingOrphanInstances.Shelley ()
 
 mkConsensusProtocolTPraos
   :: NodeConfiguration
-  -> Maybe MiscellaneousFilepaths
+  -> Maybe ProtocolFilepaths
   -> ExceptT ShelleyProtocolInstantiationError IO
              (Consensus.Protocol (ShelleyBlock TPraosStandardCrypto)
                                  ProtocolRealTPraos)
@@ -89,7 +88,7 @@ toShelleyProtocolVersion (Update _appName _appVer lastKnownBlockVersion) =
 
 
 -- TODO: support reading leader credentials
-readLeaderCredentials :: Maybe MiscellaneousFilepaths
+readLeaderCredentials :: Maybe ProtocolFilepaths
                       -> ExceptT ShelleyProtocolInstantiationError IO
                                  (Maybe (TPraosLeaderCredentials TPraosStandardCrypto))
 readLeaderCredentials _files = return Nothing

--- a/cardano-config/src/Cardano/Config/Shelley/OCert.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/OCert.hs
@@ -14,33 +14,70 @@ import           Control.Monad.Trans.Except.Extra
                    (firstExceptT, handleIOExceptT, hoistEither)
 import qualified Data.ByteString.Lazy.Char8 as LB
 
-import           Shelley.Spec.Ledger.Keys (SKey, VKeyES, sign)
+import           Cardano.Crypto.DSIGN.Class
+import           Cardano.Crypto.KES.Class
+import           Shelley.Spec.Ledger.Keys (SKey(..), VKeyES(..), Sig, sign)
 import           Shelley.Spec.Ledger.OCert
 import           Shelley.Spec.Ledger.Serialization
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto
+                   (TPraosStandardCrypto, DSIGN, KES)
 
+
+
+-- Local aliases for shorter types:
+type VerKey   = VerKeyDSIGN  (DSIGN TPraosStandardCrypto)
+type SignKey  = SignKeyDSIGN (DSIGN TPraosStandardCrypto)
+type VerKeyES = VerKeyKES    (KES TPraosStandardCrypto)
+type Cert     = OCert TPraosStandardCrypto
+
+--TODO: this code would be a lot simpler without the extra newtype wrappers
+-- that the ledger layers over the types from the Cardano.Crypto classes.
 
 signOperationalCertificate
-  :: VKeyES TPraosStandardCrypto
-  -> SKey TPraosStandardCrypto
+  :: VerKeyES
+  -> SignKey
   -- ^ Counter.
   -> Natural
   -- ^ Start of key evolving signature period.
   -> KESPeriod
-  -> OCert TPraosStandardCrypto
-signOperationalCertificate hotKESVerKey signingKey counter kesPeriod' = do
-  let oCertSig = sign signingKey (hotKESVerKey, counter, kesPeriod')
-  OCert hotKESVerKey counter kesPeriod' oCertSig
+  -> Cert
+signOperationalCertificate hotKESVerKey signingKey counter kesPeriod' =
+  let oCertSig :: Sig TPraosStandardCrypto (VKeyES TPraosStandardCrypto, Natural, KESPeriod)
+      oCertSig = sign (SKey signingKey) (VKeyES hotKESVerKey, counter, kesPeriod')
+   in OCert (VKeyES hotKESVerKey) counter kesPeriod' oCertSig
 
 data OperationalCertError = ReadOperationalCertError !FilePath !IOException
                           | DecodeOperationalCertError !FilePath !CBOR.DecoderError
                           | WriteOpertaionalCertError !FilePath !IOException
+  deriving Show
 
-readOperationalCert :: FilePath -> ExceptT OperationalCertError IO (OCert TPraosStandardCrypto)
+readOperationalCert :: FilePath -> ExceptT OperationalCertError IO (Cert, VerKey)
 readOperationalCert fp = do
   bs <- handleIOExceptT (ReadOperationalCertError fp) $ LB.readFile fp
-  firstExceptT (DecodeOperationalCertError fp) . hoistEither $ (CBOR.decodeFullDecoder "Operational Cert" fromCBORGroup bs)
+  firstExceptT (DecodeOperationalCertError fp) $ hoistEither $
+    CBOR.decodeFullDecoder "Operational Cert" decodeOperationalCert bs
+  where
 
-writeOperationalCert :: FilePath -> OCert TPraosStandardCrypto -> ExceptT OperationalCertError IO ()
-writeOperationalCert fp oCert =
-  handleIOExceptT (WriteOpertaionalCertError fp) $ LB.writeFile fp (CBOR.serializeEncoding $ toCBORGroup oCert)
+writeOperationalCert :: FilePath -> Cert -> VerKey
+                     -> ExceptT OperationalCertError IO ()
+writeOperationalCert fp oCert vkey =
+  handleIOExceptT (WriteOpertaionalCertError fp) $
+    LB.writeFile fp $ CBOR.serializeEncoding $
+      encodeOperationalCert (oCert, vkey)
+  where
+
+
+-- We encode a pair of the operational cert and the corresponding vkey.
+-- The 'OCert' type is only an instance of To/FromCBORGroup so to make it
+-- into a proper CBOR value we have to go via CBORGroup.
+
+decodeOperationalCert :: CBOR.Decoder s (Cert, VerKey)
+decodeOperationalCert = do
+    (CBORGroup oCert, vkey) <- CBOR.fromCBOR
+    return (oCert, vkey)
+
+encodeOperationalCert :: (Cert, VerKey) -> CBOR.Encoding
+encodeOperationalCert (oCert, vkey) =
+    CBOR.toCBOR (CBORGroup oCert, vkey)
+
+--TODO: renderOperationalCertError

--- a/cardano-config/src/Cardano/Config/Shelley/Parsers.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Parsers.hs
@@ -1,0 +1,35 @@
+module Cardano.Config.Shelley.Parsers
+  ( parseOperationalCertFilePath
+  , parseKesKeyFilePath
+  , parseVrfKeyFilePath
+  ) where
+
+import           Cardano.Prelude hiding (option)
+
+import           Options.Applicative hiding (command)
+
+
+parseOperationalCertFilePath :: Parser FilePath
+parseOperationalCertFilePath =
+  strOption
+    ( long "shelley-operational-certificate"
+        <> metavar "FILEPATH"
+        <> help "Path to the delegation certificate."
+    )
+
+--TODO: pass the current KES evolution, not the KES_0
+parseKesKeyFilePath :: Parser FilePath
+parseKesKeyFilePath =
+  strOption
+    ( long "shelley-kes-key"
+        <> metavar "FILEPATH"
+        <> help "Path to the KES signing key."
+    )
+
+parseVrfKeyFilePath :: Parser FilePath
+parseVrfKeyFilePath =
+  strOption
+    ( long "shelley-vrf-key"
+        <> metavar "FILEPATH"
+        <> help "Path to the VRF signing key."
+    )

--- a/cardano-config/src/Cardano/Config/Shelley/VRF.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/VRF.hs
@@ -27,6 +27,7 @@ data VRFError = ReadVRFSigningKeyError !FilePath !IOException
               | DecodeVRFVerKeyError !FilePath !CBOR.DecoderError
               | WriteVRFSigningKeyError !FilePath !IOException
               | WriteVRFVerKeyError !FilePath !IOException
+  deriving Show
 
 genVRFKeyPair :: IO (SignKeyVRF SimpleVRF, VerKeyVRF SimpleVRF)
 genVRFKeyPair = do sKeyVRF <- genKeyVRF

--- a/cardano-config/src/Cardano/Config/Topology.hs
+++ b/cardano-config/src/Cardano/Config/Topology.hs
@@ -46,12 +46,8 @@ nodeAddressToSockAddr (NodeAddress addr port) =
     Just (IP.IPv6 ipv6) -> SockAddrInet6 port 0 (IP.toHostAddress6 ipv6) 0
     Nothing             -> SockAddrInet port 0 -- Could also be any IPv6 addr
 
-nodeAddressInfo :: NodeProtocolMode -> IO [AddrInfo]
-nodeAddressInfo npm = do
-  let NodeAddress hostAddr port =
-        case npm of
-          RealProtocolMode NodeCLI{nodeAddr} -> nodeAddr
-          MockProtocolMode NodeMockCLI{mockNodeAddr} -> mockNodeAddr
+nodeAddressInfo :: NodeCLI -> IO [AddrInfo]
+nodeAddressInfo NodeCLI{nodeAddr = NodeAddress hostAddr port} = do
   let hints = defaultHints {
                 addrFlags = [AI_PASSIVE, AI_ADDRCONFIG]
               , addrSocketType = Stream
@@ -123,11 +119,9 @@ instance FromJSON NetworkTopology where
 -- | Read the `NetworkTopology` configuration from the specified file.
 -- While running a real protocol, this gives your node its own address and
 -- other remote peers it will attempt to connect to.
-readTopologyFile :: NodeProtocolMode -> IO (Either Text NetworkTopology)
-readTopologyFile npm = do
-  let topo = case npm of
-               RealProtocolMode NodeCLI{mscFp}         -> unTopology (topFile mscFp)
-               MockProtocolMode NodeMockCLI{mockMscFp} -> unTopology (topFile mockMscFp)
+readTopologyFile :: NodeCLI -> IO (Either Text NetworkTopology)
+readTopologyFile NodeCLI{topologyFile} = do
+  let topo = unTopology topologyFile
 
   eBs <- Exception.try $ BS.readFile topo
 

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -104,9 +104,9 @@ data ProtocolFilepaths =
      ProtocolFilepaths {
        byronCertFile   :: !(Maybe FilePath)
      , byronKeyFile    :: !(Maybe FilePath)
---   , shelleyKESFile  :: !(Maybe FilePath)
---   , shelleyVRFFile  :: !(Maybe FilePath)
---   , shelleyCertFile :: !(Maybe FilePath)
+     , shelleyKESFile  :: !(Maybe FilePath)
+     , shelleyVRFFile  :: !(Maybe FilePath)
+     , shelleyCertFile :: !(Maybe FilePath)
      }
 
 --TODO: things will probably be clearer if we don't use these newtype wrappers and instead

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -43,9 +43,9 @@ main = toplevelExceptionHandler $ do
       cardanoApplication :: NodeLayer -> CardanoApplication
       cardanoApplication = CardanoApplication . nlRunNode
 
-      opts :: Opt.ParserInfo NodeProtocolMode
+      opts :: Opt.ParserInfo NodeCLI
       opts =
-        Opt.info (nodeProtocolModeParser
+        Opt.info (nodeCLIParser
                     <**> helperBrief "help" "Show this help text" nodeCliHelpMain)
 
           ( Opt.fullDesc <>
@@ -59,13 +59,13 @@ main = toplevelExceptionHandler $ do
 
       nodeCliHelpMain :: String
       nodeCliHelpMain = renderHelpDoc 80 $
-        parserHelpHeader "cardano-node" nodeProtocolModeParser
+        parserHelpHeader "cardano-node" nodeCLIParser
         <$$> ""
-        <$$> parserHelpOptions nodeProtocolModeParser
+        <$$> parserHelpOptions nodeCLIParser
 
 
 initializeAllFeatures
-  :: NodeProtocolMode
+  :: NodeCLI
   -> CardanoEnvironment
   -> IO ([CardanoFeature], NodeLayer)
 initializeAllFeatures npm cardanoEnvironment = do

--- a/cardano-node/src/Cardano/Common/Parsers.hs
+++ b/cardano-node/src/Cardano/Common/Parsers.hs
@@ -39,7 +39,8 @@ import           Options.Applicative
 import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId(..))
 import           Cardano.Chain.Common (Lovelace, mkLovelace)
 
-import           Cardano.Config.CommonCLI
+import           Cardano.Config.Byron.Parsers   as Byron
+import           Cardano.Config.Shelley.Parsers as Shelley
 import           Cardano.Config.Topology
 import           Cardano.Config.Types
 
@@ -98,6 +99,9 @@ nodeMockParser = do
            , protocolFiles = ProtocolFilepaths
              { byronCertFile = Nothing
              , byronKeyFile  = Nothing
+             , shelleyKESFile  = Nothing
+             , shelleyVRFFile  = Nothing
+             , shelleyCertFile = Nothing
              }
            , validateDB = validate
            , shutdownIPC
@@ -109,9 +113,14 @@ nodeRealParser = do
   -- Filepaths
   topFp <- parseTopologyFile
   dbFp <- parseDbPath
-  delCertFp <- optional parseDelegationCert
-  sKeyFp <- optional parseSigningKey
   socketFp <- parseCLISocketPath "Path to a cardano-node socket"
+
+  -- Protocol files
+  byronCertFile   <- optional Byron.parseDelegationCert
+  byronKeyFile    <- optional Byron.parseSigningKey
+  shelleyKESFile  <- optional Shelley.parseKesKeyFilePath
+  shelleyVRFFile  <- optional Shelley.parseVrfKeyFilePath
+  shelleyCertFile <- optional Shelley.parseOperationalCertFilePath
 
   -- Node Address
   nAddress <- parseNodeAddress
@@ -130,8 +139,11 @@ nodeRealParser = do
     , databaseFile = DbFile dbFp
     , socketFile   = socketFp
     , protocolFiles = ProtocolFilepaths
-      { byronCertFile = delCertFp
-      , byronKeyFile  = sKeyFp
+      { byronCertFile
+      , byronKeyFile
+      , shelleyKESFile
+      , shelleyVRFFile
+      , shelleyCertFile
       }
     , validateDB = validate
     , shutdownIPC

--- a/cardano-node/src/Cardano/Node/Features/Node.hs
+++ b/cardano-node/src/Cardano/Node/Features/Node.hs
@@ -8,9 +8,7 @@ module Cardano.Node.Features.Node
 
 import           Cardano.Prelude
 
-import           Cardano.Config.Types (CardanoEnvironment,
-                                       CardanoEnvironment,
-                                       NodeProtocolMode (..))
+import           Cardano.Config.Types (CardanoEnvironment, NodeCLI)
 import           Cardano.Config.Logging (LoggingLayer (..),)
 import           Cardano.Node.Run
 import           Cardano.Shell.Types (CardanoFeature (..))
@@ -31,7 +29,7 @@ data NodeLayer = NodeLayer
 createNodeFeature
   :: LoggingLayer
   -> CardanoEnvironment
-  -> NodeProtocolMode
+  -> NodeCLI
   -> IO (NodeLayer, CardanoFeature)
 createNodeFeature loggingLayer _ npm = do
     -- we parse any additional configuration if there is any

--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -549,11 +549,11 @@ initLiveViewState = do
                 , lvsColorTheme             = DarkTheme
                 }
 
-setTopology :: NFData a => LiveViewBackend blk a -> NodeProtocolMode -> IO ()
-setTopology lvbe (RealProtocolMode NodeCLI{nodeAddr}) =
+setTopology :: NFData a => LiveViewBackend blk a -> NodeCLI -> IO ()
+setTopology lvbe NodeCLI{nodeAddr, nodeMode = RealProtocolMode} =
   modifyMVar_ (getbe lvbe) $ \lvs ->
     return lvs { lvsNodeId = pack $ "Port: " <> show (naPort nodeAddr) }
-setTopology lvbe npm = do
+setTopology lvbe npm@NodeCLI{nodeMode = MockProtocolMode} = do
   nc <- parseNodeConfiguration npm
   modifyMVar_ (getbe lvbe) $ \lvs ->
     return $ lvs { lvsNodeId = namenum (ncNodeId nc) }


### PR DESCRIPTION
The final patch is the one we're after, it does the final bit where we load up all the various files to make the Praos slot leader credentials.

First two patches are more refactoring. Then CLI plumbing. Finally some tweaks to the OpCert read/write code and then putting it all together by using it in the node startup code.