### PR TITLE
CAD-792 tracers:  demote the BlockFetchDecision tracer to Info

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -375,7 +375,7 @@ mkTracers traceConf tracer = do
         -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
     teeTraceBlockFetchDecision' tr =
         Tracer $ \(WithSeverity _ peers) -> do
-          meta <- mkLOMeta Notice Confidential
+          meta <- mkLOMeta Info Confidential
           let tr' = appendName "peers" tr
           traceNamedObject tr' (meta, LogValue "connectedPeers" . PureI $ fromIntegral $ length peers)
     teeTraceBlockFetchDecisionElide


### PR DESCRIPTION
The `BlockFetchDecision` tracer has inappropriately high severity, that makes it print on each block fetched, when the tracer is enabled.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
