### PR TITLE
CLI shelley command reorganisation

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -4,16 +4,16 @@ module Cardano.CLI.Shelley.Parsers
 
     -- * CLI command types
   , ShelleyCommand (..)
-  , ShelleyAddressCmd (..)
-  , ShelleyStakeAddressCmd (..)
-  , ShelleyTransactionCmd (..)
-  , ShelleyNodeCmd (..)
-  , ShelleyPoolCmd (..)
-  , ShelleyQueryCmd (..)
-  , ShelleyBlockCmd (..)
-  , ShelleySystemCmd (..)
-  , ShelleyDevOpsCmd (..)
-  , ShelleyGenesisCmd (..)
+  , AddressCmd (..)
+  , StakeAddressCmd (..)
+  , TransactionCmd (..)
+  , NodeCmd (..)
+  , PoolCmd (..)
+  , QueryCmd (..)
+  , BlockCmd (..)
+  , SystemCmd (..)
+  , DevOpsCmd (..)
+  , GenesisCmd (..)
 
     -- * CLI flag types
   , GenesisDir (..)
@@ -46,20 +46,20 @@ import qualified Prelude as Prelude
 -- | All the CLI subcommands under \"shelley\".
 --
 data ShelleyCommand
-  = ShelleyAddress      ShelleyAddressCmd
-  | ShelleyStakeAddress ShelleyStakeAddressCmd
-  | ShelleyTransaction  ShelleyTransactionCmd
-  | ShelleyNode         ShelleyNodeCmd
-  | ShelleyPool         ShelleyPoolCmd
-  | ShelleyQuery        ShelleyQueryCmd
-  | ShelleyBlock        ShelleyBlockCmd
-  | ShelleySystem       ShelleySystemCmd
-  | ShelleyDevOps       ShelleyDevOpsCmd
-  | ShelleyGenesis      ShelleyGenesisCmd
+  = AddressCmd      AddressCmd
+  | StakeAddressCmd StakeAddressCmd
+  | TransactionCmd  TransactionCmd
+  | NodeCmd         NodeCmd
+  | PoolCmd         PoolCmd
+  | QueryCmd        QueryCmd
+  | BlockCmd        BlockCmd
+  | SystemCmd       SystemCmd
+  | DevOpsCmd       DevOpsCmd
+  | GenesisCmd      GenesisCmd
   deriving (Eq, Show)
 
 
-data ShelleyAddressCmd
+data AddressCmd
   = AddressKeyGen OutputFile OutputFile
   | AddressKeyHash VerificationKeyFile
   | AddressBuild          --TODO
@@ -67,14 +67,14 @@ data ShelleyAddressCmd
   deriving (Eq, Show)
 
 
-data ShelleyStakeAddressCmd
+data StakeAddressCmd
   = StakeKeyRegister PrivKeyFile NodeAddress
   | StakeKeyDelegate PrivKeyFile PoolId Lovelace NodeAddress
   | StakeKeyDeRegister PrivKeyFile NodeAddress
   deriving (Eq, Show)
 
 
-data ShelleyTransactionCmd
+data TransactionCmd
   = TxBuild         -- { input :: [Utxo], output :: [(Address,Lovelace)], nodeAddr :: NodeAddress }
   | TxSign          -- { transaction :: Transaction, keys :: [PrivKeyFile], utxo :: [Utxo], nodeAddr :: NodeAddress }
   | TxWitness       -- { transaction :: Transaction, key :: PrivKeyFile, nodeAddr :: NodeAddress }
@@ -85,7 +85,7 @@ data ShelleyTransactionCmd
   deriving (Eq, Show)
 
 
-data ShelleyNodeCmd
+data NodeCmd
   = NodeKeyGenCold VerificationKeyFile SigningKeyFile
   | NodeKeyGenKES  VerificationKeyFile SigningKeyFile Natural
   | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
@@ -93,14 +93,14 @@ data ShelleyNodeCmd
   deriving (Eq, Show)
 
 
-data ShelleyPoolCmd
+data PoolCmd
   = PoolRegister PoolId   -- { operator :: PubKey, owner :: [PubKey], kes :: PubKey, vrf :: PubKey, rewards :: PubKey, cost :: Lovelace, margin :: Margin, nodeAddr :: NodeAddress }
   | PoolReRegister PoolId -- { operator :: PubKey, owner :: [PubKey], kes :: PubKey, vrf :: PubKey, rewards :: PubKey, cost :: Lovelace, margin :: Margin, nodeAddr :: NodeAddress }
   | PoolRetire PoolId EpochNo NodeAddress
   deriving (Eq, Show)
 
 
-data ShelleyQueryCmd
+data QueryCmd
   = QueryPoolId NodeAddress
   | QueryTip NodeAddress
   | QueryVersion NodeAddress
@@ -108,24 +108,24 @@ data ShelleyQueryCmd
   deriving (Eq, Show)
 
 
-data ShelleyBlockCmd
+data BlockCmd
   = BlockInfo BlockId NodeAddress
   deriving (Eq, Show)
 
 
-data ShelleyDevOpsCmd
+data DevOpsCmd
   = DevOpsProtocolUpdate PrivKeyFile -- { parameters :: ProtocolParams, nodeAddr :: NodeAddress }
   | DevOpsColdKeys GenesisKeyFile     -- { genesis :: GenesisKeyFile, keys :: [PubKey], nodeAddr :: NodeAddress }
   deriving (Eq, Show)
 
 
-data ShelleySystemCmd
+data SystemCmd
   = SysStart GenesisFile NodeAddress
   | SysStop NodeAddress
   deriving (Eq, Show)
 
 
-data ShelleyGenesisCmd
+data GenesisCmd
   = GenesisCreate GenesisDir (Maybe SystemStart) Lovelace
   | GenesisKeyGen OutputFile OutputFile
   deriving (Eq, Show)
@@ -173,29 +173,29 @@ parseShelleyCommands =
   Opt.subparser $
     mconcat
       [ Opt.command "address"
-          (Opt.info (ShelleyAddress <$> pAddress) $ Opt.progDesc "Shelley address commands")
+          (Opt.info (AddressCmd <$> pAddress) $ Opt.progDesc "Shelley address commands")
       , Opt.command "stake-address"
-          (Opt.info (ShelleyStakeAddress <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
+          (Opt.info (StakeAddressCmd <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
       , Opt.command "transaction"
-          (Opt.info (ShelleyTransaction <$> pTransaction) $ Opt.progDesc "Shelley transaction commands")
+          (Opt.info (TransactionCmd <$> pTransaction) $ Opt.progDesc "Shelley transaction commands")
       , Opt.command "node"
-          (Opt.info (ShelleyNode <$> pShelleyNodeCmd) $ Opt.progDesc "Shelley node operaton commands")
+          (Opt.info (NodeCmd <$> pNodeCmd) $ Opt.progDesc "Shelley node operaton commands")
       , Opt.command "stake-pool"
-          (Opt.info (ShelleyPool <$> pShelleyPoolCmd) $ Opt.progDesc "Shelley stake pool commands")
+          (Opt.info (PoolCmd <$> pPoolCmd) $ Opt.progDesc "Shelley stake pool commands")
       , Opt.command "query"
-          (Opt.info (ShelleyQuery <$> pShelleyQueryCmd) $ Opt.progDesc "Shelley node query commands")
+          (Opt.info (QueryCmd <$> pQueryCmd) $ Opt.progDesc "Shelley node query commands")
       , Opt.command "block"
-          (Opt.info (ShelleyBlock <$> pShelleyBlockCmd) $ Opt.progDesc "Shelley block commands")
+          (Opt.info (BlockCmd <$> pBlockCmd) $ Opt.progDesc "Shelley block commands")
       , Opt.command "system"
-          (Opt.info (ShelleySystem <$> pShelleySystemCmd) $ Opt.progDesc "Shelley system commands")
+          (Opt.info (SystemCmd <$> pSystemCmd) $ Opt.progDesc "Shelley system commands")
       , Opt.command "devops"
-          (Opt.info (ShelleyDevOps <$> pShelleyDevOpsCmd) $ Opt.progDesc "Shelley devops commands")
+          (Opt.info (DevOpsCmd <$> pDevOpsCmd) $ Opt.progDesc "Shelley devops commands")
       , Opt.command "genesis"
-          (Opt.info (ShelleyGenesis <$> pShelleyGenesisCmd) $ Opt.progDesc "Shelley genesis block commands")
+          (Opt.info (GenesisCmd <$> pGenesisCmd) $ Opt.progDesc "Shelley genesis block commands")
       ]
 
 
-pAddress :: Parser ShelleyAddressCmd
+pAddress :: Parser AddressCmd
 pAddress =
   Opt.subparser $
     mconcat
@@ -209,20 +209,20 @@ pAddress =
           (Opt.info pAddressBuildMultiSig $ Opt.progDesc "Build a multi-sig address")
       ]
   where
-    pAddressKeyGen :: Parser ShelleyAddressCmd
+    pAddressKeyGen :: Parser AddressCmd
     pAddressKeyGen = AddressKeyGen <$> pOutputFile <*> pOutputFile
 
-    pAddressKeyHash :: Parser ShelleyAddressCmd
+    pAddressKeyHash :: Parser AddressCmd
     pAddressKeyHash = AddressKeyHash <$> pVerificationKeyFile
 
-    pAddressBuild :: Parser ShelleyAddressCmd
+    pAddressBuild :: Parser AddressCmd
     pAddressBuild = pure AddressBuild
 
-    pAddressBuildMultiSig :: Parser ShelleyAddressCmd
+    pAddressBuildMultiSig :: Parser AddressCmd
     pAddressBuildMultiSig = pure AddressBuildMultiSig
 
 
-pStakeAddress :: Parser ShelleyStakeAddressCmd
+pStakeAddress :: Parser StakeAddressCmd
 pStakeAddress =
   Opt.subparser $
     mconcat
@@ -234,14 +234,14 @@ pStakeAddress =
           (Opt.info pStakeAddressDeRegister $ Opt.progDesc "De-register a stake address")
       ]
   where
-    pStakeAddressRegister :: Parser ShelleyStakeAddressCmd
+    pStakeAddressRegister :: Parser StakeAddressCmd
     pStakeAddressRegister = StakeKeyRegister <$> pPrivKeyFile <*> parseNodeAddress
 
-    pStakeAddressDelegate :: Parser ShelleyStakeAddressCmd
+    pStakeAddressDelegate :: Parser StakeAddressCmd
     pStakeAddressDelegate =
       StakeKeyDelegate <$> pPrivKeyFile <*> pPoolId <*> pDelegationFee <*> parseNodeAddress
 
-    pStakeAddressDeRegister :: Parser ShelleyStakeAddressCmd
+    pStakeAddressDeRegister :: Parser StakeAddressCmd
     pStakeAddressDeRegister = StakeKeyDeRegister <$> pPrivKeyFile <*> parseNodeAddress
 
     pDelegationFee :: Parser Lovelace
@@ -255,7 +255,7 @@ pStakeAddress =
 
 
 
-pTransaction :: Parser ShelleyTransactionCmd
+pTransaction :: Parser TransactionCmd
 pTransaction =
   Opt.subparser $
     mconcat
@@ -275,30 +275,30 @@ pTransaction =
           (Opt.info pTransactionInfo $ Opt.progDesc "Print information about a transaction")
       ]
   where
-    pTransactionBuild :: Parser ShelleyTransactionCmd
+    pTransactionBuild :: Parser TransactionCmd
     pTransactionBuild = pure TxBuild
 
-    pTransactionSign  :: Parser ShelleyTransactionCmd
+    pTransactionSign  :: Parser TransactionCmd
     pTransactionSign = pure TxSign
 
-    pTransactionWitness :: Parser ShelleyTransactionCmd
+    pTransactionWitness :: Parser TransactionCmd
     pTransactionWitness = pure TxWitness
 
-    pTransactionSignWit :: Parser ShelleyTransactionCmd
+    pTransactionSignWit :: Parser TransactionCmd
     pTransactionSignWit = pure TxSignWitness
 
-    pTransactionCheck  :: Parser ShelleyTransactionCmd
+    pTransactionCheck  :: Parser TransactionCmd
     pTransactionCheck = pure TxCheck
 
-    pTransactionSubmit  :: Parser ShelleyTransactionCmd
+    pTransactionSubmit  :: Parser TransactionCmd
     pTransactionSubmit = pure TxSubmit
 
-    pTransactionInfo  :: Parser ShelleyTransactionCmd
+    pTransactionInfo  :: Parser TransactionCmd
     pTransactionInfo = pure TxInfo
 
 
-pShelleyNodeCmd :: Parser ShelleyNodeCmd
-pShelleyNodeCmd =
+pNodeCmd :: Parser NodeCmd
+pNodeCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "key-gen"
@@ -315,25 +315,25 @@ pShelleyNodeCmd =
              Opt.progDesc "Issue a node operational certificate")
       ]
   where
-    pKeyGenOperator :: Parser ShelleyNodeCmd
+    pKeyGenOperator :: Parser NodeCmd
     pKeyGenOperator =
       NodeKeyGenCold <$> pVerificationKeyFile <*> pSigningKeyFile
 
-    pKeyGenKES :: Parser ShelleyNodeCmd
+    pKeyGenKES :: Parser NodeCmd
     pKeyGenKES =
       NodeKeyGenKES <$> pVerificationKeyFile <*> pSigningKeyFile <*> pDuration
 
-    pKeyGenVRF :: Parser ShelleyNodeCmd
+    pKeyGenVRF :: Parser NodeCmd
     pKeyGenVRF =
       NodeKeyGenVRF <$> pVerificationKeyFile <*> pSigningKeyFile
 
-    pIssueOpCert :: Parser ShelleyNodeCmd
+    pIssueOpCert :: Parser NodeCmd
     pIssueOpCert =
       pure NodeIssueOpCert
 
 
-pShelleyPoolCmd :: Parser ShelleyPoolCmd
-pShelleyPoolCmd =
+pPoolCmd :: Parser PoolCmd
+pPoolCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "register"
@@ -344,18 +344,18 @@ pShelleyPoolCmd =
           (Opt.info pPoolRetire $ Opt.progDesc "Retire a stake pool")
       ]
   where
-    pPoolRegster :: Parser ShelleyPoolCmd
+    pPoolRegster :: Parser PoolCmd
     pPoolRegster = PoolRegister <$> pPoolId
 
-    pPoolReRegster :: Parser ShelleyPoolCmd
+    pPoolReRegster :: Parser PoolCmd
     pPoolReRegster = PoolReRegister <$> pPoolId
 
-    pPoolRetire :: Parser ShelleyPoolCmd
+    pPoolRetire :: Parser PoolCmd
     pPoolRetire = PoolRetire <$> pPoolId <*> pEpochNo <*> parseNodeAddress
 
 
-pShelleyQueryCmd :: Parser ShelleyQueryCmd
-pShelleyQueryCmd =
+pQueryCmd :: Parser QueryCmd
+pQueryCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "pool-id"
@@ -368,32 +368,32 @@ pShelleyQueryCmd =
           (Opt.info pQueryStatus $ Opt.progDesc "Get the status of the node")
       ]
   where
-    pQueryPoolId :: Parser ShelleyQueryCmd
+    pQueryPoolId :: Parser QueryCmd
     pQueryPoolId = QueryPoolId <$> parseNodeAddress
 
-    pQueryTip :: Parser ShelleyQueryCmd
+    pQueryTip :: Parser QueryCmd
     pQueryTip = QueryTip <$> parseNodeAddress
 
-    pQueryVersion :: Parser ShelleyQueryCmd
+    pQueryVersion :: Parser QueryCmd
     pQueryVersion = QueryVersion <$> parseNodeAddress
 
-    pQueryStatus :: Parser ShelleyQueryCmd
+    pQueryStatus :: Parser QueryCmd
     pQueryStatus = QueryStatus <$> parseNodeAddress
 
 
-pShelleyBlockCmd :: Parser ShelleyBlockCmd
-pShelleyBlockCmd =
+pBlockCmd :: Parser BlockCmd
+pBlockCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "info"
           (Opt.info pBlockInfo $ Opt.progDesc "Get the node's pool id")
       ]
   where
-    pBlockInfo :: Parser ShelleyBlockCmd
+    pBlockInfo :: Parser BlockCmd
     pBlockInfo = BlockInfo <$> pBlockId <*> parseNodeAddress
 
-pShelleyDevOpsCmd :: Parser ShelleyDevOpsCmd
-pShelleyDevOpsCmd =
+pDevOpsCmd :: Parser DevOpsCmd
+pDevOpsCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "protocol-update"
@@ -402,10 +402,10 @@ pShelleyDevOpsCmd =
           (Opt.info pColdKeys $ Opt.progDesc "Cold keys")
       ]
   where
-    pProtocolUpdate :: Parser ShelleyDevOpsCmd
+    pProtocolUpdate :: Parser DevOpsCmd
     pProtocolUpdate = DevOpsProtocolUpdate <$> pPrivKeyFile
 
-    pColdKeys :: Parser ShelleyDevOpsCmd
+    pColdKeys :: Parser DevOpsCmd
     pColdKeys = DevOpsColdKeys <$> pGenesisKeyFile
 
     pGenesisKeyFile :: Parser GenesisKeyFile
@@ -418,8 +418,8 @@ pShelleyDevOpsCmd =
           )
 
 
-pShelleySystemCmd :: Parser ShelleySystemCmd
-pShelleySystemCmd =
+pSystemCmd :: Parser SystemCmd
+pSystemCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "start"
@@ -428,15 +428,15 @@ pShelleySystemCmd =
           (Opt.info pSystemStop $ Opt.progDesc "Stop system")
       ]
   where
-    pSystemStart :: Parser ShelleySystemCmd
+    pSystemStart :: Parser SystemCmd
     pSystemStart = SysStart <$> pGenesisFile <*> parseNodeAddress
 
-    pSystemStop :: Parser ShelleySystemCmd
+    pSystemStop :: Parser SystemCmd
     pSystemStop = SysStop <$> parseNodeAddress
 
 
-pShelleyGenesisCmd :: Parser ShelleyGenesisCmd
-pShelleyGenesisCmd =
+pGenesisCmd :: Parser GenesisCmd
+pGenesisCmd =
   Opt.subparser $
     mconcat
       [ Opt.command "key-gen-genesis"
@@ -454,19 +454,19 @@ pShelleyGenesisCmd =
                         ++ "template and genesis/delegation/spending keys."))
       ]
   where
-    pGenesisKeyGen :: Parser ShelleyGenesisCmd
+    pGenesisKeyGen :: Parser GenesisCmd
     pGenesisKeyGen =
       GenesisKeyGen <$> pOutputFile <*> pOutputFile
 
-    pGenesisDelegateKeyGen :: Parser ShelleyGenesisCmd
+    pGenesisDelegateKeyGen :: Parser GenesisCmd
     pGenesisDelegateKeyGen =
       GenesisKeyGen <$> pOutputFile <*> pOutputFile
 
-    pGenesisUTxOKeyGen :: Parser ShelleyGenesisCmd
+    pGenesisUTxOKeyGen :: Parser GenesisCmd
     pGenesisUTxOKeyGen =
       GenesisKeyGen <$> pOutputFile <*> pOutputFile
 
-    pGenesisCommand :: Parser ShelleyGenesisCmd
+    pGenesisCommand :: Parser GenesisCmd
     pGenesisCommand =
       GenesisCreate <$> pGenesisDir <*> pMaybeSystemStart <*> pInitialSupply
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -70,6 +70,7 @@ data ShelleyCommand
   = ShelleyKeyGenerate OutputFile
   | ShelleyKESKeyPairGenerate VerificationKeyFile SigningKeyFile Natural
   | ShelleyVRFKeyPairGenerate VerificationKeyFile SigningKeyFile
+  | ShelleyAddress ShelleyAddressCmd
   | ShelleyPool ShelleyPoolCmd
   | ShelleyStakeAddress ShelleyStakeAddressCmd
   | ShelleyTransaction ShelleyTransactionCmd
@@ -89,6 +90,13 @@ data ShelleyQueryCmd
   | QueryTip NodeAddress
   | QueryVersion NodeAddress
   | QueryStatus NodeAddress
+  deriving (Eq, Show)
+
+data ShelleyAddressCmd
+  = AddressKeyGen OutputFile OutputFile
+  | AddressKeyHash VerificationKeyFile
+  | AddressBuild          --TODO
+  | AddressBuildMultiSig  --TODO
   deriving (Eq, Show)
 
 data ShelleyPoolCmd
@@ -134,6 +142,8 @@ parseShelleyCommands =
           (Opt.info pVRFKeyGen
           $ Opt.progDesc "Generate Shelley era VRF keys."
           )
+      , Opt.command "address"
+          (Opt.info (ShelleyAddress <$> pAddress) $ Opt.progDesc "Shelley address commands")
       , Opt.command "stake-pool"
           (Opt.info (ShelleyPool <$> pShelleyPoolCmd) $ Opt.progDesc "Shelley stake pool commands")
       , Opt.command "stake-address"
@@ -194,6 +204,33 @@ pSigningKeyFile =
      <> Opt.metavar "FILEPATH"
      <> Opt.help "Output filepath of the signing key."
      )
+
+pAddress :: Parser ShelleyAddressCmd
+pAddress =
+  Opt.subparser $
+    mconcat
+      [ Opt.command "key-gen"
+          (Opt.info pAddressKeyGen $ Opt.progDesc "Create a single address key pair")
+      , Opt.command "key-hash"
+          (Opt.info pAddressKeyHash $ Opt.progDesc "Show the hash of an address key")
+      , Opt.command "build"
+          (Opt.info pAddressBuild $ Opt.progDesc "Build an address")
+      , Opt.command "build-multisig"
+          (Opt.info pAddressBuildMultiSig $ Opt.progDesc "Build a multi-sig address")
+      ]
+  where
+    pAddressKeyGen :: Parser ShelleyAddressCmd
+    pAddressKeyGen = AddressKeyGen <$> pOutputFile <*> pOutputFile
+
+    pAddressKeyHash :: Parser ShelleyAddressCmd
+    pAddressKeyHash = AddressKeyHash <$> pVerificationKeyFile
+
+    pAddressBuild :: Parser ShelleyAddressCmd
+    pAddressBuild = pure AddressBuild
+
+    pAddressBuildMultiSig :: Parser ShelleyAddressCmd
+    pAddressBuildMultiSig = pure AddressBuildMultiSig
+
 
 pStakeAddress :: Parser ShelleyStakeAddressCmd
 pStakeAddress =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -74,10 +74,7 @@ data ShelleyGenesisCmd
   deriving (Eq, Show)
 
 data ShelleyCommand
-  = ShelleyKeyGenerate OutputFile
-  | ShelleyKESKeyPairGenerate VerificationKeyFile SigningKeyFile Natural
-  | ShelleyVRFKeyPairGenerate VerificationKeyFile SigningKeyFile
-  | ShelleyAddress ShelleyAddressCmd
+  = ShelleyAddress ShelleyAddressCmd
   | ShelleyPool ShelleyPoolCmd
   | ShelleyStakeAddress ShelleyStakeAddressCmd
   | ShelleyTransaction ShelleyTransactionCmd
@@ -138,19 +135,7 @@ parseShelleyCommands :: Parser ShelleyCommand
 parseShelleyCommands =
   Opt.subparser $
     mconcat
-      [ Opt.command "key-gen"
-          (Opt.info pKeyGen
-          $ Opt.progDesc "Generate Shelley era crypto keys."
-          )
-      , Opt.command "KES-key-gen"
-          (Opt.info pKESKeyGen
-          $ Opt.progDesc "Generate Shelley era KES keys."
-          )
-      , Opt.command "VRF-key-gen"
-          (Opt.info pVRFKeyGen
-          $ Opt.progDesc "Generate Shelley era VRF keys."
-          )
-      , Opt.command "address"
+      [ Opt.command "address"
           (Opt.info (ShelleyAddress <$> pAddress) $ Opt.progDesc "Shelley address commands")
       , Opt.command "stake-pool"
           (Opt.info (ShelleyPool <$> pShelleyPoolCmd) $ Opt.progDesc "Shelley stake pool commands")
@@ -171,18 +156,6 @@ parseShelleyCommands =
       , Opt.command "genesis"
           (Opt.info (ShelleyGenesis <$> pShelleyGenesisCmd) $ Opt.progDesc "Shelley genesis block commands")
       ]
-  where
-    pKeyGen :: Parser ShelleyCommand
-    pKeyGen =
-      ShelleyKeyGenerate <$> pOutputFile
-
-    pKESKeyGen :: Parser ShelleyCommand
-    pKESKeyGen =
-      ShelleyKESKeyPairGenerate <$> pVerificationKeyFile <*> pSigningKeyFile <*> pDuration
-
-    pVRFKeyGen :: Parser ShelleyCommand
-    pVRFKeyGen =
-      ShelleyVRFKeyPairGenerate <$> pVerificationKeyFile <*> pSigningKeyFile
 
 
 pShelleyPoolCmd :: Parser ShelleyPoolCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -61,6 +61,13 @@ data ShelleyDevOpsCmd
   | DevOpsColdKeys GenesisKeyFile     -- { genesis :: GenesisKeyFile, keys :: [PubKey], nodeAddr :: NodeAddress }
   deriving (Eq, Show)
 
+data ShelleyNodeCmd
+  = NodeKeyGenCold VerificationKeyFile SigningKeyFile
+  | NodeKeyGenKES  VerificationKeyFile SigningKeyFile Natural
+  | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
+  | NodeIssueOpCert --TODO
+  deriving (Eq, Show)
+
 data ShelleyGenesisCmd
   = GenesisCreate GenesisDir (Maybe SystemStart) Lovelace
   | GenesisKeyGen OutputFile OutputFile
@@ -74,6 +81,7 @@ data ShelleyCommand
   | ShelleyPool ShelleyPoolCmd
   | ShelleyStakeAddress ShelleyStakeAddressCmd
   | ShelleyTransaction ShelleyTransactionCmd
+  | ShelleyNode  ShelleyNodeCmd
   | ShelleyQuery ShelleyQueryCmd
   | ShelleyBlock ShelleyBlockCmd
   | ShelleySystem ShelleySystemCmd
@@ -150,6 +158,8 @@ parseShelleyCommands =
           (Opt.info (ShelleyStakeAddress <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
       , Opt.command "transaction"
           (Opt.info (ShelleyTransaction <$> pTransaction) $ Opt.progDesc "Shelley transaction commands")
+      , Opt.command "node"
+          (Opt.info (ShelleyNode <$> pShelleyNodeCmd) $ Opt.progDesc "Shelley node operaton commands")
       , Opt.command "query"
           (Opt.info (ShelleyQuery <$> pShelleyQueryCmd) $ Opt.progDesc "Shelley node query commands")
       , Opt.command "block"
@@ -305,6 +315,42 @@ pTransaction =
 
     pTransactionInfo  :: Parser ShelleyTransactionCmd
     pTransactionInfo = pure TxInfo
+
+
+pShelleyNodeCmd :: Parser ShelleyNodeCmd
+pShelleyNodeCmd =
+  Opt.subparser $
+    mconcat
+      [ Opt.command "key-gen"
+          (Opt.info pKeyGenOperator $
+             Opt.progDesc "Create a key pair for node operator's offline key")
+      , Opt.command "key-gen-KES"
+          (Opt.info pKeyGenKES $
+             Opt.progDesc "Create a key pair for a node KES operational key")
+      , Opt.command "key-gen-VRF"
+          (Opt.info pKeyGenVRF $
+             Opt.progDesc "Create a key pair for a node VRF operational key")
+      , Opt.command "issue-op-cert"
+          (Opt.info pIssueOpCert $
+             Opt.progDesc "Issue a node operational certificate")
+      ]
+  where
+    pKeyGenOperator :: Parser ShelleyNodeCmd
+    pKeyGenOperator =
+      NodeKeyGenCold <$> pVerificationKeyFile <*> pSigningKeyFile
+
+    pKeyGenKES :: Parser ShelleyNodeCmd
+    pKeyGenKES =
+      NodeKeyGenKES <$> pVerificationKeyFile <*> pSigningKeyFile <*> pDuration
+
+    pKeyGenVRF :: Parser ShelleyNodeCmd
+    pKeyGenVRF =
+      NodeKeyGenVRF <$> pVerificationKeyFile <*> pSigningKeyFile
+
+    pIssueOpCert :: Parser ShelleyNodeCmd
+    pIssueOpCert =
+      pure NodeIssueOpCert
+
 
 pShelleyQueryCmd :: Parser ShelleyQueryCmd
 pShelleyQueryCmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -18,6 +18,8 @@ module Cardano.CLI.Shelley.Parsers
     -- * CLI flag types
   , GenesisDir (..)
   , OutputFile (..)
+  , SigningKeyFile (..)
+  , VerificationKeyFile (..)
   ) where
 
 import           Cardano.Prelude hiding (option)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -71,7 +71,7 @@ data ShelleyCommand
   | ShelleyKESKeyPairGenerate VerificationKeyFile SigningKeyFile Natural
   | ShelleyVRFKeyPairGenerate VerificationKeyFile SigningKeyFile
   | ShelleyPool ShelleyPoolCmd
-  | ShelleyStakeKey ShelleyStakeKeyCmd
+  | ShelleyStakeAddress ShelleyStakeAddressCmd
   | ShelleyTransaction ShelleyTransactionCmd
   | ShelleyQuery ShelleyQueryCmd
   | ShelleyBlock ShelleyBlockCmd
@@ -97,7 +97,7 @@ data ShelleyPoolCmd
   | PoolRetire PoolId EpochNo NodeAddress
   deriving (Eq, Show)
 
-data ShelleyStakeKeyCmd
+data ShelleyStakeAddressCmd
   = StakeKeyRegister PrivKeyFile NodeAddress
   | StakeKeyDelegate PrivKeyFile PoolId Lovelace NodeAddress
   | StakeKeyDeRegister PrivKeyFile NodeAddress
@@ -134,10 +134,10 @@ parseShelleyCommands =
           (Opt.info pVRFKeyGen
           $ Opt.progDesc "Generate Shelley era VRF keys."
           )
-      , Opt.command "pool"
-          (Opt.info (ShelleyPool <$> pShelleyPoolCmd) $ Opt.progDesc "Shelley pool commands")
-      , Opt.command "stake-key"
-          (Opt.info (ShelleyStakeKey <$> pStakeKey) $ Opt.progDesc "Shelley stake key commands")
+      , Opt.command "stake-pool"
+          (Opt.info (ShelleyPool <$> pShelleyPoolCmd) $ Opt.progDesc "Shelley stake pool commands")
+      , Opt.command "stake-address"
+          (Opt.info (ShelleyStakeAddress <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
       , Opt.command "transaction"
           (Opt.info (ShelleyTransaction <$> pTransaction) $ Opt.progDesc "Shelley transaction commands")
       , Opt.command "query"
@@ -195,27 +195,27 @@ pSigningKeyFile =
      <> Opt.help "Output filepath of the signing key."
      )
 
-pStakeKey :: Parser ShelleyStakeKeyCmd
-pStakeKey =
+pStakeAddress :: Parser ShelleyStakeAddressCmd
+pStakeAddress =
   Opt.subparser $
     mconcat
       [ Opt.command "register"
-          (Opt.info pStakeKeyRegister $ Opt.progDesc "Register a stake pool")
+          (Opt.info pStakeAddressRegister $ Opt.progDesc "Register a stake address")
       , Opt.command "delegate"
-          (Opt.info pStakeKeyDelegate $ Opt.progDesc "Re-register a stake pool")
+          (Opt.info pStakeAddressDelegate $ Opt.progDesc "Delegate from a stake address to a stake pool")
       , Opt.command "de-register"
-          (Opt.info pStakeKeyDeRegister $ Opt.progDesc "Retire a stake pool")
+          (Opt.info pStakeAddressDeRegister $ Opt.progDesc "De-register a stake address")
       ]
   where
-    pStakeKeyRegister :: Parser ShelleyStakeKeyCmd
-    pStakeKeyRegister = StakeKeyRegister <$> pPrivKeyFile <*> parseNodeAddress
+    pStakeAddressRegister :: Parser ShelleyStakeAddressCmd
+    pStakeAddressRegister = StakeKeyRegister <$> pPrivKeyFile <*> parseNodeAddress
 
-    pStakeKeyDelegate :: Parser ShelleyStakeKeyCmd
-    pStakeKeyDelegate =
+    pStakeAddressDelegate :: Parser ShelleyStakeAddressCmd
+    pStakeAddressDelegate =
       StakeKeyDelegate <$> pPrivKeyFile <*> pPoolId <*> pDelegationFee <*> parseNodeAddress
 
-    pStakeKeyDeRegister :: Parser ShelleyStakeKeyCmd
-    pStakeKeyDeRegister = StakeKeyDeRegister <$> pPrivKeyFile <*> parseNodeAddress
+    pStakeAddressDeRegister :: Parser ShelleyStakeAddressCmd
+    pStakeAddressDeRegister = StakeKeyDeRegister <$> pPrivKeyFile <*> parseNodeAddress
 
     pDelegationFee :: Parser Lovelace
     pDelegationFee =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -26,15 +26,14 @@ import           Cardano.Config.Shelley.VRF
                    (genVRFKeyPair, writeVRFSigningKey, writeVRFVerKey)
 import           Cardano.Config.Types (SigningKeyFile(..))
 
+
 runShelleyClientCommand :: ShelleyCommand -> ExceptT CliError IO ()
 runShelleyClientCommand cc =
   case cc of
-    ShelleyKeyGenerate fpath -> runShelleyKeyGenerate fpath
-    ShelleyKESKeyPairGenerate vKeyPath sKeyPath duration -> runShelleyKESKeyPairGeneration vKeyPath sKeyPath duration
-    ShelleyVRFKeyPairGenerate vKeyPath sKeyPath -> runShelleyVRFKeyPairGeneration vKeyPath sKeyPath
     _ -> liftIO . putStrLn $ "runShelleyClientCommand: " ++ show cc
 
 
+{-
 runShelleyKeyGenerate :: OutputFile -> ExceptT CliError IO ()
 runShelleyKeyGenerate (OutputFile fpath) = do
   kp <- liftIO $ shelleyGenKeyPair RegularShelleyKey
@@ -51,3 +50,4 @@ runShelleyVRFKeyPairGeneration (VerificationKeyFile vKeyPath) (SigningKeyFile sK
   (sKESKey, vKESKey) <- liftIO $ genVRFKeyPair
   firstExceptT VRFCliError $ writeVRFSigningKey sKeyPath sKESKey
   firstExceptT VRFCliError $ writeVRFVerKey vKeyPath vKESKey
+-}

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -19,7 +19,7 @@ import           Cardano.Api (ShelleyKeyDiscriminator (..), shelleyGenKeyPair, w
 
 import           Cardano.CLI.Key (VerificationKeyFile(..))
 import           Cardano.CLI.Ops (CliError (..))
-import           Cardano.CLI.Shelley.Parsers (OutputFile (..), ShelleyCommand(..))
+import           Cardano.CLI.Shelley.Parsers
 import           Cardano.Config.Shelley.KES
                    (genKESKeyPair, writeKESSigningKey, writeKESVerKey)
 import           Cardano.Config.Shelley.VRF
@@ -27,10 +27,65 @@ import           Cardano.Config.Shelley.VRF
 import           Cardano.Config.Types (SigningKeyFile(..))
 
 
+--
+-- CLI shelley command dispatch
+--
+
 runShelleyClientCommand :: ShelleyCommand -> ExceptT CliError IO ()
-runShelleyClientCommand cc =
-  case cc of
-    _ -> liftIO . putStrLn $ "runShelleyClientCommand: " ++ show cc
+runShelleyClientCommand (AddressCmd      cmd) = runAddressCmd      cmd
+runShelleyClientCommand (StakeAddressCmd cmd) = runStakeAddressCmd cmd
+runShelleyClientCommand (TransactionCmd  cmd) = runTransactionCmd  cmd
+runShelleyClientCommand (NodeCmd         cmd) = runNodeCmd         cmd
+runShelleyClientCommand (PoolCmd         cmd) = runPoolCmd         cmd
+runShelleyClientCommand (QueryCmd        cmd) = runQueryCmd        cmd
+runShelleyClientCommand (BlockCmd        cmd) = runBlockCmd        cmd
+runShelleyClientCommand (SystemCmd       cmd) = runSystemCmd       cmd
+runShelleyClientCommand (DevOpsCmd       cmd) = runDevOpsCmd       cmd
+runShelleyClientCommand (GenesisCmd      cmd) = runGenesisCmd      cmd
+
+
+--
+-- CLI shelley subcommand dispatch
+--
+
+runAddressCmd :: AddressCmd -> ExceptT CliError IO ()
+runAddressCmd cmd = liftIO $ putStrLn $ "runAddressCmd: " ++ show cmd
+
+
+runStakeAddressCmd :: StakeAddressCmd -> ExceptT CliError IO ()
+runStakeAddressCmd cmd = liftIO $ putStrLn $ "runStakeAddressCmd: " ++ show cmd
+
+
+runTransactionCmd :: TransactionCmd -> ExceptT CliError IO ()
+runTransactionCmd cmd = liftIO $ putStrLn $ "runTransactionCmd: " ++ show cmd
+
+
+runNodeCmd :: NodeCmd -> ExceptT CliError IO ()
+runNodeCmd cmd = liftIO $ putStrLn $ "runNodeCmd: " ++ show cmd
+
+
+runPoolCmd :: PoolCmd -> ExceptT CliError IO ()
+runPoolCmd cmd = liftIO $ putStrLn $ "runPoolCmd: " ++ show cmd
+
+
+runQueryCmd :: QueryCmd -> ExceptT CliError IO ()
+runQueryCmd cmd = liftIO $ putStrLn $ "runQueryCmd: " ++ show cmd
+
+
+runBlockCmd :: BlockCmd -> ExceptT CliError IO ()
+runBlockCmd cmd = liftIO $ putStrLn $ "runBlockCmd: " ++ show cmd
+
+
+runSystemCmd:: SystemCmd -> ExceptT CliError IO ()
+runSystemCmd cmd = liftIO $ putStrLn $ "runSystemCmd: " ++ show cmd
+
+
+runDevOpsCmd :: DevOpsCmd -> ExceptT CliError IO ()
+runDevOpsCmd cmd = liftIO $ putStrLn $ "runDevOpsCmd: " ++ show cmd
+
+
+runGenesisCmd :: GenesisCmd -> ExceptT CliError IO ()
+runGenesisCmd cmd = liftIO $ putStrLn $ "runGenesisCmd: " ++ show cmd
 
 
 {-


### PR DESCRIPTION
Move a number of the Shelley CLI subcommands around, plus some renaming and reordering. In the end there are no commands immediately under the `shelley` commnad, only further sub-commands, which contain leaf commands.