### PR TITLE
CLI key gen for cold keys (genesis, delegate, initial UTxO, and pool operator)

### DIFF
--- a/cardano-api/src/Cardano/Api/View.hs
+++ b/cardano-api/src/Cardano/Api/View.hs
@@ -36,6 +36,7 @@ import           Control.Monad.Trans.Except.Extra (handleIOExceptT, hoistEither,
 
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
 
@@ -112,9 +113,17 @@ convertTestViewError err =
     case err of
       TextViewFormatError msg -> ApiTextView msg
 
-      TextViewTypeError expected actual ->
+      TextViewTypeError [expected] actual ->
         ApiTextView $ mconcat
           [ "Expected file type ", Text.decodeLatin1 (unTextViewType expected)
+          , ", but got type ", Text.decodeLatin1 (unTextViewType actual)
+          ]
+
+      TextViewTypeError expected actual ->
+        ApiTextView $ mconcat
+          [ "Expected file type to be one of "
+          , Text.intercalate ", "
+              [ Text.decodeLatin1 (unTextViewType t) | t <- expected ]
           , ", but got type ", Text.decodeLatin1 (unTextViewType actual)
           ]
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -46,6 +46,7 @@ library
                      , cardano-binary
                      , cardano-config
                      , cardano-crypto
+                     , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-node
@@ -66,6 +67,7 @@ library
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
                      , ouroboros-network
+                     , shelley-spec-ledger
                      , text
                      , time
                      , transformers

--- a/cardano-cli/src/Cardano/CLI/Ops.hs
+++ b/cardano-cli/src/Cardano/CLI/Ops.hs
@@ -103,6 +103,7 @@ import           Cardano.Config.Protocol
                    (Protocol(..), ProtocolInstantiationError,
                     SomeConsensusProtocol(..), mkConsensusProtocol,
                     renderProtocolInstantiationError)
+import           Cardano.Config.Shelley.ColdKeys (KeyError, renderKeyError)
 import           Cardano.Config.Shelley.KES (KESError, renderKESError)
 import           Cardano.Config.Shelley.VRF (VRFError, renderVRFError)
 import           Cardano.Config.Types
@@ -255,6 +256,7 @@ data CliError
   | GenesisSpecError !Text
   | IssueUtxoError !RealPBFTError
   | KESCliError KESError
+  | KeyCliError KeyError
   | NoBlocksFound !FilePath
   | NodeSubmitTxError !RealPBFTError
   | NotEnoughTxInputs
@@ -305,6 +307,8 @@ instance Show CliError where
     = "Error SpendUTxO command: " <> (T.unpack $ renderRealPBFTError err)
   show (KESCliError err)
     = show $ renderKESError err
+  show (KeyCliError err)
+    = T.unpack $ renderKeyError err
   show (NoBlocksFound fp)
     = "Error while creating update proposal, no blocks found in: " <> fp
   show (NodeSubmitTxError err)

--- a/cardano-cli/src/Cardano/CLI/Ops.hs
+++ b/cardano-cli/src/Cardano/CLI/Ops.hs
@@ -106,6 +106,7 @@ import           Cardano.Config.Protocol
 import           Cardano.Config.Shelley.ColdKeys (KeyError, renderKeyError)
 import           Cardano.Config.Shelley.KES (KESError, renderKESError)
 import           Cardano.Config.Shelley.VRF (VRFError, renderVRFError)
+import           Cardano.Config.Shelley.OCert (OperationalCertError)
 import           Cardano.Config.Types
 import qualified Cardano.CLI.Legacy.Byron as Legacy
 
@@ -263,6 +264,7 @@ data CliError
   | NotEnoughTxOutputs
   | NoGenesisDelegationForKey !Text
   | OutputMustNotAlreadyExist !FilePath
+  | OperationalCertError OperationalCertError
   | ProtocolError !ProtocolInstantiationError
   | ProtocolParametersParseFailed !FilePath !Text
   | ReadCBORFileFailure !FilePath !Text
@@ -321,6 +323,8 @@ instance Show CliError where
     = "Transactions must have at least one output."
   show (OutputMustNotAlreadyExist fp)
     = "Output file/directory must not already exist: " <> fp
+  show (OperationalCertError err)
+    = show err --TODO: renderOperationalCertError
   show (ProtocolError err)
     = "Protocol Instantiation Error " <> (T.unpack $ renderProtocolInstantiationError err)
   show (CardanoApiError apiError)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -129,7 +129,9 @@ data SystemCmd
 
 data GenesisCmd
   = GenesisCreate GenesisDir (Maybe SystemStart) Lovelace
-  | GenesisKeyGen OutputFile OutputFile
+  | GenesisKeyGenGenesis  VerificationKeyFile SigningKeyFile
+  | GenesisKeyGenDelegate VerificationKeyFile SigningKeyFile
+  | GenesisKeyGenUTxO     VerificationKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 
@@ -458,15 +460,15 @@ pGenesisCmd =
   where
     pGenesisKeyGen :: Parser GenesisCmd
     pGenesisKeyGen =
-      GenesisKeyGen <$> pOutputFile <*> pOutputFile
+      GenesisKeyGenGenesis <$> pVerificationKeyFile <*> pSigningKeyFile
 
     pGenesisDelegateKeyGen :: Parser GenesisCmd
     pGenesisDelegateKeyGen =
-      GenesisKeyGen <$> pOutputFile <*> pOutputFile
+      GenesisKeyGenDelegate <$> pVerificationKeyFile <*> pSigningKeyFile
 
     pGenesisUTxOKeyGen :: Parser GenesisCmd
     pGenesisUTxOKeyGen =
-      GenesisKeyGen <$> pOutputFile <*> pOutputFile
+      GenesisKeyGenUTxO <$> pVerificationKeyFile <*> pSigningKeyFile
 
     pGenesisCommand :: Parser GenesisCmd
     pGenesisCommand =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -132,6 +132,8 @@ data GenesisCmd
   | GenesisKeyGenGenesis  VerificationKeyFile SigningKeyFile
   | GenesisKeyGenDelegate VerificationKeyFile SigningKeyFile
   | GenesisKeyGenUTxO     VerificationKeyFile SigningKeyFile
+  | GenesisKeyHash        VerificationKeyFile
+  | GenesisVerKey         VerificationKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 
@@ -452,6 +454,12 @@ pGenesisCmd =
       , Opt.command "key-gen-utxo"
           (Opt.info pGenesisUTxOKeyGen $
              Opt.progDesc "Create a Shelley genesis UTxO key pair")
+      , Opt.command "key-hash"
+          (Opt.info pGenesisKeyHash $
+             Opt.progDesc "Print the identifier (hash) of a public key")
+      , Opt.command "get-ver-key"
+          (Opt.info pGenesisVerKey $
+             Opt.progDesc "Derive the verification key from a signing key")
       , Opt.command "create-genesis"
           (Opt.info pGenesisCommand $
              Opt.progDesc ("Create a Shelley genesis file from a genesis "
@@ -469,6 +477,14 @@ pGenesisCmd =
     pGenesisUTxOKeyGen :: Parser GenesisCmd
     pGenesisUTxOKeyGen =
       GenesisKeyGenUTxO <$> pVerificationKeyFile <*> pSigningKeyFile
+
+    pGenesisKeyHash :: Parser GenesisCmd
+    pGenesisKeyHash =
+      GenesisKeyHash <$> pVerificationKeyFile
+
+    pGenesisVerKey :: Parser GenesisCmd
+    pGenesisVerKey =
+      GenesisVerKey <$> pVerificationKeyFile <*> pSigningKeyFile
 
     pGenesisCommand :: Parser GenesisCmd
     pGenesisCommand =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -19,7 +19,6 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Crypto.DSIGN.Class as Crypto
 
 import           Cardano.CLI.Key (VerificationKeyFile(..))
 import           Cardano.CLI.Ops (CliError (..))
@@ -171,8 +170,7 @@ runGenesisVerKey :: VerificationKeyFile -> SigningKeyFile
 runGenesisVerKey (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
     firstExceptT KeyCliError $ do
       (skey, role) <- readSigningKeySomeRole genesisKeyRoles skeyPath
-      let vkey = Ledger.VKey (Crypto.deriveVerKeyDSIGN sk)
-                   where Ledger.SKey sk = skey
+      let vkey = deriveVerKey skey
       writeVerKey role vkeyPath vkey
 
 genesisKeyRoles :: [KeyRole]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -90,6 +90,8 @@ runDevOpsCmd cmd = liftIO $ putStrLn $ "runDevOpsCmd: " ++ show cmd
 
 
 runGenesisCmd :: GenesisCmd -> ExceptT CliError IO ()
+runGenesisCmd (GenesisKeyGenGenesis  vk sk) = runGenesisKeyGenGenesis  vk sk
+runGenesisCmd (GenesisKeyGenDelegate vk sk) = runGenesisKeyGenDelegate vk sk
 runGenesisCmd cmd = liftIO $ putStrLn $ "runGenesisCmd: " ++ show cmd
 
 
@@ -125,4 +127,30 @@ runNodeKeyGenVRF (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
       (skey, vkey) <- liftIO genVRFKeyPair
       writeVRFVerKey     vkeyPath vkey
       writeVRFSigningKey skeyPath skey
+
+
+--
+-- Genesis command implementations
+--
+
+runGenesisKeyGenGenesis :: VerificationKeyFile -> SigningKeyFile
+                        -> ExceptT CliError IO ()
+runGenesisKeyGenGenesis (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
+    firstExceptT KeyCliError $ do
+      (vkey, skey) <- liftIO genKeyPair
+      writeVerKey     keyType vkeyPath vkey
+      writeSigningKey keyType skeyPath skey
+  where
+    keyType = GenesisKey
+
+
+runGenesisKeyGenDelegate :: VerificationKeyFile -> SigningKeyFile
+                         -> ExceptT CliError IO ()
+runGenesisKeyGenDelegate (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
+    firstExceptT KeyCliError $ do
+      (vkey, skey) <- liftIO genKeyPair
+      writeVerKey     keyType vkeyPath vkey
+      writeSigningKey keyType skeyPath skey
+  where
+    keyType = OperatorKey GenesisDelegateKey
 

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -23,6 +23,7 @@ library
                        Cardano.Config.Protocol.Mock
                        Cardano.Config.Protocol.Byron
                        Cardano.Config.Protocol.Shelley
+                       Cardano.Config.Shelley.ColdKeys
                        Cardano.Config.Shelley.Genesis
                        Cardano.Config.Shelley.KES
                        Cardano.Config.Shelley.OCert

--- a/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Consensus.Shelley.Node
                    (TPraosLeaderCredentials(..))
 
 import           Shelley.Spec.Ledger.PParams (ProtVer(..))
-import           Shelley.Spec.Ledger.Keys (DiscVKey(..))
+import qualified Shelley.Spec.Ledger.Keys as Ledger
 
 import           Cardano.Config.Types
                    (NodeConfiguration(..), ProtocolFilepaths(..),
@@ -115,13 +115,13 @@ readLeaderCredentials (Just ProtocolFilepaths {
 
     (opcert, vkey) <- firstExceptT OCertError $ readOperationalCert certFile
     vrfKey <- firstExceptT VRFError $ readVRFSigningKey vrfFile
-    kesKey <- firstExceptT KESError $ readKESSigningKey kesFile
+    Ledger.SKeyES kesKey <- firstExceptT KESError $ readKESSigningKey kesFile
 
     return $ Just TPraosLeaderCredentials {
                tpraosLeaderCredentialsIsCoreNode =
                  TPraosIsCoreNode {
                    tpraosIsCoreNodeOpCert     = opcert,
-                   tpraosIsCoreNodeColdVerKey = DiscVKey vkey,
+                   tpraosIsCoreNodeColdVerKey = vkey,
                    tpraosIsCoreNodeSignKeyVRF = vrfKey
                  },
                tpraosLeaderCredentialsSignKey = kesKey

--- a/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Config.Shelley.ColdKeys
+  ( KeyError(..)
+  , KeyType(..)
+  , OperatorKeyRole(..)
+  , decodeVerificationKey
+  , encodeVerificationKey
+  , genKeyPair
+  , readSigningKey
+  , readVerKey
+  , renderKeyError
+  , writeSigningKey
+  , writeVerKey
+  ) where
+
+import           Cardano.Prelude
+
+import qualified Cardano.Binary as CBOR
+import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+
+import           Cardano.Crypto.DSIGN.Class
+import           Cardano.Crypto.Random (runSecureRandom)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto
+                   (TPraosStandardCrypto, DSIGN)
+
+import           Cardano.Config.TextView
+
+
+data KeyType = GenesisKey | OperatorKey OperatorKeyRole
+
+data OperatorKeyRole = GenesisDelegateKey | StakePoolOperatorKey
+
+
+renderKeyType :: KeyType -> TextViewType
+renderKeyType GenesisKey    = "Genesis"
+renderKeyType OperatorKey{} = "Node operator"
+
+renderKeyRole :: KeyType -> TextViewTitle
+renderKeyRole GenesisKey                         = "Genesis key"
+renderKeyRole (OperatorKey GenesisDelegateKey)   = "Genesis delegate operator key"
+renderKeyRole (OperatorKey StakePoolOperatorKey) = "Stake pool operator key"
+
+
+-- Local aliases for shorter types:
+type VerKey  = VerKeyDSIGN  (DSIGN TPraosStandardCrypto)
+type SignKey = SignKeyDSIGN (DSIGN TPraosStandardCrypto)
+
+
+data KeyError = ReadSigningKeyError  !TextViewFileError
+              | ReadVerKeyError      !TextViewFileError
+              | WriteSigningKeyError !TextViewFileError
+              | WriteVerKeyError     !TextViewFileError
+  deriving Show
+
+renderKeyError :: KeyError -> Text
+renderKeyError keyErr =
+  case keyErr of
+    ReadSigningKeyError err -> "signing key read error: " <> renderTextViewFileError err
+    ReadVerKeyError err -> "verification key read error: " <> renderTextViewFileError err
+    WriteSigningKeyError err -> "signing key write error: " <> renderTextViewFileError err
+    WriteVerKeyError err -> "verification key write error: " <> renderTextViewFileError err
+
+
+genKeyPair :: IO (VerKey, SignKey)
+genKeyPair = do
+  signKey <- runSecureRandom genKeyDSIGN
+  let verKey = deriveVerKeyDSIGN signKey
+  pure (verKey, signKey)
+
+
+encodeSigningKey :: KeyType -> SignKey -> TextView
+encodeSigningKey kt sKey =
+    encodeToTextView fileType fileTitle CBOR.toCBOR sKey
+  where
+    fileType  = renderKeyType kt <> " signing key"
+    fileTitle = renderKeyRole kt
+
+
+decodeSigningKey :: KeyType -> TextView -> Either TextViewError SignKey
+decodeSigningKey kt tView = do
+    expectTextViewOfType fileType tView
+    decodeFromTextView CBOR.fromCBOR tView
+  where
+    fileType  = renderKeyType kt <> " signing key"
+
+
+encodeVerificationKey :: KeyType -> VerKey -> TextView
+encodeVerificationKey kt vkey =
+    encodeToTextView fileType fileTitle CBOR.toCBOR vkey
+  where
+    fileType  = renderKeyType kt <> " verification key"
+    fileTitle = renderKeyRole kt
+
+
+decodeVerificationKey :: KeyType -> TextView -> Either TextViewError VerKey
+decodeVerificationKey kt tView = do
+    expectTextViewOfType fileType tView
+    decodeFromTextView CBOR.fromCBOR tView
+  where
+    fileType  = renderKeyType kt <> " verification key"
+
+
+readSigningKey :: KeyType -> FilePath -> ExceptT KeyError IO SignKey
+readSigningKey kt fp =
+  firstExceptT ReadSigningKeyError $ newExceptT $
+    readTextViewEncodedFile (decodeSigningKey kt) fp
+
+
+writeSigningKey :: KeyType -> FilePath -> SignKey -> ExceptT KeyError IO ()
+writeSigningKey kt fp sKey =
+  firstExceptT WriteSigningKeyError $ newExceptT $
+    writeTextViewEncodedFile (encodeSigningKey kt) fp sKey
+
+
+readVerKey :: KeyType -> FilePath -> ExceptT KeyError IO VerKey
+readVerKey kt fp = do
+  firstExceptT ReadVerKeyError $ newExceptT $
+    readTextViewEncodedFile (decodeVerificationKey kt) fp
+
+
+writeVerKey :: KeyType -> FilePath -> VerKey -> ExceptT KeyError IO ()
+writeVerKey kt fp vKey =
+  firstExceptT WriteVerKeyError $ newExceptT $
+    writeTextViewEncodedFile (encodeVerificationKey kt) fp vKey

--- a/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
@@ -11,6 +11,7 @@ module Cardano.Config.Shelley.ColdKeys
   , decodeSigningKey
   , decodeSigningKeySomeRole
   , genKeyPair
+  , deriveVerKey
   , readSigningKey
   , readSigningKeySomeRole
   , readVerKey
@@ -66,6 +67,11 @@ genKeyPair = do
   signKey <- runSecureRandom genKeyDSIGN
   let verKey = deriveVerKeyDSIGN signKey
   pure (Ledger.DiscVKey verKey, Ledger.SKey signKey)
+
+
+deriveVerKey :: SignKey -> VerKey
+deriveVerKey (Ledger.SKey skey) =
+    Ledger.VKey (deriveVerKeyDSIGN skey)
 
 
 encodeSigningKey :: KeyRole -> SignKey -> TextView

--- a/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
@@ -27,17 +27,21 @@ import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 import           Cardano.Config.TextView
 
 
-data KeyType = GenesisKey | OperatorKey OperatorKeyRole
+data KeyType = GenesisKey
+             | GenesisUTxOKey
+             | OperatorKey OperatorKeyRole
 
 data OperatorKeyRole = GenesisDelegateKey | StakePoolOperatorKey
 
 
 renderKeyType :: KeyType -> TextViewType
-renderKeyType GenesisKey    = "Genesis"
-renderKeyType OperatorKey{} = "Node operator"
+renderKeyType GenesisKey     = "Genesis"
+renderKeyType GenesisUTxOKey = "Genesis UTxO"
+renderKeyType OperatorKey{}  = "Node operator"
 
 renderKeyRole :: KeyType -> TextViewTitle
 renderKeyRole GenesisKey                         = "Genesis key"
+renderKeyRole GenesisUTxOKey                     = "Genesis initial UTxO key"
 renderKeyRole (OperatorKey GenesisDelegateKey)   = "Genesis delegate operator key"
 renderKeyRole (OperatorKey StakePoolOperatorKey) = "Stake pool operator key"
 

--- a/cardano-config/src/Cardano/Config/TextView.hs
+++ b/cardano-config/src/Cardano/Config/TextView.hs
@@ -48,11 +48,11 @@ import           Control.Monad.Trans.Except.Extra
 
 newtype TextViewType
   = TextViewType { unTextViewType :: ByteString }
-  deriving (Eq, IsString, Show)
+  deriving (Eq, IsString, Show, Semigroup)
 
 newtype TextViewTitle
   = TextViewTitle { unTextViewTitle :: ByteString }
-  deriving (Eq, IsString, Show)
+  deriving (Eq, IsString, Show, Semigroup)
 
 -- | A 'TextView' is a structured envalope for serialised binary values
 -- with an external format with a semi-readable textual format.

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,7 @@ let
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.
     inherit (haskellPackages.cardano-node.components.exes) cardano-node;
+    inherit (haskellPackages.cardano-cli.components.exes) cardano-cli;
     inherit (haskellPackages.cardano-node.components.exes) chairman;
     # expose the db-converter from the ouroboros-network we depend on
     inherit (cardanoNodeHaskellPackages.ouroboros-consensus-byron.components.exes) db-converter;

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -15,11 +15,14 @@ let
   };
   mkNodeScript = envConfig: let
     defaultConfig = {
-      consensusProtocol = "real-pbft";
+      consensusProtocol = "RealPBFT";
       hostAddr = "127.0.0.1";
       port = 3001;
       signingKey = null;
       delegationCertificate = null;
+      kesKey = null;
+      vrfKey = null;
+      operationalCertificate = null;
       nodeId = 0;
       stateDir = "state-node-${envConfig.name}";
       socketPath = "${config.stateDir}/node.socket";
@@ -62,6 +65,9 @@ let
         socketPath
         signingKey
         delegationCertificate
+        kesKey
+        vrfKey
+        operationalCertificate
         consensusProtocol
         hostAddr
         port

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
-        "branch": "master",
+        "branch": "shelley-selfnode",
         "description": "nix scripts shared across projects",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ca80aeb33e8ca854dca77c1098a90136b9dabf2e",
-        "sha256": "0sp9v7l68xq1kg4862pcpjji918lgb6jlak4p6lpv2k4h93dypv2",
+        "rev": "667fc60294683a3eeac6c2593a4c3251071138df",
+        "sha256": "1hzva66hzjv4cdvyc8kc39bhf1r288pd8m3666f9dxcd9vavkrv3",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/ca80aeb33e8ca854dca77c1098a90136b9dabf2e.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/667fc60294683a3eeac6c2593a4c3251071138df.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ let
     packages = ps: with ps; [
        ps.cardano-node
        ps.cardano-config
+       ps.cardano-cli
     ];
 
     # These programs will be available inside the nix-shell.
@@ -49,6 +50,7 @@ let
     name = "devops-shell";
     buildInputs = [
       niv
+      cardanoNodeHaskellPackages.cardano-cli.components.exes.cardano-cli
     ];
     shellHook = ''
       echo "DevOps Tools" \
@@ -58,6 +60,7 @@ let
       echo "NOTE: you may need to export GITHUB_TOKEN if you hit rate limits with niv"
       echo "Commands:
         * niv update <package> - update package
+        * cardano-cli - used for key generation and other operations tasks
 
       "
     '';


### PR DESCRIPTION
Fill in the CLI commands for:
 * genesis key generation
 * genesis delegate key generation
 * genesis initial UTxO key generation
 * genesis key utils (key hash, derive verification key from signing key)
 * stake pool operator key generation
 * operational certificate signing

The genesis, delegate and initial UTxO keys all share the same underlying crypto key type and so share much of their implementation. The roles are distinct however so the external files are given different types to distinguish them and help avoid user error.

Creating a node operation key (genesis delegate key or stake pool operator key) also creates a certificate issue counter file, initialised to zero. This is incremented when issuing an operational certificate.