### PR TITLE
[RFC] CAD-508:  IsHash type class & stable TxIds/BlkId hashes in incoming block trace

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -39,6 +39,7 @@ library
                        Cardano.TracingOrphanInstances.Mock
                        Cardano.TracingOrphanInstances.Network
                        Cardano.TracingOrphanInstances.Shelley
+                       Data.Hash.IsHash
 
   build-depends:       base >=4.12 && <5
                      , attoparsec
@@ -60,6 +61,7 @@ library
                      , directory
                      , file-embed
                      , filepath
+                     , formatting
                      , generic-monoid
                      , iohk-monitoring
                      , lobemo-backend-aggregation
@@ -67,6 +69,7 @@ library
                      , lobemo-backend-monitoring
                      , lobemo-backend-trace-forwarder
                      , lobemo-scribe-systemd
+                     , memory
                      , network
                      , network-mux
                      , optparse-applicative
@@ -87,6 +90,7 @@ library
                      , template-haskell
                      , text
                      , time
+                     , text-builder
                      , transformers
                      , transformers-except
                      , typed-protocols

--- a/cardano-config/src/Cardano/Config/Protocol/Types.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Types.hs
@@ -11,6 +11,8 @@ import           Prelude (Show)
 
 import           Data.Aeson (ToJSON)
 
+import           Data.Hash.IsHash (IsHash)
+
 import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Util.Condense (Condense)
 import           Ouroboros.Consensus.Block (Header, BlockProtocol)
@@ -46,6 +48,8 @@ type TraceConstraints blk =
     , Condense (HeaderHash blk)
     , Condense (GenTx blk)
     , Condense (TxId (GenTx blk))
+    , IsHash (HeaderHash blk)
+    , IsHash (TxId (GenTx blk))
     , HasTxs blk
     , HasTxId (GenTx blk)
     , Show (ApplyTxErr blk)
@@ -61,4 +65,3 @@ type TraceConstraints blk =
     , ToObject (OtherHeaderEnvelopeError blk)
     , ToObject (ValidationErr (BlockProtocol blk))
     )
-

--- a/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
@@ -26,6 +26,8 @@ import           Network.Mux (WithMuxBearer (..), MuxTrace (..))
 
 import           Cardano.TracingOrphanInstances.Common
 
+import           Data.Hash.IsHash (IsHash, mediumHashHex)
+
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.BlockFetch.ClientState
                    (TraceFetchClientState (..), TraceLabelPeer (..))
@@ -385,8 +387,8 @@ instance (Show peer)
 --
 -- NOTE: this list is sorted by the unqualified name of the outermost type.
 
-instance ( Condense (HeaderHash blk)
-         , Condense (TxId (GenTx blk))
+instance ( IsHash (HeaderHash blk)
+         , IsHash (TxId (GenTx blk))
          , HasHeader blk
          , HasTxs blk
          , HasTxId (GenTx blk)
@@ -395,12 +397,12 @@ instance ( Condense (HeaderHash blk)
   toObject _verb (AnyMessage (MsgBlock blk)) =
     mkObject
       [ "kind" .= String "MsgBlock"
-      , "blkid" .= String (pack . condense $ blockHash blk)
+      , "blkid" .= String (mediumHashHex $ blockHash blk)
       , "txids" .= toJSON (presentTx <$> extractTxs blk)
       ]
    where
      presentTx :: GenTx blk -> Value
-     presentTx =  String . pack . condense . txId
+     presentTx =  String . mediumHashHex . txId
   toObject _v (AnyMessage MsgRequestRange{}) =
     mkObject [ "kind" .= String "MsgRequestRange" ]
   toObject _v (AnyMessage MsgStartBatch{}) =

--- a/cardano-config/src/Data/Hash/IsHash.hs
+++ b/cardano-config/src/Data/Hash/IsHash.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Data.Hash.IsHash
+  ( IsHash(..)
+  , hashHex
+  , mediumHashHex
+  , shortHashHex
+  , showBSHex
+  )
+where
+
+import           Prelude
+import           Data.Bits (shiftR, (.&.))
+import qualified Data.ByteArray as ByteArray
+import qualified Data.ByteString as BS
+import           Data.Word (Word8)
+import           Data.Text (Text)
+import qualified Text.Builder as T
+
+import qualified Ouroboros.Consensus.Byron.Ledger as Byron
+import           Ouroboros.Consensus.Mempool.API (GenTx, TxId)
+import qualified Cardano.Crypto as Crypto
+import qualified Cardano.Crypto.Hash.Class as CC
+import qualified Cardano.Crypto.Hash.Short as CC
+import qualified Ouroboros.Consensus.Mock.Ledger as Mock
+
+class IsHash a where
+  hashByteString :: a -> BS.ByteString
+
+-- | Prints out a bytestring in hexadecimal.
+showBSHex :: BS.ByteString -> Text
+showBSHex bs = T.run $ BS.foldr paddedShowHex mempty bs
+ where
+   paddedShowHex x xs =  T.hexadecimalDigit (fromIntegral (x `shiftR` 4) :: Word8)
+                      <> T.hexadecimalDigit (fromIntegral (x .&. 0xf) :: Word8)
+                      <> xs
+
+-- | Show only first @16@ characters of 'Hash'.
+mediumHashHex :: IsHash a => a -> Text
+mediumHashHex = showBSHex . BS.take 8 . hashByteString
+
+-- | Show only first @8@ characters of 'Hash'.
+shortHashHex :: IsHash a => a -> Text
+shortHashHex = showBSHex . BS.take 4 . hashByteString
+
+-- | Show only first @8@ characters of 'Hash'.
+hashHex :: IsHash a => a -> Text
+hashHex = showBSHex . hashByteString
+
+instance IsHash (Crypto.AbstractHash algo a) where
+  hashByteString (Crypto.AbstractHash digest) = ByteArray.convert digest
+
+instance IsHash (CC.Hash CC.ShortHash a) where
+  hashByteString = CC.getHash
+
+instance IsHash (TxId (GenTx Byron.ByronBlock)) where
+  hashByteString (Byron.ByronTxId utxoTxid) = hashByteString utxoTxid
+  hashByteString (Byron.ByronDlgId dlgCertificateId) = hashByteString dlgCertificateId
+  hashByteString (Byron.ByronUpdateProposalId updateUpId) = hashByteString updateUpId
+  hashByteString (Byron.ByronUpdateVoteId updateVoteId) = hashByteString updateVoteId
+
+instance IsHash Mock.TxId where
+  hashByteString = undefined
+
+instance IsHash (TxId (GenTx (Mock.SimpleBlock a b))) where
+  hashByteString = hashByteString . Mock.unSimpleGenTxId
+
+instance IsHash Byron.ByronHash where
+  hashByteString = hashByteString . Byron.unByronHash


### PR DESCRIPTION
Note, this PR is primarily aimed to facilitate a discussion about the problem -- which we previously had in `iohk-monitoring` (and that necessitated a workaround), and that has now popped up in https://github.com/input-output-hk/cardano-node/issues/721.

This provides uniform access to the `Bytestring` object underlying hash-like objects.

Currently the `ToObject` instances have to rely on private functionality to obtain this information.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
