### PR TITLE
First working draft of Shelley 'create-genesis' command

### DIFF
--- a/cardano-api/src/Cardano/Api/View.hs
+++ b/cardano-api/src/Cardano/Api/View.hs
@@ -42,23 +42,23 @@ import qualified Data.Text.Encoding as Text
 
 parseAddressView :: ByteString -> Either ApiError Address
 parseAddressView bs =
-  either convertTestViewError (addressFromCBOR . tvRawCBOR) $ parseTextView bs
+  either convertTextViewError (addressFromCBOR . tvRawCBOR) $ parseTextView bs
 
 parseKeyPairView :: ByteString -> Either ApiError KeyPair
 parseKeyPairView bs =
-  either convertTestViewError (keyPairFromCBOR . tvRawCBOR) $ parseTextView bs
+  either convertTextViewError (keyPairFromCBOR . tvRawCBOR) $ parseTextView bs
 
 parsePublicKeyView :: ByteString -> Either ApiError PublicKey
 parsePublicKeyView bs =
-  either convertTestViewError (publicKeyFromCBOR . tvRawCBOR) $ parseTextView bs
+  either convertTextViewError (publicKeyFromCBOR . tvRawCBOR) $ parseTextView bs
 
 parseTxSignedView :: ByteString -> Either ApiError TxSigned
 parseTxSignedView bs =
-  either convertTestViewError (txSignedFromCBOR . tvRawCBOR) $ parseTextView bs
+  either convertTextViewError (txSignedFromCBOR . tvRawCBOR) $ parseTextView bs
 
 parseTxUnsignedView :: ByteString -> Either ApiError TxUnsigned
 parseTxUnsignedView bs =
-  either convertTestViewError (txUnsignedFromCBOR . tvRawCBOR) $ parseTextView bs
+  either convertTextViewError (txUnsignedFromCBOR . tvRawCBOR) $ parseTextView bs
 
 renderAddressView :: Address -> ByteString
 renderAddressView addr =
@@ -107,8 +107,8 @@ renderTxUnsignedView tu =
 
 -- -------------------------------------------------------------------------------------------------
 
-convertTestViewError :: TextViewError -> Either ApiError b
-convertTestViewError err =
+convertTextViewError :: TextViewError -> Either ApiError b
+convertTextViewError err =
   Left $
     case err of
       TextViewFormatError msg -> ApiTextView msg

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -36,11 +36,14 @@ library
                        Cardano.CLI.Run
                        Cardano.CLI.Shelley.Parsers
                        Cardano.CLI.Shelley.Run
+                       Cardano.CLI.Shelley.Run.Genesis
                        Cardano.CLI.Tx
 
   other-modules:       Paths_cardano_cli
 
   build-depends:       base >=4.12 && <5
+                     , aeson
+                     , aeson-pretty
                      , bytestring
                      , canonical-json
                      , cardano-api
@@ -67,6 +70,7 @@ library
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
+                     , ouroboros-consensus-shelley
                      , ouroboros-network
                      , shelley-spec-ledger
                      , text

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -37,6 +37,7 @@ library
                        Cardano.CLI.Shelley.Parsers
                        Cardano.CLI.Shelley.Run
                        Cardano.CLI.Shelley.Run.Genesis
+                       Cardano.CLI.Shelley.Run.KeyGen
                        Cardano.CLI.Tx
 
   other-modules:       Paths_cardano_cli

--- a/cardano-cli/src/Cardano/CLI/Ops.hs
+++ b/cardano-cli/src/Cardano/CLI/Ops.hs
@@ -57,6 +57,7 @@ import           Cardano.Binary
 import           Cardano.Chain.Block (fromCBORABlockOrBoundary)
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
+import           Cardano.Config.Shelley.Genesis (ShelleyGenesisError, renderShelleyGenesisError)
 import qualified Cardano.Crypto.Signing as Crypto
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
@@ -102,6 +103,7 @@ import           Cardano.Config.Protocol
                    (Protocol(..), ProtocolInstantiationError,
                     SomeConsensusProtocol(..), mkConsensusProtocol,
                     renderProtocolInstantiationError)
+import           Cardano.Config.Shelley.Address (AddressError, renderAddressError)
 import           Cardano.Config.Shelley.ColdKeys (KeyError, renderKeyError)
 import           Cardano.Config.Shelley.KES (KESError, renderKESError)
 import           Cardano.Config.Shelley.VRF (VRFError, renderVRFError)
@@ -248,7 +250,8 @@ serialiseSigningKey ShelleyEra     _              = Left $ CardanoEraNotSupporte
 -- | Exception type for all errors thrown by the CLI.
 --   Well, almost all, since we don't rethrow the errors from readFile & such.
 data CliError
-  = ByronVoteDecodingError !DecoderError
+  = AddressCliError AddressError
+  | ByronVoteDecodingError !DecoderError
   | ByronVoteSubmissionError !RealPBFTError
   | ByronReadUpdateProposalFileFailure !FilePath !Text
   | ByronReadVoteFileFailure !FilePath !Text
@@ -289,9 +292,11 @@ data CliError
   | CardanoApiError !ApiError
   | IOError !FilePath !IOException
   | AesonDecode !FilePath !Text
-
+  | ShelleyGenesisError !ShelleyGenesisError
 
 instance Show CliError where
+  show (AddressCliError e)
+    = T.unpack $ renderAddressError e
   show (ByronVoteDecodingError err)
     =  "Error decoding Byron vote: " <> show err
   show (ByronVoteSubmissionError pbftErr)
@@ -376,6 +381,8 @@ instance Show CliError where
     = "File '" <> fp <> "': " ++ show ioe
   show (AesonDecode fp txt)
     = "File '" <> fp <> "': " ++ show txt
+  show (ShelleyGenesisError sge)
+    = T.unpack $ renderShelleyGenesisError sge
 
 data RealPBFTError
   = IncorrectProtocolSpecified !Protocol

--- a/cardano-cli/src/Cardano/CLI/Ops.hs
+++ b/cardano-cli/src/Cardano/CLI/Ops.hs
@@ -287,6 +287,8 @@ data CliError
   | VRFCliError VRFError
   | FileNotFoundError !FilePath
   | CardanoApiError !ApiError
+  | IOError !FilePath !IOException
+  | AesonDecode !FilePath !Text
 
 
 instance Show CliError where
@@ -369,7 +371,11 @@ instance Show CliError where
     = "Error submitting update proposal: " <> (T.unpack $ renderRealPBFTError err)
   show (VerificationKeyDeserialisationFailed fp err)
     = "Verification key '" <> fp <> "' read failure: "<> T.unpack err
-  show (VRFCliError err) = show $ renderVRFError err
+  show (VRFCliError err) = T.unpack $ renderVRFError err
+  show (IOError fp ioe)
+    = "File '" <> fp <> "': " ++ show ioe
+  show (AesonDecode fp txt)
+    = "File '" <> fp <> "': " ++ show txt
 
 data RealPBFTError
   = IncorrectProtocolSpecified !Protocol

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -29,6 +29,8 @@ import           Cardano.Config.Shelley.KES
 import           Cardano.Config.Shelley.OCert
 import           Cardano.Config.Shelley.VRF
 import           Cardano.Config.Types (SigningKeyFile(..))
+import           Cardano.CLI.Shelley.Run.Genesis (runGenesisCreate)
+
 
 
 --
@@ -46,7 +48,6 @@ runShelleyClientCommand (BlockCmd        cmd) = runBlockCmd        cmd
 runShelleyClientCommand (SystemCmd       cmd) = runSystemCmd       cmd
 runShelleyClientCommand (DevOpsCmd       cmd) = runDevOpsCmd       cmd
 runShelleyClientCommand (GenesisCmd      cmd) = runGenesisCmd      cmd
-
 
 --
 -- CLI shelley subcommand dispatch
@@ -98,8 +99,7 @@ runGenesisCmd (GenesisKeyGenDelegate vk sk ctr) = runGenesisKeyGenDelegate vk sk
 runGenesisCmd (GenesisKeyGenUTxO     vk sk)     = runGenesisKeyGenUTxO     vk sk
 runGenesisCmd (GenesisKeyHash        vk)        = runGenesisKeyHash        vk
 runGenesisCmd (GenesisVerKey         vk sk)     = runGenesisVerKey         vk sk
-runGenesisCmd cmd@GenesisCreate{} = liftIO $ putStrLn $ "runGenesisCmd: " ++ show cmd
-
+runGenesisCmd (GenesisCreate         gd ms am)  = runGenesisCreate         gd ms am
 
 --
 -- Node command implementations

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -12,13 +12,8 @@ module Cardano.CLI.Shelley.Run
 
 import           Cardano.Prelude hiding (option, trace)
 
-import qualified Data.ByteString.Char8 as BS
-
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
-
-import qualified Shelley.Spec.Ledger.Keys as Ledger
-import qualified Cardano.Crypto.Hash.Class as Crypto
 
 import           Cardano.CLI.Key (VerificationKeyFile(..))
 import           Cardano.CLI.Ops (CliError (..))
@@ -29,6 +24,7 @@ import           Cardano.Config.Shelley.KES
 import           Cardano.Config.Shelley.OCert
 import           Cardano.Config.Shelley.VRF
 import           Cardano.Config.Types (SigningKeyFile(..))
+import           Cardano.CLI.Shelley.Run.KeyGen
 import           Cardano.CLI.Shelley.Run.Genesis (runGenesisCreate)
 
 
@@ -166,61 +162,3 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKESPath)
       -- a new cert but without updating the counter.
       writeOperationalCertIssueCounter ocertCtrPath (succ issueNumber)
       writeOperationalCert certFile cert vkey
-
-
---
--- Genesis command implementations
---
-
-runGenesisKeyGenGenesis :: VerificationKeyFile -> SigningKeyFile
-                        -> ExceptT CliError IO ()
-runGenesisKeyGenGenesis = runColdKeyGen GenesisKey
-
-
-runGenesisKeyGenDelegate :: VerificationKeyFile
-                         -> SigningKeyFile
-                         -> OpCertCounterFile
-                         -> ExceptT CliError IO ()
-runGenesisKeyGenDelegate vkeyPath skeyPath (OpCertCounterFile ocertCtrPath) = do
-    runColdKeyGen (OperatorKey GenesisDelegateKey) vkeyPath skeyPath
-    firstExceptT OperationalCertError $
-      writeOperationalCertIssueCounter ocertCtrPath initialCounter
-  where
-    initialCounter = 0
-
-
-runGenesisKeyGenUTxO :: VerificationKeyFile -> SigningKeyFile
-                     -> ExceptT CliError IO ()
-runGenesisKeyGenUTxO = runColdKeyGen GenesisUTxOKey
-
-
-runColdKeyGen :: KeyRole -> VerificationKeyFile -> SigningKeyFile
-              -> ExceptT CliError IO ()
-runColdKeyGen role (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
-    firstExceptT KeyCliError $ do
-      (vkey, skey) <- liftIO genKeyPair
-      writeVerKey     role vkeyPath vkey
-      writeSigningKey role skeyPath skey
-
-
-runGenesisKeyHash :: VerificationKeyFile -> ExceptT CliError IO ()
-runGenesisKeyHash (VerificationKeyFile vkeyPath) =
-    firstExceptT KeyCliError $ do
-      (vkey, _role) <- readVerKeySomeRole genesisKeyRoles vkeyPath
-      let Ledger.KeyHash khash = Ledger.hashKey vkey
-      liftIO $ BS.putStrLn $ Crypto.getHashBytesAsHex khash
-
-
-runGenesisVerKey :: VerificationKeyFile -> SigningKeyFile
-                 -> ExceptT CliError IO ()
-runGenesisVerKey (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
-    firstExceptT KeyCliError $ do
-      (skey, role) <- readSigningKeySomeRole genesisKeyRoles skeyPath
-      let vkey = deriveVerKey skey
-      writeVerKey role vkeyPath vkey
-
-genesisKeyRoles :: [KeyRole]
-genesisKeyRoles = [ GenesisKey
-                  , GenesisUTxOKey
-                  , OperatorKey GenesisDelegateKey ]
-

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -90,12 +90,12 @@ runDevOpsCmd cmd = liftIO $ putStrLn $ "runDevOpsCmd: " ++ show cmd
 
 
 runGenesisCmd :: GenesisCmd -> ExceptT CliError IO ()
-runGenesisCmd (GenesisKeyGenGenesis  vk sk)     = runGenesisKeyGenGenesis  vk sk
+runGenesisCmd (GenesisKeyGenGenesis vk sk) = runGenesisKeyGenGenesis vk sk
 runGenesisCmd (GenesisKeyGenDelegate vk sk ctr) = runGenesisKeyGenDelegate vk sk ctr
-runGenesisCmd (GenesisKeyGenUTxO     vk sk)     = runGenesisKeyGenUTxO     vk sk
-runGenesisCmd (GenesisKeyHash        vk)        = runGenesisKeyHash        vk
-runGenesisCmd (GenesisVerKey         vk sk)     = runGenesisVerKey         vk sk
-runGenesisCmd (GenesisCreate         gd ms am)  = runGenesisCreate         gd ms am
+runGenesisCmd (GenesisKeyGenUTxO vk sk) = runGenesisKeyGenUTxO vk sk
+runGenesisCmd (GenesisKeyHash vk) = runGenesisKeyHash vk
+runGenesisCmd (GenesisVerKey vk sk) = runGenesisVerKey vk sk
+runGenesisCmd (GenesisCreate gd count ms am) = runGenesisCreate gd count ms am
 
 --
 -- Node command implementations

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TupleSections #-}
+module Cardano.CLI.Shelley.Run.Genesis
+  ( runGenesisCreate
+  ) where
+
+import           Cardano.Prelude
+
+import           Cardano.Config.Shelley.ColdKeys (KeyError, KeyRole (..), OperatorKeyRole (..),
+                    readVerKey)
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
+
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Char (isDigit)
+import           Data.Coerce (coerce)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import           Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
+
+import           Cardano.Chain.Common (Lovelace, unsafeGetLovelace)
+import           Cardano.CLI.Ops (CliError (..))
+import           Cardano.CLI.Shelley.Parsers (GenesisDir (..))
+import           Cardano.Config.Shelley.Genesis
+
+import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
+import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
+
+import qualified Prelude
+
+import           Shelley.Spec.Ledger.Keys (DiscKeyHash (..), GenKeyHash, KeyHash)
+import qualified Shelley.Spec.Ledger.Keys as Ledger
+
+import           System.Directory (listDirectory)
+import           System.FilePath ((</>), takeExtension)
+
+runGenesisCreate :: GenesisDir -> Maybe SystemStart -> Lovelace -> ExceptT CliError IO ()
+runGenesisCreate (GenesisDir gendir) mStart amount = do
+  start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
+  template <- readShelleyGenesis (gendir </> "genesis.spec.json")
+  genDlgs <- readGenDelegsMap gendir
+
+  -- create the final dynamic type and feed to updateTemplate
+  writeShelleyGenesis (gendir </> "genesis.json") (updateTemplate start amount genDlgs template)
+
+  liftIO $ putTextLn "Genesis file created, but still need to set genesis delegates and genesis distribution."
+
+-- -------------------------------------------------------------------------------------------------
+
+-- | Current UTCTime plus 30 seconds
+getCurrentTimePlus30 :: ExceptT CliError IO UTCTime
+getCurrentTimePlus30 =
+    plus30sec <$> liftIO getCurrentTime
+  where
+    plus30sec :: UTCTime -> UTCTime
+    plus30sec = addUTCTime (30 :: NominalDiffTime)
+
+
+readShelleyGenesis :: FilePath -> ExceptT CliError IO (ShelleyGenesis TPraosStandardCrypto)
+readShelleyGenesis fpath = do
+  lbs <- handleIOExceptT (IOError fpath) $ LBS.readFile fpath
+  firstExceptT (AesonDecode fpath . Text.pack) . hoistEither $ Aeson.eitherDecode' lbs
+
+updateTemplate
+    :: SystemStart -> Lovelace
+    -> (Map (GenKeyHash TPraosStandardCrypto) (KeyHash TPraosStandardCrypto))
+    -> ShelleyGenesis TPraosStandardCrypto -> ShelleyGenesis TPraosStandardCrypto
+updateTemplate start amount delKeys template =
+  template
+    { sgStartTime = start
+    , sgMaxLovelaceSupply = unsafeGetLovelace amount
+    , sgGenDelegs = delKeys
+    }
+
+writeShelleyGenesis :: FilePath -> ShelleyGenesis TPraosStandardCrypto -> ExceptT CliError IO ()
+writeShelleyGenesis fpath sg =
+  handleIOExceptT (IOError fpath) $ LBS.writeFile fpath (encodePretty sg)
+
+readGenDelegsMap :: FilePath -> ExceptT CliError IO (Map (GenKeyHash TPraosStandardCrypto) (KeyHash TPraosStandardCrypto))
+readGenDelegsMap gendir = do
+    gkm <- firstExceptT KeyCliError $ readGenesisKeys (gendir </> "genesis-keys")
+    dkm <- firstExceptT KeyCliError $ readDelegateKeys (gendir </> "delegate-keys")
+    -- Both maps should have an identical set of keys.
+    -- The mapMaybe will silently drop any map elements for which the key does not exist
+    -- in both maps.
+    pure $ Map.fromList (mapMaybe (rearrange gkm dkm) $ Map.keys gkm)
+  where
+    rearrange :: Map Int (Ledger.VKey TPraosStandardCrypto) -> Map Int (Ledger.VKey TPraosStandardCrypto)
+             -> Int -> Maybe (GenKeyHash TPraosStandardCrypto, KeyHash TPraosStandardCrypto)
+    rearrange gkm dkm i =
+      case (Map.lookup i gkm, Map.lookup i dkm) of
+        (Just a, Just b) -> Just (coerce (Ledger.hashKey a), Ledger.hashKey b)
+        _otherwise -> Nothing
+
+
+readGenesisKeys :: FilePath -> ExceptT KeyError IO (Map Int (Ledger.VKey TPraosStandardCrypto))
+readGenesisKeys gendir = do
+  files <- filter isVkey <$> liftIO (listDirectory gendir)
+  fmap Map.fromList <$> traverse (readIndexVerKey GenesisKey) $ map (gendir </>) files
+
+readDelegateKeys :: FilePath -> ExceptT KeyError IO (Map Int (Ledger.VKey TPraosStandardCrypto))
+readDelegateKeys deldir = do
+  files <- filter isVkey <$> liftIO (listDirectory deldir)
+  fmap Map.fromList <$> traverse (readIndexVerKey (OperatorKey GenesisDelegateKey)) $ map (deldir </>) files
+
+readIndexVerKey :: KeyRole -> FilePath -> ExceptT KeyError IO (Int, Ledger.VKey TPraosStandardCrypto)
+readIndexVerKey role fpath =
+  (extractIndex fpath,) <$> readVerKey role fpath
+
+extractIndex :: FilePath -> Int
+extractIndex fpath =
+  case filter isDigit fpath of
+    [] -> 0
+    xs -> Prelude.read xs
+
+isVkey :: FilePath -> Bool
+isVkey fp = takeExtension fp == ".vkey"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/KeyGen.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/KeyGen.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
+module Cardano.CLI.Shelley.Run.KeyGen
+  ( runGenesisKeyGenGenesis
+  , runGenesisKeyGenDelegate
+  , runGenesisKeyGenUTxO
+  , runGenesisKeyHash
+  , runGenesisVerKey
+  , runColdKeyGen
+  ) where
+
+import           Cardano.Prelude hiding (option, trace)
+
+import qualified Data.ByteString.Char8 as BS
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
+
+import qualified Shelley.Spec.Ledger.Keys as Ledger
+import qualified Cardano.Crypto.Hash.Class as Crypto
+
+import           Cardano.CLI.Key (VerificationKeyFile(..))
+import           Cardano.CLI.Ops (CliError (..))
+import           Cardano.CLI.Shelley.Parsers
+
+import           Cardano.Config.Shelley.ColdKeys
+import           Cardano.Config.Shelley.OCert
+import           Cardano.Config.Types (SigningKeyFile(..))
+
+
+
+runGenesisKeyGenGenesis :: VerificationKeyFile -> SigningKeyFile
+                        -> ExceptT CliError IO ()
+runGenesisKeyGenGenesis = runColdKeyGen GenesisKey
+
+
+runGenesisKeyGenDelegate :: VerificationKeyFile
+                         -> SigningKeyFile
+                         -> OpCertCounterFile
+                         -> ExceptT CliError IO ()
+runGenesisKeyGenDelegate vkeyPath skeyPath (OpCertCounterFile ocertCtrPath) = do
+    runColdKeyGen (OperatorKey GenesisDelegateKey) vkeyPath skeyPath
+    firstExceptT OperationalCertError $
+      writeOperationalCertIssueCounter ocertCtrPath initialCounter
+  where
+    initialCounter = 0
+
+
+runGenesisKeyGenUTxO :: VerificationKeyFile -> SigningKeyFile
+                     -> ExceptT CliError IO ()
+runGenesisKeyGenUTxO = runColdKeyGen GenesisUTxOKey
+
+
+runColdKeyGen :: KeyRole -> VerificationKeyFile -> SigningKeyFile
+              -> ExceptT CliError IO ()
+runColdKeyGen role (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
+    firstExceptT KeyCliError $ do
+      (vkey, skey) <- liftIO genKeyPair
+      writeVerKey     role vkeyPath vkey
+      writeSigningKey role skeyPath skey
+
+
+runGenesisKeyHash :: VerificationKeyFile -> ExceptT CliError IO ()
+runGenesisKeyHash (VerificationKeyFile vkeyPath) =
+    firstExceptT KeyCliError $ do
+      (vkey, _role) <- readVerKeySomeRole genesisKeyRoles vkeyPath
+      let Ledger.KeyHash khash = Ledger.hashKey vkey
+      liftIO $ BS.putStrLn $ Crypto.getHashBytesAsHex khash
+
+
+runGenesisVerKey :: VerificationKeyFile -> SigningKeyFile
+                 -> ExceptT CliError IO ()
+runGenesisVerKey (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
+    firstExceptT KeyCliError $ do
+      (skey, role) <- readSigningKeySomeRole genesisKeyRoles skeyPath
+      let vkey = deriveVerKey skey
+      writeVerKey role vkeyPath vkey
+
+genesisKeyRoles :: [KeyRole]
+genesisKeyRoles =
+  [ GenesisKey
+  , GenesisUTxOKey
+  , OperatorKey GenesisDelegateKey
+  ]
+

--- a/cardano-cli/test/cli/core/common
+++ b/cardano-cli/test/cli/core/common
@@ -28,7 +28,7 @@ colourRed='\e[0;31m'
 colourYellow='\e[0;33m'
 
 # Failure is the default!
-RESULT="FAILED"
+RESULT="${colourRed}FAILED [ ${testname} ]${colourReset}"
 
 ROOT=$(dirname "$0")/../../..
 ROOT=$(cd "$ROOT" > /dev/null 2>&1 && pwd)

--- a/cardano-cli/test/cli/create-genesis/data/genesis.spec.json
+++ b/cardano-cli/test/cli/create-genesis/data/genesis.spec.json
@@ -1,0 +1,19 @@
+{
+    "DecentralisationParam": 0.8,
+    "ActiveSlotsCoeff": 0.05,
+    "ProtocolMagicId": 838299499,
+    "StartTime": "2020-01-01T00:20:40Z",
+    "GenDelegs": {},
+    "UpdateQuorum": 12,
+    "MaxHeaderSize": 8192,
+    "MaxMajorPV": 25446,
+    "MaxBodySize": 2097152,
+    "MaxLovelaceSupply": 100000000,
+    "InitialFunds": {},
+    "NetworkMagic": 4036000900,
+    "EpochLength": 21600,
+    "SlotLength": 20000,
+    "SlotsPerKESPeriod": 216000,
+    "MaxKESEvolutions": 1080000,
+    "SecurityParam": 2160
+}

--- a/cardano-cli/test/cli/create-genesis/run
+++ b/cardano-cli/test/cli/create-genesis/run
@@ -1,0 +1,66 @@
+#!/bin/sh -eu
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+OUTPUT_JSON="${TEST}/genesis.json"
+
+start_time=$(TZ=UTC date --iso-8601=seconds | sed 's/+.*/Z/')
+
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}/delegate-keys/" "${OUTPUT_DIR}/genesis-keys/"
+cp "${cwd}/data/genesis.spec.json" "${OUTPUT_DIR}/"
+
+# Random number for the total supply.
+supply=$(head -100 /dev/urandom | cksum | sed 's/ .*//')
+
+# Random number for the number of genesis delegates.
+seconds=$(date +"%s")
+gendlg_count=$(( 4 + seconds % 16))
+
+error=0
+
+# Create the genesis json file and required keys.
+${CARDANO_CLI} shelley genesis create-genesis \
+    --genesis-dir "${OUTPUT_DIR}/" \
+    --start-time "${start_time}" \
+    --supply "${supply}" \
+    --genesis-delegates ${gendlg_count} \
+    > /dev/null
+
+check_supply=$(grep MaxLovelaceSupply "${OUTPUT_JSON}" | sed "s/${supply}/correct/;s/[ \"]//g")
+if test "${check_supply}" != "MaxLovelaceSupply:correct," ; then
+    echo "Bad $(grep MaxLovelaceSupply "${OUTPUT_JSON}")"
+	error=1
+	fi
+
+check_start_time=$(grep StartTime "${OUTPUT_JSON}" | sed "s/${start_time}/correct/;s/[ \"]//g")
+if test "${check_start_time}" != "StartTime:correct," ; then
+    echo "Bad $(grep StartTime "${OUTPUT_JSON}")"
+	error=1
+	fi
+
+# tree "${OUTPUT_DIR}"
+# cat "${OUTPUT_JSON}"
+# echo
+
+check_delegate_count=$(jq '.GenDelegs' < "${OUTPUT_JSON}" | grep -c ':')
+if test "${check_delegate_count}" != "${gendlg_count}" ; then
+    echo "Bad genesis delegate count: ${check_delegate_count}"
+	error=1
+	fi
+
+# Check that the sum of the initial fund amounts matches the total supply.
+check_supply=$(jq '.InitialFunds' < "${OUTPUT_JSON}" | grep ':' | sed 's/.*://;s/,//' | paste -sd+ -| bc)
+if test "${check_supply}" != "${supply}" ; then
+    echo "Bad sum of supply: ${check_supply} != ${supply}"
+	error=1
+	fi
+
+report_result ${error}

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -23,10 +23,12 @@ library
                        Cardano.Config.Protocol.Mock
                        Cardano.Config.Protocol.Byron
                        Cardano.Config.Protocol.Shelley
+                       Cardano.Config.Shelley.Address
                        Cardano.Config.Shelley.ColdKeys
                        Cardano.Config.Shelley.Genesis
                        Cardano.Config.Shelley.KES
                        Cardano.Config.Shelley.OCert
+                       Cardano.Config.Shelley.Orphans
                        Cardano.Config.Shelley.Parsers
                        Cardano.Config.Shelley.VRF
                        Cardano.Config.TextView

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -9,20 +11,21 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 
-module Cardano.Config.Orphanage where
+module Cardano.Config.Orphanage () where
 
 import           Cardano.Prelude
 import qualified Prelude
 
-import           Data.Aeson (FromJSON, parseJSON, Value(..))
+import           Data.Aeson
 import           Network.Socket (PortNumber)
 import           Data.Scientific (coefficient)
-import qualified Data.Text as T
+import qualified Data.Text as Text
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity(..))
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Cardano.Crypto.KES (SignKeyKES, SimpleKES, VerKeyKES)
+import           Ouroboros.Consensus.BlockchainTime (SlotLength (..))
 import qualified Ouroboros.Consensus.BlockchainTime as Consensus
 import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId (..))
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
@@ -30,13 +33,13 @@ import           Shelley.Spec.Ledger.Keys (VKeyES (..))
 
 
 deriving instance Generic (VKeyES TPraosStandardCrypto)
-deriving instance NFData (VKeyES TPraosStandardCrypto)
+deriving anyclass instance NFData (VKeyES TPraosStandardCrypto)
 
-deriving instance NFData (SignKeyKES (SimpleKES Ed448DSIGN))
+deriving anyclass instance NFData (SignKeyKES (SimpleKES Ed448DSIGN))
 
-deriving instance NFData (VerKeyKES (SimpleKES Ed448DSIGN))
+deriving anyclass instance NFData (VerKeyKES (SimpleKES Ed448DSIGN))
 
-deriving instance Num Consensus.SlotLength
+deriving anyclass instance Num Consensus.SlotLength
 
 deriving instance Show TracingVerbosity
 
@@ -48,7 +51,7 @@ instance FromJSON TracingVerbosity where
     err -> panic $ "Parsing of TracingVerbosity failed, "
                  <> err <> " is not a valid TracingVerbosity"
   parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                             <> "Encountered: " <> (T.pack $ Prelude.show invalid)
+                             <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
 
 instance FromJSON NodeId where
   parseJSON v = CoreId . CoreNodeId <$> parseJSON v
@@ -60,10 +63,11 @@ instance FromJSON PortNumber where
                                  Nothing -> panic $ (show portNum)
                                                   <> " is not a valid port number."
   parseJSON invalid  = panic $ "Parsing of port number failed due to type mismatch. "
-                             <> "Encountered: " <> (T.pack $ Prelude.show invalid)
+                             <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
 
 instance FromJSON Update.ApplicationName where
   parseJSON (String x) = pure $ Update.ApplicationName x
   parseJSON invalid  =
     panic $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> (T.pack $ Prelude.show invalid)
+    <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+

--- a/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
+++ b/cardano-config/src/Cardano/Config/Protocol/Shelley.hs
@@ -36,7 +36,6 @@ import qualified Shelley.Spec.Ledger.Keys as Ledger
 import           Cardano.Config.Types
                    (NodeConfiguration(..), ProtocolFilepaths(..),
                     GenesisFile (..), Update (..), LastKnownBlockVersion (..))
-import           Cardano.Config.Shelley.Genesis ()
 import           Cardano.Config.Shelley.OCert
 import           Cardano.Config.Shelley.VRF
 import           Cardano.Config.Shelley.KES

--- a/cardano-config/src/Cardano/Config/Shelley/Address.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Address.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Config.Shelley.Address
+  ( AddressError(..)
+  , AddressRole(..)
+  , ShelleyAddress
+  , genAddress
+  , genBootstrapAddress
+  , readAddress
+  , renderAddressError
+  , writeAddress
+  ) where
+
+import           Cardano.Prelude
+
+import qualified Cardano.Binary as CBOR
+import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto
+                   (TPraosStandardCrypto)
+import           Shelley.Spec.Ledger.Address (toAddr)
+import           Shelley.Spec.Ledger.Keys (KeyPair(..), hashKey)
+import           Shelley.Spec.Ledger.TxData (Addr(..))
+
+import           Cardano.Config.Shelley.ColdKeys (genKeyPair)
+import           Cardano.Config.TextView
+
+data AddressRole = BootstrapAddr
+                 | NormalAddr
+
+data AddressError = ReadAddressError TextViewFileError
+                  | WriteAddressError TextViewFileError
+
+type ShelleyAddress = Addr TPraosStandardCrypto
+
+encodeAddress :: AddressRole -> ShelleyAddress -> TextView
+encodeAddress addrRole addr =
+  encodeToTextView fileType fileTitle CBOR.toCBOR addr
+ where
+  fileType = renderAddressRole addrRole
+  fileTitle = renderAddressDescr addrRole
+
+
+decodeAddress :: AddressRole -> TextView -> Either TextViewError ShelleyAddress
+decodeAddress addrRole tView = do
+  expectTextViewOfType fileType tView
+  decodeFromTextView CBOR.fromCBOR tView
+ where
+  fileType = renderAddressRole addrRole
+
+genAddress :: IO ShelleyAddress
+genAddress = do
+  (paymentVkey, paymentSkey) <- genKeyPair
+  (stakingVkey, stakingSkey) <- genKeyPair
+  pure $ toAddr ( KeyPair {sKey = paymentSkey, vKey = paymentVkey}
+                , KeyPair {sKey = stakingSkey, vKey = stakingVkey}
+                )
+
+genBootstrapAddress :: IO ShelleyAddress
+genBootstrapAddress = do
+  (vKey', _) <- genKeyPair
+  pure . AddrBootstrap $ hashKey vKey'
+
+readAddress :: AddressRole -> FilePath -> ExceptT AddressError IO ShelleyAddress
+readAddress role fp = do
+  firstExceptT ReadAddressError $ newExceptT $
+    readTextViewEncodedFile (decodeAddress role) fp
+
+renderAddressRole :: AddressRole -> TextViewType
+renderAddressRole BootstrapAddr = "Genesis"
+renderAddressRole NormalAddr = "UTxO address"
+
+renderAddressDescr :: AddressRole -> TextViewTitle
+renderAddressDescr BootstrapAddr = "Bootstrap UTxO address"
+renderAddressDescr NormalAddr = "UTxO address"
+
+renderAddressError :: AddressError -> Text
+renderAddressError err =
+  case err of
+    ReadAddressError tvErr -> "address read error: " <> renderTextViewFileError tvErr
+    WriteAddressError tvErr -> "address write error: " <> renderTextViewFileError tvErr
+
+writeAddress :: AddressRole -> FilePath -> ShelleyAddress -> ExceptT AddressError IO ()
+writeAddress role fp addr =
+  firstExceptT WriteAddressError $ newExceptT $
+    writeTextViewEncodedFile (encodeAddress role) fp addr

--- a/cardano-config/src/Cardano/Config/Shelley/Genesis.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Genesis.hs
@@ -7,6 +7,8 @@
 
 module Cardano.Config.Shelley.Genesis
   ( ShelleyGenesis(..)
+  , ShelleyGenesisError(..)
+  , renderShelleyGenesisError
   , shelleyGenesisDefaults
   , shelleyGenesisToJSON
   , shelleyGenesisFromJSON
@@ -14,41 +16,40 @@ module Cardano.Config.Shelley.Genesis
 
 import           Cardano.Prelude
 
-import qualified Data.Text.Encoding as Text
+import qualified Data.Text as Text
 import qualified Data.Map.Strict as Map
 import qualified Data.Time as Time
 
-import           Data.Aeson (Value, ToJSON(..), toJSON, (.=),
-                             FromJSON(..), (.:),
-                             ToJSONKey(..),   ToJSONKeyFunction(..),
-                             FromJSONKey(..), FromJSONKeyFunction(..))
+import           Data.Aeson (Value, ToJSON(..), toJSON,
+                             FromJSON(..))
 import           Data.Aeson.Types    (Parser)
-import qualified Data.Aeson          as Aeson
-import qualified Data.Aeson.Encoding as Aeson
-import qualified Data.ByteString.Base16 as Base16
 
-import           Control.Monad.Fail (fail)
-
-import           Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Config.Shelley.Orphans ()
 import           Cardano.Crypto.ProtocolMagic (ProtocolMagicId(..))
 import           Cardano.Slotting.Slot (EpochSize (..))
 
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Consensus.BlockchainTime
-                   (SlotLength (..), SystemStart (..), slotLengthFromSec)
+                   (SystemStart (..), slotLengthFromSec)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..))
 import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
 
+data ShelleyGenesisError
+  = MissingGenesisKey !Text
+  | MissingDelegateKey !Text
+  | MissingGenesisAndDelegationKey !Text !Text
+  | MultipleMissingKeys ![ShelleyGenesisError]
+  deriving Eq
 
-import           Shelley.Spec.Ledger.Address (serialiseAddr, deserialiseAddr)
-import           Shelley.Spec.Ledger.Coin   (Coin(..))
-import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.Keys   (HashAlgorithm)
-import           Shelley.Spec.Ledger.Keys   (DiscKeyHash(..))
-import           Shelley.Spec.Ledger.TxData (Addr(..))
-
-
+renderShelleyGenesisError :: ShelleyGenesisError -> Text
+renderShelleyGenesisError err =
+  case err of
+    MissingGenesisKey missingGenKey -> "Missing genesis key with basename: " <> missingGenKey
+    MissingDelegateKey missingDelegKey -> "Missing delegate key with basename: " <> missingDelegKey
+    MissingGenesisAndDelegationKey mGenKey mDelegKey -> "Missing genesis key with basename: " <> mGenKey
+                                                        <> " Missing delegate key with basename: " <> mDelegKey
+    MultipleMissingKeys multipleKeys -> Text.intercalate ", " $ map renderShelleyGenesisError multipleKeys
 
 -- | Some reasonable starting defaults for constructing a 'ShelleyGenesis'.
 --
@@ -104,141 +105,3 @@ shelleyGenesisToJSON = toJSON
 
 shelleyGenesisFromJSON :: Value -> Parser (ShelleyGenesis TPraosStandardCrypto)
 shelleyGenesisFromJSON = parseJSON
-
-instance Crypto crypto => ToJSON (ShelleyGenesis crypto) where
-  toJSON sg =
-    Aeson.object
-      [ "StartTime"             .= sgStartTime sg
-        --TODO: this should not have both network magic and protocol magic
-        -- they are different names for the same thing used in two ways.
-      , "NetworkMagic"          .= sgNetworkMagic sg
-      , "ProtocolMagicId"       .= sgProtocolMagicId sg
-      , "ActiveSlotsCoeff"      .= sgActiveSlotsCoeff sg
-      , "DecentralisationParam" .= sgDecentralisationParam sg
-      , "SecurityParam"         .= sgSecurityParam sg
-      , "EpochLength"           .= sgEpochLength sg
-      , "SlotsPerKESPeriod"     .= sgSlotsPerKESPeriod sg
-      , "MaxKESEvolutions"      .= sgMaxKESEvolutions sg
-      , "SlotLength"            .= sgSlotLength sg
-      , "UpdateQuorum"          .= sgUpdateQuorum sg
-      , "MaxMajorPV"            .= sgMaxMajorPV sg
-      , "MaxLovelaceSupply"     .= sgMaxLovelaceSupply sg
-      , "MaxBodySize"           .= sgMaxBodySize sg
-      , "MaxHeaderSize"         .= sgMaxHeaderSize sg
-      , "GenDelegs"             .= sgGenDelegs sg
-      , "InitialFunds"          .= sgInitialFunds sg
-      ]
-
-instance Crypto crypto => FromJSON (ShelleyGenesis crypto) where
-  parseJSON =
-    Aeson.withObject "ShelleyGenesis" $ \ obj ->
-      ShelleyGenesis
-        <$> obj .: "StartTime"
-        <*> obj .: "NetworkMagic"
-        <*> obj .: "ProtocolMagicId"
-        <*> obj .: "ActiveSlotsCoeff"
-        <*> obj .: "DecentralisationParam"
-        <*> obj .: "SecurityParam"
-        <*> obj .: "EpochLength"
-        <*> obj .: "SlotsPerKESPeriod"
-        <*> obj .: "MaxKESEvolutions"
-        <*> obj .: "SlotLength"
-        <*> obj .: "UpdateQuorum"
-        <*> obj .: "MaxMajorPV"
-        <*> obj .: "MaxLovelaceSupply"
-        <*> obj .: "MaxBodySize"
-        <*> obj .: "MaxHeaderSize"
-        <*> obj .: "GenDelegs"
-        <*> obj .: "InitialFunds"
-
-
---
--- Simple newtype wrappers JSON conversion
---
-
--- These ones are all just newtype wrappers of numbers,
--- so newtype deriving for the JSON format is ok.
-deriving newtype instance Aeson.ToJSON   Coin
-deriving newtype instance Aeson.FromJSON Coin
-
-deriving newtype instance Aeson.ToJSON   EpochSize
-deriving newtype instance Aeson.FromJSON EpochSize
-
-deriving newtype instance Aeson.ToJSON   NetworkMagic
-deriving newtype instance Aeson.FromJSON NetworkMagic
-
-deriving newtype instance Aeson.ToJSON   SecurityParam
-deriving newtype instance Aeson.FromJSON SecurityParam
-
-deriving newtype instance Aeson.ToJSON   SlotLength
-deriving newtype instance Aeson.FromJSON SlotLength
-
--- A UTCTime, with format like "2020-04-15 11:44:07"
-deriving newtype instance Aeson.ToJSON   SystemStart
-deriving newtype instance Aeson.FromJSON SystemStart
-
-
---
--- Genesis key hashes JSON conversion, including as map keys
---
-
-deriving newtype instance ToJSONKey (DiscKeyHash disc crypto)
-deriving newtype instance Crypto crypto =>
-                          FromJSONKey (DiscKeyHash disc crypto)
-
-deriving newtype instance ToJSON (DiscKeyHash disc crypto)
-deriving newtype instance Crypto crypto =>
-                          FromJSON (DiscKeyHash disc crypto)
-
-instance ToJSONKey (Hash crypto a) where
-  toJSONKey = ToJSONKeyText hashToText (Aeson.text . hashToText)
-
-instance HashAlgorithm crypto => FromJSONKey (Hash crypto a) where
-  fromJSONKey = FromJSONKeyTextParser parseHash
-
-instance ToJSON   (Hash crypto a) where
-  toJSON = toJSON . hashToText
-
-instance HashAlgorithm crypto => FromJSON (Hash crypto a) where
-  parseJSON = Aeson.withText "hash" parseHash
-
-hashToText :: Hash crypto a -> Text
-hashToText = Text.decodeLatin1 . Crypto.getHashBytesAsHex
-
-parseHash :: HashAlgorithm crypto => Text -> Parser (Hash crypto a)
-parseHash t = do
-    bytes <- either badHex return (parseBase16 t)
-    maybe badSize return (Crypto.hashFromBytes bytes)
-  where
-    badHex _ = fail "Hashes are expected in hex encoding"
-    badSize  = fail "Hash is the wrong length"
-
-
---
--- Addresses JSON conversion, including as map keys
---
-
-instance Crypto crypto => ToJSONKey (Addr crypto) where
-  toJSONKey = ToJSONKeyText addrToText (Aeson.text . addrToText)
-
-instance Crypto crypto => FromJSONKey (Addr crypto) where
-  fromJSONKey = FromJSONKeyTextParser parseAddr
-
-instance Crypto crypto => ToJSON (Addr crypto) where
-  toJSON = toJSON . addrToText
-
-instance Crypto crypto => FromJSON (Addr crypto) where
-  parseJSON = Aeson.withText "address" parseAddr
-
-addrToText :: Crypto crypto => Addr crypto -> Text
-addrToText =
-     Text.decodeLatin1 . Base16.encode . serialiseAddr
-
-parseAddr :: Crypto crypto => Text -> Parser (Addr crypto)
-parseAddr t = do
-    bytes <- either badHex return (parseBase16 t)
-    maybe badFormat return (deserialiseAddr bytes)
-  where
-    badHex h = fail $ "Addresses are expected in hex encoding for now: " ++ show h
-    badFormat = fail "Address is not in the right format"
-

--- a/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-missing-methods #-}
+
+module Cardano.Config.Shelley.Orphans () where
+
+import           Cardano.Prelude
+
+import           Control.Monad.Fail (fail)
+import           Data.Aeson
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as Aeson
+import           Data.Aeson.Types (Parser)
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.Text.Encoding as Text
+
+import           Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Slotting.Slot (EpochSize (..))
+import           Ouroboros.Consensus.BlockchainTime
+                   (SlotLength (..), SystemStart (..))
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..))
+import           Shelley.Spec.Ledger.Address (serialiseAddr, deserialiseAddr)
+import           Shelley.Spec.Ledger.Coin (Coin(..))
+import           Shelley.Spec.Ledger.Crypto (Crypto)
+import           Shelley.Spec.Ledger.Keys (DiscKeyHash(..))
+import           Shelley.Spec.Ledger.TxData (Addr(..))
+
+instance Crypto crypto => ToJSON (ShelleyGenesis crypto) where
+  toJSON sg =
+    Aeson.object
+      [ "StartTime"             .= sgStartTime sg
+        --TODO: this should not have both network magic and protocol magic
+        -- they are different names for the same thing used in two ways.
+      , "NetworkMagic"          .= sgNetworkMagic sg
+      , "ProtocolMagicId"       .= sgProtocolMagicId sg
+      , "ActiveSlotsCoeff"      .= sgActiveSlotsCoeff sg
+      , "DecentralisationParam" .= sgDecentralisationParam sg
+      , "SecurityParam"         .= sgSecurityParam sg
+      , "EpochLength"           .= sgEpochLength sg
+      , "SlotsPerKESPeriod"     .= sgSlotsPerKESPeriod sg
+      , "MaxKESEvolutions"      .= sgMaxKESEvolutions sg
+      , "SlotLength"            .= sgSlotLength sg
+      , "UpdateQuorum"          .= sgUpdateQuorum sg
+      , "MaxMajorPV"            .= sgMaxMajorPV sg
+      , "MaxLovelaceSupply"     .= sgMaxLovelaceSupply sg
+      , "MaxBodySize"           .= sgMaxBodySize sg
+      , "MaxHeaderSize"         .= sgMaxHeaderSize sg
+      , "GenDelegs"             .= sgGenDelegs sg
+      , "InitialFunds"          .= sgInitialFunds sg
+      ]
+
+instance Crypto crypto => FromJSON (ShelleyGenesis crypto) where
+  parseJSON =
+    Aeson.withObject "ShelleyGenesis" $ \ obj ->
+      ShelleyGenesis
+        <$> obj .: "StartTime"
+        <*> obj .: "NetworkMagic"
+        <*> obj .: "ProtocolMagicId"
+        <*> obj .: "ActiveSlotsCoeff"
+        <*> obj .: "DecentralisationParam"
+        <*> obj .: "SecurityParam"
+        <*> obj .: "EpochLength"
+        <*> obj .: "SlotsPerKESPeriod"
+        <*> obj .: "MaxKESEvolutions"
+        <*> obj .: "SlotLength"
+        <*> obj .: "UpdateQuorum"
+        <*> obj .: "MaxMajorPV"
+        <*> obj .: "MaxLovelaceSupply"
+        <*> obj .: "MaxBodySize"
+        <*> obj .: "MaxHeaderSize"
+        <*> obj .: "GenDelegs"
+        <*> obj .: "InitialFunds"
+
+
+--
+-- Simple newtype wrappers JSON conversion
+--
+
+-- These are for ShelleyGenesis.
+-- These ones are all just newtype wrappers of numbers,
+-- so newtype deriving for the JSON format is ok.
+
+deriving newtype instance Aeson.ToJSON   Coin
+deriving newtype instance Aeson.FromJSON Coin
+
+deriving newtype instance Aeson.ToJSON   EpochSize
+deriving newtype instance Aeson.FromJSON EpochSize
+
+deriving newtype instance Aeson.ToJSON   NetworkMagic
+deriving newtype instance Aeson.FromJSON NetworkMagic
+
+deriving newtype instance Aeson.ToJSON   SecurityParam
+deriving newtype instance Aeson.FromJSON SecurityParam
+
+deriving newtype instance Aeson.ToJSON   SlotLength
+deriving newtype instance Aeson.FromJSON SlotLength
+
+-- A UTCTime, with format like "2020-04-15 11:44:07"
+deriving newtype instance Aeson.ToJSON   SystemStart
+deriving newtype instance Aeson.FromJSON SystemStart
+
+
+--
+-- Genesis key hashes JSON conversion, including as map keys
+--
+
+deriving newtype instance ToJSONKey (DiscKeyHash disc crypto)
+deriving newtype instance Crypto crypto =>
+                          FromJSONKey (DiscKeyHash disc crypto)
+
+deriving newtype instance ToJSON (DiscKeyHash disc crypto)
+deriving newtype instance Crypto crypto =>
+                          FromJSON (DiscKeyHash disc crypto)
+
+instance ToJSONKey (Hash crypto a) where
+  toJSONKey = ToJSONKeyText hashToText (Aeson.text . hashToText)
+
+instance HashAlgorithm crypto => FromJSONKey (Hash crypto a) where
+  fromJSONKey = FromJSONKeyTextParser parseHash
+
+instance ToJSON   (Hash crypto a) where
+  toJSON = toJSON . hashToText
+
+instance HashAlgorithm crypto => FromJSON (Hash crypto a) where
+  parseJSON = Aeson.withText "hash" parseHash
+
+hashToText :: Hash crypto a -> Text
+hashToText = Text.decodeLatin1 . Crypto.getHashBytesAsHex
+
+parseHash :: HashAlgorithm crypto => Text -> Parser (Hash crypto a)
+parseHash t = do
+    bytes <- either badHex return (parseBase16 t)
+    maybe badSize return (Crypto.hashFromBytes bytes)
+  where
+    badHex _ = fail "Hashes are expected in hex encoding"
+    badSize  = fail "Hash is the wrong length"
+
+
+--
+-- Addresses JSON conversion, including as map keys
+--
+
+instance Crypto crypto => ToJSONKey (Addr crypto) where
+  toJSONKey = ToJSONKeyText addrToText (Aeson.text . addrToText)
+
+instance Crypto crypto => FromJSONKey (Addr crypto) where
+  fromJSONKey = FromJSONKeyTextParser parseAddr
+
+instance Crypto crypto => ToJSON (Addr crypto) where
+  toJSON = toJSON . addrToText
+
+instance Crypto crypto => FromJSON (Addr crypto) where
+  parseJSON = Aeson.withText "address" parseAddr
+
+addrToText :: Crypto crypto => Addr crypto -> Text
+addrToText =
+     Text.decodeLatin1 . Base16.encode . serialiseAddr
+
+parseAddr :: Crypto crypto => Text -> Parser (Addr crypto)
+parseAddr t = do
+    bytes <- either badHex return (parseBase16 t)
+    maybe badFormat return (deserialiseAddr bytes)
+  where
+    badHex h = fail $ "Addresses are expected in hex encoding for now: " ++ show h
+    badFormat = fail "Address is not in the right format"

--- a/cardano-config/src/Cardano/TracingOrphanInstances/Shelley.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Shelley.hs
@@ -23,7 +23,7 @@ import qualified Data.Set as Set
 
 import           Cardano.TracingOrphanInstances.Common
 import           Cardano.TracingOrphanInstances.Consensus ()
-import           Cardano.Config.Shelley.Genesis ()
+import           Cardano.Config.Shelley.Orphans ()
 
 import           Ouroboros.Network.Block
                    (blockHash, blockSlot, blockNo, blockPrevHash)

--- a/cardano-config/test/Test/Cardano/Config/Examples.hs
+++ b/cardano-config/test/Test/Cardano/Config/Examples.hs
@@ -27,15 +27,17 @@ exampleShelleyGenesis :: ShelleyGenesis TPraosStandardCrypto
 exampleShelleyGenesis =
   ShelleyGenesis
     { sgStartTime = SystemStart . posixSecondsToUTCTime $ realToFrac (1234566789 :: Integer)
-    , sgNetworkMagic = NetworkMagic {unNetworkMagic = 4036000900}
-    , sgProtocolMagicId = ProtocolMagicId {unProtocolMagicId = 838299499}
-    , sgActiveSlotsCoeff = 6.259, sgDecentralisationParam = 1.9e-2
-    , sgSecurityParam = SecurityParam {maxRollbacks = 120842}
-    , sgEpochLength = EpochSize {unEpochSize = 1215}
+    , sgNetworkMagic = NetworkMagic 4036000900
+    , sgProtocolMagicId = ProtocolMagicId 838299499
+    , sgActiveSlotsCoeff = 6.259
+    , sgDecentralisationParam = 1.9e-2
+    , sgSecurityParam = SecurityParam 120842
+    , sgEpochLength = EpochSize 1215
     , sgSlotsPerKESPeriod = 8541
     , sgMaxKESEvolutions = 28899
     , sgSlotLength =  slotLengthFromSec 8
-    , sgUpdateQuorum = 16991, sgMaxMajorPV = 25446
+    , sgUpdateQuorum = 16991
+    , sgMaxMajorPV = 25446
     , sgMaxLovelaceSupply = 71
     , sgMaxBodySize = 239857
     , sgMaxHeaderSize = 217569

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -44,6 +44,10 @@ let
         packages.cardano-cli.components.tests.cardano-cli-test.platforms =
           with stdenv.lib.platforms; [ linux darwin ];
 
+        # Needed for the CLI tests.
+        # Coreutils because we need 'paste'.
+        packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
+          [buildPackages.bc buildPackages.jq buildPackages.coreutils];
       }
       {
         # Packages we wish to ignore version bounds of.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -42,12 +42,12 @@ let
 
         # Tell hydra to skip this test on windows (it does not build)
         packages.cardano-cli.components.tests.cardano-cli-test.platforms =
-          with stdenv.lib.platforms; [ linux darwin ];
+          with stdenv.lib.platforms; lib.mkForce [ linux darwin ];
 
         # Needed for the CLI tests.
         # Coreutils because we need 'paste'.
         packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
-          [buildPackages.bc buildPackages.jq buildPackages.coreutils];
+          lib.mkForce [buildPackages.bc buildPackages.jq buildPackages.coreutils];
       }
       {
         # Packages we wish to ignore version bounds of.


### PR DESCRIPTION
```
> cabal run cardano-cli:cardano-cli -- shelley genesis create-genesis
Usage: cardano-cli shelley genesis create-genesis --genesis-dir DIR 
                                                  [--genesis-delegates INT] 
                                                  [--start-time UTC_TIME]
                                                  --supply LOVELACE
  Create a Shelley genesis file from a genesis template and
  genesis/delegation/spending keys.

Available options:
  --genesis-dir DIR        The genesis directory containing the genesis template
                           and required genesis/delegation/spending keys.
  --genesis-delegates INT  The number of genesis delegates [default is 7].
  --start-time UTC_TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                           format. If unspecified, will be the current time +30
                           seconds.
  --supply LOVELACE        The initial coin supply in Lovelace which will be
                           evenly distributed across initial stake holders.
```

* Requires a `genesis.spec.json` file.
* Genesis delegates are created.
* Bootstrap Utxo addresses are created.
* Initial distribution is split approximatelt equally between the addresses.

The tests for this code can be run using:
```
cabal build all && cardano-cli/test/cli/create-genesis/run
```
