### PR TITLE
scripts: don't even attempt to use Nix in non-`--nix` modes

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -174,9 +174,15 @@ export -f actually_run
 ##
 ## Misc stuff, too few to be worth splitting out
 ##
+generate_wordpair() {
+        case ${mode} in
+                nix ) nix-shell -p diceware --run 'diceware --no-caps --num 2 --wordlist en_eff -d-' 2>/dev/null || true;;
+                * ) true;; esac
+}
+
 generate_mnemonic()
 {
-        local mnemonic="${1:-$(nix-shell -p diceware --run 'diceware --no-caps --num 2 --wordlist en_eff -d-')}"
+        local mnemonic="${1:-$(generate_wordpair)}"
         local timestamp="$(date +%s)"
         local commit="$(git rev-parse HEAD | cut -c-8)"
         local status=''
@@ -186,6 +192,6 @@ generate_mnemonic()
         else status=modified
         fi
 
-        echo "${timestamp}.${commit}.${status}.${mnemonic}"
+        echo "${timestamp}.${commit}.${status}${mnemonic:+.${mnemonic}}"
 }
 export -f generate_mnemonic


### PR DESCRIPTION
Interpret non-Nix modes as "don't use Nix at all, even for `nix-shell`", which restores complete independence from Nix in `--cabal` mode.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [x] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [x] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [x] I have added the appropriate labels to this PR.
