### PR TITLE
CAD-803 TraceLabelPeers FetchDecision:  repeated (<>) on Object loses information

### DIFF
--- a/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Network.hs
@@ -507,8 +507,10 @@ instance Show peer
       => ToObject [TraceLabelPeer peer (FetchDecision [Point header])] where
   toObject MinimalVerbosity _ = emptyObject
   toObject _ [] = emptyObject
-  toObject _ (lbl : r) = toObject MaximalVerbosity lbl <>
-                                        toObject MaximalVerbosity r
+  toObject _ xs = mkObject
+    [ "kind"  .= String "PeersFetch"
+    , "peers" .= toJSON
+      (foldl' (\acc x -> toObject MaximalVerbosity x : acc) [] xs) ]
 
 
 instance (Show peer, ToObject a) => ToObject (TraceLabelPeer peer a) where


### PR DESCRIPTION
This fixes a ToObject instance for `[TraceLabelPeer peer (FetchDecision [Point header])]`.

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [x] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
