### PR TITLE
Extend API with tx construction and improve address API and CLI

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -41,6 +41,7 @@ library
                       , cardano-slotting
                       , cborg
                       , contra-tracer
+                      , containers
                       , cryptonite
                       , formatting
                       , io-sim-classes

--- a/cardano-api/test/Test/Cardano/Api.hs
+++ b/cardano-api/test/Test/Cardano/Api.hs
@@ -11,12 +11,13 @@ import           Cardano.Api
 import           Test.Cardano.Api.Orphans ()
 
 import           Hedgehog (Property, (/==), discover)
-import qualified Hedgehog as H
+import qualified Hedgehog as Hedgehog
 
+import           Test.Cardano.Api.Gen
 
 prop_byronGenKeyPair_unique :: Property
 prop_byronGenKeyPair_unique =
-  H.property $ do
+  Hedgehog.property $ do
     -- Basic sanity test that two distinct calls to the real 'genByronKeyPair'
     -- produces two distinct KeyPairs.
     kp1 <- liftIO byronGenKeyPair
@@ -27,13 +28,25 @@ prop_byronGenKeyPair_unique =
 -- produces two distinct 'KeyPair's.
 prop_shelleyGenKeyPair_unique :: Property
 prop_shelleyGenKeyPair_unique =
-  H.property $ do
+  Hedgehog.property $ do
     kp1 <- liftIO shelleyGenKeyPair
     kp2 <- liftIO shelleyGenKeyPair
     kp1 /== kp2
+
+prop_roundtrip_AddressByron_hex :: Property
+prop_roundtrip_AddressByron_hex = do
+  Hedgehog.property $ do
+    addr <- Hedgehog.forAll genByronVerificationKeyAddress
+    Hedgehog.tripping addr addressToHex addressFromHex
+
+prop_roundtrip_AddressShelley_hex :: Property
+prop_roundtrip_AddressShelley_hex = do
+  Hedgehog.property $ do
+    addr <- Hedgehog.forAll genShelleyVerificationKeyAddress
+    Hedgehog.tripping addr addressToHex addressFromHex
 
 -- -----------------------------------------------------------------------------
 
 tests :: IO Bool
 tests =
-  H.checkParallel $$discover
+  Hedgehog.checkParallel $$discover

--- a/cardano-api/test/Test/Cardano/Api/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/CBOR.hs
@@ -15,12 +15,16 @@ import           Test.Cardano.Api.Gen
 import           Test.Cardano.Api.Orphans ()
 
 
-prop_Address_CBOR :: Property
-prop_Address_CBOR =
+prop_AddressByron_CBOR :: Property
+prop_AddressByron_CBOR =
   H.property $ do
-    nw <- H.forAll genNetwork
-    bpk <- H.forAll genVerificationKeyByron
-    let addr = byronVerificationKeyAddress bpk nw
+    addr <- H.forAll genByronVerificationKeyAddress
+    H.tripping addr addressToCBOR addressFromCBOR
+
+prop_AddressShelley_CBOR :: Property
+prop_AddressShelley_CBOR =
+  H.property $ do
+    addr <- H.forAll genShelleyVerificationKeyAddress
     H.tripping addr addressToCBOR addressFromCBOR
 
 prop_KeyPair_CBOR :: Property
@@ -34,12 +38,6 @@ prop_VerificationKey_CBOR =
   H.property $ do
     kp <- H.forAll genVerificationKey
     H.tripping kp verificationKeyToCBOR verificationKeyFromCBOR
-
-prop_ShelleyVerificationKey_CBOR :: Property
-prop_ShelleyVerificationKey_CBOR =
-  H.property $ do
-    svk <- H.forAll genShelleyVerificationKey
-    H.tripping svk shelleyVerificationKeyToCBOR shelleyVerificationKeyFromCBOR
 
 prop_TxSigned_CBOR :: Property
 prop_TxSigned_CBOR =

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -114,10 +114,9 @@ genTxSignedByron =
 
 genTxUnsigned :: Gen TxUnsigned
 genTxUnsigned =
-  -- When Shelly is sorted out, this should change to `Gen.choose`.
-  Gen.frequency
-    [ (9, genTxUnsignedByron)
-    , (1, pure TxUnsignedShelley)
+  Gen.choice
+    [ genTxUnsignedByron
+--  , genTxUnsignedShelley  --TODO
     ]
 
 genTxUnsignedByron :: Gen TxUnsigned
@@ -125,4 +124,9 @@ genTxUnsignedByron = do
   tx <- genTx
   let cbor = serialize tx
   pure $ TxUnsignedByron tx (LBS.toStrict cbor) (coerce $ hashRaw cbor)
+
+--genTxUnsignedShelley :: Gen TxUnsigned
+--genTxUnsignedShelley = fail "TODO: genTxUnsignedShelley"
+--TODO: reuse an existing generator
+
 

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -1,17 +1,15 @@
 module Test.Cardano.Api.Gen
-  ( genAddress
-  , genKeyPair
+  ( genKeyPair
   , genKeyPairByron
   , genKeyPairShelley
   , genNetwork
   , genVerificationKey
-  , genVerificationKeyByron
-  , genVerificationKeyShelley
-  , genShelleyVerificationKey
   , genTxSigned
   , genTxSignedByron
   , genTxUnsigned
   , genTxUnsignedByron
+  , genByronVerificationKeyAddress
+  , genShelleyVerificationKeyAddress
   ) where
 
 import           Cardano.Api
@@ -36,12 +34,13 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 
-genAddress :: Gen Address
-genAddress =
-  Gen.choice
-    [ byronVerificationKeyAddress <$> genVerificationKey <*> genNetwork
-    , shelleyVerificationKeyAddress <$> genVerificationKey <*> genNetwork
-    ]
+genByronVerificationKeyAddress :: Gen Address
+genByronVerificationKeyAddress =
+  byronVerificationKeyAddress <$> genVerificationKeyByron <*> genNetwork
+
+genShelleyVerificationKeyAddress :: Gen Address
+genShelleyVerificationKeyAddress =
+  shelleyVerificationKeyAddress <$> genVerificationKeyShelley <*> genNetwork
 
 genKeyPair :: Gen KeyPair
 genKeyPair =
@@ -69,11 +68,6 @@ genSeed =
     <*> Gen.word64 Range.constantBounded
     <*> Gen.word64 Range.constantBounded
     <*> Gen.word64 Range.constantBounded
-
-genShelleyVerificationKey :: Gen ShelleyVerificationKey
-genShelleyVerificationKey = do
-  KeyPairShelley vk _ <- genKeyPairShelley
-  pure vk
 
 genNetwork :: Gen Network
 genNetwork =

--- a/cardano-api/test/Test/Cardano/Api/View.hs
+++ b/cardano-api/test/Test/Cardano/Api/View.hs
@@ -15,12 +15,16 @@ import           Test.Cardano.Api.Gen
 import           Test.Cardano.Api.Orphans ()
 
 
-prop_roundtrip_Address_view :: Property
-prop_roundtrip_Address_view =
+prop_roundtrip_AddressByron_view :: Property
+prop_roundtrip_AddressByron_view =
   H.property $ do
-    nw <- H.forAll genNetwork
-    bpk <- H.forAll genVerificationKeyByron
-    let addr = byronVerificationKeyAddress bpk nw
+    addr <- H.forAll genByronVerificationKeyAddress
+    H.tripping addr renderAddressView parseAddressView
+
+prop_roundtrip_AddressShelley_view :: Property
+prop_roundtrip_AddressShelley_view =
+  H.property $ do
+    addr <- H.forAll genShelleyVerificationKeyAddress
     H.tripping addr renderAddressView parseAddressView
 
 prop_roundtrip_KeyPair_view :: Property

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -148,6 +148,11 @@ newtype BlockId
   = BlockId String -- Probably not a String
   deriving (Eq, Show)
 
+data FileDirection
+  = Input
+  | Output
+  deriving (Eq, Show)
+
 newtype GenesisFile
   = GenesisFile FilePath
   deriving (Eq, Show)
@@ -214,7 +219,7 @@ pAddress =
       [ Opt.command "key-gen"
           (Opt.info pAddressKeyGen $ Opt.progDesc "Create a single address key pair")
       , Opt.command "key-hash"
-          (Opt.info pAddressKeyHash $ Opt.progDesc "Show the hash of an address key")
+          (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key to stdout")
       , Opt.command "build"
           (Opt.info pAddressBuild $ Opt.progDesc "Build an address")
       , Opt.command "build-multisig"
@@ -222,13 +227,13 @@ pAddress =
       ]
   where
     pAddressKeyGen :: Parser AddressCmd
-    pAddressKeyGen = AddressKeyGen <$> pVerificationKeyFile <*> pSigningKeyFile
+    pAddressKeyGen = AddressKeyGen <$> pVerificationKeyFile Input <*> pSigningKeyFile Input
 
     pAddressKeyHash :: Parser AddressCmd
-    pAddressKeyHash = AddressKeyHash <$> pVerificationKeyFile
+    pAddressKeyHash = AddressKeyHash <$> pVerificationKeyFile Input
 
     pAddressBuild :: Parser AddressCmd
-    pAddressBuild = AddressBuild <$> pVerificationKeyFile
+    pAddressBuild = AddressBuild <$> pVerificationKeyFile Input
 
     pAddressBuildMultiSig :: Parser AddressCmd
     pAddressBuildMultiSig = pure AddressBuildMultiSig
@@ -330,17 +335,17 @@ pNodeCmd =
   where
     pKeyGenOperator :: Parser NodeCmd
     pKeyGenOperator =
-      NodeKeyGenCold <$> pVerificationKeyFile
-                     <*> pSigningKeyFile
+      NodeKeyGenCold <$> pVerificationKeyFile Output
+                     <*> pSigningKeyFile Output
                      <*> pOperatorCertIssueCounterFile
 
     pKeyGenKES :: Parser NodeCmd
     pKeyGenKES =
-      NodeKeyGenKES <$> pVerificationKeyFile <*> pSigningKeyFile <*> pDuration
+      NodeKeyGenKES <$> pVerificationKeyFile Output <*> pSigningKeyFile Output <*> pDuration
 
     pKeyGenVRF :: Parser NodeCmd
     pKeyGenVRF =
-      NodeKeyGenVRF <$> pVerificationKeyFile <*> pSigningKeyFile
+      NodeKeyGenVRF <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
 
     pIssueOpCert :: Parser NodeCmd
     pIssueOpCert =
@@ -481,25 +486,25 @@ pGenesisCmd =
   where
     pGenesisKeyGen :: Parser GenesisCmd
     pGenesisKeyGen =
-      GenesisKeyGenGenesis <$> pVerificationKeyFile <*> pSigningKeyFile
+      GenesisKeyGenGenesis <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
 
     pGenesisDelegateKeyGen :: Parser GenesisCmd
     pGenesisDelegateKeyGen =
-      GenesisKeyGenDelegate <$> pVerificationKeyFile
-                            <*> pSigningKeyFile
+      GenesisKeyGenDelegate <$> pVerificationKeyFile Output
+                            <*> pSigningKeyFile Output
                             <*> pOperatorCertIssueCounterFile
 
     pGenesisUTxOKeyGen :: Parser GenesisCmd
     pGenesisUTxOKeyGen =
-      GenesisKeyGenUTxO <$> pVerificationKeyFile <*> pSigningKeyFile
+      GenesisKeyGenUTxO <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
 
     pGenesisKeyHash :: Parser GenesisCmd
     pGenesisKeyHash =
-      GenesisKeyHash <$> pVerificationKeyFile
+      GenesisKeyHash <$> pVerificationKeyFile Input
 
     pGenesisVerKey :: Parser GenesisCmd
     pGenesisVerKey =
-      GenesisVerKey <$> pVerificationKeyFile <*> pSigningKeyFile
+      GenesisVerKey <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
 
     pGenesisCreate :: Parser GenesisCmd
     pGenesisCreate =
@@ -561,13 +566,13 @@ pColdSigningKeyFile =
      <> Opt.help "Filepath of the cold signing key."
      )
 
-pSigningKeyFile :: Parser SigningKeyFile
-pSigningKeyFile =
+pSigningKeyFile :: FileDirection -> Parser SigningKeyFile
+pSigningKeyFile fdir =
   SigningKeyFile <$>
    Opt.strOption
      (  Opt.long "signing-key-file"
      <> Opt.metavar "FILEPATH"
-     <> Opt.help "Output filepath of the signing key."
+     <> Opt.help (show fdir ++ " filepath of the signing key.")
      )
 
 pBlockId :: Parser BlockId
@@ -648,13 +653,13 @@ pPrivKeyFile =
       <> Opt.help "The private key file."
       )
 
-pVerificationKeyFile :: Parser VerificationKeyFile
-pVerificationKeyFile =
+pVerificationKeyFile :: FileDirection -> Parser VerificationKeyFile
+pVerificationKeyFile fdir =
   VerificationKeyFile <$>
     Opt.strOption
       (  Opt.long "verification-key-file"
       <> Opt.metavar "FILEPATH"
-      <> Opt.help "Output filepath of the verification key."
+      <> Opt.help (show fdir ++ " filepath of the verification key.")
       )
 
 pKESVerificationKeyFile :: Parser VerificationKeyFile

--- a/cardano-cli/test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test.hs
@@ -6,6 +6,7 @@ import           Cardano.Prelude
 import           Control.Monad (foldM, forM, when)
 
 import           Data.Maybe (isNothing)
+import qualified Data.List as List
 import qualified Data.Text as Text
 
 import           Prelude (String)
@@ -26,7 +27,7 @@ main = do
 
   setExecutableEnvVar "CARDANO_CLI" "cardano-cli"
 
-  tests <- filter (`notElem` ["core", "data"]) <$> listDirectory "test/cli/"
+  tests <- List.sort . filter (`notElem` ["core", "data"]) <$> listDirectory "test/cli/"
   res <- forM tests $ \ t -> rawSystem (joinPath ["test", "cli", t, "run"]) []
   if all (== ExitSuccess) res
     then exitSuccess

--- a/cardano-cli/test/cli/address-build/run
+++ b/cardano-cli/test/cli/address-build/run
@@ -1,0 +1,44 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+# Generate a key pair
+${CARDANO_CLI} shelley address key-gen \
+    --verification-key-file "${OUTPUT_DIR}/address.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/address.skey"
+
+assert_file_exists "${OUTPUT_DIR}/address.vkey"
+
+count=$(grep -c VerificationKeyShelley "${OUTPUT_DIR}/address.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/address.vkey: Expected VerificationKeyShelley"
+  error=1
+  fi
+
+${CARDANO_CLI} shelley address build \
+    --verification-key-file "${OUTPUT_DIR}/address.vkey" \
+    > "${OUTPUT_DIR}/address.build"
+
+assert_file_exists "${OUTPUT_DIR}/address.build"
+
+line_count=$(wc -l < "${OUTPUT_DIR}/address.build")
+if test "${line_count}" != 1 ; then
+  echo "Address build:"
+  cat "${OUTPUT_DIR}/address.build"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/address-key-gen/run
+++ b/cardano-cli/test/cli/address-key-gen/run
@@ -1,0 +1,37 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+${CARDANO_CLI} shelley address key-gen \
+    --verification-key-file "${OUTPUT_DIR}/address.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/address.skey"
+
+assert_file_exists "${OUTPUT_DIR}/address.vkey"
+assert_file_exists "${OUTPUT_DIR}/address.skey"
+
+count=$(grep -c VerificationKeyShelley "${OUTPUT_DIR}/address.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/address.vkey: Expected VerificationKeyShelley"
+  error=1
+  fi
+
+count=$(grep -c KeyPairShelley "${OUTPUT_DIR}/address.skey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/address.skey: Expected KeyPairShelley"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/address-key-hash/run
+++ b/cardano-cli/test/cli/address-key-hash/run
@@ -1,0 +1,46 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+# Generate a key pair
+${CARDANO_CLI} shelley address key-gen \
+    --verification-key-file "${OUTPUT_DIR}/address.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/address.skey"
+
+assert_file_exists "${OUTPUT_DIR}/address.vkey"
+
+count=$(grep -c VerificationKeyShelley "${OUTPUT_DIR}/address.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/address.vkey: Expected VerificationKeyShelley"
+  error=1
+  fi
+
+
+# Now generate the hash.
+${CARDANO_CLI} shelley address key-hash \
+    --verification-key-file "${OUTPUT_DIR}/address.vkey" \
+    > "${OUTPUT_DIR}/vkey-hash"
+
+assert_file_exists "${OUTPUT_DIR}/vkey-hash"
+
+line_count=$(wc -l < "${OUTPUT_DIR}/vkey-hash")
+if test "${line_count}" != 1 ; then
+  echo "Verification key hash:"
+  cat "${OUTPUT_DIR}/vkey-hash"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/core/common
+++ b/cardano-cli/test/cli/core/common
@@ -32,14 +32,14 @@ RESULT="${colourRed}FAILED [ ${testname} ]${colourReset}"
 
 ROOT=$(dirname "$0")/../../..
 ROOT=$(cd "$ROOT" > /dev/null 2>&1 && pwd)
-TMP=${ROOT}/tmp
-TEST=${TMP}/test/$$
+TMP="${ROOT}/tmp"
+TEST="${TMP}/$$"
 mkdir -p "${TEST}"
 
 cleanup () {
     echo "Cleaning up ${TEST}"
     rm -rf "${TEST}"
-    echo ${RESULT}
+    echo "${RESULT}"
     echo
 }
 
@@ -53,7 +53,7 @@ banner () {
 assert_file_exists () {
     if test ! -f "$1" ; then
         echo "Output file '$1' is missing."
-        fail_test
+        exit 1
     fi
 }
 

--- a/cardano-cli/test/cli/create-genesis/run
+++ b/cardano-cli/test/cli/create-genesis/run
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -u
 
 cwd=$(dirname "$0")
 

--- a/cardano-cli/test/cli/node-issue-op-cert/data/genesis.spec.json
+++ b/cardano-cli/test/cli/node-issue-op-cert/data/genesis.spec.json
@@ -1,0 +1,19 @@
+{
+    "DecentralisationParam": 0.99,
+    "ActiveSlotsCoeff": 0.99,
+    "ProtocolMagicId": 838299499,
+    "StartTime": "2020-01-01T00:20:40Z",
+    "GenDelegs": {},
+    "UpdateQuorum": 12,
+    "MaxHeaderSize": 8192,
+    "MaxMajorPV": 25446,
+    "MaxBodySize": 2097152,
+    "MaxLovelaceSupply": 100000000,
+    "InitialFunds": {},
+    "NetworkMagic": 4036000900,
+    "EpochLength": 21600,
+    "SecurityParam": 2160,
+    "SlotLength": 20,
+    "SlotsPerKESPeriod": 216000,
+    "MaxKESEvolutions": 1080000
+}

--- a/cardano-cli/test/cli/node-issue-op-cert/run
+++ b/cardano-cli/test/cli/node-issue-op-cert/run
@@ -1,0 +1,46 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}/delegate-keys/" "${OUTPUT_DIR}/genesis-keys/"
+cp "${cwd}/data/genesis.spec.json" "${OUTPUT_DIR}/"
+
+error=0
+
+${CARDANO_CLI} shelley genesis create-genesis \
+    --genesis-dir "${OUTPUT_DIR}" \
+    --genesis-delegates 1 \
+    --supply 1000 > /dev/null
+
+${CARDANO_CLI} shelley node key-gen-KES \
+	--verification-key-file "${OUTPUT_DIR}/node-kes.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/node-kes.skey" \
+    --kes-duration 100
+
+${CARDANO_CLI} shelley node issue-op-cert \
+    --hot-kes-verification-key-file "${OUTPUT_DIR}/node-kes.vkey" \
+    --cold-signing-key-file "${OUTPUT_DIR}/delegate-keys/delegate1.skey" \
+    --operational-certificate-issue-counter "${OUTPUT_DIR}/delegate-keys/delegate-opcert1.counter" \
+    --kes-period 0 \
+    --out-file "${OUTPUT_DIR}/operational.cert"
+
+assert_file_exists "${OUTPUT_DIR}/operational.cert"
+
+count=$(grep -c 'Node operational certificate' "${OUTPUT_DIR}/operational.cert")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/operational.cert: Expected 'Node operational certificate'"
+  cat "${OUTPUT_DIR}/operational.cert"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/node-key-gen-kes/run
+++ b/cardano-cli/test/cli/node-key-gen-kes/run
@@ -1,0 +1,40 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+${CARDANO_CLI} shelley node key-gen-KES \
+    --verification-key-file "${OUTPUT_DIR}/kes.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/kes.skey" \
+    --kes-duration 10
+
+assert_file_exists "${OUTPUT_DIR}/kes.vkey"
+assert_file_exists "${OUTPUT_DIR}/kes.skey"
+
+count=$(grep -c 'VKeyES TPraosStandardCrypto' "${OUTPUT_DIR}/kes.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/kes.vkey: Expected 'VKeyES TPraosStandardCrypto'"
+  cat "${OUTPUT_DIR}/kes.vkey"
+  error=1
+  fi
+
+count=$(grep -c 'SKeyES TPraosStandardCrypto' "${OUTPUT_DIR}/kes.skey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/kes.skey: Expected 'SKeyES TPraosStandardCrypto'"
+  cat "${OUTPUT_DIR}/kes.skey"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/node-key-gen-vrf/run
+++ b/cardano-cli/test/cli/node-key-gen-vrf/run
@@ -1,0 +1,39 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+${CARDANO_CLI} shelley node key-gen-VRF \
+    --verification-key-file "${OUTPUT_DIR}/vrf.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/vrf.skey"
+
+assert_file_exists "${OUTPUT_DIR}/vrf.vkey"
+assert_file_exists "${OUTPUT_DIR}/vrf.skey"
+
+count=$(grep -c 'VerKeyVRF SimpleVRF' "${OUTPUT_DIR}/vrf.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/vrf.vkey: Expected 'VerKeyVRF SimpleVRF'"
+  cat "${OUTPUT_DIR}/vrf.vkey"
+  error=1
+  fi
+
+count=$(grep -c 'SignKeyVRF SimpleVRF' "${OUTPUT_DIR}/vrf.skey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/vrf.skey: Expected 'SignKeyVRF SimpleVRF'"
+  cat "${OUTPUT_DIR}/vrf.skey"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/node-key-gen/run
+++ b/cardano-cli/test/cli/node-key-gen/run
@@ -1,0 +1,48 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+OUTPUT_DIR="${TEST}"
+
+rm -rf "${OUTPUT_DIR}"
+mkdir "${OUTPUT_DIR}"
+
+error=0
+
+${CARDANO_CLI} shelley node key-gen \
+    --verification-key-file "${OUTPUT_DIR}/key-gen.vkey" \
+    --signing-key-file "${OUTPUT_DIR}/key-gen.skey" \
+    --operational-certificate-issue-counter "${OUTPUT_DIR}/op-cert.counter"
+
+assert_file_exists "${OUTPUT_DIR}/key-gen.vkey"
+assert_file_exists "${OUTPUT_DIR}/key-gen.skey"
+assert_file_exists "${OUTPUT_DIR}/op-cert.counter"
+
+count=$(grep -c 'Node operator verification key' "${OUTPUT_DIR}/key-gen.vkey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/key-gen.vkey: Expected 'Node operator verification key'"
+  cat "${OUTPUT_DIR}/key-gen.vkey"
+  error=1
+  fi
+
+count=$(grep -c 'Node operator signing key' "${OUTPUT_DIR}/key-gen.skey")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/key-gen.skey: Expected 'Node operator signing key'"
+  cat "${OUTPUT_DIR}/key-gen.skey"
+  error=1
+  fi
+
+count=$(grep -c 'Node operational certificate issue counter' "${OUTPUT_DIR}/op-cert.counter")
+if test "${count}" != 1 ; then
+  echo "${OUTPUT_DIR}/op-cert.counter: Expected 'Node operational certificate issue counter'"
+  cat "${OUTPUT_DIR}/op-cert.counter"
+  error=1
+  fi
+
+report_result ${error}

--- a/cardano-cli/test/cli/shellcheck/run
+++ b/cardano-cli/test/cli/shellcheck/run
@@ -1,0 +1,30 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+type shellcheck > /dev/null 2>&1 || {
+    echo "Missing 'shellcheck' executable."
+    exit 1
+}
+
+# Need this if running outside "cabal test cardano-cli".
+if test -d "cardano-cli" ; then
+  cd "cardano-cli" || exit 1
+  fi
+
+shellcheck test/cli/core/common
+error=$?
+
+files=$(find test/cli -name run)
+for file in ${files} ; do
+  shellcheck "${file}"
+  error=$?
+  done
+
+report_result ${error}

--- a/cardano-cli/test/cli/version/run
+++ b/cardano-cli/test/cli/version/run
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -u
 
 cwd=$(dirname "$0")
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -51,7 +51,7 @@ let
         # Needed for the CLI tests.
         # Coreutils because we need 'paste'.
         packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
-          lib.mkForce [buildPackages.bc buildPackages.jq buildPackages.coreutils];
+          lib.mkForce [buildPackages.bc buildPackages.jq buildPackages.coreutils buildPackages.shellcheck];
       }
       {
         # Packages we wish to ignore version bounds of.


### PR DESCRIPTION
Extend the API with `buildByronTransaction` and `buildShelleyTransaction`.
Add hex format input/output for the raw address serialisation, Byron and Shelley.
Improve CLI flag `--help` text: use the right description for files as inputs or outputs.
Add more CLI integration tests.