### PR TITLE
removed -Werror from stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,8 +8,8 @@ packages:
   - cardano-node
 
 ghc-options:
-  cardano-config:       -Wall -Werror -fwarn-redundant-constraints
-  cardano-node:         -Wall -Werror -fwarn-redundant-constraints
+  cardano-config:       -Wall -fwarn-redundant-constraints
+  cardano-node:         -Wall -fwarn-redundant-constraints
 
 allow-newer: true
 


### PR DESCRIPTION
Issue
-----------

- Stack builds had GHC-option -Werror enabled, which meant that builds could break when using stack that did not break with nix or cabal. This PR removes the -Werror flag from the stack configuration.

- This PR does not result in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
