### PR TITLE
Also build with profiling on hydra + profiling nixos option

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,10 @@ let
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages cardanoNodeHaskellPackages);
 
+  profiledHaskellPackages = recRecurseIntoAttrs
+    # the Haskell.nix package set (with profiling), reduced to local packages.
+    (selectProjectPackages cardanoNodeProfiledHaskellPackages);
+
   scripts = callPackage ./nix/scripts.nix { inherit customConfig; };
   # NixOS tests run a proxy and validate it listens
   nixosTests = import ./nix/nixos/tests {
@@ -40,7 +44,7 @@ let
   };
 
   self = {
-    inherit haskellPackages scripts nixosTests environments check-hydra dockerImage;
+    inherit haskellPackages profiledHaskellPackages scripts nixosTests environments check-hydra dockerImage;
 
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -69,7 +69,6 @@ let
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
         packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;
-        profilingDetail = "default";
       })
       (lib.optionalAttrs stdenv.hostPlatform.isWindows {
         # Disable cabal-doctest tests by turning off custom setups

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -7,7 +7,7 @@ with lib; with builtins;
 let
   localPkgs = import ../. {};
   cfg = config.services.cardano-node;
-  inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages;
+  inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages cardanoNodeProfiledHaskellPackages;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: let
@@ -37,7 +37,7 @@ let
           "--topology ${cfg.topology}"
           "--host-addr ${cfg.hostAddr}"
           "--port ${toString cfg.port}"
-        ] ++ consensusParams.${cfg.consensusProtocol} ++ cfg.extraArgs;
+        ] ++ consensusParams.${cfg.consensusProtocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
         echo "Starting ${exec}: ${concatStringsSep "\"\n   echo \"" cmd}"
@@ -84,9 +84,16 @@ in {
         default = mkScript cfg;
       };
 
+      profiling = mkOption {
+        type = types.enum ["none" "time" "space" "space-module" "space-closure" "space-type" "space-retainer" "space-bio"];
+        default = "none";
+      };
+
       package = mkOption {
         type = types.package;
-        default = cardanoNodeHaskellPackages.cardano-node.components.exes.cardano-node;
+        default = if (cfg.profiling != "none")
+          then cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node
+          else cardanoNodeHaskellPackages.cardano-node.components.exes.cardano-node;
         defaultText = "cardano-node";
         description = ''
           The cardano-node package that should be used
@@ -277,6 +284,29 @@ in {
         type = types.listOf types.str;
         default = [];
         description = ''Extra CLI args for 'cardano-node'.'';
+      };
+
+      rtsArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        apply = args: if (args != [] || cfg.profilingArgs != []) then
+          ["+RTS"] ++ cfg.profilingArgs ++ args ++ ["-RTS"]
+          else [];
+        description = ''Extra CLI args for 'cardano-node', to be surrounded by "+RTS"/"-RTS"'';
+      };
+
+      profilingArgs = mkOption {
+        type = types.listOf types.str;
+        default = let commonProfilingArgs = ["--machine-readable" "-tcardano-node.stats" "-l" "-pocardano-node"];
+          in if cfg.profiling == "time" then ["-P"] ++ commonProfilingArgs
+            else if cfg.profiling == "space" then ["-h"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-module" then ["-hm"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-closure" then ["-hd"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-type" then ["-hy"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-retainer" then ["-hr"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-bio" then ["-hb"] ++ commonProfilingArgs
+            else [];
+        description = ''RTS profiling options'';
       };
 
       tracingVerbosity = mkOption {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -8,4 +8,13 @@ pkgs: _: with pkgs; {
       buildPackages
       ;
   };
+  cardanoNodeProfiledHaskellPackages = import ./haskell.nix {
+    inherit config
+      lib
+      stdenv
+      haskell-nix
+      buildPackages
+      ;
+    profiling = true;
+  };
 }

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -36,6 +36,9 @@ let
       loggingExtras = null;
       tracingVerbosity = "normal";
       dbPrefix = "db-${envConfig.name}";
+      extraArgs = [];
+      profiling = "none";
+      rtsArgs = [];
     } // (builtins.removeAttrs envConfig ["nodeConfig"]);
 
     nodeConfig = (envConfig.nodeConfig or environments.mainnet.nodeConfig)
@@ -74,7 +77,11 @@ let
         nodeConfig
         nodeId
         dbPrefix
-        tracingVerbosity;
+        tracingVerbosity
+        extraArgs
+        rtsArgs
+        profiling
+        ;
       runtimeDir = null;
       environment = envConfig.name;
       topology = topologyFile;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ded93b38ff656d3bf1b90f926bbf0ecea3fab723",
-        "sha256": "12pw3ykv2wp6kj0vj8y499p4khmzyx9r9il15l8p2wr2i7cpjxnc",
+        "rev": "f78841c2d05c6c686d3888131104360944464dc2",
+        "sha256": "1zwhskx9drd0266kcrxf5vzcgs9vfiiibzkc2h3yarfb2xl7185q",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/ded93b38ff656d3bf1b90f926bbf0ecea3fab723.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f78841c2d05c6c686d3888131104360944464dc2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
Allow easy profiling setup of cardano-node nixos service and nix scripts:
eg.
```
nix build --out-link launch_node -f ./. scripts.mainnet.node --arg customConfig '{ profiling = "time"; }'
```
(profilng setup use same semantic as in `lib.sh`)