### PR TITLE
Also build with profiling on hydra + profiling nixos option + nix eval improvement

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,12 +9,6 @@ steps:
     agents:
       system: x86_64-linux
 
-# FIXME, waiting for https://github.com/input-output-hk/haskell.nix/pull/426
-#  - label: 'release.nix'
-#    command: 'nix-build -A check-hydra -o check-hydra.sh && ./check-hydra.sh'
-#    agents:
-#      system: x86_64-linux
-
   - label: 'stack-cabal-sync'
     command: 'nix-shell ./nix -A iohkNix.stack-cabal-sync-shell --run scripts/buildkite/stack-cabal-sync.sh'
     agents:

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ stack.yaml.lock
 /profile
 /launch_*
 /state-*
+*.eventlog
+*.hp
+*.prof
+*.stats
 /cluster
 /cluster.*
 

--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ let
   };
 
   self = {
-    inherit haskellPackages profiledHaskellPackages scripts nixosTests environments check-hydra dockerImage;
+    inherit haskellPackages profiledHaskellPackages scripts nixosTests environments dockerImage;
 
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.

--- a/default.nix
+++ b/default.nix
@@ -21,10 +21,6 @@ let
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages cardanoNodeHaskellPackages);
 
-  profiledHaskellPackages = recRecurseIntoAttrs
-    # the Haskell.nix package set (with profiling), reduced to local packages.
-    (selectProjectPackages cardanoNodeProfiledHaskellPackages);
-
   scripts = callPackage ./nix/scripts.nix { inherit customConfig; };
   # NixOS tests run a proxy and validate it listens
   nixosTests = import ./nix/nixos/tests {
@@ -44,11 +40,12 @@ let
   };
 
   self = {
-    inherit haskellPackages profiledHaskellPackages scripts nixosTests environments dockerImage;
+    inherit haskellPackages scripts nixosTests environments dockerImage;
 
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.
     inherit (haskellPackages.cardano-node.components.exes) cardano-node;
+    cardano-node-profiled = cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node;
     inherit (haskellPackages.cardano-cli.components.exes) cardano-cli;
     inherit (haskellPackages.cardano-node.components.exes) chairman;
     # expose the db-converter from the ouroboros-network we depend on

--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,10 @@ let
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages cardanoNodeHaskellPackages);
 
+  profiledHaskellPackages = recRecurseIntoAttrs
+    # the Haskell.nix package set (with profiling), reduced to local packages.
+    (selectProjectPackages cardanoNodeProfiledHaskellPackages);
+
   scripts = callPackage ./nix/scripts.nix { inherit customConfig; };
   # NixOS tests run a proxy and validate it listens
   nixosTests = import ./nix/nixos/tests {
@@ -40,7 +44,7 @@ let
   };
 
   self = {
-    inherit haskellPackages scripts nixosTests environments check-hydra dockerImage;
+    inherit haskellPackages profiledHaskellPackages scripts nixosTests environments check-hydra dockerImage;
 
     inherit (haskellPackages.cardano-node.identifier) version;
     # Grab the executable component of our package.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,7 @@
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohKNix = import sources.iohk-nix {};
+  iohkNix = import sources.iohk-nix {};
   haskellNix = import sources."haskell.nix";
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
@@ -14,16 +14,16 @@ let
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
     else (builtins.trace "Using IOHK default nixpkgs"
-      iohKNix.nixpkgs);
+      iohkNix.nixpkgs);
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohKNix.overlays.haskell-nix-extra
+    ++ iohkNix.overlays.haskell-nix-extra
     # iohkNix: nix utilities and niv:
-    ++ iohKNix.overlays.iohkNix
+    ++ iohkNix.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {
@@ -31,8 +31,8 @@ let
         # commonLib: mix pkgs.lib with iohk-nix utils and our own:
         commonLib = lib // iohkNix // iohkNix.cardanoLib
           // import ./util.nix { inherit haskell-nix; }
-          # also expose our sources and overlays
-          // { inherit overlays sources; };
+          # also expose our sources, nixpkgs and overlays
+          // { inherit overlays sources nixpkgs; };
 
         svcLib = import ./svclib.nix { inherit pkgs; };
       })

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -7,7 +7,7 @@ with lib; with builtins;
 let
   localPkgs = import ../. {};
   cfg = config.services.cardano-node;
-  inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages;
+  inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages cardanoNodeProfiledHaskellPackages;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: let
@@ -37,7 +37,7 @@ let
           "--topology ${cfg.topology}"
           "--host-addr ${cfg.hostAddr}"
           "--port ${toString cfg.port}"
-        ] ++ consensusParams.${cfg.consensusProtocol} ++ cfg.extraArgs;
+        ] ++ consensusParams.${cfg.consensusProtocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
         echo "Starting ${exec}: ${concatStringsSep "\"\n   echo \"" cmd}"
@@ -84,9 +84,16 @@ in {
         default = mkScript cfg;
       };
 
+      profiling = mkOption {
+        type = types.enum ["none" "time" "space" "space-module" "space-closure" "space-type" "space-retainer" "space-bio"];
+        default = "none";
+      };
+
       package = mkOption {
         type = types.package;
-        default = cardanoNodeHaskellPackages.cardano-node.components.exes.cardano-node;
+        default = if (cfg.profiling != "none")
+          then cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node
+          else cardanoNodeHaskellPackages.cardano-node.components.exes.cardano-node;
         defaultText = "cardano-node";
         description = ''
           The cardano-node package that should be used
@@ -277,6 +284,29 @@ in {
         type = types.listOf types.str;
         default = [];
         description = ''Extra CLI args for 'cardano-node'.'';
+      };
+
+      rtsArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        apply = args: if (args != [] || cfg.profilingArgs != []) then
+          ["+RTS"] ++ cfg.profilingArgs ++ args ++ ["-RTS"]
+          else [];
+        description = ''Extra CLI args for 'cardano-node', to be surrounded by "+RTS"/"-RTS"'';
+      };
+
+      profilingArgs = mkOption {
+        type = types.listOf types.str;
+        default = let commonProfilingArgs = ["--machine-readable" "-tcardano-node.stats" "-l" "-pocardano-node"];
+          in if cfg.profiling == "time" then ["-P"] ++ commonProfilingArgs
+            else if cfg.profiling == "space" then ["-h"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-module" then ["-hm"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-closure" then ["-hd"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-type" then ["-hy"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-retainer" then ["-hr"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-bio" then ["-hb"] ++ commonProfilingArgs
+            else [];
+        description = ''RTS profiling options'';
       };
 
       tracingVerbosity = mkOption {

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -1,13 +1,13 @@
 { config
 , lib
 , pkgs
+, cardanoNodePkgs ? import ../. {}
 , ... }:
 
 with lib; with builtins;
 let
-  localPkgs = import ../. {};
   cfg = config.services.cardano-node;
-  inherit (localPkgs) svcLib commonLib cardanoNodeHaskellPackages cardanoNodeProfiledHaskellPackages;
+  inherit (cardanoNodePkgs) svcLib commonLib cardanoNodeHaskellPackages cardanoNodeProfiledHaskellPackages;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: let

--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -6,6 +6,7 @@
 with pkgs.lib;
 let
   inherit (pkgs) svcLib commonLib;
+  pkgs' = pkgs;
   byron-proxy-src = commonLib.sources.cardano-byron-proxy;
   cardano-sl-src  = commonLib.sources.cardano-sl;
   # byron-proxy-src = ../../../../cardano-byron-proxy;
@@ -40,6 +41,7 @@ in {
   name = "chairmans-cluster-test";
   nodes = {
     machine = { lib, config, pkgs, ... }: {
+      _module.args.cardanoNodePkgs = mkDefault pkgs';
       nixpkgs.overlays = commonLib.overlays;
       imports = [
         (byron-proxy-src + "/nix/nixos")

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -8,4 +8,13 @@ pkgs: _: with pkgs; {
       buildPackages
       ;
   };
+  cardanoNodeProfiledHaskellPackages = import ./haskell.nix {
+    inherit config
+      lib
+      stdenv
+      haskell-nix
+      buildPackages
+      ;
+    profiling = true;
+  };
 }

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -36,6 +36,9 @@ let
       loggingExtras = null;
       tracingVerbosity = "normal";
       dbPrefix = "db-${envConfig.name}";
+      extraArgs = [];
+      profiling = "none";
+      rtsArgs = [];
     } // (builtins.removeAttrs envConfig ["nodeConfig"]);
 
     nodeConfig = (envConfig.nodeConfig or environments.mainnet.nodeConfig)
@@ -74,7 +77,11 @@ let
         nodeConfig
         nodeId
         dbPrefix
-        tracingVerbosity;
+        tracingVerbosity
+        extraArgs
+        rtsArgs
+        profiling
+        ;
       runtimeDir = null;
       environment = envConfig.name;
       topology = topologyFile;

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -7,6 +7,7 @@ let
   inherit (pkgs) svcLib;
   pkgsModule = {
     config._module.args.pkgs = mkDefault pkgs;
+    config._module.args.cardanoNodePkgs = mkDefault pkgs;
   };
   systemdCompat.options = {
     systemd.services = mkOption {};

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -254,6 +254,7 @@ let
     };
     pkgsModule = {
       config._module.args.pkgs = mkDefault pkgs;
+      config._module.args.cardanoNodePkgs = mkDefault pkgs;
     };
     systemdCompat.options = {
       systemd.services = mkOption {};


### PR DESCRIPTION
Allow easy profiling setup of cardano-node nixos service and nix scripts:
eg.
```
nix build --out-link launch_node -f ./. scripts.mainnet.node --arg customConfig '{ profiling = "time"; }'
```
(profiling setup use same semantic as in `lib.sh`)

Also improve memoization of pkgs so that nix eval of release.nix should use about 50% less memory.