### PR TITLE
Ensure that initial fund addrs are constructed as bootstrap addrs

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -82,7 +82,6 @@ import qualified Cardano.Chain.Common  as Byron
 import qualified Cardano.Chain.Genesis as Byron
 import qualified Cardano.Chain.UTxO    as Byron
 
-import qualified Shelley.Spec.Ledger.Address   as Shelley
 import qualified Shelley.Spec.Ledger.Keys      as Shelley
 import qualified Shelley.Spec.Ledger.TxData    as Shelley
 import qualified Shelley.Spec.Ledger.Tx        as Shelley

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -19,6 +19,7 @@ module Cardano.Api
   , Network (..)
   , byronVerificationKeyAddress
   , shelleyVerificationKeyAddress
+  , shelleyVerificationKeyBootstrapAddress
 
     -- * Transactions
   , TxSigned (..)
@@ -119,6 +120,14 @@ shelleyVerificationKeyAddress vkey _nw =
         -- is all we have here
         Shelley.Addr (Shelley.KeyHashObj (Shelley.hashKey vk))
                      Shelley.StakeRefNull
+
+shelleyVerificationKeyBootstrapAddress :: VerificationKey -> Network -> Address
+shelleyVerificationKeyBootstrapAddress vkey _nw =
+  case vkey of
+    VerificationKeyByron _ -> panic "Cardano.Api.shelleyVerificationKeyBootstrapAddress: VerificationKeyByron"
+    VerificationKeyShelley vk ->
+      AddressShelley $
+        Shelley.AddrBootstrap (Shelley.hashKey vk)
 
 getVerificationKey :: SigningKey -> VerificationKey
 getVerificationKey kp =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -261,7 +261,8 @@ readInitialFundAddresses utxodir = do
                traverse (readVerKey GenesisUTxOKey)
                         (map (utxodir </>) files)
     return [ addr | vkey <- vkeys
-           , let AddressShelley addr = shelleyVerificationKeyAddress
+             -- The initial fund addresses /must/ be bootstrap addresses.
+           , let AddressShelley addr = shelleyVerificationKeyBootstrapAddress
                                          (VerificationKeyShelley vkey) Mainnet
            ]
     --TODO: need to support testnets, not just Mainnet


### PR DESCRIPTION
The initial fund addresses _must_ be bootstrap addresses. Otherwise, the node will throw this on startup:

```
cardano-node: Pointer stake addresses not allowed in initial snapshot
```