### PR TITLE
Allow tx signing to use genesis utxo keys or normal keys

### DIFF
--- a/cardano-api/src/Cardano/Api/View.hs
+++ b/cardano-api/src/Cardano/Api/View.hs
@@ -40,23 +40,23 @@ import qualified Data.ByteString.Char8 as BS
 
 parseAddressView :: ByteString -> Either ApiError Address
 parseAddressView bs =
-  either convertTextViewError (addressFromCBOR . tvRawCBOR) $ parseTextView bs
+  addressFromCBOR . tvRawCBOR =<< first ApiTextView (parseTextView bs)
 
 parseSigningKeyView :: ByteString -> Either ApiError SigningKey
 parseSigningKeyView bs =
-  either convertTextViewError (signingKeyFromCBOR . tvRawCBOR) $ parseTextView bs
+  signingKeyFromCBOR . tvRawCBOR =<< first ApiTextView (parseTextView bs)
 
 parseVerificationKeyView :: ByteString -> Either ApiError VerificationKey
 parseVerificationKeyView bs =
-  either convertTextViewError (verificationKeyFromCBOR . tvRawCBOR) $ parseTextView bs
+  verificationKeyFromCBOR . tvRawCBOR =<< first ApiTextView (parseTextView bs)
 
 parseTxSignedView :: ByteString -> Either ApiError TxSigned
 parseTxSignedView bs =
-  either convertTextViewError (txSignedFromCBOR . tvRawCBOR) $ parseTextView bs
+  txSignedFromCBOR . tvRawCBOR =<< first ApiTextView (parseTextView bs)
 
 parseTxUnsignedView :: ByteString -> Either ApiError TxUnsigned
 parseTxUnsignedView bs =
-  either convertTextViewError (txUnsignedFromCBOR . tvRawCBOR) $ parseTextView bs
+  txUnsignedFromCBOR . tvRawCBOR =<< first ApiTextView (parseTextView bs)
 
 renderAddressView :: Address -> ByteString
 renderAddressView addr =

--- a/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/ColdKeys.hs
@@ -24,6 +24,8 @@ module Cardano.Config.Shelley.ColdKeys
   , renderKeyError
   , writeSigningKey
   , writeVerKey
+  , KeyType(..)
+  , renderKeyType
   ) where
 
 import           Cardano.Prelude


### PR DESCRIPTION
The sign command needs to accept normal Shelley (and Byron) keys, but it
is also certainly helpful it it can accept genesis initial UTxO keys.
This is indeed possible, but it is currently a bit awkward.

This is rather hacky and highlights where our API modules do not compose
well with our other things. This will want a bit of tweaking.