### PR TITLE
Simplify node client config reqirements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -301,99 +301,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 7b05b277cada5e01f3a74314011814b7e1cf68f4
+  --sha256: 00ymk2jzghniiv92vp6qc4xl48agf8pd46fa86id8zsdfhmbjgyz
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-api/src/Cardano/Api/LocalStateQuery.hs
+++ b/cardano-api/src/Cardano/Api/LocalStateQuery.hs
@@ -36,7 +36,7 @@ import           Network.Mux (MuxTrace, WithMuxBearer)
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Cardano (Protocol (..), protocolInfo)
-import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Config (TopLevelConfig (..), configCodec)
 import           Ouroboros.Consensus.Ledger.Abstract (Query)
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -190,7 +190,7 @@ localInitiatorNetworkApplication proxy resultVar trce cfg pointAndQuery =
           { cChainSyncCodec
           , cTxSubmissionCodec
           , cStateQueryCodec
-          } = defaultCodecs (configBlock cfg) clientVersion
+          } = defaultCodecs (configCodec cfg) clientVersion
 
 -- | A 'LocalStateQueryClient' which executes the provided local state query
 -- and puts the result in the provided 'StrictTMVar'.

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -42,11 +42,11 @@ import           Data.Void (Void)
 
 import           Network.Mux (MuxTrace, WithMuxBearer)
 
-import           Ouroboros.Consensus.Block (BlockConfig)
+import           Ouroboros.Consensus.Block (CodecConfig)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..), GenTx)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Cardano (Protocol (..), protocolInfo)
-import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Config (TopLevelConfig (..), configCodec)
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr)
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -134,7 +134,7 @@ runTxSubmitNodeClient tsv nodeConfig trce (SocketPath socketPath) = do
             (nodeToClientProtocolVersion proxy v)
             versionData
             (localInitiatorNetworkApplication
-              trce (configBlock nodeConfig) v tsv))
+              trce (configCodec nodeConfig) v tsv))
         (supportedNodeToClientVersions proxy))
   where
     -- TODO: it should be passed as an argument
@@ -160,11 +160,11 @@ runTxSubmitNodeClient tsv nodeConfig trce (SocketPath socketPath) = do
 
 localInitiatorNetworkApplication
   :: Trace IO Text
-  -> BlockConfig ByronBlock
+  -> CodecConfig ByronBlock
   -> NodeToClientVersion ByronBlock
   -> TxSubmitVar
   -> NodeToClientProtocols 'InitiatorApp LBS.ByteString IO Void Void
-localInitiatorNetworkApplication trce blockConfig byronClientVersion tsv =
+localInitiatorNetworkApplication trce codecConfig byronClientVersion tsv =
     NodeToClientProtocols
       { localChainSyncProtocol =
           InitiatorProtocolOnly $ MuxPeer
@@ -189,7 +189,7 @@ localInitiatorNetworkApplication trce blockConfig byronClientVersion tsv =
     Codecs { cChainSyncCodec
            , cTxSubmissionCodec
            , cStateQueryCodec
-           } = defaultCodecs blockConfig byronClientVersion 
+           } = defaultCodecs codecConfig byronClientVersion
 
 
 -- | A 'LocalTxSubmissionClient' that submits transactions reading them from

--- a/cardano-cli/src/Cardano/CLI/Ops.hs
+++ b/cardano-cli/src/Cardano/CLI/Ops.hs
@@ -79,7 +79,7 @@ import           Ouroboros.Consensus.Network.NodeToClient
                    (Codecs'(..), defaultCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                    (nodeToClientProtocolVersion, supportedNodeToClientVersions)
-import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Config (TopLevelConfig (..), configCodec)
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo(..))
 import           Ouroboros.Consensus.Node.Run
                    (RunNode(..))
@@ -540,7 +540,7 @@ localInitiatorNetworkApplication proxy cfg tipVar =
              , cTxSubmissionCodec
              , cStateQueryCodec
              }
-        = defaultCodecs (configBlock cfg) clientVersion
+        = defaultCodecs (configCodec cfg) clientVersion
 
 ncCardanoEra :: NodeConfiguration -> CardanoEra
 ncCardanoEra = cardanoEraForProtocol . ncProtocol

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -37,10 +37,11 @@ import           Control.Tracer
 
 import           Network.Mux (MuxError)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
+import           Ouroboros.Consensus.Block
+                   (BlockProtocol, GetHeader (..), CodecConfig)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-                   ( TopLevelConfig, configConsensus, configBlock, configCodec )
+                   (configConsensus, configBlock, configCodec)
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -51,6 +52,7 @@ import           Ouroboros.Consensus.HardFork.History (EraParams(..), Shape(..))
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Cardano
 
+import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Block (BlockNo, HasHeader, Point, Tip)
 import qualified Ouroboros.Network.Block as Block
@@ -96,7 +98,9 @@ chairmanTest tracer ptcl runningTime optionalProgressThreshold socketPaths = do
     -- Run the chairman and get the final snapshot of the chain from each node.
     chainsSnapshot <- runChairman
                         tracer
-                        cfg securityParam
+                        (configCodec cfg)
+                        (nodeNetworkMagic (Proxy :: Proxy blk) cfg)
+                        securityParam
                         runningTime
                         socketPaths
 
@@ -288,7 +292,8 @@ progressCondition minBlockNo (ConsensusSuccess _ tips) =
 
 runChairman :: RunNode blk
             => Tracer IO String
-            -> TopLevelConfig blk
+            -> CodecConfig blk
+            -> NetworkMagic
             -> SecurityParam
             -- ^ security parameter, if a fork is deeper than it 'runChairman'
             -- will throw an exception.
@@ -297,7 +302,7 @@ runChairman :: RunNode blk
             -> [SocketPath]
             -- ^ local socket dir
             -> IO (ChainsSnapshot blk)
-runChairman tracer cfg securityParam runningTime socketPaths = do
+runChairman tracer cfg networkMagic securityParam runningTime socketPaths = do
 
     let initialChains = Map.fromList [ (socketPath, AF.Empty AF.AnchorGenesis)
                                      | socketPath <- socketPaths]
@@ -310,9 +315,10 @@ runChairman tracer cfg securityParam runningTime socketPaths = do
             tracer
             iomgr
             cfg
-            securityParam
-            chainsVar
+            networkMagic
             sockPath
+            chainsVar
+            securityParam
 
     atomically (readTVar chainsVar)
 
@@ -333,18 +339,20 @@ createConnection
      RunNode blk
   => Tracer IO String
   -> IOManager
-  -> TopLevelConfig blk
-  -> SecurityParam
-  -> ChainsVar IO blk
+  -> CodecConfig blk
+  -> NetworkMagic
   -> SocketPath
+  -> ChainsVar IO blk
+  -> SecurityParam
   -> IO ()
 createConnection
   tracer
   iomgr
   cfg
-  securityParam
+  networkMagic
+  socketPath@(SocketFile path)
   chainsVar
-  socketPath@(SocketFile path) =
+  securityParam =
       connectTo
         (localSnocket iomgr path)
         NetworkConnectTracers {
@@ -352,13 +360,14 @@ createConnection
             nctHandshakeTracer = nullTracer
             }
         (localInitiatorNetworkApplication
-            socketPath
-            chainsVar
-            securityParam
             (showTracing tracer)
             nullTracer
             nullTracer
-            cfg)
+            cfg
+            networkMagic
+            socketPath
+            chainsVar
+            securityParam)
         path
         `catch` handleMuxError tracer chainsVar socketPath
 
@@ -500,10 +509,7 @@ localInitiatorNetworkApplication
      , MonadTimer m
      , MonadThrow (STM m)
      )
-  => SocketPath
-  -> ChainsVar m blk
-  -> SecurityParam
-  -> Tracer m (ChairmanTrace blk)
+  => Tracer m (ChairmanTrace blk)
   -> Tracer m (TraceSendRecv (ChainSync blk (Tip blk)))
   -- ^ tracer which logs all chain-sync messages send and received by the client
   -- (see 'Ouroboros.Network.Protocol.ChainSync.Type' in 'ouroboros-network'
@@ -512,12 +518,17 @@ localInitiatorNetworkApplication
   -- ^ tracer which logs all local tx submission protocol messages send and
   -- received by the client (see 'Ouroboros.Network.Protocol.LocalTxSubmission.Type'
   -- in 'ouroboros-network' package).
-  -> TopLevelConfig blk
+  -> CodecConfig blk
+  -> NetworkMagic
+  -> SocketPath
+  -> ChainsVar m blk
+  -> SecurityParam
   -> Versions NtC.NodeToClientVersion DictVersion
               (LocalConnectionId -> OuroborosApplication InitiatorApp ByteString m () Void)
-localInitiatorNetworkApplication sockPath chainsVar securityParam
-                                 chairmanTracer chainSyncTracer
-                                 localTxSubmissionTracer cfg =
+localInitiatorNetworkApplication chairmanTracer chainSyncTracer
+                                 localTxSubmissionTracer
+                                 cfg networkMagic
+                                 sockPath chainsVar securityParam =
     foldMapVersions
       (\v ->
         versionedNodeToClientProtocols
@@ -526,11 +537,10 @@ localInitiatorNetworkApplication sockPath chainsVar securityParam
           (protocols v))
       (supportedNodeToClientVersions proxy)
   where
-    -- TODO: it should be passed as an argument
     proxy :: Proxy blk
     proxy = Proxy
 
-    versionData = NodeToClientVersionData (nodeNetworkMagic proxy cfg)
+    versionData = NodeToClientVersionData networkMagic
 
     protocols :: NodeToClientVersion blk
               -> NodeToClientProtocols InitiatorApp ByteString m () Void
@@ -561,6 +571,4 @@ localInitiatorNetworkApplication sockPath chainsVar securityParam
         Codecs { cChainSyncCodec
                , cTxSubmissionCodec
                , cStateQueryCodec
-               } = clientCodecs (configCodec cfg) byronClientVersion
-
-
+               } = clientCodecs cfg byronClientVersion

--- a/cardano-node/src/Cardano/Chairman.hs
+++ b/cardano-node/src/Cardano/Chairman.hs
@@ -40,7 +40,7 @@ import           Network.Mux (MuxError)
 import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-                   ( TopLevelConfig, configConsensus, configBlock )
+                   ( TopLevelConfig, configConsensus, configBlock, configCodec )
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -561,6 +561,6 @@ localInitiatorNetworkApplication sockPath chainsVar securityParam
         Codecs { cChainSyncCodec
                , cTxSubmissionCodec
                , cStateQueryCodec
-               } = clientCodecs (configBlock cfg) byronClientVersion
+               } = clientCodecs (configCodec cfg) byronClientVersion
 
 

--- a/cardano-node/src/Cardano/Node/Submission.hs
+++ b/cardano-node/src/Cardano/Node/Submission.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                   (nodeToClientProtocolVersion,
                    supportedNodeToClientVersions)
 import           Ouroboros.Consensus.Node.Run (RunNode, nodeNetworkMagic)
-import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Config (TopLevelConfig (..), configCodec)
 
 import           Ouroboros.Network.Mux
                    ( AppType(..), OuroborosApplication(..),
@@ -176,7 +176,7 @@ localInitiatorNetworkApplication tracer cfg tx =
                , cTxSubmissionCodec
                , cStateQueryCodec
                }
-          = defaultCodecs (configBlock cfg) clientVersion
+          = defaultCodecs (configCodec cfg) clientVersion
 
 
 -- | A 'LocalTxSubmissionClient' that submits exactly one transaction, and then

--- a/stack.yaml
+++ b/stack.yaml
@@ -127,7 +127,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 776d76c24fb96ef4fb64f427f3989f1004ba2907
+    commit: 7b05b277cada5e01f3a74314011814b7e1cf68f4
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
Update for the consensus config codec changes

This consensus API change reduces the amount of config that is needed
for node clients. We should now be able to take advantage of this in
various places: the API, CLI and chairman to reduce the amount of setup
config that is needed.

As a demo of this, slightly simplify config requirements for the chairman.
This is mainly as an example of how we can make the client network code
require less config.
    
At the top level, the chairman still needs a few more things, but
that's special to the chairman test.

So overall this is a stepping stone to reduced config params needed for
things like tx submit in the API and CLI.