### PR TITLE
nixos/cardano-node: remove consensusProtocol

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -37,7 +37,7 @@ let
           "--topology ${cfg.topology}"
           "--host-addr ${cfg.hostAddr}"
           "--port ${toString cfg.port}"
-        ] ++ consensusParams.${cfg.consensusProtocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
+        ] ++ consensusParams.${cfg.nodeConfig.Protocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
         echo "Starting ${exec}: ${concatStringsSep "\"\n   echo \"" cmd}"
@@ -183,16 +183,6 @@ in {
         default = null;
         description = ''
           Operational certificate
-        '';
-      };
-
-      consensusProtocol = mkOption {
-        default = "RealPBFT";
-        type = types.enum ["RealPBFT" "TPraos"];
-        description = ''
-          Consensus initially used by the node:
-            - TPraos: Praos consensus algorithm
-            - RealPBFT: Permissive BFT consensus algorithm using the real ledger
         '';
       };
 

--- a/nix/nixos/chairman-as-a-service.nix
+++ b/nix/nixos/chairman-as-a-service.nix
@@ -11,7 +11,7 @@ let
   chairman = pkgs.cardanoNodeHaskellPackages.cardano-node.components.exes.chairman;
   envConfig = environments.${cfg.environment};
   mkChairmanConfig = nodeConfig: chairmanConfig: {
-    inherit (nodeConfig) package genesisFile genesisHash genesisHashPath stateDir pbftThreshold consensusProtocol;
+    inherit (nodeConfig) package genesisFile genesisHash genesisHashPath stateDir pbftThreshold;
     inherit (chairmanConfig) timeout k slot-length node-ids nodeConfigFile nodeConfig;
   };
   mkScript = cfg:

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -16,7 +16,6 @@ let
   };
   mkNodeScript = envConfig: let
     defaultConfig = {
-      consensusProtocol = "RealPBFT";
       hostAddr = "127.0.0.1";
       port = 3001;
       signingKey = null;
@@ -72,7 +71,6 @@ let
         kesKey
         vrfKey
         operationalCertificate
-        consensusProtocol
         hostAddr
         port
         nodeConfig


### PR DESCRIPTION
consensusProtocol is a redundant parameter as it is specified in
nodeConfig for the environment

Issue
-----------

-

- This PR **results**/**does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
