### PR TITLE
Make the systemd dependency optional

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -10,8 +10,17 @@ build-type:            Simple
 cabal-version:         >= 1.10
 extra-source-files:    README.md
 
+flag systemd
+  description: Enable systemd support
+  default:     True
+  manual:      False
+
 library
   hs-source-dirs:      src
+
+  if os(linux) && flag(systemd)
+    cpp-options:       -DSYSTEMD
+    build-depends:     lobemo-scribe-systemd
 
   exposed-modules:     Cardano.Config.Byron.Parsers
                        Cardano.Config.Byron.Protocol
@@ -67,7 +76,6 @@ library
                      , lobemo-backend-ekg
                      , lobemo-backend-monitoring
                      , lobemo-backend-trace-forwarder
-                     , lobemo-scribe-systemd
                      , network
                      , network-mux
                      , optparse-applicative

--- a/cardano-config/src/Cardano/Config/Logging.hs
+++ b/cardano-config/src/Cardano/Config/Logging.hs
@@ -48,7 +48,7 @@ import           Cardano.BM.Data.SubTrace
 import qualified Cardano.BM.Observer.Monadic as Monadic
 import qualified Cardano.BM.Observer.STM as Stm
 import           Cardano.BM.Plugin (loadPlugin)
-#if defined(linux_HOST_OS)
+#if defined(SYSTEMD)
 import           Cardano.BM.Scribe.Systemd (plugin)
 #endif
 import           Cardano.BM.Setup (setupTrace_, shutdown)
@@ -184,7 +184,7 @@ createLoggingFeature ver _ nodecli@NodeCLI{configFile} = do
      Cardano.BM.Backend.Monitoring.plugin logConfig trace switchBoard
        >>= loadPlugin switchBoard
 
-#if defined(linux_HOST_OS)
+#if defined(SYSTEMD)
      Cardano.BM.Scribe.Systemd.plugin logConfig trace switchBoard "cardano"
        >>= loadPlugin switchBoard
 #endif


### PR DESCRIPTION
One might not want `systemd`, or not be able to link against `systemd`. This should make it possible to disable it via a flag.