### PR TITLE
Eliminate config file for tx submission in API and CLI

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -301,99 +301,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
-  --sha256: 00rrka2452kd7ij86yjmmrc3kgsradcwi7q3riwmjnba5wiav1x4
+  tag: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
+  --sha256: 1v0ksjw1fp9md91igya9vlmnvw5z81jylywgwc2svx125k9b79bj
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -14,6 +14,7 @@ module Cardano.Api.TxSubmit
   ( TxSubmitStatus (..)
   , renderTxSubmitStatus
   , submitTransaction
+  , prepareTxByron
   , prepareTxShelley
   ) where
 
@@ -84,13 +85,13 @@ submitTransaction nodeEnv txs = do
   tvar <- newTxSubmitVar
   res <- race
             (runTxSubmitNode tvar nullTracer (naeConfig nodeEnv) (naeSocket nodeEnv))
-            (submitTx tvar $ prepareTx txs)
+            (submitTx tvar $ prepareTxByron txs)
   case res of
     Left _ -> panic "Cardano.Api.TxSubmit.submitTransaction: runTxSubmitNode terminated unexpectedly."
     Right st -> pure st
 
-prepareTx :: TxSigned -> GenTx ByronBlock
-prepareTx txs =
+prepareTxByron :: TxSigned -> GenTx ByronBlock
+prepareTxByron txs =
   case txs of
     TxSignedByron tx _txCbor _txHash vwit ->
       let aTxAux = Byron.annotateTxAux (Byron.mkTxAux tx vwit)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -91,7 +91,7 @@ data TransactionCmd
   | TxWitness       -- { transaction :: Transaction, key :: PrivKeyFile, nodeAddr :: NodeAddress }
   | TxSignWitness   -- { transaction :: Transaction, witnesses :: [Witness], nodeAddr :: NodeAddress }
   | TxCheck         -- { transaction :: Transaction, nodeAddr :: NodeAddress }
-  | TxSubmit FilePath ConfigYamlFilePath
+  | TxSubmit FilePath Network
   | TxInfo          -- { transaction :: Transaction, nodeAddr :: NodeAddress }
   deriving (Eq, Show)
 
@@ -363,7 +363,7 @@ pTransaction =
 
     pTransactionSubmit  :: Parser TransactionCmd
     pTransactionSubmit = TxSubmit <$> pTxSubmitFile
-                                  <*> (ConfigYamlFilePath <$> parseConfigFile)
+                                  <*> pNetwork
 
     pTransactionInfo  :: Parser TransactionCmd
     pTransactionInfo = pure TxInfo

--- a/cardano-config/src/Cardano/Config/Byron/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Byron/Protocol.hs
@@ -16,6 +16,10 @@ module Cardano.Config.Byron.Protocol
     -- | Use this when you want to handle protocols generically
   , mkSomeConsensusProtocolRealPBFT
 
+    -- * Client support
+  , mkNodeClientProtocolRealPBFT
+  , mkSomeNodeClientProtocolRealPBFT
+
     -- * Errors
   , ByronProtocolInstantiationError(..)
   , renderByronProtocolInstantiationError
@@ -31,6 +35,7 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
 
 import qualified Cardano.Chain.Genesis as Genesis
+import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
 import qualified Cardano.Crypto.Signing as Signing
@@ -43,8 +48,23 @@ import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Cardano.Config.Types
                    (NodeConfiguration(..), ProtocolFilepaths(..),
                     GenesisFile (..), Update (..), LastKnownBlockVersion (..),
-                    SomeConsensusProtocol(..))
+                    SomeConsensusProtocol(..), SomeNodeClientProtocol(..))
 import           Cardano.TracingOrphanInstances.Byron ()
+
+
+------------------------------------------------------------------------------
+-- Real Byron protocol, client support
+--
+
+mkNodeClientProtocolRealPBFT :: EpochSlots
+                             -> ProtocolClient ByronBlock ProtocolRealPBFT
+mkNodeClientProtocolRealPBFT epochSlots =
+    ProtocolClientRealPBFT epochSlots
+
+
+mkSomeNodeClientProtocolRealPBFT :: EpochSlots -> SomeNodeClientProtocol
+mkSomeNodeClientProtocolRealPBFT epochSlots =
+    SomeNodeClientProtocol (mkNodeClientProtocolRealPBFT epochSlots)
 
 
 ------------------------------------------------------------------------------

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -7,14 +7,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Config.Protocol
   ( Protocol(..)
-  , ProtocolInstantiationError(..)
+  , mkConsensusProtocol
   , SomeConsensusProtocol(..)
   , TraceConstraints
-  , mkConsensusProtocol
+  , ProtocolInstantiationError(..)
   , renderProtocolInstantiationError
   ) where
 
@@ -45,20 +44,20 @@ mkConsensusProtocol config@NodeConfiguration{ncProtocol} files =
     case ncProtocol of
       -- Mock protocols
       BFT      -> firstExceptT MockProtocolInstantiationError $
-                    mkConsensusProtocolBFT   config
+                    mkSomeConsensusProtocolBFT   config
 
       MockPBFT -> firstExceptT MockProtocolInstantiationError $
-                    mkConsensusProtocolPBFT  config
+                    mkSomeConsensusProtocolPBFT  config
 
       Praos    -> firstExceptT MockProtocolInstantiationError $
-                    mkConsensusProtocolPraos config
+                    mkSomeConsensusProtocolPraos config
 
       -- Real protocols
       RealPBFT -> firstExceptT ByronProtocolInstantiationError $
-                    mkConsensusProtocolRealPBFT config files
+                    mkSomeConsensusProtocolRealPBFT config files
 
       TPraos   -> firstExceptT ShelleyProtocolInstantiationError $
-                    SomeConsensusProtocol <$> mkConsensusProtocolTPraos config files
+                    mkSomeConsensusProtocolTPraos config files
 
 
 ------------------------------------------------------------------------------

--- a/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
@@ -215,4 +215,3 @@ renderShelleyProtocolInstantiationError pie =
   where
     missingFlagMessage flag =
       "To create blocks, the --" <> flag <> " must also be specified"
-

--- a/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
@@ -16,6 +16,10 @@ module Cardano.Config.Shelley.Protocol
     -- | Use this when you want to handle protocols generically
   , mkSomeConsensusProtocolTPraos
 
+    -- * Client support
+  , mkNodeClientProtocolTPraos
+  , mkSomeNodeClientProtocolTPraos
+
     -- * Errors
   , ShelleyProtocolInstantiationError(..)
   , renderShelleyProtocolInstantiationError
@@ -44,11 +48,25 @@ import           Shelley.Spec.Ledger.PParams (ProtVer(..))
 import           Cardano.Config.Types
                    (NodeConfiguration(..), ProtocolFilepaths(..),
                     GenesisFile (..), Update (..), LastKnownBlockVersion (..),
-                    SomeConsensusProtocol(..))
+                    SomeConsensusProtocol(..), SomeNodeClientProtocol(..))
 import           Cardano.Config.Shelley.OCert
 import           Cardano.Config.Shelley.VRF
 import           Cardano.Config.Shelley.KES
 import           Cardano.TracingOrphanInstances.Shelley ()
+
+
+------------------------------------------------------------------------------
+-- Shelley protocol, client support
+--
+
+mkNodeClientProtocolTPraos :: ProtocolClient (ShelleyBlock TPraosStandardCrypto)
+                                             ProtocolRealTPraos
+mkNodeClientProtocolTPraos = ProtocolClientRealTPraos
+
+
+mkSomeNodeClientProtocolTPraos :: SomeNodeClientProtocol
+mkSomeNodeClientProtocolTPraos =
+    SomeNodeClientProtocol mkNodeClientProtocolTPraos
 
 
 ------------------------------------------------------------------------------

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -33,6 +33,7 @@ module Cardano.Config.Types
     , Fd (..)
     , parseNodeConfiguration
     , parseNodeConfigurationFP
+    , SomeNodeClientProtocol(..)
     ) where
 
 import           Prelude (show)
@@ -51,7 +52,7 @@ import qualified Cardano.Chain.Update as Update
 import           Cardano.Chain.Slotting (EpochSlots)
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)
 import           Ouroboros.Consensus.Block (Header, BlockProtocol)
-import qualified Ouroboros.Consensus.Cardano as Consensus (Protocol)
+import qualified Ouroboros.Consensus.Cardano as Consensus (Protocol, ProtocolClient)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
 import           Ouroboros.Consensus.Mempool.API
@@ -377,3 +378,15 @@ type TraceConstraints blk =
     , ToObject (OtherHeaderEnvelopeError blk)
     , ToObject (ValidationErr (BlockProtocol blk))
     )
+
+--------------------------------------------------------------------------------
+-- Node client requirements
+--------------------------------------------------------------------------------
+
+data SomeNodeClientProtocol where
+
+     SomeNodeClientProtocol
+       :: RunNode blk
+       => Consensus.ProtocolClient blk (BlockProtocol blk)
+       -> SomeNodeClientProtocol
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -127,7 +127,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 97dd6cf6a09c2dbffe36f4d7e4b7bfff3ea27c70
+    commit: 18ef245af8181cf3bc208b71c7c4f8502137dbbb
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
The consensus now supports a ClientProtocolInfo interface which requires
much less configuration than the ProtocolInfo needed to actually run a
node, but should be enough to do use the client protocols.

Use this for the tx submission in the API and the CLI.