### PR TITLE
Keep metrics out of the log files.

### DIFF
--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -256,6 +256,8 @@ options:
       - EKGViewBK  
       - kind: UserDefinedBK
         name: LiveViewBackend
+    cardano.node.Forge.metrics:
+      - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK
       - KatipBK


### PR DESCRIPTION
I wish we could do this once and for all. They should never appear in
log files by default.