### PR TITLE
CAD-900: Node traces processed txs num.

### DIFF
--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -400,12 +400,12 @@ instance IsEffectuator (LiveViewBackend blk) Text where
                                     { lvsMempoolBytes = lvsMempoolBytes'
                                     , lvsMempoolBytesPerc = percentage
                                     }
-                    LogValue "txsProcessed" (PureI txsProcessed) ->
+                    LogValue "txsProcessedNum" (PureI txsProcessedNum) ->
                         modifyMVar_ (getbe lvbe) $ \lvs -> do
 
-                                checkForUnexpectedThunks ["txsProcessed LiveViewBackend"] lvs
+                                checkForUnexpectedThunks ["txsProcessedNum LiveViewBackend"] lvs
 
-                                return $ lvs { lvsTransactions = lvsTransactions lvs + fromIntegral txsProcessed }
+                                return $ lvs { lvsTransactions = fromIntegral txsProcessedNum }
 
                     _ -> pure ()
 


### PR DESCRIPTION
Issue
-----------

- Node traces the number of processed transactions.

- related to https://github.com/input-output-hk/cardano-benchmarking/pull/51

- This PR **does not result** in breaking changes to upstream dependencies.

Checklist
---------
- [ ] This PR contains all the work required to resolve the linked issue.

- [ ] The work contained has sufficient documentation to describe what it does and how to do it.

- [ ] The work has sufficient tests and/or testing.

- [ ] I have committed clear and descriptive commits. Be considerate as somebody else will have to read these.

- [ ] I have added the appropriate labels to this PR.
