### PR TITLE
Fix sharing of cardanoNodePkgs among nixos service instances

### DIFF
--- a/nix/nixos/tests/chairmans-cluster.nix
+++ b/nix/nixos/tests/chairmans-cluster.nix
@@ -41,7 +41,6 @@ in {
   name = "chairmans-cluster-test";
   nodes = {
     machine = { lib, config, pkgs, ... }: {
-      _module.args.cardanoNodePkgs = mkDefault pkgs';
       nixpkgs.overlays = commonLib.overlays;
       imports = [
         (byron-proxy-src + "/nix/nixos")
@@ -58,6 +57,7 @@ in {
       ];
 
       services.cardano-cluster = cardano-cluster-config;
+      services.cardano-node.cardanoNodePkgs = pkgs';
 
       ## Time
       services.timesyncd.enable = false;

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -7,7 +7,6 @@ let
   inherit (pkgs) svcLib;
   pkgsModule = {
     config._module.args.pkgs = mkDefault pkgs;
-    config._module.args.cardanoNodePkgs = mkDefault pkgs;
   };
   systemdCompat.options = {
     systemd.services = mkOption {};
@@ -16,6 +15,7 @@ let
   };
   mkNodeScript = envConfig: let
     defaultConfig = {
+      cardanoNodePkgs = pkgs;
       hostAddr = "127.0.0.1";
       port = 3001;
       signingKey = null;
@@ -64,6 +64,7 @@ let
     serviceConfig = {
       inherit environments;
       inherit (config)
+        cardanoNodePkgs
         stateDir
         socketPath
         signingKey

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -251,10 +251,10 @@ let
     injectServiceConfigs = {
       config.services.chairman = chairman-config;
       config.services.cardano-cluster = cardano-cluster-config;
+      config.services.cardano-node.cardanoNodePkgs = pkgs;
     };
     pkgsModule = {
       config._module.args.pkgs = mkDefault pkgs;
-      config._module.args.cardanoNodePkgs = mkDefault pkgs;
     };
     systemdCompat.options = {
       systemd.services = mkOption {};


### PR DESCRIPTION
This restore the optimization that was disabled in https://github.com/input-output-hk/cardano-node/pull/902/commits/576e20a9f9887b0d7323275dbe801661b05ac586 (due to default values not working for modules) in a working way.