### PR TITLE
scripts: check for missing tmux

### DIFF
--- a/scripts/lib-cluster.sh
+++ b/scripts/lib-cluster.sh
@@ -3,6 +3,8 @@
 
 TMUX_CONFIG="$(mktemp -t --suffix=tmuXXXXXXXX)"
 run_3node_cluster() {
+        command -v tmux >/dev/null 2>&1 || { echo >&2 "ERROR: This script requires tmux, which is missing. Please install it."; exit 1; }
+
         dprint "run_3node_cluster: $*"
         local config="$1" topo="${2:-indexed}" delegate="${3:-indexed}"
 


### PR DESCRIPTION
Just a quick warning if we are not running on `nix` and do not pull `tmux` as a dependency.

Fixes #924.