### PR TITLE
CAD-970 disable output to console if LiveView active

### DIFF
--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -44,9 +44,8 @@ ApplicationVersion: 1
 
 # The node can run in either the SimpleView or LiveView. The SimpleView just
 # uses standard output, optionally with log output. The LiveView is a text
-# console on Linux with a live view of various node metrics. To use LiveView
-# disable the default output to 'stdout' in "defaultScribes" section.
-# And, also set "TraceBlockFetchDecisions: True" to see the connected peers.
+# console on Linux and Mac OSX with a live view of various node metrics.
+# When LiveView is used logging output to 'stdout' is automatically disabled.
 ViewMode: SimpleView
 #ViewMode: LiveView
 
@@ -110,7 +109,7 @@ defaultBackends:
 # For the Katip logging backend we must set up outputs (called scribes)
 # The available types of scribe are:
 #   FileSK for files
-#   StdoutSK/StdoutSK for stdout/stderr
+#   StdoutSK/StderrSK for stdout/stderr
 #   JournalSK for systemd's journal system
 #   DevNullSK ignores all output
 # The scribe output format can be ScText or ScJson. Log rotation settings can
@@ -129,8 +128,6 @@ setupScribes:
 defaultScribes:
   - - FileSK
     - "logs/mainnet.log"
-  # When using "ViewMode: LiveView" above, comment out the following directive
-  # to stop output to 'stdout'
   - - StdoutSK
     - stdout
 
@@ -152,6 +149,7 @@ rotation:
 TraceBlockFetchClient: False
 
 # Trace BlockFetch decisions made by the BlockFetch client.
+# needed to display "peers" and their block height in LiveView
 TraceBlockFetchDecisions: False
 
 # Trace BlockFetch protocol messages.


### PR DESCRIPTION
automatically disables logging to the console if in "LiveView" (on Linux and Mac OSX, LiveView is anyway ignored on Windows)

description in configuration file has been adapted.