### PR TITLE
Rename cli commands for stake addresses and keys

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -70,14 +70,15 @@ data AddressCmd
   = AddressKeyGen VerificationKeyFile SigningKeyFile
   | AddressKeyHash VerificationKeyFile
   | AddressBuildStaking VerificationKeyFile VerificationKeyFile
-  | AddressBuildReward VerificationKeyFile
   | AddressBuildEnterprise VerificationKeyFile
   | AddressBuildMultiSig  --TODO
   | AddressInfo Text
   deriving (Eq, Show)
 
 data StakeAddressCmd
-  = StakeKeyRegister PrivKeyFile NodeAddress
+  = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
+  | StakeAddressBuild VerificationKeyFile
+  | StakeKeyRegister PrivKeyFile NodeAddress
   | StakeKeyDelegate PrivKeyFile PoolId Lovelace NodeAddress
   | StakeKeyDeRegister PrivKeyFile NodeAddress
   | StakeKeyRegistrationCert VerificationKeyFile OutputFile
@@ -111,7 +112,6 @@ data NodeCmd
   | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
   | NodeIssueOpCert VerificationKeyFile SigningKeyFile OpCertCounterFile
                     KESPeriod OutputFile
-  | NodeStakingKeyGen  VerificationKeyFile SigningKeyFile
   | NodeStakePoolKeyGen  VerificationKeyFile SigningKeyFile
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -112,12 +112,12 @@ data NodeCmd
   | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
   | NodeIssueOpCert VerificationKeyFile SigningKeyFile OpCertCounterFile
                     KESPeriod OutputFile
-  | NodeStakePoolKeyGen  VerificationKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 
 data PoolCmd
-  = PoolRegister PoolId   -- { operator :: PubKey, owner :: [PubKey], kes :: PubKey, vrf :: PubKey, rewards :: PubKey, cost :: Lovelace, margin :: Margin, nodeAddr :: NodeAddress }
+  = PoolKeyGen VerificationKeyFile SigningKeyFile
+  | PoolRegister PoolId   -- { operator :: PubKey, owner :: [PubKey], kes :: PubKey, vrf :: PubKey, rewards :: PubKey, cost :: Lovelace, margin :: Margin, nodeAddr :: NodeAddress }
   | PoolReRegister PoolId -- { operator :: PubKey, owner :: [PubKey], kes :: PubKey, vrf :: PubKey, rewards :: PubKey, cost :: Lovelace, margin :: Margin, nodeAddr :: NodeAddress }
   | PoolRetire PoolId EpochNo NodeAddress
   | PoolRegistrationCert

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -69,8 +69,7 @@ data ShelleyCommand
 data AddressCmd
   = AddressKeyGen VerificationKeyFile SigningKeyFile
   | AddressKeyHash VerificationKeyFile
-  | AddressBuildStaking VerificationKeyFile VerificationKeyFile
-  | AddressBuildEnterprise VerificationKeyFile
+  | AddressBuild VerificationKeyFile (Maybe VerificationKeyFile)
   | AddressBuildMultiSig  --TODO
   | AddressInfo Text
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -290,9 +290,6 @@ pNodeCmd =
       , Opt.command "issue-op-cert"
           (Opt.info pIssueOpCert $
              Opt.progDesc "Issue a node operational certificate")
-      , Opt.command "key-gen-stake-pool"
-          (Opt.info pStakePoolKeyPair $
-             Opt.progDesc "Create a stake pool key pair")
       ]
   where
     pKeyGenOperator :: Parser NodeCmd
@@ -317,17 +314,14 @@ pNodeCmd =
                       <*> pKesPeriod
                       <*> pOutputFile
 
-    pStakePoolKeyPair :: Parser NodeCmd
-    pStakePoolKeyPair = NodeStakePoolKeyGen
-                          <$> pVerificationKeyFile Output
-                          <*> pSigningKeyFile Output
-
 
 pPoolCmd :: Parser PoolCmd
 pPoolCmd =
   Opt.subparser $
     mconcat
-      [ Opt.command "register"
+      [ Opt.command "key-gen"
+          (Opt.info pPoolKeyGen $ Opt.progDesc "Create a stake pool operator's offline key pair")
+      , Opt.command "register"
           (Opt.info pPoolRegster $ Opt.progDesc "Register a stake pool")
       , Opt.command "re-register"
           (Opt.info pPoolReRegster $ Opt.progDesc "Re-register a stake pool")
@@ -339,6 +333,11 @@ pPoolCmd =
           (Opt.info pStakePoolRetirmentCert $ Opt.progDesc "Create a stake pool deregistration certificate")
       ]
   where
+    pPoolKeyGen :: Parser PoolCmd
+    pPoolKeyGen = PoolKeyGen
+                    <$> pVerificationKeyFile Output
+                    <*> pSigningKeyFile Output
+
     pPoolRegster :: Parser PoolCmd
     pPoolRegster = PoolRegister <$> pPoolId
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -95,12 +95,10 @@ pAddressCmd =
           (Opt.info pAddressKeyGen $ Opt.progDesc "Create a single address key pair.")
       , Opt.command "key-hash"
           (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key to stdout.")
-      , Opt.command "build-staking"
-          (Opt.info pAddressBuildStaking $ Opt.progDesc "Build a standard Shelley address (capable of receiving payments and staking).")
-      , Opt.command "build-enterprise"
-          (Opt.info pAddressBuildEnterprise $ Opt.progDesc "Build a Shelley enterprise address (can recieve payments but not able to stake, eg for exchanges).")
+      , Opt.command "build"
+          (Opt.info pAddressBuild $ Opt.progDesc "Build a Shelley payment addres, with optional delegation to a stake address.")
       , Opt.command "build-multisig"
-          (Opt.info pAddressBuildMultiSig $ Opt.progDesc "Build a multi-sig address.")
+          (Opt.info pAddressBuildMultiSig $ Opt.progDesc "Build a Shelley payment multi-sig address.")
       , Opt.command "info"
           (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
       ]
@@ -111,14 +109,11 @@ pAddressCmd =
     pAddressKeyHash :: Parser AddressCmd
     pAddressKeyHash = AddressKeyHash <$> pVerificationKeyFile Input
 
-    pAddressBuildStaking :: Parser AddressCmd
-    pAddressBuildStaking =
-      AddressBuildStaking
+    pAddressBuild :: Parser AddressCmd
+    pAddressBuild =
+      AddressBuild
         <$> pPaymentVerificationKeyFile
-        <*> pStakingVerificationKeyFile
-
-    pAddressBuildEnterprise :: Parser AddressCmd
-    pAddressBuildEnterprise = AddressBuildEnterprise <$> pPaymentVerificationKeyFile
+        <*> Opt.optional pStakingVerificationKeyFile
 
     pAddressBuildMultiSig :: Parser AddressCmd
     pAddressBuildMultiSig = pure AddressBuildMultiSig

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -41,7 +41,7 @@ parseShelleyCommands =
   Opt.subparser $
     mconcat
       [ Opt.command "address"
-          (Opt.info (AddressCmd <$> pAddressCmd) $ Opt.progDesc "Shelley address commands")
+          (Opt.info (AddressCmd <$> pAddressCmd) $ Opt.progDesc "Shelley payment address commands")
       , Opt.command "stake-address"
           (Opt.info (StakeAddressCmd <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
       , Opt.command "transaction"
@@ -97,8 +97,6 @@ pAddressCmd =
           (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key to stdout.")
       , Opt.command "build-staking"
           (Opt.info pAddressBuildStaking $ Opt.progDesc "Build a standard Shelley address (capable of receiving payments and staking).")
-      , Opt.command "build-reward"
-          (Opt.info pAddressBuildReward $ Opt.progDesc "Build a Shelley reward address (special address for recieving staking rewards).")
       , Opt.command "build-enterprise"
           (Opt.info pAddressBuildEnterprise $ Opt.progDesc "Build a Shelley enterprise address (can recieve payments but not able to stake, eg for exchanges).")
       , Opt.command "build-multisig"
@@ -118,10 +116,6 @@ pAddressCmd =
       AddressBuildStaking
         <$> pPaymentVerificationKeyFile
         <*> pStakingVerificationKeyFile
-
-
-    pAddressBuildReward :: Parser AddressCmd
-    pAddressBuildReward = AddressBuildReward <$> pStakingVerificationKeyFile
 
     pAddressBuildEnterprise :: Parser AddressCmd
     pAddressBuildEnterprise = AddressBuildEnterprise <$> pPaymentVerificationKeyFile
@@ -146,7 +140,11 @@ pStakeAddress :: Parser StakeAddressCmd
 pStakeAddress =
   Opt.subparser $
     mconcat
-      [ Opt.command "register"
+      [ Opt.command "key-gen"
+          (Opt.info pStakeAddressKeyGen $ Opt.progDesc "Create a stake address key pair")
+      , Opt.command "build"
+          (Opt.info pStakeAddressBuild $ Opt.progDesc "Build a stake address")
+      , Opt.command "register"
           (Opt.info pStakeAddressRegister $ Opt.progDesc "Register a stake address")
       , Opt.command "delegate"
           (Opt.info pStakeAddressDelegate $ Opt.progDesc "Delegate from a stake address to a stake pool")
@@ -160,6 +158,15 @@ pStakeAddress =
           (Opt.info pStakeAddressDelegationCert $ Opt.progDesc "Create a stake address delegation certificate")
       ]
   where
+    pStakeAddressKeyGen :: Parser StakeAddressCmd
+    pStakeAddressKeyGen = StakeAddressKeyGen
+                            <$> pVerificationKeyFile Output
+                            <*> pSigningKeyFile Output
+
+    pStakeAddressBuild :: Parser StakeAddressCmd
+    pStakeAddressBuild = StakeAddressBuild <$> pStakingVerificationKeyFile
+
+
     pStakeAddressRegister :: Parser StakeAddressCmd
     pStakeAddressRegister = StakeKeyRegister <$> pPrivKeyFile <*> parseNodeAddress
 
@@ -283,9 +290,6 @@ pNodeCmd =
       , Opt.command "issue-op-cert"
           (Opt.info pIssueOpCert $
              Opt.progDesc "Issue a node operational certificate")
-      , Opt.command "key-gen-staking"
-          (Opt.info pStakingKeyPair $
-             Opt.progDesc "Create an address staking key pair")
       , Opt.command "key-gen-stake-pool"
           (Opt.info pStakePoolKeyPair $
              Opt.progDesc "Create a stake pool key pair")
@@ -312,11 +316,6 @@ pNodeCmd =
                       <*> pOperatorCertIssueCounterFile
                       <*> pKesPeriod
                       <*> pOutputFile
-
-    pStakingKeyPair :: Parser NodeCmd
-    pStakingKeyPair = NodeStakingKeyGen
-                        <$> pVerificationKeyFile Output
-                        <*> pSigningKeyFile Output
 
     pStakePoolKeyPair :: Parser NodeCmd
     pStakePoolKeyPair = NodeStakePoolKeyGen

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -30,7 +30,6 @@ runAddressCmd cmd =
     AddressKeyGen vkf skf -> runAddressKeyGen  vkf skf
     AddressKeyHash vkf -> runAddressKeyHash vkf
     AddressBuildStaking payVk stkVk -> runAddressBuildStaking payVk stkVk
-    AddressBuildReward stkVk -> runAddressBuildReward stkVk
     AddressBuildEnterprise payVk -> runAddressBuildEnterprise payVk
     AddressBuildMultiSig {} -> runAddressBuildMultiSig
     AddressInfo txt -> runAddressInfo txt
@@ -58,13 +57,6 @@ runAddressBuildStaking (VerificationKeyFile payVkeyFp) (VerificationKeyFile stkV
     payVKey <- newExceptT $ readPaymentVerificationKey payVkeyFp
     let addr = shelleyVerificationKeyAddress payVKey (Just stkVKey)
     liftIO $ Text.putStrLn $ addressToHex addr
-
-runAddressBuildReward :: VerificationKeyFile -> ExceptT CliError IO ()
-runAddressBuildReward (VerificationKeyFile stkVkeyFp) =
-  firstExceptT CardanoApiError $ do
-    stkVKey <- ExceptT $ readStakingVerificationKey stkVkeyFp
-    let rwdAddr = AddressShelleyReward $ shelleyVerificationKeyRewardAddress stkVKey
-    liftIO . Text.putStrLn $ addressToHex rwdAddr
 
 runAddressBuildEnterprise :: VerificationKeyFile -> ExceptT CliError IO ()
 runAddressBuildEnterprise (VerificationKeyFile payVkeyFp) =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -5,11 +5,7 @@ module Cardano.CLI.Shelley.Run.Node
 import           Cardano.Prelude
 
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
-
-import           Cardano.Api (SigningKey(..), StakingVerificationKey (..), 
-                   writeSigningKey, writeVerificationKeyStakePool,
-                   writeStakingVerificationKey)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 import           Cardano.Config.Shelley.ColdKeys hiding (writeSigningKey)
 import           Cardano.Config.Shelley.KES
@@ -28,7 +24,6 @@ runNodeCmd (NodeKeyGenKES  vk sk)     = runNodeKeyGenKES  vk sk
 runNodeCmd (NodeKeyGenVRF  vk sk)     = runNodeKeyGenVRF  vk sk
 runNodeCmd (NodeIssueOpCert vk sk ctr p out) =
   runNodeIssueOpCert vk sk ctr p out
-runNodeCmd (NodeStakePoolKeyGen vk sk) = runNodeStakePoolKeyGen vk sk
 
 
 --
@@ -102,11 +97,4 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKESPath)
       -- a new cert but without updating the counter.
       writeOperationalCertIssueCounter ocertCtrPath (succ issueNumber)
       writeOperationalCert certFile cert vkey
-
-runNodeStakePoolKeyGen :: VerificationKeyFile -> SigningKeyFile -> ExceptT CliError IO ()
-runNodeStakePoolKeyGen (VerificationKeyFile vkFp) (SigningKeyFile skFp) = do
-  (vkey, skey) <- liftIO genKeyPair
-  firstExceptT CardanoApiError . newExceptT $ writeVerificationKeyStakePool vkFp vkey
-  --TODO: writeSigningKey should really come from Cardano.Config.Shelley.ColdKeys
-  firstExceptT CardanoApiError . newExceptT $ writeSigningKey skFp (SigningKeyShelley skey)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -28,7 +28,6 @@ runNodeCmd (NodeKeyGenKES  vk sk)     = runNodeKeyGenKES  vk sk
 runNodeCmd (NodeKeyGenVRF  vk sk)     = runNodeKeyGenVRF  vk sk
 runNodeCmd (NodeIssueOpCert vk sk ctr p out) =
   runNodeIssueOpCert vk sk ctr p out
-runNodeCmd (NodeStakingKeyGen vk sk) = runNodeStakingKeyGen vk sk
 runNodeCmd (NodeStakePoolKeyGen vk sk) = runNodeStakePoolKeyGen vk sk
 
 
@@ -103,15 +102,6 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKESPath)
       -- a new cert but without updating the counter.
       writeOperationalCertIssueCounter ocertCtrPath (succ issueNumber)
       writeOperationalCert certFile cert vkey
-
-runNodeStakingKeyGen :: VerificationKeyFile -> SigningKeyFile -> ExceptT CliError IO ()
-runNodeStakingKeyGen (VerificationKeyFile vkFp) (SigningKeyFile skFp) = do
-  (vkey, skey) <- liftIO genKeyPair
-  firstExceptT CardanoApiError
-    . newExceptT
-    $ writeStakingVerificationKey vkFp (StakingVerificationKeyShelley vkey)
-  --TODO: writeSigningKey should really come from Cardano.Config.Shelley.ColdKeys
-  firstExceptT CardanoApiError . newExceptT $ writeSigningKey skFp (SigningKeyShelley skey)
 
 runNodeStakePoolKeyGen :: VerificationKeyFile -> SigningKeyFile -> ExceptT CliError IO ()
 runNodeStakePoolKeyGen (VerificationKeyFile vkFp) (SigningKeyFile skFp) = do

--- a/cardano-cli/test/cli/address-build/run
+++ b/cardano-cli/test/cli/address-build/run
@@ -12,7 +12,7 @@ setup_data_dir "${testname}"
 
 error=0
 
-${CARDANO_CLI} shelley address build-staking \
+${CARDANO_CLI} shelley address build \
     --payment-verification-key-file "${DATA_DIR}/payment.vkey" \
     --staking-verification-key-file "${DATA_DIR}/staking.vkey" \
     > "${TEST_DIR}/staking-address.hex"
@@ -21,15 +21,7 @@ fail_on_error $?
 assert_file_exists "${TEST_DIR}/staking-address.hex"
 assert_line_count 1 "${TEST_DIR}/staking-address.hex"
 
-${CARDANO_CLI} shelley address build-reward \
-    --staking-verification-key-file "${DATA_DIR}/staking.vkey" \
-    > "${TEST_DIR}/reward-address.hex"
-fail_on_error $?
-
-assert_file_exists "${TEST_DIR}/reward-address.hex"
-assert_line_count 1 "${TEST_DIR}/reward-address.hex"
-
-${CARDANO_CLI} shelley address build-enterprise \
+${CARDANO_CLI} shelley address build \
     --payment-verification-key-file "${DATA_DIR}/payment.vkey" \
     > "${TEST_DIR}/enterprise-address.hex"
 fail_on_error $?

--- a/cardano-cli/test/cli/stake-address-build/data/staking.vkey
+++ b/cardano-cli/test/cli/stake-address-build/data/staking.vkey
@@ -1,0 +1,4 @@
+type: StakingVerificationKeyShelley
+title: Free form text
+cbor-hex:
+ 18b95820972f8bd32379667540183a0277cf2282f9681368d4a7dc377d5e21cf90804571

--- a/cardano-cli/test/cli/stake-address-build/run
+++ b/cardano-cli/test/cli/stake-address-build/run
@@ -1,0 +1,23 @@
+#!/bin/sh -u
+
+cwd=$(dirname "$0")
+
+# shellcheck source=/dev/null
+. "${cwd}/../core/common"
+
+# shellcheck disable=SC2154
+banner "${testname}"
+
+setup_data_dir "${testname}"
+
+error=0
+
+${CARDANO_CLI} shelley stake-address build \
+    --staking-verification-key-file "${DATA_DIR}/staking.vkey" \
+    > "${TEST_DIR}/reward-address.hex"
+fail_on_error $?
+
+assert_file_exists "${TEST_DIR}/reward-address.hex"
+assert_line_count 1 "${TEST_DIR}/reward-address.hex"
+
+report_result ${error}

--- a/cardano-cli/test/cli/stake-address-key-gen/run
+++ b/cardano-cli/test/cli/stake-address-key-gen/run
@@ -10,7 +10,7 @@ banner "${testname}"
 
 error=0
 
-${CARDANO_CLI} shelley node key-gen-staking \
+${CARDANO_CLI} shelley stake-address key-gen \
     --verification-key-file "${TEST_DIR}/key-gen-staking.vkey" \
     --signing-key-file "${TEST_DIR}/key-gen-staking.skey"
 

--- a/cardano-cli/test/cli/stake-pool-key-gen/run
+++ b/cardano-cli/test/cli/stake-pool-key-gen/run
@@ -10,7 +10,7 @@ banner "${testname}"
 
 error=0
 
-${CARDANO_CLI} shelley node key-gen-stake-pool \
+${CARDANO_CLI} shelley stake-pool key-gen \
     --verification-key-file "${TEST_DIR}/key-gen-stake-pool.vkey" \
     --signing-key-file "${TEST_DIR}/key-gen-stake-pool.skey"
 


### PR DESCRIPTION
This better aligns the CLI names with the Shellley concepts.

Rename:
 * `shelley node key-gen-staking` -> `shelley stake-address key-gen`
 * `shelley address build-reward` -> `shelley stake-address build`
 * `shelley node key-gen-stake-pool` -> `shelley stake-pool key-gen`

The rationale for the first two is that the `stake-address` command is
the command for stake addresses, simple as that.

For the third, the node command covers the node's operational keys and
certificates. The stake-pool command covers the operator's offline key
and registration. These two subcommands could be merged, but that is
the current division between them.

Merge:
 * `shelley address build-staking` -> `shelley address build`
 * `shelley address build-enterprise` -> `shelley address build`

It is simpler this way and more closely matches the concepts. There are
payment addresses, which always have a payment credential, and
optionally they can refer to a stake address that the stake rights will
be delegated to.

So we have one concept of building payment addresses, and a couple
different ways to handle how the associated stake address is handled.

Another reason to keep it as one command is that once we add in script
credentials then we would get a combinatorial explosion of commands, but
when we use flags in the CLI then all the combinations can be expressed
directly using the combinations of independent flags.

So the relevant usage text is now:
```
Usage: cardano-cli shelley address COMMAND
  Shelley payment address commands

Available commands:
  key-gen                  Create a single address key pair.
  key-hash                 Print the hash of an address key to stdout.
  build                    Build a Shelley payment addres, with optional
                           delegation to a stake address.
  build-multisig           Build a Shelley payment multi-sig address.
  info                     Print information about an address.
```
And for `build` specifically now that it is a single command with an optional stake key.
```
Usage: cardano-cli shelley address build --payment-verification-key-file FILEPATH
                                         [--staking-verification-key-file FILEPATH]
  Build a Shelley payment addres, with optional delegation to a stake address.

Available options:
  --payment-verification-key-file FILEPATH
                           Filepath of the payment verification key.
  --staking-verification-key-file FILEPATH
                           Filepath of the staking verification key.
```
```
Usage: cardano-cli shelley stake-address COMMAND
  Shelley stake address commands

Available commands:
  key-gen                  Create a stake address key pair
  build                    Build a stake address
  register                 Register a stake address
  delegate                 Delegate from a stake address to a stake pool
  de-register              De-register a stake address
  registration-certificate Create a stake address registration certificate
  deregistration-certificate
                           Create a stake address deregistration certificate
  delegation-certificate   Create a stake address delegation certificate
```
```
Usage: cardano-cli shelley stake-pool COMMAND
  Shelley stake pool commands

Available commands:
  key-gen                  Create a stake pool operator's offline key pair
  register                 Register a stake pool
  re-register              Re-register a stake pool
  retire                   Retire a stake pool
  registration-certificate Create a stake pool registration certificate
  deregistration-certificate
                           Create a stake pool deregistration certificate
```