### PR TITLE
bump haskell.nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ded93b38ff656d3bf1b90f926bbf0ecea3fab723",
-        "sha256": "12pw3ykv2wp6kj0vj8y499p4khmzyx9r9il15l8p2wr2i7cpjxnc",
+        "rev": "f330b2407ea303e894e7ea208935faf234b8d753",
+        "sha256": "0yymbii6lsm2skj6xq79gznhm4z2fy4hvl6nbffswxadlmnvj6s7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/ded93b38ff656d3bf1b90f926bbf0ecea3fab723.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f330b2407ea303e894e7ea208935faf234b8d753.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
This is so that input-output-hk/haskell.nix#604 is included (macOS 200% cpu utilisation fix) /cc @karknu 