### PR TITLE
Add API and CLI for query for stake (pool) distribution

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -63,6 +63,7 @@ module Cardano.Api
   , renderLocalStateQueryError
   , queryFilteredUTxOFromLocalState
   , queryPParamsFromLocalState
+  , queryStakeDistributionFromLocalState
 
     -- * Node local chain sync related
   , getLocalTip

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.Helpers
   , renderHelpersError
   , serialiseSigningKey
   , validateCBOR
-  , writeProtocolParameters
   ) where
 
 import           Cardano.Prelude
@@ -20,9 +19,7 @@ import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Term (decodeTerm, encodeTerm)
 import           Codec.CBOR.Write (toLazyByteString)
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
-import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as LB
-import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Text as Text
 import           System.Directory (doesPathExist)
 
@@ -31,13 +28,11 @@ import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Chain.Block (fromCBORABlockOrBoundary)
 import qualified Cardano.Chain.UTxO as UTxO
-import           Cardano.CLI.Shelley.Commands (OutputFile(..))
 import           Cardano.Config.Protocol (CardanoEra(..))
 import           Cardano.Config.Types
 import           Cardano.Crypto (SigningKey(..))
 import qualified Cardano.Crypto as Crypto
 
-import           Shelley.Spec.Ledger.PParams (PParams)
 
 data HelpersError
   = CardanoEraNotSupportedFail !CardanoEra
@@ -122,9 +117,3 @@ validateCBOR cborObject bs =
       (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s Update.Vote)
       Right "Valid Byron vote."
 
-writeProtocolParameters :: Maybe OutputFile -> PParams -> ExceptT HelpersError IO ()
-writeProtocolParameters mOutFile pparams =
-  case mOutFile of
-    Nothing -> liftIO $ LBS.putStrLn (encodePretty pparams)
-    Just (OutputFile fpath) ->
-      handleIOExceptT (IOError' fpath) $ LBS.writeFile fpath (encodePretty pparams)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -152,6 +152,7 @@ data QueryCmd
   | QueryProtocolParameters Network (Maybe OutputFile)
   | QueryTip Network
   | QueryFilteredUTxO Address Network (Maybe OutputFile)
+  | QueryStakeDistribution Network (Maybe OutputFile)
   | QueryVersion NodeAddress
   | QueryStatus NodeAddress
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -370,6 +370,8 @@ pQueryCmd =
           (Opt.info pQueryTip $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)")
       , Opt.command "filtered-utxo"
           (Opt.info pQueryFilteredUTxO $ Opt.progDesc "Get the node's current UTxO filtered by address")
+      , Opt.command "stake-distribution"
+          (Opt.info pQueryStakeDistribution $ Opt.progDesc "Get the node's current aggregated stake distribution")
       , Opt.command "version"
           (Opt.info pQueryVersion $ Opt.progDesc "Get the node version")
       , Opt.command "status"
@@ -393,6 +395,12 @@ pQueryCmd =
       QueryFilteredUTxO
         <$> pHexEncodedAddress
         <*> pNetwork
+        <*> pMaybeOutputFile
+
+    pQueryStakeDistribution :: Parser QueryCmd
+    pQueryStakeDistribution =
+      QueryStakeDistribution
+        <$> pNetwork
         <*> pMaybeOutputFile
 
     pQueryVersion :: Parser QueryCmd


### PR DESCRIPTION
Command usage
```
$ cardano-cli shelley query stake-distribution
Usage: cardano-cli shelley query stake-distribution (--mainnet | 
                                                      --testnet-magic INT) 
                                                    [--out-file FILE]
  Get the node's current aggregated stake distribution

Available options:
  --mainnet                Use the mainnet magic id.
  --testnet-magic INT      Specify a testnet magic id.
  --out-file FILE          Optional output file. Default is to write to stdout.
```

Example output
```
$ cardano-cli shelley query stake-distribution --testnet-magic 42
                           PoolId                                 Stake frac
------------------------------------------------------------------------------
617fc52b887838cab1305fe07bafa00d1559464237e6f0a302111088ea4dce3e   1.000e0
```