### PR TITLE
Fix the VRF hash in the pool registration certificates

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -17,7 +17,7 @@ import           Cardano.Api (ApiError(..), ShelleyCoin, ShelleyStakePoolMargin,
                    shelleyRetireStakePool, writeCertificate)
 
 import qualified Shelley.Spec.Ledger.Address as Shelley
-import           Shelley.Spec.Ledger.Keys (hash, hashKey)
+import           Shelley.Spec.Ledger.Keys (hashKey, hashVerKeyVRF)
 import qualified Shelley.Spec.Ledger.Slot as Shelley
 
 import           Cardano.Config.Shelley.ColdKeys
@@ -101,7 +101,7 @@ runStakePoolRegistrationCert
 
     let registrationCert = shelleyRegisterStakePool
                              (hashKey stakePoolVerKey)
-                             (hash vrfVerKey)
+                             (hashVerKeyVRF vrfVerKey)
                              pldg
                              pCost
                              pMrgn


### PR DESCRIPTION
Have to use the special hashVerKeyVRF and not the generic hash.