### PR TITLE
cabal: Replace canonical-json git version with hackage release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,9 +37,6 @@ package byron-spec-chain
 package byron-spec-ledger
   tests: False
 
-package canonical-json
-  tests: False
-
 package cardano-crypto
   tests: False
 
@@ -395,12 +392,6 @@ source-repository-package
   tag: 9a7c676c387b9e196ca391649c5a19adc6b06fc5
   --sha256: 0bnk6z9aldah37qr92bmzhp32dyyd18bapdcrs2qk2w8j7h19kj2
   subdir: Win32-network
-
-source-repository-package
-  type: git
-  location: http://github.com/well-typed/canonical-json
-  tag: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f
-  --sha256: 02fzn1xskis1lc1pkz0j92v6ipd89ww0k2p3dvwpm3yap5dpnm7k
 
 source-repository-package
   type: git

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -63,7 +63,7 @@ library
                      , bytestring
                      , base16-bytestring
                      , base58-bytestring
-                     , canonical-json
+                     , canonical-json >= 0.6 && < 0.7
                      , cardano-api
                      , cardano-binary
                      , cardano-config

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -58,7 +58,7 @@ library
                      , async
                      , base16-bytestring
                      , bytestring
-                     , canonical-json
+                     , canonical-json >= 0.6 && < 0.7
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-wrapper


### PR DESCRIPTION
Replaces a git source repo in cabal.project with version bounds in cabal files.

I _think_ this commit corresponds to version 0.6.0.0 on hackage:

https://github.com/well-typed/canonical-json/commit/ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f

Noticed while looking at input-output-hk/cardano-haskell#16.