### PR TITLE
cabal.project:  enable single-command removal of source-repository-package stanzas

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -103,6 +103,10 @@ package shelley-spec-ledger
 package cardano-ledger
   tests: False
 
+-- The two following one-liners will restore / cut off the remainder of this file (for nix-shell users):
+-- git checkout HEAD "$(git rev-parse --show-toplevel)"/cabal.project
+-- sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project
+-- Please do not put any `source-repository-package` clause above this line.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base

--- a/scripts/cabal-inside-nix-shell.sh
+++ b/scripts/cabal-inside-nix-shell.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project


### PR DESCRIPTION
This makes the Nix-backed Cabal workflow smoother -- step 3 is reduced to a single shell command:

1. have an unmodified `cardano-node` checkout
1. `nix-shell`
1. ~edit `cabal.project`, so that it contains no source-repository-package clauses~
   - now becomes `scripts/cabal-inside-nix-shell.sh`
1. all `cabal` commands work, and use the Nix cache

# Background

The benefits of this workflow are:

1. Compared to regular, Nix-unassisted Cabal workflow:
   - all dependencies are cached
   - the entire dependency environment has passed CI
   - if we start with no `dist-newstyle` local directory, then it is almost certain[1] that if the local target builds locally, then it also builds in CI -- and vice versa.
2. Compared to plain Nix, where we used just `nix-build`:
   - interactivity, as we don't rebuild packages from scratch, and can easily pass options to GHC, etc

Footnotes:
  1. I've chosen to say "almost certain", but in my practice I don't remember a single case where this relationship was violated.