### PR TITLE
Add CLI command to get Pool Id

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,6 +1,12 @@
 # Changelog for cardano-api
 
-## cardano-api 1.12.0
+## 1.11.0 -- April 2020
 
-- Not yet ready for a public release.
-- Significant extensions used internally by the CLI.
+- Initial version of the API package. The package provides client-side
+  functionality for constructing and submiting transactions.
+
+  The API is not yet stable in this release.
+
+- Initial transaction API with Byron support and Shelley stubs (#787)
+- Shelley address key pair generation (#799)
+

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -141,6 +141,7 @@ data PoolCmd
       EpochNo
       -- ^ Epoch in which to retire the stake pool. --TODO: Double check this
       OutputFile
+  | PoolGetId VerificationKeyFile
 
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -351,6 +351,9 @@ pPoolCmd =
           (Opt.info pStakePoolRegistrationCert $ Opt.progDesc "Create a stake pool registration certificate")
       , Opt.command "deregistration-certificate"
           (Opt.info pStakePoolRetirementCert $ Opt.progDesc "Create a stake pool deregistration certificate")
+      , Opt.command "id"
+          (Opt.info pId $
+             Opt.progDesc "Build pool id from the offline key")
       ]
   where
     pPoolRegster :: Parser PoolCmd
@@ -361,6 +364,9 @@ pPoolCmd =
 
     pPoolRetire :: Parser PoolCmd
     pPoolRetire = PoolRetire <$> pPoolId <*> pEpochNo <*> parseNodeAddress
+
+    pId :: Parser PoolCmd
+    pId = PoolGetId <$> pVerificationKeyFile Output
 
 
 pQueryCmd :: Parser QueryCmd


### PR DESCRIPTION
This adds a command cardano-cli shelley node pool-id, that takes the cold
verification key, and produces the stake pool id, by hashing it.

Closes #1018