### PR TITLE
Hedgehog testing of pioneers exercise 1

### DIFF
--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -4,10 +4,9 @@ import           Cardano.Prelude hiding (option)
 
 import           Control.Monad.Trans.Except.Exit (orDie)
 import qualified Options.Applicative as Opt
-import           Options.Applicative (ParserInfo, ParserPrefs, showHelpOnEmpty)
 
-import           Cardano.CLI.Parsers (parseClientCommand)
-import           Cardano.CLI.Run (ClientCommand, renderClientCommandError, runClientCommand)
+import           Cardano.CLI.Parsers (opts, pref)
+import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.Config.TopHandler
 
 
@@ -17,17 +16,3 @@ main = toplevelExceptionHandler $ do
   co <- Opt.customExecParser pref opts
 
   orDie renderClientCommandError $ runClientCommand co
-
-  where
-    pref :: ParserPrefs
-    pref = Opt.prefs showHelpOnEmpty
-
-    opts :: ParserInfo ClientCommand
-    opts =
-      Opt.info (parseClientCommand <**> Opt.helper)
-        ( Opt.fullDesc
-          <> Opt.header
-          "cardano-cli - utility to support a variety of key\
-          \ operations (genesis generation, migration,\
-          \ pretty-printing..) for different system generations."
-        )

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -131,7 +131,6 @@ executable cardano-cli
                      , optparse-applicative
                      , text
                      , transformers-except
-
   default-extensions:  NoImplicitPrelude
 
 test-suite cardano-cli-test
@@ -151,6 +150,34 @@ test-suite cardano-cli-test
                       , text
                       , text-ansi
                       , unix
+
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+test-suite cardano-cli-pioneers
+  hs-source-dirs:       test
+  main-is:              cardano-cli-pioneers.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        base
+                      , cardano-cli
+                      , cardano-prelude
+                      , directory
+                      , hedgehog
+                      , optparse-applicative
+                      , text
+                      , transformers-except
+
+  other-modules:        Test.OptParse
+                        Test.Pioneers.Exercise1
 
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -1,16 +1,31 @@
 module Cardano.CLI.Parsers
-  ( parseClientCommand
+  ( opts
+  , pref
   ) where
 
 import           Cardano.Prelude
 
 import           Options.Applicative
+import qualified Options.Applicative as Opt
 
 import           Cardano.Config.Parsers (command')
 import           Cardano.CLI.Byron.Parsers   (parseByronCommands)
 import           Cardano.CLI.Run (ClientCommand(..))
 import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
 
+
+opts :: ParserInfo ClientCommand
+opts =
+  Opt.info (parseClientCommand <**> Opt.helper)
+    ( Opt.fullDesc
+      <> Opt.header
+      "cardano-cli - utility to support a variety of key\
+      \ operations (genesis generation, migration,\
+      \ pretty-printing..) for different system generations."
+    )
+
+pref :: ParserPrefs
+pref = Opt.prefs showHelpOnEmpty
 
 parseClientCommand :: Parser ClientCommand
 parseClientCommand =

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -40,6 +40,7 @@ data ClientCommand =
 data ClientCommandErrors
   = ByronClientError ByronClientCmdError
   | ShelleyClientError ShelleyClientCmdError
+  deriving Show
   --TODO: We should include an AgnosticClientError
 
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -1,0 +1,101 @@
+module Test.OptParse
+  ( doFilesExist
+  , evalCardanoCLIParser
+  , execCardanoCLIParser
+  , fileCleanup
+  , propertyOnce
+  ) where
+
+import           Cardano.Prelude
+import           Prelude (String)
+
+import           System.IO.Error
+import           Control.Monad.Trans.Except.Extra (runExceptT)
+import qualified Data.Text as Text
+import           Options.Applicative (ParserHelp(..), ParserResult(..))
+import qualified Options.Applicative as Opt
+import           Options.Applicative.Help.Chunk
+import           Options.Applicative.Help.Pretty
+import           System.Directory (doesFileExist, removeFile)
+
+import           Cardano.CLI.Parsers (opts, pref)
+import           Cardano.CLI.Run (ClientCommand(..),
+                   renderClientCommandError, runClientCommand)
+
+import qualified Hedgehog as H
+import           Hedgehog.Internal.Property (failWith)
+
+-- | Purely evalutate the cardano-cli parser.
+-- e.g evalCardanoCLIParser ["shelley"] would be equivalent to cabal exec cardano-cli shelley
+-- without running underlying IO.
+evalCardanoCLIParser :: [String] -> Opt.ParserResult ClientCommand
+evalCardanoCLIParser args = Opt.execParserPure pref opts args
+
+-- | This takes a 'ParserResult', which is pure, and executes it.
+execCardanoCLIParser
+  :: [FilePath]
+  -- ^ Files to clean up on failure
+  -> String
+  -- ^ Name of command, used in error rendering
+  -> Opt.ParserResult ClientCommand
+  -- ^ ParserResult to execute
+  -> H.PropertyT IO ()
+execCardanoCLIParser fps cmdName pureParseResult =
+  case pureParseResult of
+
+    -- The pure 'ParserResult' succeeds and we can then execute the result.
+    -- This would be equivalent to `cabal exec cardano-cli ...`
+    Success cmd -> execClientCommand cmd
+
+    -- The pure `ParserResult` failed and we clean up any created files
+    -- and fail with `optparse-applicative`'s error message
+    Failure failure -> let (parserHelp, _exitCode, cols) = Opt.execFailure failure cmdName
+                           helpMessage = renderHelp cols parserHelp cmdName
+
+                       in liftIO (fileCleanup fps) >> failWith Nothing helpMessage
+
+
+    CompletionInvoked compl -> do msg <- lift $ Opt.execCompletion compl cmdName
+                                  liftIO (fileCleanup fps) >> failWith Nothing msg
+
+
+-- | Executes a `ClientCommand`. If successful the property passes
+-- if not, the property fails and the error is rendered.
+execClientCommand :: ClientCommand -> H.PropertyT IO ()
+execClientCommand cmd = do e <- lift . runExceptT $ runClientCommand cmd
+                           case e of
+                             Left cmdErrors -> failWith Nothing . Text.unpack $ renderClientCommandError cmdErrors
+                             Right _ -> H.success
+
+--------------------------------------------------------------------------------
+-- Error rendering & Clean up
+--------------------------------------------------------------------------------
+
+-- | Checks if all files gives exists. If this fails, all files are deleted.
+doFilesExist :: [FilePath] -> H.PropertyT IO ()
+doFilesExist [] = return ()
+doFilesExist allFiles@(file:rest) = do
+  exists <- liftIO $ doesFileExist file
+  if exists == True
+  then doFilesExist rest
+  else liftIO (fileCleanup allFiles) >> failWith Nothing (file <> " has not been successfully created.")
+
+fileCleanup :: [FilePath] -> IO ()
+fileCleanup fps = mapM_ (\fp -> removeFile fp `catch` fileExists) fps
+ where
+   fileExists e
+     | isDoesNotExistError e = return ()
+     | otherwise = throwIO e
+
+-- These were lifted from opt-parsers-applicative and slightly modified
+
+customHelpText :: Opt.ParserHelp -> Doc
+customHelpText (ParserHelp e s h _ b f) = extractChunk . vsepChunks $ [e, s, h, b, f]
+
+-- | Convert a help text to 'String'.
+renderHelp :: Int -> Opt.ParserHelp -> String -> String
+renderHelp cols pHelp testName =
+  "Failure in: " ++ testName ++ "\n\n" ++ ((`displayS` "") . renderPretty 1.0 cols $ customHelpText pHelp)
+
+propertyOnce :: H.PropertyT IO () -> H.Property
+propertyOnce =  H.withTests 1 . H.property

--- a/cardano-cli/test/Test/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/Test/Pioneers/Exercise1.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Pioneers.Exercise1
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+
+import           Test.OptParse
+
+
+-- | 1. We generate a key pair
+--   2. We check for the existence of the key pair
+--   3. We use the generated verification key to build a shelley payment address.
+prop_buildShelleyPaymentAddress :: Property
+prop_buildShelleyPaymentAddress =
+  propertyOnce $ do
+
+    -- Key filepaths
+    let verKey = "payment-verification-key-file"
+        signKey = "payment-signing-key-file"
+        allFiles = [verKey, signKey]
+
+    -- Generate payment verification key
+    execCardanoCLIParser
+      allFiles
+      "prop_buildShelleyPaymentAddress.payment_keypair_gen"
+        $ evalCardanoCLIParser [ "shelley","address","key-gen"
+                               , "--verification-key-file", verKey
+                               , "--signing-key-file", signKey
+                               ]
+
+    doFilesExist [verKey, signKey]
+
+    -- Build shelley payment address
+    execCardanoCLIParser
+      allFiles
+      "prop_buildShelleyPaymentAddress.build_payment_address"
+        $ evalCardanoCLIParser [ "shelley", "address", "build"
+                               , "--payment-verification-key-file", verKey
+                               ]
+
+    liftIO $ fileCleanup [verKey, signKey]
+    H.success
+
+
+
+-- | 1. We generate a key payment pair
+--   2. We generate a staking key pair
+--   2. We check for the existence of the key pairs
+--   3. We use the payment verification key & staking verification key
+--      to build a shelley stake address.
+prop_buildShelleyStakeAddress :: Property
+prop_buildShelleyStakeAddress =
+  propertyOnce $ do
+
+    -- Key filepaths
+    let stakeVerKey = "stake-verification-key-file"
+        stakeSignKey = "stake-signing-key-file"
+        paymentVerKey = "payment-verification-key-file"
+        paymentSignKey = "payment-signing-key-file"
+        allFiles = [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
+
+    -- Generate stake verification key
+    execCardanoCLIParser
+      allFiles
+      "prop_buildShelleyStakeAddress.payment_keypair__gen"
+        $ evalCardanoCLIParser [ "shelley","address","key-gen"
+                               , "--verification-key-file", paymentVerKey
+                               , "--signing-key-file", paymentSignKey
+                               ]
+    -- Generate payment verification key
+    execCardanoCLIParser
+      allFiles
+      "prop_buildShelleyStakeAddress.stake_keypair_gen"
+        $ evalCardanoCLIParser [ "shelley","stake-address","key-gen"
+                               , "--verification-key-file", stakeVerKey
+                               , "--signing-key-file", stakeSignKey
+                               ]
+
+    doFilesExist allFiles
+
+    -- Build shelley stake address
+    execCardanoCLIParser
+      allFiles
+      "prop_buildShelleyStakeAddress.build_staking_address"
+        $ evalCardanoCLIParser [ "shelley", "address", "build"
+                               , "--payment-verification-key-file", paymentVerKey
+                               , "--stake-verification-key-file", stakeVerKey
+                               ]
+
+    liftIO $ fileCleanup allFiles
+    H.success
+
+-- -----------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  H.checkSequential
+    $ H.Group "Pioneers Example 1"
+        [ ("prop_buildShelleyPaymentAddress", prop_buildShelleyPaymentAddress)
+        , ("prop_buildShelleyStakeAddress", prop_buildShelleyStakeAddress)
+        ]

--- a/cardano-cli/test/cardano-cli-pioneers.hs
+++ b/cardano-cli/test/cardano-cli-pioneers.hs
@@ -1,0 +1,17 @@
+
+import           Cardano.Prelude
+
+import           Hedgehog.Main (defaultMain)
+import           System.IO (BufferMode (..))
+import qualified System.IO as IO
+
+import qualified Test.Pioneers.Exercise1
+
+main :: IO ()
+main = do
+  IO.hSetBuffering IO.stdout LineBuffering
+  IO.hSetBuffering IO.stderr LineBuffering
+
+  defaultMain [ Test.Pioneers.Exercise1.tests
+
+              ]


### PR DESCRIPTION
Tests the building of payment and stake addresses as described in [pioneers exercise 1](https://github.com/input-output-hk/cardano-tutorials/blob/master/pioneers-testnet/pioneers-exercise-1.md). The test failures leverage `optparse-applicative` errors.