### PR TITLE
CAD-1132 trace sum of tx sizes as estimator for block size

### DIFF
--- a/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
@@ -40,6 +40,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool.API
                    (GenTx, GenTxId, HasTxId, TraceEventMempool (..), ApplyTxErr,
                    MempoolSize(..), TxId, txId)
+import           Ouroboros.Consensus.Node.Run (RunNode(..))
 import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
@@ -217,7 +218,9 @@ showT = pack . show
 
 instance ( Condense (HeaderHash blk)
          , HasTxId tx
+         , tx ~ GenTx blk
          , LedgerSupportsProtocol blk
+         , RunNode blk
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (OtherHeaderEnvelopeError blk)
@@ -743,7 +746,9 @@ instance ToObject MempoolSize where
 
 instance ( Condense (HeaderHash blk)
          , HasTxId tx
+         , tx ~ GenTx blk
          , LedgerSupportsProtocol blk
+         , RunNode blk
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (OtherHeaderEnvelopeError blk)
@@ -754,6 +759,7 @@ instance ( Condense (HeaderHash blk)
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "block hash" .=  (condense $ blockHash blk)
+      , "sum tx sizes" .= toJSON (foldl' (\acc tx -> acc + nodeTxInBlockSize tx) 0 txs)
       , "tx ids" .= toJSON (map (show . txId) txs)
       ]
   toObject _verb (TraceAdoptedBlock slotNo blk _txs) =

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -46,10 +46,10 @@ import           Cardano.BM.Data.Transformers
 
 import           Ouroboros.Consensus.Block (Header, realPointSlot)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), TraceBlockchainTimeEvent (..))
-import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Mempool.API
                    (GenTx, MempoolSize (..), TraceEventMempool (..))
+import           Ouroboros.Consensus.Node.Run (RunNode(..))
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
@@ -245,7 +245,7 @@ mkTracers
   :: forall peer localPeer blk.
      ( LedgerSupportsProtocol blk
      , TraceConstraints blk
-     , ShowQuery (Query blk)
+     , RunNode blk
      , Show peer, Eq peer
      , Show localPeer
      )


### PR DESCRIPTION
our need is to add the block's size to this message since we relate many metrics in the benchmarking to effective block size. Currently, the block's size is not traced. So the sum of the sizes of all transactions in a block seems to be a good estimator of the block's size.
