### PR TITLE
CAD-1132 trace block size in AdoptedBlock event

### DIFF
--- a/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
@@ -22,14 +22,14 @@ import           Cardano.TracingOrphanInstances.Common
 import           Cardano.TracingOrphanInstances.Network (showTip, showPoint)
 
 import           Ouroboros.Consensus.Block
-                   (BlockProtocol, Header, headerPoint,
+                   (BlockProtocol, Header, getHeader, headerPoint,
                     RealPoint, realPointSlot, realPointHash)
 import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
                    (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                    (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
-                   (TraceChainSyncServerEvent(..))
+                   (TraceChainSyncServerEvent (..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                    (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.HeaderValidation
@@ -40,6 +40,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool.API
                    (GenTx, GenTxId, HasTxId, TraceEventMempool (..), ApplyTxErr,
                    MempoolSize(..), TxId, txId)
+import           Ouroboros.Consensus.Node.Run (RunNode (..))
 import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
@@ -217,7 +218,7 @@ showT = pack . show
 
 instance ( Condense (HeaderHash blk)
          , HasTxId tx
-         , LedgerSupportsProtocol blk
+         , RunNode blk
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (OtherHeaderEnvelopeError blk)
@@ -744,7 +745,7 @@ instance ToObject MempoolSize where
 
 instance ( Condense (HeaderHash blk)
          , HasTxId tx
-         , LedgerSupportsProtocol blk
+         , RunNode blk
          , Show (TxId tx)
          , ToObject (LedgerError blk)
          , ToObject (OtherHeaderEnvelopeError blk)
@@ -755,6 +756,7 @@ instance ( Condense (HeaderHash blk)
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "block hash" .=  (condense $ blockHash blk)
+      , "block size" .= toJSON (nodeBlockFetchSize (getHeader blk))
       , "tx ids" .= toJSON (map (show . txId) txs)
       ]
   toObject _verb (TraceAdoptedBlock slotNo blk _txs) =
@@ -762,6 +764,7 @@ instance ( Condense (HeaderHash blk)
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "block hash" .=  (condense $ blockHash blk)
+      , "block size" .= toJSON (nodeBlockFetchSize (getHeader blk))
       ]
   toObject _verb (TraceBlockFromFuture currentSlot tip) =
     mkObject

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -46,10 +46,10 @@ import           Cardano.BM.Data.Transformers
 
 import           Ouroboros.Consensus.Block (Header, realPointSlot)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), TraceBlockchainTimeEvent (..))
-import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Mempool.API
                    (GenTx, MempoolSize (..), TraceEventMempool (..))
+import qualified Ouroboros.Consensus.Node.Run as Consensus (RunNode)
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
@@ -243,9 +243,8 @@ initialBlockchainCounters = BlockchainCounters 0 0 0 0 0
 --
 mkTracers
   :: forall peer localPeer blk.
-     ( LedgerSupportsProtocol blk
+     ( Consensus.RunNode blk
      , TraceConstraints blk
-     , ShowQuery (Query blk)
      , Show peer, Eq peer
      , Show localPeer
      )


### PR DESCRIPTION
added the block's size in the traced event AdoptedBlock.
this simplifies analysis of benchmarking results.
the size is available from the block's header. Thanks @mrBliss  for pointing this out!