### PR TITLE
Refactor Cardano.Tracing.Tracers

### DIFF
--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -55,7 +55,6 @@ import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 
-
 -- | Perform an action that expects ProtocolInfo for Byron/PBFT,
 --   with attendant configuration.
 withRealPBFT

--- a/cardano-config/src/Cardano/Config/TraceConfig.hs
+++ b/cardano-config/src/Cardano/Config/TraceConfig.hs
@@ -2,53 +2,11 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-{-# OPTIONS_GHC -Wno-partial-fields #-}
-
 module Cardano.Config.TraceConfig
-  (
-    TraceConfig
-  , traceConfigEnabled
-  , traceConfigVerbosity
-  , traceConfigMute
+  ( TraceOptions (..)
+  , TraceSelection (..)
   , traceConfigParser
-
-  , TraceId
-  , traceEnabled
-
-  -- Per-trace toggles, alpha-sorted.
-  -- Note, the TraceConfig' type itself MUST not be exported.
-  -- The explanation is provided at its declaration site.
-  , traceAcceptPolicy
-  , traceBlockFetchClient
-  , traceBlockFetchDecisions
-  , traceBlockFetchProtocol
-  , traceBlockFetchProtocolSerialised
-  , traceBlockFetchServer
-  , traceChainDB
-  , traceChainSyncClient
-  , traceChainSyncBlockServer
-  , traceChainSyncHeaderServer
-  , traceChainSyncProtocol
-  , traceDnsResolver
-  , traceDnsSubscription
-  , traceErrorPolicy
-  , traceForge
-  , traceForgeState
-  , traceHandshake
-  , traceIpSubscription
-  , traceLocalChainSyncProtocol
-  , traceLocalErrorPolicy
-  , traceLocalHandshake
-  , traceLocalTxSubmissionProtocol
-  , traceLocalTxSubmissionServer
-  , traceLocalStateQueryProtocol
-  , traceMempool
-  , traceMux
-  , traceTxInbound
-  , traceTxOutbound
-  , traceTxSubmissionProtocol
-  )
-where
+  ) where
 
 import           Prelude (Show(..))
 import           Cardano.Prelude hiding (show)
@@ -61,37 +19,13 @@ import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import           Cardano.Config.Orphanage ()
 
 
-newtype TraceConfig = TraceConfig TraceConfig'
+data TraceOptions
+  = TracingOff
+  | TracingOn TraceSelection
+  deriving Show
 
-instance Show TraceConfig where
-  show (TraceConfig tr) = show tr
-
-type TraceId = TraceConfig' -> Bool
-
--- | Tracing configuration -- either disabled completely,
---   or carries verbosity + fine-grained toggles.
---
---   Note, how this type has exported partial accessors,
---   but also, how these cannot be used outside the module,
---   because this type itself is not exported.
---   This, therefore confines the partiality to the module.
---
---   The tradeoff, is that instead of exporting accessors as tags,
---   we'd need to declare an ADT to enumerate the tracers,
---   and that enumeration would also have had to be maintained
---   -- thereby severely reducing benefits of totalisation.
---
---   Finally -- this type must not be exported.
---   If it is not clear why, please re-read the above.
-data TraceConfig'
-
-  -- | Intended to mirror Configuration with TurnOnLogging: False.
-  = TracingDisabled
-
-  -- | Detailed tracing options.  Except for verbosity, eaach option controls
-  --   a particular tracer.
-  | TraceOptions
-  -- Common part.
+data TraceSelection
+  = TraceSelection
   { traceVerbosity :: !TracingVerbosity
 
   -- Per-trace toggles, alpha-sorted.
@@ -126,58 +60,38 @@ data TraceConfig'
   , traceTxSubmissionProtocol :: !Bool
   } deriving (Eq, Show)
 
-traceConfigMute :: TraceConfig
-traceConfigMute = TraceConfig TracingDisabled
 
-traceConfigParser :: Object -> Parser TraceConfig
+traceConfigParser :: Object -> Parser TraceOptions
 traceConfigParser v =
-  fmap TraceConfig $
-   TraceOptions
-     <$> v .:? "TracingVerbosity" .!= NormalVerbosity
-     -- Per-trace toggles, alpha-sorted.
-     <*> v .:? "TraceAcceptPolicy" .!= False
-     <*> v .:? "TraceBlockFetchClient" .!= False
-     <*> v .:? "TraceBlockFetchDecisions" .!= True
-     <*> v .:? "TraceBlockFetchProtocol" .!= False
-     <*> v .:? "TraceBlockFetchProtocolSerialised" .!= False
-     <*> v .:? "TraceBlockFetchServer" .!= False
-     <*> v .:? "TraceChainDb" .!= True
-     <*> v .:? "TraceChainSyncClient" .!= True
-     <*> v .:? "TraceChainSyncBlockServer" .!= False
-     <*> v .:? "TraceChainSyncHeaderServer" .!= False
-     <*> v .:? "TraceChainSyncProtocol" .!= False
-     <*> v .:? "TraceDNSResolver" .!= False
-     <*> v .:? "TraceDNSSubscription" .!= True
-     <*> v .:? "TraceErrorPolicy" .!= True
-     <*> v .:? "TraceForge" .!= True
-     <*> v .:? "TraceForgeState" .!= True
-     <*> v .:? "TraceHandshake" .!= False
-     <*> v .:? "TraceIpSubscription" .!= True
-     <*> v .:? "TraceLocalChainSyncProtocol" .!= False
-     <*> v .:? "TraceLocalErrorPolicy" .!= True
-     <*> v .:? "TraceLocalHandshake" .!= False
-     <*> v .:? "TraceLocalTxSubmissionProtocol" .!= False
-     <*> v .:? "TraceLocalTxSubmissionServer" .!= False
-     <*> v .:? "TraceLocalStateQueryProtocol" .!= False
-     <*> v .:? "TraceMempool" .!= True
-     <*> v .:? "TraceMux" .!= True
-     <*> v .:? "TraceTxInbound" .!= False
-     <*> v .:? "TraceTxOutbound" .!= False
-     <*> v .:? "TraceTxSubmissionProtocol" .!= False
-
--- | Is tracing enabled at all?
-traceConfigEnabled :: TraceConfig -> Bool
-traceConfigEnabled = \case
-  TraceConfig TracingDisabled -> False
-  TraceConfig TraceOptions{} -> True
-
--- | Is a particular trace enabled in the config?
-traceEnabled :: TraceConfig -> TraceId -> Bool
-traceEnabled (TraceConfig TracingDisabled) _ = False
-traceEnabled (TraceConfig topts@TraceOptions{}) proj = proj topts
-{-# INLINE traceEnabled #-}
-
-traceConfigVerbosity :: TraceConfig -> TracingVerbosity
-traceConfigVerbosity = \case
-  TraceConfig TracingDisabled -> MinimalVerbosity
-  TraceConfig TraceOptions{traceVerbosity} -> traceVerbosity
+  TracingOn <$> (TraceSelection
+    <$> v .:? "TracingVerbosity" .!= NormalVerbosity
+    -- Per-trace toggles, alpha-sorted.
+    <*> v .:? "TraceAcceptPolicy" .!= False
+    <*> v .:? "TraceBlockFetchClient" .!= False
+    <*> v .:? "TraceBlockFetchDecisions" .!= True
+    <*> v .:? "TraceBlockFetchProtocol" .!= False
+    <*> v .:? "TraceBlockFetchProtocolSerialised" .!= False
+    <*> v .:? "TraceBlockFetchServer" .!= False
+    <*> v .:? "TraceChainDb" .!= True
+    <*> v .:? "TraceChainSyncClient" .!= True
+    <*> v .:? "TraceChainSyncBlockServer" .!= False
+    <*> v .:? "TraceChainSyncHeaderServer" .!= False
+    <*> v .:? "TraceChainSyncProtocol" .!= False
+    <*> v .:? "TraceDNSResolver" .!= False
+    <*> v .:? "TraceDNSSubscription" .!= True
+    <*> v .:? "TraceErrorPolicy" .!= True
+    <*> v .:? "TraceForge" .!= True
+    <*> v .:? "TraceForgeState" .!= True
+    <*> v .:? "TraceHandshake" .!= False
+    <*> v .:? "TraceIpSubscription" .!= True
+    <*> v .:? "TraceLocalChainSyncProtocol" .!= False
+    <*> v .:? "TraceLocalErrorPolicy" .!= True
+    <*> v .:? "TraceLocalHandshake" .!= False
+    <*> v .:? "TraceLocalTxSubmissionProtocol" .!= False
+    <*> v .:? "TraceLocalTxSubmissionServer" .!= False
+    <*> v .:? "TraceLocalStateQueryProtocol" .!= False
+    <*> v .:? "TraceMempool" .!= True
+    <*> v .:? "TraceMux" .!= True
+    <*> v .:? "TraceTxInbound" .!= False
+    <*> v .:? "TraceTxOutbound" .!= False
+    <*> v .:? "TraceTxSubmissionProtocol" .!= False)

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -206,7 +206,7 @@ data NodeConfiguration =
     , ncLoggingSwitch :: Bool
     , ncLogMetrics :: Bool
     , ncSocketPath :: Maybe SocketPath
-    , ncTraceConfig :: TraceConfig
+    , ncTraceConfig :: TraceOptions
     , ncViewMode :: ViewMode
     , ncUpdate :: Update
     } deriving Show
@@ -233,7 +233,7 @@ instance FromJSON NodeConfiguration where
                 loggingSwitch <- v .:? "TurnOnLogging" .!= True
                 logMetrics <- v .:? "TurnOnLogMetrics" .!= True
                 traceConfig <- if not loggingSwitch
-                               then pure traceConfigMute
+                               then return TracingOff
                                else traceConfigParser v
 
                 pure $ NodeConfiguration
@@ -411,21 +411,21 @@ instance HasTxMaxSize (ExtLedgerState (SimpleBlock a b)) where
 --
 -- When you need a 'Show' or 'Condense' instance for more types, just add the
 -- appropriate constraint here. There's no need to modify the consensus
--- code-base, unless the corresponding instance is missing.
+-- code-base, unless the corresponding instance is missing. Note we are aiming to
+-- remove all `Condense` constaints by defining the relevant 'ToObject' instance
+-- in 'cardano-node'
 type TraceConstraints blk =
     ( Condense blk
     , Condense [blk]
     , Condense (Header blk)
     , Condense (HeaderHash blk)
     , Condense (GenTx blk)
-    , Condense (TxId (GenTx blk))
     , HasTxs blk
     , HasTxId (GenTx blk)
     , Show (ApplyTxErr blk)
     , Show (GenTx blk)
     , Show (GenTxId blk)
     , Show blk
-    , Show (Header blk)
     , Show (TxId (GenTx blk))
     , ToJSON   (TxId (GenTx blk))
     , ToObject (ApplyTxErr blk)

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -420,6 +420,7 @@ type TraceConstraints blk =
     , Condense (Header blk)
     , Condense (HeaderHash blk)
     , Condense (GenTx blk)
+    , Condense (TxId (GenTx blk))
     , HasTxs blk
     , HasTxId (GenTx blk)
     , Show (ApplyTxErr blk)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -34,7 +34,7 @@ import qualified Data.Text as Text
 import           Network.Mux (MuxTrace, WithMuxBearer)
 import qualified Network.Socket as Socket (SockAddr)
 
-import           Cardano.Slotting.Slot (EpochNo)
+import           Cardano.Slotting.Slot (EpochNo (..))
 
 import           Cardano.BM.Data.Aggregated (Measurable (..))
 import           Cardano.BM.Data.LogItem (LOContent (..), LoggerName,
@@ -354,7 +354,7 @@ teeTraceChainTipElide
 teeTraceChainTipElide = elideToLogObject
 
 traceChainInformation :: Trace IO Text -> ChainInformation -> IO ()
-traceChainInformation tr ChainInformation { slots, blocks, density } = do
+traceChainInformation tr ChainInformation { slots, blocks, density, epoch, slotInEpoch } = do
   -- TODO this is executed each time the chain changes. How cheap is it?
   meta <- mkLOMeta Critical Confidential
   let tr' = appendName "metrics" tr
@@ -366,10 +366,8 @@ traceChainInformation tr ChainInformation { slots, blocks, density } = do
   traceD "density"     (fromRational density)
   traceI "slotNum"     slots
   traceI "blockNum"    blocks
-  traceI "slotInEpoch" (slots `rem` epochSlots)
-  traceI "epoch"       (slots `div` epochSlots)
- where
-   epochSlots :: Word64 = 21600  -- TODO
+  traceI "slotInEpoch" slotInEpoch
+  traceI "epoch"       (unEpochNo epoch)
 
 teeTraceChainTip'
   :: HasHeader (Header blk)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -15,7 +15,7 @@ module Cardano.Tracing.Tracers
   ( BlockchainCounters
   , Tracers (..)
   , TraceConstraints
-  , TraceConfig
+  , TraceOptions
   , initialBlockchainCounters
   , mkTracers
   , nullTracers
@@ -28,9 +28,9 @@ import           GHC.Clock (getMonotonicTimeNSec)
 import           Control.Tracer
 
 import           Codec.CBOR.Read (DeserialiseFailure)
-import           Data.Functor.Contravariant (contramap)
+import           Data.Aeson (ToJSON)
 import           Data.IORef (IORef, atomicModifyIORef', readIORef)
-import           Data.Text (Text, pack)
+import qualified Data.Text as Text
 import           Network.Mux (MuxTrace, WithMuxBearer)
 import qualified Network.Socket as Socket (SockAddr)
 
@@ -46,20 +46,25 @@ import           Cardano.BM.Trace (traceNamedObject, appendName)
 import           Cardano.BM.Data.Tracer (WithSeverity (..), annotateSeverity)
 import           Cardano.BM.Data.Transformers
 
-import           Ouroboros.Consensus.Block (ForgeState, Header, realPointSlot)
+import           Ouroboros.Consensus.Block (BlockProtocol, Header, realPointSlot)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), TraceBlockchainTimeEvent (..))
-import           Ouroboros.Consensus.Mempool.API
-                   (MempoolSize (..), TraceEventMempool (..))
+import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
+import           Ouroboros.Consensus.Ledger.Abstract (LedgerErr, LedgerState)
+import           Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Mempool.API (MempoolSize (..), TraceEventMempool (..))
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx, GenTxId, TxId)
 import qualified Ouroboros.Consensus.Node.Run as Consensus (RunNode)
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
+import           Ouroboros.Consensus.Protocol.Abstract (CannotLead, ValidationErr)
+import           Ouroboros.Consensus.Util.Condense (Condense) -- This should be removed
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Point, BlockNo(..), HasHeader(..),
-                                          StandardHash, blockNo, pointSlot,
-                                          unBlockNo, unSlotNo)
+                                          HeaderHash, StandardHash, blockNo,
+                                          pointSlot, unBlockNo, unSlotNo)
 import           Ouroboros.Network.BlockFetch.Decision (FetchDecision, FetchDecline (..))
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
@@ -83,6 +88,7 @@ data Tracers peer localPeer blk = Tracers
   , consensusTracers :: Consensus.Tracers IO peer localPeer blk
     -- | Tracers for the node-to-node protocols.
   , nodeToNodeTracers :: NodeToNode.Tracers IO peer blk DeserialiseFailure
+    --, serialisedBlockTracer :: NodeToNode.SerialisedTracer IO peer blk (SerialisedBlockTrace)
     -- | Tracers for the node-to-client protocols
   , nodeToClientTracers :: NodeToClient.Tracers IO localPeer blk DeserialiseFailure
     -- | Trace the IP subscription manager
@@ -249,13 +255,12 @@ mkTracers
      , TraceConstraints blk
      , Show peer, Eq peer
      , Show localPeer
-     , Transformable Text IO (ForgeState blk)
      )
-  => TraceConfig
+  => TraceOptions
   -> Trace IO Text
   -> IORef BlockchainCounters
   -> IO (Tracers peer localPeer blk)
-mkTracers traceConf tracer bcCounters = do
+mkTracers traceConf' tracer bcCounters = do
   -- We probably don't want to pay the extra IO cost per-counter-increment. -- sk
   staticMetaCC <- mkLOMeta Critical Confidential
   let name :: LoggerName = "metrics.Forge"
@@ -275,419 +280,481 @@ mkTracers traceConf tracer bcCounters = do
 
   -- prepare |Outcome|
   blockForgeOutcomeExtractor <- mkOutcomeExtractor
-
   elidedChainDB <- newstate  -- for eliding messages in ChainDB tracer
   elidedFetchDecision <- newstate  -- for eliding messages in FetchDecision tracer
 
-  pure Tracers
-    { chainDBTracer
-        = tracerOnOff traceConf traceChainDB
-          $ annotateSeverity
-          $ teeTraceChainTip tracingVerbosity elidedChainDB
-          $ appendName "ChainDB"
-          $ tracer
-    , consensusTracers
-        = mkConsensusTracers elidedFetchDecision blockForgeOutcomeExtractor forgeTracers
-    , nodeToClientTracers
-    , nodeToNodeTracers
-    , ipSubscriptionTracer
-        = tracerOnOff traceConf traceIpSubscription
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "IpSubscription" tracer
-    , dnsSubscriptionTracer
-        = tracerOnOff traceConf traceDnsSubscription
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "DnsSubscription" tracer
-    , dnsResolverTracer
-        = tracerOnOff traceConf traceDnsResolver
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "DnsResolver" tracer
-    , errorPolicyTracer
-        = tracerOnOff traceConf traceErrorPolicy
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "ErrorPolicy" tracer
-    , localErrorPolicyTracer
-        = tracerOnOff traceConf traceLocalErrorPolicy
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "LocalErrorPolicy" tracer
-    , acceptPolicyTracer
-        = tracerOnOff traceConf traceAcceptPolicy
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "AcceptPolicy" tracer
-    , muxTracer
-        = tracerOnOff traceConf traceMux
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "Mux" tracer
-    , handshakeTracer
-        = tracerOnOff traceConf traceHandshake
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "Handshake" tracer
-    , localHandshakeTracer
-        = tracerOnOff traceConf traceLocalHandshake
-          $ annotateSeverity
-          $ toLogObject' tracingVerbosity
-          $ appendName "LocalHandshake" tracer
+  case traceConf' of
+    TracingOn traceConf ->
+      pure Tracers
+        { chainDBTracer
+            = annotateSeverity . teeTraceChainTip traceConf' bcCounters elidedChainDB $ appendName "ChainDB" tracer
+        , consensusTracers
+            = mkConsensusTracers' elidedFetchDecision blockForgeOutcomeExtractor forgeTracers tracer (TracingOn traceConf) bcCounters
+        , nodeToClientTracers = nodeToClientTracers' (TracingOn traceConf) tracer
+        , nodeToNodeTracers = nodeToNodeTracers' (TracingOn traceConf) tracer
+        , ipSubscriptionTracer = tracerOnOff (traceIpSubscription traceConf) "IpSubscription" tracer
+        , dnsSubscriptionTracer=  tracerOnOff (traceDnsSubscription traceConf) "DnsSubscription" tracer
+        , dnsResolverTracer = tracerOnOff (traceDnsResolver traceConf) "DnsResolver" tracer
+        , errorPolicyTracer = tracerOnOff (traceErrorPolicy traceConf) "ErrorPolicy" tracer
+        , localErrorPolicyTracer = tracerOnOff (traceLocalErrorPolicy traceConf) "LocalErrorPolicy" tracer
+        , acceptPolicyTracer = tracerOnOff (traceAcceptPolicy traceConf) "AcceptPolicy" tracer
+        , muxTracer = tracerOnOff (traceMux traceConf) "Mux" tracer
+        , handshakeTracer = tracerOnOff (traceHandshake traceConf) "Handshake" tracer
+        , localHandshakeTracer = tracerOnOff (traceLocalHandshake traceConf) "LocalHandshake" tracer
+        }
+    TracingOff ->
+      pure Tracers
+        { chainDBTracer = nullTracer
+        , consensusTracers = mkConsensusTracers' elidedFetchDecision blockForgeOutcomeExtractor forgeTracers nullTracer TracingOff  bcCounters
+        , nodeToClientTracers = nodeToClientTracers' TracingOff nullTracer
+        , nodeToNodeTracers = nodeToNodeTracers' TracingOff nullTracer
+        , ipSubscriptionTracer = nullTracer
+        , dnsSubscriptionTracer= nullTracer
+        , dnsResolverTracer = nullTracer
+        , errorPolicyTracer = nullTracer
+        , localErrorPolicyTracer = nullTracer
+        , acceptPolicyTracer = nullTracer
+        , muxTracer = nullTracer
+        , handshakeTracer = nullTracer
+        , localHandshakeTracer = nullTracer
+        }
+
+--------------------------------------------------------------------------------
+-- Chain DB Tracers
+--------------------------------------------------------------------------------
+
+teeTraceChainTip
+  :: ( Condense (HeaderHash blk)
+     , LedgerSupportsProtocol blk
+     , ToObject (Header blk)
+     )
+  => TraceOptions
+  -> IORef BlockchainCounters
+  -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
+  -> Trace IO Text
+  -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
+teeTraceChainTip tconf bChainCounters elided tr =
+  case tconf of
+    TracingOff -> nullTracer
+    TracingOn tSelect ->
+      Tracer $ \ev -> do
+       traceWith (teeTraceChainTip' tr) ev
+       traceWith (notifyForkIsCreated bChainCounters tr) ev
+       traceWith (teeTraceChainTipElide (traceVerbosity tSelect) elided tr) ev
+
+teeTraceChainTipElide
+  :: ( Condense (HeaderHash blk)
+     , LedgerSupportsProtocol blk
+     , ToObject (Header blk)
+     )
+  => TracingVerbosity
+  -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
+  -> Trace IO Text
+  -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
+teeTraceChainTipElide = elideToLogObject
+
+traceChainInformation :: Trace IO Text -> ChainInformation -> IO ()
+traceChainInformation tr ChainInformation { slots, blocks, density } = do
+  -- TODO this is executed each time the chain changes. How cheap is it?
+  meta <- mkLOMeta Critical Confidential
+  let tr' = appendName "metrics" tr
+      traceD :: Text -> Double -> IO ()
+      traceD msg d = traceNamedObject tr' (meta, LogValue msg (PureD d))
+      traceI :: Integral a => Text -> a -> IO ()
+      traceI msg i = traceNamedObject tr' (meta, LogValue msg (PureI (fromIntegral i)))
+
+  traceD "density"     (fromRational density)
+  traceI "slotNum"     slots
+  traceI "blockNum"    blocks
+  traceI "slotInEpoch" (slots `rem` epochSlots)
+  traceI "epoch"       (slots `div` epochSlots)
+ where
+   epochSlots :: Word64 = 21600  -- TODO
+
+teeTraceChainTip'
+  :: HasHeader (Header blk)
+  => Trace IO Text -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
+teeTraceChainTip' tr =
+    Tracer $ \(WithSeverity _ ev') ->
+      case ev' of
+          (ChainDB.TraceAddBlockEvent ev) -> case ev of
+            ChainDB.SwitchedToAFork     newTipInfo _ newChain ->
+              traceChainInformation tr (chainInformation newTipInfo newChain)
+            ChainDB.AddedToCurrentChain newTipInfo _ newChain ->
+              traceChainInformation tr (chainInformation newTipInfo newChain)
+            _ -> pure ()
+          _ -> pure ()
+
+notifyForkIsCreated
+  :: IORef BlockchainCounters
+  -> Trace IO Text
+  -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
+notifyForkIsCreated bcCounters tr =
+    Tracer $ \(WithSeverity _ ev') ->
+      case ev' of
+          ChainDB.TraceAddBlockEvent ev -> case ev of
+              ChainDB.SwitchedToAFork {} -> do
+                  updatesForksCreated <- atomicModifyIORef' bcCounters (\cnts -> let nc = bcForksCreatedNum cnts + 1
+                                                                                 in (cnts { bcForksCreatedNum = nc }, nc)
+                                                                       )
+                  traceCounter "forksCreatedNum" updatesForksCreated tr
+              _ -> pure ()
+          _ -> pure ()
+
+--------------------------------------------------------------------------------
+-- Consensus Tracers
+--------------------------------------------------------------------------------
+
+mkConsensusTracers'
+  :: ( Condense (HeaderHash blk) -- to remove
+     , Show peer
+     , Eq peer
+     , ToJSON (GenTxId blk)
+     , ToObject (ApplyTxErr blk)
+     , ToObject (CannotLead (BlockProtocol blk))
+     , ToObject (GenTx blk)
+     , ToObject (LedgerErr (LedgerState blk))
+     , ToObject (OtherHeaderEnvelopeError blk)
+     , ToObject (ValidationErr (BlockProtocol blk))
+     , Consensus.RunNode blk
+     )
+  => MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
+  -> (OutcomeEnhancedTracer IO (Consensus.TraceForgeEvent blk) -> Tracer IO (Consensus.TraceForgeEvent blk))
+  -> ForgeTracers
+  -> Trace IO Text
+  -> TraceOptions
+  -> IORef BlockchainCounters
+  -> Consensus.Tracers' peer localPeer blk (Tracer IO)
+mkConsensusTracers' elidingFetchDecision measureBlockForging forgeTracers tracer t@(TracingOn traceConf) bChainCounters = do
+  Consensus.Tracers
+    { Consensus.chainSyncClientTracer = tracerOnOff (traceChainSyncClient traceConf) "ChainSyncClient" tracer
+    , Consensus.chainSyncServerHeaderTracer = tracerOnOff (traceChainSyncHeaderServer traceConf) "ChainSyncHeaderServer" tracer
+    , Consensus.chainSyncServerBlockTracer = tracerOnOff (traceChainSyncHeaderServer traceConf) "ChainSyncHeaderServer" tracer
+    , Consensus.blockFetchDecisionTracer = annotateSeverity $ teeTraceBlockFetchDecision t elidingFetchDecision $ appendName "ChainSyncBlockServer" tracer
+    , Consensus.blockFetchClientTracer = tracerOnOff (traceBlockFetchClient traceConf) "BlockFetchClient" tracer
+    , Consensus.blockFetchServerTracer = tracerOnOff (traceBlockFetchServer traceConf) "BlockFetchServer" tracer
+    , Consensus.forgeStateTracer = createForgeStateTracer (traceForgeState traceConf) tracer
+    , Consensus.txInboundTracer = tracerOnOff (traceTxInbound traceConf) "TxInbound" tracer
+    , Consensus.txOutboundTracer = tracerOnOff (traceTxOutbound traceConf) "TxOutbound" tracer
+    , Consensus.localTxSubmissionServerTracer = tracerOnOff (traceLocalTxSubmissionServer traceConf) "LocalTxSubmissionServer" tracer
+    , Consensus.mempoolTracer = mempoolTracer traceConf tracer bChainCounters
+    , Consensus.forgeTracer
+      = Tracer $ \ev -> do
+          traceWith (forgeTracer forgeTracers t bChainCounters tracer) ev
+          traceWith ( measureBlockForging
+                    $ toLogObject' tracingVerbosity
+                    $ appendName "ForgeTime" tracer ) ev
+
+    , Consensus.blockchainTimeTracer
+      = Tracer $ \ev ->
+          traceWith (toLogObject tracer) (readableTraceBlockchainTimeEvent ev)
+
     }
-  where
-    -- Turn on/off a tracer depending on what was parsed from the command line.
-    tracerOnOff :: TraceConfig -> TraceId -> Tracer IO a -> Tracer IO a
-    tracerOnOff tc getter tracer' =
-      if traceEnabled tc getter then tracer' else nullTracer
+ where
+  tracingVerbosity :: TracingVerbosity
+  tracingVerbosity = traceVerbosity traceConf
 
-    teeTraceChainTip :: TracingVerbosity
-                     -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
-                     -> Trace IO Text
-                     -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-    teeTraceChainTip tverb elided tr = Tracer $ \ev -> do
-        traceWith (teeTraceChainTip' tr) ev
-        traceWith (notifyForkIsCreated) ev
-        traceWith (teeTraceChainTipElide tverb elided tr) ev
-    teeTraceChainTipElide :: TracingVerbosity
-                          -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
-                          -> Trace IO Text
-                          -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-    teeTraceChainTipElide = elideToLogObject
+mkConsensusTracers' _ _ _ _ TracingOff _ = Consensus.Tracers
+  { Consensus.chainSyncClientTracer = nullTracer
+  , Consensus.chainSyncServerHeaderTracer = nullTracer
+  , Consensus.chainSyncServerBlockTracer = nullTracer
+  , Consensus.blockFetchDecisionTracer = nullTracer
+  , Consensus.blockFetchClientTracer = nullTracer
+  , Consensus.blockFetchServerTracer = nullTracer
+  , Consensus.forgeStateTracer = nullTracer
+  , Consensus.txInboundTracer = nullTracer
+  , Consensus.txOutboundTracer = nullTracer
+  , Consensus.localTxSubmissionServerTracer = nullTracer
+  , Consensus.mempoolTracer = nullTracer
+  , Consensus.forgeTracer = nullTracer
+  , Consensus.blockchainTimeTracer = nullTracer
+  }
 
-    traceChainInformation :: Trace IO Text
-                          -> ChainInformation
-                          -> IO ()
-    traceChainInformation tr ChainInformation { slots, blocks, density } = do
-        -- TODO this is executed each time the chain changes. How cheap is it?
-        meta <- mkLOMeta Critical Confidential
-        let tr' = appendName "metrics" tr
-            traceD :: Text -> Double -> IO ()
-            traceD msg d = traceNamedObject tr' (meta, LogValue msg (PureD d))
-            traceI :: Integral a => Text -> a -> IO ()
-            traceI msg i = traceNamedObject tr' (meta, LogValue msg (PureI (fromIntegral i)))
+createForgeStateTracer :: Show a => Bool -> Trace IO Text -> Tracer IO a
+createForgeStateTracer True tracer = showTracing $ withName "ForgeState" tracer
+createForgeStateTracer False _ = nullTracer
 
-        traceD "density"     (fromRational density)
-        traceI "slotNum"     slots
-        traceI "blockNum"    blocks
-        traceI "slotInEpoch" (slots `rem` epochSlots)
-        traceI "epoch"       (slots `div` epochSlots)
-      where
-        epochSlots :: Word64 = 21600  -- TODO
+teeForge
+  :: ( Condense (HeaderHash blk)
+     , Consensus.RunNode blk
+     , ToObject (CannotLead (BlockProtocol blk))
+     , ToObject (LedgerErr (LedgerState blk))
+     , ToObject (OtherHeaderEnvelopeError blk)
+     , ToObject (ValidationErr (BlockProtocol blk))
+     )
+  => ForgeTracers
+  -> TracingVerbosity
+  -> Trace IO Text
+  -> Tracer IO (WithSeverity (Consensus.TraceForgeEvent blk))
+teeForge ft tverb tr = Tracer $ \ev -> do
+  traceWith (teeForge' tr) ev
+  flip traceWith ev $ fanning $ \(WithSeverity _ e) ->
+    case e of
+      Consensus.TraceNotCannotLead _ _ -> teeForge' (ftTraceNotCannotLead ft)
+      Consensus.TraceForgedBlock{} -> teeForge' (ftForged ft)
+      Consensus.TraceStartLeadershipCheck{} -> teeForge' (ftForgeAboutToLead ft)
+      Consensus.TraceNoLedgerState{} -> teeForge' (ftCouldNotForge ft)
+      Consensus.TraceNoLedgerView{} -> teeForge' (ftCouldNotForge ft)
+      Consensus.TraceAdoptedBlock{} -> teeForge' (ftAdopted ft)
+      Consensus.TraceDidntAdoptBlock{} -> teeForge' (ftDidntAdoptBlock ft)
+      Consensus.TraceForgedInvalidBlock{} -> teeForge' (ftForgedInvalid ft)
+      Consensus.TraceNodeNotLeader{} -> teeForge' (ftTraceNodeNotLeader ft)
+      Consensus.TraceBlockFromFuture{} -> teeForge' (ftTraceBlockFromFuture ft)
+      Consensus.TraceSlotIsImmutable{} -> teeForge' (ftTraceSlotIsImmutable ft)
+      Consensus.TraceNodeIsLeader{} -> teeForge' (ftTraceNodeIsLeader ft)
+  traceWith (toLogObject' tverb tr) ev
 
-    teeTraceChainTip' :: Trace IO Text
-                      -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-    teeTraceChainTip' tr =
-        Tracer $ \(WithSeverity _ ev') ->
-          case ev' of
-              (ChainDB.TraceAddBlockEvent ev) -> case ev of
-                  ChainDB.SwitchedToAFork     newTipInfo _ newChain ->
-                    traceChainInformation tr (chainInformation newTipInfo newChain)
-                  ChainDB.AddedToCurrentChain newTipInfo _ newChain ->
-                    traceChainInformation tr (chainInformation newTipInfo newChain)
-                  _ -> pure ()
-              _ -> pure ()
+teeForge'
+  :: Trace IO Text
+  -> Tracer IO (WithSeverity (Consensus.TraceForgeEvent blk))
+teeForge' tr =
+  Tracer $ \(WithSeverity _ ev) -> do
+    meta <- mkLOMeta Critical Confidential
+    traceNamedObject (appendName "metrics" tr) . (meta,) $
+      case ev of
+        Consensus.TraceNotCannotLead _ _ -> panic "FIXME"
+        Consensus.TraceForgedBlock slot _ _ _ ->
+          LogValue "forgedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceStartLeadershipCheck slot ->
+          LogValue "aboutToLeadSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceNoLedgerState slot _ ->
+          LogValue "couldNotForgeSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceNoLedgerView slot _ ->
+          LogValue "couldNotForgeSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceAdoptedBlock slot _ _ ->
+          LogValue "adoptedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceDidntAdoptBlock slot _ ->
+          LogValue "notAdoptedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceForgedInvalidBlock slot _ _ ->
+          LogValue "forgedInvalidSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceNodeNotLeader slot ->
+          LogValue "nodeNotLeader" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceBlockFromFuture slot _slotNo ->
+          LogValue "blockFromFuture" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceSlotIsImmutable slot _tipPoint _tipBlkNo ->
+          LogValue "slotIsImmutable" $ PureI $ fromIntegral $ unSlotNo slot
+        Consensus.TraceNodeIsLeader slot ->
+          LogValue "nodeIsLeader" $ PureI $ fromIntegral $ unSlotNo slot
 
-    notifyForkIsCreated :: Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-    notifyForkIsCreated =
-        Tracer $ \(WithSeverity _ ev') ->
-          case ev' of
-              ChainDB.TraceAddBlockEvent ev -> case ev of
-                  ChainDB.SwitchedToAFork {} ->
-                      atomicModifyIORef' bcCounters (\cnts ->
-                        let nc = bcForksCreatedNum cnts + 1 in (cnts { bcForksCreatedNum = nc }, nc))
-                      >>= traceCounter "forksCreatedNum"
-                  _ -> pure ()
-              _ -> pure ()
 
-    teeTraceBlockFetchDecision
-        :: TracingVerbosity
-        -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
-        -> Trace IO Text
-        -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
-    teeTraceBlockFetchDecision tverb eliding tr = Tracer $ \ev -> do
-      traceWith (teeTraceBlockFetchDecision' tr) ev
-      traceWith (teeTraceBlockFetchDecisionElide tverb eliding tr) ev
-    teeTraceBlockFetchDecision'
-        :: Trace IO Text
-        -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
-    teeTraceBlockFetchDecision' tr =
-        Tracer $ \(WithSeverity _ peers) -> do
-          meta <- mkLOMeta Info Confidential
-          let tr' = appendName "peers" tr
-          traceNamedObject tr' (meta, LogValue "connectedPeers" . PureI $ fromIntegral $ length peers)
-    teeTraceBlockFetchDecisionElide
-        :: TracingVerbosity
-        -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
-        -> Trace IO Text
-        -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
-    teeTraceBlockFetchDecisionElide = elideToLogObject
+forgeTracer
+  :: ( Condense (HeaderHash blk)
+     , Consensus.RunNode blk
+     , ToObject (CannotLead (BlockProtocol blk))
+     , ToObject (LedgerErr (LedgerState blk))
+     , ToObject (OtherHeaderEnvelopeError blk)
+     , ToObject (ValidationErr (BlockProtocol blk))
+     )
+  => ForgeTracers
+  -> TraceOptions
+  -> IORef BlockchainCounters
+  -> Trace IO Text
+  -> Tracer IO (Consensus.TraceForgeEvent blk)
+forgeTracer forgeTracers tOptions bcCounters tracer =
+  case tOptions of
+    TracingOff -> nullTracer
+    TracingOn tselect ->
+     Tracer $ \ev -> do
+      traceWith (measureTxsEnd tracer) ev
+      traceWith (notifyBlockForging bcCounters tracer) ev
+      traceWith (notifySlotsMissedIfNeeded bcCounters tracer) ev
+      -- Consensus tracer
+      traceWith (annotateSeverity
+                   $ teeForge forgeTracers (traceVerbosity tselect)
+                   $ appendName "Forge" tracer) ev
 
-    mempoolMetricsTraceTransformer :: Trace IO a
-                                   -> Tracer IO (TraceEventMempool blk)
-    mempoolMetricsTraceTransformer tr = Tracer $ \mempoolEvent -> do
-        let tr' = appendName "metrics" tr
-            (_n, tot) = case mempoolEvent of
-                  TraceMempoolAddedTx     _tx0 _ tot0 -> (1, tot0)
-                  TraceMempoolRejectedTx  _tx0 _ tot0 -> (1, tot0)
-                  TraceMempoolRemoveTxs   txs0   tot0 -> (length txs0, tot0)
-                  TraceMempoolManuallyRemovedTxs txs0 txs1 tot0
-                                                    -> ( length txs0 + length txs1
-                                                       , tot0
-                                                       )
-            logValue1 :: LOContent a
-            logValue1 = LogValue "txsInMempool" $ PureI $ fromIntegral (msNumTxs tot)
 
-            logValue2 :: LOContent a
-            logValue2 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
+notifyBlockForging
+  :: IORef BlockchainCounters
+  -> Trace IO Text
+  -> Tracer IO (Consensus.TraceForgeEvent blk)
+notifyBlockForging bcCounters tr = Tracer $ \case
+  Consensus.TraceForgedBlock {} -> do
+    updatedBlocksForged <- atomicModifyIORef' bcCounters (\cnts -> let nc = bcBlocksForgedNum cnts + 1
+                                                                   in (cnts { bcBlocksForgedNum = nc }, nc)
+                                                         )
+    traceCounter "blocksForgedNum" updatedBlocksForged tr
+  -- The rest of the constructors.
+  _ -> pure ()
 
-        meta <- mkLOMeta Critical Confidential
-        traceNamedObject tr' (meta, logValue1)
-        traceNamedObject tr' (meta, logValue2)
+notifySlotsMissedIfNeeded
+  :: IORef BlockchainCounters
+  -> Trace IO Text
+  -> Tracer IO (Consensus.TraceForgeEvent blk)
+notifySlotsMissedIfNeeded bcCounters tr = Tracer $ \case
+  Consensus.TraceNodeIsLeader {} -> do
+    updatedNodeIsLeaderNum <- atomicModifyIORef' bcCounters (\cnts -> let nc = bcNodeIsLeaderNum cnts + 1
+                                                                      in (cnts { bcNodeIsLeaderNum = nc }, nc)
+                                                            )
+    traceCounter "nodeIsLeaderNum" updatedNodeIsLeaderNum tr
+  Consensus.TraceNodeNotLeader {} -> do
+    -- Not is not a leader again, so now the number of blocks forged by this node
+    -- should be equal to the number of slots when this node was a leader.
+    counters <- readIORef bcCounters
+    let howManyBlocksWereForged = bcBlocksForgedNum counters
+        timesNodeWasALeader = bcNodeIsLeaderNum counters
+        numberOfMissedSlots = timesNodeWasALeader - howManyBlocksWereForged
+    if numberOfMissedSlots > 0
+    then do
+        -- Node was a leader more times than the number of forged blocks,
+        -- it means that some slots were missed.
+      updatesSlotsMissed <- atomicModifyIORef' bcCounters (\cnts -> let nc = bcSlotsMissedNum cnts + numberOfMissedSlots
+                                                                    in (cnts { bcSlotsMissedNum = nc }, nc)
+                                                          )
+      traceCounter "slotsMissedNum" updatesSlotsMissed tr
+    else return ()
+  -- The rest of the constructors.
+  _ -> pure ()
 
-    notifyTxsProcessed :: Tracer IO (TraceEventMempool blk)
-    notifyTxsProcessed = Tracer $ \case
-      TraceMempoolRemoveTxs [] _ -> return ()
-      TraceMempoolRemoveTxs txs _ ->
-        -- TraceMempoolRemoveTxs are previously valid transactions that are no longer valid because of
-        -- changes in the ledger state. These transactions are already removed from the mempool,
-        -- so we can treat them as completely processed.
-        atomicModifyIORef' bcCounters (\cnts ->
-          let nc = bcTxsProcessedNum cnts + fromIntegral (length txs) in (cnts { bcTxsProcessedNum = nc }, nc))
-        >>= traceCounter "txsProcessedNum"
-      -- The rest of the constructors.
-      _ -> return ()
 
-    mempoolTracer :: TraceConfig -> Tracer IO (TraceEventMempool blk)
-    mempoolTracer tc = Tracer $ \ev -> do
-        traceWith (mempoolMetricsTraceTransformer tracer) ev
-        traceWith (notifyTxsProcessed) ev
-        traceWith (measureTxsStart tracer) ev
-        let tr = appendName "Mempool" tracer
-        traceWith (mpTracer tr) ev
-      where
-        mpTracer :: Trace IO Text -> Tracer IO (TraceEventMempool blk)
-        mpTracer tr = annotateSeverity $ toLogObject' (traceConfigVerbosity tc) tr
+--------------------------------------------------------------------------------
+-- Mempool Tracers
+--------------------------------------------------------------------------------
 
-    forgeTracer
-        :: ForgeTracers
-        -> TraceConfig
-        -> Tracer IO (Consensus.TraceForgeEvent blk)
-    forgeTracer forgeTracers tc = Tracer $ \ev -> do
-        traceWith (measureTxsEnd tracer) ev
-        traceWith (notifyBlockForging) ev
-        traceWith (notifySlotsMissedIfNeeded) ev
-        traceWith (consensusForgeTracer) ev
-      where
-        -- The consensus tracer.
-        consensusForgeTracer = tracerOnOff traceConf traceForge
-          $ annotateSeverity
-          $ teeForge forgeTracers (traceConfigVerbosity tc)
-          $ appendName "Forge" tracer
+notifyTxsProcessed :: IORef BlockchainCounters -> Trace IO Text -> Tracer IO (TraceEventMempool blk)
+notifyTxsProcessed bcCounters tr = Tracer $ \case
+  TraceMempoolRemoveTxs [] _ -> return ()
+  TraceMempoolRemoveTxs txs _ -> do
+    -- TraceMempoolRemoveTxs are previously valid transactions that are no longer valid because of
+    -- changes in the ledger state. These transactions are already removed from the mempool,
+    -- so we can treat them as completely processed.
+    updatedTxProcessed <- atomicModifyIORef' bcCounters (\cnts -> let nc = bcTxsProcessedNum cnts + fromIntegral (length txs)
+                                                                  in (cnts { bcTxsProcessedNum = nc }, nc)
+                                                        )
+    traceCounter "txsProcessedNum" updatedTxProcessed tr
+  -- The rest of the constructors.
+  _ -> return ()
 
-        notifyBlockForging = Tracer $ \case
-          Consensus.TraceForgedBlock {} ->
-            atomicModifyIORef' bcCounters (\cnts ->
-              let nc = bcBlocksForgedNum cnts + 1 in (cnts { bcBlocksForgedNum = nc }, nc))
-            >>= traceCounter "blocksForgedNum"
-          -- The rest of the constructors.
-          _ -> pure ()
 
-        notifySlotsMissedIfNeeded = Tracer $ \case
-          Consensus.TraceNodeIsLeader {} ->
-            atomicModifyIORef' bcCounters (\cnts ->
-              let nc = bcNodeIsLeaderNum cnts + 1 in (cnts { bcNodeIsLeaderNum = nc }, nc))
-            >>= traceCounter "nodeIsLeaderNum"
-          Consensus.TraceNodeNotLeader {} -> do
-            -- Not is not a leader again, so now the number of blocks forged by this node
-            -- should be equal to the number of slots when this node was a leader.
-            counters <- readIORef bcCounters
-            let howManyBlocksWereForged = bcBlocksForgedNum counters
-                timesNodeWasALeader = bcNodeIsLeaderNum counters
-                numberOfMissedSlots = timesNodeWasALeader - howManyBlocksWereForged
-            when (numberOfMissedSlots > 0) $
-              -- Node was a leader more times than the number of forged blocks,
-              -- it means that some slots were missed.
-              atomicModifyIORef' bcCounters (\cnts ->
-                let nc = bcSlotsMissedNum cnts + numberOfMissedSlots in (cnts { bcSlotsMissedNum = nc }, nc))
-              >>= traceCounter "slotsMissedNum"
-          -- The rest of the constructors.
-          _ -> pure ()
+mempoolMetricsTraceTransformer :: Trace IO a -> Tracer IO (TraceEventMempool blk)
+mempoolMetricsTraceTransformer tr = Tracer $ \mempoolEvent -> do
+  let tr' = appendName "metrics" tr
+      (_n, tot) = case mempoolEvent of
+                    TraceMempoolAddedTx     _tx0 _ tot0 -> (1, tot0)
+                    TraceMempoolRejectedTx  _tx0 _ tot0 -> (1, tot0)
+                    TraceMempoolRemoveTxs   txs0   tot0 -> (length txs0, tot0)
+                    TraceMempoolManuallyRemovedTxs txs0 txs1 tot0 -> ( length txs0 + length txs1, tot0)
+      logValue1 :: LOContent a
+      logValue1 = LogValue "txsInMempool" $ PureI $ fromIntegral (msNumTxs tot)
+      logValue2 :: LOContent a
+      logValue2 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
+  meta <- mkLOMeta Critical Confidential
+  traceNamedObject tr' (meta, logValue1)
+  traceNamedObject tr' (meta, logValue2)
 
-    teeForge
-      :: ForgeTracers
-      -> TracingVerbosity
-      -> Trace IO Text
-      -> Tracer IO (WithSeverity (Consensus.TraceForgeEvent blk))
-    teeForge ft tverb tr = Tracer $ \ev -> do
-      traceWith (teeForge' tr) ev
-      flip traceWith ev $ fanning $ \(WithSeverity _ e) ->
-        case e of
-          Consensus.TraceForgedBlock{} -> teeForge' (ftForged ft)
-          Consensus.TraceStartLeadershipCheck{} -> teeForge' (ftForgeAboutToLead ft)
-          Consensus.TraceNoLedgerState{} -> teeForge' (ftCouldNotForge ft)
-          Consensus.TraceNoLedgerView{} -> teeForge' (ftCouldNotForge ft)
-          Consensus.TraceAdoptedBlock{} -> teeForge' (ftAdopted ft)
-          Consensus.TraceDidntAdoptBlock{} -> teeForge' (ftDidntAdoptBlock ft)
-          Consensus.TraceForgedInvalidBlock{} -> teeForge' (ftForgedInvalid ft)
-          Consensus.TraceNodeNotLeader{} -> teeForge' (ftTraceNodeNotLeader ft)
-          Consensus.TraceNotCannotLead{} -> teeForge' (ftTraceNotCannotLead ft)
-          Consensus.TraceBlockFromFuture{} -> teeForge' (ftTraceBlockFromFuture ft)
-          Consensus.TraceSlotIsImmutable{} -> teeForge' (ftTraceSlotIsImmutable ft)
-          Consensus.TraceNodeIsLeader{} -> teeForge' (ftTraceNodeIsLeader ft)
+mempoolTracer
+  :: ( Show (ApplyTxErr blk)
+     , ToJSON (GenTxId blk)
+     , ToObject (ApplyTxErr blk)
+     , ToObject (GenTx blk)
+     )
+  => TraceSelection
+  -> Trace IO Text
+  -> IORef BlockchainCounters
+  -> Tracer IO (TraceEventMempool blk)
+mempoolTracer tc tracer bChainCounters = Tracer $ \ev -> do
+    traceWith (mempoolMetricsTraceTransformer tracer) ev
+    traceWith (notifyTxsProcessed bChainCounters tracer) ev
+    traceWith (measureTxsStart tracer) ev
+    let tr = appendName "Mempool" tracer
+    traceWith (mpTracer tc tr) ev
 
-      traceWith (toLogObject' tverb tr) ev
+mpTracer :: ( Show (ApplyTxErr blk)
+            , ToJSON (GenTxId blk)
+            , ToObject (ApplyTxErr blk)
+            , ToObject (GenTx blk)
+            )
+         => TraceSelection -> Trace IO Text -> Tracer IO (TraceEventMempool blk)
+mpTracer tc tr = annotateSeverity $ toLogObject' (traceVerbosity tc) tr
 
-    teeForge'
-      :: Trace IO Text
-      -> Tracer IO (WithSeverity (Consensus.TraceForgeEvent blk))
-    teeForge' tr =
-      Tracer $ \(WithSeverity _ ev) -> do
-        meta <- mkLOMeta Critical Confidential
-        traceNamedObject (appendName "metrics" tr) . (meta,) $
-          case ev of
-            Consensus.TraceForgedBlock slot _ _ _ ->
-              LogValue "forgedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceStartLeadershipCheck slot ->
-              LogValue "aboutToLeadSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceNoLedgerState slot _ ->
-              LogValue "couldNotForgeSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceNoLedgerView slot _ ->
-              LogValue "couldNotForgeSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceAdoptedBlock slot _ _ ->
-              LogValue "adoptedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceDidntAdoptBlock slot _ ->
-              LogValue "notAdoptedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceForgedInvalidBlock slot _ _ ->
-              LogValue "forgedInvalidSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceNodeNotLeader slot ->
-              LogValue "nodeNotLeader" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceNotCannotLead slot _ ->
-              LogValue "notCannotLead" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceBlockFromFuture slot _slotNo ->
-              LogValue "blockFromFuture" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceSlotIsImmutable slot _tipPoint _tipBlkNo ->
-              LogValue "slotIsImmutable" $ PureI $ fromIntegral $ unSlotNo slot
-            Consensus.TraceNodeIsLeader slot ->
-              LogValue "nodeIsLeader" $ PureI $ fromIntegral $ unSlotNo slot
+nodeToClientTracers'
+  :: Show localPeer
+  => TraceOptions
+  -> Trace IO Text
+  -> NodeToClient.Tracers' localPeer blk DeserialiseFailure (Tracer IO)
+nodeToClientTracers' (TracingOn traceConf) tracer = NodeToClient.Tracers
+  { NodeToClient.tChainSyncTracer
+    = tracerOnOff (traceLocalChainSyncProtocol traceConf) "LocalChainSyncProtocol" tracer
+  , NodeToClient.tTxSubmissionTracer
+    = tracerOnOff (traceLocalTxSubmissionProtocol traceConf) "LocalTxSubmissionProtocol" tracer
+  , NodeToClient.tStateQueryTracer
+    = tracerOnOff (traceLocalStateQueryProtocol traceConf) "LocalStateQueryProtocol" tracer
+  }
 
-    mkConsensusTracers
-        :: MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
-        -> (OutcomeEnhancedTracer IO (Consensus.TraceForgeEvent blk) -> Tracer IO (Consensus.TraceForgeEvent blk))
-        -> ForgeTracers
-        -> Consensus.Tracers' peer localPeer blk (Tracer IO)
-    mkConsensusTracers elidingFetchDecision measureBlockForging forgeTracers = Consensus.Tracers
-      { Consensus.chainSyncClientTracer
-        = tracerOnOff traceConf traceChainSyncClient
-          $ toLogObject' tracingVerbosity
-          $ appendName "ChainSyncClient" tracer
-      , Consensus.chainSyncServerHeaderTracer
-        =  tracerOnOff traceConf traceChainSyncHeaderServer
-          $ toLogObject' tracingVerbosity
-          $ appendName "ChainSyncHeaderServer" tracer
-      , Consensus.chainSyncServerBlockTracer
-        = tracerOnOff traceConf traceChainSyncBlockServer
-          $ toLogObject' tracingVerbosity
-          $ appendName "ChainSyncBlockServer" tracer
-      , Consensus.blockFetchDecisionTracer
-        = tracerOnOff traceConf traceBlockFetchDecisions
-          $ annotateSeverity
-          $ teeTraceBlockFetchDecision tracingVerbosity elidingFetchDecision
-          $ appendName "BlockFetchDecision" tracer
-      , Consensus.blockFetchClientTracer
-        = tracerOnOff traceConf traceBlockFetchClient
-          $ toLogObject' tracingVerbosity
-          $ appendName "BlockFetchClient" tracer
-      , Consensus.blockFetchServerTracer
-        = tracerOnOff traceConf traceBlockFetchServer
-          $ toLogObject' tracingVerbosity
-          $ appendName "BlockFetchServer" tracer
-      , Consensus.txInboundTracer
-        = tracerOnOff traceConf traceTxInbound
-          $ toLogObject' tracingVerbosity
-          $ appendName "TxInbound" tracer
-      , Consensus.txOutboundTracer
-        = tracerOnOff traceConf traceTxOutbound
-          $ toLogObject' tracingVerbosity
-          $ appendName "TxOutbound" tracer
-      , Consensus.localTxSubmissionServerTracer
-        = tracerOnOff traceConf traceLocalTxSubmissionServer
-          $ toLogObject' tracingVerbosity
-          $ appendName "LocalTxSubmissionServer" tracer
-      , Consensus.mempoolTracer
-        = tracerOnOff traceConf traceMempool
-          $ mempoolTracer traceConf
-      , Consensus.forgeStateTracer
-        = tracerOnOff traceConf traceForgeState
-          $ toLogObject' tracingVerbosity
-          $ appendName "ForgeState" tracer
-      , Consensus.forgeTracer
-        = Tracer $ \ev -> do
-            traceWith (forgeTracer forgeTracers traceConf) ev
-            traceWith ( measureBlockForging
-                      $ toLogObject' tracingVerbosity
-                      $ appendName "ForgeTime" tracer) ev
-      , Consensus.blockchainTimeTracer
-        = Tracer $ \ev ->
-            traceWith (toLogObject tracer) (readableTraceBlockchainTimeEvent ev)
-      }
 
-    tracingVerbosity :: TracingVerbosity
-    tracingVerbosity = traceConfigVerbosity traceConf
+nodeToClientTracers' TracingOff _ = NodeToClient.Tracers
+  { NodeToClient.tChainSyncTracer = nullTracer
+  , NodeToClient.tTxSubmissionTracer = nullTracer
+  , NodeToClient.tStateQueryTracer = nullTracer
+  }
 
-    readableTraceBlockchainTimeEvent :: TraceBlockchainTimeEvent -> Text
-    readableTraceBlockchainTimeEvent ev = case ev of
-        TraceStartTimeInTheFuture (SystemStart start) toWait ->
-          "Waiting " <> show toWait <> " until genesis start time at " <> show start
-        TraceCurrentSlotUnknown time _ ->
-          "Too far from the chain tip to determine the current slot number for the time "
-           <> show time
+--------------------------------------------------------------------------------
+-- NodeToNode Tracers
+--------------------------------------------------------------------------------
 
-    nodeToClientTracers
-      :: NodeToClient.Tracers' localPeer blk DeserialiseFailure (Tracer IO)
-    nodeToClientTracers = NodeToClient.Tracers
-      { NodeToClient.tChainSyncTracer
-        = tracerOnOff traceConf traceLocalChainSyncProtocol
-        $ showTracing $ withName "LocalChainSyncProtocol" tracer
-      , NodeToClient.tTxSubmissionTracer
-        = tracerOnOff traceConf traceLocalTxSubmissionProtocol
-        $ showTracing $ withName "LocalTxSubmissionProtocol" tracer
-      , NodeToClient.tStateQueryTracer
-        = tracerOnOff traceConf traceLocalStateQueryProtocol
-        $ showTracing $ withName "LocalStateQueryProtocol" tracer
-      }
+nodeToNodeTracers'
+  :: ( Show (GenTx blk)
+     , Condense (HeaderHash blk) -- needs to be removed
+     , Show peer
+     , Show (TxId (GenTx blk))
+     )
+  => TraceOptions
+  -> Trace IO Text
+  -> NodeToNode.Tracers' peer blk DeserialiseFailure (Tracer IO)
+nodeToNodeTracers' (TracingOn traceConf) tracer = NodeToNode.Tracers
+  { NodeToNode.tChainSyncTracer = tracerOnOff (traceChainSyncProtocol traceConf) "ChainSyncProtocol" tracer
+  , NodeToNode.tChainSyncSerialisedTracer = tracerOnOff (traceChainSyncProtocol traceConf) "ChainSyncProtocol" tracer
+  , NodeToNode.tBlockFetchTracer = tracerOnOff (traceBlockFetchProtocol traceConf) "BlockFetchProtocol" tracer
+  , NodeToNode.tBlockFetchSerialisedTracer = tracerOnOff (traceBlockFetchProtocolSerialised traceConf) "BlockFetchProtocolSerialised" tracer
+  , NodeToNode.tTxSubmissionTracer = tracerOnOff (traceTxSubmissionProtocol traceConf) "TxSubmissionProtocol" tracer
+  }
 
-    nodeToNodeTracers
-      :: NodeToNode.Tracers' peer blk DeserialiseFailure (Tracer IO)
-    nodeToNodeTracers = NodeToNode.Tracers
-      { NodeToNode.tChainSyncTracer
-        = tracerOnOff traceConf traceChainSyncProtocol
-        $ showTracing $ withName "ChainSyncProtocol" tracer
-      , NodeToNode.tChainSyncSerialisedTracer
-        = tracerOnOff traceConf traceChainSyncProtocol
-        $ showTracing $ withName "ChainSyncProtocol" tracer
-      , NodeToNode.tBlockFetchTracer
-        = tracerOnOff traceConf traceBlockFetchProtocol
-        $ toLogObject' tracingVerbosity
-        $ appendName "BlockFetchProtocol" tracer
-      , NodeToNode.tBlockFetchSerialisedTracer
-        = tracerOnOff traceConf traceBlockFetchProtocolSerialised
-        $ showTracing $ withName "BlockFetchProtocolSerialised" tracer
-      , NodeToNode.tTxSubmissionTracer
-        = tracerOnOff traceConf traceTxSubmissionProtocol
-        $ toLogObject' tracingVerbosity
-        $ appendName "TxSubmissionProtocol" tracer
-      }
+nodeToNodeTracers' TracingOff _ = NodeToNode.Tracers
+  { NodeToNode.tChainSyncTracer = nullTracer
+  , NodeToNode.tChainSyncSerialisedTracer = nullTracer
+  , NodeToNode.tBlockFetchTracer = nullTracer
+  , NodeToNode.tBlockFetchSerialisedTracer = nullTracer
+  , NodeToNode.tTxSubmissionTracer = nullTracer
+  }
 
-    traceCounter
-      :: Text
-      -> Word64
-      -> IO ()
-    traceCounter logValueName aCounter = do
-      meta <- mkLOMeta Notice Public
-      traceNamedObject (appendName "metrics" tracer)
-                       (meta, LogValue logValueName (PureI $ fromIntegral aCounter))
+teeTraceBlockFetchDecision
+    :: ( Eq peer
+       , HasHeader blk
+       , Show peer
+       )
+    => TraceOptions
+    -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
+    -> Trace IO Text
+    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+teeTraceBlockFetchDecision traceconf eliding tr =
+  case traceconf of
+    TracingOff -> nullTracer
+    TracingOn traceSelection ->
+      Tracer $ \ev -> do
+        traceWith (teeTraceBlockFetchDecision' tr) ev
+        traceWith (teeTraceBlockFetchDecisionElide (traceVerbosity traceSelection) eliding tr) ev
+
+
+teeTraceBlockFetchDecision'
+    :: Trace IO Text
+    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+teeTraceBlockFetchDecision' tr =
+    Tracer $ \(WithSeverity _ peers) -> do
+      meta <- mkLOMeta Info Confidential
+      let tr' = appendName "peers" tr
+      traceNamedObject tr' (meta, LogValue "connectedPeers" . PureI $ fromIntegral $ length peers)
+
+teeTraceBlockFetchDecisionElide
+    :: ( Eq peer
+       , HasHeader blk
+       , Show peer
+       )
+    => TracingVerbosity
+    -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
+    -> Trace IO Text
+    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+teeTraceBlockFetchDecisionElide = elideToLogObject
+
 
 -- | get information about a chain fragment
 
@@ -738,9 +805,35 @@ chainInformation newTipInfo frag = ChainInformation
       Right b -> b
 
 
---
--- Tracing utils
---
+--------------------------------------------------------------------------------
+-- Trace Helpers
+--------------------------------------------------------------------------------
+
+readableTraceBlockchainTimeEvent :: TraceBlockchainTimeEvent -> Text
+readableTraceBlockchainTimeEvent ev = case ev of
+    TraceStartTimeInTheFuture (SystemStart start) toWait ->
+      "Waiting " <> show toWait <> " until genesis start time at " <> show start
+    TraceCurrentSlotUnknown time _ ->
+      "Too far from the chain tip to determine the current slot number for the time "
+       <> show time
+
+traceCounter
+  :: Text
+  -> Word64
+  -> Trace IO Text
+  -> IO ()
+traceCounter logValueName aCounter tracer = do
+  meta <- mkLOMeta Notice Public
+  traceNamedObject (appendName "metrics" tracer)
+                   (meta, LogValue logValueName (PureI $ fromIntegral aCounter))
+
+tracerOnOff
+  :: Transformable Text IO a
+  => Bool -> LoggerName -> Trace IO Text -> Tracer IO a
+tracerOnOff False _ _ = nullTracer
+tracerOnOff True name trcer = annotateSeverity
+                                $ toLogObject' MinimalVerbosity
+                                $ appendName name trcer
 
 withName :: String -> Trace IO Text -> Tracer IO String
-withName name tr = contramap pack $ toLogObject $ appendName (pack name) tr
+withName name tr = contramap Text.pack $ toLogObject $ appendName (Text.pack name) tr

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -84,7 +84,9 @@ defaultBackends:
 # The Prometheus monitoring system exports EKG metrics. Uncomment the following
 # to listen on the given port. Output is provided on
 # http://localhost:12789/metrics
-# hasPrometheus: 12789
+# hasPrometheus:
+#   - "127.0.0.1"
+#   - 12789
 
 # To enable the 'TraceForwarder' backend, uncomment the following setting. Log
 # items are then forwarded based on an entry in 'mapBackends' to a separate

--- a/scripts/lib-cluster.sh
+++ b/scripts/lib-cluster.sh
@@ -3,6 +3,7 @@
 
 TMUX_CONFIG="$(mktemp -t --suffix=tmuXXXXXXXX)"
 run_3node_cluster() {
+        command -v tmux >/dev/null 2>&1 || { echo >&2 "ERROR: This script requires tmux, which is missing. Please install it."; exit 1; }
         dprint "run_3node_cluster: $*"
         local config="$1" topo="${2:-indexed}" delegate="${3:-indexed}"
 


### PR DESCRIPTION
- First PR towards making `Cardano.Tracing.Tracers` more easily understandable & explicit.
- All constraints are now explicit,  many functions from within `where` clauses are moved to the top level & given type signatures.
-  `TraceConfig'` is simplified and partial function free.

