### PR TITLE
CAD-1139: Fix trace node's release

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -362,10 +362,11 @@ handleSimpleNode p trace nodeTracers npm onKernel = do
 
          meta <- mkLOMeta Notice Public
          let rTr = appendName "release" tr
+             nTr = appendName "networkMagic" tr 
              vTr = appendName "version" tr
              cTr = appendName "commit"  tr
          traceNamedObject rTr (meta, LogMessage (show (ncProtocol nc)))
-         traceNamedObject rTr (meta, LogMessage ("NetworkMagic " <> show (unNetworkMagic . getNetworkMagic $ Consensus.configBlock cfg)))
+         traceNamedObject nTr (meta, LogMessage ("NetworkMagic " <> show (unNetworkMagic . getNetworkMagic $ Consensus.configBlock cfg)))
          traceNamedObject vTr (meta, LogMessage . pack . showVersion $ version)
          traceNamedObject cTr (meta, LogMessage gitRev)
 


### PR DESCRIPTION
Bug fix.

There's two things node sends in the same trace, but it's incorrect: node's release should be sent in `cardano.node.release`, and `NetworkMagic` - in `cardano.node.networkMagic`.