### PR TITLE
Fix node is leader -> slots lead label in LiveView

### DIFF
--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -960,7 +960,7 @@ nodeInfoLabels =
            ,                    txt "block number:"
            ,                    txt "chain density:"
            , padTop (T.Pad 1) $ txt "blocks minted:"
-           ,                    txt "node is leader:"
+           ,                    txt "slots lead:"
            ,                    txt "slots missed:"
            ,                    txt "forks created:"
            , padTop (T.Pad 1) $ txt "TXs processed:"


### PR DESCRIPTION
"Node is leader" doesn't make sense and has invited a bunch of questions in the pioneers forum. Change this to "slots lead" for clarity.