### PR TITLE
Always print error when genesis file is not found

### DIFF
--- a/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
@@ -126,7 +126,7 @@ readShelleyGenesis :: GenesisFile
                               (ShelleyGenesis TPraosStandardCrypto)
 readShelleyGenesis (GenesisFile file) =
     firstExceptT (GenesisReadError file) $
-      ExceptT $
+      ExceptT $ handle (\(e :: IOException) -> return $ Left $ show e) $
         Aeson.eitherDecodeFileStrict' file
 
 


### PR DESCRIPTION
I noticed that when I run a node at a ff network, with the genesis file at a wrong path, I get one of the following logs:
```
Shutting down..
cardano-node: /wrong/genesis/path: openBinaryFile: does not exist (No such file or directory)⏎
```
or 
```
Shutting down..
```
The second error completely lacks any information about what went wrong and can leave the user wondering.

I think this is the result of 2 issues:
- `eitherDecodeFileStrict'` doesn't graciously handle such errors. We should make sure to catch any exception and properly wrap it, so it doesn't escape `ExceptT`. This is what this pr does.
- The node sometimes gets stuck on shutdown, maybe trying to kill some resources. This issue is orthogonal, but makes matter worse, since the exception message never reaches the user.

This pr makes sure that the user gets a proper log, even if the node later gets stuck on shutdown:
```
There was an error parsing the genesis file: /wrong/genesis/path Error:
"/wrong/genesis/path: openBinaryFile: does  not exist (No such file or directory)"

Shutting down..
```


