### PR TITLE
iohk-nix: reset qa/ff environments from genesis

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "77c5e906fb9042ed2bc4b84be40b31f7196c1c73",
-        "sha256": "1mjp2yiwk7rrgiysfr1hx9k9pra0cl39mvr9sgi05jjxcars9ngs",
+        "rev": "8b1d65ba294708b12d7b15103ac35431d9b60819",
+        "sha256": "1z23lw28s3wa5bf5yr89i61m413ad299lyhv02i9r36p28wjl94g",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/77c5e906fb9042ed2bc4b84be40b31f7196c1c73.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/8b1d65ba294708b12d7b15103ac35431d9b60819.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
resets friends and family and shelley qa environments in preparation of the new released version.