### PR TITLE
Restore configurability of traces

### DIFF
--- a/cardano-config/src/Cardano/Config/TraceConfig.hs
+++ b/cardano-config/src/Cardano/Config/TraceConfig.hs
@@ -30,6 +30,7 @@ data TraceSelection
 
   -- Per-trace toggles, alpha-sorted.
   , traceAcceptPolicy :: !Bool
+  , traceBlockchainTime :: !Bool
   , traceBlockFetchClient :: !Bool
   , traceBlockFetchDecisions :: !Bool
   , traceBlockFetchProtocol :: !Bool
@@ -67,6 +68,7 @@ traceConfigParser v =
     <$> v .:? "TracingVerbosity" .!= NormalVerbosity
     -- Per-trace toggles, alpha-sorted.
     <*> v .:? "TraceAcceptPolicy" .!= False
+    <*> v .:? "TraceBlockchainTime" .!= False
     <*> v .:? "TraceBlockFetchClient" .!= False
     <*> v .:? "TraceBlockFetchDecisions" .!= True
     <*> v .:? "TraceBlockFetchProtocol" .!= False

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -452,8 +452,8 @@ mkConsensusTracers' protoInfo elidingFetchDecision measureBlockForging
                     $ toLogObject' tracingVerbosity
                     $ appendName "ForgeTime" tracer ) ev
 
-    , Consensus.blockchainTimeTracer
-      = Tracer $ \ev ->
+    , Consensus.blockchainTimeTracer = tracerOnOff' (traceBlockchainTime traceConf) $
+      Tracer $ \ev ->
           traceWith (toLogObject tracer) (readableTraceBlockchainTimeEvent ev)
 
     }
@@ -906,6 +906,11 @@ tracerOnOff False _ _ = nullTracer
 tracerOnOff True name trcer = annotateSeverity
                                 $ toLogObject' MinimalVerbosity
                                 $ appendName name trcer
+
+tracerOnOff'
+  :: Bool -> Tracer IO a -> Tracer IO a
+tracerOnOff' False _ = nullTracer
+tracerOnOff' True tr = tr
 
 instance Show a => Show (WithSeverity a) where
   show (WithSeverity _sev a) = show a


### PR DESCRIPTION
Restore configurability that a number of traces had lost:

- ChainDB
- DnsSubscription
- BlockFetchDecision
- ForgeState
- Forge
- Mempool

Add configurability for the BlockchainTime trace (off by default).