### PR TITLE
add missing extra-dep in stack.yaml

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -126,10 +126,10 @@ renderShelleyGenesisCmdError err =
         <> "delegate VRF key file indexes: " <> textShow vfiles
     ShelleyGenesisFilesNoIndex files ->
       "The genesis keys files are expected to have a numeric index but these do not:\n"
-        <> unlines (map Text.pack files)
+        <> Text.unlines (map Text.pack files)
     ShelleyGenesisFilesDupIndex files ->
       "The genesis keys files are expected to have a unique numeric index but these do not:\n"
-        <> unlines (map Text.pack files)
+        <> Text.unlines (map Text.pack files)
 
 
 runGenesisCmd :: GenesisCmd -> ExceptT ShelleyGenesisCmdError IO ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,6 +27,7 @@ extra-deps:
   - micro-recursion-schemes-5.0.2.2
   - streaming-binary-0.3.0.1
   - canonical-json-0.6.0.0
+  - base64-0.4.1
   - brick-0.47
   - binary-0.8.7.0
   - bimap-0.4.0


### PR DESCRIPTION
```console
$ stack install 
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for cardano-api-1.13.0:
    base64 needed, but the stack configuration has no specified version  (latest matching version is 0.4.1)
needed since cardano-api is a build target.

Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps in /home/ktorz/Documents/IOHK/cardano-node/stack.yaml:

- base64-0.4.1@sha256:aedc26f581f81a112af588eec8cf9c2e8db219a60fafc1cb77fd73672f1f7dcb,2832

Plan construction failed.
```