### PR TITLE
fix mainnet magic for shelley when submitting transactions

### DIFF
--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -71,7 +71,7 @@ submitTx network socketPath tx =
                       (protocolClientInfo (mkNodeClientProtocolRealPBFT
                                              (EpochSlots 21600)
                                              (SecurityParam 2160)))
-                      network
+                      (toByronNetworkMagic network)
                       socketPath
                       genTx
           case result of
@@ -84,7 +84,7 @@ submitTx network socketPath tx =
                       nullTracer
                       iocp
                       (protocolClientInfo mkNodeClientProtocolTPraos)
-                      network
+                      (toShelleyNetworkMagic network)
                       socketPath
                       genTx
           case result of
@@ -98,7 +98,7 @@ submitGenTx
   => Tracer IO Text
   -> IOManager
   -> ProtocolClientInfo blk
-  -> Network
+  -> NetworkMagic
   -> SocketPath
   -> GenTx blk
   -> IO (SubmitResult (ApplyTxErr blk))
@@ -123,7 +123,7 @@ localInitiatorNetworkApplication
   -- received by the client (see 'Ouroboros.Network.Protocol.LocalTxSubmission.Type'
   -- in 'ouroboros-network' package).
   -> ProtocolClientInfo blk
-  -> Network
+  -> NetworkMagic
   -> TMVar (SubmitResult (ApplyTxErr blk)) -- ^ Result will be placed here
   -> GenTx blk
   -> Versions NtC.NodeToClientVersion DictVersion
@@ -141,7 +141,7 @@ localInitiatorNetworkApplication tracer cfg nm resultVar genTx =
     proxy :: Proxy blk
     proxy = Proxy
 
-    versionData = NodeToClientVersionData { networkMagic = toNetworkMagic nm }
+    versionData = NodeToClientVersionData { networkMagic }
 
     protocols clientVersion tx =
         NodeToClientProtocols {

--- a/cardano-api/src/Cardano/Api/Types.hs
+++ b/cardano-api/src/Cardano/Api/Types.hs
@@ -14,8 +14,9 @@ module Cardano.Api.Types
     Address (..)
   , Network (..)
   , NetworkMagic (..)
-  , toNetworkMagic
   , toByronNetworkMagic
+  , toShelleyNetworkMagic
+  , toByronNetworkMagicType
   , toShelleyNetwork
   , SigningKey (..)
   , GenesisVerificationKey (..)
@@ -270,8 +271,20 @@ toNetworkMagic nw =
     Mainnet    -> NetworkMagic 764824073 -- The network magic for mainnet
     Testnet nm -> nm
 
-toByronNetworkMagic :: Network -> Byron.NetworkMagic
+toByronNetworkMagic :: Network -> NetworkMagic
 toByronNetworkMagic nw =
+  case nw of
+    Mainnet    -> NetworkMagic 764824073 -- The network magic for mainnet
+    Testnet nm -> nm
+
+toShelleyNetworkMagic :: Network -> NetworkMagic
+toShelleyNetworkMagic nw =
+  case nw of
+    Mainnet    -> NetworkMagic 1 -- The network magic for mainnet
+    Testnet nm -> nm
+
+toByronNetworkMagicType :: Network -> Byron.NetworkMagic
+toByronNetworkMagicType nw =
   case nw of
     Mainnet                   -> Byron.NetworkMainOrStage
     Testnet (NetworkMagic nm) -> Byron.NetworkTestnet nm

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -25,10 +25,10 @@ import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
 import           Cardano.Config.Protocol (CardanoEra, RealPBFTError,
-                   ncCardanoEra, renderRealPBFTError)
+                                          ncCardanoEra, renderRealPBFTError)
 import           Cardano.Config.Types
 
-import           Cardano.Api (Network, toByronNetworkMagic)
+import           Cardano.Api (Network, toByronNetworkMagicType)
 import           Cardano.CLI.Byron.Commands
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis
@@ -146,7 +146,7 @@ runPrintSigningKeyAddress :: CardanoEra -> Network -> SigningKeyFile -> ExceptT 
 runPrintSigningKeyAddress era network skF = do
   sK <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey era skF
   let sKeyAddress = prettyAddress
-                  . Common.makeVerKeyAddress (toByronNetworkMagic network)
+                  . Common.makeVerKeyAddress (toByronNetworkMagicType network)
                   . Crypto.toVerification
                   $ sK
   liftIO $ putTextLn sKeyAddress


### PR DESCRIPTION
  A '--mainnet' on 'cardano-cli shelley transaction submit' would wrongly
  use the Byron magic for mainnet and cause the cli to fail with:

  cardano-cli: HandshakeError (Refused NodeToClientV_2 "version data mismatch:
       NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 1}}
    /= NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 764824073}}

  which is unlikly to be what we want.