### PR TITLE
Remove class HasTxMaxSize

### DIFF
--- a/cardano-node/src/Cardano/Node/TUI/LiveView.hs
+++ b/cardano-node/src/Cardano/Node/TUI/LiveView.hs
@@ -15,8 +15,7 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Cardano.Node.TUI.LiveView
-    ( HasTxMaxSize
-    , LiveViewBackend (..)
+    ( LiveViewBackend (..)
     , realize
     , effectuate
     , captureCounters


### PR DESCRIPTION
getMaxTxSize is no longer used as it has been replaced by maxTxSize
from the LedgerSupportsMempool class.