### PR TITLE
Fix pool influence CLI parser such that it parses a double

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1384,7 +1384,7 @@ pMinRefund =
 pDepositDecay :: Parser (Maybe Rational)
 pDepositDecay =
   optional
-    $ Opt.option Opt.auto
+    $ Opt.option readRationalAsDouble
         (  Opt.long "deposit-decay-rate"
         <> Opt.metavar "DOUBLE"
         <> Opt.help "The deposit decay rate."
@@ -1414,7 +1414,7 @@ pPoolMinRefund =
 pPoolDecayRate :: Parser (Maybe Rational)
 pPoolDecayRate =
   optional
-    $ Opt.option Opt.auto
+    $ Opt.option readRationalAsDouble
         (  Opt.long "pool-deposit-decay-rate"
         <> Opt.metavar "DOUBLE"
         <> Opt.help "Decay rate for pool deposits."

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1445,7 +1445,7 @@ pNumberOfPools =
 pPoolInfluence :: Parser (Maybe Rational)
 pPoolInfluence =
   optional
-    $ Opt.option Opt.auto
+    $ Opt.option readRationalAsDouble
         (  Opt.long "pool-influence"
         <> Opt.metavar "DOUBLE"
         <> Opt.help "Pool influence."
@@ -1524,3 +1524,6 @@ pFieldUnitInterval = Opt.auto >>= checkUnitInterval
      case mkUnitInterval $ toRational dbl of
        Just interval -> return interval
        Nothing -> fail "Please enter a value in the range [0,1]"
+
+readRationalAsDouble :: Opt.ReadM Rational
+readRationalAsDouble = toRational <$> (Opt.auto :: Opt.ReadM Double)


### PR DESCRIPTION
There are a couple of other parsers in this module, `pDepositDecay` and `pPoolDecayRate`, that I've addressed. 

However, it seems that those fields have recently been removed from `PParams` in `cardano-ledger-specs` (see https://github.com/input-output-hk/cardano-ledger-specs/commit/aa88ee580bdc3349c65b773aacf913a3a3eb0fa7). So, once we update our dependencies, they'll be removed anyways.