### PR TITLE
Fix output of cardano-node --version command

### DIFF
--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -85,7 +85,7 @@ parseVersionCmd =
 runVersionCommand :: IO ()
 runVersionCommand =
     putTextLn $ mconcat
-      [ "cardano-cli ", renderVersion version
+      [ "cardano-node ", renderVersion version
       , " - ", Text.pack os, "-", Text.pack arch
       , " - ", Text.pack compilerName, "-", renderVersion compilerVersion
       , "\ngit rev ", gitRev


### PR DESCRIPTION
cardano-node is outputting cardano-cli in its version. Likely a copy/pate error.