### PR TITLE
Fix CLI version strings

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,8 +11,9 @@
 # }'
 , sourcesOverride ? {}
 # pinned version of nixpkgs augmented with overlays (iohk-nix and our packages).
-, pkgs ? import ./nix { inherit system crossSystem config sourcesOverride; }
-, gitrev ? pkgs.iohkNix.commitIdFromGitRepoOrZero ./.git
+, pkgs ? import ./nix/default.nix { inherit system crossSystem config sourcesOverride gitrev; }
+# Git sha1 hash, to be passed when not building from a git work tree.
+, gitrev ? null
 }:
 with pkgs; with commonLib;
 let

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,6 +2,7 @@
 , crossSystem ? null
 , config ? {}
 , sourcesOverride ? {}
+, gitrev ? null
 }:
 let
   sources = import ./sources.nix { inherit pkgs; }
@@ -26,6 +27,7 @@ let
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {
+        inherit gitrev;
 
         # commonLib: mix pkgs.lib with iohk-nix utils and our own:
         commonLib = lib // iohkNix // iohkNix.cardanoLib

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -6,6 +6,7 @@ pkgs: _: with pkgs; {
       stdenv
       haskell-nix
       buildPackages
+      gitrev
       ;
   };
   cardanoNodeProfiledHaskellPackages = import ./haskell.nix {
@@ -14,6 +15,7 @@ pkgs: _: with pkgs; {
       stdenv
       haskell-nix
       buildPackages
+      gitrev
       ;
     profiling = true;
   };


### PR DESCRIPTION
When using the nix build of `cardano-node`, the version information was incorrect.

```
$ cardano-node version
cardano-cli 1.13.0 - linux-x86_64 - ghc-8.6
git rev 0000000000000000000000000000000000000000
```

This PR fixes it.

Test with https://hydra.iohk.io/job/Cardano/cardano-node-pr-1283/cardano-node-linux/latest/download/1/cardano-node-1.13.0-linux.tar.gz