### PR TITLE
Fix broken nix-shell

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -72,6 +72,9 @@ let
         # Stamp executables with the git revision
         packages.cardano-cli.components.exes.cardano-cli.postInstall = setGitRev;
         packages.cardano-node.components.exes.cardano-node.postInstall = setGitRev;
+        # Work around Haskell.nix issue when setting postInstall on components
+        packages.cardano-cli.components.all.postInstall = lib.mkForce setGitRev;
+        packages.cardano-node.components.all.postInstall = lib.mkForce setGitRev;
       }
       {
         # Packages we wish to ignore version bounds of.


### PR DESCRIPTION
The nix-shell got broken by #1283, oops.

It looks like the jobs in buildkite which would have checked this are commented out.

And the nix-shell is not built (and cached) by Hydra - check how it's done in cardano-wallet.
