### PR TITLE
Preparation in the node for the composite Byron;Shelley protocol.

### DIFF
--- a/cardano-api/src/Cardano/Api/LocalStateQuery.hs
+++ b/cardano-api/src/Cardano/Api/LocalStateQuery.hs
@@ -36,7 +36,7 @@ import           Cardano.BM.Data.Tracer (ToLogObject (..), nullTracer)
 import           Cardano.BM.Trace (Trace, appendName, logInfo)
 
 import           Cardano.Config.Protocol ()
-import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolTPraos)
+import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolShelley)
 import           Cardano.Config.Types (SocketPath (..))
 
 import qualified Codec.CBOR.Term as CBOR
@@ -156,7 +156,7 @@ queryUTxOFromLocalState network socketPath qFilter point = do
   let pointAndQuery = (point, utxoFilter)
   newExceptT $ queryNodeLocalState
     nullTracer
-    (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos)
+    (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolShelley)
     network
     socketPath
     pointAndQuery
@@ -177,7 +177,7 @@ queryPParamsFromLocalState network socketPath point = do
   newExceptT $ liftIO $
     queryNodeLocalState
       nullTracer
-      (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos)
+      (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolShelley)
       network
       socketPath
       pointAndQuery
@@ -198,7 +198,7 @@ queryStakeDistributionFromLocalState network socketPath point = do
   newExceptT $ liftIO $
     queryNodeLocalState
       nullTracer
-      (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos)
+      (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolShelley)
       network
       socketPath
       pointAndQuery
@@ -214,7 +214,7 @@ queryLocalLedgerState network socketPath point = do
             newExceptT . liftIO $
               queryNodeLocalState
                 nullTracer
-                (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos)
+                (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolShelley)
                 network
                 socketPath
                 (point, GetCBOR GetCurrentLedgerState) -- Get CBOR-in-CBOR version
@@ -241,7 +241,7 @@ queryDelegationsAndRewardsFromLocalState network socketPath addrs point = do
     res <- newExceptT $ liftIO $
       queryNodeLocalState
         nullTracer
-        (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos)
+        (pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolShelley)
         network
         socketPath
         pointAndQuery

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -46,8 +46,8 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
 
-import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolRealPBFT)
-import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolTPraos)
+import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolByron)
+import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolShelley)
 import           Cardano.Config.Types (SocketPath(..))
 
 
@@ -81,7 +81,7 @@ submitTx network socketPath tx =
           result <- submitGenTx
                       nullTracer
                       iocp
-                      (protocolClientInfo (mkNodeClientProtocolRealPBFT
+                      (protocolClientInfo (mkNodeClientProtocolByron
                                              (EpochSlots 21600)
                                              (SecurityParam 2160)))
                       network
@@ -96,7 +96,7 @@ submitTx network socketPath tx =
           result <- submitGenTx
                       nullTracer
                       iocp
-                      (protocolClientInfo mkNodeClientProtocolTPraos)
+                      (protocolClientInfo mkNodeClientProtocolShelley)
                       network
                       socketPath
                       genTx

--- a/cardano-api/src/Cardano/Api/Types.hs
+++ b/cardano-api/src/Cardano/Api/Types.hs
@@ -16,6 +16,8 @@ module Cardano.Api.Types
   , NetworkMagic (..)
   , toNetworkMagic
   , toByronNetworkMagic
+  , toByronRequiresNetworkMagic
+  , toByronProtocolMagic
   , toShelleyNetwork
   , SigningKey (..)
   , GenesisVerificationKey (..)
@@ -111,6 +113,7 @@ import qualified Cardano.Crypto.Hash.Class   as Crypto
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
 
 import qualified Cardano.Chain.Common as Byron
+import qualified Cardano.Chain.Genesis as Byron
 import qualified Cardano.Chain.UTxO   as Byron
 import qualified Cardano.Crypto       as Byron
 
@@ -293,6 +296,14 @@ toByronNetworkMagic nw =
   case nw of
     Mainnet                   -> Byron.NetworkMainOrStage
     Testnet (NetworkMagic nm) -> Byron.NetworkTestnet nm
+
+toByronRequiresNetworkMagic :: Network -> Byron.RequiresNetworkMagic
+toByronRequiresNetworkMagic Mainnet   = Byron.RequiresNoMagic
+toByronRequiresNetworkMagic Testnet{} = Byron.RequiresMagic
+
+toByronProtocolMagic :: Network -> Byron.ProtocolMagicId
+toByronProtocolMagic Mainnet = Byron.mainnetProtocolMagicId
+toByronProtocolMagic (Testnet (NetworkMagic pm)) = Byron.ProtocolMagicId pm
 
 toShelleyNetwork :: Network -> Shelley.Network
 toShelleyNetwork  Mainnet    = Shelley.Mainnet

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -74,7 +74,8 @@ data ByronCommand =
     --- Delegation Related Commands ---
 
   | IssueDelegationCertificate
-        ConfigYamlFilePath
+        Network
+        CardanoEra
         EpochNumber
         -- ^ The epoch from which the delegation is valid.
         SigningKeyFile
@@ -84,7 +85,7 @@ data ByronCommand =
         NewCertificateFile
         -- ^ Filepath of the newly created delegation certificate.
   | CheckDelegation
-        ConfigYamlFilePath
+        Network
         CertificateFile
         VerificationKeyFile
         VerificationKeyFile
@@ -100,7 +101,9 @@ data ByronCommand =
         -- ^ Filepath of transaction to submit.
 
   | SpendGenesisUTxO
-        ConfigYamlFilePath
+        GenesisFile
+        Network
+        CardanoEra
         NewTxFile
         -- ^ Filepath of the newly created transaction.
         SigningKeyFile
@@ -110,7 +113,8 @@ data ByronCommand =
         (NonEmpty TxOut)
         -- ^ Tx output.
   | SpendUTxO
-        ConfigYamlFilePath
+        Network
+        CardanoEra
         NewTxFile
         -- ^ Filepath of the newly created transaction.
         SigningKeyFile
@@ -133,13 +137,13 @@ data ByronCommand =
 
 
 data NodeCmd = CreateVote
-               ConfigYamlFilePath
+               Network
                SigningKeyFile
                FilePath -- filepath to update proposal
                Bool
                FilePath
              | UpdateProposal
-               ConfigYamlFilePath
+               Network
                SigningKeyFile
                ProtocolVersion
                SoftwareVersion

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -61,7 +61,7 @@ import           Cardano.Api (Network(..), NetworkMagic(..))
 import           Cardano.Config.Types
 import           Cardano.Config.Parsers
                    (parseIntegral, parseFraction, parseLovelace, readDouble,
-                    parseFilePath,  parseConfigFile, parseSigningKeyFile,
+                    parseFilePath,  parseSigningKeyFile,
                     parseGenesisFile, command', parseFlag')
 import           Cardano.Config.Protocol (CardanoEra(..))
 
@@ -125,7 +125,8 @@ parseDelegationRelatedValues =
         "Create a delegation certificate allowing the\
         \ delegator to sign blocks on behalf of the issuer"
         $ IssueDelegationCertificate
-        <$> (ConfigYamlFilePath <$> parseConfigFile)
+        <$> parseNetwork
+        <*> parseCardanoEra
         <*> ( EpochNumber
                 <$> parseIntegral
                       "since-epoch"
@@ -144,7 +145,7 @@ parseDelegationRelatedValues =
         "Verify that a given certificate constitutes a valid\
         \ delegation relationship between keys."
         $ CheckDelegation
-            <$> (ConfigYamlFilePath <$> parseConfigFile)
+            <$> parseNetwork
             <*> parseCertificateFile
                   "certificate"
                   "The certificate embodying delegation to verify."
@@ -321,7 +322,9 @@ parseTxRelatedValues =
         "issue-genesis-utxo-expenditure"
         "Write a file with a signed transaction, spending genesis UTxO."
         $ SpendGenesisUTxO
-            <$> (ConfigYamlFilePath <$> parseConfigFile)
+            <$> parseGenesisFile "genesis-json"
+            <*> parseNetwork
+            <*> parseCardanoEra
             <*> parseNewTxFile "tx"
             <*> parseSigningKeyFile
                   "wallet-key"
@@ -335,7 +338,8 @@ parseTxRelatedValues =
         "issue-utxo-expenditure"
         "Write a file with a signed transaction, spending normal UTxO."
         $ SpendUTxO
-            <$> (ConfigYamlFilePath <$> parseConfigFile)
+            <$> parseNetwork
+            <*> parseCardanoEra
             <*> parseNewTxFile "tx"
             <*> parseSigningKeyFile
                   "wallet-key"
@@ -366,7 +370,7 @@ pNodeCmd =
 parseByronUpdateProposal :: Parser NodeCmd
 parseByronUpdateProposal = do
   UpdateProposal
-    <$> (ConfigYamlFilePath <$> parseConfigFile)
+    <$> parseNetwork
     <*> parseSigningKeyFile "signing-key" "Path to signing key."
     <*> parseProtocolVersion
     <*> parseSoftwareVersion
@@ -411,7 +415,7 @@ parseByronUpdateProposalSubmission =
 parseByronVote :: Parser NodeCmd
 parseByronVote =
   CreateVote
-    <$> (ConfigYamlFilePath <$> parseConfigFile)
+    <$> parseNetwork
     <*> (SigningKeyFile <$> parseFilePath "signing-key" "Filepath of signing key.")
     <*> parseFilePath "proposal-filepath" "Filepath of Byron update proposal."
     <*> parseVoteBool

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense(..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.NodeToClient (withIOManager)
 
-import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolRealPBFT)
+import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolByron)
 
 import           Cardano.Api (Network(..), getLocalTip)
 import           Cardano.CLI.Environment
@@ -46,7 +46,7 @@ runGetLocalNodeTip :: Network -> ExceptT ByronQueryError IO ()
 runGetLocalNodeTip network = do
     sockPath <- firstExceptT ByronQueryEnvVarSocketErr $ readEnvSocketPath
     let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $
-          mkNodeClientProtocolRealPBFT
+          mkNodeClientProtocolByron
             (EpochSlots 21600)
             (SecurityParam 2160)
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -25,10 +25,10 @@ import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
 import           Cardano.Config.Protocol (CardanoEra, RealPBFTError,
-                   ncCardanoEra, renderRealPBFTError)
+                   renderRealPBFTError)
 import           Cardano.Config.Types
 
-import           Cardano.Api (Network, toByronNetworkMagic)
+import           Cardano.Api (Network(..), toByronNetworkMagic, toByronProtocolMagic)
 import           Cardano.CLI.Byron.Commands
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis
@@ -81,16 +81,19 @@ runByronClientCommand c =
     PrintSigningKeyAddress era netMagic skF -> runPrintSigningKeyAddress era netMagic skF
     Keygen era nskf passReq -> runKeygen era nskf passReq
     ToVerification era skFp nvkFp -> runToVerification era skFp nvkFp
-    IssueDelegationCertificate configFp epoch issuerSK delVK cert -> runIssueDelegationCertificate configFp epoch issuerSK delVK cert
-    CheckDelegation configFp cert issuerVF delegateVF -> runCheckDelegation configFp cert issuerVF delegateVF
+    IssueDelegationCertificate nw era epoch issuerSK delVK cert ->
+      runIssueDelegationCertificate nw era epoch issuerSK delVK cert
+    CheckDelegation nw cert issuerVF delegateVF -> runCheckDelegation nw cert issuerVF delegateVF
     SubmitTx network fp -> runSubmitTx network fp
-    SpendGenesisUTxO configFp nftx ctKey genRichAddr outs -> runSpendGenesisUTxO configFp nftx ctKey genRichAddr outs
-    SpendUTxO configFp nftx ctKey ins outs -> runSpendUTxO configFp nftx ctKey ins outs
+    SpendGenesisUTxO genFp nw era nftx ctKey genRichAddr outs ->
+      runSpendGenesisUTxO genFp nw era nftx ctKey genRichAddr outs
+    SpendUTxO nw era nftx ctKey ins outs ->
+      runSpendUTxO nw era nftx ctKey ins outs
 
 
 runNodeCmd :: NodeCmd -> ExceptT ByronClientCmdError IO ()
-runNodeCmd (CreateVote configFp sKey upPropFp voteBool outputFp) =
-  firstExceptT ByronCmdVoteError $ runVoteCreation configFp sKey upPropFp voteBool outputFp
+runNodeCmd (CreateVote nw sKey upPropFp voteBool outputFp) =
+  firstExceptT ByronCmdVoteError $ runVoteCreation nw sKey upPropFp voteBool outputFp
 
 runNodeCmd (SubmitUpdateProposal network proposalFp) =
   withIOManagerE $ \iomgr ->
@@ -101,9 +104,9 @@ runNodeCmd (SubmitVote network voteFp) =
   withIOManagerE $ \iomgr ->
     firstExceptT ByronCmdVoteError $ submitByronVote iomgr network voteFp
 
-runNodeCmd (UpdateProposal configFp sKey pVer sVer sysTag insHash outputFp params) =
+runNodeCmd (UpdateProposal nw sKey pVer sVer sysTag insHash outputFp params) =
   firstExceptT ByronCmdUpdateProposalError
-    $ runProposalCreation configFp sKey pVer sVer sysTag insHash outputFp params
+    $ runProposalCreation nw sKey pVer sVer sysTag insHash outputFp params
 
 runGenesisCommand :: NewDirectory -> GenesisParameters -> CardanoEra -> ExceptT ByronClientCmdError IO ()
 runGenesisCommand outDir params era = do
@@ -136,11 +139,18 @@ runMigrateDelegateKeyFrom oldEra oldKey newEra (NewSigningKeyFile newKey) = do
 
 runPrintGenesisHash :: GenesisFile -> ExceptT ByronClientCmdError IO ()
 runPrintGenesisHash genFp = do
-    gen <- firstExceptT ByronCmdGenesisError $ readGenesis genFp
-    liftIO . putTextLn $ formatter gen
+    genesis <- firstExceptT ByronCmdGenesisError $
+                 readGenesis genFp dummyNetwork
+    liftIO . putTextLn $ formatter genesis
   where
-    formatter :: (a, Genesis.GenesisHash)-> Text
-    formatter = F.sformat Crypto.hashHexF . Genesis.unGenesisHash . snd
+    -- For this purpose of getting the hash, it does not matter what network
+    -- value we use here.
+    dummyNetwork = Mainnet
+
+    formatter :: Genesis.Config -> Text
+    formatter = F.sformat Crypto.hashHexF
+              . Genesis.unGenesisHash
+              . Genesis.configGenesisHash
 
 runPrintSigningKeyAddress :: CardanoEra -> Network -> SigningKeyFile -> ExceptT ByronClientCmdError IO ()
 runPrintSigningKeyAddress era network skF = do
@@ -165,29 +175,35 @@ runToVerification era skFp (NewVerificationKeyFile vkFp) = do
   firstExceptT ByronCmdHelpersError $ ensureNewFile TL.writeFile vkFp vKey
 
 runIssueDelegationCertificate
-        :: ConfigYamlFilePath -> EpochNumber -> SigningKeyFile -> VerificationKeyFile -> NewCertificateFile
+        :: Network
+        -> CardanoEra
+        -> EpochNumber
+        -> SigningKeyFile
+        -> VerificationKeyFile
+        -> NewCertificateFile
         -> ExceptT ByronClientCmdError IO ()
-runIssueDelegationCertificate configFp epoch issuerSK delegateVK cert = do
-  nc <- liftIO $ parseNodeConfigurationFP configFp
+runIssueDelegationCertificate nw era epoch issuerSK delegateVK cert = do
   vk <- firstExceptT ByronCmdKeyFailure $ readPaymentVerificationKey delegateVK
-  sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey (ncCardanoEra nc) issuerSK
-  pmId <- firstExceptT ByronCmdGenesisError . readProtocolMagicId $ ncGenesisFile nc
+  sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey era issuerSK
   let byGenDelCert :: Delegation.Certificate
-      byGenDelCert = issueByronGenesisDelegation pmId epoch sk vk
+      byGenDelCert = issueByronGenesisDelegation (toByronProtocolMagic nw) epoch sk vk
   sCert <- hoistEither . first ByronCmdDelegationError
-             $ serialiseDelegationCert (ncCardanoEra nc) byGenDelCert
+             $ serialiseDelegationCert era byGenDelCert
   firstExceptT ByronCmdHelpersError $ ensureNewFileLBS (nFp cert) sCert
 
 
 runCheckDelegation
-        :: ConfigYamlFilePath -> CertificateFile -> VerificationKeyFile -> VerificationKeyFile
+        :: Network
+        -> CertificateFile
+        -> VerificationKeyFile
+        -> VerificationKeyFile
         -> ExceptT ByronClientCmdError IO ()
-runCheckDelegation configFp cert issuerVF delegateVF = do
-  nc <- liftIO $ parseNodeConfigurationFP configFp
+runCheckDelegation nw cert issuerVF delegateVF = do
   issuerVK <- firstExceptT ByronCmdKeyFailure $ readPaymentVerificationKey issuerVF
   delegateVK <- firstExceptT ByronCmdKeyFailure $ readPaymentVerificationKey delegateVF
-  pmId <- firstExceptT ByronCmdGenesisError $ readProtocolMagicId $ ncGenesisFile nc
-  firstExceptT ByronCmdDelegationError $ checkByronGenesisDelegation cert pmId issuerVK delegateVK
+  firstExceptT ByronCmdDelegationError $
+    checkByronGenesisDelegation cert (toByronProtocolMagic nw)
+                                issuerVK delegateVK
 
 runSubmitTx :: Network -> TxFile -> ExceptT ByronClientCmdError IO ()
 runSubmitTx network fp =
@@ -197,25 +213,33 @@ runSubmitTx network fp =
 
 
 runSpendGenesisUTxO
-        :: ConfigYamlFilePath -> NewTxFile -> SigningKeyFile -> Common.Address -> NonEmpty TxOut
+        :: GenesisFile
+        -> Network
+        -> CardanoEra
+        -> NewTxFile
+        -> SigningKeyFile
+        -> Common.Address
+        -> NonEmpty TxOut
         -> ExceptT ByronClientCmdError IO ()
-runSpendGenesisUTxO configFp (NewTxFile ctTx) ctKey genRichAddr outs = do
-    nc <- liftIO $ parseNodeConfigurationFP configFp
-    sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey (ncCardanoEra nc) ctKey
+runSpendGenesisUTxO genesisFile nw era (NewTxFile ctTx) ctKey genRichAddr outs = do
+    genesis <- firstExceptT ByronCmdGenesisError $ readGenesis genesisFile nw
+    sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey era ctKey
 
-    tx <- firstExceptT ByronCmdRealPBFTError $
-            issueGenesisUTxOExpenditure nc genRichAddr outs sk
+    let tx = txSpendGenesisUTxOByronPBFT genesis nw sk genRichAddr outs
     firstExceptT ByronCmdHelpersError $ ensureNewFileLBS ctTx $ toCborTxAux tx
 
 runSpendUTxO
-        :: ConfigYamlFilePath -> NewTxFile -> SigningKeyFile -> NonEmpty TxIn -> NonEmpty TxOut
+        :: Network
+        -> CardanoEra
+        -> NewTxFile
+        -> SigningKeyFile
+        -> NonEmpty TxIn
+        -> NonEmpty TxOut
         -> ExceptT ByronClientCmdError IO ()
-runSpendUTxO configFp (NewTxFile ctTx) ctKey ins outs = do
-    nc <- liftIO $ parseNodeConfigurationFP configFp
-    sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey (ncCardanoEra nc) ctKey
+runSpendUTxO nw era (NewTxFile ctTx) ctKey ins outs = do
+    sk <- firstExceptT ByronCmdKeyFailure $ readEraSigningKey era ctKey
 
-    gTx <- firstExceptT ByronCmdRealPBFTError $
-             issueUTxOExpenditure nc ins outs sk
+    let gTx = txSpendUTxOByronPBFT nw sk ins outs
     firstExceptT ByronCmdHelpersError . ensureNewFileLBS ctTx $ toCborTxAux gTx
 
 withIOManagerE :: (IOManager -> ExceptT e IO a) -> ExceptT e IO a

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -57,7 +57,7 @@ import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Cardano
                    (protocolClientInfo, SecurityParam(..))
 
-import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolRealPBFT)
+import           Cardano.Config.Byron.Protocol (mkNodeClientProtocolByron)
 
 import           Cardano.Api (Network, submitGenTx)
 import           Cardano.CLI.Environment
@@ -214,7 +214,7 @@ nodeSubmitTx iomgr network gentx = do
       --TODO: print failures
       return ()
   where
-    ptcl = mkNodeClientProtocolRealPBFT
+    ptcl = mkNodeClientProtocolByron
              (EpochSlots 21600)
              (SecurityParam 2160)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -33,7 +33,7 @@ import           Cardano.CLI.Helpers (HelpersError, pPrintCBOR, renderHelpersErr
 import           Cardano.CLI.Shelley.Parsers (OutputFile (..), QueryCmd (..))
 
 import           Cardano.Config.Shelley.Orphans ()
-import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolTPraos)
+import           Cardano.Config.Shelley.Protocol (mkNodeClientProtocolShelley)
 
 import           Cardano.Crypto.Hash.Class (getHashBytesAsHex)
 
@@ -104,7 +104,9 @@ runQueryProtocolParameters
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryProtocolParameters network mOutFile = do
   sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+  let ptclClientInfo = pClientInfoCodecConfig
+                     . protocolClientInfo
+                     $ mkNodeClientProtocolShelley
   tip <- liftIO $ withIOManager $ \iomgr ->
     getLocalTip iomgr ptclClientInfo network sockPath
   pparams <- firstExceptT NodeLocalStateQueryError $
@@ -125,7 +127,9 @@ runQueryTip
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryTip network mOutFile = do
   sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+  let ptclClientInfo = pClientInfoCodecConfig
+                     . protocolClientInfo
+                     $ mkNodeClientProtocolShelley
   tip <- liftIO $ withIOManager $ \iomgr ->
     getLocalTip iomgr ptclClientInfo network sockPath
   case mOutFile of
@@ -140,7 +144,9 @@ runQueryUTxO
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryUTxO qfilter network mOutFile = do
   sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+  let ptclClientInfo = pClientInfoCodecConfig
+                     . protocolClientInfo
+                     $ mkNodeClientProtocolShelley
   tip <- liftIO $ withIOManager $ \iomgr ->
             getLocalTip iomgr ptclClientInfo network sockPath
   filteredUtxo <- firstExceptT NodeLocalStateQueryError $
@@ -153,7 +159,9 @@ runQueryLedgerState
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryLedgerState network mOutFile = do
   sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+  let ptclClientInfo = pClientInfoCodecConfig
+                     . protocolClientInfo
+                     $ mkNodeClientProtocolShelley
   tip <- liftIO $ withIOManager $ \iomgr ->
             getLocalTip iomgr ptclClientInfo network sockPath
   els <- firstExceptT NodeLocalStateQueryError $
@@ -171,7 +179,9 @@ runQueryStakeAddressInfo
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryStakeAddressInfo addr network mOutFile = do
     sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-    let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+    let ptclClientInfo = pClientInfoCodecConfig
+                       . protocolClientInfo
+                       $ mkNodeClientProtocolShelley
     tip <- liftIO $ withIOManager $ \iomgr ->
       getLocalTip iomgr ptclClientInfo network sockPath
     delegsAndRwds <- firstExceptT NodeLocalStateQueryError $
@@ -241,7 +251,9 @@ runQueryStakeDistribution
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryStakeDistribution network mOutFile = do
   sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  let ptclClientInfo = pClientInfoCodecConfig . protocolClientInfo $ mkNodeClientProtocolTPraos
+  let ptclClientInfo = pClientInfoCodecConfig
+                     . protocolClientInfo
+                     $ mkNodeClientProtocolShelley
   tip <- liftIO $ withIOManager $ \iomgr ->
     getLocalTip iomgr ptclClientInfo network sockPath
   stakeDist <- firstExceptT NodeLocalStateQueryError $

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -17,7 +17,7 @@ import           Cardano.Config.TextView
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath,
                    renderEnvSocketError)
 
-import           Cardano.Config.Types hiding (Update)
+import           Cardano.Config.Types
 
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.Config.Types (CertificateFile (..))

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -40,6 +40,7 @@ library
                        Cardano.Config.Shelley.Parsers
                        Cardano.Config.Shelley.Protocol
                        Cardano.Config.Shelley.VRF
+                       Cardano.Config.Cardano.Protocol
                        Cardano.Config.TextView
                        Cardano.Config.Topology
                        Cardano.Config.TopHandler

--- a/cardano-config/src/Cardano/Config/Byron/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Byron/Protocol.hs
@@ -10,15 +10,15 @@ module Cardano.Config.Byron.Protocol
   (
     -- * Protocol exposing the specific type
     -- | Use this when you need the specific instance
-    mkConsensusProtocolRealPBFT
+    mkConsensusProtocolByron
 
     -- * Protocols hiding the specific type
     -- | Use this when you want to handle protocols generically
-  , mkSomeConsensusProtocolRealPBFT
+  , mkSomeConsensusProtocolByron
 
     -- * Client support
-  , mkNodeClientProtocolRealPBFT
-  , mkSomeNodeClientProtocolRealPBFT
+  , mkNodeClientProtocolByron
+  , mkSomeNodeClientProtocolByron
 
     -- * Errors
   , ByronProtocolInstantiationError(..)
@@ -61,19 +61,19 @@ import           Cardano.TracingOrphanInstances.Byron ()
 -- Real Byron protocol, client support
 --
 
-mkNodeClientProtocolRealPBFT :: EpochSlots
-                             -> SecurityParam
-                             -> ProtocolClient ByronBlock ProtocolRealPBFT
-mkNodeClientProtocolRealPBFT epochSlots securityParam =
+mkNodeClientProtocolByron :: EpochSlots
+                          -> SecurityParam
+                          -> ProtocolClient ByronBlock ProtocolRealPBFT
+mkNodeClientProtocolByron epochSlots securityParam =
     ProtocolClientRealPBFT epochSlots securityParam
 
 
-mkSomeNodeClientProtocolRealPBFT :: EpochSlots
-                                 -> SecurityParam
-                                 -> SomeNodeClientProtocol
-mkSomeNodeClientProtocolRealPBFT epochSlots securityParam =
+mkSomeNodeClientProtocolByron :: EpochSlots
+                              -> SecurityParam
+                              -> SomeNodeClientProtocol
+mkSomeNodeClientProtocolByron epochSlots securityParam =
     SomeNodeClientProtocol
-      (mkNodeClientProtocolRealPBFT epochSlots securityParam)
+      (mkNodeClientProtocolByron epochSlots securityParam)
 
 
 ------------------------------------------------------------------------------
@@ -87,28 +87,28 @@ mkSomeNodeClientProtocolRealPBFT epochSlots securityParam =
 -- This also serves a purpose as a sanity check that we have all the necessary
 -- type class instances available.
 --
-mkSomeConsensusProtocolRealPBFT
+mkSomeConsensusProtocolByron
   :: NodeByronProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ByronProtocolInstantiationError IO SomeConsensusProtocol
-mkSomeConsensusProtocolRealPBFT nc files =
+mkSomeConsensusProtocolByron nc files =
 
     -- Applying the SomeConsensusProtocol here is a check that
-    -- the type of mkConsensusProtocolRealPBFT fits all the class
+    -- the type of mkConsensusProtocolByron fits all the class
     -- constraints we need to run the protocol.
-    SomeConsensusProtocol <$> mkConsensusProtocolRealPBFT nc files
+    SomeConsensusProtocol <$> mkConsensusProtocolByron nc files
 
 
 -- | Instantiate 'Consensus.Protocol' for Byron specifically.
 --
 -- Use this when you need to run the consensus with this specific protocol.
 --
-mkConsensusProtocolRealPBFT
+mkConsensusProtocolByron
   :: NodeByronProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ByronProtocolInstantiationError IO
              (Consensus.Protocol IO ByronBlock ProtocolRealPBFT)
-mkConsensusProtocolRealPBFT NodeByronProtocolConfiguration {
+mkConsensusProtocolByron NodeByronProtocolConfiguration {
                            npcByronGenesisFile,
                            npcByronReqNetworkMagic,
                            npcByronPbftSignatureThresh,

--- a/cardano-config/src/Cardano/Config/Cardano/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Cardano/Protocol.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans  #-}
+
+module Cardano.Config.Cardano.Protocol
+  (
+    -- * Protocol exposing the specific type
+    -- | Use this when you need the specific instance
+    mkConsensusProtocolCardano
+
+    -- * Protocols hiding the specific type
+    -- | Use this when you want to handle protocols generically
+  , mkSomeConsensusProtocolCardano
+
+    -- * Client support
+  , mkNodeClientProtocolCardano
+  , mkSomeNodeClientProtocolCardano
+
+    -- * Errors
+  , CardanoProtocolInstantiationError(..)
+  , renderCardanoProtocolInstantiationError
+  ) where
+
+import           Prelude
+
+import qualified Data.Text as T
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
+
+import           Cardano.Chain.Slotting (EpochSlots)
+
+import qualified Cardano.Chain.Update as Byron
+
+import           Ouroboros.Consensus.Cardano hiding (Protocol)
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
+import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
+
+import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
+import           Ouroboros.Consensus.Cardano.Condense ()
+
+import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
+import qualified Shelley.Spec.Ledger.PParams as Shelley
+
+import           Cardano.Config.Types
+                   (NodeByronProtocolConfiguration(..),
+                    NodeShelleyProtocolConfiguration(..),
+                    ProtocolFilepaths(..), SomeConsensusProtocol(..),
+                    SomeNodeClientProtocol(..),
+                    HasKESMetricsData(..), KESMetricsData(..))
+
+import           Cardano.TracingOrphanInstances.Byron ()
+import           Cardano.TracingOrphanInstances.Shelley ()
+import           Cardano.TracingOrphanInstances.HardFork ()
+
+import qualified Cardano.Config.Byron.Protocol as Byron
+import qualified Cardano.Config.Shelley.Protocol as Shelley
+
+
+--TODO: move ToObject tracing instances to Cardano.TracingOrphanInstances.Consensus
+--      and do them generically for the hard fork combinator
+instance HasKESMetricsData (CardanoBlock c) where
+    getKESMetricsData _protoInfo _forgeState = NoKESMetricsData
+    --TODO distinguish on the era and use getKESMetricsData on the appropriate era
+
+
+------------------------------------------------------------------------------
+-- Real Cardano protocol, client support
+--
+
+mkNodeClientProtocolCardano :: EpochSlots
+                            -> SecurityParam
+                            -> ProtocolClient (CardanoBlock TPraosStandardCrypto)
+                                              ProtocolCardano
+mkNodeClientProtocolCardano epochSlots securityParam =
+    ProtocolClientCardano epochSlots securityParam
+
+
+mkSomeNodeClientProtocolCardano :: EpochSlots
+                                -> SecurityParam
+                                -> SomeNodeClientProtocol
+mkSomeNodeClientProtocolCardano epochSlots securityParam =
+    SomeNodeClientProtocol
+      (mkNodeClientProtocolCardano epochSlots securityParam)
+
+
+------------------------------------------------------------------------------
+-- Real Cardano protocol
+--
+
+-- | Make 'SomeConsensusProtocol' using the Cardano instance.
+--
+-- The Cardano protocol instance is currently the sequential composition of
+-- the Byron and Shelley protocols, and will likely be extended in future
+-- with further sequentially composed protocol revisions.
+--
+-- The use of 'SomeConsensusProtocol' lets us handle multiple protocols in a
+-- generic way.
+--
+-- This also serves a purpose as a sanity check that we have all the necessary
+-- type class instances available.
+--
+mkSomeConsensusProtocolCardano
+  :: NodeByronProtocolConfiguration
+  -> NodeShelleyProtocolConfiguration
+  -> Maybe ProtocolFilepaths
+  -> ExceptT CardanoProtocolInstantiationError IO SomeConsensusProtocol
+mkSomeConsensusProtocolCardano ncb ncs files =
+
+    -- Applying the SomeConsensusProtocol here is a check that
+    -- the type of mkConsensusProtocolCardano fits all the class
+    -- constraints we need to run the protocol.
+    SomeConsensusProtocol <$> mkConsensusProtocolCardano ncb ncs files
+
+
+-- | Instantiate 'Consensus.Protocol' for Byron specifically.
+--
+-- Use this when you need to run the consensus with this specific protocol.
+--
+mkConsensusProtocolCardano
+  :: NodeByronProtocolConfiguration
+  -> NodeShelleyProtocolConfiguration
+  -> Maybe ProtocolFilepaths
+  -> ExceptT CardanoProtocolInstantiationError IO
+             (Consensus.Protocol IO (CardanoBlock TPraosStandardCrypto)
+                                    ProtocolCardano)
+mkConsensusProtocolCardano NodeByronProtocolConfiguration {
+                             npcByronGenesisFile,
+                             npcByronReqNetworkMagic,
+                             npcByronPbftSignatureThresh,
+                             npcByronApplicationName,
+                             npcByronApplicationVersion,
+                             npcByronSupportedProtocolVersionMajor,
+                             npcByronSupportedProtocolVersionMinor,
+                             npcByronSupportedProtocolVersionAlt
+                           }
+                           NodeShelleyProtocolConfiguration {
+                             npcShelleyGenesisFile,
+                             npcShelleySupportedProtocolVersionMajor,
+                             npcShelleySupportedProtocolVersionMinor,
+                             npcShelleyMaxSupportedProtocolVersion
+                           }
+                           files = do
+    byronGenesis <-
+      firstExceptT CardanoProtocolInstantiationErrorByron $
+        Byron.readGenesis npcByronGenesisFile npcByronReqNetworkMagic
+
+    byronLeaderCredentials <-
+      firstExceptT CardanoProtocolInstantiationErrorByron $
+        Byron.readLeaderCredentials byronGenesis files
+
+    shelleyGenesis <-
+      firstExceptT CardanoProtocolInstantiationErrorShelley $
+        Shelley.readGenesis npcShelleyGenesisFile
+
+    shelleyLeaderCredentials <-
+      firstExceptT CardanoProtocolInstantiationErrorShelley $
+        Shelley.readLeaderCredentials files
+
+    return $!
+      Consensus.ProtocolCardano
+        -- Byron parameters
+        byronGenesis
+        (PBftSignatureThreshold <$> npcByronPbftSignatureThresh)
+        (Byron.ProtocolVersion npcByronSupportedProtocolVersionMajor
+                               npcByronSupportedProtocolVersionMinor
+                               npcByronSupportedProtocolVersionAlt)
+        (Byron.SoftwareVersion npcByronApplicationName
+                               npcByronApplicationVersion)
+        byronLeaderCredentials
+
+        -- Shelley parameters
+        shelleyGenesis
+        (Shelley.ProtVer npcShelleySupportedProtocolVersionMajor
+                         npcShelleySupportedProtocolVersionMinor)
+        npcShelleyMaxSupportedProtocolVersion
+        shelleyLeaderCredentials
+
+        -- Hard fork parameters
+        Consensus.NoHardCodedTransition --TODO
+
+
+------------------------------------------------------------------------------
+-- Errors
+--
+
+data CardanoProtocolInstantiationError =
+       CardanoProtocolInstantiationErrorByron
+         Byron.ByronProtocolInstantiationError
+
+     | CardanoProtocolInstantiationErrorShelley
+         Shelley.ShelleyProtocolInstantiationError
+  deriving Show
+
+renderCardanoProtocolInstantiationError :: CardanoProtocolInstantiationError
+                                        -> T.Text
+renderCardanoProtocolInstantiationError
+  (CardanoProtocolInstantiationErrorByron err) =
+    Byron.renderByronProtocolInstantiationError err
+
+renderCardanoProtocolInstantiationError
+  (CardanoProtocolInstantiationErrorShelley err) =
+    Shelley.renderShelleyProtocolInstantiationError err
+

--- a/cardano-config/src/Cardano/Config/Mock/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Mock/Protocol.hs
@@ -7,15 +7,15 @@ module Cardano.Config.Mock.Protocol
   (
     -- * Protocols exposing the specific type
     -- | Use these when you need the specific instance
-    mkConsensusProtocolBFT
-  , mkConsensusProtocolPBFT
-  , mkConsensusProtocolPraos
+    mkConsensusProtocolMockBFT
+  , mkConsensusProtocolMockPBFT
+  , mkConsensusProtocolMockPraos
 
     -- * Protocols hiding the specific type
     -- | Use these when you want to handle protocols generically
-  , mkSomeConsensusProtocolBFT
-  , mkSomeConsensusProtocolPBFT
-  , mkSomeConsensusProtocolPraos
+  , mkSomeConsensusProtocolMockBFT
+  , mkSomeConsensusProtocolMockPBFT
+  , mkSomeConsensusProtocolMockPraos
   ) where
 
 import           Cardano.Prelude
@@ -41,9 +41,9 @@ import           Cardano.TracingOrphanInstances.Mock ()
 -- Mock/testing protocols
 --
 
-mkSomeConsensusProtocolBFT,
-  mkSomeConsensusProtocolPBFT,
-  mkSomeConsensusProtocolPraos
+mkSomeConsensusProtocolMockBFT,
+  mkSomeConsensusProtocolMockPBFT,
+  mkSomeConsensusProtocolMockPraos
   :: NodeMockProtocolConfiguration
   -> SomeConsensusProtocol
 
@@ -51,23 +51,23 @@ mkSomeConsensusProtocolBFT,
 -- the type of mkConsensusProtocolRealPBFT fits all the class
 -- constraints we need to run the protocol.
 
-mkSomeConsensusProtocolBFT nc =
-    SomeConsensusProtocol $ mkConsensusProtocolBFT nc
+mkSomeConsensusProtocolMockBFT nc =
+    SomeConsensusProtocol $ mkConsensusProtocolMockBFT nc
 
-mkSomeConsensusProtocolPBFT nc =
-    SomeConsensusProtocol $ mkConsensusProtocolPBFT nc
+mkSomeConsensusProtocolMockPBFT nc =
+    SomeConsensusProtocol $ mkConsensusProtocolMockPBFT nc
 
-mkSomeConsensusProtocolPraos nc =
-    SomeConsensusProtocol $ mkConsensusProtocolPraos nc
+mkSomeConsensusProtocolMockPraos nc =
+    SomeConsensusProtocol $ mkConsensusProtocolMockPraos nc
 
 
-mkConsensusProtocolBFT
+mkConsensusProtocolMockBFT
   :: NodeMockProtocolConfiguration
   -> Consensus.Protocol IO
                (SimpleBlock SimpleMockCrypto
                             (SimpleBftExt SimpleMockCrypto BftMockCrypto))
                (Bft BftMockCrypto)
-mkConsensusProtocolBFT NodeMockProtocolConfiguration {
+mkConsensusProtocolMockBFT NodeMockProtocolConfiguration {
                              npcMockNodeId       = nodeId,
                              npcMockNumCoreNodes = numCoreNodes
                            } =
@@ -78,13 +78,13 @@ mkConsensusProtocolBFT NodeMockProtocolConfiguration {
         (defaultEraParams mockSecurityParam mockSlotLength)
 
 
-mkConsensusProtocolPBFT
+mkConsensusProtocolMockPBFT
   :: NodeMockProtocolConfiguration
   -> Consensus.Protocol IO
                (SimpleBlock SimpleMockCrypto
                             (SimplePBftExt SimpleMockCrypto PBftMockCrypto))
                (PBft PBftMockCrypto)
-mkConsensusProtocolPBFT NodeMockProtocolConfiguration {
+mkConsensusProtocolMockPBFT NodeMockProtocolConfiguration {
                               npcMockNodeId       = nodeId,
                               npcMockNumCoreNodes = numCoreNodes
                             } =
@@ -98,13 +98,13 @@ mkConsensusProtocolPBFT NodeMockProtocolConfiguration {
         nodeId
 
 
-mkConsensusProtocolPraos
+mkConsensusProtocolMockPraos
   :: NodeMockProtocolConfiguration
   -> Consensus.Protocol IO
                (SimpleBlock SimpleMockCrypto
                             (SimplePraosExt SimpleMockCrypto PraosMockCrypto))
                (Praos PraosMockCrypto)
-mkConsensusProtocolPraos NodeMockProtocolConfiguration {
+mkConsensusProtocolMockPraos NodeMockProtocolConfiguration {
                                npcMockNodeId       = nodeId,
                                npcMockNumCoreNodes = numCoreNodes
                              } =

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -18,7 +18,7 @@ import qualified Data.Text as Text
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity(..))
 import qualified Cardano.Chain.Update as Update
-import           Ouroboros.Consensus.NodeId (NodeId(..), CoreNodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 
 deriving instance Show TracingVerbosity
@@ -33,8 +33,8 @@ instance FromJSON TracingVerbosity where
   parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
                              <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
 
-instance FromJSON NodeId where
-  parseJSON v = CoreId . CoreNodeId <$> parseJSON v
+instance FromJSON CoreNodeId where
+  parseJSON v = CoreNodeId <$> parseJSON v
 
 
 instance FromJSON PortNumber where

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -24,9 +24,7 @@ module Cardano.Config.Protocol
     -- a protocol.
   , CardanoEra(..)
   , SomeNodeClientProtocol(..)
-  , cardanoEraForProtocol
   , mkNodeClientProtocol
-  , ncCardanoEra
 
     -- * Errors
   , RealPBFTError(..)
@@ -117,15 +115,6 @@ mkNodeClientProtocol protocol =
 data CardanoEra = ByronEraLegacy | ByronEra | ShelleyEra
   deriving Show
 
-cardanoEraForProtocol :: Protocol -> CardanoEra
-cardanoEraForProtocol BFT      = ShelleyEra
-cardanoEraForProtocol Praos    = ShelleyEra
-cardanoEraForProtocol MockPBFT = ShelleyEra
-cardanoEraForProtocol RealPBFT = ByronEra
-cardanoEraForProtocol TPraos   = ShelleyEra
-
-ncCardanoEra :: NodeConfiguration -> CardanoEra
-ncCardanoEra = cardanoEraForProtocol . ncProtocol
 
 ------------------------------------------------------------------------------
 -- Errors

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -27,7 +27,6 @@ module Cardano.Config.Protocol
   , cardanoEraForProtocol
   , mkNodeClientProtocol
   , ncCardanoEra
-  , withRealPBFT
 
     -- * Errors
   , RealPBFTError(..)
@@ -37,7 +36,7 @@ module Cardano.Config.Protocol
 import           Cardano.Prelude
 
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, left)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
 import qualified Data.Text as Text
 
 import           Cardano.Config.Types
@@ -51,24 +50,7 @@ import           Cardano.Config.Mock.Protocol
 import           Cardano.Config.Shelley.Protocol
 
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
-import           Ouroboros.Consensus.Node.Run (RunNode)
 
-
--- | Perform an action that expects ProtocolInfo for Byron/PBFT,
---   with attendant configuration.
-withRealPBFT
-  :: NodeConfiguration
-  -> (RunNode ByronBlock
-        => Consensus.Protocol IO ByronBlock Consensus.ProtocolRealPBFT
-        -> ExceptT RealPBFTError IO a)
-  -> ExceptT RealPBFTError IO a
-withRealPBFT nc action = do
-  SomeConsensusProtocol p <- firstExceptT FromProtocolError $
-                               mkConsensusProtocol nc Nothing
-  case p of
-    proto@Consensus.ProtocolRealPBFT{} -> action proto
-    _ -> left $ IncorrectProtocolSpecified (ncProtocol nc)
 
 ------------------------------------------------------------------------------
 -- Conversions from configuration into specific protocols and their params

--- a/cardano-config/src/Cardano/Config/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Protocol.hs
@@ -65,18 +65,18 @@ mkConsensusProtocol NodeConfiguration{ncProtocolConfig} files =
       -- Mock protocols
       NodeProtocolConfigurationMock config ->
         case npcMockProtocol config of
-          MockBFT   -> pure $ mkSomeConsensusProtocolBFT   config
-          MockPBFT  -> pure $ mkSomeConsensusProtocolPBFT  config
-          MockPraos -> pure $ mkSomeConsensusProtocolPraos config
+          MockBFT   -> pure $ mkSomeConsensusProtocolMockBFT   config
+          MockPBFT  -> pure $ mkSomeConsensusProtocolMockPBFT  config
+          MockPraos -> pure $ mkSomeConsensusProtocolMockPraos config
 
       -- Real protocols
       NodeProtocolConfigurationByron config ->
         firstExceptT ByronProtocolInstantiationError $
-          mkSomeConsensusProtocolRealPBFT config files
+          mkSomeConsensusProtocolByron config files
 
       NodeProtocolConfigurationShelley config ->
         firstExceptT ShelleyProtocolInstantiationError $
-          mkSomeConsensusProtocolTPraos config files
+          mkSomeConsensusProtocolShelley config files
 
 
 mkNodeClientProtocol :: Protocol -> SomeNodeClientProtocol
@@ -87,16 +87,16 @@ mkNodeClientProtocol protocol =
       -- Mock protocols
       NodeProtocolConfigurationMock config ->
         case npcMockProtocol config of
-          BFT      -> mkNodeClientProtocolBFT
-          MockPBFT -> mkNodeClientProtocolPBFT
-          Praos    -> mkNodeClientProtocolPraos
+          BFT      -> mkNodeClientProtocolMockBFT
+          MockPBFT -> mkNodeClientProtocolMockPBFT
+          Praos    -> mkNodeClientProtocolMockPraos
 -}
       MockProtocol _ ->
         panic "TODO: mkNodeClientProtocol NodeProtocolConfigurationMock"
 
       -- Real protocols
       ByronProtocol ->
-        mkSomeNodeClientProtocolRealPBFT
+        mkSomeNodeClientProtocolByron
           --TODO: this is only the correct value for mainnet
           -- not for Byron testnets. This value is needed because
           -- to decode legacy EBBs one needs to know how many
@@ -107,7 +107,7 @@ mkNodeClientProtocol protocol =
           (Consensus.SecurityParam 2160)
 
       ShelleyProtocol ->
-        mkSomeNodeClientProtocolTPraos
+        mkSomeNodeClientProtocolShelley
 
 
 -- | Many commands have variants or file formats that depend on the era.

--- a/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Protocol.hs
@@ -10,15 +10,15 @@ module Cardano.Config.Shelley.Protocol
   (
     -- * Protocol exposing the specific type
     -- | Use this when you need the specific instance
-    mkConsensusProtocolTPraos
+    mkConsensusProtocolShelley
 
     -- * Protocols hiding the specific type
     -- | Use this when you want to handle protocols generically
-  , mkSomeConsensusProtocolTPraos
+  , mkSomeConsensusProtocolShelley
 
     -- * Client support
-  , mkNodeClientProtocolTPraos
-  , mkSomeNodeClientProtocolTPraos
+  , mkNodeClientProtocolShelley
+  , mkSomeNodeClientProtocolShelley
 
     -- * Errors
   , ShelleyProtocolInstantiationError(..)
@@ -64,14 +64,14 @@ import           Cardano.TracingOrphanInstances.Shelley ()
 -- Shelley protocol, client support
 --
 
-mkNodeClientProtocolTPraos :: ProtocolClient (ShelleyBlock TPraosStandardCrypto)
-                                             ProtocolRealTPraos
-mkNodeClientProtocolTPraos = ProtocolClientRealTPraos
+mkNodeClientProtocolShelley :: ProtocolClient (ShelleyBlock TPraosStandardCrypto)
+                                              ProtocolRealTPraos
+mkNodeClientProtocolShelley = ProtocolClientRealTPraos
 
 
-mkSomeNodeClientProtocolTPraos :: SomeNodeClientProtocol
-mkSomeNodeClientProtocolTPraos =
-    SomeNodeClientProtocol mkNodeClientProtocolTPraos
+mkSomeNodeClientProtocolShelley :: SomeNodeClientProtocol
+mkSomeNodeClientProtocolShelley =
+    SomeNodeClientProtocol mkNodeClientProtocolShelley
 
 
 ------------------------------------------------------------------------------
@@ -85,29 +85,29 @@ mkSomeNodeClientProtocolTPraos =
 -- This also serves a purpose as a sanity check that we have all the necessary
 -- type class instances available.
 --
-mkSomeConsensusProtocolTPraos
+mkSomeConsensusProtocolShelley
   :: NodeShelleyProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ShelleyProtocolInstantiationError IO SomeConsensusProtocol
-mkSomeConsensusProtocolTPraos nc files =
+mkSomeConsensusProtocolShelley nc files =
 
     -- Applying the SomeConsensusProtocol here is a check that
-    -- the type of mkConsensusProtocolTPraos fits all the class
+    -- the type of mkConsensusProtocolShelley fits all the class
     -- constraints we need to run the protocol.
-    SomeConsensusProtocol <$> mkConsensusProtocolTPraos nc files
+    SomeConsensusProtocol <$> mkConsensusProtocolShelley nc files
 
 
 -- | Instantiate 'Consensus.Protocol' for Shelley specifically.
 --
 -- Use this when you need to run the consensus with this specific protocol.
 --
-mkConsensusProtocolTPraos
+mkConsensusProtocolShelley
   :: NodeShelleyProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ShelleyProtocolInstantiationError IO
              (Consensus.Protocol IO (ShelleyBlock TPraosStandardCrypto)
                                  ProtocolRealTPraos)
-mkConsensusProtocolTPraos NodeShelleyProtocolConfiguration {
+mkConsensusProtocolShelley NodeShelleyProtocolConfiguration {
                             npcShelleyGenesisFile,
                             npcShelleySupportedProtocolVersionMajor,
                             npcShelleySupportedProtocolVersionMinor,

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -229,49 +229,58 @@ data NodeConfiguration =
     } deriving Show
 
 instance FromJSON NodeConfiguration where
-  parseJSON = withObject "NodeConfiguration" $ \v -> do
-                nId <- v .:? "NodeId"
-                ptcl <- v .: "Protocol" .!= RealPBFT
-                genFile <- v .: "GenesisFile" .!= "genesis/genesis.json"
-                numCoreNode <- v .:? "NumCoreNodes"
-                rNetworkMagic <- v .:? "RequiresNetworkMagic" .!= RequiresNoMagic
-                pbftSignatureThresh <- v .:? "PBftSignatureThreshold"
-                vMode <- v .:? "ViewMode" .!= LiveView
-                socketPath <- v .:? "SocketPath"
+  parseJSON =
+    withObject "NodeConfiguration" $ \v -> do
 
-                -- Update Parameters
-                appName <- v .:? "ApplicationName" .!= Update.ApplicationName "cardano-sl"
-                appVersion <- v .:? "ApplicationVersion" .!= 1
-                lkBlkVersionMajor <- v .:? "LastKnownBlockVersion-Major" .!= 0
-                lkBlkVersionMinor <- v .:? "LastKnownBlockVersion-Minor" .!= 2
-                lkBlkVersionAlt <- v .:? "LastKnownBlockVersion-Alt" .!= 0
-                maxMajorPV <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
+      -- Node parameters, not protocol-specific
+      socketPath <- v .:? "SocketPath"
 
-                -- Logging
-                loggingSwitch <- v .:? "TurnOnLogging" .!= True
-                logMetrics <- v .:? "TurnOnLogMetrics" .!= True
-                traceConfig <- if not loggingSwitch
-                               then return TracingOff
-                               else traceConfigParser v
+      -- Protocol parameters
+      ptcl <- v .: "Protocol" .!= RealPBFT
+      genFile <- v .: "GenesisFile" .!= "genesis/genesis.json"
 
-                pure $ NodeConfiguration
-                         { ncProtocol = ptcl
-                         , ncGenesisFile = genFile
-                         , ncNodeId = nId
-                         , ncNumCoreNodes = numCoreNode
-                         , ncReqNetworkMagic = rNetworkMagic
-                         , ncPbftSignatureThresh = pbftSignatureThresh
-                         , ncLoggingSwitch = loggingSwitch
-                         , ncLogMetrics = logMetrics
-                         , ncSocketPath = socketPath
-                         , ncTraceConfig = traceConfig
-                         , ncViewMode = vMode
-                         , ncUpdate = (Update appName appVersion (LastKnownBlockVersion
-                                                                    lkBlkVersionMajor
-                                                                    lkBlkVersionMinor
-                                                                    lkBlkVersionAlt))
-                         , ncMaxMajorPV = maxMajorPV
-                         }
+      -- Byron-specific protocol parameters
+      rNetworkMagic <- v .:? "RequiresNetworkMagic" .!= RequiresNoMagic
+      pbftSignatureThresh <- v .:? "PBftSignatureThreshold"
+
+      -- Mock protocol parameters
+      nId <- v .:? "NodeId"
+      numCoreNode <- v .:? "NumCoreNodes"
+
+      -- Update system parameters
+      appName <- v .:? "ApplicationName" .!= Update.ApplicationName "cardano-sl"
+      appVersion <- v .:? "ApplicationVersion" .!= 1
+      lkBlkVersionMajor <- v .:? "LastKnownBlockVersion-Major" .!= 0
+      lkBlkVersionMinor <- v .:? "LastKnownBlockVersion-Minor" .!= 2
+      lkBlkVersionAlt <- v .:? "LastKnownBlockVersion-Alt" .!= 0
+      maxMajorPV <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
+
+      -- Logging
+      vMode <- v .:? "ViewMode" .!= LiveView
+      loggingSwitch <- v .:? "TurnOnLogging" .!= True
+      logMetrics <- v .:? "TurnOnLogMetrics" .!= True
+      traceConfig <- if not loggingSwitch
+                     then return TracingOff
+                     else traceConfigParser v
+
+      pure NodeConfiguration {
+             ncProtocol = ptcl
+           , ncGenesisFile = genFile
+           , ncNodeId = nId
+           , ncNumCoreNodes = numCoreNode
+           , ncReqNetworkMagic = rNetworkMagic
+           , ncPbftSignatureThresh = pbftSignatureThresh
+           , ncLoggingSwitch = loggingSwitch
+           , ncLogMetrics = logMetrics
+           , ncSocketPath = socketPath
+           , ncTraceConfig = traceConfig
+           , ncViewMode = vMode
+           , ncUpdate = (Update appName appVersion (LastKnownBlockVersion
+                                                      lkBlkVersionMajor
+                                                      lkBlkVersionMinor
+                                                      lkBlkVersionAlt))
+           , ncMaxMajorPV = maxMajorPV
+           }
 
 parseNodeConfigurationFP :: ConfigYamlFilePath -> IO NodeConfiguration
 parseNodeConfigurationFP (ConfigYamlFilePath fp) = do

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -240,9 +240,9 @@ instance FromJSON NodeConfiguration where
       ncProtocol <- v .: "Protocol" .!= RealPBFT
       ncGenesisFile <-
         case ncProtocol of
-          BFT      -> v .: "GenesisFile" .!= "genesis/genesis.json"
-          Praos    -> v .: "GenesisFile" .!= "genesis/genesis.json"
-          MockPBFT -> v .: "GenesisFile" .!= "genesis/genesis.json"
+          BFT      -> v .: "GenesisFile"
+          Praos    -> v .: "GenesisFile"
+          MockPBFT -> v .: "GenesisFile"
           RealPBFT -> do
             primary   <- v .:? "ByronGenesisFile"
             secondary <- v .:? "GenesisFile"
@@ -276,13 +276,13 @@ instance FromJSON NodeConfiguration where
       -- Update system parameters
       appName <- v .:? "ApplicationName" .!= Update.ApplicationName "cardano-sl"
       appVersion <- v .:? "ApplicationVersion" .!= 1
-      lkBlkVersionMajor <- v .:? "LastKnownBlockVersion-Major" .!= 0
-      lkBlkVersionMinor <- v .:? "LastKnownBlockVersion-Minor" .!= 2
+      lkBlkVersionMajor <- v .: "LastKnownBlockVersion-Major"
+      lkBlkVersionMinor <- v .: "LastKnownBlockVersion-Minor"
       lkBlkVersionAlt <- v .:? "LastKnownBlockVersion-Alt" .!= 0
       maxMajorPV <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
 
       -- Logging
-      ncViewMode      <- v .:? "ViewMode"         .!= LiveView
+      ncViewMode      <- v .:? "ViewMode"         .!= SimpleView
       ncLoggingSwitch <- v .:? "TurnOnLogging"    .!= True
       ncLogMetrics    <- v .:? "TurnOnLogMetrics" .!= True
       ncTraceConfig   <- if ncLoggingSwitch

--- a/cardano-config/src/Cardano/TracingOrphanInstances/HardFork.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/HardFork.hs
@@ -53,13 +53,6 @@ instance Condense (OneEraHash xs) where
 -- instances for Header HardForkBlock
 --
 
-instance All (Condense `Compose` Header) xs => Condense (Header (HardForkBlock xs)) where
-    condense =
-          hcollapse
-        . hcmap (Proxy @ (Condense `Compose` Header)) (K . condense)
-        . getOneEraHeader
-        . getHardForkHeader
-
 instance All (ToObject `Compose` Header) xs => ToObject (Header (HardForkBlock xs)) where
     toObject verb =
           hcollapse


### PR DESCRIPTION
Refactoring and changes plus the actual addition of the support for the new
composite protocol in `cardano-config`

The existing protocols are renamed to the Byron and Shelley protocols and
this new composite one is called the Cardano protocol because it's the
protocol that will run on the Cardano mainnet.