### PR TITLE
Fix ByteString ToJSON instance in Cardano.Config.Shelley.Orphans

### DIFF
--- a/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
@@ -95,7 +95,7 @@ hashToText = Text.decodeLatin1 . Crypto.getHashBytesAsHex
 -- not printable should be hex encoded for readability.
 instance ToJSON ByteString where
   toJSON bs =
-    toJSON $
+    toJSON . Text.decodeLatin1 $
       if BS.all isPrint bs
         then bs
         else Base16.encode bs


### PR DESCRIPTION
It seems that this ToJSON implementation for ByteString was recursing
infinitely. It would continually call toJSON on a ByteString, repeatedly
calling itself.

Closes #1244 