### PR TITLE
CAD-1262: Remove 'Forks created' metric.

### DIFF
--- a/cardano-node/src/Cardano/Node/TUI/Drawing.hs
+++ b/cardano-node/src/Cardano/Node/TUI/Drawing.hs
@@ -66,7 +66,6 @@ data LiveViewState blk a = LiveViewState
   , lvsNodeCannotLead       :: !Word64
   , lvsLeaderNum            :: !Word64
   , lvsSlotsMissedNum       :: !Word64
-  , lvsCreatedForksNum      :: !Word64
   , lvsTransactions         :: !Word64
   , lvsPeersConnected       :: !Word64
   , lvsMempool              :: !Word64
@@ -201,7 +200,6 @@ nodeInfoLabels =
            ,                    txt "slots lead:"
            ,                    txt "slots missed:"
            ,                    txt "cannot lead:"
-           ,                    txt "forks created:"
            , padTop (Pad 1) $ txt "TXs processed:"
            , padTop (Pad 1) $ txt "peers:"
            ]
@@ -231,7 +229,6 @@ nodeInfoValues lvs =
            ,                  str (show . lvsLeaderNum $ lvs)
            ,                  str (show . lvsSlotsMissedNum $ lvs)
            ,                  str (show . lvsNodeCannotLead $ lvs)
-           ,                  str (show . lvsCreatedForksNum $ lvs)
            , padTop (Pad 1) $ str (show . lvsTransactions $ lvs)
            , padTop (Pad 1) $ str (show . lvsPeersConnected $ lvs)
            ]

--- a/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
+++ b/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
@@ -223,13 +223,6 @@ instance IsEffectuator (LiveViewBackend blk) Text where
 
                                 return $ lvs { lvsSlotsMissedNum = fromIntegral missedSlotsNum }
 
-                    LogValue "forksCreatedNum" (PureI createdForksNum) ->
-                        modifyMVar_ (getbe lvbe) $ \lvs -> do
-
-                                checkForUnexpectedThunks ["forksCreatedNum LiveViewBackend"] lvs
-
-                                return $ lvs { lvsCreatedForksNum = fromIntegral createdForksNum }
-
                     _ -> pure ()
 
                 checkForUnexpectedThunks ["Cardano node metrics dispatch LiveViewBackend"] lvbe
@@ -354,7 +347,6 @@ initLiveViewState = do
                 , lvsNodeCannotLead         = 0
                 , lvsLeaderNum              = 0
                 , lvsSlotsMissedNum         = 0
-                , lvsCreatedForksNum        = 0
                 , lvsTransactions           = 0
                 , lvsPeersConnected         = 0
                 , lvsMempool                = 0


### PR DESCRIPTION
After a long discussion (initiated by https://github.com/input-output-hk/cardano-node/issues/1211), it's still unclear how to measure "forks events" properly and if this metric is needed in the TUI at all. So currently we remove `forks created:` metric from the TUI.