### PR TITLE
Parse Byron Base58 address using str reader

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -593,7 +593,7 @@ parseWord optname desc metvar = option (fromInteger <$> auto)
 
 parseAddress :: String -> String -> Parser Address
 parseAddress opt desc =
-  option (cliParseBase58Address <$> auto)
+  option (cliParseBase58Address <$> str)
     $ long opt <> metavar "ADDR" <> help desc
 
 parseCardanoEra :: Parser CardanoEra


### PR DESCRIPTION
For some reason, we were using the `auto` reader to parse Base58
addresses in the Byron CLI.

Because the `auto` reader uses the `Read` typeclass, this would require
the user to specify the address on the command-line in an odd way, e.g.
`'"base58AddressHere"'` or `\"base58AddressHere\"`.