### PR TITLE
CAD-1131:  add a UTxO size trace to TraceStartLeadershipCheck messages & lots of cleanups

### DIFF
--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -25,6 +25,7 @@ library
   exposed-modules:     Cardano.Config.Byron.Parsers
                        Cardano.Config.GitRev
                        Cardano.Config.GitRevFromGit
+                       Cardano.Config.LedgerQueries
                        Cardano.Config.Logging
                        Cardano.Config.Orphanage
                        Cardano.Config.Parsers
@@ -48,6 +49,7 @@ library
                      , aeson
                      , async
                      , base16-bytestring
+                     , byron-spec-ledger
                      , bytestring
                      , canonical-json >= 0.6 && < 0.7
                      , cardano-binary

--- a/cardano-config/src/Cardano/Config/LedgerQueries.hs
+++ b/cardano-config/src/Cardano/Config/LedgerQueries.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Config.LedgerQueries
+  (LedgerQueries(..))
+where
+
+import           Prelude (Int, error, (.))
+
+import qualified Data.Map.Strict as Map
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Byron.Spec.Ledger.Core (Relation(..))
+
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
+import qualified Ouroboros.Consensus.Byron.Ledger.Ledger as Byron
+
+import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
+import qualified Shelley.Spec.Ledger.LedgerState as Shelley
+import qualified Shelley.Spec.Ledger.UTxO as Shelley
+
+import qualified Ouroboros.Consensus.Cardano as Cardano
+import qualified Ouroboros.Consensus.Cardano.Block as Cardano
+
+import qualified Ouroboros.Consensus.Mock.Ledger as Mock
+
+
+class LedgerQueries blk where
+  ledgerUtxoSize :: LedgerState blk -> Int
+
+instance LedgerQueries Byron.ByronBlock where
+  ledgerUtxoSize = size . Byron.unUTxO . Byron.cvsUtxo . Byron.byronLedgerState
+
+instance LedgerQueries (Shelley.ShelleyBlock c) where
+  ledgerUtxoSize =
+    (\(Shelley.UTxO xs)-> Map.size xs) . Shelley._utxo . Shelley._utxoState . Shelley.esLState . Shelley.nesEs . Shelley.shelleyState
+
+instance LedgerQueries (Cardano.CardanoBlock c) where
+  ledgerUtxoSize = \case
+    Cardano.LedgerStateByron   ledgerByron   -> ledgerUtxoSize ledgerByron
+    Cardano.LedgerStateShelley ledgerShelley -> ledgerUtxoSize ledgerShelley
+    _ -> error "ledgerUtxoSize:  unhandled CardanoBlock case"
+
+instance LedgerQueries (Mock.SimpleBlock a b) where
+  ledgerUtxoSize _ = error "ledgerUtxoSize:  not implemented for SimpleBlock"

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -90,6 +90,7 @@ import           Ouroboros.Consensus.Shelley.Protocol.Crypto.HotKey (HotKey (..)
 
 import           Ouroboros.Network.Block (HeaderHash, MaxSlotNo(..))
 
+import           Cardano.Config.LedgerQueries
 import           Cardano.Config.Orphanage ()
 import           Cardano.Config.TraceConfig
 import           Cardano.Crypto (RequiresNetworkMagic(..))
@@ -678,6 +679,7 @@ type TraceConstraints blk =
     , Condense (TxId (GenTx blk))
     , HasTxs blk
     , HasTxId (GenTx blk)
+    , LedgerQueries blk
     , Show (ApplyTxErr blk)
     , Show (GenTx blk)
     , Show (GenTxId blk)

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -42,6 +42,7 @@ library
                        Cardano.Node.Protocol.Types
                        Cardano.Node.Run
                        Cardano.Node.Shutdown
+                       Cardano.Tracing.Kernel
                        Cardano.Tracing.Peer
                        Cardano.Tracing.Tracers
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -88,6 +88,7 @@ library
                      , tracer-transformers
                      , transformers
                      , transformers-except
+                     , unordered-containers
 
 
   default-language:    Haskell2010

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -128,10 +128,10 @@ runNode loggingLayer npm@NodeCLI{protocolFiles} = do
     upTimeThread <- Async.async $ traceNodeUpTime (appendName "metrics" trace) =<< getMonotonicTimeNSec
 
     -- This IORef contains node kernel structure which holds node kernel.
-    -- We use it to extract information about connected peers periodically.
+    -- Used for ledger queries and peer connection status.
     nodeKernelData :: NodeKernelData blk <- mkNodeKernelData
 
-    tracers <- mkTracers (ncTraceConfig nc) trace
+    tracers <- mkTracers (ncTraceConfig nc) trace nodeKernelData
 
     case viewmode of
       SimpleView -> do

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -90,6 +90,7 @@ import           Cardano.Node.Protocol
                     SomeConsensusProtocol(..), renderProtocolInstantiationError)
 import           Cardano.Node.Socket (gatherConfiguredSockets, SocketOrSocketInfo(..))
 import           Cardano.Node.Shutdown
+import           Cardano.Tracing.Kernel
 import           Cardano.Tracing.Peer
 import           Cardano.Tracing.Tracers
 #ifdef UNIX
@@ -237,11 +238,11 @@ traceNodeUpTime tr nodeLaunchTime = do
 handlePeersList
   :: NFData a
   => Trace IO Text
-  -> IORef (NodeKernelData blk)
+  -> NodeKernelData blk
   -> LiveViewBackend blk a
   -> IO ()
-handlePeersList tr nodeKernIORef lvbe = forever $ do
-  peers <- getCurrentPeers nodeKernIORef
+handlePeersList tr nodeKern lvbe = forever $ do
+  peers <- getCurrentPeers nodeKern
   storePeersInLiveView peers lvbe
   tracePeers tr peers
   threadDelay 2000000 -- 2 seconds.
@@ -249,10 +250,10 @@ handlePeersList tr nodeKernIORef lvbe = forever $ do
 
 handlePeersListSimple
   :: Trace IO Text
-  -> IORef (NodeKernelData blk)
+  -> NodeKernelData blk
   -> IO ()
-handlePeersListSimple tr nodeKernIORef = forever $ do
-  getCurrentPeers nodeKernIORef >>= tracePeers tr
+handlePeersListSimple tr nodeKern = forever $ do
+  getCurrentPeers nodeKern >>= tracePeers tr
   threadDelay 2000000 -- 2 seconds.
 
 -- | Sets up a simple node, which will run the chain sync protocol and block

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveTraversable     #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Tracing.Kernel
+  ( NodeKernelData (..)
+  , mkNodeKernelData
+  , setNodeKernel
+  , mapNodeKernelDataIO
+  -- * Re-exports
+  , NodeKernel (..)
+  , LocalConnectionId
+  , RemoteConnectionId
+  , StrictMaybe(..)
+  , fromSMaybe
+  ) where
+
+import           Cardano.Prelude hiding (atomically)
+
+import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe(..), fromSMaybe)
+
+import           Ouroboros.Consensus.Node (NodeKernel(..))
+import           Ouroboros.Consensus.Util.Orphans ()
+
+import           Ouroboros.Network.NodeToClient (LocalConnectionId)
+import           Ouroboros.Network.NodeToNode (RemoteConnectionId)
+
+
+newtype NodeKernelData blk =
+  NodeKernelData
+  { unNodeKernelData :: IORef (StrictMaybe (NodeKernel IO RemoteConnectionId LocalConnectionId blk))
+  }
+
+deriving instance Foldable    StrictMaybe
+deriving instance Traversable StrictMaybe
+
+mkNodeKernelData :: IO (NodeKernelData blk)
+mkNodeKernelData = NodeKernelData <$> newIORef SNothing
+
+setNodeKernel :: NodeKernelData blk
+              -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
+              -> IO ()
+setNodeKernel (NodeKernelData ref) nodeKern =
+  writeIORef ref $ SJust nodeKern
+
+mapNodeKernelDataIO ::
+  (NodeKernel IO RemoteConnectionId LocalConnectionId blk -> IO a)
+  -> NodeKernelData blk
+  -> IO (StrictMaybe a)
+mapNodeKernelDataIO f (NodeKernelData ref) =
+  readIORef ref >>= traverse f

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -1,16 +1,11 @@
-{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE DeriveTraversable     #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
 module Cardano.Tracing.Peer
   ( Peer (..)
-  , NodeKernelData (..)
   , getCurrentPeers
-  , initialNodeKernelData
   , ppPeer
-  , setNodeKernel
   , tracePeers
   ) where
 
@@ -20,7 +15,6 @@ import           Prelude (String)
 import qualified Control.Monad.Class.MonadSTM.Strict as STM
 
 import           Data.Aeson (ToJSON(..), toJSON, Value (..), (.=))
-import           Data.IORef (IORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -44,6 +38,8 @@ import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
 import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..), PeerFetchStatus (..), readFetchClientState)
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteConnectionId)
+
+import           Cardano.Tracing.Kernel
 
 data Peer blk =
   Peer
@@ -84,45 +80,11 @@ ppStatus PeerFetchStatusAberrant = "aberrant"
 ppStatus PeerFetchStatusBusy     = "fetching"
 ppStatus PeerFetchStatusReady {} = "ready"
 
-
-data SMaybe a
-  = SNothing
-  | SJust !a
-  deriving (Foldable, Functor, Generic, NFData, NoUnexpectedThunks, Traversable)
-
-fromSMaybe :: a -> SMaybe a -> a
-fromSMaybe x SNothing = x
-fromSMaybe _ (SJust x) = x
-
-newtype LVNodeKernel blk = LVNodeKernel
-  { getNodeKernel :: NodeKernel IO RemoteConnectionId LocalConnectionId blk }
-  deriving (Generic)
-
-instance NoUnexpectedThunks (LVNodeKernel blk) where
-    whnfNoUnexpectedThunks _ _ = pure NoUnexpectedThunks
-
-instance NFData (LVNodeKernel blk) where
-    rnf _ = ()
-
-newtype NodeKernelData blk = NodeKernelData (SMaybe (LVNodeKernel blk))
-
-initialNodeKernelData :: NodeKernelData blk
-initialNodeKernelData = NodeKernelData SNothing
-
-setNodeKernel :: IORef (NodeKernelData blk)
-              -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
-              -> IO ()
-setNodeKernel nodeKernIORef nodeKern = do
-  let actualNodeKernelData = NodeKernelData (SJust (LVNodeKernel nodeKern))
-  -- We do it once, so don't need an atomic updating here.
-  writeIORef nodeKernIORef actualNodeKernelData
-
 getCurrentPeers
-  :: IORef (NodeKernelData blk)
+  :: NodeKernelData blk
   -> IO [Peer blk]
-getCurrentPeers nodeKernIORef = do
-  NodeKernelData aKernel <- readIORef nodeKernIORef
-  fromSMaybe mempty <$> sequence (extractPeers . getNodeKernel <$> aKernel)
+getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
+                      <&> fromSMaybe mempty
  where
   tuple3pop :: (a, b, c) -> (a, b)
   tuple3pop (a, b, _) = (a, b)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -83,6 +83,7 @@ import           Cardano.Config.TraceConfig
 import           Cardano.Config.Types
                    (TraceConstraints, HasKESMetricsData (..), KESMetricsData (..),
                     MaxKESEvolutions (..), OperationalCertStartKESPeriod (..))
+import           Cardano.Tracing.Kernel
 import           Cardano.Tracing.MicroBenchmarking
 
 -- For tracing instances

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -78,6 +78,7 @@ import           Ouroboros.Network.Subscription
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 
+import           Cardano.Config.LedgerQueries
 import           Cardano.Config.TraceConfig
 import           Cardano.Config.Types
                    (TraceConstraints, HasKESMetricsData (..), KESMetricsData (..),


### PR DESCRIPTION
1. Factors the `Cardano.Tracing.Kernel` module for `NodeKernel` access.
2. `Cardano.Config.LedgerQuery` for a ledger queries typeclass.
3. Enhance the `TraceStartLeadershipCheck` message with a UTxO size value.
4. Switch over to the newly available `Shelley.Spec.Ledger.BaseTypes.StrictMaybe`.
5. Clean up the overall tracer setup somewhat.

Sample messages:
```
{"at":"2020-06-23T22:30:54.43Z","env":"1.14.0:00000","ns":["cardano.node.Forge"],"data":{"kind":"TraceStartLeadershipCheck","slot":0},"app":[],"msg":"","pid":"12379","loc":null,"host":"andromed","sev":"Info","thread":"37"}
{"at":"2020-06-23T22:30:54.63Z","env":"1.14.0:00000","ns":["cardano.node.Forge"],"data":{"kind":"TraceStartLeadershipCheck","slot":1,"utxoSize":3},"app":[],"msg":"","pid":"12379","loc":null,"host":"andromed","sev":"Info","thread":"37"}
```

Note the absence of `utxoSize` for slot 0, when there's no `NodeKernel` available yet.