### PR TITLE
Expect an EpochState from the GetCurrentEpochState query

### DIFF
--- a/cardano-api/src/Cardano/Api/LocalStateQuery.hs
+++ b/cardano-api/src/Cardano/Api/LocalStateQuery.hs
@@ -208,7 +208,7 @@ queryLocalLedgerState
   => Network
   -> SocketPath
   -> Point blk
-  -> ExceptT LocalStateQueryError IO (Either LByteString (Ledger.LedgerState TPraosStandardCrypto))
+  -> ExceptT LocalStateQueryError IO (Either LByteString (Ledger.EpochState TPraosStandardCrypto))
 queryLocalLedgerState network socketPath point = do
   lbs <- fmap unSerialised <$>
             newExceptT . liftIO $

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -47,7 +47,7 @@ import           Ouroboros.Network.Block (getTipPoint)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr(..))
 import           Shelley.Spec.Ledger.Keys (Hash, KeyHash(..), KeyRole (..), VerKeyVRF)
-import           Shelley.Spec.Ledger.LedgerState (LedgerState)
+import           Shelley.Spec.Ledger.LedgerState (EpochState)
 import           Shelley.Spec.Ledger.PParams (PParams)
 import           Shelley.Spec.Ledger.TxData (TxId (..), TxIn (..), TxOut (..))
 import           Shelley.Spec.Ledger.UTxO (UTxO (..))
@@ -205,7 +205,7 @@ writeStakeAddressInfo mOutFile dr@(DelegationsAndRewards _delegsAndRwds) =
       handleIOExceptT (ShelleyQueryWriteStakeAddressInfoError fpath)
         $ LBS.writeFile fpath (encodePretty dr)
 
-writeLedgerState :: Maybe OutputFile -> LedgerState TPraosStandardCrypto -> ExceptT ShelleyQueryCmdError IO ()
+writeLedgerState :: Maybe OutputFile -> EpochState TPraosStandardCrypto -> ExceptT ShelleyQueryCmdError IO ()
 writeLedgerState mOutFile lstate =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty lstate)

--- a/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -27,8 +28,10 @@ import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCryp
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
 import qualified Shelley.Spec.Ledger.Credential as Ledger
 import           Shelley.Spec.Ledger.Crypto (Crypto)
+import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
+import qualified Shelley.Spec.Ledger.Rewards as Ledger
 import           Shelley.Spec.Ledger.MetaData (MetaDataHash(..))
 import           Shelley.Spec.Ledger.PParams (PParams' (..))
 import qualified Shelley.Spec.Ledger.PParams as Ledger
@@ -67,18 +70,26 @@ deriving newtype instance ToJSON (TxId c)
 deriving newtype instance Crypto c => ToJSON (UTxO c)
 
 deriving newtype instance ToJSON (MetaDataHash c)
+deriving newtype instance ToJSON Ledger.LogWeight
+deriving newtype instance ToJSON Ledger.Likelihood
+deriving newtype instance ToJSON (Ledger.Stake TPraosStandardCrypto)
 
 deriving anyclass instance ToJSON (Ledger.GenDelegs TPraosStandardCrypto)
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates TPraosStandardCrypto)
 deriving anyclass instance ToJSON (Ledger.StakePools TPraosStandardCrypto)
 
 deriving instance ToJSON Ledger.Ptr
+deriving instance ToJSON Ledger.AccountState
 
 deriving instance ToJSON (Ledger.DPState TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.DState TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.FutureGenDeleg TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.InstantaneousRewards TPraosStandardCrypto)
+deriving instance ToJSON (Ledger.SnapShot TPraosStandardCrypto)
+deriving instance ToJSON (Ledger.SnapShots TPraosStandardCrypto)
+deriving instance ToJSON (Ledger.NonMyopic TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.LedgerState TPraosStandardCrypto)
+deriving instance ToJSON (Ledger.EpochState TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.PParams' StrictMaybe)
 deriving instance ToJSON (Ledger.PState TPraosStandardCrypto)
 deriving instance ToJSON (Ledger.StakeReference TPraosStandardCrypto)


### PR DESCRIPTION
Fixes #1333.

The `GetCurrentLedgerState` query was changed in consensus to
`GetCurrentEpochState` so that it includes more information that will help
debugging (https://github.com/input-output-hk/ouroboros-network/pull/2288).

In this repo, we were still trying to decode it as a `LedgerState` instead of
an `EpochState`, which always failed. Fix it by trying to decode it as an
`EpochState`.