### PR TITLE
Add a new node config entry: TestShelleyHardForkAtVersion

### DIFF
--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -301,10 +301,21 @@ data NodeHardForkProtocolConfiguration =
        -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
        --
-       -- Obviously if this is used, all the nodes in the test cluster much be
+       -- Obviously if this is used, all the nodes in the test cluster must be
        -- configured the same, or they will disagree.
        --
        npcTestShelleyHardForkAtEpoch :: Maybe EpochNo
+
+       -- | For testing purposes we support specifying that the hard fork
+       -- happens at a given major protocol version. For example this can be
+       -- used to cause the Shelley hard fork to occur at the transition from
+       -- protocol version 0 to version 1 (rather than the default of from 1 to
+       -- 2) which can make the test setup simpler.
+       --
+       -- Obviously if this is used, all the nodes in the test cluster must be
+       -- configured the same, or they will disagree.
+       --
+     , npcTestShelleyHardForkAtVersion :: Maybe Word
      }
   deriving Show
 
@@ -416,9 +427,11 @@ instance FromJSON NodeConfiguration where
              }
 
       parseHardForkProtocol v = do
-        npcTestShelleyHardForkAtEpoch <- v .:? "TestShelleyHardForkAtEpoch"
+        npcTestShelleyHardForkAtEpoch   <- v .:? "TestShelleyHardForkAtEpoch"
+        npcTestShelleyHardForkAtVersion <- v .:? "TestShelleyHardForkAtVersion"
         pure NodeHardForkProtocolConfiguration {
-               npcTestShelleyHardForkAtEpoch
+               npcTestShelleyHardForkAtEpoch,
+               npcTestShelleyHardForkAtVersion
              }
 
 

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -121,7 +121,8 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcShelleyMaxSupportedProtocolVersion
                            }
                            NodeHardForkProtocolConfiguration {
-                             npcTestShelleyHardForkAtEpoch
+                             npcTestShelleyHardForkAtEpoch,
+                             npcTestShelleyHardForkAtVersion
                            }
                            files = do
     byronGenesis <-
@@ -173,7 +174,11 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
            -- Version 1 is Byron with Ouroboros Permissive BFT
            -- Version 2 is Shelley
            --
-           Nothing -> Consensus.NoHardCodedTransition 2
+           -- But we also provide an override to allow for simpler test setups
+           -- such as triggering at the 0 -> 1 transition .
+           --
+           Nothing -> Consensus.NoHardCodedTransition
+                        (maybe 2 fromIntegral npcTestShelleyHardForkAtVersion)
 
            -- Alternatively, for testing we can transition at a specific epoch.
            --


### PR DESCRIPTION
Setting this, e.g.
TestShelleyHardForkAtVersion: 1

Should cause the hard fork to occur when the protocol major version
eraches this value, rather than the default of 2.

This allows a simpler test setup. Otherwise, given that Byron genesis
always starts at protocol version 0, it needs two protocol updates
(includng a node restart) to get to the hard fork.