### PR TITLE
Correct the hashing of pool metadata in the cli

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -189,5 +189,5 @@ runPoolMetaDataHash (PoolMetaDataFile poolMDPath) = do
     . hoistEither
     $ decodeAndValidateStakePoolMetadata metaDataBytes
   let metaDataHash :: Crypto.Hash Crypto.Blake2b_256 ByteString
-      metaDataHash = Crypto.hash metaDataBytes
+      metaDataHash = Crypto.hashRaw (\x -> x) metaDataBytes
   liftIO $ BS.putStrLn (Crypto.getHashBytesAsHex metaDataHash)


### PR DESCRIPTION
The foolish hashing API strikes again.

I'll go fix that once and for all...

$ echo -n '{"homepage":"https://iohk.io","name":"Genesis Pool C","ticker":"GPC","description":"Lorem Ipsum Dolor Sit Amet."}' > pool.json

$ cardano-cli shelley stake-pool metadata-hash --pool-metadata-file pool.json
8241de08075886a7d09c847c9bbd1719459dac0bd0a2f085e673611ebb9a5965