### PR TITLE
Implement JSON output support for Shelley tip query command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -133,8 +133,8 @@ runQueryTip network mOutFile = do
   tip <- liftIO $ withIOManager $ \iomgr ->
     getLocalTip iomgr ptclClientInfo network sockPath
   case mOutFile of
-    Just (OutputFile fpath) -> liftIO . writeFile fpath $ show tip
-    Nothing -> liftIO $ putTextLn (show tip)
+    Just (OutputFile fpath) -> liftIO . LBS.writeFile fpath $ encodePretty tip
+    Nothing -> liftIO $ LBS.putStrLn (encodePretty tip)
 
 
 runQueryUTxO

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -12,13 +14,15 @@ import           Cardano.Prelude
 import qualified Prelude
 
 import           Data.Aeson
-import           Network.Socket (PortNumber)
 import           Data.Scientific (coefficient)
 import qualified Data.Text as Text
+import           Network.Socket (PortNumber)
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity(..))
 import qualified Cardano.Chain.Update as Update
+import           Cardano.Slotting.Block (BlockNo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Network.Block (HeaderHash, Tip (..))
 
 
 deriving instance Show TracingVerbosity
@@ -50,3 +54,14 @@ instance FromJSON Update.ApplicationName where
   parseJSON invalid  =
     panic $ "Parsing of application name failed due to type mismatch. "
     <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+
+instance ToJSON (HeaderHash blk) => ToJSON (Tip blk) where
+  toJSON TipGenesis = object [ "genesis" .= True ]
+  toJSON (Tip slotNo headerHash blockNo) =
+    object
+      [ "slotNo"     .= slotNo
+      , "headerHash" .= headerHash
+      , "blockNo"    .= blockNo
+      ]
+
+deriving newtype instance ToJSON BlockNo

--- a/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
+++ b/cardano-config/src/Cardano/Config/Shelley/Orphans.hs
@@ -24,8 +24,10 @@ import           Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.TracingOrphanInstances.Common ()
 
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash(..))
 
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
+import           Shelley.Spec.Ledger.BlockChain (HashHeader(..))
 import qualified Shelley.Spec.Ledger.Credential as Ledger
 import           Shelley.Spec.Ledger.Crypto (Crypto)
 import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
@@ -68,6 +70,9 @@ instance Crypto c => ToJSON (TxOut c) where
 deriving newtype instance ToJSON (TxId c)
 
 deriving newtype instance Crypto c => ToJSON (UTxO c)
+
+deriving newtype instance ToJSON (ShelleyHash c)
+deriving newtype instance ToJSON (HashHeader c)
 
 deriving newtype instance ToJSON (MetaDataHash c)
 deriving newtype instance ToJSON Ledger.LogWeight


### PR DESCRIPTION
Closes #1340.

Before:

```
$ cardano-cli shelley query tip --testnet-magic 42
Tip (SlotNo {unSlotNo = 57}) (ShelleyHash {unShelleyHash = HashHeader {unHashHeader = 5820355fd1b83b8e71191f135366ae3c07d7408dcd54329e219cead4bb0bf15f875d}}) (BlockNo {unBlockNo = 2})
```

After:

```
$ cardano-cli shelley query tip --testnet-magic 42
{
    "blockNo": 2,
    "headerHash": "5820355fd1b83b8e71191f135366ae3c07d7408dcd54329e219cead4bb0bf15f875d",
    "slotNo": 57
}
```