### PR TITLE
 Bump version to 1.15.0 and update changelogs 

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for cardano-api
 
+## 1.14.2 -- June 2020
+
+- Fix the query that dumps the ledger state as JSON (#1333)
+
+## 1.14.1 -- June 2020
+
+No changes in the cardano-api. There were changes in the cardano-node.
+
 ## 1.14.0 -- June 2020
 
 - Improvements to the strongly-typed API (#1112, #1220, #1227, #1246)

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for cardano-api
 
+## 1.15.0 -- July 2020
+
+- Fix the ledger state dump query (#1333, #1334)
+- Support for Byron witnesses in Shelley txs in the typed API (#1339)
+- Support for Bech32 serialisation in the typed API (#1382)
+- Support for other additional functionality in the typed API (#1337, #1375)
+- More tests for the typed API (#1360, #1369, #1378)
+- Moving code around to eliminate the cardano-config package (#1289, #1380)
+
 ## 1.14.2 -- June 2020
 
 - Fix the query that dumps the ledger state as JSON (#1333)

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,5 +1,5 @@
 name:                   cardano-api
-version:                1.14.0
+version:                1.14.2
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,5 +1,5 @@
 name:                   cardano-api
-version:                1.14.2
+version:                1.15.0
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for cardano-cli
 
+## 1.15.0 -- July 2020
+
+- Fix the ledger state dump query (#1333, #1334)
+- Fix the format of Byron addresses used in Byron CLI commands (#1326)
+- Port CLI commands to use the new API (#1341, #1375, #1396, #1397)
+- Change to JSON output for the "query tip" command (#1340, #1365)
+- Moving code around to eliminate the cardano-config package (#1289, #1316)
+
 ## 1.14.2 -- June 2020
 
 - Fix the hashing of stake pool metadata

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for cardano-cli
 
+## 1.14.2 -- June 2020
+
+- Fix the hashing of stake pool metadata
+- Fix the query that dumps the ledger state as JSON (#1333)
+
+## 1.14.1 -- June 2020
+
+No changes in the cardano-cli. There were changes in the cardano-node.
+
 ## 1.14.0 -- June 2020
 
 - New flags for transaction metadata in tx construction (#1233)

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-cli
-version:               1.14.0
+version:               1.14.2
 description:           The Cardano command-line interface.
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-cli
-version:               1.14.2
+version:               1.15.0
 description:           The Cardano command-line interface.
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog for cardano-node
 
+## 1.14.2 -- June 2020
+
+No changes in the node. There were changes in the cardano-api and cardano-cli.
+
+## 1.14.1 -- June 2020
+
+- Include the libsodium.dll info Windows build artefacts (#1327)
+- Fix compiler warnings on Windows (#1303)
+- Split live view code into more modules (#1323)
+
 ## 1.14.0 -- June 2020
 
 ### node changes

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,55 @@
 # Changelog for cardano-node
 
+## 1.15.0 -- July 2020
+
+### node changes
+
+- Support for triggering a hard fork at a specific epoch (#1328)
+- Support for triggering a hard fork at a specific protocol version (#1345)
+- Changes resulting from refactoring in the Cardano API library (#1289, #1316,
+  #1380, #1384)
+- Update the README build instructions, including libsodium (#1325, #1361, #1362)
+- Trace the UTxO size in block forging to help the benchmarking tools (#1329)
+- Remove the "forks created" metric from the live view (#1315)
+
+### consensus changes
+- Fix an off-by-one error in the KES cert validity period (#2306)
+- Fix KES-related tests (#2306)
+- Fix bugs found by the hard fork tests (#2310, #2312)
+- Fix bugs found by the hard fork tests in the hard fork tests themselves (#2305)
+- Extend hard fork tests to include network partitions at interesting times
+  around or during the hard fork (#2292, #2337, #2342)
+- Prefer blocks we created, irrespective of the VRF value (#1286, #2348)
+- Allow setting the intial Praos nonce (#2005, #2289)
+- Richer support for queries when using multiple protocol eras to allow some
+  queries to be answered outside of the era to which they belong (#2349)
+- Optimisation in chain selection for forks (#1223, #2323)
+- Preparation for removing EBBs (#2322, #2336, #2339)
+- Clarify and document the interface for triggering a hard fork (#2307)
+- Internal cleanups and refactoring (#2327, #2328, #2329)
+
+### ledger changes
+- Fix bug in the pool reaping that could cause a crash on epoch boundaries (#1593)
+- Fix a preservation of value bug in rewards to retired stake pools (#1598, #1604)
+- Fix a bug in pool reaping when multiple pools share a reward account (#1605)
+- Fix the calculation of non-myopic rewards that is queried by the wallet (#1601)
+- Allow update proposals to be submitted near the end of an epoch, but apply
+  them only at the end of the following epoch (#1574)
+- Simpler calculation for turning the VRF output into the leader value (#1579)
+- Check the VRF for BFT blocks too (#1590)
+- Tests and other clean-up for witnesses for spending from Byron address in
+  Shelley transactions (#1573, #1591)
+- Additional tests for serialisation of parts of the ledger state (#1603)
+- Fix the presentation of pool metadata hashes in JSON output (#1596)
+- Clean up the serialisation used with hashing (#1602)
+
+### network changes
+- Additional concurrency utilities (#2298)
+- Improved tests for error handling of socket send/recv (#2317)
+- Port existing DNS-related bug fixes to the new DNS provider in the p2p
+  governor (#1873, #1893, #2311)
+- Internal cleanups (#2096)
+
 ## 1.14.2 -- June 2020
 
 No changes in the node. There were changes in the cardano-api and cardano-cli.

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-node
-version:               1.14.0
+version:               1.14.2
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-node
-version:               1.14.2
+version:               1.15.0
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io


### PR DESCRIPTION
Also cherry-pick the 1.14.2 release changelog updates from the 1.14.x branch.