### PR TITLE
CAD-1347 cli:  new key hashing commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -81,6 +81,7 @@ data AddressCmd
 
 data StakeAddressCmd
   = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
+  | StakeAddressKeyHash VerificationKeyFile (Maybe OutputFile)
   | StakeAddressBuild VerificationKeyFile NetworkId (Maybe OutputFile)
   | StakeKeyRegister PrivKeyFile NodeAddress
   | StakeKeyDelegate PrivKeyFile PoolId Lovelace NodeAddress

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -125,6 +125,7 @@ data NodeCmd
   = NodeKeyGenCold VerificationKeyFile SigningKeyFile OpCertCounterFile
   | NodeKeyGenKES  VerificationKeyFile SigningKeyFile
   | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
+  | NodeKeyHashVRF  VerificationKeyFile (Maybe OutputFile)
   | NodeIssueOpCert VerificationKeyFile SigningKeyFile OpCertCounterFile
                     KESPeriod OutputFile
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -343,6 +343,9 @@ pNodeCmd =
       , Opt.command "key-gen-VRF"
           (Opt.info pKeyGenVRF $
              Opt.progDesc "Create a key pair for a node VRF operational key")
+      , Opt.command "key-hash-VRF"
+          (Opt.info pKeyHashVRF $
+             Opt.progDesc "Print hash of a node's operational VRF key.")
       , Opt.command "issue-op-cert"
           (Opt.info pIssueOpCert $
              Opt.progDesc "Issue a node operational certificate")
@@ -361,6 +364,10 @@ pNodeCmd =
     pKeyGenVRF :: Parser NodeCmd
     pKeyGenVRF =
       NodeKeyGenVRF <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
+
+    pKeyHashVRF :: Parser NodeCmd
+    pKeyHashVRF =
+      NodeKeyHashVRF <$> pVerificationKeyFile Input <*> pMaybeOutputFile
 
     pIssueOpCert :: Parser NodeCmd
     pIssueOpCert =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -127,7 +127,7 @@ pAddressCmd =
       [ Opt.command "key-gen"
           (Opt.info pAddressKeyGen $ Opt.progDesc "Create an address key pair.")
       , Opt.command "key-hash"
-          (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key to stdout.")
+          (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key.")
       , Opt.command "build"
           (Opt.info pAddressBuild $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address.")
       , Opt.command "build-multisig"
@@ -183,6 +183,8 @@ pStakeAddress =
           (Opt.info pStakeAddressKeyGen $ Opt.progDesc "Create a stake address key pair")
       , Opt.command "build"
           (Opt.info pStakeAddressBuild $ Opt.progDesc "Build a stake address")
+      , Opt.command "key-hash"
+          (Opt.info pStakeAddressKeyHash $ Opt.progDesc "Print the hash of a stake address key.")
       , Opt.command "register"
           (Opt.info pStakeAddressRegister $ Opt.progDesc "Register a stake address")
       , Opt.command "delegate"
@@ -203,6 +205,9 @@ pStakeAddress =
     pStakeAddressKeyGen = StakeAddressKeyGen
                             <$> pVerificationKeyFile Output
                             <*> pSigningKeyFile Output
+
+    pStakeAddressKeyHash :: Parser StakeAddressCmd
+    pStakeAddressKeyHash = StakeAddressKeyHash <$> pStakeVerificationKeyFile <*> pMaybeOutputFile
 
     pStakeAddressBuild :: Parser StakeAddressCmd
     pStakeAddressBuild = StakeAddressBuild <$> pStakeVerificationKeyFile


### PR DESCRIPTION
1. Add a `cardano-cli shelley stake-address key-hash` subcommand.
1. Add a `cardano-cli shelley node key-hash-VRF` subcommand.