### PR TITLE
Fix Cardano CLI tests on MacOS:

### DIFF
--- a/cardano-cli/test/cli/core/common
+++ b/cardano-cli/test/cli/core/common
@@ -65,7 +65,7 @@ assert_string () {
 }
 
 assert_line_count () {
-  line_count=$(wc -l < "$2")
+  line_count=$(wc -l < "$2" | xargs)
   if test "${line_count}" != "$1" ; then
     echo "$2: line count is ${line_count} "
     cat "$2"

--- a/cardano-cli/test/cli/genesis-create/run
+++ b/cardano-cli/test/cli/genesis-create/run
@@ -12,7 +12,8 @@ setup_data_dir "${testname}"
 
 OUTPUT_JSON="${TEST_DIR}/genesis.json"
 
-start_time=$(TZ=UTC date --iso-8601=seconds | sed 's/+.*/Z/')
+# Equivalent to 'TZ=UTC date --iso-8601=seconds'
+start_time=$(TZ=UTC date +"%Y-%m-%dT%H:%M:%S+00:00" | sed 's/+.*/Z/')
 
 cp "${DATA_DIR}/genesis.spec.json" "${TEST_DIR}/"
 
@@ -69,14 +70,14 @@ if test "${check_supply}" != "${supply}" ; then
 
 jq '.genDelegs' < "${OUTPUT_JSON}" | grep ': {' > "${TEST_DIR}/genesis-delegate.pairs"
 
-keyhash_count=$(sed 's/:.*//' < "${TEST_DIR}/genesis-delegate.pairs" | sort | uniq | wc -l)
+keyhash_count=$(sed 's/:.*//' < "${TEST_DIR}/genesis-delegate.pairs" | sort | uniq | wc -l | xargs)
 if test "${keyhash_count}" != "${gendlg_count}" ; then
     echo "Genesis keyhashes are not unique."
     cat "${TEST_DIR}/genesis-delegate.pairs"
     error=1
     fi
 
-keyhash_delegate_count=$(sort "${TEST_DIR}/genesis-delegate.pairs" | uniq | wc -l)
+keyhash_delegate_count=$(sort "${TEST_DIR}/genesis-delegate.pairs" | uniq | wc -l | xargs)
 if test "${keyhash_delegate_count}" != "${gendlg_count}" ; then
     echo "Genesis delegate keyhashes are not unique (${keyhash_delegate_count} != ${gendlg_count})."
     cat "${TEST_DIR}/genesis-delegate.pairs"

--- a/cardano-cli/test/cli/shellcheck/run
+++ b/cardano-cli/test/cli/shellcheck/run
@@ -8,7 +8,7 @@ cwd=$(dirname "$0")
 # shellcheck disable=SC2154
 banner "${testname}"
 
-type shellcheck > /dev/null 2>&1 || {
+shellcheck --version > /dev/null 2>&1 || {
     echo "Missing 'shellcheck' executable."
     exit 1
 }


### PR DESCRIPTION
    * Use date in a cross-platform way to work on MacOS (OpenBSD) and Linux
    * Use xargs to strip whitespace from either side of the line count so
      that line count comparisions work on MacOS
    * Invoke shellcheck differently to avoid use of 'type', which triggers
      a lint error on MacOS