### PR TITLE
Support more key types in cli address commands

### DIFF
--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -2771,6 +2771,18 @@ instance HasTextEnvelope (SigningKey ByronKey) where
     textEnvelopeType _ = "SigningKeyByron"
     -- TODO: fix these inconsistent names for the public testnet re-spin
 
+instance CastVerificationKeyRole ByronKey PaymentExtendedKey where
+    castVerificationKey (ByronVerificationKey vk) =
+        PaymentExtendedVerificationKey
+          (Byron.unVerificationKey vk)
+
+instance CastVerificationKeyRole ByronKey PaymentKey where
+    castVerificationKey =
+        (castVerificationKey :: VerificationKey PaymentExtendedKey
+                             -> VerificationKey PaymentKey)
+      . (castVerificationKey :: VerificationKey ByronKey
+                             -> VerificationKey PaymentExtendedKey)
+
 
 --
 -- Shelley payment keys

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -709,13 +709,13 @@ instance SerialiseAddress StakeAddress where
       deserialiseFromBech32 AsStakeAddress t
 
 
-makeByronAddress :: VerificationKey ByronKey
-                 -> NetworkId
+makeByronAddress :: NetworkId
+                 -> VerificationKey ByronKey
                  -> Address era
-makeByronAddress (ByronVerificationKey vk) nid =
+makeByronAddress nw (ByronVerificationKey vk) =
     ByronAddress $
       Byron.makeVerKeyAddress
-        (toByronNetworkMagic nid)
+        (toByronNetworkMagic nw)
         vk
 
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
@@ -98,7 +98,8 @@ roundtrip_VerificationKey_envelope roletoken =
                     (deserialiseFromTextEnvelope (AsVerificationKey roletoken))
 
 roundtrip_SigningKey_envelope :: (Key keyrole,
-                                  Eq (SigningKey keyrole))
+                                  Eq (SigningKey keyrole),
+                                  Show (SigningKey keyrole))
                               => AsType keyrole -> Property
 roundtrip_SigningKey_envelope roletoken =
   H.property $ do

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -24,13 +24,18 @@ import           Test.Cardano.Api.Gen (genSeed)
 import           Test.Cardano.Api.Orphans ()
 
 genAddressByron :: Gen (Address Byron)
-genAddressByron = makeByronAddress <$> genVerificationKey AsByronKey <*> genNetworkId
+genAddressByron = makeByronAddress <$> genNetworkId
+                                   <*> genVerificationKey AsByronKey
 
 genAddressShelley :: Gen (Address Shelley)
 genAddressShelley =
   Gen.choice
-    [ makeShelleyAddress <$> genNetworkId <*> genPaymentCredential <*> genStakeAddressReference
-    , makeByronAddress <$> genVerificationKey AsByronKey <*> genNetworkId
+    [ makeShelleyAddress <$> genNetworkId
+                         <*> genPaymentCredential
+                         <*> genStakeAddressReference
+
+    , makeByronAddress   <$> genNetworkId
+                         <*> genVerificationKey AsByronKey
     ]
 
 genKESPeriod :: Gen KESPeriod

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -16,6 +16,7 @@ module Cardano.CLI.Shelley.Commands
   , TextViewCmd (..)
 
     -- * CLI flag types
+  , AddressKeyType (..)
   , GenesisDir (..)
   , TxInCount (..)
   , TxOutCount (..)
@@ -73,7 +74,7 @@ data ShelleyCommand
 
 
 data AddressCmd
-  = AddressKeyGen VerificationKeyFile SigningKeyFile
+  = AddressKeyGen AddressKeyType VerificationKeyFile SigningKeyFile
   | AddressKeyHash VerificationKeyFile (Maybe OutputFile)
   | AddressBuild VerificationKeyFile (Maybe VerificationKeyFile) NetworkId (Maybe OutputFile)
   | AddressBuildMultiSig  --TODO
@@ -274,6 +275,12 @@ newtype GenesisDir
 data ITNKeyFile
   = ITNVerificationKeyFile VerificationKeyFile
   | ITNSigningKeyFile SigningKeyFile
+  deriving (Eq, Show)
+
+data AddressKeyType
+  = AddressKeyShelley
+  | AddressKeyShelleyExtended
+  | AddressKeyByron
   deriving (Eq, Show)
 
 newtype OpCertCounterFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -79,6 +79,7 @@ data AddressCmd
   | AddressBuild VerificationKeyFile (Maybe VerificationKeyFile) NetworkId (Maybe OutputFile)
   | AddressBuildMultiSig  --TODO
   | AddressInfo Text
+  | AddressConvertKey SigningKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 data StakeAddressCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -137,7 +137,9 @@ pAddressCmd =
       ]
   where
     pAddressKeyGen :: Parser AddressCmd
-    pAddressKeyGen = AddressKeyGen <$> pVerificationKeyFile Output <*> pSigningKeyFile Output
+    pAddressKeyGen = AddressKeyGen <$> pAddressKeyType
+                                   <*> pVerificationKeyFile Output
+                                   <*> pSigningKeyFile Output
 
     pAddressKeyHash :: Parser AddressCmd
     pAddressKeyHash = AddressKeyHash <$> pPaymentVerificationKeyFile <*> pMaybeOutputFile
@@ -693,6 +695,26 @@ data FileDirection
   = Input
   | Output
   deriving (Eq, Show)
+
+pAddressKeyType :: Parser AddressKeyType
+pAddressKeyType =
+    Opt.flag' AddressKeyShelley
+      (  Opt.long "normal-key"
+      <> Opt.help "Use a normal Shelley-era key (default)."
+      )
+  <|>
+    Opt.flag' AddressKeyShelleyExtended
+      (  Opt.long "extended-key"
+      <> Opt.help "Use an extended ed25519 Shelley-era key."
+      )
+  <|>
+    Opt.flag' AddressKeyByron
+      (  Opt.long "byron-key"
+      <> Opt.help "Use a Byron-era key."
+      )
+  <|>
+    pure AddressKeyShelley
+
 
 pProtocolParamsFile :: Parser ProtocolParamsFile
 pProtocolParamsFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -134,6 +134,8 @@ pAddressCmd =
           (Opt.info pAddressBuildMultiSig $ Opt.progDesc "Build a Shelley payment multi-sig address.")
       , Opt.command "info"
           (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
+      , Opt.command "convert"
+          (Opt.info pAddressConvert $ Opt.progDesc "Convert a Byron signing key file.")
       ]
   where
     pAddressKeyGen :: Parser AddressCmd
@@ -159,6 +161,9 @@ pAddressCmd =
     pAddressInfo :: Parser AddressCmd
     pAddressInfo = AddressInfo <$> pAddress
 
+    pAddressConvert :: Parser AddressCmd
+    pAddressConvert = AddressConvertKey <$> pByronKeyFile Input
+                                        <*> pSigningKeyFile Output
 
 pPaymentVerificationKeyFile :: Parser VerificationKeyFile
 pPaymentVerificationKeyFile =
@@ -854,6 +859,16 @@ pSigningKeyFile fdir =
       (  Opt.long "signing-key-file"
       <> Opt.metavar "FILE"
       <> Opt.help (show fdir ++ " filepath of the signing key.")
+      <> Opt.completer (Opt.bashCompleter "file")
+      )
+
+pByronKeyFile :: FileDirection -> Parser SigningKeyFile
+pByronKeyFile fdir =
+  SigningKeyFile <$>
+    Opt.strOption
+      (  Opt.long "byron-signing-key-file"
+      <> Opt.metavar "FILE"
+      <> Opt.help (show fdir ++ " filepath of the Byron format signing key.")
       <> Opt.completer (Opt.bashCompleter "file")
       )
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Cardano.CLI.Shelley.Run.Address
   ( ShelleyAddressCmdError
   , renderShelleyAddressCmdError
@@ -19,7 +21,7 @@ import           Cardano.Api.Typed
 
 import           Cardano.CLI.Shelley.Parsers
                    (OutputFile (..), SigningKeyFile (..), VerificationKeyFile (..),
-                    AddressCmd (..))
+                    AddressCmd (..), AddressKeyType (..))
 import           Cardano.CLI.Shelley.Run.Address.Info (ShelleyAddressInfoError,
                    runAddressInfo)
 
@@ -40,66 +42,143 @@ renderShelleyAddressCmdError err =
 runAddressCmd :: AddressCmd -> ExceptT ShelleyAddressCmdError IO ()
 runAddressCmd cmd =
   case cmd of
-    AddressKeyGen vkf skf -> runAddressKeyGen vkf skf
+    AddressKeyGen kt vkf skf -> runAddressKeyGen kt vkf skf
     AddressKeyHash vkf mOFp -> runAddressKeyHash vkf mOFp
     AddressBuild payVk stkVk nw mOutFp -> runAddressBuild payVk stkVk nw mOutFp
     AddressBuildMultiSig {} -> runAddressBuildMultiSig
     AddressInfo txt -> firstExceptT ShelleyAddressCmdAddressInfoError $ runAddressInfo txt
 
-runAddressKeyGen :: VerificationKeyFile -> SigningKeyFile -> ExceptT ShelleyAddressCmdError IO ()
-runAddressKeyGen (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
-    skey <- liftIO $ generateSigningKey AsPaymentKey
-    let vkey = getVerificationKey skey
-    firstExceptT ShelleyAddressCmdWriteFileError
-      . newExceptT
-      $ writeFileTextEnvelope skeyPath (Just skeyDesc) skey
-    firstExceptT ShelleyAddressCmdWriteFileError
-      . newExceptT
-      $ writeFileTextEnvelope vkeyPath (Just vkeyDesc) vkey
+
+runAddressKeyGen :: AddressKeyType
+                 -> VerificationKeyFile
+                 -> SigningKeyFile
+                 -> ExceptT ShelleyAddressCmdError IO ()
+runAddressKeyGen kt (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) =
+    case kt of
+      AddressKeyShelley         -> generateAndWriteKeyFiles AsPaymentKey
+      AddressKeyShelleyExtended -> generateAndWriteKeyFiles AsPaymentExtendedKey
+      AddressKeyByron           -> generateAndWriteKeyFiles AsByronKey
   where
+    generateAndWriteKeyFiles asType = do
+      skey <- liftIO $ generateSigningKey asType
+      let vkey = getVerificationKey skey
+      firstExceptT ShelleyAddressCmdWriteFileError
+        . newExceptT
+        $ writeFileTextEnvelope skeyPath (Just skeyDesc) skey
+      firstExceptT ShelleyAddressCmdWriteFileError
+        . newExceptT
+        $ writeFileTextEnvelope vkeyPath (Just vkeyDesc) vkey
+
     skeyDesc, vkeyDesc :: TextViewDescription
     skeyDesc = TextViewDescription "Payment Signing Key"
     vkeyDesc = TextViewDescription "Payment Verification Key"
 
-runAddressKeyHash :: VerificationKeyFile -> Maybe OutputFile -> ExceptT ShelleyAddressCmdError IO ()
-runAddressKeyHash (VerificationKeyFile vkeyPath) mOutputFp = do
-  paymentVerKey <- firstExceptT ShelleyAddressCmdReadFileError
-    . newExceptT
-    $ readFileTextEnvelope (AsVerificationKey AsPaymentKey) vkeyPath
 
-  let hexKeyHash = serialiseToRawBytesHex (verificationKeyHash paymentVerKey)
+runAddressKeyHash :: VerificationKeyFile
+                  -> Maybe OutputFile
+                  -> ExceptT ShelleyAddressCmdError IO ()
+runAddressKeyHash vkeyPath mOutputFp = do
+  vkey <- firstExceptT ShelleyAddressCmdReadFileError $
+            readAddressVerificationKeyFile vkeyPath
+
+  let hexKeyHash = foldSomeAddressVerificationKey
+                     (serialiseToRawBytesHex . verificationKeyHash) vkey
 
   case mOutputFp of
     Just (OutputFile fpath) -> liftIO $ BS.writeFile fpath hexKeyHash
     Nothing -> liftIO $ BS.putStrLn hexKeyHash
+
 
 runAddressBuild :: VerificationKeyFile
                 -> Maybe VerificationKeyFile
                 -> NetworkId
                 -> Maybe OutputFile
                 -> ExceptT ShelleyAddressCmdError IO ()
-runAddressBuild (VerificationKeyFile payVkeyFp) mstkVkeyFp nw mOutFp = do
-    payVKey <- firstExceptT ShelleyAddressCmdReadFileError
-      . newExceptT
-      $ readFileTextEnvelope (AsVerificationKey AsPaymentKey) payVkeyFp
-    let paymentCred = PaymentCredentialByKey (verificationKeyHash payVKey)
+runAddressBuild payVkeyFp mstkVkeyFp nw mOutFp = do
+    payVKey <- firstExceptT ShelleyAddressCmdReadFileError $
+                 readAddressVerificationKeyFile payVkeyFp
 
-    stakeAddrRef <- firstExceptT ShelleyAddressCmdReadFileError $
-      case mstkVkeyFp of
-        Just (VerificationKeyFile stkVkeyFp) ->
-          toStakeAddrRef
-            <$> newExceptT (readFileTextEnvelope (AsVerificationKey AsStakeKey) stkVkeyFp)
-        Nothing -> pure NoStakeAddress
+    addr <- case payVKey of
+              AByronVerificationKey vk ->
+                return (makeByronAddress nw vk)
 
-    let addr = makeShelleyAddress nw paymentCred stakeAddrRef
-        addrText = serialiseAddress addr
+              APaymentVerificationKey vk ->
+                buildShelleyAddress vk
+
+              APaymentExtendedVerificationKey vk ->
+                buildShelleyAddress (castVerificationKey vk)
+
+              AGenesisUTxOVerificationKey vk ->
+                buildShelleyAddress (castVerificationKey vk)
+
+    let addrText = serialiseAddress addr
 
     case mOutFp of
       Just (OutputFile fpath) -> liftIO $ Text.writeFile fpath addrText
-      Nothing -> liftIO $ Text.putStrLn addrText
+      Nothing                 -> liftIO $ Text.putStrLn        addrText
+
   where
-    toStakeAddrRef :: VerificationKey StakeKey -> StakeAddressReference
-    toStakeAddrRef = StakeAddressByValue . StakeCredentialByKey . verificationKeyHash
+    buildShelleyAddress vkey = do
+      mstakeVKey <-
+        case mstkVkeyFp of
+          Nothing -> pure Nothing
+          Just (VerificationKeyFile stkVkeyFp) ->
+            firstExceptT ShelleyAddressCmdReadFileError $
+              fmap Just $ newExceptT $
+                readFileTextEnvelope (AsVerificationKey AsStakeKey) stkVkeyFp
+
+      let paymentCred  = PaymentCredentialByKey (verificationKeyHash vkey)
+          stakeAddrRef = maybe NoStakeAddress
+                               (StakeAddressByValue . StakeCredentialByKey
+                                                    . verificationKeyHash)
+                               mstakeVKey
+          address      = makeShelleyAddress nw paymentCred stakeAddrRef
+
+      return address
+
+
+--
+-- Handling the variety of address key types
+--
+
+-- TODO: if we could make unions like this an instance of the Key class then
+-- it would simplify some of the code above
+data SomeAddressVerificationKey
+  = AByronVerificationKey           (VerificationKey ByronKey)
+  | APaymentVerificationKey         (VerificationKey PaymentKey)
+  | APaymentExtendedVerificationKey (VerificationKey PaymentExtendedKey)
+  | AGenesisUTxOVerificationKey     (VerificationKey GenesisUTxOKey)
+
+foldSomeAddressVerificationKey :: (forall keyrole. Key keyrole =>
+                                   VerificationKey keyrole -> a)
+                               -> SomeAddressVerificationKey -> a
+foldSomeAddressVerificationKey f (AByronVerificationKey           vk) = f vk
+foldSomeAddressVerificationKey f (APaymentVerificationKey         vk) = f vk
+foldSomeAddressVerificationKey f (APaymentExtendedVerificationKey vk) = f vk
+foldSomeAddressVerificationKey f (AGenesisUTxOVerificationKey     vk) = f vk
+
+readAddressVerificationKeyFile
+  :: VerificationKeyFile
+  -> ExceptT (FileError TextEnvelopeError) IO SomeAddressVerificationKey
+readAddressVerificationKeyFile (VerificationKeyFile vkfile) =
+    newExceptT $
+      readFileTextEnvelopeAnyOf fileTypes vkfile
+  where
+    fileTypes =
+      [ FromSomeType (AsVerificationKey AsByronKey)
+                     AByronVerificationKey
+      , FromSomeType (AsVerificationKey AsPaymentKey)
+                     APaymentVerificationKey
+      , FromSomeType (AsVerificationKey AsPaymentExtendedKey)
+                     APaymentExtendedVerificationKey
+      , FromSomeType (AsVerificationKey AsGenesisUTxOKey)
+                     AGenesisUTxOVerificationKey
+      ]
+
+
+--
+-- Multisig addresses
+--
 
 runAddressBuildMultiSig :: ExceptT ShelleyAddressCmdError IO ()
 runAddressBuildMultiSig =


### PR DESCRIPTION
* Add API support for Shelley era extended ed25519 keys
* Extend CLI address commands to handle multiple key types (normal,
   extended and byron)
* New CLI command to convert signing keys from Byron era file formats

Together this should allow testing of Byron witness support and testing
of Byron addresses created in the Byron era using Byron CLI commands
and then spending from them after the hard fork in the Shelley era.