### PR TITLE
Disable tests in bech32 package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,6 +34,9 @@ package ouroboros-consensus-shelley
 package ouroboros-consensus-mock
   tests: False
 
+package bech32
+  tests: False
+
 package byron-spec-chain
   tests: False
 


### PR DESCRIPTION
To avoid unnecessary tests and also avoid invoking tests which in an earlier version of bech32 invokes the bech32 executable that may not exist and cause test failure.