### PR TITLE
Add more hedghog tests

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -128,6 +128,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Gen
                         Test.Cardano.Api.Ledger
                         Test.Cardano.Api.Orphans
+                        Test.Cardano.Api.Typed.Bech32
                         Test.Cardano.Api.Typed.CBOR
                         Test.Cardano.Api.Typed.Envelope
                         Test.Cardano.Api.Typed.Gen

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -84,11 +84,13 @@ module Cardano.Api.Typed (
     -- * Building transactions
     -- | Constructing and inspecting transactions
     TxBody(..),
-    TxId,
+    TxId(..),
     getTxId,
     TxIn(..),
     TxOut(..),
     TxIx(..),
+    TTL,
+    TxFee,
     Lovelace(..),
     makeByronTransaction,
     makeShelleyTransaction,
@@ -898,6 +900,11 @@ data TxBody era where
        -> Maybe Shelley.MetaData
        -> TxBody Shelley
 
+deriving instance Eq (TxBody Byron)
+deriving instance Show (TxBody Byron)
+
+deriving instance Eq (TxBody Shelley)
+deriving instance Show (TxBody Shelley)
 
 instance HasTypeProxy (TxBody Byron) where
     data AsType (TxBody Byron) = AsByronTxBody
@@ -954,6 +961,7 @@ data ByronTxBodyConversionError =
        ByronTxBodyEmptyTxIns
      | ByronTxBodyEmptyTxOuts
      | ByronTxBodyLovelaceOverflow (TxOut Byron)
+     deriving Show
 
 makeByronTransaction :: [TxIn]
                      -> [TxOut Byron]
@@ -1047,6 +1055,11 @@ data Tx era where
        :: Shelley.Tx ShelleyCrypto
        -> Tx Shelley
 
+deriving instance Eq (Tx Byron)
+deriving instance Show (Tx Byron)
+
+deriving instance Eq (Tx Shelley)
+deriving instance Show (Tx Shelley)
 
 instance HasTypeProxy (Tx Byron) where
     data AsType (Tx Byron) = AsByronTx
@@ -1097,6 +1110,11 @@ data Witness era where
        :: Shelley.MultiSig ShelleyCrypto
        -> Witness Shelley
 
+deriving instance Eq (Witness Byron)
+deriving instance Show (Witness Byron)
+
+deriving instance Eq (Witness Shelley)
+deriving instance Show (Witness Shelley)
 
 instance HasTypeProxy (Witness Byron) where
     data AsType (Witness Byron) = AsByronWitness
@@ -2423,7 +2441,6 @@ serialiseToBech32 a =
                          ++ show (bech32PrefixFor a)
                          ++ ", " ++ show err
 
-
 deserialiseFromBech32 :: SerialiseAsBech32 a
                       => AsType a -> Text -> Either Bech32DecodeError a
 deserialiseFromBech32 asType bech32Str = do
@@ -2470,7 +2487,7 @@ data Bech32DecodeError =
        -- correspond to the prefix that should be used for the payload value.
      | Bech32WrongPrefix Text Text
 
-  deriving Show
+  deriving (Eq, Show)
 
 instance Error Bech32DecodeError where
   displayError err = case err of

--- a/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Cardano.Api.Typed.Bech32
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import           Cardano.Api.Typed
+
+import           Hedgehog (Gen, Property, discover)
+import qualified Hedgehog as H
+
+import           Test.Cardano.Api.Typed.Gen
+
+prop_roundtrip_Address_Shelley :: Property
+prop_roundtrip_Address_Shelley = roundtrip_Bech32 AsShelleyAddress genAddressShelley
+
+prop_roundtrip_StakeAddress :: Property
+prop_roundtrip_StakeAddress = roundtrip_Bech32 AsStakeAddress genStakeAddress
+
+-- -----------------------------------------------------------------------------
+
+roundtrip_Bech32
+  :: (SerialiseAsBech32 a, Eq a, Show a)
+  => AsType a -> Gen a -> Property
+roundtrip_Bech32 typeProxy gen =
+  H.property $ do
+    val <- H.forAll gen
+    H.tripping val serialiseToBech32 (deserialiseFromBech32 typeProxy)
+
+-- -----------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  H.checkParallel $$discover

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -17,21 +17,30 @@ import           Test.Cardano.Api.Typed.Gen
 import           Test.Cardano.Api.Typed.Orphans ()
 
 
+prop_roundtrip_txbody_byron_CBOR :: Property
+prop_roundtrip_txbody_byron_CBOR =
+  roundtrip_CBOR AsByronTxBody genTxBodyByron
 
-{-
--- CBOR tests to fill in
+prop_roundtrip_txbody_shelley_CBOR :: Property
+prop_roundtrip_txbody_shelley_CBOR =
+  roundtrip_CBOR AsShelleyTxBody genTxBodyShelley
 
--- TODO: Currently undefined
-(TxBody Byron)
-(TxBody Shelley)
--- TODO: Currently undefined
-(Tx Byron)
-(Tx Shelley)
--- TODO: Currently undefined
-(Witness Byron)
-(Witness Shelley)
+prop_roundtrip_tx_byron_CBOR :: Property
+prop_roundtrip_tx_byron_CBOR =
+  roundtrip_CBOR AsByronTx genTxByron
 
--}
+prop_roundtrip_tx_shelley_CBOR :: Property
+prop_roundtrip_tx_shelley_CBOR =
+  roundtrip_CBOR AsShelleyTx genTxShelley
+
+
+prop_roundtrip_witness_shelley_CBOR :: Property
+prop_roundtrip_witness_shelley_CBOR =
+  roundtrip_CBOR AsShelleyWitness genShelleyWitness
+
+prop_roundtrip_witness_byron_CBOR :: Property
+prop_roundtrip_witness_byron_CBOR =
+  roundtrip_CBOR AsByronWitness genByronKeyWitness
 
 prop_roundtrip_operational_certificate_CBOR :: Property
 prop_roundtrip_operational_certificate_CBOR =

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -6,6 +6,7 @@ import           Hedgehog.Main (defaultMain)
 import qualified Test.Cardano.Api
 import qualified Test.Cardano.Api.Convert
 import qualified Test.Cardano.Api.Ledger
+import qualified Test.Cardano.Api.Typed.Bech32
 import qualified Test.Cardano.Api.Typed.CBOR
 import qualified Test.Cardano.Api.Typed.RawBytes
 import qualified Test.Cardano.Api.Typed.Envelope
@@ -16,6 +17,8 @@ main =
     [ Test.Cardano.Api.Convert.tests
     , Test.Cardano.Api.Ledger.tests
     , Test.Cardano.Api.tests
+
+    , Test.Cardano.Api.Typed.Bech32.tests
     , Test.Cardano.Api.Typed.CBOR.tests
     , Test.Cardano.Api.Typed.Envelope.tests
     , Test.Cardano.Api.Typed.RawBytes.tests

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -193,6 +193,7 @@ test-suite cardano-cli-pioneers
                         Test.CLI.Shelley.Golden.TextEnvelope.Certificates.OperationalCertificate
                         Test.CLI.Shelley.Golden.TextEnvelope.Certificates.StakeAddressCertificates
                         Test.CLI.Shelley.Golden.TextEnvelope.Certificates.StakePoolCertificates
+                        Test.CLI.Shelley.Golden.TextEnvelope.Keys.ExtendedPaymentKeys
                         Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisDelegateKeys
                         Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisKeys
                         Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisUTxOKeys

--- a/cardano-cli/test/Test/CLI/Byron/Golden/TextEnvelope/PaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Byron/Golden/TextEnvelope/PaymentKeys.hs
@@ -9,7 +9,6 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 
 
-
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.CLI.Shelley.Golden.TextEnvelope.Keys.ExtendedPaymentKeys
+  ( golden_shelleyExtendedPaymentKeys
+  ) where
+
+import           Cardano.Prelude
+
+import           Cardano.Api.Typed (AsType(..), HasTextEnvelope (..))
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+
+import           Test.OptParse
+
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyExtendedPaymentKeys :: Property
+golden_shelleyExtendedPaymentKeys =
+  propertyOnce $ do
+
+    -- Reference keys
+    let referenceVerKey = "test/Test/golden/shelley/keys/extended_payment_keys/verification_key"
+        referenceSignKey = "test/Test/golden/shelley/keys/extended_payment_keys/signing_key"
+
+    -- Key filepaths
+    let verKey = "extended-payment-verification-key-file"
+        signKey = "extended-payment-signing-key-file"
+        createdFiles = [verKey, signKey]
+
+    -- Generate payment verification key
+    execCardanoCLIParser
+      createdFiles
+        $ evalCardanoCLIParser [ "shelley","address","key-gen"
+                               , "--extended-key"
+                               , "--verification-key-file", verKey
+                               , "--signing-key-file", signKey
+                               ]
+
+    assertFilesExist createdFiles
+
+
+    let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
+        verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
+
+    -- Check the newly created files have not deviated from the
+    -- golden files
+    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
+    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
+
+    liftIO $ fileCleanup createdFiles
+    H.success

--- a/cardano-cli/test/Test/CLI/Shelley/Tests.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Tests.hs
@@ -20,6 +20,8 @@ import           Test.CLI.Shelley.Golden.TextEnvelope.Certificates.StakePoolCert
 
 import           Test.CLI.Shelley.Golden.Metadata.StakePoolMetadata
                    (golden_stakePoolMetadataHash)
+import           Test.CLI.Shelley.Golden.TextEnvelope.Keys.ExtendedPaymentKeys
+                   (golden_shelleyExtendedPaymentKeys)
 import           Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisDelegateKeys
                    (golden_shelleyGenesisDelegateKeys)
 import           Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisUTxOKeys
@@ -44,7 +46,8 @@ keyTests :: IO Bool
 keyTests =
   H.checkSequential
     $ H.Group "TextEnvelope Key Goldens"
-        [ ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
+        [ ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
+        , ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
         , ("golden_shelleyStakeKeys", golden_shelleyStakeKeys)
         , ("golden_shelleyGenesisKeys", golden_shelleyGenesisKeys)
         , ("golden_shelleyGenesisDelegateKeys", golden_shelleyGenesisDelegateKeys)

--- a/cardano-cli/test/Test/golden/shelley/keys/extended_payment_keys/signing_key
+++ b/cardano-cli/test/Test/golden/shelley/keys/extended_payment_keys/signing_key
@@ -1,0 +1,5 @@
+{
+    "type": "PaymentSigningKeyShelley extended ed25519",
+    "description": "Payment Signing Key",
+    "cborHex": "5880c0eb138a32cde8de380312a08bae4383939520c84f8242f0262b54fa7f12724daa13fcf3663749f3b0fb231f02a63b46703d2a0904fb2f2ff383c1cce52af5af1f9591d2f4bef7008a549512ea2c51d78fe5954977045715303579bfdebfe1c34b3c13ea151f2652db80ea369878f2dd042aa78a1d17b9a78b941c856ea9ff21"
+}

--- a/cardano-cli/test/Test/golden/shelley/keys/extended_payment_keys/verification_key
+++ b/cardano-cli/test/Test/golden/shelley/keys/extended_payment_keys/verification_key
@@ -1,0 +1,5 @@
+{
+    "type": "PaymentVerificationKeyShelley extended ed25519",
+    "description": "Payment Verification Key",
+    "cborHex": "58401f9591d2f4bef7008a549512ea2c51d78fe5954977045715303579bfdebfe1c34b3c13ea151f2652db80ea369878f2dd042aa78a1d17b9a78b941c856ea9ff21"
+}


### PR DESCRIPTION
- Depends on #1423 
- Add extended payment key golden test
- Add `SerialiseAsCBOR` roundtrip tests for `TxBody`, `Tx` and `Witness` types
- Add Bech32 roundtrip tests