### PR TITLE
Improve tx submit api and port tx submit cli to new api

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -24,10 +24,10 @@ library
                         Cardano.Api.TextView
                         Cardano.Api.Typed
                         Cardano.Api.LocalChainSync
+                        Cardano.Api.TxSubmit
 
   other-modules:        Cardano.Api.Convert
                         Cardano.Api.Error
-                        Cardano.Api.TxSubmit
                         Cardano.Api.TxSubmit.ErrorRender
                         Cardano.Api.TxSubmit.Types
                         Cardano.Api.Types

--- a/cardano-api/src/Cardano/Api/LocalChainSync.hs
+++ b/cardano-api/src/Cardano/Api/LocalChainSync.hs
@@ -15,29 +15,16 @@ import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Protocol.ChainSync.Client
                    (ChainSyncClient(..), ClientStIdle(..), ClientStNext(..))
 
-import           Ouroboros.Consensus.Cardano (ProtocolClient)
-import           Ouroboros.Consensus.Block (BlockProtocol)
-import           Ouroboros.Consensus.Node.Run (RunNode)
-
 
 -- | Get the node's tip using the local chain sync protocol.
-getLocalTip
-  :: forall blk.
-     RunNode blk
-  => FilePath
-  -> NetworkId
-  -> ProtocolClient blk (BlockProtocol blk)
-  -> IO (Tip blk)
-getLocalTip sockPath network ptcl = do
+getLocalTip :: LocalNodeConnectInfo mode block -> IO (Tip block)
+getLocalTip connctInfo = do
     resultVar <- newEmptyTMVarIO
     connectToLocalNode
-      sockPath
-      network
-      ptcl
-      (\_ -> nullLocalNodeClientProtocols {
+      connctInfo
+      nullLocalNodeClientProtocols {
         localChainSyncClient = Just (chainSyncGetCurrentTip resultVar)
-      })
-
+      }
     atomically (takeTMVar resultVar)
 
 chainSyncGetCurrentTip :: forall blk.

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -1,206 +1,121 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
-{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Cardano.Api.TxSubmit
   ( submitTx
-  , submitGenTx
-  , TxSubmitResult(..)
+  , TxForMode(..)
+  , TxSubmitResultForMode(..)
   , renderTxSubmitResult
   ) where
 
 import           Cardano.Prelude
 
-import           Control.Tracer
-import           Control.Concurrent.STM
-
-import           Cardano.Api.Types
-import           Cardano.Api.TxSubmit.ErrorRender (renderApplyMempoolPayloadErr)
-
-import           Ouroboros.Consensus.Cardano (protocolClientInfo, SecurityParam(..))
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
-import           Ouroboros.Consensus.Network.NodeToClient
-import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo(..))
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                  (nodeToClientProtocolVersion, supportedNodeToClientVersions)
-import           Ouroboros.Consensus.Node.Run
-
-import           Ouroboros.Network.Driver (runPeer)
-import           Ouroboros.Network.Mux
-import           Ouroboros.Network.NodeToClient hiding (NodeToClientVersion (..))
-import qualified Ouroboros.Network.NodeToClient as NtC
-import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
 
-import           Cardano.Chain.Slotting (EpochSlots (..))
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock, mkShelleyTx)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
-import qualified Cardano.Chain.UTxO as Byron
-
-import           Ouroboros.Consensus.Shelley.Ledger.Mempool (mkShelleyTx)
-import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Cardano.Block
+                   (GenTx (GenTxByron, GenTxShelley),
+                    CardanoApplyTxErr, HardForkApplyTxErr (ApplyTxErrByron,
+                      ApplyTxErrShelley, ApplyTxErrWrongEra))
 
-import           Cardano.Api.Protocol.Byron (mkNodeClientProtocolByron)
-import           Cardano.Api.Protocol.Shelley (mkNodeClientProtocolShelley)
-import           Cardano.Config.Types (SocketPath(..))
+import           Cardano.Api.Typed
+import           Cardano.Api.TxSubmit.ErrorRender
 
 
-data TxSubmitResult
-   = TxSubmitSuccess
-   | TxSubmitFailureByron   (ApplyTxErr ByronBlock)
-   | TxSubmitFailureShelley (ApplyTxErr (ShelleyBlock TPraosStandardCrypto))
-   deriving Show
+data TxForMode mode where
 
-renderTxSubmitResult :: TxSubmitResult -> Text
+     TxForByronMode
+       :: Tx Byron
+       -> TxForMode ByronMode
+
+     TxForShelleyMode
+       :: Tx Shelley
+       -> TxForMode ShelleyMode
+
+     TxForCardanoMode
+       :: Either (Tx Byron) (Tx Shelley)
+       -> TxForMode CardanoMode
+
+
+data TxSubmitResultForMode mode where
+
+     TxSubmitSuccess
+       :: TxSubmitResultForMode mode
+
+     TxSubmitFailureByronMode
+       :: ApplyTxErr ByronBlock
+       -> TxSubmitResultForMode ByronMode
+
+     TxSubmitFailureShelleyMode
+       :: ApplyTxErr (ShelleyBlock TPraosStandardCrypto)
+       -> TxSubmitResultForMode ShelleyMode
+
+     TxSubmitFailureCardanoMode
+       :: CardanoApplyTxErr TPraosStandardCrypto
+       -> TxSubmitResultForMode CardanoMode
+
+deriving instance Show (TxSubmitResultForMode ByronMode)
+deriving instance Show (TxSubmitResultForMode ShelleyMode)
+deriving instance Show (TxSubmitResultForMode CardanoMode)
+
+submitTx :: forall mode block.
+            LocalNodeConnectInfo mode block
+         -> TxForMode mode
+         -> IO (TxSubmitResultForMode mode)
+submitTx connctInfo txformode =
+    case (localNodeConsensusMode connctInfo, txformode) of
+      (ByronMode{}, TxForByronMode (ByronTx tx)) -> do
+        let genTx = Byron.ByronTx (Byron.byronIdTx tx) tx
+        result <- submitTxToNodeLocal connctInfo genTx
+        case result of
+          SubmitSuccess      -> return TxSubmitSuccess
+          SubmitFail failure -> return (TxSubmitFailureByronMode failure)
+
+      (ShelleyMode{}, TxForShelleyMode (ShelleyTx tx)) -> do
+        let genTx = mkShelleyTx tx
+        result <- submitTxToNodeLocal connctInfo genTx
+        case result of
+          SubmitSuccess      -> return TxSubmitSuccess
+          SubmitFail failure -> return (TxSubmitFailureShelleyMode failure)
+
+      (CardanoMode{}, TxForCardanoMode etx) -> do
+        let genTx = case etx of
+              Left  (ByronTx   tx) -> GenTxByron (Byron.ByronTx (Byron.byronIdTx tx) tx)
+              Right (ShelleyTx tx) -> GenTxShelley (mkShelleyTx tx)
+        result <- submitTxToNodeLocal connctInfo genTx
+        case result of
+          SubmitSuccess      -> return TxSubmitSuccess
+          SubmitFail failure -> return (TxSubmitFailureCardanoMode failure)
+
+
+renderTxSubmitResult :: TxSubmitResultForMode mode -> Text
 renderTxSubmitResult res =
   case res of
     TxSubmitSuccess -> "Transaction submitted successfully."
-    TxSubmitFailureByron err ->
+
+    TxSubmitFailureByronMode err ->
       "Failed to submit Byron transaction: " <> renderApplyMempoolPayloadErr err
-    TxSubmitFailureShelley err ->
+
+    TxSubmitFailureShelleyMode err ->
       -- TODO: Write render function for Shelley tx submission errors.
       "Failed to submit Shelley transaction: " <> show err
 
-submitTx
-  :: Network
-  -> SocketPath
-  -> TxSigned
-  -> IO TxSubmitResult
-submitTx network socketPath tx =
-    NtC.withIOManager $ \iocp ->
-      case tx of
-        TxSignedByron txbody _txCbor _txHash vwit -> do
-          let aTxAux = Byron.annotateTxAux (Byron.mkTxAux txbody vwit)
-              genTx  = Byron.ByronTx (Byron.byronIdTx aTxAux) aTxAux
-          result <- submitGenTx
-                      nullTracer
-                      iocp
-                      (protocolClientInfo (mkNodeClientProtocolByron
-                                             (EpochSlots 21600)
-                                             (SecurityParam 2160)))
-                      network
-                      socketPath
-                      genTx
-          case result of
-            SubmitSuccess  -> return TxSubmitSuccess
-            SubmitFail err -> return (TxSubmitFailureByron err)
+    TxSubmitFailureCardanoMode (ApplyTxErrByron err) ->
+      "Failed to submit Byron transaction: " <> renderApplyMempoolPayloadErr err
 
-        TxSignedShelley stx -> do
-          let genTx = mkShelleyTx stx
-          result <- submitGenTx
-                      nullTracer
-                      iocp
-                      (protocolClientInfo mkNodeClientProtocolShelley)
-                      network
-                      socketPath
-                      genTx
-          case result of
-            SubmitSuccess  -> return TxSubmitSuccess
-            SubmitFail err -> return (TxSubmitFailureShelley err)
+    TxSubmitFailureCardanoMode (ApplyTxErrShelley err) ->
+      -- TODO: Write render function for Shelley tx submission errors.
+      "Failed to submit Shelley transaction: " <> show err
 
-
-submitGenTx
-  :: forall blk.
-     RunNode blk
-  => Tracer IO Text
-  -> IOManager
-  -> ProtocolClientInfo blk
-  -> Network
-  -> SocketPath
-  -> GenTx blk
-  -> IO (SubmitResult (ApplyTxErr blk))
-submitGenTx tracer iomgr cfg nm (SocketPath path) genTx = do
-    resultVar <- newEmptyTMVarIO
-    connectTo
-      (localSnocket iomgr path)
-      NetworkConnectTracers {
-          nctMuxTracer       = nullTracer,
-          nctHandshakeTracer = nullTracer
-          }
-      (localInitiatorNetworkApplication tracer cfg nm resultVar genTx)
-      path
-      --`catch` handleMuxError tracer chainsVar socketPath
-    atomically (readTMVar resultVar)
-
-localInitiatorNetworkApplication
-  :: forall blk.
-     RunNode blk
-  => Tracer IO Text
-  -- ^ tracer which logs all local tx submission protocol messages send and
-  -- received by the client (see 'Ouroboros.Network.Protocol.LocalTxSubmission.Type'
-  -- in 'ouroboros-network' package).
-  -> ProtocolClientInfo blk
-  -> Network
-  -> TMVar (SubmitResult (ApplyTxErr blk)) -- ^ Result will be placed here
-  -> GenTx blk
-  -> Versions NtC.NodeToClientVersion DictVersion
-               (OuroborosApplication InitiatorMode LocalAddress LByteString IO () Void)
-localInitiatorNetworkApplication tracer cfg nm resultVar genTx =
-    foldMapVersions
-      (\v ->
-        NtC.versionedNodeToClientProtocols
-          (nodeToClientProtocolVersion proxy v)
-          versionData
-          (\_ _ -> protocols v genTx))
-      (supportedNodeToClientVersions proxy)
-  where
-
-    proxy :: Proxy blk
-    proxy = Proxy
-
-    versionData = NodeToClientVersionData { networkMagic = toNetworkMagic nm }
-
-    protocols clientVersion tx =
-        NodeToClientProtocols {
-          localChainSyncProtocol =
-            InitiatorProtocolOnly $
-              MuxPeer
-                nullTracer
-                cChainSyncCodec
-                chainSyncPeerNull
-
-        , localTxSubmissionProtocol =
-            InitiatorProtocolOnly $
-              MuxPeerRaw $ \channel -> do
-                traceWith tracer "Submitting transaction"
-                (result, trailing)
-                 <- runPeer nullTracer -- (contramap show tracer)
-                            cTxSubmissionCodec
-                            channel
-                            (localTxSubmissionClientPeer
-                               (txSubmissionClientSingle tx))
-                case result of
-                  SubmitSuccess -> traceWith tracer "Transaction accepted"
-                  SubmitFail _  -> traceWith tracer "Transaction rejected"
-                atomically $ putTMVar resultVar result
-                return ((), trailing)
-
-        , localStateQueryProtocol =
-            InitiatorProtocolOnly $
-              MuxPeer
-                nullTracer
-                cStateQueryCodec
-                localStateQueryPeerNull
-        }
-      where
-        Codecs
-          { cChainSyncCodec
-          , cTxSubmissionCodec
-          , cStateQueryCodec
-          } = defaultCodecs (pClientInfoCodecConfig cfg) clientVersion
-
-txSubmissionClientSingle
-  :: forall tx reject m.
-     Applicative m
-  => tx
-  -> LocalTxSubmissionClient tx reject m (SubmitResult reject)
-txSubmissionClientSingle tx =
-    LocalTxSubmissionClient $
-    pure $ SendMsgSubmitTx tx $ \result ->
-    pure (SendMsgDone result)
+    TxSubmitFailureCardanoMode (ApplyTxErrWrongEra mismatch) ->
+      "Failed to submit transaction due to era mismatch: " <> show mismatch

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -226,6 +227,11 @@ module Cardano.Api.Typed (
 
     -- ** Low level protocol interaction with a Cardano node
     connectToLocalNode,
+    LocalNodeConnectInfo(..),
+    ByronMode,
+    ShelleyMode,
+    CardanoMode,
+    NodeConsensusMode(..),
     LocalNodeClientProtocols(..),
     nullLocalNodeClientProtocols,
 --  connectToRemoteNode,
@@ -235,6 +241,7 @@ module Cardano.Api.Typed (
 
     -- *** Local tx submission
     LocalTxSubmissionClient(..),
+    submitTxToNodeLocal,
 
     -- *** Local state query
     LocalStateQueryClient(..),
@@ -362,7 +369,8 @@ import           Ouroboros.Network.Mux
                     RunMiniProtocol(InitiatorProtocolOnly))
 
 -- TODO: it'd be nice if the consensus imports needed were a bit more coherent
-import           Ouroboros.Consensus.Cardano (ProtocolClient, protocolClientInfo)
+import           Ouroboros.Consensus.Cardano
+                   (SecurityParam, ProtocolClient, protocolClientInfo)
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Ledger.Abstract (Query)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
@@ -373,6 +381,10 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                   (BlockNodeToClientVersion, TranslateNetworkProtocolVersion,
                    nodeToClientProtocolVersion, supportedNodeToClientVersions)
 import           Ouroboros.Consensus.Node.Run (SerialiseNodeToClientConstraints)
+
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
 
 --
 -- Crypto API used by consensus and Shelley (and should be used by Byron)
@@ -394,6 +406,8 @@ import qualified Cardano.Crypto.ProtocolMagic as Byron
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.Genesis as Byron
 import qualified Cardano.Chain.UTxO   as Byron
+import qualified Cardano.Chain.Slotting as Byron
+
 
 --
 -- Shelley imports
@@ -430,6 +444,9 @@ import           Shelley.Spec.Ledger.TxData
 -- Other config and common types
 --
 import qualified Cardano.Api.TextView as TextView
+import           Cardano.Api.Protocol.Byron   (mkNodeClientProtocolByron)
+import           Cardano.Api.Protocol.Shelley (mkNodeClientProtocolShelley)
+import           Cardano.Api.Protocol.Cardano (mkNodeClientProtocolCardano)
 
 import           Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Client as TxSubmission
@@ -2248,28 +2265,71 @@ issueOperationalCertificate (KesVerificationKey kesVKey)
 -- Node IPC protocols
 --
 
-data LocalNodeClientProtocols blk =
+data ByronMode
+data ShelleyMode
+data CardanoMode
+
+data LocalNodeConnectInfo mode block =
+     LocalNodeConnectInfo {
+       localNodeSocketPath    :: FilePath,
+       localNodeNetworkId     :: NetworkId,
+       localNodeConsensusMode :: NodeConsensusMode mode block
+     }
+
+data NodeConsensusMode mode block where
+
+     ByronMode
+       :: Byron.EpochSlots
+       -> SecurityParam
+       -> NodeConsensusMode ByronMode ByronBlock
+
+     ShelleyMode
+       :: NodeConsensusMode ShelleyMode (ShelleyBlock ShelleyCrypto)
+
+     CardanoMode
+       :: Byron.EpochSlots
+       -> SecurityParam
+       -> NodeConsensusMode CardanoMode (CardanoBlock ShelleyCrypto)
+
+
+withNodeProtocolClient
+  :: NodeConsensusMode mode block
+  -> (   (SerialiseNodeToClientConstraints block,
+          TranslateNetworkProtocolVersion block)
+      => ProtocolClient block (BlockProtocol block) -> a)
+  -> a
+withNodeProtocolClient (ByronMode epochSlots securityParam) f =
+    f (mkNodeClientProtocolByron epochSlots securityParam)
+
+withNodeProtocolClient ShelleyMode f =
+    f (mkNodeClientProtocolShelley)
+
+withNodeProtocolClient (CardanoMode epochSlots securityParam) f =
+    f (mkNodeClientProtocolCardano epochSlots securityParam)
+
+
+data LocalNodeClientProtocols block =
      LocalNodeClientProtocols {
        localChainSyncClient
          :: Maybe (ChainSyncClient
-                    blk
-                    (Tip blk)
+                    block
+                    (Tip block)
                     IO ())
 
      , localTxSubmissionClient
          :: Maybe (LocalTxSubmissionClient
-                    (GenTx blk)
-                    (ApplyTxErr blk)
+                    (GenTx block)
+                    (ApplyTxErr block)
                     IO ())
 
      , localStateQueryClient
          :: Maybe (LocalStateQueryClient
-                    blk
-                    (Query blk)
+                    block
+                    (Query block)
                     IO ())
      }
 
-nullLocalNodeClientProtocols :: LocalNodeClientProtocols blk
+nullLocalNodeClientProtocols :: LocalNodeClientProtocols block
 nullLocalNodeClientProtocols =
     LocalNodeClientProtocols {
       localChainSyncClient    = Nothing,
@@ -2281,16 +2341,17 @@ nullLocalNodeClientProtocols =
 -- | Establish a connection to a node and execute the given set of protocol
 -- handlers.
 --
-connectToLocalNode :: forall blk.
-                      (SerialiseNodeToClientConstraints blk,
-                       TranslateNetworkProtocolVersion blk)
-                   => FilePath  -- ^ The local socket path.
-                   -> NetworkId
-                   -> ProtocolClient blk (BlockProtocol blk)
-                   -> (BlockNodeToClientVersion blk -> LocalNodeClientProtocols blk)
+connectToLocalNode :: forall mode block.
+                      LocalNodeConnectInfo mode block
+                   -> LocalNodeClientProtocols block
                    -> IO ()
-connectToLocalNode path nw ptcl clientptcls =
+connectToLocalNode LocalNodeConnectInfo {
+                     localNodeSocketPath    = path,
+                     localNodeNetworkId     = network,
+                     localNodeConsensusMode = mode
+                   } clientptcls =
     withIOManager $ \iomgr ->
+      withNodeProtocolClient mode $ \ptcl ->
       connectTo
         (localSnocket iomgr path)
         NetworkConnectTracers {
@@ -2301,18 +2362,20 @@ connectToLocalNode path nw ptcl clientptcls =
             (\v -> versionedNodeToClientProtocols
                      (nodeToClientProtocolVersion proxy v)
                      NodeToClientVersionData {
-                       networkMagic = toNetworkMagic nw
+                       networkMagic = toNetworkMagic network
                      }
-                     (\_conn _runOrStop -> protocols v))
+                     (\_conn _runOrStop -> protocols ptcl v))
             (supportedNodeToClientVersions proxy))
         path
   where
-    proxy :: Proxy blk
+    proxy :: Proxy block
     proxy = Proxy
 
-    protocols :: BlockNodeToClientVersion blk
+    protocols :: SerialiseNodeToClientConstraints block
+              => ProtocolClient block (BlockProtocol block)
+              -> BlockNodeToClientVersion block
               -> NodeToClientProtocols InitiatorMode LBS.ByteString IO () Void
-    protocols clientVersion =
+    protocols ptcl clientVersion =
       let Codecs {
               cChainSyncCodec
             , cTxSubmissionCodec
@@ -2324,7 +2387,7 @@ connectToLocalNode path nw ptcl clientptcls =
             localChainSyncClient,
             localTxSubmissionClient,
             localStateQueryClient
-          } = clientptcls clientVersion
+          } = clientptcls
 
        in NodeToClientProtocols {
             localChainSyncProtocol =
@@ -2363,28 +2426,24 @@ connectToLocalNode path nw ptcl clientptcls =
 -- | Establish a connection to a node and execute a single query using the
 -- local state query protocol.
 --
-queryNodeLocalState :: forall blk result.
-                      (SerialiseNodeToClientConstraints blk,
-                       TranslateNetworkProtocolVersion blk)
-                    => FilePath  -- ^ The local socket path.
-                    -> NetworkId
-                    -> ProtocolClient blk (BlockProtocol blk)
-                    -> (Point blk, Query blk result)
+queryNodeLocalState :: forall mode block result.
+                       LocalNodeConnectInfo mode block
+                    -> (Point block, Query block result)
                     -> IO (Either AcquireFailure result)
-queryNodeLocalState path nw ptcl pointAndQuery = do
+queryNodeLocalState connctInfo pointAndQuery = do
     resultVar <- newEmptyTMVarIO
     connectToLocalNode
-      path nw ptcl
-      (\_ -> nullLocalNodeClientProtocols {
+      connctInfo
+      nullLocalNodeClientProtocols {
         localStateQueryClient =
           Just (localStateQuerySingle resultVar pointAndQuery)
-      })
+      }
     atomically (takeTMVar resultVar)
   where
     localStateQuerySingle
       :: TMVar (Either AcquireFailure result)
-      -> (Point blk, Query blk result)
-      -> LocalStateQueryClient blk (Query blk) IO ()
+      -> (Point block, Query block result)
+      -> LocalStateQueryClient block (Query block) IO ()
     localStateQuerySingle resultVar (point, query) =
       LocalStateQueryClient $ pure $
         SendMsgAcquire point $
@@ -2405,6 +2464,29 @@ queryNodeLocalState path nw ptcl pointAndQuery = do
             atomically $ putTMVar resultVar (Left failure)
             pure $ StateQuery.SendMsgDone ()
         }
+
+submitTxToNodeLocal :: forall mode block.
+                       LocalNodeConnectInfo mode block
+                    -> GenTx block
+                    -> IO (SubmitResult (ApplyTxErr block))
+submitTxToNodeLocal connctInfo tx = do
+    resultVar <- newEmptyTMVarIO
+    connectToLocalNode
+      connctInfo
+      nullLocalNodeClientProtocols {
+        localTxSubmissionClient =
+          Just (localTxSubmissionClientSingle resultVar)
+      }
+    atomically (takeTMVar resultVar)
+  where
+    localTxSubmissionClientSingle
+      :: TMVar (SubmitResult (ApplyTxErr block))
+      -> LocalTxSubmissionClient (GenTx block) (ApplyTxErr block) IO ()
+    localTxSubmissionClientSingle resultVar =
+        LocalTxSubmissionClient $
+        pure $ SendMsgSubmitTx tx $ \result -> do
+        atomically $ putTMVar resultVar result
+        pure (TxSubmission.SendMsgDone ())
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -96,7 +96,7 @@ data ByronCommand =
     -----------------------------------
 
   | SubmitTx
-        Network
+        NetworkId
         TxFile
         -- ^ Filepath of transaction to submit.
 
@@ -152,11 +152,11 @@ data NodeCmd = CreateVote
                FilePath
                [ParametersToUpdate]
              | SubmitUpdateProposal
-               Network
+               NetworkId
                FilePath
                -- ^ Update proposal filepath.
              | SubmitVote
-               Network
+               NetworkId
                FilePath
                -- ^ Vote filepath.
               deriving Show

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -316,7 +316,7 @@ parseTxRelatedValues =
         "submit-tx"
         "Submit a raw, signed transaction, in its on-wire representation."
         $ SubmitTx
-            <$> parseNetwork
+            <$> pNetworkId
             <*> parseTxFile "tx"
     , command'
         "issue-genesis-utxo-expenditure"
@@ -382,7 +382,7 @@ parseByronUpdateProposal = do
 parseByronVoteSubmission :: Parser NodeCmd
 parseByronVoteSubmission = do
   SubmitVote
-    <$> parseNetwork
+    <$> pNetworkId
     <*> parseFilePath "filepath" "Filepath of Byron update proposal vote."
 
 parseParametersToUpdate :: Parser [ParametersToUpdate]
@@ -408,7 +408,7 @@ parseParametersToUpdate =
 parseByronUpdateProposalSubmission :: Parser NodeCmd
 parseByronUpdateProposalSubmission =
   SubmitUpdateProposal
-    <$> parseNetwork
+    <$> pNetworkId
     <*> parseFilePath "filepath" "Filepath of Byron update proposal."
 
 

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -34,9 +34,9 @@ import           Cardano.Crypto.Signing (SigningKey, noPassSafeSigner)
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool
 import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Network.NodeToClient (IOManager)
 
 import           Cardano.Api (Network, toByronProtocolMagic)
+import           Cardano.Api.Typed (NetworkId)
 import           Cardano.CLI.Byron.Key (CardanoEra(..), ByronKeyFailure, readEraSigningKey)
 import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
 import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
@@ -191,14 +191,13 @@ readByronUpdateProposal fp =
 
 
 submitByronUpdateProposal
-  :: IOManager
-  -> Network
+  :: NetworkId
   -> FilePath
   -> ExceptT ByronUpdateProposalError IO ()
-submitByronUpdateProposal iomgr network proposalFp = do
+submitByronUpdateProposal network proposalFp = do
     proposalBs <- readByronUpdateProposal proposalFp
     aProposal <- hoistEither $ deserialiseByronUpdateProposal proposalBs
     let genTx = convertProposalToGenTx aProposal
     traceWith stdoutTracer $
       "Update proposal TxId: " ++ condense (txId genTx)
-    firstExceptT ByronUpdateProposalTxError $ nodeSubmitTx iomgr network genTx
+    firstExceptT ByronUpdateProposalTxError $ nodeSubmitTx network genTx

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -25,9 +25,9 @@ import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx(..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Network.IOManager (IOManager)
 
 import           Cardano.Api (Network, toByronProtocolMagic)
+import           Cardano.Api.Typed (NetworkId)
 
 import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
 import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
@@ -91,13 +91,12 @@ serialiseByronVote :: Vote -> LByteString
 serialiseByronVote = Binary.serialize
 
 submitByronVote
-  :: IOManager
-  -> Network
+  :: NetworkId
   -> FilePath
   -> ExceptT ByronVoteError IO ()
-submitByronVote iomgr network voteFp = do
+submitByronVote network voteFp = do
     voteBs <- liftIO $ LB.readFile voteFp
     vote <- hoistEither $ deserialiseByronVote voteBs
     let genTx = convertVoteToGenTx vote
     traceWith stdoutTracer ("Vote TxId: " ++ condense (txId genTx))
-    firstExceptT ByronVoteTxSubmissionError $ nodeSubmitTx iomgr network genTx
+    firstExceptT ByronVoteTxSubmissionError $ nodeSubmitTx network genTx

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -44,7 +44,6 @@ import           Prelude
 import           Data.Set (Set)
 import           Data.Text (Text)
 
-import qualified Cardano.Api as OldApi
 import           Cardano.Api.Typed hiding (PoolId, Hash)
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
@@ -113,7 +112,7 @@ data TransactionCmd
   | TxWitness       -- { transaction :: Transaction, key :: PrivKeyFile, nodeAddr :: NodeAddress }
   | TxSignWitness   -- { transaction :: Transaction, witnesses :: [Witness], nodeAddr :: NodeAddress }
   | TxCheck         -- { transaction :: Transaction, nodeAddr :: NodeAddress }
-  | TxSubmit FilePath OldApi.Network
+  | TxSubmit FilePath NetworkId
   | TxCalculateMinFee
       TxBodyFile
       (Maybe NetworkId)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -37,7 +37,6 @@ import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.TxData as Shelley
 
-import qualified Cardano.Api as OldApi
 import           Cardano.Api.Typed hiding (PoolId)
 
 import           Cardano.Slotting.Slot (EpochNo (..))
@@ -317,7 +316,7 @@ pTransaction =
 
     pTransactionSubmit  :: Parser TransactionCmd
     pTransactionSubmit = TxSubmit <$> pTxSubmitFile
-                                  <*> pNetwork
+                                  <*> pNetworkId
 
     pTransactionCalculateMinFee :: Parser TransactionCmd
     pTransactionCalculateMinFee =
@@ -1056,27 +1055,16 @@ pITNVerificationKeyFile =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pNetwork :: Parser OldApi.Network
-pNetwork =
-  pMainnet <|> fmap OldApi.Testnet pTestnetMagic
-
 pNetworkId :: Parser NetworkId
 pNetworkId =
-  pMainnet' <|> fmap Testnet pTestnetMagic
+  pMainnet <|> fmap Testnet pTestnetMagic
  where
-   pMainnet' :: Parser NetworkId
-   pMainnet' =
+   pMainnet :: Parser NetworkId
+   pMainnet =
     Opt.flag' Mainnet
       (  Opt.long "mainnet"
       <> Opt.help "Use the mainnet magic id."
       )
-
-pMainnet :: Parser OldApi.Network
-pMainnet =
-  Opt.flag' OldApi.Mainnet
-    (  Opt.long "mainnet"
-    <> Opt.help "Use the mainnet magic id."
-    )
 
 pTestnetMagic :: Parser NetworkMagic
 pTestnetMagic =


### PR DESCRIPTION
Improve the interface for the general interface for connecting to a
node and interacting via the protocols. This now fits the style of the
typed API better, in that it follows the GADT era style, with specific
constructors for specific era.

Add a submitTxToNodeLocal using this style, and port the submitTx
wrapper to it too.

Then adjust all the CLI modules that use submitTx and the other actions
for connecting to the node.

These changes should also make it easier to integrate with an improved
way to pass in which node protocol we expect. All the node connection
related params are bundled togther which should make the cli plumbing a
bit simpler.