### PR TITLE
chairman:  relax the default progress requirement by one slot more

### DIFF
--- a/cardano-node/chairman/Cardano/Chairman.hs
+++ b/cardano-node/chairman/Cardano/Chairman.hs
@@ -136,7 +136,7 @@ deriveProgressThreshold _ _ (Just progressThreshold) = progressThreshold
 
 -- If only the progress threshold is not specified, derive it from the running time
 deriveProgressThreshold slotLength runningTime Nothing =
-    Block.BlockNo (floor (runningTime / getSlotLengthDiffTime slotLength) - 1)
+    Block.BlockNo (floor (runningTime / getSlotLengthDiffTime slotLength) - 2)
 
 
 getSlotLengthDiffTime :: SlotLength -> DiffTime


### PR DESCRIPTION
This relaxes the Chairman test's default progress requirement -- which should eliminate occasional CI failures where that threshold is violated due to startup jitter.