### PR TITLE
Implement support for specifying node protocol in CLI (V2)

### DIFF
--- a/cardano-api/src/Cardano/Api/LocalChainSync.hs
+++ b/cardano-api/src/Cardano/Api/LocalChainSync.hs
@@ -8,7 +8,6 @@ module Cardano.Api.LocalChainSync
 import           Cardano.Prelude hiding (atomically, catch)
 
 import           Control.Concurrent.STM
-
 import           Cardano.Api.Typed
 
 import           Ouroboros.Network.Block (Tip)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -113,7 +113,7 @@ data TransactionCmd
   | TxWitness       -- { transaction :: Transaction, key :: PrivKeyFile, nodeAddr :: NodeAddress }
   | TxSignWitness   -- { transaction :: Transaction, witnesses :: [Witness], nodeAddr :: NodeAddress }
   | TxCheck         -- { transaction :: Transaction, nodeAddr :: NodeAddress }
-  | TxSubmit FilePath NetworkId
+  | TxSubmit Protocol NetworkId FilePath
   | TxCalculateMinFee
       TxBodyFile
       (Maybe NetworkId)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -44,6 +44,7 @@ import           Prelude
 import           Data.Set (Set)
 import           Data.Text (Text)
 
+import           Cardano.Api.Protocol (Protocol)
 import           Cardano.Api.Typed hiding (PoolId, Hash)
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
@@ -172,7 +173,7 @@ data PoolCmd
 
 data QueryCmd
   = QueryPoolId NodeAddress
-  | QueryProtocolParameters NetworkId (Maybe OutputFile)
+  | QueryProtocolParameters Protocol NetworkId (Maybe OutputFile)
   | QueryTip NetworkId (Maybe OutputFile)
   | QueryStakeDistribution NetworkId (Maybe OutputFile)
   | QueryStakeAddressInfo StakeAddress NetworkId (Maybe OutputFile)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -174,12 +174,12 @@ data PoolCmd
 data QueryCmd
   = QueryPoolId NodeAddress
   | QueryProtocolParameters Protocol NetworkId (Maybe OutputFile)
-  | QueryTip NetworkId (Maybe OutputFile)
-  | QueryStakeDistribution NetworkId (Maybe OutputFile)
-  | QueryStakeAddressInfo StakeAddress NetworkId (Maybe OutputFile)
-  | QueryUTxO QueryFilter NetworkId (Maybe OutputFile)
+  | QueryTip Protocol NetworkId (Maybe OutputFile)
+  | QueryStakeDistribution Protocol NetworkId (Maybe OutputFile)
+  | QueryStakeAddressInfo Protocol StakeAddress NetworkId (Maybe OutputFile)
+  | QueryUTxO Protocol QueryFilter NetworkId (Maybe OutputFile)
   | QueryVersion NodeAddress
-  | QueryLedgerState NetworkId (Maybe OutputFile)
+  | QueryLedgerState Protocol NetworkId (Maybe OutputFile)
   | QueryStatus NodeAddress
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -462,25 +462,28 @@ pQueryCmd =
         <*> pMaybeOutputFile
 
     pQueryTip :: Parser QueryCmd
-    pQueryTip = QueryTip <$> pNetworkId <*> pMaybeOutputFile
+    pQueryTip = QueryTip <$> pProtocol <*> pNetworkId <*> pMaybeOutputFile
 
     pQueryUTxO :: Parser QueryCmd
     pQueryUTxO =
       QueryUTxO
-        <$> pQueryFilter
+        <$> pProtocol
+        <*> pQueryFilter
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryStakeDistribution :: Parser QueryCmd
     pQueryStakeDistribution =
       QueryStakeDistribution
-        <$> pNetworkId
+        <$> pProtocol
+        <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryStakeAddressInfo :: Parser QueryCmd
     pQueryStakeAddressInfo =
       QueryStakeAddressInfo
-        <$> pFilterByStakeAddress
+        <$> pProtocol
+        <*> pFilterByStakeAddress
         <*> pNetworkId
         <*> pMaybeOutputFile
 
@@ -488,7 +491,7 @@ pQueryCmd =
     pQueryVersion = QueryVersion <$> parseNodeAddress
 
     pQueryLedgerState :: Parser QueryCmd
-    pQueryLedgerState = QueryLedgerState <$> pNetworkId <*> pMaybeOutputFile
+    pQueryLedgerState = QueryLedgerState <$> pProtocol <*> pNetworkId <*> pMaybeOutputFile
 
     pQueryStatus :: Parser QueryCmd
     pQueryStatus = QueryStatus <$> parseNodeAddress

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -319,8 +319,9 @@ pTransaction =
     pTransactionCheck = pure TxCheck
 
     pTransactionSubmit  :: Parser TransactionCmd
-    pTransactionSubmit = TxSubmit <$> pTxSubmitFile
+    pTransactionSubmit = TxSubmit <$> pProtocol
                                   <*> pNetworkId
+                                  <*> pTxSubmitFile
 
     pTransactionCalculateMinFee :: Parser TransactionCmd
     pTransactionCalculateMinFee =

--- a/cardano-config/src/Cardano/Config/Orphanage.hs
+++ b/cardano-config/src/Cardano/Config/Orphanage.hs
@@ -14,13 +14,17 @@ import           Cardano.Prelude
 import qualified Prelude
 
 import           Data.Aeson
+import qualified Data.ByteString.Base16 as B16
 import           Data.Scientific (coefficient)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import           Network.Socket (PortNumber)
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity(..))
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Slotting.Block (BlockNo (..))
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash(..))
+import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Network.Block (HeaderHash, Tip (..))
 
@@ -64,4 +68,8 @@ instance ToJSON (HeaderHash blk) => ToJSON (Tip blk) where
       , "blockNo"    .= blockNo
       ]
 
+instance ToJSON (OneEraHash xs) where
+  toJSON (OneEraHash bs) = toJSON . Text.decodeLatin1 . B16.encode $ bs
+
+deriving newtype instance ToJSON ByronHash
 deriving newtype instance ToJSON BlockNo

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -202,6 +202,7 @@ executable chairman
                      , containers
                      , cardano-api
                      , cardano-config
+                     , cardano-ledger
                      , cardano-prelude
                      , contra-tracer
                      , cardano-prelude

--- a/cardano-node/chairman/chairman.hs
+++ b/cardano-node/chairman/chairman.hs
@@ -15,12 +15,17 @@ import qualified Options.Applicative as Opt
 import           Ouroboros.Consensus.BlockchainTime (SlotLength, slotLengthFromSec)
 import           Ouroboros.Consensus.Cardano (SecurityParam(..))
 import           Ouroboros.Network.Block (BlockNo)
+import           Cardano.Chain.Slotting (EpochSlots(..))
 
 import           Cardano.Api.Typed (NetworkMagic(..))
-import           Cardano.Api.Protocol (mkNodeClientProtocol)
+import           Cardano.Api.Protocol.Types
+import           Cardano.Api.Protocol.Byron
+import           Cardano.Api.Protocol.Cardano
+import           Cardano.Api.Protocol.Shelley
 import           Cardano.Config.Types (SocketPath(..))
-import           Cardano.Node.Types (ConfigYamlFilePath(..),
-                   ncProtocol, parseNodeConfigurationFP)
+import           Cardano.Node.Types
+                   (ConfigYamlFilePath(..), parseNodeConfigurationFP,
+                    Protocol(..), ncProtocol)
 import           Cardano.Config.Parsers
 import           Cardano.Chairman (chairmanTest)
 
@@ -48,6 +53,25 @@ main = do
       caSocketPaths
       someNodeClientProtocol
       caNetworkMagic
+
+--TODO: replace this with the new stuff from Cardano.Api.Protocol
+mkNodeClientProtocol :: Protocol -> SomeNodeClientProtocol
+mkNodeClientProtocol protocol =
+    case protocol of
+      MockProtocol _ ->
+        panic "TODO: mkNodeClientProtocol NodeProtocolConfigurationMock"
+
+      -- Real protocols
+      ByronProtocol ->
+        mkSomeNodeClientProtocolByron
+          (EpochSlots 21600) (SecurityParam 2160)
+
+      ShelleyProtocol ->
+        mkSomeNodeClientProtocolShelley
+
+      CardanoProtocol ->
+        mkSomeNodeClientProtocolCardano
+          (EpochSlots 21600) (SecurityParam 2160)
 
 data ChairmanArgs = ChairmanArgs {
       -- | Stop the test after given number of seconds. The chairman will

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -12,9 +12,8 @@ import           Cardano.Prelude
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
-import           Cardano.Api.Protocol (MockProtocol(..))
 import           Cardano.Node.Types (NodeConfiguration(..), NodeProtocolConfiguration(..),
-                    NodeMockProtocolConfiguration(..))
+                    NodeMockProtocolConfiguration(..), MockProtocol(..))
 import           Cardano.Config.Types (ProtocolFilepaths(..))
 
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol(..))

--- a/cardano-node/src/Cardano/Node/TUI/Drawing.hs
+++ b/cardano-node/src/Cardano/Node/TUI/Drawing.hs
@@ -41,7 +41,7 @@ import qualified Graphics.Vty as Vty
 import           Numeric (showFFloat)
 import           Text.Printf (printf)
 
-import           Cardano.Api.Protocol(Protocol(..))
+import           Cardano.Node.Types (Protocol(..))
 import           Cardano.Tracing.Peer (Peer(..), ppPeer)
 
 data ColorTheme

--- a/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
+++ b/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
@@ -24,12 +24,12 @@ import           Data.Time.Clock (diffUTCTime, getCurrentTime)
 import           Data.Version (showVersion)
 import qualified Graphics.Vty as Vty
 
-import           Cardano.Api.Protocol (Protocol(..), MockProtocol(..))
 import           Cardano.BM.Data.Aggregated (Measurable(..))
 import           Cardano.BM.Data.Backend (BackendKind(..), IsBackend(..), IsEffectuator(..))
 import           Cardano.BM.Data.Counter (Platform(..))
 import           Cardano.BM.Data.LogItem (LogObject(..), LOContent(..), LOMeta(..), utc2ns)
 import           Cardano.Config.GitRev (gitRev)
+import           Cardano.Node.Types (Protocol(..), MockProtocol(..))
 import           Cardano.Node.TUI.Drawing (ColorTheme(..), LiveViewState(..), LiveViewThread(..),
                    Screen(..), darkTheme, drawUI, lightTheme)
 


### PR DESCRIPTION
This means that on the command line you can select if you're talking to a node
that is in Byron-only mode, Shelley-mode or the composite Cardano mode.

We have to handle the queries slightly differently in these cases.

