### PR TITLE
GITHUB-1086:  shut down the switchboard at exit

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -49,7 +49,7 @@ import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
 
 import           Cardano.Config.GitRev (gitRev)
-import           Cardano.Node.Logging (LoggingLayer (..), Severity (..))
+import           Cardano.Node.Logging (LoggingLayer (..), Severity (..), shutdownLoggingLayer)
 #ifdef UNIX
 import           Cardano.Node.TraceConfig (traceBlockFetchDecisions)
 #endif
@@ -196,6 +196,7 @@ runNode loggingLayer npm@NodeCLI{protocolFiles} = do
         Async.uninterruptibleCancel upTimeThread
         Async.uninterruptibleCancel peersThread
 #endif
+    shutdownLoggingLayer loggingLayer
 
 -- | Add the application name and unqualified hostname to the logging
 -- layer basic trace.


### PR DESCRIPTION
1. Expose `LoggingLayer` shutdown functionality, that was removed during `cardano-shell` elimination.  This allows proper termination of the switchboard thread.
2. Shutdown the `LoggingLayer` at exit.