### PR TITLE
Eliminate dependency on lens

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -83,8 +83,8 @@ library
                      , formatting
                      , io-sim-classes
                      , iproute
-                     , lens
                      , memory
+                     , microlens
                      , network
                      , network-mux
                      , network-uri

--- a/cardano-cli/src/Cardano/CLI/Legacy/Byron.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Byron.hs
@@ -14,7 +14,7 @@ import           Cardano.Prelude hiding (option)
 
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
-import           Control.Lens (LensLike, _Left)
+import           Lens.Micro (LensLike, _Left)
 import           Data.Coerce (coerce)
 import           Data.Semigroup ((<>))
 import           Data.Text (Text)


### PR DESCRIPTION
Even though lens is already pulled in because of the dependency on it in
`cardano-ledger-specs`, simple uses of lenses like this can be catered by
`microlens`.