### PR TITLE
Execute the cardano-cli at the process level

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -184,6 +184,7 @@ test-suite cardano-cli-pioneers
                       , directory
                       , hedgehog
                       , optparse-applicative
+                      , process
                       , temporary
                       , text
                       , time

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -183,6 +183,7 @@ test-suite cardano-cli-pioneers
                       , containers
                       , directory
                       , hedgehog
+                      , lifted-base
                       , optparse-applicative
                       , process
                       , temporary

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
@@ -84,7 +84,6 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
   liftIO $ IO.createDirectoryIfMissing True "tmp"
   tempDir <- liftIO $ IO.createTempDirectory "tmp" "test"
   let genesisFile = tempDir <> "/genesis.json"
-  let cleanupPaths = [tempDir]
   
   fmtStartTime <- fmap formatIso8601 $ liftIO DT.getCurrentTime
 
@@ -93,8 +92,7 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
   (utxoCount, fmtUtxoCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
 
   -- Create the genesis json file and required keys
-  OP.execCardanoCLIParser cleanupPaths $
-    OP.evalCardanoCLIParser
+  void $ liftIO $ OP.execCardanoCLI
       [ "shelley","genesis","create"
       , "--testnet-magic", "12"
       , "--start-time", fmtStartTime

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
@@ -16,9 +16,7 @@ import qualified Data.List as L
 import qualified Data.Set as S
 import qualified Data.Time.Clock as DT
 import qualified Data.Time.Format as DT
-import qualified System.Directory as IO
 import qualified System.IO as IO
-import qualified System.IO.Temp as IO
 
 import Hedgehog (Property, forAll, (===))
 
@@ -80,9 +78,7 @@ parseTotalSupply = J.withObject "Object" $ \ o -> do
   fmap sum (sequence (fmap (J.parseJSON @Int . snd) (HM.toList initialFunds)))
 
 golden_shelleyGenesisCreate :: Property
-golden_shelleyGenesisCreate = OP.propertyOnce $ do
-  liftIO $ IO.createDirectoryIfMissing True "tmp"
-  tempDir <- liftIO $ IO.createTempDirectory "tmp" "test"
+golden_shelleyGenesisCreate = OP.propertyOnce $ OP.workspace "tmp/genesis-create" $ \tempDir -> do
   let genesisFile = tempDir <> "/genesis.json"
   
   fmtStartTime <- fmap formatIso8601 $ liftIO DT.getCurrentTime

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -29,6 +29,7 @@ import           Cardano.CLI.Run (ClientCommand(..),
                    renderClientCommandError, runClientCommand)
 
 import qualified System.Process as IO
+import qualified System.Environment as IO
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
@@ -50,7 +51,11 @@ execCardanoCLI
   -- ^ Arguments to the CLI command
   -> IO String
   -- ^ Captured stdout
-execCardanoCLI arguments = IO.readProcess "cabal" ("exec":"--":"cardano-cli":arguments) ""
+execCardanoCLI arguments = do
+  maybeCardanoCli <- IO.lookupEnv "CARDANO_CLI"
+  case maybeCardanoCli of
+    Just cardanoCli -> IO.readProcess cardanoCli arguments ""
+    Nothing -> IO.readProcess "cabal" ("exec":"--":"cardano-cli":arguments) ""
 
 -- | This takes a 'ParserResult', which is pure, and executes it.
 execCardanoCLIParser

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -4,6 +4,7 @@ module Test.OptParse
   , equivalence
   , evalCardanoCLIParser
   , execCardanoCLIParser
+  , execCardanoCLI
   , fileCleanup
   , propertyOnce
   ) where
@@ -27,6 +28,8 @@ import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (ClientCommand(..),
                    renderClientCommandError, runClientCommand)
 
+import qualified System.Process as IO
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
 import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
@@ -38,6 +41,16 @@ import           Hedgehog.Internal.Source (getCaller)
 -- without running underlying IO.
 evalCardanoCLIParser :: [String] -> Opt.ParserResult ClientCommand
 evalCardanoCLIParser args = Opt.execParserPure pref opts args
+
+-- | Execute cardano-cli via the command line.
+--
+-- Waits for the process to finish and returns the stdout.
+execCardanoCLI
+  :: [String]
+  -- ^ Arguments to the CLI command
+  -> IO String
+  -- ^ Captured stdout
+execCardanoCLI arguments = IO.readProcess "cabal" ("exec":"--":"cardano-cli":arguments) ""
 
 -- | This takes a 'ParserResult', which is pure, and executes it.
 execCardanoCLIParser


### PR DESCRIPTION
New `execCardanoCLI` function which uses one of:

* `$CARDANO_CLI` if it is defined
* `cabal exec -- cardano-cli` otherwise

New `workspace` function which creates a temporary directory and cleans it up.  The clean up is signalled by writing a `done` file.

The `Genesis.Create` test is modified to use `execCardanoCLI` and `workspace`.

New dependency on `process` library.