### PR TITLE
Update dependencies on consensus and ledger 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -168,78 +168,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
-  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  tag: 47e2075f751d8370222a2aad32f37699a341ec40
+  --sha256: 0jz2zhcif6gpkdzl4b9dribfb0qk7fjz9lfjza8c3bf88an4w0zw
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
@@ -326,92 +326,92 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
-  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  tag: dae680f8e6b0af611c323554c375f50b3bfd5308
+  --sha256: 06431j67milg51ih1wpac829fniw0qlbzzj9vc1xshn445b5vy4n
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-config/src/Cardano/Config/Types.hs
+++ b/cardano-config/src/Cardano/Config/Types.hs
@@ -51,6 +51,7 @@ import           Ouroboros.Consensus.Block (Header, BlockProtocol, ForgeState(..
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
+import           Ouroboros.Consensus.Ledger.Inspect (LedgerWarning)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
                    (GenTxId, HasTxId, HasTxs(..), ApplyTxErr)
 import           Ouroboros.Consensus.Mock.Ledger.Block (SimpleBlock)
@@ -288,6 +289,7 @@ type TraceConstraints blk =
     , ToObject (GenTx blk)
     , ToObject (Header blk)
     , ToObject (LedgerError blk)
+    , ToObject (LedgerWarning blk)
     , ToObject (OtherHeaderEnvelopeError blk)
     , ToObject (ValidationErr (BlockProtocol blk))
     , ToObject (CannotLead (BlockProtocol blk))

--- a/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/Consensus.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Protocol.BFT  as BFT
 import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Inspect (LedgerWarning)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx, GenTxId,
                    HasTxId, TxId, txId)
 import           Ouroboros.Consensus.Mempool.API (TraceEventMempool (..), MempoolSize(..))
@@ -294,8 +295,10 @@ instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
 
 
 instance ( Condense (HeaderHash blk)
+         , Show (LedgerWarning blk)
          , LedgerSupportsProtocol blk
-         , ToObject (Header blk))
+         , ToObject (Header blk)
+         , ToObject (LedgerWarning blk))
       => Transformable Text IO (ChainDB.TraceEvent blk) where
   trTransformer = trStructuredText
 
@@ -303,7 +306,9 @@ instance ( Condense (HeaderHash blk)
 
 
 
-instance (Condense (HeaderHash blk), LedgerSupportsProtocol blk)
+instance (Condense (HeaderHash blk),
+          Show (LedgerWarning blk),
+          LedgerSupportsProtocol blk)
       => HasTextFormatter (ChainDB.TraceEvent blk) where
     formatText = \case
       ChainDB.TraceAddBlockEvent ev -> case ev of
@@ -324,9 +329,11 @@ instance (Condense (HeaderHash blk), LedgerSupportsProtocol blk)
         ChainDB.TrySwitchToAFork pt _ -> \_o ->
           "Block fits onto some fork: " <> condenseT pt
         ChainDB.AddedToCurrentChain ws _ _ c -> \_o ->
-          "Chain extended, new tip: " <> condenseT (AF.headPoint c)
+          "Chain extended, new tip: " <> condenseT (AF.headPoint c) <>
+          Text.concat [ "\nWarning: " <> showT w | w <- ws ]
         ChainDB.SwitchedToAFork ws _ _ c -> \_o ->
-          "Switched to a fork, new tip: " <> condenseT (AF.headPoint c)
+          "Switched to a fork, new tip: " <> condenseT (AF.headPoint c) <>
+          Text.concat [ "\nWarning: " <> showT w | w <- ws ]
         ChainDB.AddBlockValidation ev' -> case ev' of
           ChainDB.InvalidBlock err pt -> \_o ->
             "Invalid block " <> condenseT pt <> ": " <> showT err
@@ -543,7 +550,8 @@ instance Condense (HeaderHash blk)
 
 instance ( Condense (HeaderHash blk)
          , LedgerSupportsProtocol blk
-         , ToObject (Header blk))
+         , ToObject (Header blk)
+         , ToObject (LedgerWarning blk))
       => ToObject (ChainDB.TraceEvent blk) where
   toObject verb (ChainDB.TraceAddBlockEvent ev) = case ev of
     ChainDB.IgnoreBlockOlderThanK pt ->
@@ -577,16 +585,20 @@ instance ( Condense (HeaderHash blk)
       mkObject $
                [ "kind" .= String "TraceAddBlockEvent.AddedToCurrentChain"
                , "newtip" .= showPoint verb (AF.headPoint extended)
-               ] ++
-               [ "headers" .= toJSON (toObject verb `map` addedHdrsNewChain base extended)
+               ]
+            ++ [ "headers" .= toJSON (toObject verb `map` addedHdrsNewChain base extended)
                | verb == MaximalVerbosity ]
+            ++ [ "warnings" .= toJSON (map (toObject verb) warnings)
+               | not (null warnings) ]
     ChainDB.SwitchedToAFork warnings _ old new ->
       mkObject $
                [ "kind" .= String "TraceAddBlockEvent.SwitchedToAFork"
                , "newtip" .= showPoint verb (AF.headPoint new)
-               ] ++
-               [ "headers" .= toJSON (toObject verb `map` addedHdrsNewChain old new)
+               ]
+            ++ [ "headers" .= toJSON (toObject verb `map` addedHdrsNewChain old new)
                | verb == MaximalVerbosity ]
+            ++ [ "warnings" .= toJSON (map (toObject verb) warnings)
+               | not (null warnings) ]
     ChainDB.AddBlockValidation ev' -> case ev' of
       ChainDB.InvalidBlock err pt ->
         mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidBlock"

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -194,7 +194,7 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.BlockInTheFuture _ _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.StoreButDontChange _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.TrySwitchToAFork _ _))) = False
-  doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.SwitchedToAFork _ _ _))) = False
+  doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.SwitchedToAFork{}))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddBlockValidation (ChainDB.InvalidBlock _ _)))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddBlockValidation (ChainDB.InvalidCandidate _)))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddBlockValidation ChainDB.CandidateContainsFutureBlocksExceedingClockSkew{}))) = False
@@ -202,7 +202,7 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
   doelide (WithSeverity _ (ChainDB.TraceCopyToImmDBEvent _)) = True
   doelide _ = False
   conteliding _tverb _tr _ (Nothing, _count) = return (Nothing, 0)
-  conteliding tverb tr ev@(WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddedToCurrentChain _pt _ _))) (_old, oldt) = do
+  conteliding tverb tr ev@(WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddedToCurrentChain{}))) (_old, oldt) = do
       tnow <- fromIntegral <$> getMonotonicTimeNSec
       let deltat = tnow - oldt
       if (deltat > 1250000000)  -- report at most every 1250 ms
@@ -392,9 +392,9 @@ teeTraceChainTip' tr =
     Tracer $ \(WithSeverity _ ev') ->
       case ev' of
           (ChainDB.TraceAddBlockEvent ev) -> case ev of
-            ChainDB.SwitchedToAFork     newTipInfo _ newChain ->
+            ChainDB.SwitchedToAFork _warnings newTipInfo _ newChain ->
               traceChainInformation tr (chainInformation newTipInfo newChain)
-            ChainDB.AddedToCurrentChain newTipInfo _ newChain ->
+            ChainDB.AddedToCurrentChain _warnings newTipInfo _ newChain ->
               traceChainInformation tr (chainInformation newTipInfo newChain)
             _ -> pure ()
           _ -> pure ()

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -55,6 +55,7 @@ import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), TraceBloc
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerErr, LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import           Ouroboros.Consensus.Ledger.Inspect (LedgerWarning)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx, GenTxId, HasTxs, TxId)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Mempool.API (MempoolSize (..), TraceEventMempool (..))
@@ -345,8 +346,10 @@ mkTracers TracingOff _ _ =
 
 teeTraceChainTip
   :: ( Condense (HeaderHash blk)
+     , Show (LedgerWarning blk)
      , LedgerSupportsProtocol blk
      , ToObject (Header blk)
+     , ToObject (LedgerWarning blk)
      )
   => TraceOptions
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
@@ -360,8 +363,10 @@ teeTraceChainTip (TracingOn trSel) elided tr =
 
 teeTraceChainTipElide
   :: ( Condense (HeaderHash blk)
+     , Show (LedgerWarning blk)
      , LedgerSupportsProtocol blk
      , ToObject (Header blk)
+     , ToObject (LedgerWarning blk)
      )
   => TracingVerbosity
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)

--- a/stack.yaml
+++ b/stack.yaml
@@ -59,7 +59,7 @@ extra-deps:
   - websockets-0.12.6.1
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 6611345670dad971fbd03594a00b5ef8afa4cae6
+    commit: 47e2075f751d8370222a2aad32f37699a341ec40
     subdirs:
       # small-steps
       - semantics/executable-spec
@@ -122,7 +122,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 11e5609e01f4703870e88b2712e2c14da0338b65
+    commit: dae680f8e6b0af611c323554c375f50b3bfd5308
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
A couple tracers gained some extra warning fields. Log the new ledger
warnings

Only properly supported for the JSON logging, not for the human
readable, since I can't quite see how it's supposed to be done without
HasTextFormatter constaints propagating everywhere, which does not seem
to be the intended pattern.