### PR TITLE
Set the initial Shelley nonce to the genesis file hash

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -63,6 +63,7 @@ library
                      , deepseq
                      , cardano-api
                      , cardano-config
+                     , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-prelude


### PR DESCRIPTION
Connect up the plumbing as had always been intended. This links the
Shelley genesis into the chain at the point of the hard fork by setting
the intial Praos nonce to be the hash of the Shelley genesis file.

We use the simple hash of the file itself. No canonicalisation.