### PR TITLE
Upgrade to latest haskell.nix hash that works

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
-        "branch": "master",
+        "branch": "33445e4fb94281e7e3f2fae15586590e1a42e154",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "36836c1f580a021e99e7ad3ad23f4257e7ffda2b",
-        "sha256": "0jsg3lairnfn9i74dj6r88n53y5ca724wv9lvak67cbhmxgj35df",
+        "rev": "33445e4fb94281e7e3f2fae15586590e1a42e154",
+        "sha256": "0ilc55g0gcfj5skihhg2zgz1xf9vpv16793a1bi9zv2jj7nnwnmf",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/36836c1f580a021e99e7ad3ad23f4257e7ffda2b.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/33445e4fb94281e7e3f2fae15586590e1a42e154.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
`33445e4fb94281e7e3f2fae15586590e1a42e154` is the latest working hash without local changes.

The next commit fails in this manner:

```
➜  cardano-node git:(upgrade-to-latest-haskell.nix-hash-that-works) ✗ niv update haskell.nix -b 4cac8bd00f4c70079a92adf9e341fde86c375e2a
Update haskell.nix
Done: Update haskell.nix
➜  cardano-node git:(upgrade-to-latest-haskell.nix-hash-that-works) ✗ nix-build -A scripts.shelley_testnet.node -o shelley-testnet-node
error: value is a function while a set was expected, at /Users/jky/wrk/iohk/cardano-node/nix/default.nix:47:14
```