### PR TITLE
CODEOWNERS change for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
 
-# /doc folder and README.* needs to be owned by @docs
+# /doc folder and README.* needs to be owned by @docs-access
 doc                          @docs-access
 README.*                     @docs-access
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,10 @@
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
 
+# /doc folder and README.* needs to be owned by @docs
+doc                          @docs-access
+README.*                     @docs-access
+
 .buildkite                   @devops
 ci                           @devops
 configuration                @devops


### PR DESCRIPTION
The docs team needs to make rapid changes to documentation in-repo, but ONLY within /doc and potentially the README.rst. We are asking that the CODEOWNERS file be changed so that PRs modifying ONLY these files can go through an expedited process of being approved only by other members of @input-output-hk/docs-access.