### PR TITLE
devops-shell: add cluster-hfc scripts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,7 +61,7 @@ let
     inherit (haskellPackages.cardano-node.identifier) version;
 
     cluster = mkCluster customConfig;
-    clusterTests = import ./nix/supervisord-cluster/tests { inherit pkgs mkCluster cardano-cli cardano-node; };
+    clusterTests = import ./nix/supervisord-cluster/tests { inherit pkgs mkCluster cardano-cli cardano-node cardanolib-py; };
 
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);
 

--- a/nix/cardanolib-py/README.md
+++ b/nix/cardanolib-py/README.md
@@ -1,0 +1,3 @@
+# cardano-lib-py
+
+* Used for testing cardano-node clusters locally

--- a/nix/cardanolib-py/default.nix
+++ b/nix/cardanolib-py/default.nix
@@ -1,0 +1,13 @@
+{
+  python3Packages
+, cardano-cli
+}:
+
+python3Packages.buildPythonPackage {
+  version = "1.0.0";
+  pname = "cardano-lib-py";
+  src = ./.;
+  propagatedBuildInputs = [
+    cardano-cli
+  ];
+}

--- a/nix/cardanolib-py/setup.py
+++ b/nix/cardanolib-py/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="cardanolib-py",
+    version="1.0.0",
+    author="Samuel Leathers",
+    author_email="samuel.leathers@iohk.io",
+    description="Library for interacting with cardano-cli in python",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/input-output-hk/cardano-node",
+    py_modules= ["cardanolib"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -51,4 +51,6 @@ pkgs: _: with pkgs; {
   inherit (cardanoNodeHaskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
 
   mkCluster = callPackage ./supervisord-cluster;
+  hfcCluster = callPackage ./supervisord-cluster/hfc {};
+  cardanolib-py = callPackage ./cardanolib-py {};
 }

--- a/nix/supervisord-cluster/base-env.nix
+++ b/nix/supervisord-cluster/base-env.nix
@@ -11,7 +11,7 @@ rec {
   confKey = "local";
   private = false;
   networkConfig = {
-    GenesisFile = "keys/genesis.json";
+    GenesisFile = "shelley/genesis.json";
     Protocol = "TPraos";
     RequiresNetworkMagic = "RequiresMagic";
     LastKnownBlockVersion-Major = 0;

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -83,9 +83,9 @@ let
     lib.nameValuePair "program:bft${toString i}" {
       command = let
         envConfig = baseEnvConfig // rec {
-          operationalCertificate = "${stateDir}/keys/node-bft${toString i}/op.cert";
-          kesKey = "${stateDir}/keys/node-bft${toString i}/kes.skey";
-          vrfKey = "${stateDir}/keys/node-bft${toString i}/vrf.skey";
+          operationalCertificate = "${stateDir}/nodes/node-bft${toString i}/op.cert";
+          kesKey = "${stateDir}/nodes/node-bft${toString i}/kes.skey";
+          vrfKey = "${stateDir}/nodes/node-bft${toString i}/vrf.skey";
           topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
           socketPath = "${stateDir}/bft${toString i}.socket";
           dbPrefix = "db-bft${toString i}";
@@ -102,9 +102,9 @@ let
     lib.nameValuePair "program:pool${toString i}" {
       command = let
         envConfig = baseEnvConfig // rec {
-          operationalCertificate = "${stateDir}/keys/node-pool${toString i}/op.cert";
-          kesKey = "${stateDir}/keys/node-pool${toString i}/kes.skey";
-          vrfKey = "${stateDir}/keys/node-pool${toString i}/vrf.skey";
+          operationalCertificate = "${stateDir}/nodes/node-pool${toString i}/op.cert";
+          kesKey = "${stateDir}/nodes/node-pool${toString i}/kes.skey";
+          vrfKey = "${stateDir}/nodes/node-pool${toString i}/vrf.skey";
           topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
           socketPath = "${stateDir}/pool${toString i}.socket";
           dbPrefix = "db-pool${toString i}";
@@ -137,91 +137,91 @@ let
   genFiles = ''
     PATH=${path}
     rm -rf ${stateDir}
-    mkdir -p ${stateDir}/{keys,webserver}
+    mkdir -p ${stateDir}/{shelley,webserver}
     cp ${__toFile "node.json" (__toJSON baseEnvConfig.nodeConfig)} ${stateDir}/config.json
-    cp ${pkgs.writeText "genesis.spec.json" (__toJSON genesisSpecMergedJSON)} ${stateDir}/keys/genesis.spec.json
+    cp ${pkgs.writeText "genesis.spec.json" (__toJSON genesisSpecMergedJSON)} ${stateDir}/shelley/genesis.spec.json
     cardano-cli shelley genesis create --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-                                       --genesis-dir ${stateDir}/keys \
+                                       --genesis-dir ${stateDir}/shelley \
                                        --gen-genesis-keys ${toString numBft} \
                                        --gen-utxo-keys 1
     jq -r --arg systemStart $(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds") \
            '.systemStart = $systemStart |
             .updateQuorum = ${toString numBft} |
             .initialFunds = (${__toJSON initialFunds})' \
-    ${stateDir}/keys/genesis.json | sponge ${stateDir}/keys/genesis.json
+    ${stateDir}/shelley/genesis.json | sponge ${stateDir}/shelley/genesis.json
     for i in {1..${toString numBft}}
     do
-      mkdir -p "${stateDir}/keys/node-bft$i"
-      ln -s "../delegate-keys/delegate$i.vrf.skey" "${stateDir}/keys/node-bft$i/vrf.skey"
-      ln -s "../delegate-keys/delegate$i.vrf.vkey" "${stateDir}/keys/node-bft$i/vrf.vkey"
+      mkdir -p "${stateDir}/nodes/node-bft$i"
+      ln -s "../../shelley/delegate-keys/delegate$i.vrf.skey" "${stateDir}/nodes/node-bft$i/vrf.skey"
+      ln -s "../../shelley/delegate-keys/delegate$i.vrf.vkey" "${stateDir}/nodes/node-bft$i/vrf.vkey"
       cardano-cli shelley node key-gen-KES \
-        --verification-key-file "${stateDir}/keys/node-bft$i/kes.vkey" \
-        --signing-key-file "${stateDir}/keys/node-bft$i/kes.skey"
+        --verification-key-file "${stateDir}/nodes/node-bft$i/kes.vkey" \
+        --signing-key-file "${stateDir}/nodes/node-bft$i/kes.skey"
       cardano-cli shelley node issue-op-cert \
         --kes-period 0 \
-        --cold-signing-key-file "${stateDir}/keys/delegate-keys/delegate$i.skey" \
-        --kes-verification-key-file "${stateDir}/keys/node-bft$i/kes.vkey" \
-        --operational-certificate-issue-counter-file "${stateDir}/keys/delegate-keys/delegate$i.counter" \
-        --out-file "${stateDir}/keys/node-bft$i/op.cert"
+        --cold-signing-key-file "${stateDir}/shelley/delegate-keys/delegate$i.skey" \
+        --kes-verification-key-file "${stateDir}/nodes/node-bft$i/kes.vkey" \
+        --operational-certificate-issue-counter-file "${stateDir}/shelley/delegate-keys/delegate$i.counter" \
+        --out-file "${stateDir}/nodes/node-bft$i/op.cert"
       BFT_PORT=$(("${toString basePort}" + $i))
-      echo "$BFT_PORT" > "${stateDir}/keys/node-bft$i/port"
+      echo "$BFT_PORT" > "${stateDir}/nodes/node-bft$i/port"
     done
     for i in {1..${toString numPools}}
     do
-      mkdir -p "${stateDir}/keys/node-pool$i"
+      mkdir -p "${stateDir}/nodes/node-pool$i"
       echo "Generating Pool $i Secrets"
       cardano-cli shelley address key-gen \
-        --signing-key-file "${stateDir}/keys/node-pool$i/owner-utxo.skey" \
-        --verification-key-file "${stateDir}/keys/node-pool$i/owner-utxo.vkey"
+        --signing-key-file "${stateDir}/nodes/node-pool$i/owner-utxo.skey" \
+        --verification-key-file "${stateDir}/nodes/node-pool$i/owner-utxo.vkey"
       cardano-cli shelley stake-address key-gen \
-        --signing-key-file "${stateDir}/keys/node-pool$i/owner-stake.skey" \
-        --verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey"
+        --signing-key-file "${stateDir}/nodes/node-pool$i/owner-stake.skey" \
+        --verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey"
       # Payment addresses
       cardano-cli shelley address build \
-        --payment-verification-key-file "${stateDir}/keys/node-pool$i/owner-utxo.vkey" \
-        --stake-verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey" \
+        --payment-verification-key-file "${stateDir}/nodes/node-pool$i/owner-utxo.vkey" \
+        --stake-verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey" \
         --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-        --out-file "${stateDir}/keys/node-pool$i/owner.addr"
+        --out-file "${stateDir}/nodes/node-pool$i/owner.addr"
       # Stake addresses
       cardano-cli shelley stake-address build \
-        --stake-verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey" \
+        --stake-verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey" \
         --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-        --out-file "${stateDir}/keys/node-pool$i/owner-stake.addr"
+        --out-file "${stateDir}/nodes/node-pool$i/owner-stake.addr"
       # Stake addresses registration certs
       cardano-cli shelley stake-address registration-certificate \
-        --stake-verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey" \
-        --out-file "${stateDir}/keys/node-pool$i/stake.reg.cert"
+        --stake-verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey" \
+        --out-file "${stateDir}/nodes/node-pool$i/stake.reg.cert"
 
       cardano-cli shelley stake-address key-gen \
-        --signing-key-file "${stateDir}/keys/node-pool$i/reward.skey" \
-        --verification-key-file "${stateDir}/keys/node-pool$i/reward.vkey"
+        --signing-key-file "${stateDir}/nodes/node-pool$i/reward.skey" \
+        --verification-key-file "${stateDir}/nodes/node-pool$i/reward.vkey"
       # Stake reward addresses registration certs
       cardano-cli shelley stake-address registration-certificate \
-        --stake-verification-key-file "${stateDir}/keys/node-pool$i/reward.vkey" \
-        --out-file "${stateDir}/keys/node-pool$i/stake-reward.reg.cert"
+        --stake-verification-key-file "${stateDir}/nodes/node-pool$i/reward.vkey" \
+        --out-file "${stateDir}/nodes/node-pool$i/stake-reward.reg.cert"
       cardano-cli shelley node key-gen \
-        --cold-verification-key-file "${stateDir}/keys/node-pool$i/cold.vkey" \
-        --cold-signing-key-file "${stateDir}/keys/node-pool$i/cold.skey" \
-        --operational-certificate-issue-counter-file "${stateDir}/keys/node-pool$i/cold.counter"
+        --cold-verification-key-file "${stateDir}/nodes/node-pool$i/cold.vkey" \
+        --cold-signing-key-file "${stateDir}/nodes/node-pool$i/cold.skey" \
+        --operational-certificate-issue-counter-file "${stateDir}/nodes/node-pool$i/cold.counter"
       cardano-cli shelley node key-gen-KES \
-        --verification-key-file "${stateDir}/keys/node-pool$i/kes.vkey" \
-        --signing-key-file "${stateDir}/keys/node-pool$i/kes.skey"
+        --verification-key-file "${stateDir}/nodes/node-pool$i/kes.vkey" \
+        --signing-key-file "${stateDir}/nodes/node-pool$i/kes.skey"
       cardano-cli shelley node key-gen-VRF \
-        --verification-key-file "${stateDir}/keys/node-pool$i/vrf.vkey" \
-        --signing-key-file "${stateDir}/keys/node-pool$i/vrf.skey"
+        --verification-key-file "${stateDir}/nodes/node-pool$i/vrf.vkey" \
+        --signing-key-file "${stateDir}/nodes/node-pool$i/vrf.skey"
 
       # Stake address delegation certs
       cardano-cli shelley stake-address delegation-certificate \
-        --stake-verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey" \
-        --cold-verification-key-file  "${stateDir}/keys/node-pool$i/cold.vkey" \
-        --out-file "${stateDir}/keys/node-pool$i/owner-stake.deleg.cert"
+        --stake-verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey" \
+        --cold-verification-key-file  "${stateDir}/nodes/node-pool$i/cold.vkey" \
+        --out-file "${stateDir}/nodes/node-pool$i/owner-stake.deleg.cert"
 
       cardano-cli shelley node issue-op-cert \
         --kes-period 0 \
-        --cold-signing-key-file "${stateDir}/keys/node-pool$i/cold.skey" \
-        --kes-verification-key-file "${stateDir}/keys/node-pool$i/kes.vkey" \
-        --operational-certificate-issue-counter-file "${stateDir}/keys/node-pool$i/cold.counter" \
-        --out-file "${stateDir}/keys/node-pool$i/op.cert"
+        --cold-signing-key-file "${stateDir}/nodes/node-pool$i/cold.skey" \
+        --kes-verification-key-file "${stateDir}/nodes/node-pool$i/kes.vkey" \
+        --operational-certificate-issue-counter-file "${stateDir}/nodes/node-pool$i/cold.counter" \
+        --out-file "${stateDir}/nodes/node-pool$i/op.cert"
 
       echo "Generating Pool $i Metadata"
       jq -n \
@@ -235,55 +235,55 @@ let
       METADATA_HASH=$(cardano-cli shelley stake-pool metadata-hash --pool-metadata-file "${stateDir}/webserver/pool$i.json")
       POOL_IP="127.0.0.1"
       POOL_PORT=$(("${toString basePort}" + "${toString numBft}" + $i))
-      echo "$POOL_PORT" > "${stateDir}/keys/node-pool$i/port"
+      echo "$POOL_PORT" > "${stateDir}/nodes/node-pool$i/port"
       POOL_PLEDGE=$(( $RANDOM % 1000000000 + 1000000000000))
-      echo $POOL_PLEDGE > "${stateDir}/keys/node-pool$i/pledge"
+      echo $POOL_PLEDGE > "${stateDir}/nodes/node-pool$i/pledge"
       POOL_MARGIN_NUM=$(( $RANDOM % 10 + 1))
 
       cardano-cli shelley stake-pool registration-certificate \
-        --cold-verification-key-file "${stateDir}/keys/node-pool$i/cold.vkey" \
-        --vrf-verification-key-file "${stateDir}/keys/node-pool$i/vrf.vkey" \
+        --cold-verification-key-file "${stateDir}/nodes/node-pool$i/cold.vkey" \
+        --vrf-verification-key-file "${stateDir}/nodes/node-pool$i/vrf.vkey" \
         --pool-pledge "$POOL_PLEDGE" \
         --pool-margin "$(jq -n $POOL_MARGIN_NUM/10)" \
         --pool-cost "$(($RANDOM % 100000000))" \
-        --pool-reward-account-verification-key-file "${stateDir}/keys/node-pool$i/reward.vkey" \
-        --pool-owner-stake-verification-key-file "${stateDir}/keys/node-pool$i/owner-stake.vkey" \
+        --pool-reward-account-verification-key-file "${stateDir}/nodes/node-pool$i/reward.vkey" \
+        --pool-owner-stake-verification-key-file "${stateDir}/nodes/node-pool$i/owner-stake.vkey" \
         --metadata-url "$METADATA_URL" \
         --metadata-hash "$METADATA_HASH" \
         --pool-relay-port "$POOL_PORT" \
         --pool-relay-ipv4 "127.0.0.1" \
         --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-        --out-file "${stateDir}/keys/node-pool$i/register.cert"
+        --out-file "${stateDir}/nodes/node-pool$i/register.cert"
 
     done
 
-    # Copy genesis-utxo key to ${stateDir}/keys
+    # Copy genesis-utxo key to ${stateDir}/shelley
 
-    cp ${./genesis-utxo.vkey} ${stateDir}/keys/genesis-utxo.vkey
-    cp ${./genesis-utxo.skey} ${stateDir}/keys/genesis-utxo.skey
+    cp ${./genesis-utxo.vkey} ${stateDir}/shelley/genesis-utxo.vkey
+    cp ${./genesis-utxo.skey} ${stateDir}/shelley/genesis-utxo.skey
 
     # Tranfer funds, register pools and delegations, all in one big transaction:
 
-    jq .protocolParams < ${stateDir}/keys/genesis.json > ${stateDir}/pparams.json
+    jq .protocolParams < ${stateDir}/shelley/genesis.json > ${stateDir}/pparams.json
 
     TXIN_ADDR=$(cardano-cli shelley genesis initial-addr \
                     --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-                    --verification-key-file ${stateDir}/keys/genesis-utxo.vkey)
+                    --verification-key-file ${stateDir}/shelley/genesis-utxo.vkey)
 
     cardano-cli shelley transaction build-raw \
         --ttl 1000 \
         --fee 0 \
         --tx-in $(cardano-cli shelley genesis initial-txin \
                     --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-                    --verification-key-file ${stateDir}/keys/genesis-utxo.vkey) \
+                    --verification-key-file ${stateDir}/shelley/genesis-utxo.vkey) \
         --tx-out "$TXIN_ADDR+0" \
         ${lib.concatMapStringsSep "" (i: ''
-          --tx-out $(cat "${stateDir}/keys/node-pool${toString i}/owner.addr")+${toString delegatePoolAmount} \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/stake.reg.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/stake-reward.reg.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/register.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/owner-stake.deleg.cert" \'') (lib.genList (i: i + 1) numPools)}
-        --out-file "${stateDir}/keys/transfer-register-delegate-tx.txbody"
+          --tx-out $(cat "${stateDir}/nodes/node-pool${toString i}/owner.addr")+${toString delegatePoolAmount} \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/stake.reg.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/stake-reward.reg.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/register.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/owner-stake.deleg.cert" \'') (lib.genList (i: i + 1) numPools)}
+        --out-file "${stateDir}/shelley/transfer-register-delegate-tx.txbody"
     FEE=$(cardano-cli shelley transaction calculate-min-fee \
                 --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
                 --protocol-params-file ${stateDir}/pparams.json \
@@ -291,38 +291,38 @@ let
                 --tx-out-count ${toString (numPools + 1)} \
                 --witness-count ${toString (3 * numPools + 1)} \
                 --byron-witness-count 0 \
-                --tx-body-file "${stateDir}/keys/transfer-register-delegate-tx.txbody" |
+                --tx-body-file "${stateDir}/shelley/transfer-register-delegate-tx.txbody" |
                 cut -d' ' -f1)
 
     TXIN_ADDR_HEX=$(bech32 <<< "$TXIN_ADDR")
 
     TXOUT_AMOUNT=$(jq --arg addr "$TXIN_ADDR_HEX" \
                       --arg fee "$FEE" \
-    '.initialFunds[$addr] - ($fee|tonumber) - (.protocolParams.poolDeposit + (2 * .protocolParams.keyDeposit) + ${toString delegatePoolAmount}) * ${toString numPools}' < ${stateDir}/keys/genesis.json)
+    '.initialFunds[$addr] - ($fee|tonumber) - (.protocolParams.poolDeposit + (2 * .protocolParams.keyDeposit) + ${toString delegatePoolAmount}) * ${toString numPools}' < ${stateDir}/shelley/genesis.json)
     cardano-cli shelley transaction build-raw \
         --ttl 1000 \
         --fee "$FEE" \
         --tx-in $(cardano-cli shelley genesis initial-txin \
                     --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-                    --verification-key-file ${stateDir}/keys/genesis-utxo.vkey) \
+                    --verification-key-file ${stateDir}/shelley/genesis-utxo.vkey) \
         --tx-out "$TXIN_ADDR+$TXOUT_AMOUNT" \
         ${lib.concatMapStringsSep "" (i: ''
-          --tx-out $(cat "${stateDir}/keys/node-pool${toString i}/owner.addr")+${toString delegatePoolAmount} \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/stake.reg.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/stake-reward.reg.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/register.cert" \
-          --certificate-file "${stateDir}/keys/node-pool${toString i}/owner-stake.deleg.cert" \'') (lib.genList (i: i + 1) numPools)}
-        --out-file "${stateDir}/keys/transfer-register-delegate-tx.txbody"
+          --tx-out $(cat "${stateDir}/nodes/node-pool${toString i}/owner.addr")+${toString delegatePoolAmount} \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/stake.reg.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/stake-reward.reg.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/register.cert" \
+          --certificate-file "${stateDir}/nodes/node-pool${toString i}/owner-stake.deleg.cert" \'') (lib.genList (i: i + 1) numPools)}
+        --out-file "${stateDir}/shelley/transfer-register-delegate-tx.txbody"
 
     cardano-cli shelley transaction sign \
-      --signing-key-file ${stateDir}/keys/genesis-utxo.skey \
+      --signing-key-file ${stateDir}/shelley/genesis-utxo.skey \
       ${lib.concatMapStringsSep "" (i: ''
-        --signing-key-file "${stateDir}/keys/node-pool${toString i}/owner-stake.skey" \
-        --signing-key-file "${stateDir}/keys/node-pool${toString i}/reward.skey" \
-        --signing-key-file "${stateDir}/keys/node-pool${toString i}/cold.skey" \'') (lib.genList (i: i + 1) numPools)}
+        --signing-key-file "${stateDir}/nodes/node-pool${toString i}/owner-stake.skey" \
+        --signing-key-file "${stateDir}/nodes/node-pool${toString i}/reward.skey" \
+        --signing-key-file "${stateDir}/nodes/node-pool${toString i}/cold.skey" \'') (lib.genList (i: i + 1) numPools)}
       --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
-      --tx-body-file  "${stateDir}/keys/transfer-register-delegate-tx.txbody" \
-      --out-file      "${stateDir}/keys/transfer-register-delegate-tx.tx"
+      --tx-body-file  "${stateDir}/shelley/transfer-register-delegate-tx.txbody" \
+      --out-file      "${stateDir}/shelley/transfer-register-delegate-tx.tx"
 
   '';
 
@@ -337,7 +337,7 @@ let
     while [ ! -S $CARDANO_NODE_SOCKET_PATH ]; do echo "Waiting 5 seconds for bft node to start"; sleep 5; done
     echo "Transfering genesis funds to pool owners, register pools and delegations"
     cardano-cli shelley transaction submit \
-      --tx-file ${stateDir}/keys/transfer-register-delegate-tx.tx \
+      --tx-file ${stateDir}/shelley/transfer-register-delegate-tx.tx \
       --testnet-magic ${toString genesisSpecMergedJSON.networkMagic}
     sleep 5
     echo 'Cluster started. Run `stop-cluster` to stop'

--- a/nix/supervisord-cluster/genesis-utxo.skey
+++ b/nix/supervisord-cluster/genesis-utxo.skey
@@ -1,5 +1,5 @@
 {
-    "type": "Genesis UTxO signing key",
+    "type": "GenesisUTxOSigningKey_ed25519",
     "description": "Genesis Initial UTxO Signing Key",
     "cborHex": "58201f0655ba7500f4e923cac3741e730a325b7f2df549f949a19f7f7995de021964"
 }

--- a/nix/supervisord-cluster/genesis-utxo.vkey
+++ b/nix/supervisord-cluster/genesis-utxo.vkey
@@ -1,5 +1,5 @@
 {
-    "type": "Genesis UTxO verification key",
+    "type": "GenesisUTxOVerificationKey_ed25519",
     "description": "Genesis Initial UTxO Verification Key",
     "cborHex": "582055d24618feb099af69a9588cb6beb2e103f451a4f3869949576b7765aaef7c7a"
 }

--- a/nix/supervisord-cluster/hfc/base-env.nix
+++ b/nix/supervisord-cluster/hfc/base-env.nix
@@ -1,0 +1,27 @@
+{
+  defaultLogConfig
+, stateDir
+}:
+
+rec {
+  inherit stateDir;
+  useByronWallet = true;
+  relaysNew = "127.0.0.1";
+  edgePort = 3001;
+  confKey = "local";
+  private = false;
+  networkConfig = {
+    ByronGenesisFile = "byron/genesis.json";
+    ShelleyGenesisFile = "shelley/genesis.json";
+    Protocol = "Cardano";
+    RequiresNetworkMagic = "RequiresMagic";
+    LastKnownBlockVersion-Major = 0;
+    LastKnownBlockVersion-Minor = 0;
+    LastKnownBlockVersion-Alt = 0;
+    PBftSignatureThreshold = 0.9;
+    MaxKnownMajorProtocolVersion = 2;
+
+  };
+  nodeConfig = networkConfig // defaultLogConfig;
+  consensusProtocol = networkConfig.Protocol;
+}

--- a/nix/supervisord-cluster/hfc/byron-params.json
+++ b/nix/supervisord-cluster/hfc/byron-params.json
@@ -1,0 +1,23 @@
+{
+  "heavyDelThd":     "300000000000",
+  "maxBlockSize":    "2000000",
+  "maxTxSize":       "4096",
+  "maxHeaderSize":   "2000000",
+  "maxProposalSize": "700",
+  "mpcThd": "20000000000000",
+  "scriptVersion": 0,
+  "slotDuration": "2000",
+  "softforkRule": {
+    "initThd": "900000000000000",
+    "minThd": "600000000000000",
+    "thdDecrement": "50000000000000"
+  },
+  "txFeePolicy": {
+    "multiplier": "43946000000",
+    "summand": "155381000000000"
+  },
+  "unlockStakeEpoch": "18446744073709551615",
+  "updateImplicit": "10000",
+  "updateProposalThd": "100000000000000",
+  "updateVoteThd": "1000000000000"
+}

--- a/nix/supervisord-cluster/hfc/default.nix
+++ b/nix/supervisord-cluster/hfc/default.nix
@@ -1,0 +1,133 @@
+{
+  pkgs
+, lib
+, cardano-cli
+, bech32
+, jq
+, numBft ? 3
+, basePort ? 30000
+, securityParam ? 10
+, stateDir ? "./state-cluster"
+, ...
+}:
+let
+  mkStartScript = envConfig: let
+    systemdCompat.options = {
+      systemd.services = lib.mkOption {};
+      users = lib.mkOption {};
+      assertions = lib.mkOption {};
+    };
+    eval = let
+      extra = {
+        services.cardano-node = {
+          enable = true;
+          inherit (envConfig) operationalCertificate kesKey vrfKey delegationCertificate signingKey topology nodeConfig nodeConfigFile port dbPrefix socketPath;
+          inherit stateDir;
+        };
+      };
+    in lib.evalModules {
+      prefix = [];
+      modules = import ../../nixos/module-list.nix ++ [ systemdCompat extra ];
+      args = { inherit pkgs; };
+    };
+  in pkgs.writeScript "cardano-node" ''
+    #!${pkgs.stdenv.shell}
+    ${eval.config.services.cardano-node.script}
+  '';
+  baseEnvConfig = pkgs.callPackage ./base-env.nix { inherit (pkgs.commonLib.cardanoLib) defaultLogConfig; inherit stateDir; };
+
+  supervisorConfig = pkgs.writeText "supervisor.conf" (pkgs.commonLib.supervisord.writeSupervisorConfig ({
+    supervisord = {
+      logfile = "${stateDir}/supervisord.log";
+      pidfile = "${stateDir}/supervisord.pid";
+    };
+    supervisorctl = {};
+    inet_http_server = {
+      port = "127.0.0.1:9001";
+    };
+    "rpcinterface:supervisor" = {
+      "supervisor.rpcinterface_factory" = "supervisor.rpcinterface:make_main_rpcinterface";
+    };
+  } // lib.listToAttrs (map (i:
+    lib.nameValuePair "program:bft${toString i}" {
+      command = let
+        envConfig = baseEnvConfig // rec {
+          operationalCertificate = "${stateDir}/nodes/node-bft${toString i}/op.cert";
+          kesKey = "${stateDir}/nodes/node-bft${toString i}/kes.skey";
+          vrfKey = "${stateDir}/nodes/node-bft${toString i}/vrf.skey";
+          signingKey = "${stateDir}/nodes/node-bft${toString i}/byron-deleg.key";
+          delegationCertificate = "${stateDir}/nodes/node-bft${toString i}/byron-deleg.json";
+          topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
+          socketPath = "${stateDir}/bft${toString i}.socket";
+          dbPrefix = "db-bft${toString i}";
+          port = basePort + i;
+          nodeConfigFile = "${stateDir}/config.json";
+        };
+        script = mkStartScript envConfig;
+      in "${script}";
+      stdout_logfile = "${stateDir}/bft${toString i}.stdout";
+      stderr_logfile = "${stateDir}/bft${toString i}.stderr";
+    }
+  ) (lib.genList (i: i + 1) numBft))));
+  topologyFile = selfPort: {
+    Producers = map (p:
+      {
+        addr = "127.0.0.1";
+        port = p;
+        valency = 1;
+      }) (lib.filter (p: p != selfPort) (lib.genList (i: basePort + i + 1) (numBft)));
+  };
+  start = pkgs.writeScriptBin "start-cluster-hfc" ''
+    set -euo pipefail
+    if [ -f ${stateDir}/supervisord.pid ]
+    then
+      echo "Cluster already running. Please run `stop-cluster` first!"
+    fi
+    rm -rf ${stateDir}
+    mkdir -p ${stateDir}/shelley
+    cp ${./byron-params.json} ${stateDir}/byron-params.json
+    START_TIME_SHELLEY=$(date --utc +"%Y-%m-%dT%H:%M:%SZ" --date="5 seconds")
+    START_TIME=$(date +%s --date="$START_TIME_SHELLEY")
+    cardano-cli genesis --protocol-magic 42 --k ${toString securityParam} --n-poor-addresses 0 --n-delegate-addresses ${toString numBft} --total-balance ${toString (1000000000000000 * numBft)} --byron-formats --delegate-share 1 --avvm-entry-count 0 --avvm-entry-balance 0 --protocol-parameters-file ${stateDir}/byron-params.json --genesis-output-dir ${stateDir}/byron --start-time "$START_TIME"
+    mv ${stateDir}/byron-params.json ${stateDir}/byron/params.json
+    jq -r '.securityParam = ${toString securityParam} | .updateQuorum = ${toString numBft}' < ${./genesis.spec.json} > ${stateDir}/shelley/genesis.spec.json
+    cardano-cli shelley genesis create --genesis-dir ${stateDir}/shelley --testnet-magic 42 --gen-genesis-keys 3 --start-time "$START_TIME_SHELLEY"
+    cp ${__toFile "node.json" (__toJSON baseEnvConfig.nodeConfig)} ${stateDir}/config.json
+    chmod u+w ${stateDir}/config.json
+    for i in {1..${toString numBft}}
+    do
+      mkdir -p "${stateDir}/nodes/node-bft$i"
+      ln -s "../../shelley/delegate-keys/delegate$i.vrf.skey" "${stateDir}/nodes/node-bft$i/vrf.skey"
+      ln -s "../../shelley/delegate-keys/delegate$i.vrf.vkey" "${stateDir}/nodes/node-bft$i/vrf.vkey"
+      cardano-cli shelley node key-gen-KES \
+        --verification-key-file "${stateDir}/nodes/node-bft$i/kes.vkey" \
+        --signing-key-file "${stateDir}/nodes/node-bft$i/kes.skey"
+      cardano-cli shelley node issue-op-cert \
+        --kes-period 0 \
+        --cold-signing-key-file "${stateDir}/shelley/delegate-keys/delegate$i.skey" \
+        --kes-verification-key-file "${stateDir}/nodes/node-bft$i/kes.vkey" \
+        --operational-certificate-issue-counter-file "${stateDir}/shelley/delegate-keys/delegate$i.counter" \
+        --out-file "${stateDir}/nodes/node-bft$i/op.cert"
+      INDEX=$(printf "%03d" $(($i - 1)))
+      ln -s "../..//byron/delegate-keys.$INDEX.key" "${stateDir}/nodes/node-bft$i/byron-deleg.key"
+      ln -s "../..//byron/delegation-cert.$INDEX.json" "${stateDir}/nodes/node-bft$i/byron-deleg.json"
+      BFT_PORT=$(("${toString basePort}" + $i))
+      echo "$BFT_PORT" > "${stateDir}/nodes/node-bft$i/port"
+    done
+    ${pkgs.python3Packages.supervisor}/bin/supervisord --config ${supervisorConfig} $@
+    while [ ! -S $CARDANO_NODE_SOCKET_PATH ]; do echo "Waiting 5 seconds for bft node to start"; sleep 5; done
+    echo 'Cluster started. Run `stop-cluster` to stop'
+  '';
+  stop = pkgs.writeScriptBin "stop-cluster-hfc" ''
+    set -euo pipefail
+    ${pkgs.python3Packages.supervisor}/bin/supervisorctl stop all
+    if [ -f ${stateDir}/supervisord.pid ]
+    then
+      kill $(<${stateDir}/supervisord.pid)
+      echo "Cluster terminated!"
+    else
+      echo "Cluster is not running!"
+    fi
+  '';
+
+in { inherit start stop; }

--- a/nix/supervisord-cluster/hfc/genesis.spec.json
+++ b/nix/supervisord-cluster/hfc/genesis.spec.json
@@ -1,0 +1,44 @@
+{
+    "activeSlotsCoeff": 0.1,
+    "protocolParams": {
+        "poolDeposit": 500000000,
+        "protocolVersion": {
+            "minor": 0,
+            "major": 2
+        },
+        "minUTxOValue": 1000000,
+        "decentralisationParam": 1,
+        "maxTxSize": 16384,
+        "minPoolCost": 228000000,
+        "minFeeA": 44,
+        "maxBlockBodySize": 65536,
+        "minFeeB": 155381,
+        "eMax": 18,
+        "extraEntropy": {
+            "tag": "NeutralNonce"
+        },
+        "maxBlockHeaderSize": 1100,
+        "keyDeposit": 400000,
+        "nOpt": 50,
+        "rho": 1.78650067e-3,
+        "tau": 0.1,
+        "a0": 0.1
+    },
+    "protocolMagicId": 42,
+    "genDelegs": {},
+    "updateQuorum": 3,
+    "networkId": "Testnet",
+    "initialFunds": {},
+    "maxLovelaceSupply": 45000000000000000,
+    "networkMagic": 42,
+    "epochLength": 1000,
+    "staking": {
+        "pools": {},
+        "stake": {}
+    },
+    "systemStart": "2020-07-08T02:39:16.033076859Z",
+    "slotsPerKESPeriod": 7200,
+    "slotLength": 0.2,
+    "maxKESEvolutions": 64,
+    "securityParam": 10
+}

--- a/nix/supervisord-cluster/tests/base.py
+++ b/nix/supervisord-cluster/tests/base.py
@@ -1,13 +1,14 @@
-"""Usage: cluster-test.py [--network-magic=MAGIC] [--state-dir=DIR]
+"""Usage: cluster-test.py [--network-magic=INT] [--state-dir=DIR] [--num-delegs=INT]
 
 Options:
     -n, --network-magic <magic>  network magic [default: 42]
+    -d, --num-delegs <int>  number of delegators [default: 1]
     -s, --state-dir <dir>  state directory [default: "./state-cluster-test"]
 """
 
 from docopt import docopt
-from clusterlib import ClusterLib
+from cardanolib import CardanoCluster,CardanoCLIWrapper
 
 arguments = docopt(__doc__)
-cluster = ClusterLib(arguments['--network-magic'], arguments["--state-dir"])
-cluster.refresh_pparams()
+cluster = CardanoCluster(int(arguments['--network-magic']), arguments["--state-dir"], int(arguments['--num-delegs']), "shelley")
+cluster.cli.refresh_pparams()

--- a/nix/supervisord-cluster/tests/update-proposal.py
+++ b/nix/supervisord-cluster/tests/update-proposal.py
@@ -3,14 +3,11 @@ import time
 
 from base import cluster
 
-sleep_time = cluster.slot_length * cluster.epoch_length
-print(f"Waiting 1 epoch to submit proposal ({sleep_time} seconds)")
-time.sleep(sleep_time)
-cluster.submit_update_proposal(["--decentralization-parameter", "0.5"])
-print(f"Update Proposal submited. Sleeping until next epoch ({sleep_time} seconds)")
-time.sleep(sleep_time + 15)
-cluster.refresh_pparams()
-d = cluster.pparams["decentralisationParam"]
+cluster.submit_update_proposal([("decentralization-parameter", "0.5")])
+print(f"Update Proposal submited. Sleeping until next epoch")
+cluster.sleep_until_next_epoch()
+cluster.cli.refresh_pparams()
+d = cluster.cli.pparams["decentralisationParam"]
 if d == 0.5:
     print("Cluster update proposal successful!")
     sys.exit(0)

--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,7 @@ let
 
   devops = let
     cluster = mkCluster customConfig;
+    inherit hfcCluster;
   in
     stdenv.mkDerivation {
     name = "devops-shell";
@@ -55,8 +56,12 @@ let
       bech32
       cardano-node
       python3Packages.supervisor
+      python3Packages.ipython
       cluster.start
       cluster.stop
+      hfcCluster.start
+      hfcCluster.stop
+      cardanolib-py
     ];
     shellHook = ''
       echo "DevOps Tools" \

--- a/shell.nix
+++ b/shell.nix
@@ -91,6 +91,8 @@ let
         * cardano-cli - used for key generation and other operations tasks
         * start-cluster - start a local development cluster
         * stop-cluster - stop a local development cluster
+        * start-cluster-hfc - start a local development cluster for testing hfc
+        * stop-cluster-hfc - stop a local development cluster for testing hfc
 
       "
     '';


### PR DESCRIPTION
Adds support for local testing of hard forks

* Refactors python helper code into a library (cardanolib-py)
* Separate out cluster logic and CLI wrapper classes (CLI wrapper is used by cluster)
* Renames keys to shelley to be specific for era