### PR TITLE
Allow genesis keys as tx witnesses in the API and CLI

### DIFF
--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -1329,6 +1329,7 @@ data ShelleyWitnessSigningKey =
      | WitnessPaymentExtendedKey (SigningKey PaymentExtendedKey)
      | WitnessStakeKey           (SigningKey StakeKey)
      | WitnessStakePoolKey       (SigningKey StakePoolKey)
+     | WitnessGenesisKey         (SigningKey GenesisKey)
      | WitnessGenesisDelegateKey (SigningKey GenesisDelegateKey)
      | WitnessGenesisUTxOKey     (SigningKey GenesisUTxOKey)
 
@@ -1365,6 +1366,7 @@ toShelleySigningKey key = case key of
   WitnessPaymentKey     (PaymentSigningKey     sk) -> ShelleyNormalSigningKey sk
   WitnessStakeKey       (StakeSigningKey       sk) -> ShelleyNormalSigningKey sk
   WitnessStakePoolKey   (StakePoolSigningKey   sk) -> ShelleyNormalSigningKey sk
+  WitnessGenesisKey     (GenesisSigningKey     sk) -> ShelleyNormalSigningKey sk
   WitnessGenesisUTxOKey (GenesisUTxOSigningKey sk) -> ShelleyNormalSigningKey sk
   WitnessGenesisDelegateKey (GenesisDelegateSigningKey sk) ->
     ShelleyNormalSigningKey sk

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -311,6 +311,7 @@ data SomeWitnessSigningKey
   | APaymentExtendedSigningKey (Api.SigningKey Api.PaymentExtendedKey)
   | AStakeSigningKey           (Api.SigningKey Api.StakeKey)
   | AStakePoolSigningKey       (Api.SigningKey Api.StakePoolKey)
+  | AGenesisSigningKey         (Api.SigningKey Api.GenesisKey)
   | AGenesisDelegateSigningKey (Api.SigningKey Api.GenesisDelegateKey)
   | AGenesisUTxOSigningKey     (Api.SigningKey Api.GenesisUTxOKey)
 
@@ -332,6 +333,8 @@ readSigningKeyFile (SigningKeyFile skfile) =
                           AStakeSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsStakePoolKey)
                           AStakePoolSigningKey
+      , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisKey)
+                          AGenesisSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisDelegateKey)
                           AGenesisDelegateSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisUTxOKey)
@@ -348,6 +351,7 @@ categoriseWitnessSigningKey swsk =
     APaymentExtendedSigningKey sk -> Right (Api.WitnessPaymentExtendedKey sk)
     AStakeSigningKey           sk -> Right (Api.WitnessStakeKey           sk)
     AStakePoolSigningKey       sk -> Right (Api.WitnessStakePoolKey       sk)
+    AGenesisSigningKey         sk -> Right (Api.WitnessGenesisKey sk)
     AGenesisDelegateSigningKey sk -> Right (Api.WitnessGenesisDelegateKey sk)
     AGenesisUTxOSigningKey     sk -> Right (Api.WitnessGenesisUTxOKey     sk)
 


### PR DESCRIPTION
Transactions with certs for updating the genesis delegates have to be
signed by the genesis keys themselves, hence the need for witnessing
transactions with genesis keys (not just genesis delegate keys).