### PR TITLE
Add command for converting various Byron keys to their Shelley counterpart

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -180,6 +180,7 @@ test-suite cardano-cli-pioneers
                       , aeson
                       , bech32 >= 1.1.0
                       , bytestring
+                      , base16-bytestring
                       , cardano-api
                       , cardano-cli
                       , cardano-prelude

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -49,6 +49,7 @@ library
                        Cardano.CLI.Shelley.Run.Address.Info
                        Cardano.CLI.Shelley.Run.Genesis
                        Cardano.CLI.Shelley.Run.Governance
+                       Cardano.CLI.Shelley.Run.Key
                        Cardano.CLI.Shelley.Run.Node
                        Cardano.CLI.Shelley.Run.Pool
                        Cardano.CLI.Shelley.Run.Query

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -2,18 +2,11 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.Helpers
-  ( ConversionError(..)
-  , HelpersError(..)
-  , convertITNVerificationKey
-  , convertITNSigningKey
-  , dataPartToBase16
-  , decodeBech32Key
+  ( HelpersError(..)
   , ensureNewFile
   , ensureNewFileLBS
   , pPrintCBOR
   , readCBOR
-  , readBech32
-  , renderConversionError
   , renderHelpersError
   , textShow
   , validateCBOR
@@ -21,31 +14,22 @@ module Cardano.CLI.Helpers
 
 import           Cardano.Prelude
 
-import           Codec.Binary.Bech32 (DataPart, HumanReadablePart, dataPartToBytes,
-                   dataPartToText)
-import qualified Codec.Binary.Bech32 as Bech32
 import           Codec.CBOR.Pretty (prettyHexEnc)
 import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Term (decodeTerm, encodeTerm)
 import           Control.Exception (IOException)
-import qualified Control.Exception as Exception
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Char8 as SC
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as Text
 import           System.Directory (doesPathExist)
 
-import           Cardano.Api.Typed (SigningKey(..), StakeKey, VerificationKey(..))
 import           Cardano.Binary (Decoder, fromCBOR)
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Chain.Block (fromCBORABlockOrBoundary)
 import qualified Cardano.Chain.UTxO as UTxO
 import           Cardano.Config.Types
-import qualified Cardano.Crypto.DSIGN as DSIGN
 
-import qualified Shelley.Spec.Ledger.Keys as Shelley
 
 data HelpersError
   = CBORPrettyPrintError !DeserialiseFailure
@@ -120,79 +104,6 @@ validateCBOR cborObject bs =
       (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s Update.Vote)
       Right "Valid Byron vote."
 
---------------------------------------------------------------------------------
--- ITN verification/signing key conversion to Haskell verficiation/signing keys
---------------------------------------------------------------------------------
-
-data ConversionError
-  = Bech32DecodingError
-      -- ^ Bech32 key
-      !Text
-      !Bech32.DecodingError
-  | Bech32ErrorExtractingByes !DataPart
-  | Bech32ReadError !FilePath !Text
-  | ITNError !HumanReadablePart !DataPart
-  | SigningKeyDeserializationError !ByteString
-  | VerificationKeyDeserializationError !ByteString
-  deriving Show
-
-renderConversionError :: ConversionError -> Text
-renderConversionError err =
-  case err of
-    Bech32DecodingError key decErr ->
-      "Error decoding Bech32 key: " <> key <> " Error: " <> textShow decErr
-    Bech32ErrorExtractingByes dp ->
-      "Unable to extract bytes from: " <> dataPartToText dp
-    Bech32ReadError fp readErr ->
-      "Error reading bech32 key at: " <> textShow fp <> " Error: " <> readErr
-    ITNError hRpart dp ->
-      "Error extracting a ByteString from DataPart: " <> Bech32.dataPartToText dp <>
-      " With human readable part: " <> Bech32.humanReadablePartToText hRpart
-    SigningKeyDeserializationError sKey ->
-      "Error deserialising signing key: " <> textShow (SC.unpack sKey)
-    VerificationKeyDeserializationError vKey ->
-      "Error deserialising verification key: " <> textShow (SC.unpack vKey)
-
--- | Convert public ed25519 key to a Shelley stake verification key
-convertITNVerificationKey :: Text -> Either ConversionError (VerificationKey StakeKey)
-convertITNVerificationKey pubKey = do
-  (_, _, keyBS) <- decodeBech32Key pubKey
-  case DSIGN.rawDeserialiseVerKeyDSIGN keyBS of
-    Just verKey -> Right . StakeVerificationKey $ Shelley.VKey verKey
-    Nothing -> Left $ VerificationKeyDeserializationError keyBS
-
--- | Convert private ed22519 key to a Shelley signing key.
-convertITNSigningKey :: Text -> Either ConversionError (SigningKey StakeKey)
-convertITNSigningKey privKey = do
-  (_, _, keyBS) <- decodeBech32Key privKey
-  case DSIGN.rawDeserialiseSignKeyDSIGN keyBS of
-    Just signKey -> Right $ StakeSigningKey signKey
-    Nothing -> Left $ SigningKeyDeserializationError keyBS
-
--- | Convert ITN Bech32 public or private keys to 'ByteString's
-decodeBech32Key :: Text -> Either ConversionError (HumanReadablePart, DataPart, ByteString)
-decodeBech32Key key =
-  case Bech32.decodeLenient key of
-    Left err -> Left $ Bech32DecodingError key err
-    Right (hRpart, dataPart) -> case Bech32.dataPartToBytes dataPart of
-                                  Nothing -> Left $ ITNError hRpart dataPart
-                                  Just bs -> Right (hRpart, dataPart, bs)
-
-dataPartToBase16 :: DataPart -> Either ConversionError ByteString
-dataPartToBase16 dp = case dataPartToBytes dp of
-                        Just bs -> Right $ Base16.encode bs
-                        Nothing -> Left $ Bech32ErrorExtractingByes dp
-
-readBech32 :: FilePath -> IO (Either ConversionError Text)
-readBech32 fp = do
-  eStr <- Exception.try $ readFile fp
-  case eStr of
-    Left e -> return . Left $ Bech32ReadError fp $ handler e
-    Right str -> return . Right . Text.concat $ Text.words str
- where
-  handler :: IOException -> Text
-  handler e = Text.pack $ "Cardano.Api.Convert.readBech32: "
-                        ++ displayException e
 
 textShow :: Show a => a -> Text
 textShow = Text.pack . show

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -5,6 +5,7 @@ module Cardano.CLI.Shelley.Commands
     ShelleyCommand (..)
   , AddressCmd (..)
   , StakeAddressCmd (..)
+  , KeyCmd (..)
   , TransactionCmd (..)
   , NodeCmd (..)
   , PoolCmd (..)
@@ -65,6 +66,7 @@ import           Shelley.Spec.Ledger.TxData (MIRPot)
 data ShelleyCommand
   = AddressCmd      AddressCmd
   | StakeAddressCmd StakeAddressCmd
+  | KeyCmd          KeyCmd
   | TransactionCmd  TransactionCmd
   | NodeCmd         NodeCmd
   | PoolCmd         PoolCmd
@@ -83,7 +85,6 @@ data AddressCmd
   | AddressBuild VerificationKeyFile (Maybe VerificationKeyFile) NetworkId (Maybe OutputFile)
   | AddressBuildMultiSig  --TODO
   | AddressInfo Text (Maybe OutputFile)
-  | AddressConvertKey SigningKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 data StakeAddressCmd
@@ -96,9 +97,12 @@ data StakeAddressCmd
   | StakeKeyRegistrationCert VerificationKeyFile OutputFile
   | StakeKeyDelegationCert VerificationKeyFile StakePoolVerificationKeyHashOrFile OutputFile
   | StakeKeyDeRegistrationCert VerificationKeyFile OutputFile
-  | StakeKeyITNConversion ITNKeyFile (Maybe OutputFile)
   deriving (Eq, Show)
 
+data KeyCmd
+  = KeyConvertByronPaymentKey SigningKeyFile SigningKeyFile
+  | KeyConvertITNStakeKey ITNKeyFile (Maybe OutputFile)
+  deriving (Eq, Show)
 
 data TransactionCmd
   = TxBuildRaw

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -18,12 +18,14 @@ module Cardano.CLI.Shelley.Commands
 
     -- * CLI flag types
   , AddressKeyType (..)
+  , ByronKeyType (..)
+  , ByronKeyFormat (..)
   , GenesisDir (..)
   , TxInCount (..)
   , TxOutCount (..)
   , TxShelleyWitnessCount (..)
   , TxByronWitnessCount (..)
-  , ITNKeyFile (..)
+  , SomeKeyFile (..)
   , OpCertCounterFile (..)
   , OutputFile (..)
   , ProtocolParamsFile (..)
@@ -32,6 +34,7 @@ module Cardano.CLI.Shelley.Commands
   , TxBodyFile (..)
   , TxFile (..)
   , VerificationKeyFile (..)
+  , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
   , MetaDataFile (..)
   , PoolId (..)
@@ -46,6 +49,7 @@ module Cardano.CLI.Shelley.Commands
 import           Prelude
 import           Data.Set (Set)
 import           Data.Text (Text)
+import           Data.ByteString (ByteString)
 
 import           Cardano.Api.Protocol (Protocol)
 import           Cardano.Api.Typed hiding (PoolId)
@@ -100,9 +104,9 @@ data StakeAddressCmd
   deriving (Eq, Show)
 
 data KeyCmd
-  = KeyConvertByronPaymentKey SigningKeyFile SigningKeyFile
-  | KeyConvertByronGenesisVerificationKey VerificationKeyFile VerificationKeyFile
-  | KeyConvertITNStakeKey ITNKeyFile (Maybe OutputFile)
+  = KeyConvertByronKey ByronKeyType SomeKeyFile OutputFile
+  | KeyConvertByronGenesisVKey VerificationKeyBase64 OutputFile
+  | KeyConvertITNStakeKey SomeKeyFile OutputFile
   deriving (Eq, Show)
 
 data TransactionCmd
@@ -284,15 +288,28 @@ newtype GenesisDir
   = GenesisDir FilePath
   deriving (Eq, Show)
 
-data ITNKeyFile
-  = ITNVerificationKeyFile VerificationKeyFile
-  | ITNSigningKeyFile SigningKeyFile
+-- | Either a verification or signing key, used for conversions and other
+-- commands that make sense for both.
+--
+data SomeKeyFile
+  = AVerificationKeyFile VerificationKeyFile
+  | ASigningKeyFile SigningKeyFile
   deriving (Eq, Show)
 
 data AddressKeyType
   = AddressKeyShelley
   | AddressKeyShelleyExtended
   | AddressKeyByron
+  deriving (Eq, Show)
+
+data ByronKeyType
+  = ByronPaymentKey  ByronKeyFormat
+  | ByronGenesisKey  ByronKeyFormat
+  | ByronDelegateKey ByronKeyFormat
+  deriving (Eq, Show)
+
+data ByronKeyFormat = NonLegacyByronKeyFormat
+                    | LegacyByronKeyFormat
   deriving (Eq, Show)
 
 newtype OpCertCounterFile
@@ -317,6 +334,11 @@ newtype TxFile
 
 newtype VerificationKeyFile
   = VerificationKeyFile FilePath
+  deriving (Eq, Show)
+
+-- | A raw verification key given in Base64, and decoded into a ByteString.
+newtype VerificationKeyBase64
+  = VerificationKeyBase64 String
   deriving (Eq, Show)
 
 -- | UTxO query filtering options.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -49,7 +49,6 @@ module Cardano.CLI.Shelley.Commands
 import           Prelude
 import           Data.Set (Set)
 import           Data.Text (Text)
-import           Data.ByteString (ByteString)
 
 import           Cardano.Api.Protocol (Protocol)
 import           Cardano.Api.Typed hiding (PoolId)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -101,6 +101,7 @@ data StakeAddressCmd
 
 data KeyCmd
   = KeyConvertByronPaymentKey SigningKeyFile SigningKeyFile
+  | KeyConvertByronGenesisVerificationKey VerificationKeyFile VerificationKeyFile
   | KeyConvertITNStakeKey ITNKeyFile (Maybe OutputFile)
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -67,7 +67,7 @@ parseShelleyCommands =
       , Opt.command "stake-address"
           (Opt.info (StakeAddressCmd <$> pStakeAddress) $ Opt.progDesc "Shelley stake address commands")
       , Opt.command "key"
-          (Opt.info (KeyCmd <$> pKeyCmd) $ Opt.progDesc "Shelley key conversion commands")
+          (Opt.info (KeyCmd <$> pKeyCmd) $ Opt.progDesc "Shelley key utility commands")
       , Opt.command "transaction"
           (Opt.info (TransactionCmd <$> pTransaction) $ Opt.progDesc "Shelley transaction commands")
       , Opt.command "node"
@@ -255,12 +255,22 @@ pKeyCmd :: Parser KeyCmd
 pKeyCmd =
   Opt.subparser $
     mconcat
-      [ Opt.command "convert-byron-payment-signing-key"
-          (Opt.info pKeyConvertByronPaymentKey $ Opt.progDesc "Convert a Byron payment signing key to a Shelley payment signing key")
-      , Opt.command "convert-byron-genesis-key"
-          (Opt.info pKeyConvertByronGenesisVerificationKey $ Opt.progDesc "Convert a Base64-encoded Byron genesis verification key to a Shelley genesis verification key")
-      , Opt.command "convert-itn-key"
-          (Opt.info pKeyConvertITNKey $ Opt.progDesc "Convert an Incentivized Testnet (ITN) non-extended signing or verification key to a corresponding Shelley stake key")
+      [ Opt.command "convert-byron-payment-key" $
+          Opt.info pKeyConvertByronPaymentKey $
+            Opt.progDesc $ "Convert a Byron payment signing key to a Shelley "
+                        ++ "payment signing key"
+
+      , Opt.command "convert-byron-genesis-vkey-base64" $
+          Opt.info pKeyConvertByronGenesisVerificationKey $
+            Opt.progDesc $ "Convert a Base64-encoded Byron genesis "
+                        ++ "verification key to a Shelley genesis "
+                        ++ "verification key"
+
+      , Opt.command "convert-itn-key" $
+          Opt.info pKeyConvertITNKey $
+            Opt.progDesc $ "Convert an Incentivized Testnet (ITN) non-extended "
+                        ++ "signing or verification key to a corresponding "
+                        ++ "Shelley stake key"
       ]
   where
     pKeyConvertByronPaymentKey :: Parser KeyCmd
@@ -292,7 +302,28 @@ pKeyCmd =
         <*> pMaybeOutputFile
 
     pITNKeyFIle :: Parser ITNKeyFile
-    pITNKeyFIle = pITNSigningKeyFile <|> pITNVerificationKeyFile
+    pITNKeyFIle = pITNSigningKeyFile
+              <|> pITNVerificationKeyFile
+
+    pITNSigningKeyFile :: Parser ITNKeyFile
+    pITNSigningKeyFile =
+      ITNSigningKeyFile . SigningKeyFile <$>
+        Opt.strOption
+          (  Opt.long "itn-signing-key-file"
+          <> Opt.metavar "FILE"
+          <> Opt.help "Filepath of the ITN signing key."
+          <> Opt.completer (Opt.bashCompleter "file")
+          )
+
+    pITNVerificationKeyFile :: Parser ITNKeyFile
+    pITNVerificationKeyFile =
+      ITNVerificationKeyFile . VerificationKeyFile <$>
+        Opt.strOption
+          (  Opt.long "itn-verification-key-file"
+          <> Opt.metavar "FILE"
+          <> Opt.help "Filepath of the ITN verification key."
+          <> Opt.completer (Opt.bashCompleter "file")
+          )
 
 pTransaction :: Parser TransactionCmd
 pTransaction =
@@ -883,16 +914,6 @@ pColdSigningKeyFile =
       )
     )
 
-pITNSigningKeyFile :: Parser ITNKeyFile
-pITNSigningKeyFile =
-  ITNSigningKeyFile . SigningKeyFile <$>
-    Opt.strOption
-      (  Opt.long "itn-signing-key-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the ITN signing key."
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
-
 pSomeSigningKeyFiles :: Parser [SigningKeyFile]
 pSomeSigningKeyFiles =
   some $
@@ -1098,16 +1119,6 @@ pKESVerificationKeyFile =
         <> Opt.internal
         )
     )
-
-pITNVerificationKeyFile :: Parser ITNKeyFile
-pITNVerificationKeyFile =
-  ITNVerificationKeyFile . VerificationKeyFile <$>
-    Opt.strOption
-      (  Opt.long "itn-verification-key-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the ITN verification key."
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
 
 pNetworkId :: Parser NetworkId
 pNetworkId =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -257,6 +257,8 @@ pKeyCmd =
     mconcat
       [ Opt.command "convert-byron-payment-signing-key"
           (Opt.info pKeyConvertByronPaymentKey $ Opt.progDesc "Convert a Byron payment signing key to a Shelley payment signing key")
+      , Opt.command "convert-byron-genesis-key"
+          (Opt.info pKeyConvertByronGenesisVerificationKey $ Opt.progDesc "Convert a Base64-encoded Byron genesis verification key to a Shelley genesis verification key")
       , Opt.command "convert-itn-key"
           (Opt.info pKeyConvertITNKey $ Opt.progDesc "Convert an Incentivized Testnet (ITN) non-extended signing or verification key to a corresponding Shelley stake key")
       ]
@@ -267,14 +269,30 @@ pKeyCmd =
         <$> pByronKeyFile Input
         <*> pSigningKeyFile Output
 
+    pKeyConvertByronGenesisVerificationKey :: Parser KeyCmd
+    pKeyConvertByronGenesisVerificationKey =
+      KeyConvertByronGenesisVerificationKey
+        <$> pByronGenesisVerificationKeyFile
+        <*> pVerificationKeyFile Output
+
+    pByronGenesisVerificationKeyFile :: Parser VerificationKeyFile
+    pByronGenesisVerificationKeyFile =
+      VerificationKeyFile <$>
+        Opt.strOption
+          (  Opt.long "byron-genesis-verification-key-file"
+          <> Opt.metavar "FILE"
+          <> Opt.help "Filepath of the Byron genesis verification key."
+          <> Opt.completer (Opt.bashCompleter "file")
+          )
+
     pKeyConvertITNKey :: Parser KeyCmd
     pKeyConvertITNKey =
       KeyConvertITNStakeKey
-        <$> pITNKeyFile
+        <$> pITNKeyFIle
         <*> pMaybeOutputFile
 
-    pITNKeyFile :: Parser ITNKeyFile
-    pITNKeyFile = pITNSigningKeyFile <|> pITNVerificationKeyFile
+    pITNKeyFIle :: Parser ITNKeyFile
+    pITNKeyFIle = pITNSigningKeyFile <|> pITNVerificationKeyFile
 
 pTransaction :: Parser TransactionCmd
 pTransaction =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -13,6 +13,7 @@ import           Cardano.CLI.Shelley.Parsers
 
 import           Cardano.CLI.Shelley.Run.Address
 import           Cardano.CLI.Shelley.Run.Governance
+import           Cardano.CLI.Shelley.Run.Key
 import           Cardano.CLI.Shelley.Run.StakeAddress
 import           Cardano.CLI.Shelley.Run.Transaction
 import           Cardano.CLI.Shelley.Run.Node
@@ -32,6 +33,7 @@ data ShelleyClientCmdError
   | ShelleyCmdTextViewError !ShelleyTextViewFileError
   | ShelleyCmdTransactionError !ShelleyTxCmdError
   | ShelleyCmdQueryError !ShelleyQueryCmdError
+  | ShelleyCmdKeyError !ShelleyKeyCmdError
   deriving Show
 
 renderShelleyClientCmdError :: ShelleyClientCmdError -> Text
@@ -46,6 +48,7 @@ renderShelleyClientCmdError err =
     ShelleyCmdTextViewError txtViewErr -> renderShelleyTextViewFileError txtViewErr
     ShelleyCmdTransactionError txErr -> renderShelleyTxCmdError txErr
     ShelleyCmdQueryError queryErr -> renderShelleyQueryCmdError queryErr
+    ShelleyCmdKeyError keyErr -> renderShelleyKeyCmdError keyErr
 
 --
 -- CLI shelley command dispatch
@@ -54,6 +57,7 @@ renderShelleyClientCmdError err =
 runShelleyClientCommand :: ShelleyCommand -> ExceptT ShelleyClientCmdError IO ()
 runShelleyClientCommand (AddressCmd      cmd) = firstExceptT ShelleyCmdAddressError $ runAddressCmd cmd
 runShelleyClientCommand (StakeAddressCmd cmd) = firstExceptT ShelleyCmdStakeAddressError $ runStakeAddressCmd cmd
+runShelleyClientCommand (KeyCmd          cmd) = firstExceptT ShelleyCmdKeyError $ runKeyCmd cmd
 runShelleyClientCommand (TransactionCmd  cmd) = firstExceptT ShelleyCmdTransactionError $ runTransactionCmd  cmd
 runShelleyClientCommand (NodeCmd         cmd) = firstExceptT ShelleyCmdNodeError $ runNodeCmd cmd
 runShelleyClientCommand (PoolCmd         cmd) = firstExceptT ShelleyCmdPoolError $ runPoolCmd cmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -4,6 +4,9 @@ module Cardano.CLI.Shelley.Run.Key
   ( ShelleyKeyCmdError
   , renderShelleyKeyCmdError
   , runKeyCmd
+
+    -- * Exports for testing
+  , decodeBech32Key
   ) where
 
 import           Cardano.Prelude

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -1,0 +1,86 @@
+module Cardano.CLI.Shelley.Run.Key
+  ( ShelleyKeyCmdError
+  , renderShelleyKeyCmdError
+  , runKeyCmd
+  ) where
+
+import           Cardano.Prelude
+
+import qualified Data.Text as Text
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither,
+                   newExceptT)
+
+import           Cardano.Api.TextView (TextViewDescription (..))
+import           Cardano.Api.Typed
+
+import           Cardano.CLI.Byron.Key (ByronKeyFailure, CardanoEra (..),
+                   readEraSigningKey, renderByronKeyFailure)
+import           Cardano.CLI.Helpers
+import           Cardano.CLI.Shelley.Parsers (ITNKeyFile (..), KeyCmd (..),
+                   OutputFile (..), SigningKeyFile (..),
+                   VerificationKeyFile (..))
+
+data ShelleyKeyCmdError
+  = ShelleyKeyCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyKeyCmdWriteFileError !(FileError ())
+  | ShelleyKeyCmdByronKeyFailure !ByronKeyFailure
+  | ShelleyKeyCmdItnKeyConvError !ConversionError
+  deriving Show
+
+renderShelleyKeyCmdError :: ShelleyKeyCmdError -> Text
+renderShelleyKeyCmdError err =
+  case err of
+    ShelleyKeyCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyKeyCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyKeyCmdByronKeyFailure e -> renderByronKeyFailure e
+    ShelleyKeyCmdItnKeyConvError convErr -> renderConversionError convErr
+
+runKeyCmd :: KeyCmd -> ExceptT ShelleyKeyCmdError IO ()
+runKeyCmd cmd =
+  case cmd of
+    KeyConvertByronPaymentKey skfOld skfNew ->
+      runConvertByronPaymentKey skfOld skfNew
+    KeyConvertITNStakeKey itnKeyFile mOutFile ->
+      runSingleITNKeyConversion itnKeyFile mOutFile
+
+runConvertByronPaymentKey
+  :: SigningKeyFile -- ^ Input file: old format
+  -> SigningKeyFile -- ^ Output file: new format
+  -> ExceptT ShelleyKeyCmdError IO ()
+runConvertByronPaymentKey skeyPathOld (SigningKeyFile skeyPathNew) = do
+    sk <- firstExceptT ShelleyKeyCmdByronKeyFailure $
+            readEraSigningKey ByronEra skeyPathOld
+    firstExceptT ShelleyKeyCmdWriteFileError . newExceptT $
+      writeFileTextEnvelope skeyPathNew (Just skeyDesc) (ByronSigningKey sk)
+  where
+    skeyDesc = TextViewDescription "Payment Signing Key"
+
+runSingleITNKeyConversion
+  :: ITNKeyFile
+  -> Maybe OutputFile
+  -> ExceptT ShelleyKeyCmdError IO ()
+runSingleITNKeyConversion (ITNVerificationKeyFile (VerificationKeyFile vk)) mOutFile = do
+  bech32publicKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $ readBech32 vk
+  vkey <- hoistEither
+    . first ShelleyKeyCmdItnKeyConvError
+    $ convertITNVerificationKey bech32publicKey
+  case mOutFile of
+    Just (OutputFile fp) ->
+      firstExceptT ShelleyKeyCmdWriteFileError
+        . newExceptT
+        $ writeFileTextEnvelope fp Nothing vkey
+    Nothing -> print vkey
+
+runSingleITNKeyConversion (ITNSigningKeyFile (SigningKeyFile sk)) mOutFile = do
+  bech32privateKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $ readBech32 sk
+  skey <- hoistEither
+    . first ShelleyKeyCmdItnKeyConvError
+    $ convertITNSigningKey bech32privateKey
+  case mOutFile of
+    Just (OutputFile fp) ->
+      firstExceptT ShelleyKeyCmdWriteFileError
+        . newExceptT
+        $ writeFileTextEnvelope fp Nothing skey
+    Nothing -> print skey

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -6,28 +6,34 @@ module Cardano.CLI.Shelley.Run.Key
 
 import           Cardano.Prelude
 
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT,
                    handleIOExceptT, hoistEither, hoistMaybe, newExceptT)
+import qualified Control.Exception as Exception
 
-import           Cardano.Api.TextView (TextViewDescription (..))
-import           Cardano.Api.Typed
+import qualified Codec.Binary.Bech32 as Bech32
 
-import           Cardano.CLI.Byron.Key (ByronKeyFailure, CardanoEra (..),
-                   readEraSigningKey, renderByronKeyFailure)
-import           Cardano.CLI.Helpers
-import           Cardano.CLI.Shelley.Parsers (ITNKeyFile (..), KeyCmd (..),
-                   OutputFile (..), SigningKeyFile (..),
-                   VerificationKeyFile (..))
-
+import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.DSIGN.Class as Crypto
 import qualified Cardano.Crypto.Signing as Byron.Crypto
 import qualified Cardano.Crypto.Wallet as Crypto.HD
 
 import qualified Shelley.Spec.Ledger.Keys as Shelley
+
+import           Cardano.Api.TextView (TextViewDescription (..))
+import           Cardano.Api.Typed hiding (Bech32DecodeError(..))
+
+import           Cardano.CLI.Byron.Key (ByronKeyFailure, CardanoEra (..),
+                   readEraSigningKey, renderByronKeyFailure)
+import           Cardano.CLI.Helpers (textShow)
+import           Cardano.CLI.Shelley.Parsers (ITNKeyFile (..), KeyCmd (..),
+                   OutputFile (..), SigningKeyFile (..),
+                   VerificationKeyFile (..))
+
 
 data ShelleyKeyCmdError
   = ShelleyKeyCmdReadFileError !(FileError TextEnvelopeError)
@@ -95,12 +101,19 @@ runConvertByronGenesisVerificationKey (VerificationKeyFile oldVkFp)
   firstExceptT ShelleyKeyCmdWriteFileError . newExceptT $
     writeFileTextEnvelope newVkFp Nothing shelleyGenesisVKey
 
+
+--------------------------------------------------------------------------------
+-- ITN verification/signing key conversion to Haskell verficiation/signing keys
+--------------------------------------------------------------------------------
+
 runSingleITNKeyConversion
   :: ITNKeyFile
   -> Maybe OutputFile
   -> ExceptT ShelleyKeyCmdError IO ()
-runSingleITNKeyConversion (ITNVerificationKeyFile (VerificationKeyFile vk)) mOutFile = do
-  bech32publicKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $ readBech32 vk
+runSingleITNKeyConversion (ITNVerificationKeyFile (VerificationKeyFile vk))
+                          mOutFile = do
+  bech32publicKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $
+                     readFileITNKey vk
   vkey <- hoistEither
     . first ShelleyKeyCmdItnKeyConvError
     $ convertITNVerificationKey bech32publicKey
@@ -112,7 +125,8 @@ runSingleITNKeyConversion (ITNVerificationKeyFile (VerificationKeyFile vk)) mOut
     Nothing -> print vkey
 
 runSingleITNKeyConversion (ITNSigningKeyFile (SigningKeyFile sk)) mOutFile = do
-  bech32privateKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $ readBech32 sk
+  bech32privateKey <- firstExceptT ShelleyKeyCmdItnKeyConvError . newExceptT $
+                      readFileITNKey sk
   skey <- hoistEither
     . first ShelleyKeyCmdItnKeyConvError
     $ convertITNSigningKey bech32privateKey
@@ -122,3 +136,69 @@ runSingleITNKeyConversion (ITNSigningKeyFile (SigningKeyFile sk)) mOutFile = do
         . newExceptT
         $ writeFileTextEnvelope fp Nothing skey
     Nothing -> print skey
+
+
+data ConversionError
+  = Bech32DecodingError
+      -- ^ Bech32 key
+      !Text
+      !Bech32.DecodingError
+  | Bech32ErrorExtractingByes !Bech32.DataPart
+  | Bech32ReadError !FilePath !IOException
+  | ITNError !Bech32.HumanReadablePart !Bech32.DataPart
+  | SigningKeyDeserializationError !ByteString
+  | VerificationKeyDeserializationError !ByteString
+  deriving Show
+
+renderConversionError :: ConversionError -> Text
+renderConversionError err =
+  case err of
+    Bech32DecodingError key decErr ->
+      "Error decoding Bech32 key: " <> key <> " Error: " <> textShow decErr
+    Bech32ErrorExtractingByes dp ->
+      "Unable to extract bytes from: " <> Bech32.dataPartToText dp
+    Bech32ReadError fp readErr ->
+      "Error reading bech32 key at: " <> textShow fp
+                        <> " Error: " <> Text.pack (displayException readErr)
+    ITNError hRpart dp ->
+      "Error extracting a ByteString from DataPart: " <> Bech32.dataPartToText dp <>
+      " With human readable part: " <> Bech32.humanReadablePartToText hRpart
+    SigningKeyDeserializationError sKey ->
+      "Error deserialising signing key: " <> textShow (BS.unpack sKey)
+    VerificationKeyDeserializationError vKey ->
+      "Error deserialising verification key: " <> textShow (BS.unpack vKey)
+
+-- | Convert public ed25519 key to a Shelley stake verification key
+convertITNVerificationKey :: Text -> Either ConversionError (VerificationKey StakeKey)
+convertITNVerificationKey pubKey = do
+  (_, _, keyBS) <- decodeBech32Key pubKey
+  case DSIGN.rawDeserialiseVerKeyDSIGN keyBS of
+    Just verKey -> Right . StakeVerificationKey $ Shelley.VKey verKey
+    Nothing -> Left $ VerificationKeyDeserializationError keyBS
+
+-- | Convert private ed22519 key to a Shelley signing key.
+convertITNSigningKey :: Text -> Either ConversionError (SigningKey StakeKey)
+convertITNSigningKey privKey = do
+  (_, _, keyBS) <- decodeBech32Key privKey
+  case DSIGN.rawDeserialiseSignKeyDSIGN keyBS of
+    Just signKey -> Right $ StakeSigningKey signKey
+    Nothing -> Left $ SigningKeyDeserializationError keyBS
+
+-- | Convert ITN Bech32 public or private keys to 'ByteString's
+decodeBech32Key :: Text
+                -> Either ConversionError
+                          (Bech32.HumanReadablePart, Bech32.DataPart, ByteString)
+decodeBech32Key key =
+  case Bech32.decodeLenient key of
+    Left err -> Left $ Bech32DecodingError key err
+    Right (hRpart, dataPart) -> case Bech32.dataPartToBytes dataPart of
+                                  Nothing -> Left $ ITNError hRpart dataPart
+                                  Just bs -> Right (hRpart, dataPart, bs)
+
+readFileITNKey :: FilePath -> IO (Either ConversionError Text)
+readFileITNKey fp = do
+  eStr <- Exception.try $ readFile fp
+  case eStr of
+    Left e -> return . Left $ Bech32ReadError fp e
+    Right str -> return . Right . Text.concat $ Text.words str
+

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -11,18 +11,16 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither,
+import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT,
                    newExceptT)
 
 import           Cardano.Api.TextView (TextViewDescription (..))
 import           Cardano.Api.Typed
 
-import           Cardano.CLI.Helpers
 import           Cardano.CLI.Shelley.Parsers
 
 data ShelleyStakeAddressCmdError
-  = ShelleyStakeAddressConvError !ConversionError
-  | ShelleyStakeAddressKeyPairError
+  = ShelleyStakeAddressKeyPairError
       !Text
       -- ^ bech32 private key
       !Text
@@ -34,7 +32,6 @@ data ShelleyStakeAddressCmdError
 renderShelleyStakeAddressCmdError :: ShelleyStakeAddressCmdError -> Text
 renderShelleyStakeAddressCmdError err =
   case err of
-    ShelleyStakeAddressConvError convErr -> renderConversionError convErr
     ShelleyStakeAddressKeyPairError bech32PrivKey bech32PubKey ->
       "Error while deriving the shelley verification key from bech32 private Key: " <> bech32PrivKey <>
       " Corresponding bech32 public key: " <> bech32PubKey
@@ -52,7 +49,6 @@ runStakeAddressCmd (StakeKeyDelegationCert stkKeyVerKeyFp stkPoolVerKeyHashOrFp 
   runStakeKeyDelegationCert stkKeyVerKeyFp stkPoolVerKeyHashOrFp outputFp
 runStakeAddressCmd (StakeKeyDeRegistrationCert stkKeyVerKeyFp outputFp) =
   runStakeKeyDeRegistrationCert stkKeyVerKeyFp outputFp
-runStakeAddressCmd (StakeKeyITNConversion itnKeyFile mOutFile) = runSingleITNKeyConversion itnKeyFile mOutFile
 runStakeAddressCmd cmd = liftIO $ putStrLn $ "runStakeAddressCmd: " ++ show cmd
 
 
@@ -164,32 +160,3 @@ runStakeKeyDeRegistrationCert (VerificationKeyFile vkFp) (OutputFile oFp) = do
   where
     deregCertDesc :: TextViewDescription
     deregCertDesc = TextViewDescription "Stake Address Deregistration Certificate"
-
-
-runSingleITNKeyConversion
-  :: ITNKeyFile
-  -> Maybe OutputFile
-  -> ExceptT ShelleyStakeAddressCmdError IO ()
-runSingleITNKeyConversion (ITNVerificationKeyFile (VerificationKeyFile vk)) mOutFile = do
-  bech32publicKey <- firstExceptT ShelleyStakeAddressConvError . newExceptT $ readBech32 vk
-  vkey <- hoistEither
-    . first ShelleyStakeAddressConvError
-    $ convertITNVerificationKey bech32publicKey
-  case mOutFile of
-    Just (OutputFile fp) ->
-      firstExceptT ShelleyStakeAddressWriteFileError
-        . newExceptT
-        $ writeFileTextEnvelope fp Nothing vkey
-    Nothing -> print vkey
-
-runSingleITNKeyConversion (ITNSigningKeyFile (SigningKeyFile sk)) mOutFile = do
-  bech32privateKey <- firstExceptT ShelleyStakeAddressConvError . newExceptT $ readBech32 sk
-  skey <- hoistEither
-    . first ShelleyStakeAddressConvError
-    $ convertITNSigningKey bech32privateKey
-  case mOutFile of
-    Just (OutputFile fp) ->
-      firstExceptT ShelleyStakeAddressWriteFileError
-        . newExceptT
-        $ writeFileTextEnvelope fp Nothing skey
-    Nothing -> print skey

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -310,9 +310,13 @@ data SomeWitnessSigningKey
   | APaymentSigningKey         (Api.SigningKey Api.PaymentKey)
   | APaymentExtendedSigningKey (Api.SigningKey Api.PaymentExtendedKey)
   | AStakeSigningKey           (Api.SigningKey Api.StakeKey)
+  | AStakeExtendedSigningKey   (Api.SigningKey Api.StakeExtendedKey)
   | AStakePoolSigningKey       (Api.SigningKey Api.StakePoolKey)
   | AGenesisSigningKey         (Api.SigningKey Api.GenesisKey)
+  | AGenesisExtendedSigningKey (Api.SigningKey Api.GenesisExtendedKey)
   | AGenesisDelegateSigningKey (Api.SigningKey Api.GenesisDelegateKey)
+  | AGenesisDelegateExtendedSigningKey
+                               (Api.SigningKey Api.GenesisDelegateExtendedKey)
   | AGenesisUTxOSigningKey     (Api.SigningKey Api.GenesisUTxOKey)
 
 readSigningKeyFile
@@ -331,12 +335,18 @@ readSigningKeyFile (SigningKeyFile skfile) =
                           APaymentExtendedSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsStakeKey)
                           AStakeSigningKey
+      , Api.FromSomeType (Api.AsSigningKey Api.AsStakeExtendedKey)
+                          AStakeExtendedSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsStakePoolKey)
                           AStakePoolSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisKey)
                           AGenesisSigningKey
+      , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisExtendedKey)
+                          AGenesisExtendedSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisDelegateKey)
                           AGenesisDelegateSigningKey
+      , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisDelegateExtendedKey)
+                          AGenesisDelegateExtendedSigningKey
       , Api.FromSomeType (Api.AsSigningKey Api.AsGenesisUTxOKey)
                           AGenesisUTxOSigningKey
       ]
@@ -350,9 +360,13 @@ categoriseWitnessSigningKey swsk =
     APaymentSigningKey         sk -> Right (Api.WitnessPaymentKey         sk)
     APaymentExtendedSigningKey sk -> Right (Api.WitnessPaymentExtendedKey sk)
     AStakeSigningKey           sk -> Right (Api.WitnessStakeKey           sk)
+    AStakeExtendedSigningKey   sk -> Right (Api.WitnessStakeExtendedKey   sk)
     AStakePoolSigningKey       sk -> Right (Api.WitnessStakePoolKey       sk)
     AGenesisSigningKey         sk -> Right (Api.WitnessGenesisKey sk)
+    AGenesisExtendedSigningKey sk -> Right (Api.WitnessGenesisExtendedKey sk)
     AGenesisDelegateSigningKey sk -> Right (Api.WitnessGenesisDelegateKey sk)
+    AGenesisDelegateExtendedSigningKey sk
+                                  -> Right (Api.WitnessGenesisDelegateExtendedKey sk)
     AGenesisUTxOSigningKey     sk -> Right (Api.WitnessGenesisUTxOKey     sk)
 
 runTxGetTxId :: TxBodyFile -> ExceptT ShelleyTxCmdError IO ()

--- a/cardano-cli/test/Test/ITN.hs
+++ b/cardano-cli/test/Test/ITN.hs
@@ -48,14 +48,14 @@ prop_convertITNKeys =
     -- Generate haskell stake verification key
     execCardanoCLIParser
       allFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","convert-itn-key"
+        $ evalCardanoCLIParser [ "shelley","key","convert-itn-key"
                                , "--itn-verification-key-file", itnVerKeyFp
                                , "--out-file", outputHaskellVerKeyFp
                                ]
     -- Generate haskell signing key
     execCardanoCLIParser
       allFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","convert-itn-key"
+        $ evalCardanoCLIParser [ "shelley","key","convert-itn-key"
                                , "--itn-signing-key-file", itnSignKeyFp
                                , "--out-file", outputHaskellSignKeyFp
                                ]

--- a/cardano-cli/test/Test/ITN.hs
+++ b/cardano-cli/test/Test/ITN.hs
@@ -6,9 +6,10 @@ module Test.ITN
 
 import           Cardano.Prelude
 
-import           Codec.Binary.Bech32 (humanReadablePartToText)
+import qualified Data.ByteString.Base16 as Base16
+import qualified Codec.Binary.Bech32 as Bech32
 
-import           Cardano.CLI.Helpers (dataPartToBase16, decodeBech32Key)
+import           Cardano.CLI.Shelley.Run.Key (decodeBech32Key)
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
@@ -72,10 +73,10 @@ prop_convertITNKeys =
 golden_bech32Decode :: Property
 golden_bech32Decode = propertyOnce $ do
     (vHumReadPart, vDataPart , _) <- H.evalEither $ decodeBech32Key itnVerKey
-    vDataPartBase16 <- H.evalEither $ dataPartToBase16 vDataPart
+    Just vDataPartBase16 <- pure (dataPartToBase16 vDataPart)
 
     (sHumReadPart, sDataPart , _) <- H.evalEither $ decodeBech32Key itnSignKey
-    sDataPartBase16 <- H.evalEither $ dataPartToBase16 sDataPart
+    Just sDataPartBase16 <- pure (dataPartToBase16 sDataPart)
 
     -- Based on https://slowli.github.io/bech32-buffer/ which are in Base16
     let expectedHumanReadPartVerificationKey = "ed25519_pk"
@@ -85,14 +86,17 @@ golden_bech32Decode = propertyOnce $ do
 
 
     -- ITN Verification key decode check
-    expectedHumanReadPartVerificationKey === humanReadablePartToText vHumReadPart
+    expectedHumanReadPartVerificationKey === Bech32.humanReadablePartToText vHumReadPart
     expectedDataPartVerificationKey ===  vDataPartBase16
 
 
     -- ITN Signing key decode check
-    expectedHumanReadPartSigningKey === humanReadablePartToText sHumReadPart
+    expectedHumanReadPartSigningKey === Bech32.humanReadablePartToText sHumReadPart
     expectedDataPartSigningKey === sDataPartBase16
     H.success
+  where
+    dataPartToBase16 :: Bech32.DataPart -> Maybe ByteString
+    dataPartToBase16 = fmap Base16.encode . Bech32.dataPartToBytes
 
 tests :: IO Bool
 tests =


### PR DESCRIPTION
Add support for converting:
 * payment keys
 * genesis keys
 * genesis delegate keys

Support either verification or signing keys.

Support current or legacy (ie SL) formats.

Also add special conversion for Byron genesis verification keys in base64,
as they appear in the Byron genesis file as `issuerPK`.
