### PR TITLE
Fix Condense instance of OneEraHash

### DIFF
--- a/cardano-config/src/Cardano/TracingOrphanInstances/HardFork.hs
+++ b/cardano-config/src/Cardano/TracingOrphanInstances/HardFork.hs
@@ -22,12 +22,12 @@ import           Cardano.Prelude hiding (All)
 import           Data.Aeson
 import           Data.SOP.Strict
 
+import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.TracingOrphanInstances.Common
 import           Cardano.TracingOrphanInstances.Consensus ()
 
 import           Cardano.Slotting.Slot (EpochSize(..))
 import           Ouroboros.Consensus.Block (BlockProtocol)
-import           Ouroboros.Consensus.Block.Abstract (ConvertRawHash(toRawHash))
 import           Ouroboros.Consensus.BlockchainTime (getSlotLength)
 import           Ouroboros.Consensus.Protocol.Abstract
                    (ValidationErr, CannotLead, ChainIndepState)
@@ -55,8 +55,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense(..))
 -- instances for hashes
 --
 
-instance CanHardFork xs => Condense (OneEraHash xs) where
-    condense = condense . toRawHash (Proxy :: Proxy (HardForkBlock xs))
+instance Condense (OneEraHash xs) where
+    condense = condense . Crypto.UnsafeHash . getOneEraHash
 
 --
 -- instances for Header HardForkBlock


### PR DESCRIPTION
`OneEraHash` is the `HeaderHash` type of `CardanoBlock`.

Now instead of

    "\214\157\227\245\SI\135CSI\238\241\185\196\137\FS;@\ETBB\208\201>\128\145\206\162\185\207\ETB\245t\180"<32b>

it should print the base16 encoding.