### PR TITLE
iohk-nix: update shelley_qa and mainnet_candidate environments

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "95f7dfdff554223606f6be266c36eabe81cbe800",
-        "sha256": "05ibcw52jg7q66sd0vqj0fv3zlz7mdrfywys9111n4bj9rd9rl1n",
+        "rev": "437649c24ab8e30d6f08154a22da809a991971a3",
+        "sha256": "1y784yhdwpmgdjwxnrbzabnpfkbzy9lxi7kpqf9w9kypv9qmszpq",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/95f7dfdff554223606f6be266c36eabe81cbe800.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/437649c24ab8e30d6f08154a22da809a991971a3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This updates genesis for mainnet-candidate and shelley_qa.