### PR TITLE
opcert extended keys

### DIFF
--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -2281,6 +2281,9 @@ instance Error OperationalCertIssueError where
 issueOperationalCertificate :: VerificationKey KesKey
                             -> Either (SigningKey StakePoolKey)
                                       (SigningKey GenesisDelegateExtendedKey)
+                               --TODO: this may be better with a type that
+                               -- captured the three (four?) choices, stake pool
+                               -- or genesis delegate, extended or normal.
                             -> Shelley.KESPeriod
                             -> OperationalCertificateIssueCounter
                             -> Either OperationalCertIssueError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -524,7 +524,7 @@ pNodeCmd =
 
     pNewCounter :: Parser NodeCmd
     pNewCounter =
-      NodeNewCounter <$> pKESVerificationKeyFile
+      NodeNewCounter <$> pColdVerificationKeyFile
                      <*> pCounterValue
                      <*> pOperatorCertIssueCounterFile
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -208,8 +208,12 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKesPath)
     ocertCtrDesc :: Word64 -> TextViewDescription
     ocertCtrDesc n = TextViewDescription $ "Next certificate issue number: " <> BS.pack (show n)
 
-    possibleBlockIssuers :: [FromSomeType HasTextEnvelope (SigningKey StakePoolKey)]
+    possibleBlockIssuers
+      :: [FromSomeType HasTextEnvelope
+                       (Either (SigningKey StakePoolKey)
+                               (SigningKey GenesisDelegateExtendedKey))]
     possibleBlockIssuers =
-      [ FromSomeType (AsSigningKey AsStakePoolKey)       id
-      , FromSomeType (AsSigningKey AsGenesisDelegateKey) castSigningKey
+      [ FromSomeType (AsSigningKey AsStakePoolKey)        Left
+      , FromSomeType (AsSigningKey AsGenesisDelegateKey) (Left . castSigningKey)
+      , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey) Right
       ]


### PR DESCRIPTION
Allow signing node operational certificates with extended genesis delegate signing keys.
Needed for legacy keys which use extended format.