### PR TITLE
Update install.md

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -126,11 +126,11 @@ We change our working directory to the downloaded source code folder:
     cd cardano-node
 
 For reproducible builds, we should check out a specific release, a specific "tag".
-For the Shelley Testnet, we will use tag `1.14.2`, which we can check out as follows:
+For the Shelley Testnet, we will use tag `1.15.1`, which we can check out as follows:
 
     git fetch --all --tags
     git tag
-    git checkout tags/1.14.2
+    git checkout tags/1.15.1
 
 
 ## Build and install the node


### PR DESCRIPTION
listed version of cardano-node to DL no longer works with rest of instructions. Specifically, when trying `cardano-node run <options>`, getting errors about invalid blocks and the program just hangs

![isItRunning](https://user-images.githubusercontent.com/18726389/87890318-3dd7a500-c9f3-11ea-932e-593d07d62a37.PNG)
