### PR TITLE
iohk-nix: update all environments to support hard fork

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "00788ac974a517846dba09bd5e095757011cb083",
-        "sha256": "0lxffzd31a359d7j9q0vwaj6d5lq0ka5df6g0g30rm91sw7jkpnj",
+        "rev": "e8ab244409fa9356aaf77e01623895415a0ac7e5",
+        "sha256": "1py0jih5x7zahfg07rszwrq74arv9k6k3zcfmqsfss3p6vklynbf",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/00788ac974a517846dba09bd5e095757011cb083.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/e8ab244409fa9356aaf77e01623895415a0ac7e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -1,3 +1,5 @@
+# WARNING!!! Do not use this file except for chairman test. Not supported for general usage.
+
 { pkgs, cardano-cli-packages ? pkgs.cardanoNodeHaskellPackages.cardano-cli.components.exes }:
 with builtins; with pkgs.lib;
 let
@@ -7,12 +9,12 @@ let
   ## mkNodeConfig
   ##   :: ServiceConfig AttrSet -> NodeId Int -> NodeConfig AttrSet
   mkNodeConfig = cfg: NodeId:
-    cfg.nodeConfig //
-    { inherit NodeId; } //
+    removeAttrs (cfg.nodeConfig //
+    { inherit NodeId; Protocol = "RealPBFT"; } //
     (optionalAttrs (cfg.protover-major or null != null) { LastKnownBlockVersion-Major = cfg.protover-major; }) //
     (optionalAttrs (cfg.protover-minor or null != null) { LastKnownBlockVersion-Minor = cfg.protover-minor; }) //
     (optionalAttrs (cfg.protover-alt   or null != null) { LastKnownBlockVersion-Alt   = cfg.protover-alt;   }) //
-    (optionalAttrs (cfg.genesisFile != null) { GenesisFile = cfg.genesisFile;   });
+    (optionalAttrs (cfg.genesisFile != null) { GenesisFile = cfg.genesisFile;   })) [ "ByronGenesisFile" "ShelleyGenesisFile" ];
 
   ## mkFullyConnectedLocalClusterTopologyWithProxy
   ##   :: (Int NodeId -> String Address)


### PR DESCRIPTION
Adds support for Testnet/Mainnet to switch to Cardano protocol in anticipation of the upcoming hard fork.