### PR TITLE
Export the pNetworkId and pProtocol CLI parsers

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -6,6 +6,10 @@ module Cardano.CLI.Shelley.Parsers
     -- * CLI command and flag types
   , module Cardano.CLI.Shelley.Commands
 
+    -- * CLI option parsers
+  , pNetworkId
+  , pProtocol
+
     -- * Field parser and renderers
   , parseTxIn
   , renderTxIn


### PR DESCRIPTION
At the moment, I've just copy and pasted the implementations of the following parsers into `cardano-rest`:

- [`pNetworkId`](https://github.com/input-output-hk/cardano-rest/blob/a1fb5facb432eac8e24955472419a26ce2f504e6/submit-api/src/Cardano/TxSubmit/Parsers.hs#L56-L60)

- [`pProtocol`](https://github.com/input-output-hk/cardano-rest/blob/a1fb5facb432eac8e24955472419a26ce2f504e6/submit-api/src/Cardano/TxSubmit/Parsers.hs#L81-L85)

However, it'd be nicer to just export them such that they can be imported by `cardano-rest`.