### PR TITLE
cardano-node service: make genesis file optional

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -150,7 +150,7 @@ in {
      # TODO: remove
      genesisFile = mkOption {
         type = types.path;
-        default = envConfig.genesisFile;
+        default = envConfig.genesisFile or null;
         description = ''
           Genesis json file
         '';


### PR DESCRIPTION
genesisFile is only used by chairman test now. This allows it to not be set in envConfig (as it's been removed).