### PR TITLE
Genesis hash consistency

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -231,6 +231,7 @@ data GenesisCmd
   | GenesisVerKey VerificationKeyFile SigningKeyFile
   | GenesisTxIn VerificationKeyFile NetworkId (Maybe OutputFile)
   | GenesisAddr VerificationKeyFile NetworkId (Maybe OutputFile)
+  | GenesisHashFile GenesisFile
   deriving (Eq, Show)
 
 --

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -775,6 +775,10 @@ pGenesisCmd =
           (Opt.info pGenesisCreate $
              Opt.progDesc ("Create a Shelley genesis file from a genesis "
                         ++ "template and genesis/delegation/spending keys."))
+
+      , Opt.command "hash"
+          (Opt.info pGenesisHash $
+             Opt.progDesc "Compute the hash of a genesis file")
       ]
   where
     pGenesisKeyGen :: Parser GenesisCmd
@@ -815,6 +819,10 @@ pGenesisCmd =
                     <*> pMaybeSystemStart
                     <*> pInitialSupply
                     <*> pNetworkId
+
+    pGenesisHash :: Parser GenesisCmd
+    pGenesisHash =
+      GenesisHashFile <$> pGenesisFile
 
     pGenesisDir :: Parser GenesisDir
     pGenesisDir =

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -138,6 +138,7 @@ library cardano-node-config
   build-depends:       aeson
                      , base >=4.12 && <5
                      , cardano-api
+                     , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-config

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -24,8 +24,6 @@ import qualified Data.Text as T
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
-import qualified Cardano.Crypto.Hash.Class as Crypto
-
 import qualified Cardano.Chain.Update as Byron
 
 import           Ouroboros.Consensus.Cardano hiding (Protocol)
@@ -38,7 +36,6 @@ import           Ouroboros.Consensus.Cardano.Condense ()
 
 import           Ouroboros.Consensus.Shelley.Protocol (TPraosStandardCrypto)
 import qualified Shelley.Spec.Ledger.PParams as Shelley
-import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 
 import           Cardano.Node.Types
                    (NodeByronProtocolConfiguration(..),
@@ -109,6 +106,7 @@ mkConsensusProtocolCardano
                                     ProtocolCardano)
 mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcByronGenesisFile,
+                             npcByronGenesisFileHash,
                              npcByronReqNetworkMagic,
                              npcByronPbftSignatureThresh,
                              npcByronApplicationName,
@@ -119,6 +117,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                            }
                            NodeShelleyProtocolConfiguration {
                              npcShelleyGenesisFile,
+                             npcShelleyGenesisFileHash,
                              npcShelleySupportedProtocolVersionMajor,
                              npcShelleySupportedProtocolVersionMinor,
                              npcShelleyMaxSupportedProtocolVersion
@@ -131,7 +130,9 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                            files = do
     byronGenesis <-
       firstExceptT CardanoProtocolInstantiationErrorByron $
-        Byron.readGenesis npcByronGenesisFile npcByronReqNetworkMagic
+        Byron.readGenesis npcByronGenesisFile
+                          npcByronGenesisFileHash
+                          npcByronReqNetworkMagic
 
     byronLeaderCredentials <-
       firstExceptT CardanoProtocolInstantiationErrorByron $
@@ -140,6 +141,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
     (shelleyGenesis, shelleyGenesisHash) <-
       firstExceptT CardanoProtocolInstantiationErrorShelley $
         Shelley.readGenesis npcShelleyGenesisFile
+                            npcShelleyGenesisFileHash
 
     shelleyLeaderCredentials <-
       firstExceptT CardanoProtocolInstantiationErrorShelley $
@@ -159,7 +161,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
 
         -- Shelley parameters
         shelleyGenesis
-        (Shelley.Nonce (Crypto.castHash shelleyGenesisHash))
+        (Shelley.genesisHashToPraosNonce shelleyGenesisHash)
         (Shelley.ProtVer npcShelleySupportedProtocolVersionMajor
                          npcShelleySupportedProtocolVersionMinor)
         npcShelleyMaxSupportedProtocolVersion

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "bdd0387dca92dafbea61fbe3a9e4a28ea8b96b8d",
-        "sha256": "10m1ix2bpylzwsrndflr44qpdksp588bxc3bdq716csh06my4v47",
+        "rev": "a0d796bb481bdd7b1dfad3b1529d440734de9c07",
+        "sha256": "18zj7bshw0ph16ffaw438mm8ajlh3dn0ns7k92h0ppjsq2cd7hyy",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/bdd0387dca92dafbea61fbe3a9e4a28ea8b96b8d.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/a0d796bb481bdd7b1dfad3b1529d440734de9c07.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -78,7 +78,7 @@ let
   };
   extraBuilds = {
     # only build nixos tests on first supported system (linux)
-    inherit (pkgsFor (builtins.head  supportedSystems)) nixosTests;
+    inherit (pkgsFor (builtins.head  supportedSystems));
     # Environments listed in Network Configuration page
     cardano-deployment = pkgs.iohkNix.cardanoLib.mkConfigHtml { inherit (pkgs.iohkNix.cardanoLib.environments) mainnet testnet shelley_testnet mainnet_candidate; };
   } // (builtins.listToAttrs (map makeRelease [
@@ -143,7 +143,6 @@ let
       (optional windowsBuild jobs.cardano-node-win64)
       (optionals windowsBuild (collectJobs jobs.${mingwW64.config}.checks))
       (map (cluster: collectJobs jobs.${cluster}.scripts.node.${head supportedSystems}) [ "mainnet" "testnet" "staging" "shelley_qa" "shelley_testnet" ])
-      (collectJobs jobs.nixosTests.chairmansCluster)
       [
         jobs.cardano-node-linux
         jobs.cardano-node-macos


### PR DESCRIPTION
Add an optional {Byron,Shelley}GenesisHash config and sanity check

New optional entries in the config file

ByronGenesisHash
ShelleyGenesisHash

As hex encoded hashes. If specified these are checked against the actual
genesis file and an error reported on any mismatch.

This guards against accidental changes (either by users or by any tools
that incorrectly apply some transformation to the file).

Also add `cardano-cli shelley genesis hash`

Used to compute the expected genesis hash to include in the config file.

This command is specific to Shelley. The Byron hash is computed
differently and there is already a command for that.

