### PR TITLE
Default byron-witness-count CLI option to 0

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1398,7 +1398,8 @@ pTxByronWitnessCount =
     Opt.option Opt.auto
       (  Opt.long "byron-witness-count"
       <> Opt.metavar "NATURAL"
-      <> Opt.help "The number of Byron key witnesses."
+      <> Opt.help "The number of Byron key witnesses (default is 0)."
+      <> Opt.value 0
       )
 
 pQueryFilter :: Parser QueryFilter


### PR DESCRIPTION
Closes #1489. 

Most users probably won't utilize this CLI option, so it makes sense to default it to 0 as opposed to forcing them to specify a value.