### PR TITLE
Bumps iohk-nix niv pin for updated mainnet shelley genesis

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ace53df00d9cf5533cd1f52ffdd2ace7cf9e86f6",
-        "sha256": "0wqmfgik4zzmxicrqg1yf2gzj6r6ks9jfrpk3zzywirbv577ni9x",
+        "rev": "fcdedb374eb4f9f01c105baf18513bdbb746716a",
+        "sha256": "135ghvmn1j6ga30ib5n9ix4yq9xncmlm8aycx1r2s3v760cax2fk",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/ace53df00d9cf5533cd1f52ffdd2ace7cf9e86f6.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/fcdedb374eb4f9f01c105baf18513bdbb746716a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
* Updates iohk-nix pin for updated shelley genesis
* Diff at: https://github.com/input-output-hk/iohk-nix/pull/417/files