### PR TITLE
Properly render HeaderHash in BlockFetch message ToObject instance

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -801,7 +801,6 @@ nodeToClientTracers' trSel verb tr =
 
 nodeToNodeTracers'
   :: ( Consensus.RunNode blk
-     , Condense (HeaderHash blk)
      , Condense (TxId (GenTx blk))
      , HasTxs blk
      , Show peer


### PR DESCRIPTION
From @deepfire on Slack:

> By the way, it appears, that there was an unfortunate log format change since 1.16:
> ```
> {"at":"2020-07-23T16:34:30.33Z","env":"1.16.0:00000","ns":["cardano.node.BlockFetchProtocol"],"data":{"peer":"ConnectionId {localAddress = 127.0.0.1:41457, remoteAddress = 127.0.0.1:3002}","kind":"Recv","msg":{"kind":"MsgBlock","block size":10198,"tx ids":["txid: TxId {_unTxId = \"107f4268ca0ba0f0fc40834d72fc671ad38c030d2e51bd5bccc633e63f43ea22\"}","txid: TxId {_unTxId = \"43d86bcc929613eb9de1d4d21e087466c6fe072382d4606c0ade802181f9bb3e\"}","txid: TxId {_unTxId = 
> ...
> \"68e5a0fae84036fb7ad946fc2382db38dd9fcae99ed8a3ba39ffaff86b1ae0be\"}","txid: TxId {_unTxId = \"9eee2e303f10140e9297c54b95ed5f6a2ddb1743b9792aa1bd1f76053e6fce0b\"}","txid: TxId {_unTxId = \"c45766cf58ce8bf914032764a619aecfa3bdcbd778e251b71af923b0c2172e2c\"}"],"block hash":"\"e473ff09335770a3f1a7260b2784b2217a0eff2504b144b5b7e1e266a1aa8959\""}},"app":[],"msg":"","pid":"6831","loc":null,"host":"andromed","sev":"Debug","thread":"78"}
> ```
> the block hash field now has the " chars inside

According to Duncan, this has happened because the hash `Show` instance was recently fixed to use String syntax with `""` rather than printing raw hex. 

Really, we shouldn't be using `Condense` and `Show` instances in our `ToObject` instances anyways.