### PR TITLE
Useful hedgehog annotations on CLI command failure

### DIFF
--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
@@ -26,7 +26,7 @@ golden_shelleyAddressBuild = OP.propertyOnce $ OP.workspace "tmp/address-build" 
 
   void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressVKeyFile
 
-  stakingAddressText <- OP.noteEvalM . liftIO $ OP.execCardanoCLI
+  stakingAddressText <- OP.noteEvalM $ OP.execCardanoCLI
     [ "shelley","address","build"
     , "--testnet-magic", "14"
     , "--payment-verification-key-file", addressVKeyFile
@@ -41,7 +41,7 @@ golden_shelleyAddressBuild = OP.propertyOnce $ OP.workspace "tmp/address-build" 
 
   void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressSKeyFile
 
-  enterpriseAddressText <- OP.noteEvalM . liftIO $ OP.execCardanoCLI
+  enterpriseAddressText <- OP.noteEvalM $ OP.execCardanoCLI
     [ "shelley","address","build"
     , "--testnet-magic", "14"
     , "--payment-verification-key-file", addressVKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Info.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Info.hs
@@ -20,7 +20,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
   when False $ do
     let byronBase58 = "DdzFFzCqrhsg9F1joqXWJdGKwn6MaNavCqPsrZcjADRjA4ifEtrBmREJZyCojtuexKjMKNFr6CoU7Gx6PPR7pq14JxvPZuuk2xVkzn8p"
 
-    infoText1 <- OP.noteEvalM . liftIO $ OP.execCardanoCLI
+    infoText1 <- OP.noteEvalM $ OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", byronBase58
       ]
@@ -30,7 +30,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
 
     let byronHex = "82d818584283581c120e97e4ca7b831373c1060853d4896314e17d567a5723879b9a20eaa101581e581c135a115dd5dba68c28fb7e9409729ffc0503219ff7f9c08e84d13319001a28d0b871"
 
-    infoText2 <- OP.noteEvalM . liftIO $ OP.execCardanoCLI
+    infoText2 <- OP.noteEvalM $ OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", byronHex
       ]
@@ -40,7 +40,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
 
     let shelleyHex = "82065820d8b4a892f2f6f1820d350c207d17d4cd7e7a1f7e0a83059e2d698a65ab8f96ed"
 
-    infoText3 <- OP.noteEvalM . liftIO $ OP.execCardanoCLI
+    infoText3 <- OP.noteEvalM $ OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", shelleyHex
       ]

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
@@ -20,7 +20,7 @@ golden_shelleyAddressKeyGen = OP.propertyOnce $ OP.workspace "tmp/address-key-ge
   addressVKeyFile <- OP.noteTempFile tempDir "address.vkey"
   addressSKeyFile <- OP.noteTempFile tempDir "address.skey"
 
-  void $ liftIO $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "shelley","address","key-gen"
     , "--verification-key-file", addressVKeyFile
     , "--signing-key-file", addressSKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
@@ -95,7 +95,7 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
     (utxoCount, fmtUtxoCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
 
     -- Create the genesis json file and required keys
-    void $ liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","genesis","create"
         , "--testnet-magic", "12"
         , "--start-time", fmtStartTime
@@ -155,7 +155,7 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
     (utxoCount, fmtUtxoCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
 
     -- Create the genesis json file and required keys
-    void $ liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","genesis","create"
         , "--testnet-magic", "12"
         , "--start-time", fmtStartTime

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
@@ -20,7 +20,7 @@ golden_shelleyGenesisInitialTxIn = OP.propertyOnce $ do
     goldenUtxoHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
     utxoHashFile <- OP.noteTempFile tempDir "utxo_hash"
 
-    utxoHash <-liftIO $ OP.execCardanoCLI
+    utxoHash <- OP.execCardanoCLI
         [ "shelley","genesis","initial-txin"
         , "--testnet-magic", "16"
         , "--verification-key-file", verificationKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
@@ -19,7 +19,7 @@ golden_shelleyGenesisKeyGenDelegate = OP.propertyOnce $ do
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
     operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","genesis","key-gen-delegate"
         , "--verification-key-file", verificationKeyFile
         , "--signing-key-file", signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
@@ -18,7 +18,7 @@ golden_shelleyGenesisKeyGenGenesis = OP.propertyOnce $ do
     verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","genesis","key-gen-genesis"
         , "--verification-key-file", verificationKeyFile
         , "--signing-key-file", signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
@@ -18,7 +18,7 @@ golden_shelleyGenesisKeyGenUtxo = OP.propertyOnce $ do
     utxoVerificationKeyFile <- OP.noteTempFile tempDir "utxo.vkey"
     utxoSigningKeyFile <- OP.noteTempFile tempDir "utxo.skey"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","genesis","key-gen-utxo"
         , "--verification-key-file", utxoVerificationKeyFile
         , "--signing-key-file", utxoSigningKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
@@ -20,7 +20,7 @@ golden_shelleyGenesisKeyHash = OP.propertyOnce $ do
     goldenGenesisVerificationKeyHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key.key-hash"
     genesisVerificationKeyHashFile <- OP.noteTempFile tempDir "key-hash.hex"
 
-    genesisVerificationKeyHash <- liftIO $ OP.execCardanoCLI
+    genesisVerificationKeyHash <- OP.execCardanoCLI
         [ "shelley","genesis","key-hash"
         , "--verification-key-file", referenceVerificationKey
         ]

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
@@ -30,7 +30,7 @@ golden_shelleyNodeIssueOpCert = OP.propertyOnce $ do
     --    cabal run cardano-cli:cardano-cli -- shelley node key-gen-KES \
     --        --verification-key-file cardano-cli/test/cli/node-issue-op-cert/data/node-kes.vkey \
     --        --signing-key-file /dev/null
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","node","issue-op-cert"
         , "--hot-kes-verification-key-file", hotKesVerificationKeyFile
         , "--cold-signing-key-file", coldSigningKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
@@ -19,7 +19,7 @@ golden_shelleyNodeKeyGen = OP.propertyOnce $ do
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
     opCertCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","node","key-gen"
         , "--verification-key-file", verificationKeyFile
         , "--signing-key-file", signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
@@ -18,7 +18,7 @@ golden_shelleyNodeKeyGenKes = OP.propertyOnce $ do
     verificationKey <- OP.noteTempFile tempDir "kes.vkey"
     signingKey <- OP.noteTempFile tempDir "kes.skey"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","node","key-gen-KES"
         , "--verification-key-file", verificationKey
         , "--signing-key-file", signingKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
@@ -18,7 +18,7 @@ golden_shelleyNodeKeyGenVrf = OP.propertyOnce $ do
     verificationKey <- OP.noteTempFile tempDir "kes.vkey"
     signingKey <- OP.noteTempFile tempDir "kes.skey"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","node","key-gen-VRF"
         , "--verification-key-file", verificationKey
         , "--signing-key-file", signingKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
@@ -19,7 +19,7 @@ golden_shelleyStakeAddressBuild = OP.propertyOnce $ do
     verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     rewardAddressFile <- OP.noteTempFile tempDir "reward-address.hex"
 
-    rewardAddress <- liftIO $ OP.execCardanoCLI
+    rewardAddress <- OP.execCardanoCLI
         [ "shelley","stake-address","build"
         , "--mainnet"
         , "--staking-verification-key-file", verificationKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
@@ -18,7 +18,7 @@ golden_shelleyStakeAddressDeregistrationCertificate = OP.propertyOnce $ do
     verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     deregistrationCertFile <- OP.noteTempFile tempDir "deregistrationCertFile"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","stake-address","deregistration-certificate"
         , "--staking-verification-key-file", verificationKeyFile
         , "--out-file", deregistrationCertFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
@@ -18,7 +18,7 @@ golden_shelleyStakeAddressKeyGen = OP.propertyOnce $ do
     verificationKeyFile <- OP.noteTempFile tempDir "kes.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "kes.skey"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","stake-address","key-gen"
         , "--verification-key-file", verificationKeyFile
         , "--signing-key-file", signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
@@ -18,7 +18,7 @@ golden_shelleyStakeAddressRegistrationCertificate = OP.propertyOnce $ do
     keyGenStakingVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
 
-    void . liftIO $ OP.execCardanoCLI
+    void $ OP.execCardanoCLI
         [ "shelley","stake-address","registration-certificate"
         , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
         , "--out-file", registrationCertFile


### PR DESCRIPTION
This improves the `hedgehog` output when invocation of the CLI fails.

Previously CLI failure looked like this:

```
  ● golden_shelleyStakeAddressRegistrationCertificate passed 0 tests (running)
  ○ 16/25 complete (running)
Invalid option `--out-files'

Did you mean this?
    --out-file

Usage: cardano-cli shelley stake-address registration-certificate --stake-verification-key-file FILE
  ✗ golden_shelleyStakeAddressRegistrationCertificate failed at test/Test/OptParse.hs:244:33
    after 1 test.
  
        ┏━━ test/Test/OptParse.hs ━━━
    243 ┃ propertyOnce :: H.PropertyT IO () -> H.Property
    244 ┃ propertyOnce =  H.withTests 1 . H.property
        ┃ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ┃ │ ━━━ Exception (IOException) ━━━
        ┃ │ readCreateProcess: cabal "exec" "--" "cardano-cli" "shelley" "stake-address" "registration-certificate" "--staking-verification-key-file" "test/Test/golden/shelley/keys/stake_keys/verification_key" "--out-files" "tmp/stake-address-registration-certificate/test-08dd7abc55943679/registration.cert" (exit 1): failed
```

Above the `stderr` is arbitrarily interleaved in with other test output, and the error is not particularly useful and not associated with the failing test case.

Now the CLI failure looks like this, showing clearly, the command, stdout, stderr, and exit code:

```
  ✗ golden_shelleyStakeAddressRegistrationCertificate failed at test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs:21:12
    after 1 test.
  
       ┏━━ test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs ━━━
    15 ┃ golden_shelleyStakeAddressRegistrationCertificate :: Property
    16 ┃ golden_shelleyStakeAddressRegistrationCertificate = OP.propertyOnce $ do
    17 ┃   OP.workspace "tmp/stake-address-registration-certificate" $ \tempDir -> do
       ┃   │ Workspace: cardano-cli/tmp/stake-address-registration-certificate/test-480be8dbfbc65e5c
    18 ┃     keyGenStakingVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
       ┃     │ cardano-cli/test/Test/golden/shelley/keys/stake_keys/verification_key
    19 ┃     registrationCertFile <- OP.noteTempFile tempDir "regi stration.cert"
       ┃     │ cardano-cli/tmp/stake-address-registration-certificate/test-480be8dbfbc65e5c/regi stration.cert
    20 ┃ 
    21 ┃     void $ OP.execCardanoCLI
    22 ┃         [ "shelley","stake-address","registration-certificate"
    23 ┃         , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
    24 ┃         , "--out-files", registrationCertFile
    25 ┃         ]
       ┃         ^
       ┃         │ Process exited with non-zero exit-code
       ┃         │ ━━━━ command ━━━━
       ┃         │ cardano-cli shelley stake-address registration-certificate --staking-verification-key-file test/Test/golden/shelley/keys/stake_keys/verification_key --out-files "tmp/stake-address-registration-certificate/test-3a457631a893b18b/regi stration.cert"
       ┃         │ ━━━━ stdout ━━━━
       ┃         │ 
       ┃         │ ━━━━ stderr ━━━━
       ┃         │ Invalid option `--out-files'
       ┃         │ 
       ┃         │ Did you mean this?
       ┃         │     --out-file
       ┃         │ 
       ┃         │ Usage: cardano-cli shelley stake-address registration-certificate --stake-verification-key-file FILE
       ┃         │                                                                   --out-file FILE
       ┃         │   Create a stake address registration certificate
       ┃         │ 
       ┃         │ ━━━━ exit code ━━━━
       ┃         │ 1
    26 ┃ 
    27 ┃     OP.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
  
    This failure can be reproduced by running:
    > recheck (Size 0) (Seed 6318384335668956750 240684346131424873) golden_shelleyStakeAddressRegistrationCertificate
```
