### PR TITLE
Minor dependency trimming

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -414,13 +414,6 @@ source-repository-package
   --sha256: 1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04
   subdir: cborg
 
-source-repository-package
-  type: git
-  location: https://github.com/snoyberg/http-client.git
-  tag: 1a75bdfca014723dd5d40760fad854b3f0f37156
-  --sha256: 0537bjhk9bzhvl76haswsv7xkkyzrmv5xfph3fydcd953q08hqdb
-  subdir: http-client
-
 constraints:
     ip < 1.5
   , hedgehog >= 1.0

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -41,7 +41,6 @@ library
                      , aeson
                      , async
                      , base16-bytestring
-                     , byron-spec-ledger
                      , bytestring
                      , canonical-json >= 0.6 && < 0.7
                      , cardano-binary

--- a/cardano-config/src/Cardano/Config/LedgerQueries.hs
+++ b/cardano-config/src/Cardano/Config/LedgerQueries.hs
@@ -14,8 +14,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Unary
 
-import           Byron.Spec.Ledger.Core (Relation(..))
-
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
@@ -35,7 +33,7 @@ class LedgerQueries blk where
   ledgerUtxoSize :: LedgerState blk -> Int
 
 instance LedgerQueries Byron.ByronBlock where
-  ledgerUtxoSize = size . Byron.unUTxO . Byron.cvsUtxo . Byron.byronLedgerState
+  ledgerUtxoSize = Map.size . Byron.unUTxO . Byron.cvsUtxo . Byron.byronLedgerState
 
 instance LedgerQueries (Shelley.ShelleyBlock c) where
   ledgerUtxoSize =


### PR DESCRIPTION
I was actually hoping to remove all dependencies on the ledger testsuites, which bring in `lens`, `goblins`, the byron spec ledger (totally unused by `cardano-node`), but the ledger testsuites are used by the tests of the node.

I'm getting rid of `lens` in another way here: https://github.com/input-output-hk/cardano-ledger-specs/pull/1705

So this PR barely does any dependency trimming, but it would have been a shame to throw away this minor cleanup.