### PR TITLE
CAD-1395: LiveView, correct quitting.

### DIFF
--- a/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
+++ b/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
@@ -320,8 +320,11 @@ eventHandler lvs  (VtyEvent e)         =
         Vty.EvKey  Vty.KEsc        []        -> continue $ lvs { lvsScreen = MainView }
         _                                -> continue lvs
   where
-    stopNodeThread :: MonadIO m => m ()
-    stopNodeThread =
+    stopNodeThread :: MonadIO m => m (Async ())
+    stopNodeThread = liftIO $ Async.async $ do
+      -- Because of this 100ms delay, Vty will be halted _before_ stopping node's thread.
+      -- It keeps the terminal in the normal state after quitting.
+      threadDelay 100000
       case getLVThread (lvsNodeThread lvs) of
         Nothing -> return ()
         Just t  -> liftIO $ Async.cancel t


### PR DESCRIPTION
This PR fixes a bug: https://github.com/input-output-hk/cardano-node/issues/1454

There was a problem with terminal's state after quitting the node from the `LiveView`-mode: TUI artifacts and broken cursor. Now threads are stopping in another order, so the terminal has correct state after quitting.