### PR TITLE
Add legacy key generation documentation

### DIFF
--- a/doc/stake-pool-operations/keys_and_addresses.md
+++ b/doc/stake-pool-operations/keys_and_addresses.md
@@ -16,6 +16,21 @@ cardano-cli shelley address key-gen \
 ```
 This creates two files (`payment.vkey` and `payment.skey`), one containing the _public verification key_, one the _private signing key_.
 
+#### Legacy key
+
+To generate Byron-era _payment key:
+
+Payment key files use the following format:
+```json
+{
+    "type": "PaymentSigningKeyByron_ed25519_bip32",
+    "description": "Payment Signing Key",
+    "cborHex": "hex-here"
+}
+```
+
+Where the `hex-here` is generated as `0x5880 | xprv | pub | chaincode`
+
 #### Stake key pair
 To generate a _stake key pair_ :
 


### PR DESCRIPTION
I can't find any command for generating legacy keys and there are no tests for this, but empirically this works. I also documented the format for the cborHex in the legacy payment key case since it's really not obvious (you would think it's just the `xprv | chaincode`)