### PR TITLE
Add cardano-cli as build-tools

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -234,3 +234,5 @@ test-suite cardano-cli-test
                         -Wpartial-fields
                         -Wcompat
                         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+  build-tools:          cardano-cli


### PR DESCRIPTION
This ensures that `cabal test all` will first compile the `cardano-cli` executable.