### PR TITLE
Infer temporary test workspace name from module name

### DIFF
--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
@@ -16,7 +16,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressBuild :: Property
-golden_shelleyAddressBuild = OP.propertyOnce $ OP.workspace "tmp/address-build" $ \tempDir -> do
+golden_shelleyAddressBuild = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/payment_keys/verification_key"
   addressSKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
   goldenStakingAddressHexFile <- OP.noteInputFile "test/Test/golden/shelley/addresses/staking-address.hex"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
@@ -16,7 +16,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressKeyGen :: Property
-golden_shelleyAddressKeyGen = OP.propertyOnce $ OP.workspace "tmp/address-key-gen" $ \tempDir -> do
+golden_shelleyAddressKeyGen = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- OP.noteTempFile tempDir "address.vkey"
   addressSKeyFile <- OP.noteTempFile tempDir "address.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
@@ -71,7 +71,7 @@ parseTotalSupply = J.withObject "Object" $ \ o -> do
 
 golden_shelleyGenesisCreate :: Property
 golden_shelleyGenesisCreate = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-create" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     sourceGenesisSpecFile <- OP.noteInputFile "test/Test/golden/shelley/genesis/genesis.spec.json"
     genesisSpecFile <- OP.noteTempFile tempDir "genesis.spec.json"
 
@@ -146,7 +146,7 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
       OP.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
       OP.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
-  OP.workspace "tmp/genesis-create" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     let genesisFile = tempDir <> "/genesis.json"
 
     fmtStartTime <- fmap formatIso8601 $ liftIO DT.getCurrentTime

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
@@ -15,7 +15,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyGenesisInitialTxIn :: Property
 golden_shelleyGenesisInitialTxIn = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-initial-txin" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
     goldenUtxoHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
     utxoHashFile <- OP.noteTempFile tempDir "utxo_hash"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyGenesisKeyGenDelegate :: Property
 golden_shelleyGenesisKeyGenDelegate = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-key-gen-delegate" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
     operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "op-cert.counter"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyGenesisKeyGenGenesis :: Property
 golden_shelleyGenesisKeyGenGenesis = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-key-gen-genesis" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyGenesisKeyGenUtxo :: Property
 golden_shelleyGenesisKeyGenUtxo = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-key-gen-utxo" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     utxoVerificationKeyFile <- OP.noteTempFile tempDir "utxo.vkey"
     utxoSigningKeyFile <- OP.noteTempFile tempDir "utxo.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
@@ -15,7 +15,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyGenesisKeyHash :: Property
 golden_shelleyGenesisKeyHash = OP.propertyOnce $ do
-  OP.workspace "tmp/genesis-key-hash" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     referenceVerificationKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key"
     goldenGenesisVerificationKeyHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key.key-hash"
     genesisVerificationKeyHashFile <- OP.noteTempFile tempDir "key-hash.hex"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Metadata/StakePoolMetadata.hs
@@ -9,12 +9,10 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 golden_stakePoolMetadataHash :: Property
-golden_stakePoolMetadataHash =
-    propertyOnce $ do
-
+golden_stakePoolMetadataHash = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
       let referenceStakePoolMetaData = "test/Test/golden/shelley/metadata/stake_pool_metadata_hash"
 
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
@@ -15,7 +15,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyNodeIssueOpCert :: Property
 golden_shelleyNodeIssueOpCert = OP.propertyOnce $ do
-  OP.workspace "tmp/node-issue-op-cert" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     hotKesVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/kes_keys/verification_key"
     coldSigningKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"
     originalOperationalCertificateIssueCounterFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyNodeKeyGen :: Property
 golden_shelleyNodeKeyGen = OP.propertyOnce $ do
-  OP.workspace "tmp/node-key-gen" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
     opCertCounterFile <- OP.noteTempFile tempDir "op-cert.counter"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyNodeKeyGenKes :: Property
 golden_shelleyNodeKeyGenKes = OP.propertyOnce $ do
-  OP.workspace "tmp/node-key-gen-kes" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- OP.noteTempFile tempDir "kes.vkey"
     signingKey <- OP.noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyNodeKeyGenVrf :: Property
 golden_shelleyNodeKeyGenVrf = OP.propertyOnce $ do
-  OP.workspace "tmp/node-key-gen-vrf" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKey <- OP.noteTempFile tempDir "kes.vkey"
     signingKey <- OP.noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
@@ -15,7 +15,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyStakeAddressBuild :: Property
 golden_shelleyStakeAddressBuild = OP.propertyOnce $ do
-  OP.workspace "tmp/stake-address-build" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     rewardAddressFile <- OP.noteTempFile tempDir "reward-address.hex"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyStakeAddressDeregistrationCertificate :: Property
 golden_shelleyStakeAddressDeregistrationCertificate = OP.propertyOnce $ do
-  OP.workspace "tmp/stake-address-deregistration-certificate" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     deregistrationCertFile <- OP.noteTempFile tempDir "deregistrationCertFile"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyStakeAddressKeyGen :: Property
 golden_shelleyStakeAddressKeyGen = OP.propertyOnce $ do
-  OP.workspace "tmp/stake-address-key-gen" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     verificationKeyFile <- OP.noteTempFile tempDir "kes.vkey"
     signingKeyFile <- OP.noteTempFile tempDir "kes.skey"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyStakeAddressRegistrationCertificate :: Property
 golden_shelleyStakeAddressRegistrationCertificate = OP.propertyOnce $ do
-  OP.workspace "tmp/stake-address-registration-certificate" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     keyGenStakingVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
     registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakePool/RegistrationCertificate.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 
 golden_shelleyStakePoolRegistrationCertificate :: Property
 golden_shelleyStakePoolRegistrationCertificate = OP.propertyOnce $ do
-  OP.workspace "tmp/stake-pool-registration-certificate" $ \tempDir -> do
+  OP.moduleWorkspace "tmp" $ \tempDir -> do
     operatorVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/operator.vkey"
     vrfVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/vrf.vkey"
     ownerVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/owner.vkey"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/MIRCertificate.hs
@@ -11,14 +11,13 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 -- | 1. Generate stake key pair
 --   2. Create MIR certificate
 --   s. Check the TextEnvelope serialization format has not changed.
 golden_shelleyMIRCertificate :: Property
-golden_shelleyMIRCertificate =
-  propertyOnce $ do
+golden_shelleyMIRCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceMIRCertificate = "test/Test/golden/shelley/certificates/mir_certificate"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/OperationalCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/OperationalCertificate.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 -- | 1. Create KES key pair.
 --   2. Create cold keys.
 --   3. Create operational certificate.
 --   4. Check the TextEnvelope serialization format has not changed.
 golden_shelleyOperationalCertificate :: Property
-golden_shelleyOperationalCertificate =
-  propertyOnce $ do
-
+golden_shelleyOperationalCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceOperationalCertificate = "test/Test/golden/shelley/certificates/operational_certificate"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -11,15 +11,13 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeAddressCertificates :: Property
-golden_shelleyStakeAddressCertificates =
-  propertyOnce $ do
-
+golden_shelleyStakeAddressCertificates = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference files
     let referenceRegistrationCertificate = "test/Test/golden/shelley/certificates/stake_address_registration_certificate"
         referenceDeregistrationCertificate = "test/Test/golden/shelley/certificates/stake_address_deregistration_certificate"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakePoolCertificates.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakePoolCertificates.hs
@@ -11,7 +11,7 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 -- | 1. Create cold key pair.
 --   2. Create stake key pair.
@@ -20,9 +20,7 @@ import           Test.OptParse
 --   5. Create stake pool deregistration/retirement certificate.
 --   6. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakePoolCertificates :: Property
-golden_shelleyStakePoolCertificates =
-  propertyOnce $ do
-
+golden_shelleyStakePoolCertificates = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference files
     let referenceRegistrationCertificate = "test/Test/golden/shelley/certificates/stake_pool_registration_certificate"
         referenceDeregistrationCertificate = "test/Test/golden/shelley/certificates/stake_pool_deregistration_certificate"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyExtendedPaymentKeys :: Property
-golden_shelleyExtendedPaymentKeys =
-  propertyOnce $ do
-
+golden_shelleyExtendedPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/extended_payment_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/extended_payment_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair & operational certificate counter file
 --   2. Check for the existence of the key pair & counter file
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisDelegateKeys :: Property
-golden_shelleyGenesisDelegateKeys =
-  propertyOnce $ do
-
+golden_shelleyGenesisDelegateKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/genesis_delegate_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed
 golden_shelleyGenesisKeys :: Property
-golden_shelleyGenesisKeys =
-  propertyOnce $ do
-
+golden_shelleyGenesisKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/genesis_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/genesis_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisUTxOKeys :: Property
-golden_shelleyGenesisUTxOKeys =
-  propertyOnce $ do
-
+golden_shelleyGenesisUTxOKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/genesis_utxo_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/genesis_utxo_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/KESKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyKESKeys :: Property
-golden_shelleyKESKeys =
-  propertyOnce $ do
-
+golden_shelleyKESKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/kes_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/kes_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/PaymentKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyPaymentKeys :: Property
-golden_shelleyPaymentKeys =
-  propertyOnce $ do
-
+golden_shelleyPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/payment_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/payment_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/StakeKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeKeys :: Property
-golden_shelleyStakeKeys =
-  propertyOnce $ do
-
+golden_shelleyStakeKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/stake_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/stake_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/VRFKeys.hs
@@ -11,16 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
-golden_shelleyVRFKeys =
-  propertyOnce $ do
-
+golden_shelleyVRFKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceVerKey = "test/Test/golden/shelley/keys/vrf_keys/verification_key"
         referenceSignKey = "test/Test/golden/shelley/keys/vrf_keys/signing_key"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Tx.hs
@@ -11,15 +11,14 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Create tx body
 --   3. Sign tx body
 --   4. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTx :: Property
-golden_shelleyTx =
-  propertyOnce $ do
+golden_shelleyTx = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceTx = "test/Test/golden/shelley/tx/tx"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/TxBody.hs
@@ -11,14 +11,13 @@ import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 
-import           Test.OptParse
+import           Test.OptParse as OP
 
 
 -- | 1. We create a 'TxBody Shelley' file.
 --   2. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTxBody :: Property
-golden_shelleyTxBody =
-  propertyOnce $ do
+golden_shelleyTxBody = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
     -- Reference keys
     let referenceTxBody = "test/Test/golden/shelley/tx/txbody"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextView/DecodeCbor.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTextViewDecodeCbor :: Property
-golden_shelleyTextViewDecodeCbor = OP.propertyOnce $ OP.workspace "tmp/decode-cbor" $ \tempDir -> do
+golden_shelleyTextViewDecodeCbor = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   unsignedTxFile <- OP.noteInputFile "test/Test/golden/shelley/tx/unsigned.tx"
   decodedTxtFile <- OP.noteTempFile tempDir "decoded.txt"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Build.hs
@@ -13,7 +13,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionBuild :: Property
-golden_shelleyTransactionBuild = OP.propertyOnce $ OP.workspace "tmp/transaction-build" $ \tempDir -> do
+golden_shelleyTransactionBuild = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   -- Use the same (faked) TxIn for both transactions.
   let txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
 

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/CalculateMinFee.hs
@@ -14,7 +14,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionCalculateMinFee :: Property
-golden_shelleyTransactionCalculateMinFee = OP.propertyOnce $ OP.workspace "tmp/transaction-calculate-min-fee" $ \tempDir -> do
+golden_shelleyTransactionCalculateMinFee = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   protocolParamsJsonFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-calculate-min-fee/protocol-params.json"
   txBodyFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-calculate-min-fee/tx-body-file"
   minFeeTxtFile <- OP.noteTempFile tempDir "min-fee.txt"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Sign.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Sign.hs
@@ -13,7 +13,7 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionSign :: Property
-golden_shelleyTransactionSign = OP.propertyOnce $ OP.workspace "tmp/transaction-calculate-min-fee" $ \tempDir -> do
+golden_shelleyTransactionSign = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-sign/tx-body-file"
   initialUtxo1SigningKeyFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-sign/initial-utxo1.skey"
   initialUtxo2SigningKeyFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-sign/initial-utxo2.skey"


### PR DESCRIPTION
A workspace is a temporary directory created for CLI tests so that the CLI can write to it.  The directory is cleaned up if the test is successful, but left behind for inspection if it fails.

This change infers the workspace name from the module name rather than use a hard coded string.  The module name is derived from the call stack, which is something we already have.

### Rationale
I was finding I was spending a lot of time fine combing through the workspace names to make sure they are correct.  Inferring the name saves time and reduces the opportunity for error.

Also previously I've chosen some derivative of the command name as the workspace name, but some tests invoke multiple commands, so the correct name is not clear.

Finally, using the module name makes it easy to match up the output files to the module that contains the failing test.

I'm about to modernise the remaining hedgehog tests to use workspaces (among other things) so having this change will save time there.

### Example
The PR results in the following change in workspace names.

From:
```
cardano-cli/tmp/address-build
cardano-cli/tmp/address-key-gen
cardano-cli/tmp/decode-cbor
cardano-cli/tmp/genesis-create
cardano-cli/tmp/genesis-initial-txin
cardano-cli/tmp/genesis-key-gen-delegate
cardano-cli/tmp/genesis-key-gen-utxo
cardano-cli/tmp/genesis-key-hash
cardano-cli/tmp/node-issue-op-cert
cardano-cli/tmp/node-key-gen
cardano-cli/tmp/node-key-gen-kes
cardano-cli/tmp/node-key-gen-vrf
cardano-cli/tmp/stake-address-build
cardano-cli/tmp/stake-address-deregistration-certificate
cardano-cli/tmp/stake-address-key-gen
cardano-cli/tmp/stake-address-registration-certificate
cardano-cli/tmp/stake-pool-registration-certificate
cardano-cli/tmp/transaction-build
cardano-cli/tmp/transaction-calculate-min-fee
```

To:
```
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.Create
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.InitialTxIn
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.KeyGenDelegate
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.KeyGenGenesis
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.KeyGenUtxo
cardano-cli/tmp/Test.CLI.Shelley.Golden.Genesis.KeyHash
cardano-cli/tmp/Test.CLI.Shelley.Golden.Node.IssueOpCert
cardano-cli/tmp/Test.CLI.Shelley.Golden.Node.KeyGen
cardano-cli/tmp/Test.CLI.Shelley.Golden.Node.KeyGenKes
cardano-cli/tmp/Test.CLI.Shelley.Golden.Node.KeyGenVrf
cardano-cli/tmp/Test.CLI.Shelley.Golden.StakeAddress.Build
cardano-cli/tmp/Test.CLI.Shelley.Golden.StakeAddress.DeregistrationCertificate
cardano-cli/tmp/Test.CLI.Shelley.Golden.StakeAddress.KeyGen
cardano-cli/tmp/Test.CLI.Shelley.Golden.StakeAddress.RegistrationCertificate
cardano-cli/tmp/Test.CLI.Shelley.Golden.StakePool.RegistrationCertificate
cardano-cli/tmp/Test.CLI.Shelley.Golden.TextView.DecodeCbor
cardano-cli/tmp/Test.CLI.Shelley.Golden.Transaction.Build
cardano-cli/tmp/Test.CLI.Shelley.Golden.Transaction.CalculateMinFee
cardano-cli/tmp/Test.CLI.Shelley.Golden.Transaction.Sign
```