### PR TITLE
Tidy up remaining tests

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -234,3 +234,5 @@ test-suite cardano-cli-test
                         -Wpartial-fields
                         -Wcompat
                         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+  build-tools:          cardano-cli

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Build.hs
@@ -5,18 +5,15 @@ module Test.CLI.Shelley.Golden.Address.Build
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
-import qualified Control.DeepSeq as CSD
-import qualified Control.Exception as E
 import qualified System.IO as IO
 import qualified Test.OptParse as OP
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressBuild :: Property
-golden_shelleyAddressBuild = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyAddressBuild = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/payment_keys/verification_key"
   addressSKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
   goldenStakingAddressHexFile <- OP.noteInputFile "test/Test/golden/shelley/addresses/staking-address.hex"
@@ -24,32 +21,32 @@ golden_shelleyAddressBuild = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempD
   stakingAddressHexFile <- OP.noteTempFile tempDir "staking-address.hex"
   enterpriseAddressHexFile <- OP.noteTempFile tempDir "enterprise-address.hex"
 
-  void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressVKeyFile
+  void $ OP.readFile addressVKeyFile
 
-  stakingAddressText <- OP.noteEvalM $ OP.execCardanoCLI
+  stakingAddressText <- OP.execCardanoCLI
     [ "shelley","address","build"
     , "--testnet-magic", "14"
     , "--payment-verification-key-file", addressVKeyFile
     , "--staking-verification-key-file", addressSKeyFile
     ]
 
-  goldenStakingAddressHex <- OP.noteEvalM . liftIO $ IO.readFile goldenStakingAddressHexFile
+  goldenStakingAddressHex <- OP.readFile goldenStakingAddressHexFile
 
   liftIO $ IO.writeFile stakingAddressHexFile stakingAddressText
 
-  OP.equivalence [] stakingAddressText goldenStakingAddressHex
+  OP.equivalence stakingAddressText goldenStakingAddressHex
 
-  void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressSKeyFile
+  void $ OP.readFile addressSKeyFile
 
-  enterpriseAddressText <- OP.noteEvalM $ OP.execCardanoCLI
+  enterpriseAddressText <- OP.execCardanoCLI
     [ "shelley","address","build"
     , "--testnet-magic", "14"
     , "--payment-verification-key-file", addressVKeyFile
     , "--staking-verification-key-file", addressSKeyFile
     ]
 
-  goldenEnterpriseAddressHex <- OP.noteEvalM . liftIO $ IO.readFile goldenEnterpriseAddressHexFile
+  goldenEnterpriseAddressHex <- OP.readFile goldenEnterpriseAddressHexFile
 
   liftIO $ IO.writeFile enterpriseAddressHexFile enterpriseAddressText
 
-  OP.equivalence [] enterpriseAddressText goldenEnterpriseAddressHex
+  OP.equivalence enterpriseAddressText goldenEnterpriseAddressHex

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Info.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/Info.hs
@@ -20,7 +20,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
   when False $ do
     let byronBase58 = "DdzFFzCqrhsg9F1joqXWJdGKwn6MaNavCqPsrZcjADRjA4ifEtrBmREJZyCojtuexKjMKNFr6CoU7Gx6PPR7pq14JxvPZuuk2xVkzn8p"
 
-    infoText1 <- OP.noteEvalM $ OP.execCardanoCLI
+    infoText1 <- OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", byronBase58
       ]
@@ -30,7 +30,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
 
     let byronHex = "82d818584283581c120e97e4ca7b831373c1060853d4896314e17d567a5723879b9a20eaa101581e581c135a115dd5dba68c28fb7e9409729ffc0503219ff7f9c08e84d13319001a28d0b871"
 
-    infoText2 <- OP.noteEvalM $ OP.execCardanoCLI
+    infoText2 <- OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", byronHex
       ]
@@ -40,7 +40,7 @@ golden_shelleyAddressInfo = OP.propertyOnce $ do
 
     let shelleyHex = "82065820d8b4a892f2f6f1820d350c207d17d4cd7e7a1f7e0a83059e2d698a65ab8f96ed"
 
-    infoText3 <- OP.noteEvalM $ OP.execCardanoCLI
+    infoText3 <- OP.execCardanoCLI
       [ "shelley","address","info"
       , "--address", shelleyHex
       ]

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Address/KeyGen.hs
@@ -5,18 +5,14 @@ module Test.CLI.Shelley.Golden.Address.KeyGen
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
-import qualified Control.DeepSeq as CSD
-import qualified Control.Exception as E
-import qualified System.IO as IO
 import qualified Test.OptParse as OP
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressKeyGen :: Property
-golden_shelleyAddressKeyGen = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyAddressKeyGen = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- OP.noteTempFile tempDir "address.vkey"
   addressSKeyFile <- OP.noteTempFile tempDir "address.skey"
 
@@ -26,8 +22,8 @@ golden_shelleyAddressKeyGen = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \temp
     , "--signing-key-file", addressSKeyFile
     ]
 
-  void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressVKeyFile
-  void $ OP.noteEvalM $ liftIO $ E.evaluate . CSD.force =<< IO.readFile addressSKeyFile
+  void $ OP.readFile addressVKeyFile
+  void $ OP.readFile addressSKeyFile
 
   OP.assertFileOccurences 1 "PaymentVerificationKeyShelley" addressVKeyFile
   OP.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/Create.hs
@@ -6,35 +6,23 @@ module Test.CLI.Shelley.Golden.Genesis.Create
   ) where
 
 import           Cardano.Prelude
-
+import           Hedgehog (Property, forAll, (===))
 import           Prelude (String)
 
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Types as J
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
-import qualified Data.Time.Clock as DT
-import qualified Data.Time.Format as DT
-import qualified System.Directory as IO
-
-import           Hedgehog (Property, forAll, (===))
-
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
+import qualified Data.Time.Clock as DT
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as G
 import qualified Hedgehog.Range as R
+import qualified System.Directory as IO
 import qualified Test.OptParse as OP
 
 {- HLINT ignore "Use camelCase" -}
-
--- | Format the given time as an ISO 8601 date-time string
-formatIso8601 :: DT.UTCTime -> String
-formatIso8601 = DT.formatTime DT.defaultTimeLocale (DT.iso8601DateFormat (Just "%H:%M:%SZ"))
-
--- | Return the supply value with the result of the supplied function as a tuple
-withSnd :: (a -> b) -> a -> (a, b)
-withSnd f a = (a, f a)
 
 parseMaxLovelaceSupply :: J.Value -> J.Parser Int
 parseMaxLovelaceSupply = J.withObject "Object" $ \o -> o J..: "maxLovelaceSupply"
@@ -79,11 +67,11 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
 
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap OP.formatIso8601 $ liftIO DT.getCurrentTime
 
-    (supply, fmtSupply) <- fmap (withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
-    (delegateCount, fmtDelegateCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
-    (utxoCount, fmtUtxoCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
+    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
+    (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
+    (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
 
     -- Create the genesis json file and required keys
     void $ OP.execCardanoCLI
@@ -149,11 +137,11 @@ golden_shelleyGenesisCreate = OP.propertyOnce $ do
   OP.moduleWorkspace "tmp" $ \tempDir -> do
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap OP.formatIso8601 $ liftIO DT.getCurrentTime
 
-    (supply, fmtSupply) <- fmap (withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
-    (delegateCount, fmtDelegateCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
-    (utxoCount, fmtUtxoCount) <- fmap (withSnd show) $ forAll $ G.int (R.linear 4 19)
+    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
+    (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
+    (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
 
     -- Create the genesis json file and required keys
     void $ OP.execCardanoCLI

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/InitialTxIn.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Genesis.InitialTxIn
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified System.IO as IO
@@ -14,20 +13,19 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisInitialTxIn :: Property
-golden_shelleyGenesisInitialTxIn = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
-    goldenUtxoHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
-    utxoHashFile <- OP.noteTempFile tempDir "utxo_hash"
+golden_shelleyGenesisInitialTxIn = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
+  goldenUtxoHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
+  utxoHashFile <- OP.noteTempFile tempDir "utxo_hash"
 
-    utxoHash <- OP.execCardanoCLI
-        [ "shelley","genesis","initial-txin"
-        , "--testnet-magic", "16"
-        , "--verification-key-file", verificationKeyFile
-        ]
+  utxoHash <- OP.execCardanoCLI
+      [ "shelley","genesis","initial-txin"
+      , "--testnet-magic", "16"
+      , "--verification-key-file", verificationKeyFile
+      ]
 
-    liftIO $ IO.writeFile utxoHashFile utxoHash
+  liftIO $ IO.writeFile utxoHashFile utxoHash
 
-    goldenUtxoHash <- OP.noteEvalM . liftIO $ IO.readFile goldenUtxoHashFile
+  goldenUtxoHash <- OP.readFile goldenUtxoHashFile
 
-    OP.equivalence [] utxoHash goldenUtxoHash
+  OP.equivalence utxoHash goldenUtxoHash

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenDelegate.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Genesis.KeyGenDelegate
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,26 +12,25 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenDelegate :: Property
-golden_shelleyGenesisKeyGenDelegate = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
-    signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
-    operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
+golden_shelleyGenesisKeyGenDelegate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
+  operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","genesis","key-gen-delegate"
-        , "--verification-key-file", verificationKeyFile
-        , "--signing-key-file", signingKeyFile
-        , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
-        ]
+  void $ OP.execCardanoCLI
+    [ "shelley","genesis","key-gen-delegate"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
+    ]
 
-    OP.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ verificationKeyFile
-    OP.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ signingKeyFile
-    OP.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ operationalCertificateIssueCounterFile
+  OP.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ verificationKeyFile
+  OP.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ signingKeyFile
+  OP.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ operationalCertificateIssueCounterFile
 
-    OP.assertFileOccurences 1 "Genesis delegate operator key" $ verificationKeyFile
-    OP.assertFileOccurences 1 "Genesis delegate operator key" $ signingKeyFile
+  OP.assertFileOccurences 1 "Genesis delegate operator key" $ verificationKeyFile
+  OP.assertFileOccurences 1 "Genesis delegate operator key" $ signingKeyFile
 
-    OP.assertEndsWithSingleNewline verificationKeyFile
-    OP.assertEndsWithSingleNewline signingKeyFile
-    OP.assertEndsWithSingleNewline operationalCertificateIssueCounterFile
+  OP.assertEndsWithSingleNewline verificationKeyFile
+  OP.assertEndsWithSingleNewline signingKeyFile
+  OP.assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenGenesis.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Genesis.KeyGenGenesis
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,19 +12,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenGenesis :: Property
-golden_shelleyGenesisKeyGenGenesis = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
-    signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
+golden_shelleyGenesisKeyGenGenesis = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","genesis","key-gen-genesis"
-        , "--verification-key-file", verificationKeyFile
-        , "--signing-key-file", signingKeyFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","genesis","key-gen-genesis"
+      , "--verification-key-file", verificationKeyFile
+      , "--signing-key-file", signingKeyFile
+      ]
 
-    OP.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ verificationKeyFile
-    OP.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ signingKeyFile
+  OP.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ verificationKeyFile
+  OP.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ signingKeyFile
 
-    OP.assertEndsWithSingleNewline verificationKeyFile
-    OP.assertEndsWithSingleNewline signingKeyFile
+  OP.assertEndsWithSingleNewline verificationKeyFile
+  OP.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyGenUtxo.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Genesis.KeyGenUtxo
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,19 +12,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenUtxo :: Property
-golden_shelleyGenesisKeyGenUtxo = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    utxoVerificationKeyFile <- OP.noteTempFile tempDir "utxo.vkey"
-    utxoSigningKeyFile <- OP.noteTempFile tempDir "utxo.skey"
+golden_shelleyGenesisKeyGenUtxo = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  utxoVerificationKeyFile <- OP.noteTempFile tempDir "utxo.vkey"
+  utxoSigningKeyFile <- OP.noteTempFile tempDir "utxo.skey"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","genesis","key-gen-utxo"
-        , "--verification-key-file", utxoVerificationKeyFile
-        , "--signing-key-file", utxoSigningKeyFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","genesis","key-gen-utxo"
+      , "--verification-key-file", utxoVerificationKeyFile
+      , "--signing-key-file", utxoSigningKeyFile
+      ]
 
-    OP.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" $ utxoVerificationKeyFile
-    OP.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ utxoSigningKeyFile
+  OP.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" $ utxoVerificationKeyFile
+  OP.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ utxoSigningKeyFile
 
-    OP.assertEndsWithSingleNewline utxoVerificationKeyFile
-    OP.assertEndsWithSingleNewline utxoSigningKeyFile
+  OP.assertEndsWithSingleNewline utxoVerificationKeyFile
+  OP.assertEndsWithSingleNewline utxoSigningKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Genesis/KeyHash.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Genesis.KeyHash
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property, (===))
 
 import qualified System.IO as IO
@@ -14,19 +13,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyHash :: Property
-golden_shelleyGenesisKeyHash = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    referenceVerificationKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key"
-    goldenGenesisVerificationKeyHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key.key-hash"
-    genesisVerificationKeyHashFile <- OP.noteTempFile tempDir "key-hash.hex"
+golden_shelleyGenesisKeyHash = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  referenceVerificationKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key"
+  goldenGenesisVerificationKeyHashFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_keys/verification_key.key-hash"
+  genesisVerificationKeyHashFile <- OP.noteTempFile tempDir "key-hash.hex"
 
-    genesisVerificationKeyHash <- OP.execCardanoCLI
-        [ "shelley","genesis","key-hash"
-        , "--verification-key-file", referenceVerificationKey
-        ]
+  genesisVerificationKeyHash <- OP.execCardanoCLI
+      [ "shelley","genesis","key-hash"
+      , "--verification-key-file", referenceVerificationKey
+      ]
 
-    liftIO $ IO.writeFile genesisVerificationKeyHashFile genesisVerificationKeyHash
+  liftIO $ IO.writeFile genesisVerificationKeyHashFile genesisVerificationKeyHash
 
-    goldenGenesisVerificationKeyHash <- OP.noteEvalM . liftIO $ IO.readFile goldenGenesisVerificationKeyHashFile
+  goldenGenesisVerificationKeyHash <- OP.readFile goldenGenesisVerificationKeyHashFile
 
-    genesisVerificationKeyHash === goldenGenesisVerificationKeyHash
+  genesisVerificationKeyHash === goldenGenesisVerificationKeyHash

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Metadata/StakePoolMetadata.hs
@@ -5,45 +5,32 @@ module Test.CLI.Shelley.Golden.Metadata.StakePoolMetadata
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
+import qualified Test.OptParse as OP
 
 golden_stakePoolMetadataHash :: Property
-golden_stakePoolMetadataHash = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-      let referenceStakePoolMetaData = "test/Test/golden/shelley/metadata/stake_pool_metadata_hash"
+golden_stakePoolMetadataHash = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  referenceStakePoolMetaData <- OP.noteInputFile "test/Test/golden/shelley/metadata/stake_pool_metadata_hash"
 
+  stakePoolMetadataFile <- OP.noteTempFile tempDir "stake-pool-metadata.json"
+  outputStakePoolMetadataHashFp <- OP.noteTempFile tempDir "stake-pool-metadata-hash.txt"
 
-      let stakePoolMetadataFp = "stake-pool-metadata.json"
-          outputStakePoolMetadataHashFp = "stake-pool-metadata-hash.txt"
-          allFiles = [stakePoolMetadataFp, outputStakePoolMetadataHashFp]
+  -- Write the example stake pool metadata to disk
+  liftIO $ writeFile stakePoolMetadataFile exampleStakePoolMetadata
 
-      -- Write the example stake pool metadata to disk
-      liftIO $ writeFile stakePoolMetadataFp exampleStakePoolMetadata
-      assertFilesExist [stakePoolMetadataFp]
+  -- Hash the stake pool metadata
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-pool","metadata-hash"
+    , "--pool-metadata-file", stakePoolMetadataFile
+    , "--out-file", outputStakePoolMetadataHashFp
+    ]
 
-      -- Hash the stake pool metadata
-      execCardanoCLIParser
-        allFiles
-          $ evalCardanoCLIParser [ "shelley","stake-pool","metadata-hash"
-                                , "--pool-metadata-file", stakePoolMetadataFp
-                                , "--out-file", outputStakePoolMetadataHashFp
-                                ]
+  -- Check that the stake pool metadata hash file content is correct.
+  expectedStakePoolMetadataHash <- OP.readFile referenceStakePoolMetaData
+  actualStakePoolMetadataHash <- OP.readFile outputStakePoolMetadataHashFp
 
-      -- Check for existence of the stake pool metadata hash file.
-      assertFilesExist [outputStakePoolMetadataHashFp]
-
-      -- Check that the stake pool metadata hash file content is correct.
-      expectedStakePoolMetadataHash <- liftIO $ readFile referenceStakePoolMetaData
-      actualStakePoolMetadataHash <- liftIO $ readFile outputStakePoolMetadataHashFp
-
-      equivalence allFiles expectedStakePoolMetadataHash actualStakePoolMetadataHash
-
-      liftIO $ fileCleanup allFiles
-
-      H.success
+  OP.equivalence expectedStakePoolMetadataHash actualStakePoolMetadataHash
   where
     exampleStakePoolMetadata :: Text
     exampleStakePoolMetadata = "{\"homepage\":\"https://iohk.io\",\"name\":\"Genesis Pool C\",\"ticker\":\"GPC\",\"description\":\"Lorem Ipsum Dolor Sit Amet.\"}"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/IssueOpCert.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Node.IssueOpCert
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified System.Directory as IO
@@ -14,33 +13,32 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeIssueOpCert :: Property
-golden_shelleyNodeIssueOpCert = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    hotKesVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/kes_keys/verification_key"
-    coldSigningKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"
-    originalOperationalCertificateIssueCounterFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
-    operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "delegate-op-cert.counter"
-    operationalCertFile <- OP.noteTempFile tempDir "operational.cert"
+golden_shelleyNodeIssueOpCert = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  hotKesVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/kes_keys/verification_key"
+  coldSigningKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"
+  originalOperationalCertificateIssueCounterFile <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
+  operationalCertificateIssueCounterFile <- OP.noteTempFile tempDir "delegate-op-cert.counter"
+  operationalCertFile <- OP.noteTempFile tempDir "operational.cert"
 
-    void . liftIO $ IO.copyFile originalOperationalCertificateIssueCounterFile operationalCertificateIssueCounterFile
+  void . liftIO $ IO.copyFile originalOperationalCertificateIssueCounterFile operationalCertificateIssueCounterFile
 
-    -- We could generate the required keys here, but then if the ket generation fails this
-    -- test would also fail which is misleading.
-    -- However, the keys can be generated eg:
-    --    cabal run cardano-cli:cardano-cli -- shelley node key-gen-KES \
-    --        --verification-key-file cardano-cli/test/cli/node-issue-op-cert/data/node-kes.vkey \
-    --        --signing-key-file /dev/null
-    void $ OP.execCardanoCLI
-        [ "shelley","node","issue-op-cert"
-        , "--hot-kes-verification-key-file", hotKesVerificationKeyFile
-        , "--cold-signing-key-file", coldSigningKeyFile
-        , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
-        , "--kes-period", "0"
-        , "--out-file", operationalCertFile
-        ]
+  -- We could generate the required keys here, but then if the KES generation fails this
+  -- test would also fail which is misleading.
+  -- However, the keys can be generated eg:
+  --    cabal run cardano-cli:cardano-cli -- shelley node key-gen-KES \
+  --        --verification-key-file cardano-cli/test/cli/node-issue-op-cert/data/node-kes.vkey \
+  --        --signing-key-file /dev/null
+  void $ OP.execCardanoCLI
+      [ "shelley","node","issue-op-cert"
+      , "--hot-kes-verification-key-file", hotKesVerificationKeyFile
+      , "--cold-signing-key-file", coldSigningKeyFile
+      , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
+      , "--kes-period", "0"
+      , "--out-file", operationalCertFile
+      ]
 
-    OP.assertFileOccurences 1 "NodeOperationalCertificate" $ operationalCertFile
-    OP.assertFileOccurences 1 "Next certificate issue number: 1" $ operationalCertificateIssueCounterFile
+  OP.assertFileOccurences 1 "NodeOperationalCertificate" $ operationalCertFile
+  OP.assertFileOccurences 1 "Next certificate issue number: 1" $ operationalCertificateIssueCounterFile
 
-    OP.assertEndsWithSingleNewline operationalCertFile
-    OP.assertEndsWithSingleNewline operationalCertificateIssueCounterFile
+  OP.assertEndsWithSingleNewline operationalCertFile
+  OP.assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGen.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Node.KeyGen
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,23 +12,22 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGen :: Property
-golden_shelleyNodeKeyGen = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
-    signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
-    opCertCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
+golden_shelleyNodeKeyGen = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- OP.noteTempFile tempDir "key-gen.skey"
+  opCertCounterFile <- OP.noteTempFile tempDir "op-cert.counter"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","node","key-gen"
-        , "--verification-key-file", verificationKeyFile
-        , "--signing-key-file", signingKeyFile
-        , "--operational-certificate-issue-counter", opCertCounterFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","node","key-gen"
+      , "--verification-key-file", verificationKeyFile
+      , "--signing-key-file", signingKeyFile
+      , "--operational-certificate-issue-counter", opCertCounterFile
+      ]
 
-    OP.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" $ verificationKeyFile
-    OP.assertFileOccurences 1 "StakePoolSigningKey_ed25519" $ signingKeyFile
-    OP.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ opCertCounterFile
+  OP.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" $ verificationKeyFile
+  OP.assertFileOccurences 1 "StakePoolSigningKey_ed25519" $ signingKeyFile
+  OP.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ opCertCounterFile
 
-    OP.assertEndsWithSingleNewline verificationKeyFile
-    OP.assertEndsWithSingleNewline signingKeyFile
-    OP.assertEndsWithSingleNewline opCertCounterFile
+  OP.assertEndsWithSingleNewline verificationKeyFile
+  OP.assertEndsWithSingleNewline signingKeyFile
+  OP.assertEndsWithSingleNewline opCertCounterFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenKes.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Node.KeyGenKes
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,19 +12,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGenKes :: Property
-golden_shelleyNodeKeyGenKes = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKey <- OP.noteTempFile tempDir "kes.vkey"
-    signingKey <- OP.noteTempFile tempDir "kes.skey"
+golden_shelleyNodeKeyGenKes = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- OP.noteTempFile tempDir "kes.vkey"
+  signingKey <- OP.noteTempFile tempDir "kes.skey"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","node","key-gen-KES"
-        , "--verification-key-file", verificationKey
-        , "--signing-key-file", signingKey
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","node","key-gen-KES"
+      , "--verification-key-file", verificationKey
+      , "--signing-key-file", signingKey
+      ]
 
-    OP.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
-    OP.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+  OP.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
+  OP.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
 
-    OP.assertEndsWithSingleNewline verificationKey
-    OP.assertEndsWithSingleNewline signingKey
+  OP.assertEndsWithSingleNewline verificationKey
+  OP.assertEndsWithSingleNewline signingKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Node/KeyGenVrf.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.Node.KeyGenVrf
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,19 +12,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGenVrf :: Property
-golden_shelleyNodeKeyGenVrf = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKey <- OP.noteTempFile tempDir "kes.vkey"
-    signingKey <- OP.noteTempFile tempDir "kes.skey"
+golden_shelleyNodeKeyGenVrf = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- OP.noteTempFile tempDir "kes.vkey"
+  signingKey <- OP.noteTempFile tempDir "kes.skey"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","node","key-gen-VRF"
-        , "--verification-key-file", verificationKey
-        , "--signing-key-file", signingKey
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","node","key-gen-VRF"
+      , "--verification-key-file", verificationKey
+      , "--signing-key-file", signingKey
+      ]
 
-    OP.assertFileOccurences 1 "VRF Verification Key" verificationKey
-    OP.assertFileOccurences 1 "VRF Signing Key" signingKey
+  OP.assertFileOccurences 1 "VRF Verification Key" verificationKey
+  OP.assertFileOccurences 1 "VRF Signing Key" signingKey
 
-    OP.assertEndsWithSingleNewline verificationKey
-    OP.assertEndsWithSingleNewline signingKey
+  OP.assertEndsWithSingleNewline verificationKey
+  OP.assertEndsWithSingleNewline signingKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/Build.hs
@@ -5,26 +5,23 @@ module Test.CLI.Shelley.Golden.StakeAddress.Build
   ) where
 
 import           Cardano.Prelude
+import           Hedgehog (Property)
 
-import           Hedgehog (Property, (===))
-
-import qualified System.IO as IO
 import qualified Test.OptParse as OP
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressBuild :: Property
-golden_shelleyStakeAddressBuild = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
-    rewardAddressFile <- OP.noteTempFile tempDir "reward-address.hex"
+golden_shelleyStakeAddressBuild = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
+  verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
+  goldenRewardAddressFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/reward_address"
 
-    rewardAddress <- OP.execCardanoCLI
-        [ "shelley","stake-address","build"
-        , "--mainnet"
-        , "--staking-verification-key-file", verificationKeyFile
-        ]
+  rewardAddress <- OP.execCardanoCLI
+      [ "shelley","stake-address","build"
+      , "--mainnet"
+      , "--staking-verification-key-file", verificationKeyFile
+      ]
 
-    void . liftIO $ IO.writeFile rewardAddressFile rewardAddress
+  goldenRewardsAddress <- OP.readFile goldenRewardAddressFile
 
-    rewardAddress === "stake1uxqmgfzls3vn7c7qlu3fdycz2nmh5p5sl2w7t7tfetp8evqacghf3\n"
+  OP.equivalence rewardAddress goldenRewardsAddress

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/DeregistrationCertificate.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.StakeAddress.DeregistrationCertificate
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,17 +12,16 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressDeregistrationCertificate :: Property
-golden_shelleyStakeAddressDeregistrationCertificate = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
-    deregistrationCertFile <- OP.noteTempFile tempDir "deregistrationCertFile"
+golden_shelleyStakeAddressDeregistrationCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
+  deregistrationCertFile <- OP.noteTempFile tempDir "deregistrationCertFile"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","stake-address","deregistration-certificate"
-        , "--staking-verification-key-file", verificationKeyFile
-        , "--out-file", deregistrationCertFile
-        ]
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","deregistration-certificate"
+    , "--staking-verification-key-file", verificationKeyFile
+    , "--out-file", deregistrationCertFile
+    ]
 
-    OP.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
+  OP.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
 
-    OP.assertEndsWithSingleNewline deregistrationCertFile
+  OP.assertEndsWithSingleNewline deregistrationCertFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/KeyGen.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.StakeAddress.KeyGen
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,19 +12,18 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressKeyGen :: Property
-golden_shelleyStakeAddressKeyGen = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    verificationKeyFile <- OP.noteTempFile tempDir "kes.vkey"
-    signingKeyFile <- OP.noteTempFile tempDir "kes.skey"
+golden_shelleyStakeAddressKeyGen = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- OP.noteTempFile tempDir "kes.vkey"
+  signingKeyFile <- OP.noteTempFile tempDir "kes.skey"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","stake-address","key-gen"
-        , "--verification-key-file", verificationKeyFile
-        , "--signing-key-file", signingKeyFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","stake-address","key-gen"
+      , "--verification-key-file", verificationKeyFile
+      , "--signing-key-file", signingKeyFile
+      ]
 
-    OP.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
-    OP.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
+  OP.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
+  OP.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
 
-    OP.assertEndsWithSingleNewline verificationKeyFile
-    OP.assertEndsWithSingleNewline signingKeyFile
+  OP.assertEndsWithSingleNewline verificationKeyFile
+  OP.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakeAddress/RegistrationCertificate.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.StakeAddress.RegistrationCertificate
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,17 +12,16 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressRegistrationCertificate :: Property
-golden_shelleyStakeAddressRegistrationCertificate = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    keyGenStakingVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
-    registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
+golden_shelleyStakeAddressRegistrationCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  keyGenStakingVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
+  registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","stake-address","registration-certificate"
-        , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
-        , "--out-file", registrationCertFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","stake-address","registration-certificate"
+      , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
+      , "--out-file", registrationCertFile
+      ]
 
-    OP.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
+  OP.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
-    OP.assertEndsWithSingleNewline registrationCertFile
+  OP.assertEndsWithSingleNewline registrationCertFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/StakePool/RegistrationCertificate.hs
@@ -5,7 +5,6 @@ module Test.CLI.Shelley.Golden.StakePool.RegistrationCertificate
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
 import qualified Test.OptParse as OP
@@ -13,26 +12,25 @@ import qualified Test.OptParse as OP
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakePoolRegistrationCertificate :: Property
-golden_shelleyStakePoolRegistrationCertificate = OP.propertyOnce $ do
-  OP.moduleWorkspace "tmp" $ \tempDir -> do
-    operatorVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/operator.vkey"
-    vrfVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/vrf.vkey"
-    ownerVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/owner.vkey"
-    registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
+golden_shelleyStakePoolRegistrationCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  operatorVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/operator.vkey"
+  vrfVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/vrf.vkey"
+  ownerVerificationKeyFile <- OP.noteInputFile "test/Test/golden/shelley/node-pool/owner.vkey"
+  registrationCertFile <- OP.noteTempFile tempDir "registration.cert"
 
-    void $ OP.execCardanoCLI
-        [ "shelley","stake-pool","registration-certificate"
-        , "--testnet-magic", "42"
-        , "--pool-pledge", "0"
-        , "--pool-cost", "0"
-        , "--pool-margin", "0"
-        , "--cold-verification-key-file", operatorVerificationKeyFile
-        , "--vrf-verification-key-file", vrfVerificationKeyFile
-        , "--reward-account-verification-key-file", ownerVerificationKeyFile
-        , "--pool-owner-stake-verification-key-file", ownerVerificationKeyFile
-        , "--out-file", registrationCertFile
-        ]
+  void $ OP.execCardanoCLI
+      [ "shelley","stake-pool","registration-certificate"
+      , "--testnet-magic", "42"
+      , "--pool-pledge", "0"
+      , "--pool-cost", "0"
+      , "--pool-margin", "0"
+      , "--cold-verification-key-file", operatorVerificationKeyFile
+      , "--vrf-verification-key-file", vrfVerificationKeyFile
+      , "--reward-account-verification-key-file", ownerVerificationKeyFile
+      , "--pool-owner-stake-verification-key-file", ownerVerificationKeyFile
+      , "--out-file", registrationCertFile
+      ]
 
-    OP.assertFileOccurences 1 "Stake Pool Registration Certificate" registrationCertFile
+  OP.assertFileOccurences 1 "Stake Pool Registration Certificate" registrationCertFile
 
-    OP.assertEndsWithSingleNewline registrationCertFile
+  OP.assertEndsWithSingleNewline registrationCertFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/GenesisDelegationCertificate.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/GenesisDelegationCertificate.hs
@@ -5,13 +5,7 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Certificates.GenesisDelegation
   ) where
 
 import           Cardano.Prelude
-
---import           Cardano.Api.Typed (AsType(..), HasTextEnvelope (..))
-
 import           Hedgehog (Property)
---import qualified Hedgehog as H
-
---import           Test.OptParse
 
 golden_shelleyGenesisDelegationCertificate :: Property
 golden_shelleyGenesisDelegationCertificate = panic "TODO"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -4,83 +4,71 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Certificates.StakeAddressCertificate
   ( golden_shelleyStakeAddressCertificates
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeAddressCertificates :: Property
-golden_shelleyStakeAddressCertificates = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference files
-    let referenceRegistrationCertificate = "test/Test/golden/shelley/certificates/stake_address_registration_certificate"
-        referenceDeregistrationCertificate = "test/Test/golden/shelley/certificates/stake_address_deregistration_certificate"
+golden_shelleyStakeAddressCertificates = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference files
+  referenceRegistrationCertificate <- OP.noteInputFile "test/Test/golden/shelley/certificates/stake_address_registration_certificate"
+  referenceDeregistrationCertificate <- OP.noteInputFile "test/Test/golden/shelley/certificates/stake_address_deregistration_certificate"
 
-    -- Key filepaths
-    let verKey = "stake-verification-key-file"
-        signKey = "stake-signing-key-file"
-        deregistrationCertificate = "stake-address-deregistration-certificate"
-        registrationCertificate = "stake-address-registration-certificate"
-        createdFiles = [verKey, signKey, deregistrationCertificate, registrationCertificate]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "stake-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "stake-signing-key-file"
+  deregistrationCertificate <- OP.noteTempFile tempDir "stake-address-deregistration-certificate"
+  registrationCertificate <- OP.noteTempFile tempDir "stake-address-registration-certificate"
 
-    -- Generate stake verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","key-gen"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
-    assertFilesExist [verKey, signKey]
+  -- Generate stake verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","key-gen"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    -- Create stake address registration certificate
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","registration-certificate"
-                               , "--stake-verification-key-file", verKey
-                               , "--out-file", registrationCertificate
-                               ]
+  OP.assertFilesExist [verKey, signKey]
 
-    let registrationCertificateType = textEnvelopeType AsCertificate
+  -- Create stake address registration certificate
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","registration-certificate"
+    , "--stake-verification-key-file", verKey
+    , "--out-file", registrationCertificate
+    ]
 
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles registrationCertificateType referenceRegistrationCertificate registrationCertificate
+  let registrationCertificateType = textEnvelopeType AsCertificate
 
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat registrationCertificateType referenceRegistrationCertificate registrationCertificate
 
-    -- Create stake address deregistration certificate
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","deregistration-certificate"
-                               , "--stake-verification-key-file", verKey
-                               , "--out-file", deregistrationCertificate
-                               ]
+  -- Create stake address deregistration certificate
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","deregistration-certificate"
+    , "--stake-verification-key-file", verKey
+    , "--out-file", deregistrationCertificate
+    ]
 
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
 
- -- TODO: After delegation-certificate command is fixed to take a hash instead of a verfication key
- {-
-    -- Create stake address delegation certificate
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","delegation-certificate"
-                               , "--stake-verification-key-file", verKey
-                               , "--cold-verification-key-file", verKey --TODO: Should be stake pool's hash
-                               , "--out-file", deregistrationCertificate
-                               ]
+-- TODO: After delegation-certificate command is fixed to take a hash instead of a verfication key
+{-
+  -- Create stake address delegation certificate
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","delegation-certificate"
+    , "--stake-verification-key-file", verKey
+    , "--cold-verification-key-file", verKey --TODO: Should be stake pool's hash
+    , "--out-file", deregistrationCertificate
+    ]
 
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
-
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
 -}
-
-    liftIO $ fileCleanup createdFiles
-    H.success

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -4,49 +4,37 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.ExtendedPaymentKeys
   ( golden_shelleyExtendedPaymentKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyExtendedPaymentKeys :: Property
-golden_shelleyExtendedPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/extended_payment_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/extended_payment_keys/signing_key"
+golden_shelleyExtendedPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/extended_payment_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "extended-payment-verification-key-file"
-        signKey = "extended-payment-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "extended-payment-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "extended-payment-signing-key-file"
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--extended-key"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--extended-key"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -4,53 +4,41 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisDelegateKeys
   ( golden_shelleyGenesisDelegateKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair & operational certificate counter file
 --   2. Check for the existence of the key pair & counter file
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisDelegateKeys :: Property
-golden_shelleyGenesisDelegateKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/genesis_delegate_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"
-        referenceOpCertCounter = "test/Test/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
+golden_shelleyGenesisDelegateKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/signing_key"
+  referenceOpCertCounter <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
 
-    -- Key filepaths
-    let verKey = "genesis-delegate-verification-key-file"
-        signKey = "genesis-delegate-signing-key-file"
-        opCertCounter = "delegate-operational-cert-counter-file"
-        createdFiles = [opCertCounter, verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "genesis-delegate-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "genesis-delegate-signing-key-file"
+  opCertCounter <- OP.noteTempFile tempDir "delegate-operational-cert-counter-file"
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","genesis","key-gen-delegate"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               , "--operational-certificate-issue-counter-file", opCertCounter
-                               ]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","genesis","key-gen-delegate"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    , "--operational-certificate-issue-counter-file", opCertCounter
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisDelegateKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisDelegateKey)
+      operationalCertCounterType = textEnvelopeType AsOperationalCertificateIssueCounter
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisDelegateKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisDelegateKey)
-        operationalCertCounterType = textEnvelopeType AsOperationalCertificateIssueCounter
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-    checkTextEnvelopeFormat createdFiles operationalCertCounterType referenceOpCertCounter opCertCounter
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  OP.checkTextEnvelopeFormat operationalCertCounterType referenceOpCertCounter opCertCounter

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -4,48 +4,37 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.GenesisUTxOKeys
   ( golden_shelleyGenesisUTxOKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
+import qualified Test.OptParse as OP
 
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisUTxOKeys :: Property
-golden_shelleyGenesisUTxOKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/genesis_utxo_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/genesis_utxo_keys/signing_key"
+golden_shelleyGenesisUTxOKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/genesis_utxo_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "genesis-utxo-verification-key-file"
-        signKey = "genesis-utxo-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "genesis-utxo-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "genesis-utxo-signing-key-file"
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","genesis","key-gen-utxo"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","genesis","key-gen-utxo"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisUTxOKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisUTxOKey)
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisUTxOKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisUTxOKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/KESKeys.hs
@@ -4,48 +4,36 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.KESKeys
   ( golden_shelleyKESKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyKESKeys :: Property
-golden_shelleyKESKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/kes_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/kes_keys/signing_key"
+golden_shelleyKESKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/kes_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "kes-verification-key-file"
-        signKey = "kes-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "kes-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "kes-signing-key-file"
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","node","key-gen-KES"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","node","key-gen-KES"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/PaymentKeys.hs
@@ -4,48 +4,36 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.PaymentKeys
   ( golden_shelleyPaymentKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyPaymentKeys :: Property
-golden_shelleyPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/payment_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/payment_keys/signing_key"
+golden_shelleyPaymentKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/payment_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "payment-verification-key-file"
-        signKey = "payment-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "payment-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "payment-signing-key-file"
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/StakeKeys.hs
@@ -4,48 +4,36 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.StakeKeys
   ( golden_shelleyStakeKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeKeys :: Property
-golden_shelleyStakeKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/stake_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/stake_keys/signing_key"
+golden_shelleyStakeKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/stake_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "stake-verification-key-file"
-        signKey = "stake-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "stake-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "stake-signing-key-file"
 
-    -- Generate stake key pair
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","key-gen"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate stake key pair
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","key-gen"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
 
-
-    let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Keys/VRFKeys.hs
@@ -4,47 +4,36 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Keys.VRFKeys
   ( golden_shelleyVRFKeys
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
-golden_shelleyVRFKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceVerKey = "test/Test/golden/shelley/keys/vrf_keys/verification_key"
-        referenceSignKey = "test/Test/golden/shelley/keys/vrf_keys/signing_key"
+golden_shelleyVRFKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- OP.noteInputFile "test/Test/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <- OP.noteInputFile "test/Test/golden/shelley/keys/vrf_keys/signing_key"
 
-    -- Key filepaths
-    let verKey = "vrf-verification-key-file"
-        signKey = "vrf-signing-key-file"
-        createdFiles = [verKey, signKey]
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "vrf-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "vrf-signing-key-file"
 
-    -- Generate vrf verification key
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","node","key-gen-VRF"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  -- Generate vrf verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","node","key-gen-VRF"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    assertFilesExist createdFiles
+  let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
 
-    let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
-        verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles verificationKeyType referenceVerKey verKey
-    checkTextEnvelopeFormat createdFiles signingKeyType referenceSignKey signKey
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  OP.checkTextEnvelopeFormat signingKeyType referenceSignKey signKey

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Tx.hs
@@ -4,72 +4,55 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Tx.Tx
   ( golden_shelleyTx
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Create tx body
 --   3. Sign tx body
 --   4. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTx :: Property
-golden_shelleyTx = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceTx = "test/Test/golden/shelley/tx/tx"
+golden_shelleyTx = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  let referenceTx = "test/Test/golden/shelley/tx/tx"
 
-    -- Key filepaths
-    let paymentVerKey = "payment-verification-key-file"
-        paymentSignKey = "payment-signing-key-file"
-        transactionFile = "tx-file"
-        transactionBodyFile = "tx-body-file"
-        createdFiles = [ paymentVerKey
-                       , paymentSignKey
-                       , transactionBodyFile
-                       , transactionBodyFile
-                       , transactionFile]
+  -- Key filepaths
+  paymentVerKey <- OP.noteTempFile tempDir "payment-verification-key-file"
+  paymentSignKey <- OP.noteTempFile tempDir "payment-signing-key-file"
+  transactionFile <- OP.noteTempFile tempDir "tx-file"
+  transactionBodyFile <- OP.noteTempFile tempDir "tx-body-file"
 
+  -- Generate payment signing key to sign transaction
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--verification-key-file", paymentVerKey
+    , "--signing-key-file", paymentSignKey
+    ]
 
-    -- Generate payment signing key to sign transaction
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--verification-key-file", paymentVerKey
-                               , "--signing-key-file", paymentSignKey
-                               ]
+  -- Create transaction body
+  void $ OP.execCardanoCLI
+    [ "shelley","transaction", "build-raw"
+    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
+    , "--fee", "1000000"
+    , "--ttl", "500000"
+    , "--out-file", transactionBodyFile
+    ]
 
-    -- Create transaction body
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","transaction", "build-raw"
-                               , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-                               , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
-                               , "--fee", "1000000"
-                               , "--ttl", "500000"
-                               , "--out-file", transactionBodyFile
-                               ]
+  -- Sign transaction
+  void $ OP.execCardanoCLI
+    [ "shelley","transaction", "sign"
+    , "--tx-body-file", transactionBodyFile
+    , "--signing-key-file", paymentSignKey
+    , "--mainnet"
+    , "--out-file", transactionFile
+    ]
 
-    -- Sign transaction
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","transaction", "sign"
-                               , "--tx-body-file", transactionBodyFile
-                               , "--signing-key-file", paymentSignKey
-                               , "--mainnet"
-                               , "--out-file", transactionFile
-                               ]
+  let txType = textEnvelopeType AsShelleyTx
 
-    assertFilesExist createdFiles
-
-    let txType = textEnvelopeType AsShelleyTx
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles txType referenceTx transactionFile
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat txType referenceTx transactionFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/TxBody.hs
@@ -4,46 +4,34 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Tx.TxBody
   ( golden_shelleyTxBody
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse as OP
-
+import qualified Test.OptParse as OP
 
 -- | 1. We create a 'TxBody Shelley' file.
 --   2. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTxBody :: Property
-golden_shelleyTxBody = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \_ -> do
-    -- Reference keys
-    let referenceTxBody = "test/Test/golden/shelley/tx/txbody"
+golden_shelleyTxBody = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceTxBody <- OP.noteInputFile "test/Test/golden/shelley/tx/txbody"
 
-    -- Key filepaths
-    let transactionBodyFile = "transaction-body-file"
-        createdFiles = [transactionBodyFile]
+  -- Key filepaths
+  transactionBodyFile <- OP.noteTempFile tempDir "transaction-body-file"
 
+  -- Create transaction body
+  void $ OP.execCardanoCLI
+    [ "shelley","transaction", "build-raw"
+    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
+    , "--fee", "1000000"
+    , "--ttl", "500000"
+    , "--out-file", transactionBodyFile
+    ]
 
-    -- Create transaction body
-    execCardanoCLIParser
-      createdFiles
-        $ evalCardanoCLIParser [ "shelley","transaction", "build-raw"
-                               , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-                               , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
-                               , "--fee", "1000000"
-                               , "--ttl", "500000"
-                               , "--out-file", transactionBodyFile
-                               ]
+  let txBodyType = textEnvelopeType AsShelleyTxBody
 
-    assertFilesExist createdFiles
-
-    let txBodyType = textEnvelopeType AsShelleyTxBody
-
-    -- Check the newly created files have not deviated from the
-    -- golden files
-    checkTextEnvelopeFormat createdFiles txBodyType referenceTxBody transactionBodyFile
-
-    liftIO $ fileCleanup createdFiles
-    H.success
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  OP.checkTextEnvelopeFormat txBodyType referenceTxBody transactionBodyFile

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Witness.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextEnvelope/Tx/Witness.hs
@@ -5,13 +5,7 @@ module Test.CLI.Shelley.Golden.TextEnvelope.Tx.Witness
   ) where
 
 import           Cardano.Prelude
-
---import           Cardano.Api.Typed (AsType(..), HasTextEnvelope (..))
-
 import           Hedgehog (Property)
---import qualified Hedgehog as H
-
---import           Test.OptParse
 
 golden_shelleyWitness :: Property
 golden_shelleyWitness = panic "TODO"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/TextView/DecodeCbor.hs
@@ -20,7 +20,7 @@ golden_shelleyTextViewDecodeCbor = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ 
 
   -- Defaults to signing a Mainnet transaction.
 
-  decodedTxt <- OP.noteEvalM $ OP.execCardanoCLI
+  decodedTxt <- OP.execCardanoCLI
     [ "shelley","text-view","decode-cbor"
     , "--file", unsignedTxFile
     ]

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Build.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Build.hs
@@ -22,7 +22,7 @@ golden_shelleyTransactionBuild = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \t
 
   txBodyOutFile <- OP.noteTempFile tempDir "tx-body-out"
 
-  void . OP.noteEvalM $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "shelley","transaction","build-raw"
     , "--tx-in", txIn
     , "--tx-out", txOut

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/CalculateMinFee.hs
@@ -19,7 +19,7 @@ golden_shelleyTransactionCalculateMinFee = OP.propertyOnce $ OP.moduleWorkspace 
   txBodyFile <- OP.noteInputFile "test/Test/golden/shelley/transaction-calculate-min-fee/tx-body-file"
   minFeeTxtFile <- OP.noteTempFile tempDir "min-fee.txt"
 
-  minFeeTxt <- OP.noteEvalM $ OP.execCardanoCLI
+  minFeeTxt <- OP.execCardanoCLI
     [ "shelley","transaction","calculate-min-fee"
     , "--tx-in-count", "32"
     , "--tx-out-count", "27"

--- a/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Sign.hs
+++ b/cardano-cli/test/Test/CLI/Shelley/Golden/Transaction/Sign.hs
@@ -25,7 +25,7 @@ golden_shelleyTransactionSign = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \te
 
   -- Defaults to signing a Mainnet transaction
 
-  void . OP.noteEvalM $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "shelley","transaction","sign"
     , "--mainnet"
     , "--tx-body-file", txBodyFile
@@ -38,7 +38,7 @@ golden_shelleyTransactionSign = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \te
 
   -- Sign for a testnet with a testnet network magic of 11, but use two signing keys
 
-  void . OP.noteEvalM $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "shelley","transaction","sign"
     , "--mainnet"
     , "--tx-body-file", txBodyFile
@@ -53,7 +53,7 @@ golden_shelleyTransactionSign = OP.propertyOnce $ OP.moduleWorkspace "tmp" $ \te
   -- Sign a pool registration transaction.
   -- TODO: This needs to use an unsigned tx with a registration certificate
 
-  void . OP.noteEvalM $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "shelley","transaction","sign"
     , "--mainnet"
     , "--tx-body-file", txBodyFile

--- a/cardano-cli/test/Test/CLI/Version.hs
+++ b/cardano-cli/test/Test/CLI/Version.hs
@@ -14,6 +14,6 @@ import qualified Test.OptParse as OP
 
 golden_version :: Property
 golden_version = OP.propertyOnce $ do
-  void . OP.noteEvalM $ OP.execCardanoCLI
+  void $ OP.execCardanoCLI
     [ "version"
     ]

--- a/cardano-cli/test/Test/ITN.hs
+++ b/cardano-cli/test/Test/ITN.hs
@@ -54,73 +54,63 @@ prop_convertITNKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> d
   -- Check for existence of the converted ITN keys
   OP.assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
 
+
 -- | 1. Convert a bech32 ITN extended signing key to a haskell stake signing key
 prop_convertITNExtendedSigningKey :: Property
-prop_convertITNExtendedSigningKey =
-  propertyOnce $ do
-    let itnExtendedSignKey = "ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj\
-                             \f38hkyn0shcycyaha4k9tmjy6xgvzaz7stw5t7rqjadyjcwfyx6k"
+prop_convertITNExtendedSigningKey = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  let itnExtendedSignKey = "\
+    \ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj\
+    \f38hkyn0shcycyaha4k9tmjy6xgvzaz7stw5t7rqjadyjcwfyx6k"
 
-        -- ITN input file paths
-        itnSignKeyFp = "itnExtendedSignKey.key"
+  -- ITN input file paths
+  itnSignKeyFp <- OP.noteTempFile tempDir "itnExtendedSignKey.key"
 
-        -- Converted keys output file paths
-        outputHaskellSignKeyFp = "stake-signing.key"
+  -- Converted keys output file paths
+  outputHaskellSignKeyFp <- OP.noteTempFile tempDir "stake-signing.key"
 
-        allFiles = [itnSignKeyFp, outputHaskellSignKeyFp]
+  -- Write ITN keys to disk
+  liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
+  OP.assertFilesExist [itnSignKeyFp]
 
-    -- Write ITN keys to disk
-    liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
-    assertFilesExist [itnSignKeyFp]
+  -- Generate haskell signing key
+  void $ OP.execCardanoCLI
+    [ "shelley","key","convert-itn-extended-key"
+    , "--itn-signing-key-file", itnSignKeyFp
+    , "--out-file", outputHaskellSignKeyFp
+    ]
 
-    -- Generate haskell signing key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","key","convert-itn-extended-key"
-                               , "--itn-signing-key-file", itnSignKeyFp
-                               , "--out-file", outputHaskellSignKeyFp
-                               ]
-
-    -- Check for existence of the converted ITN keys
-    assertFilesExist [outputHaskellSignKeyFp]
-
-    liftIO $ fileCleanup allFiles
-
-    H.success
+  -- Check for existence of the converted ITN keys
+  OP.assertFilesExist [outputHaskellSignKeyFp]
 
 -- | 1. Convert a bech32 ITN BIP32 signing key to a haskell stake signing key
 prop_convertITNBIP32SigningKey :: Property
-prop_convertITNBIP32SigningKey =
-  propertyOnce $ do
-    let itnExtendedSignKey = "xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka\
-                             \jcza9ud848ckdqf48md9njzc5pkujfxwu2j8wdvtxkx02n3s2qa\
-                             \euhqnfx6zu9dyccpua6vf5x3kur9hsganq2kl0yw7y9hpunts0e9kc5xv3pz0yj"
-        -- ITN input file paths
-        itnSignKeyFp = "itnBIP32SignKey.key"
+prop_convertITNBIP32SigningKey = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  let itnExtendedSignKey = "\
+    \xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka\
+    \jcza9ud848ckdqf48md9njzc5pkujfxwu2j8wdvtxkx02n3s2qa\
+    \euhqnfx6zu9dyccpua6vf5x3kur9hsganq2kl0yw7y9hpunts0e9kc5xv3pz0yj"
 
-        -- Converted keys output file paths
-        outputHaskellSignKeyFp = "stake-signing.key"
+  -- ITN input file paths
+  itnSignKeyFp <- OP.noteTempFile tempDir "itnBIP32SignKey.key"
 
-        allFiles = [itnSignKeyFp, outputHaskellSignKeyFp]
+  -- Converted keys output file paths
+  outputHaskellSignKeyFp <- OP.noteTempFile tempDir "stake-signing.key"
 
-    -- Write ITN keys to disk
-    liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
-    assertFilesExist [itnSignKeyFp]
+  -- Write ITN keys to disk
+  liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
 
-    -- Generate haskell signing key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","key","convert-itn-bip32-key"
-                               , "--itn-signing-key-file", itnSignKeyFp
-                               , "--out-file", outputHaskellSignKeyFp
-                               ]
+  OP.assertFilesExist [itnSignKeyFp]
 
-    -- Check for existence of the converted ITN keys
-    assertFilesExist [outputHaskellSignKeyFp]
+  -- Generate haskell signing key
+  void $ OP.execCardanoCLI
+    [ "shelley","key","convert-itn-bip32-key"
+    , "--itn-signing-key-file", itnSignKeyFp
+    , "--out-file", outputHaskellSignKeyFp
+    ]
 
-    liftIO $ fileCleanup allFiles
+  -- Check for existence of the converted ITN keys
+  OP.assertFilesExist [outputHaskellSignKeyFp]
 
-    H.success
 
 -- | We check our 'decodeBech32Key' outputs against https://slowli.github.io/bech32-buffer/
 -- using 'itnVerKey' & 'itnSignKey' as inputs.

--- a/cardano-cli/test/Test/ITN.hs
+++ b/cardano-cli/test/Test/ITN.hs
@@ -4,18 +4,14 @@ module Test.ITN
   ( tests
   ) where
 
+import           Cardano.CLI.Shelley.Run.Key (decodeBech32Key)
 import           Cardano.Prelude
+import           Hedgehog (Property, (===))
 
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.ByteString.Base16 as Base16
-
-import           Cardano.CLI.Shelley.Run.Key (decodeBech32Key)
-
-import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
-
-import           Test.OptParse
-
+import qualified Test.OptParse as OP
 
 -- | Bech32 verification key
 itnVerKey :: Text
@@ -28,45 +24,35 @@ itnSignKey = "ed25519_sk1yhnetcmla9pskrvp5z5ff2v8gkenhmluy736jd6nrxrlxcgn70zsy94
 -- | 1. Convert a bech32 ITN key pair to a haskell stake verification key and signing key
 --   2. Derive the haskell verification key from the haskell signing key.
 prop_convertITNKeys :: Property
-prop_convertITNKeys =
-  propertyOnce $ do
+prop_convertITNKeys = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- ITN input file paths
+  itnVerKeyFp <- OP.noteTempFile tempDir "itnVerKey.key"
+  itnSignKeyFp <- OP.noteTempFile tempDir "itnSignKey.key"
 
-        -- ITN input file paths
-    let itnVerKeyFp = "itnVerKey.key"
-        itnSignKeyFp = "itnSignKey.key"
+  -- Converted keys output file paths
+  outputHaskellVerKeyFp <- OP.noteTempFile tempDir "haskell-verification-key.key"
+  outputHaskellSignKeyFp <- OP.noteTempFile tempDir "haskell-signing-key.key"
 
-        -- Converted keys output file paths
-        outputHaskellVerKeyFp = "haskell-verification-key.key"
-        outputHaskellSignKeyFp = "haskell-signing-key.key"
+  -- Write ITN keys to disk
+  liftIO $ writeFile itnVerKeyFp itnVerKey
+  liftIO $ writeFile itnSignKeyFp itnSignKey
+  OP.assertFilesExist [itnVerKeyFp, itnSignKeyFp]
 
-        allFiles = [itnVerKeyFp, itnSignKeyFp, outputHaskellVerKeyFp, outputHaskellSignKeyFp]
+  -- Generate haskell stake verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","key","convert-itn-key"
+    , "--itn-verification-key-file", itnVerKeyFp
+    , "--out-file", outputHaskellVerKeyFp
+    ]
+  -- Generate haskell signing key
+  void $ OP.execCardanoCLI
+    [ "shelley","key","convert-itn-key"
+    , "--itn-signing-key-file", itnSignKeyFp
+    , "--out-file", outputHaskellSignKeyFp
+    ]
 
-    -- Write ITN keys to disk
-    liftIO $ writeFile itnVerKeyFp itnVerKey
-    liftIO $ writeFile itnSignKeyFp itnSignKey
-    assertFilesExist [itnVerKeyFp, itnSignKeyFp]
-
-    -- Generate haskell stake verification key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","key","convert-itn-key"
-                               , "--itn-verification-key-file", itnVerKeyFp
-                               , "--out-file", outputHaskellVerKeyFp
-                               ]
-    -- Generate haskell signing key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","key","convert-itn-key"
-                               , "--itn-signing-key-file", itnSignKeyFp
-                               , "--out-file", outputHaskellSignKeyFp
-                               ]
-
-    -- Check for existence of the converted ITN keys
-    assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
-
-    liftIO $ fileCleanup allFiles
-
-    H.success
+  -- Check for existence of the converted ITN keys
+  OP.assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
 
 -- | 1. Convert a bech32 ITN extended signing key to a haskell stake signing key
 prop_convertITNExtendedSigningKey :: Property
@@ -139,29 +125,28 @@ prop_convertITNBIP32SigningKey =
 -- | We check our 'decodeBech32Key' outputs against https://slowli.github.io/bech32-buffer/
 -- using 'itnVerKey' & 'itnSignKey' as inputs.
 golden_bech32Decode :: Property
-golden_bech32Decode = propertyOnce $ do
-    (vHumReadPart, vDataPart , _) <- H.evalEither $ decodeBech32Key itnVerKey
-    Just vDataPartBase16 <- pure (dataPartToBase16 vDataPart)
+golden_bech32Decode = OP.propertyOnce $ do
+  (vHumReadPart, vDataPart , _) <- H.evalEither $ decodeBech32Key itnVerKey
+  Just vDataPartBase16 <- pure (dataPartToBase16 vDataPart)
 
-    (sHumReadPart, sDataPart , _) <- H.evalEither $ decodeBech32Key itnSignKey
-    Just sDataPartBase16 <- pure (dataPartToBase16 sDataPart)
+  (sHumReadPart, sDataPart , _) <- H.evalEither $ decodeBech32Key itnSignKey
+  Just sDataPartBase16 <- pure (dataPartToBase16 sDataPart)
 
-    -- Based on https://slowli.github.io/bech32-buffer/ which are in Base16
-    let expectedHumanReadPartVerificationKey = "ed25519_pk"
-        expectedDataPartVerificationKey = "6e77922c4deb7a46d4030650a1f7ad0ab38ca23b1b7794988931bd1069f7454d"
-        expectedHumanReadPartSigningKey = "ed25519_sk"
-        expectedDataPartSigningKey = "25e795e37fe9430b0d81a0a894a98745b33beffc27a3a937531987f36113f3c5"
+  -- Based on https://slowli.github.io/bech32-buffer/ which are in Base16
+  let expectedHumanReadPartVerificationKey = "ed25519_pk"
+      expectedDataPartVerificationKey = "6e77922c4deb7a46d4030650a1f7ad0ab38ca23b1b7794988931bd1069f7454d"
+      expectedHumanReadPartSigningKey = "ed25519_sk"
+      expectedDataPartSigningKey = "25e795e37fe9430b0d81a0a894a98745b33beffc27a3a937531987f36113f3c5"
+
+  -- ITN Verification key decode check
+  expectedHumanReadPartVerificationKey === Bech32.humanReadablePartToText vHumReadPart
+  expectedDataPartVerificationKey ===  vDataPartBase16
 
 
-    -- ITN Verification key decode check
-    expectedHumanReadPartVerificationKey === Bech32.humanReadablePartToText vHumReadPart
-    expectedDataPartVerificationKey ===  vDataPartBase16
+  -- ITN Signing key decode check
+  expectedHumanReadPartSigningKey === Bech32.humanReadablePartToText sHumReadPart
+  expectedDataPartSigningKey === sDataPartBase16
 
-
-    -- ITN Signing key decode check
-    expectedHumanReadPartSigningKey === Bech32.humanReadablePartToText sHumReadPart
-    expectedDataPartSigningKey === sDataPartBase16
-    H.success
   where
     dataPartToBase16 :: Bech32.DataPart -> Maybe ByteString
     dataPartToBase16 = fmap Base16.encode . Bech32.dataPartToBytes

--- a/cardano-cli/test/Test/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/Test/Pioneers/Exercise1.hs
@@ -5,47 +5,35 @@ module Test.Pioneers.Exercise1
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
+
 import qualified Hedgehog as H
-
-import           Test.OptParse
-
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. We use the generated verification key to build a shelley payment address.
 prop_buildShelleyPaymentAddress :: Property
-prop_buildShelleyPaymentAddress =
-  propertyOnce $ do
+prop_buildShelleyPaymentAddress = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "payment-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "payment-signing-key-file"
 
-    -- Key filepaths
-    let verKey = "payment-verification-key-file"
-        signKey = "payment-signing-key-file"
-        allFiles = [verKey, signKey]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
+  OP.assertFilesExist [verKey, signKey]
 
-    assertFilesExist [verKey, signKey]
-
-    -- Build shelley payment address
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley", "address", "build"
-                               , "--payment-verification-key-file", verKey
-                               , "--mainnet"
-                               ]
-
-    liftIO $ fileCleanup [verKey, signKey]
-    H.success
-
-
+  -- Build shelley payment address
+  void $ OP.execCardanoCLI
+    [ "shelley", "address", "build"
+    , "--payment-verification-key-file", verKey
+    , "--mainnet"
+    ]
 
 -- | 1. We generate a key payment pair
 --   2. We generate a staking key pair
@@ -53,44 +41,36 @@ prop_buildShelleyPaymentAddress =
 --   3. We use the payment verification key & staking verification key
 --      to build a shelley stake address.
 prop_buildShelleyStakeAddress :: Property
-prop_buildShelleyStakeAddress =
-  propertyOnce $ do
+prop_buildShelleyStakeAddress = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  stakeVerKey <- OP.noteTempFile tempDir "stake-verification-key-file"
+  stakeSignKey <- OP.noteTempFile tempDir "stake-signing-key-file"
+  paymentVerKey <- OP.noteTempFile tempDir "payment-verification-key-file"
+  paymentSignKey <- OP.noteTempFile tempDir "payment-signing-key-file"
 
-    -- Key filepaths
-    let stakeVerKey = "stake-verification-key-file"
-        stakeSignKey = "stake-signing-key-file"
-        paymentVerKey = "payment-verification-key-file"
-        paymentSignKey = "payment-signing-key-file"
-        allFiles = [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
+  -- Generate payment verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--verification-key-file", paymentVerKey
+    , "--signing-key-file", paymentSignKey
+    ]
 
-    -- Generate payment verification key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--verification-key-file", paymentVerKey
-                               , "--signing-key-file", paymentSignKey
-                               ]
-    -- Generate stake verification key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","key-gen"
-                               , "--verification-key-file", stakeVerKey
-                               , "--signing-key-file", stakeSignKey
-                               ]
+  -- Generate stake verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","key-gen"
+    , "--verification-key-file", stakeVerKey
+    , "--signing-key-file", stakeSignKey
+    ]
 
-    assertFilesExist allFiles
+  OP.assertFilesExist [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
 
-    -- Build shelley stake address
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley", "address", "build"
-                               , "--payment-verification-key-file", paymentVerKey
-                               , "--stake-verification-key-file", stakeVerKey
-                               , "--mainnet"
-                               ]
-
-    liftIO $ fileCleanup allFiles
-    H.success
+  -- Build shelley stake address
+  void $ OP.execCardanoCLI
+    [ "shelley", "address", "build"
+    , "--payment-verification-key-file", paymentVerKey
+    , "--stake-verification-key-file", stakeVerKey
+    , "--mainnet"
+    ]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/Test/Pioneers/Exercise2.hs
@@ -5,64 +5,53 @@ module Test.Pioneers.Exercise2
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse
+import qualified Hedgehog as H
+import qualified Test.OptParse as OP
 
 -- | 1. We generate a payment signing key
 --   2. We create a tx body
 --   3. We sign the tx body with the generated payment signing key
 prop_createTransaction :: Property
-prop_createTransaction =
-  propertyOnce $ do
+prop_createTransaction = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  paymentVerKey <- OP.noteTempFile tempDir "payment-verification-key-file"
+  paymentSignKey <- OP.noteTempFile tempDir "payment-signing-key-file"
+  transactionBodyFile <- OP.noteTempFile tempDir "transaction-body"
+  transactionFile <- OP.noteTempFile tempDir "transaction-file"
 
-    -- Key filepaths
-    let paymentVerKey = "payment-verification-key-file"
-        paymentSignKey = "payment-signing-key-file"
-        transactionBodyFile = "transaction-body"
-        transactionFile = "transactionFile"
-        allFiles = [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]
+  -- Generate payment signing key to sign transaction
+  void $ OP.execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--verification-key-file", paymentVerKey
+    , "--signing-key-file", paymentSignKey
+    ]
 
-    -- Generate payment signing key to sign transaction
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","address","key-gen"
-                               , "--verification-key-file", paymentVerKey
-                               , "--signing-key-file", paymentSignKey
-                               ]
+  OP.assertFilesExist [paymentVerKey, paymentSignKey]
 
-    assertFilesExist [paymentVerKey, paymentSignKey]
+  -- Create transaction body
+  void $ OP.execCardanoCLI
+    [ "shelley","transaction", "build-raw"
+    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
+    , "--fee", "1000000"
+    , "--ttl", "500000"
+    , "--out-file", transactionBodyFile
+    ]
 
-    -- Create transaction body
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","transaction", "build-raw"
-                               , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-                               , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
-                               , "--fee", "1000000"
-                               , "--ttl", "500000"
-                               , "--out-file", transactionBodyFile
-                               ]
+  OP.assertFilesExist [transactionBodyFile]
 
-    assertFilesExist [transactionBodyFile]
+  -- Sign transaction
+  void $ OP.execCardanoCLI
+    [ "shelley","transaction", "sign"
+    , "--tx-body-file", transactionBodyFile
+    , "--signing-key-file", paymentSignKey
+    , "--mainnet"
+    , "--out-file", transactionFile
+    ]
 
-    -- Sign transaction
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","transaction", "sign"
-                               , "--tx-body-file", transactionBodyFile
-                               , "--signing-key-file", paymentSignKey
-                               , "--mainnet"
-                               , "--out-file", transactionFile
-                               ]
-
-
-    assertFilesExist allFiles
-
-    liftIO $ fileCleanup allFiles
-    H.success
+  OP.assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/Test/Pioneers/Exercise3.hs
@@ -5,64 +5,55 @@ module Test.Pioneers.Exercise3
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse
+import qualified Hedgehog as H
+import qualified Test.OptParse as OP
 
 -- | 1. Create KES key pair.
 --   2. Create cold keys.
 --   3. Create operational certificate.
 --   4. Create VRF key pair.
 prop_createOperationalCertificate :: Property
-prop_createOperationalCertificate =
-  propertyOnce $ do
-    -- Key filepaths
-    let kesVerKey = "KES-verification-key-file"
-        kesSignKey = "KES-signing-key-file"
-        coldVerKey = "cold-verification-key-file"
-        coldSignKey = "cold-signing-key-file"
-        operationalCertCounter = "operational-certificate-counter-file"
-        operationalCert = "operational-certificate-file"
-        allFiles = [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]
+prop_createOperationalCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  kesVerKey <- OP.noteTempFile tempDir "KES-verification-key-file"
+  kesSignKey <- OP.noteTempFile tempDir "KES-signing-key-file"
+  coldVerKey <- OP.noteTempFile tempDir "cold-verification-key-file"
+  coldSignKey <- OP.noteTempFile tempDir "cold-signing-key-file"
+  operationalCertCounter <- OP.noteTempFile tempDir "operational-certificate-counter-file"
+  operationalCert <- OP.noteTempFile tempDir "operational-certificate-file"
 
-    -- Create KES key pair
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","node","key-gen-KES"
-                               , "--verification-key-file", kesVerKey
-                               , "--signing-key-file", kesSignKey
-                               ]
+  -- Create KES key pair
+  void $ OP.execCardanoCLI
+    [ "shelley","node","key-gen-KES"
+    , "--verification-key-file", kesVerKey
+    , "--signing-key-file", kesSignKey
+    ]
 
-    assertFilesExist [kesSignKey, kesVerKey]
+  OP.assertFilesExist [kesSignKey, kesVerKey]
 
-    -- Create cold key pair
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","node","key-gen"
-                               , "--cold-verification-key-file", coldVerKey
-                               , "--cold-signing-key-file", coldSignKey
-                               , "--operational-certificate-issue-counter", operationalCertCounter
-                               ]
+  -- Create cold key pair
+  void $ OP.execCardanoCLI
+    [ "shelley","node","key-gen"
+    , "--cold-verification-key-file", coldVerKey
+    , "--cold-signing-key-file", coldSignKey
+    , "--operational-certificate-issue-counter", operationalCertCounter
+    ]
 
-    assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
+  OP.assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
 
-    -- Create operational certificate
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","node","issue-op-cert"
-                               , "--kes-verification-key-file", kesVerKey
-                               , "--cold-signing-key-file", coldSignKey
-                               , "--operational-certificate-issue-counter", operationalCertCounter
-                               , "--kes-period", "1000"
-                               , "--out-file", operationalCert
-                               ]
+  -- Create operational certificate
+  void $ OP.execCardanoCLI
+    [ "shelley","node","issue-op-cert"
+    , "--kes-verification-key-file", kesVerKey
+    , "--cold-signing-key-file", coldSignKey
+    , "--operational-certificate-issue-counter", operationalCertCounter
+    , "--kes-period", "1000"
+    , "--out-file", operationalCert
+    ]
 
-    assertFilesExist allFiles
-
-    liftIO $ fileCleanup allFiles
-    H.success
+  OP.assertFilesExist [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/Test/Pioneers/Exercise4.hs
@@ -5,44 +5,36 @@ module Test.Pioneers.Exercise4
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 
-import           Test.OptParse
+import qualified Hedgehog as H
+import qualified Test.OptParse as OP
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 prop_createStakeAddressRegistrationCertificate :: Property
-prop_createStakeAddressRegistrationCertificate =
-  propertyOnce $ do
+prop_createStakeAddressRegistrationCertificate = OP.propertyOnce . OP.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  verKey <- OP.noteTempFile tempDir "stake-verification-key-file"
+  signKey <- OP.noteTempFile tempDir "stake-signing-key-file"
+  stakeRegCert <- OP.noteTempFile tempDir "stake-registration-certificate-file"
 
-    -- Key filepaths
-    let verKey = "stake-verification-key-file"
-        signKey = "stake-signing-key-file"
-        stakeRegCert = "stake-registration-certificate-file"
-        allFiles = [verKey, signKey, stakeRegCert]
+  -- Generate stake verification key
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","key-gen"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+  OP.assertFilesExist [verKey, signKey]
 
-    -- Generate stake verification key
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","key-gen"
-                               , "--verification-key-file", verKey
-                               , "--signing-key-file", signKey
-                               ]
-    assertFilesExist [verKey, signKey]
+  -- Create stake address registration certificate
+  void $ OP.execCardanoCLI
+    [ "shelley","stake-address","registration-certificate"
+    , "--stake-verification-key-file", verKey
+    , "--out-file", stakeRegCert
+    ]
 
-    -- Create stake address registration certificate
-    execCardanoCLIParser
-      allFiles
-        $ evalCardanoCLIParser [ "shelley","stake-address","registration-certificate"
-                               , "--stake-verification-key-file", verKey
-                               , "--out-file", stakeRegCert
-                               ]
-
-    assertFilesExist allFiles
-    liftIO $ fileCleanup allFiles
-    H.success
+  OP.assertFilesExist [verKey, signKey, stakeRegCert]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/golden/shelley/keys/stake_keys/reward_address
+++ b/cardano-cli/test/Test/golden/shelley/keys/stake_keys/reward_address
@@ -1,0 +1,1 @@
+stake1uxqmgfzls3vn7c7qlu3fdycz2nmh5p5sl2w7t7tfetp8evqacghf3


### PR DESCRIPTION
It's recommended to review this PR with this link https://github.com/input-output-hk/cardano-node/pull/1592/files?w=1

### Summary
* Convert all remaining tests to use workspaces so that they don't need to manually handle cleanup, which is error prone.  Possible errors prevented include, accidentally creating stray files that get committed, failing to clean up files, sharing files between concurrently run tests.
* Remove `fps` (files to cleanup) argument from `equivalence` and `checkTextEnvelopeFormat` functions because the argument was no longer used.
* New `readFile` function in `OptParse` module, the use of which does not require `liftIO` and handles exceptions in a way that produces useful test output.
* Use `void . execCardanoCLI` in place of `execCardanoCLIParser allFiles . evalCardanoCLIParser []` for brevity.
* Includes https://github.com/input-output-hk/cardano-node/pull/1589 which adds `cardano-cli` as `build-tools` of cli tests to ensure that the CLI executable is always built before running tests.
* Remove unused functions `evalCardanoCLIParser`, `execCardanoCLIParser` and `fileCleanup`