### PR TITLE
fix start-cluster and stop-cluster scripts

### DIFF
--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -327,6 +327,7 @@ let
   '';
 
   start = pkgs.writeScriptBin "start-cluster" ''
+    #!${pkgs.bash}/bin/bash
     set -euo pipefail
     if [ -f ${stateDir}/supervisord.pid ]
     then
@@ -338,11 +339,13 @@ let
     echo "Transfering genesis funds to pool owners, register pools and delegations"
     cardano-cli shelley transaction submit \
       --tx-file ${stateDir}/shelley/transfer-register-delegate-tx.tx \
-      --testnet-magic ${toString genesisSpecMergedJSON.networkMagic}
+      --testnet-magic ${toString genesisSpecMergedJSON.networkMagic} \
+      --shelley-mode
     sleep 5
     echo 'Cluster started. Run `stop-cluster` to stop'
   '';
   stop = pkgs.writeScriptBin "stop-cluster" ''
+    #!${pkgs.bash}/bin/bash
     set -euo pipefail
     ${pkgs.python3Packages.supervisor}/bin/supervisorctl stop all
     if [ -f ${stateDir}/supervisord.pid ]


### PR DESCRIPTION
* the `start-cluster` is missing `--shelley-mode` and is failing with `cardano-cli: HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})`
* the scripts are missing shebang and therefore are not detected by "exec" as scripts (e.g. when running from python scripts)