### PR TITLE
Bump iohk-nix for correct testnet shelley systemStart

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ce214b0e19942fee5c1dfcb086ff29cac086be31",
-        "sha256": "07qf5453vdbxq8sq4gmp7nl07q3kyqfjiyy2lfxkyi2cwg09l4cq",
+        "rev": "f345d26508966e434d8db57d6c3b4ce4202c9fb5",
+        "sha256": "1xcar2r6jm68dp5s8kc2rii0rcg47w41qc1akazbngkj1x6hf1r2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/ce214b0e19942fee5c1dfcb086ff29cac086be31.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/f345d26508966e434d8db57d6c3b4ce4202c9fb5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
cf. https://github.com/input-output-hk/iohk-nix/pull/427/files