### PR TITLE
Organize byron commands similarly to shelley commands (maintaining backwards compatibility)

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -9,7 +9,7 @@ import           Prelude (String)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
-import           Cardano.CLI.Byron.Parsers (parseByronCommands)
+import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
 import           Cardano.CLI.Run (ClientCommand (..))
 import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
 
@@ -34,7 +34,7 @@ pref = Opt.prefs showHelpOnEmpty
 parseClientCommand :: Parser ClientCommand
 parseClientCommand =
   asum
-    [ parseByron
+    [ parseByron <|> backwardsCompatibilityCommands
     , parseShelley
     , parseDisplayVersion
     ]
@@ -45,7 +45,10 @@ parseByron =
   subparser $ mconcat
     [ commandGroup "Byron specific commands"
     , metavar "Byron specific commands"
-    , parseByronCommands
+    , command'
+        "byron"
+        "Byron specific commands"
+         parseByronCommands
     ]
 
 parseShelley :: Parser ClientCommand


### PR DESCRIPTION
- All the previous commands exist at the top level (but hidden in the help) however there is one breaking change. Previous commands under `byron` had to be moved under `governance`. These were: 
 ```
  create-update-proposal   Create an update proposal.
  create-proposal-vote     Create an update proposal vote.
  submit-update-proposal   Submit an update proposal.
  submit-proposal-vote     Submit a proposal vote.
```
Previous grouping:
```
cabal exec cardano-cli                                                                                                                                       
cardano-cli - utility to support a variety of key operations (genesis
generation, migration, pretty-printing..) for different system generations.

Usage: cardano-cli (Byron specific commands | Shelley specific commands | 
                     Miscellaneous commands)

Available options:
  --version                Show the cardano-cli version
  -h,--help                Show this help text

Byron specific commands
  byron                    Byron node operation commands
  genesis                  Create genesis.
  print-genesis-hash       Compute hash of a genesis file.
  keygen                   Generate a signing key.
  to-verification          Extract a verification key in its base64 form.
  signing-key-public       Pretty-print a signing key's verification key (not a
                           secret).
  signing-key-address      Print address of a signing key.
  migrate-delegate-key-from
                           Migrate a delegate key from an older version.
  issue-delegation-certificate
                           Create a delegation certificate allowing the
                           delegator to sign blocks on behalf of the issuer
  check-delegation         Verify that a given certificate constitutes a valid
                           delegation relationship between keys.
  submit-tx                Submit a raw, signed transaction, in its on-wire
                           representation.
  issue-genesis-utxo-expenditure
                           Write a file with a signed transaction, spending
                           genesis UTxO.
  issue-utxo-expenditure   Write a file with a signed transaction, spending
                           normal UTxO.
  get-tip                  Get the tip of your local node's blockchain
  validate-cbor            Validate a CBOR blockchain object.
  pretty-print-cbor        Pretty print a CBOR file.

Shelley specific commands
  shelley                  Shelley specific commands

Miscellaneous commands
  version                  Show the cardano-cli version
```


New grouping:
```
cabal exec cardano-cli                                                                                                                                     
cardano-cli - utility to support a variety of key operations (genesis
generation, migration, pretty-printing..) for different system generations.

Usage: cardano-cli (Byron specific commands | Shelley specific commands | 
                     Miscellaneous commands)

Available options:
  --version                Show the cardano-cli version
  -h,--help                Show this help text

Byron specific commands
  byron                    Byron specific commands

Shelley specific commands
  shelley                  Shelley specific commands

Miscellaneous commands
  version                  Show the cardano-cli version
```