### PR TITLE
Default hlint file

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,82 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Unused LANGUAGE pragma"}
+- ignore: {name: "Use bimap"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Redundant flip"}
+- ignore: {name: "Redundant where"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Redundant as"}
+- ignore: {name: "Parse error: lexical error in string/character literal at character '\\n'"}
+- ignore: {name: "Replace case with maybe"}
+- ignore: {name: "Use first"}
+- ignore: {name: "Use record patterns"}
+- ignore: {name: "Use :"}
+- ignore: {name: "Use const"}
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/cardano-node/test/Test/Common/Base.hs
+++ b/cardano-node/test/Test/Common/Base.hs
@@ -11,9 +11,8 @@ import           Control.Monad.IO.Class (liftIO)
 import           Data.Bool
 import           Data.Either (Either (..))
 import           Data.Function (($), (.))
-import           Data.Functor
 import           Data.Int
-import           Data.Maybe (Maybe (..), fromMaybe, listToMaybe)
+import           Data.Maybe (Maybe (..), listToMaybe, maybe)
 import           Data.Monoid (Monoid (..))
 import           Data.Semigroup (Semigroup (..))
 import           Data.String (String)
@@ -72,7 +71,7 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
 -- the block fails.
 moduleWorkspace :: HasCallStack => FilePath -> (FilePath -> H.PropertyT IO ()) -> H.PropertyT IO ()
 moduleWorkspace prefixPath f = GHC.withFrozenCallStack $ do
-  let srcModule = fromMaybe "UnknownModule" (fmap (GHC.srcLocModule . snd) (listToMaybe (getCallStack callStack)))
+  let srcModule = maybe "UnknownModule"  (GHC.srcLocModule . snd) (listToMaybe (getCallStack callStack))
   workspace (prefixPath <> "/" <> srcModule) f
 
 createDirectoryIfMissing :: HasCallStack => FilePath -> H.PropertyT IO ()

--- a/cardano-node/test/Test/Common/Process.hs
+++ b/cardano-node/test/Test/Common/Process.hs
@@ -34,7 +34,7 @@ createProcess :: HasCallStack
   -> H.PropertyT IO (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
 createProcess cp = GHC.withFrozenCallStack $ do
   case IO.cmdspec cp of
-    RawCommand cmd args -> H.annotate $ "Command line: " <> cmd <> " " <> L.intercalate " " args
+    RawCommand cmd args -> H.annotate $ "Command line: " <> cmd <> " " <> L.unwords args
     ShellCommand cmd -> H.annotate $ "Command line: " <> cmd
   H.evalM . liftIO $ IO.createProcess cp
 

--- a/default.nix
+++ b/default.nix
@@ -73,6 +73,11 @@ let
     checks = recurseIntoAttrs {
       # `checks.tests` collect results of executing the tests:
       tests = collectChecks haskellPackages;
+
+      hlint = callPackage iohkNix.tests.hlint {
+        src = ./. ;
+        projects = attrNames (selectProjectPackages cardanoNodeHaskellPackages);
+      };
     };
 
     shell = import ./shell.nix {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -6,11 +6,10 @@
 , stdenv
 , haskell-nix
 , buildPackages
-, config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc865"
+, compiler
 # Enable profiling
-, profiling ? config.haskellNix.profiling or false
+, profiling ? false
 # Enable asserts for given packages
 , assertedPackages ? []
 # Version info, to be passed when not building from a git work tree
@@ -39,12 +38,6 @@ let
   } // {
     inherit src;
     compiler-nix-name = compiler;
-    #ghc = buildPackages.haskell-nix.compiler.${compiler};
-    pkg-def-extras = lib.optional stdenv.hostPlatform.isLinux (hackage: {
-      packages = {
-        "systemd" = (((hackage.systemd)."2.2.0").revisions).default;
-      };
-    });
     modules = [
       { compiler.nix-name = compiler; }
       # Allow reinstallation of Win32

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,10 @@
 # our packages overlay
-pkgs: _: with pkgs; {
+pkgs: _: with pkgs;
+  let
+    compiler = config.haskellNix.compiler or "ghc865";
+  in {
   cardanoNodeHaskellPackages = import ./haskell.nix {
-    inherit config
+    inherit compiler
       pkgs
       lib
       stdenv
@@ -11,7 +14,7 @@ pkgs: _: with pkgs; {
       ;
   };
   cardanoNodeProfiledHaskellPackages = import ./haskell.nix {
-    inherit config
+    inherit compiler
       pkgs
       lib
       stdenv
@@ -53,4 +56,11 @@ pkgs: _: with pkgs; {
   mkCluster = callPackage ./supervisord-cluster;
   hfcCluster = callPackage ./supervisord-cluster/hfc {};
   cardanolib-py = callPackage ./cardanolib-py {};
+
+  inherit ((haskell-nix.hackage-package {
+    name = "hlint";
+    version = "3.1.6";
+    compiler-nix-name = compiler;
+    inherit (cardanoNodeHaskellPackages) index-state;
+  }).components.exes) hlint;
 }


### PR DESCRIPTION
This file disables all the `hlint` rules in the project that might cause the lint to fail.

To test if `hlint` works in CI, delete the `.hlint.yaml` file and the build should fail.

This PR was created so that the SRE team can create a commit on top to enable `hlint` in CI.  See https://jira.iohk.io/browse/SRE-131