### PR TITLE
Remove unused language pragmas

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,7 +7,6 @@
 
 
 # Warnings currently triggered by your code
-- ignore: {name: "Unused LANGUAGE pragma"}
 - ignore: {name: "Use bimap"}
 - ignore: {name: "Move brackets to avoid $"}
 - ignore: {name: "Redundant bracket"}

--- a/cardano-api/src/Cardano/Api/LocalChainSync.hs
+++ b/cardano-api/src/Cardano/Api/LocalChainSync.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Api.LocalChainSync

--- a/cardano-api/src/Cardano/Api/Protocol.hs
+++ b/cardano-api/src/Cardano/Api/Protocol.hs
@@ -1,13 +1,9 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 
 module Cardano.Api.Protocol

--- a/cardano-api/src/Cardano/Api/TextView.hs
+++ b/cardano-api/src/Cardano/Api/TextView.hs
@@ -56,8 +56,8 @@ data TextView = TextView
   } deriving (Eq, Show)
 
 instance ToJSON TextView where
-  toJSON (TextView (TextViewType tvType) (TextViewDescription desc) rawCBOR) =
-    object [ "type" .= Text.decodeUtf8 tvType
+  toJSON (TextView (TextViewType tvType') (TextViewDescription desc) rawCBOR) =
+    object [ "type" .= Text.decodeUtf8 tvType'
            , "description" .= Text.decodeUtf8 desc
            , "cborHex" .= (Text.decodeUtf8 $ Base16.encode rawCBOR)
            ]

--- a/cardano-api/src/Cardano/Api/TextView.hs
+++ b/cardano-api/src/Cardano/Api/TextView.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -97,13 +97,13 @@ runStakePoolRegistrationCert
     stakePoolVerKey <- firstExceptT ShelleyPoolReadFileError
       . newExceptT
       $ readFileTextEnvelope (AsVerificationKey AsStakePoolKey) sPvkeyFp
-    let stakePoolId = verificationKeyHash stakePoolVerKey
+    let stakePoolId' = verificationKeyHash stakePoolVerKey
 
     -- VRF verification key
     vrfVerKey <- firstExceptT ShelleyPoolReadFileError
       . newExceptT
       $ readFileTextEnvelope (AsVerificationKey AsVrfKey) vrfVkeyFp
-    let vrfKeyHash = verificationKeyHash vrfVerKey
+    let vrfKeyHash' = verificationKeyHash vrfVerKey
 
     -- Pool reward account
     stakeVerKey <- firstExceptT ShelleyPoolReadFileError
@@ -121,17 +121,17 @@ runStakePoolRegistrationCert
             $ readFileTextEnvelope (AsVerificationKey AsStakeKey) fp
         )
         ownerVerFps
-    let stakePoolOwners = map verificationKeyHash sPoolOwnerVkeys
+    let stakePoolOwners' = map verificationKeyHash sPoolOwnerVkeys
 
     let stakePoolParams =
           StakePoolParameters
-            { stakePoolId = stakePoolId
-            , stakePoolVRF = vrfKeyHash
+            { stakePoolId = stakePoolId'
+            , stakePoolVRF = vrfKeyHash'
             , stakePoolCost = pCost
             , stakePoolMargin = pMrgn
             , stakePoolRewardAccount = rewardAccountAddr
             , stakePoolPledge = pldg
-            , stakePoolOwners = stakePoolOwners
+            , stakePoolOwners = stakePoolOwners'
             , stakePoolRelays = relays
             , stakePoolMetadata = mbMetadata
             }
@@ -156,8 +156,8 @@ runStakePoolRetirementCert (VerificationKeyFile sPvkeyFp) retireEpoch (OutputFil
       . newExceptT
       $ readFileTextEnvelope (AsVerificationKey AsStakePoolKey) sPvkeyFp
 
-    let stakePoolId = verificationKeyHash stakePoolVerKey
-        retireCert = makeStakePoolRetirementCertificate stakePoolId retireEpoch
+    let stakePoolId' = verificationKeyHash stakePoolVerKey
+        retireCert = makeStakePoolRetirementCertificate stakePoolId' retireEpoch
 
     firstExceptT ShelleyPoolWriteFileError
       . newExceptT

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Cardano.CLI.Shelley.Run.Pool
   ( ShelleyPoolCmdError
   , renderShelleyPoolCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -1,13 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 

--- a/cardano-node/chairman/Cardano/Chairman.hs
+++ b/cardano-node/chairman/Cardano/Chairman.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/cardano-node/src/Cardano/Node/Configuration/Socket.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Socket.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Node.Configuration.Socket

--- a/cardano-node/src/Cardano/Node/Protocol/Mock.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Mock.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Node.Protocol.Mock

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Tracing.Config

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/cardano-node/src/Cardano/Tracing/Metrics.hs
+++ b/cardano-node/src/Cardano/Tracing/Metrics.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 module Cardano.Tracing.Metrics
   ( KESMetricsData (..)
@@ -16,12 +15,12 @@ import           Cardano.Prelude
 import           Cardano.Crypto.KES.Class (Period)
 import           Ouroboros.Consensus.Block (ForgeState (..))
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Unary
 import           Ouroboros.Consensus.Mock.Ledger.Block (SimpleBlock)
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool ()
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto.HotKey (HotKey (..))
-import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.Unary
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 
 

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}

--- a/cardano-node/test/Test/Common/Process.hs
+++ b/cardano-node/test/Test/Common/Process.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Common.Process
   ( createProcess

--- a/cardano-node/test/Test/Common/Process.hs
+++ b/cardano-node/test/Test/Common/Process.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Common.Process
   ( createProcess


### PR DESCRIPTION
Removed unused language pragmas and enable `hlint` rule for this.

Surprisingly we depend on `NamedFieldPuns` to suppress warnings.  See below.