### PR TITLE
release.nix: no build of dockerImage on darwin, no musl64 tests.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,7 +60,6 @@ let
 
     inherit (haskellPackages.cardano-node.identifier) version;
 
-    cluster = mkCluster customConfig;
     clusterTests = import ./nix/supervisord-cluster/tests { inherit pkgs mkCluster cardano-cli cardano-node cardanolib-py; };
 
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);

--- a/default.nix
+++ b/default.nix
@@ -60,7 +60,7 @@ let
 
     inherit (haskellPackages.cardano-node.identifier) version;
 
-    clusterTests = import ./nix/supervisord-cluster/tests { inherit pkgs mkCluster cardano-cli cardano-node cardanolib-py; };
+    clusterTests = recRecurseIntoAttrs (import ./nix/supervisord-cluster/tests { inherit pkgs; });
 
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);
 

--- a/nix/supervisord-cluster/tests/default.nix
+++ b/nix/supervisord-cluster/tests/default.nix
@@ -1,10 +1,7 @@
 {
   pkgs
-, mkCluster
-, cardano-cli
-, cardanolib-py
-, cardano-node
 }: let
+  inherit (pkgs) mkCluster cardano-cli cardanolib-py cardano-node;
   stateDir = "./state-cluster-test";
   # We want a really short duration for tests
   cluster' = mkCluster {

--- a/release.nix
+++ b/release.nix
@@ -106,7 +106,7 @@ let
   nonDefaultBuildSystems = tail supportedSystems;
 
   # Paths or prefixes of paths of derivations to build only on the default system (ie. linux on hydra):
-  onlyBuildOnDefaultSystem = [ ["checks" "hlint"] ["dockerImage"] ];
+  onlyBuildOnDefaultSystem = [ ["checks" "hlint"] ["dockerImage"] ["clusterTests"] ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [ ["shell"] ]
     ++ onlyBuildOnDefaultSystem;


### PR DESCRIPTION
 those builds fails, are useless, and slow-down ci.