### PR TITLE
WIP: Lazy show tvar in tests

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -291,6 +291,7 @@ test-suite cardano-node-test
                       , resourcet
                       , shelley-spec-ledger
                       , shelley-spec-ledger-test
+                      , stm
                       , temporary
                       , time
 

--- a/cardano-node/test/Test/Cardano/Node/Chairman.hs
+++ b/cardano-node/test/Test/Cardano/Node/Chairman.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -9,6 +10,7 @@ module Test.Cardano.Node.Chairman
 import           Cardano.Prelude
 import           Hedgehog (Property, discover)
 
+import qualified Control.Concurrent.STM as STM
 import qualified Data.Time.Clock as DTC
 import qualified Data.Time.Clock.POSIX as DTC
 import qualified Hedgehog as H
@@ -16,6 +18,13 @@ import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified Test.Common.Base as H
 import qualified Test.Common.Process as H
+
+prop_lazyAnnotations :: Property
+prop_lazyAnnotations = H.propertyOnce $ do
+  tv <- H.newTVar @Int 0
+  void . H.evalM . liftIO . STM.atomically $ STM.writeTVar tv 1
+  _ <- H.lazyShowTVar tv
+  H.failure
 
 prop_spawnOneNode :: Property
 prop_spawnOneNode = H.propertyOnce . H.workspace "temp/chairman" $ \tempDir -> do


### PR DESCRIPTION
This is a demo to demonstrate a fun and potentially controversial idea and gauge the reaction.

Here is a new `newTVar` function which can be used to create a TVar and annotate its initial and final value at the point the test completes (whether success or failure).

It works by using lazy IO.  Internally it uses `unsafeInterleaveIO` to ensure the final value is not read until it is forced by `hedgehog` annotation machinery, which runs after the test completes.

Example output:
```
  ✗ prop_lazyAnnotations failed at test/Test/Cardano/Node/Chairman.hs:27:3
    after 1 test.
  
       ┏━━ test/Test/Cardano/Node/Chairman.hs ━━━
    22 ┃ prop_lazyAnnotations :: Property
    23 ┃ prop_lazyAnnotations = H.propertyOnce $ do
    24 ┃   tv <- H.newTVar @Int 0
       ┃   │ 0 -> 1
    25 ┃   void . H.evalM . liftIO . STM.atomically $ STM.writeTVar tv 1
    26 ┃   _ <- H.lazyShowTVar tv
       ┃   │ 1
    27 ┃   H.failure
       ┃   ^^^^^^^^^
```

Note that the annotation on line `24` reports the `TVar` having transitioned from its initial value of `0` to the value of `1` by the end of the test.