### PR TITLE
Allow to build for non-systemd systems

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -279,13 +279,6 @@ source-repository-package
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
   --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
-  subdir:   plugins/scribe-systemd
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir:   plugins/backend-aggregation
 
 source-repository-package
@@ -424,3 +417,7 @@ constraints:
 
 package comonad
   flags: -test-doctests
+
+-- force systemd off until there's a solution to
+-- https://github.com/haskell/cabal/issues/5444
+flags: -systemd


### PR DESCRIPTION
This will disable systemd integration for all cabal users,
but fixes #1200.

There are two other ways to fix this:

* provide a hackage overlay, which contains lobemo-scribe-systemd
  only or all 3rdparty packages and then add that overlay to
  cabal.project (downside: stack doesn't seem to be able to use
  hackage overlays)
* provide 2 cabal.project files and let user choose via e.g.:
  --project-file=cabal.project.nosystemd
  (downside: maintaining yet another file)

----

Edit: third option could be to document for non-systemd users how to edit cabal.project, but I guess that's a bit awkward?