### PR TITLE
cabal.project: use multiple subdirs 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -90,42 +90,13 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-base
   tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
   --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: binary
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: binary/test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: cardano-crypto-class
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: cardano-crypto-tests
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: slotting
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
-  subdir: cardano-crypto-praos
+  subdir:
+    binary
+    binary/test
+    cardano-crypto-class
+    cardano-crypto-praos
+    cardano-crypto-tests
+    slotting
 
 source-repository-package
   type: git
@@ -138,90 +109,27 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-ledger-specs
   tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
   --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/ledger/impl
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/crypto
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/ledger/impl/test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/crypto/test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/chain/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: byron/ledger/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: semantics/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: semantics/small-steps-test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: shelley/chain-and-ledger/dependencies/non-integer
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: shelley/chain-and-ledger/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
-  subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
+  subdir:
+    byron/chain/executable-spec
+    byron/crypto
+    byron/crypto/test
+    byron/ledger/executable-spec
+    byron/ledger/impl
+    byron/ledger/impl/test
+    semantics/executable-spec
+    semantics/small-steps-test
+    shelley/chain-and-ledger/dependencies/non-integer
+    shelley/chain-and-ledger/executable-spec
+    shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 53f963be6c4b19a6bb710f9fa5e34db1c5a33a01
-  --sha256: 06d21hbl800k018rpf9i8r83d7wjzfgsp3qj23k1mqr2031f55cc
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 53f963be6c4b19a6bb710f9fa5e34db1c5a33a01
-  --sha256: 06d21hbl800k018rpf9i8r83d7wjzfgsp3qj23k1mqr2031f55cc
-  subdir: test
+  tag: 547633477b5f686da5195a0f7ae031d95475dd36
+  --sha256: 150l598fzmmp3505vxdwgnv0h7qvwaqwdqz2njb6am64qmmxlhpc
+  subdir:
+    cardano-prelude
+    cardano-prelude-test
 
 source-repository-package
   type: git
@@ -234,140 +142,34 @@ source-repository-package
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   tag: d4bb653fcef181befe3883490c66faed46b6197d
   --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir: iohk-monitoring
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   contra-tracer
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   plugins/scribe-systemd
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   plugins/backend-aggregation
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   plugins/backend-ekg
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   plugins/backend-monitoring
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   plugins/backend-trace-forwarder
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
-  subdir:   tracer-transformers
+  subdir:
+    contra-tracer
+    iohk-monitoring
+    plugins/backend-aggregation
+    plugins/backend-ekg
+    plugins/backend-monitoring
+    plugins/backend-trace-forwarder
+    plugins/scribe-systemd
+    tracer-transformers
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
   tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
   --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-network
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: io-sim
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-consensus
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-consensus-byron
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-consensus-shelley
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-consensus-cardano
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: typed-protocols
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: typed-protocols-examples
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: ouroboros-network-framework
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: network-mux
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: io-sim-classes
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
-  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
-  subdir: Win32-network
+  subdir:
+    io-sim
+    io-sim-classes
+    network-mux
+    ouroboros-consensus
+    ouroboros-consensus-byron
+    ouroboros-consensus-cardano
+    ouroboros-consensus-shelley
+    ouroboros-network
+    ouroboros-network-framework
+    typed-protocols
+    typed-protocols-examples
+    Win32-network
 
 constraints:
     hedgehog >= 1.0


### PR DESCRIPTION
For some reason, using `.` as a `subdir` doesn't seem to be supported. For now, work around it by having two entries for `cardano-prelude`.

*UPDATE:* since https://github.com/input-output-hk/cardano-prelude/pull/127, the `subdir`s of `cardano-prelude` are now `cardano-prelude` and `cardano-prelude-test`, so we have only need a single entry now :relieved:.