### PR TITLE
Use a released version of cborg 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,9 +46,6 @@ package ouroboros-consensus
 package ouroboros-consensus-cardano
   tests: False
 
-package ouroboros-consensus-cardano
-  tests: False
-
 package ouroboros-network
   tests: False
 

--- a/cabal.project
+++ b/cabal.project
@@ -349,13 +349,6 @@ source-repository-package
   --sha256: 1sykn9vnbccv2z4kjdf78y65wn4ljqfamlb9xwjv5y4d07h5r6yj
   subdir: Win32-network
 
-source-repository-package
-  type: git
-  location: https://github.com/well-typed/cborg.git
-  tag: 42a83192749774268337258f4f94c97584b80ca6
-  --sha256: 1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04
-  subdir: cborg
-
 constraints:
     ip < 1.5
   , hedgehog >= 1.0

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -83,7 +83,7 @@ library
                      , cardano-prelude
                      , cardano-slotting
                      , contra-tracer
-                     , cborg >= 0.2.2 && < 0.3
+                     , cborg >= 0.2.4 && < 0.3
                      , containers
                      , directory
                      , filepath

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -82,7 +82,7 @@ library
                      , cardano-prelude
                      , cardano-slotting
                      , contra-tracer
-                     , cborg >= 0.2.2 && < 0.3
+                     , cborg >= 0.2.4 && < 0.3
                      , containers
                      , directory
                      , filepath

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,6 +23,7 @@ extra-deps:
   - binary-0.8.7.0
   - bimap-0.4.0
   - canonical-json-0.6.0.0
+  - cborg-0.2.4.0
   - clock-0.8
   - config-ini-0.2.4.0
   - containers-0.5.11.0
@@ -137,12 +138,6 @@ extra-deps:
         - ouroboros-network-testing
         - ouroboros-network-framework
         - Win32-network
-
-    # Includes updated pretty printing function
-  - git: https://github.com/well-typed/cborg.git
-    commit: 42a83192749774268337258f4f94c97584b80ca6
-    subdirs:
-        - cborg
 
 nix:
     shell-file: nix/stack-shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -144,11 +144,5 @@ extra-deps:
     subdirs:
         - cborg
 
-    # Includes a windows build fix (https://github.com/snoyberg/http-client/pull/430)
-  - git: https://github.com/snoyberg/http-client.git
-    commit: 1a75bdfca014723dd5d40760fad854b3f0f37156
-    subdirs:
-        - http-client
-
 nix:
     shell-file: nix/stack-shell.nix


### PR DESCRIPTION
The dependency on cborg was pinned to an unreleased revision to bring in
<https://github.com/well-typed/cborg/pull/223>. That PR has been included in
`cborg-0.2.3.0`, so we can remove the dependency pin in favour of bumping the
lower version bound on the dependency.

Instead of using 0.2.3 as the lower version bound, bump it to >= 0.2.4, as this
version is compatible with the last version of the `primitive` package, which
will soon be needed by `cardano-ledger-specs`, see
<https://github.com/input-output-hk/cardano-ledger-specs/pull/1785>.

Another advantage of using a released version is that the package will now be
stored in the global cabal store and shared between projects (although that will
also be the case for source dependencies in Cabal 3.4.0.0).