### PR TITLE
Enable more hlint rules

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,18 +7,7 @@
 
 
 # Warnings currently triggered by your code
-- ignore: {name: "Move brackets to avoid $"}
-- ignore: {name: "Redundant bracket"}
-- ignore: {name: "Redundant flip"}
-- ignore: {name: "Use camelCase"}
-- ignore: {name: "Use newtype instead of data"}
-- ignore: {name: "Redundant $"}
-- ignore: {name: "Reduce duplication"}
-- ignore: {name: "Use first"}
-- ignore: {name: "Use record patterns"}
-- ignore: {name: "Use :"}
-- ignore: {name: "Use const"}
-
+# - ignore: {name: "Move brackets to avoid $"}
 
 # Specify additional command line arguments
 #

--- a/cardano-api/src/Cardano/Api/TextView.hs
+++ b/cardano-api/src/Cardano/Api/TextView.hs
@@ -59,7 +59,7 @@ instance ToJSON TextView where
   toJSON (TextView (TextViewType tvType') (TextViewDescription desc) rawCBOR) =
     object [ "type" .= Text.decodeUtf8 tvType'
            , "description" .= Text.decodeUtf8 desc
-           , "cborHex" .= (Text.decodeUtf8 $ Base16.encode rawCBOR)
+           , "cborHex" .= Text.decodeUtf8 (Base16.encode rawCBOR)
            ]
 
 instance FromJSON TextView where
@@ -99,7 +99,7 @@ renderTextViewError tve =
      <> " Expected one of: "
      <> Text.intercalate ", "
           [ Text.decodeLatin1 (unTextViewType expType) | expType <- expTypes ]
-     <> " Actual: " <> (Text.decodeLatin1 (unTextViewType actType))
+     <> " Actual: " <> Text.decodeLatin1 (unTextViewType actType)
     TextViewAesonDecodeError decErr -> "TextView aeson decode error: " <> textShow decErr
     TextViewDecodeError decErr -> "TextView decode error: " <> textShow decErr
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -6,15 +6,14 @@ module Test.Cardano.Api.Typed.CBOR
   ) where
 
 import           Cardano.Api.Typed
-
 import           Cardano.Prelude
-
 import           Hedgehog (Gen, Property, discover)
-import qualified Hedgehog as H
-
 import           Test.Cardano.Api.Typed.Gen
 import           Test.Cardano.Api.Typed.Orphans ()
 
+import qualified Hedgehog as H
+
+{- HLINT ignore "Use camelCase" -}
 
 -- TODO: Need to add PaymentExtendedKey roundtrip tests however
 -- we can't derive an Eq instance for Crypto.HD.XPrv

--- a/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
@@ -7,14 +7,14 @@ module Test.Cardano.Api.Typed.Envelope
   ) where
 
 import           Cardano.Api.Typed
-
 import           Cardano.Prelude
-
 import           Hedgehog (Property, discover)
-import qualified Hedgehog as H
-
 import           Test.Cardano.Api.Typed.Gen
 import           Test.Cardano.Api.Typed.Orphans ()
+
+import qualified Hedgehog as H
+
+{- HLINT ignore "Use camelCase" -}
 
 prop_roundtrip_ByronVerificationKey_envelope :: Property
 prop_roundtrip_ByronVerificationKey_envelope =

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -246,12 +246,12 @@ genShelleyWitness = Gen.choice [genShelleyKeyWitness, genShelleyBootstrapWitness
 
 genShelleyWitnessSigningKey :: Gen ShelleyWitnessSigningKey
 genShelleyWitnessSigningKey =
-  Gen.choice [ WitnessPaymentKey <$>  (genSigningKey AsPaymentKey)
-             , WitnessPaymentExtendedKey <$>  (genSigningKey AsPaymentExtendedKey)
-             , WitnessStakeKey <$>  (genSigningKey AsStakeKey)
-             , WitnessStakePoolKey <$>  (genSigningKey AsStakePoolKey)
-             , WitnessGenesisDelegateKey <$>  (genSigningKey AsGenesisDelegateKey)
-             , WitnessGenesisUTxOKey <$>  (genSigningKey AsGenesisUTxOKey)
+  Gen.choice [ WitnessPaymentKey <$>  genSigningKey AsPaymentKey
+             , WitnessPaymentExtendedKey <$>  genSigningKey AsPaymentExtendedKey
+             , WitnessStakeKey <$>  genSigningKey AsStakeKey
+             , WitnessStakePoolKey <$>  genSigningKey AsStakePoolKey
+             , WitnessGenesisDelegateKey <$>  genSigningKey AsGenesisDelegateKey
+             , WitnessGenesisUTxOKey <$>  genSigningKey AsGenesisUTxOKey
              ]
 {-
 -- TODO: makeShelleyScriptWitness = undefined

--- a/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -6,14 +6,14 @@ module Test.Cardano.Api.Typed.RawBytes
   ) where
 
 import           Cardano.Api.Typed
-
 import           Cardano.Prelude
-
 import           Hedgehog (Property, discover)
-import qualified Hedgehog as H
-
 import           Test.Cardano.Api.Typed.Gen
 import           Test.Cardano.Api.Typed.Orphans ()
+
+import qualified Hedgehog as H
+
+{- HLINT ignore "Use camelCase" -}
 
 -- Address CBOR round trips
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -83,8 +83,8 @@ checkDlgCert
   -> Crypto.VerificationKey
   -> Crypto.VerificationKey -> [Text]
 checkDlgCert cert magic issuerVK' delegateVK' =
-  mconcat $
-  [ [ sformat ("Certificate does not have a valid signature.")
+  mconcat
+  [ [ sformat "Certificate does not have a valid signature."
       | not (Dlg.isValid magic' cert')
     ]
   , [ sformat ("Certificate issuer ".vkF." doesn't match expected: ".vkF)

--- a/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
@@ -51,7 +51,7 @@ import qualified Cardano.Crypto as Crypto
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Key
 import           Cardano.CLI.Helpers (textShow)
-import           Cardano.CLI.Types (GenesisFile(..))
+import           Cardano.CLI.Types (GenesisFile (..))
 
 data ByronGenesisError
   = ByronDelegationCertSerializationError !ByronDelegationError
@@ -120,7 +120,7 @@ mkGenesisSpec gp = do
     ExceptT . pure $ canonicalDecodePretty protoParamsRaw
 
   -- We're relying on the generator to fake AVVM and delegation.
-  genesisDelegation <- withExceptT (MakeGenesisDelegationError) $
+  genesisDelegation <- withExceptT MakeGenesisDelegationError $
     Genesis.mkGenesisDelegation []
 
   withExceptT GenesisSpecError $
@@ -235,7 +235,7 @@ serialiseGenesis = canonicalEncodePretty
 
 writeSecrets :: FilePath -> String -> String -> (a -> IO (Either ByronGenesisError LB.ByteString)) -> [a] -> IO ()
 writeSecrets outDir prefix suffix secretOp xs =
-  forM_ (zip xs $ [0::Int ..]) $
+  forM_ (zip xs [0::Int ..]) $
   \(secret, nr)-> do
     let filename = outDir </> prefix <> "." <> printf "%03d" nr <> "." <> suffix
     result <- secretOp secret

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -140,7 +140,7 @@ readPaymentVerificationKey (VerificationKeyFile fp) = do
   -- Verification Key
   let eVk = hoistEither . Crypto.parseFullVerificationKey . fromString $ UTF8.toString vkB
   -- Convert error to 'CliError'
-  firstExceptT (VerificationKeyDeserialisationFailed fp . T.pack . show) $ eVk
+  firstExceptT (VerificationKeyDeserialisationFailed fp . T.pack . show) eVk
 
 
 serialisePoorKey :: CardanoEra -> Genesis.PoorSecret

--- a/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
@@ -29,7 +29,7 @@ import qualified Cardano.Crypto.Wallet as Wallet
 -- 3. the rest must be absent (Nothing)
 --
 -- Legacy reference: https://github.com/input-output-hk/cardano-sl/blob/release/3.0.1/lib/src/Pos/Util/UserSecret.hs#L189
-data LegacyDelegateKey =  LegacyDelegateKey { lrkSigningKey :: !SigningKey}
+newtype LegacyDelegateKey =  LegacyDelegateKey { lrkSigningKey :: SigningKey}
 
 encodeXPrv :: Wallet.XPrv -> E.Encoding
 encodeXPrv a = E.encodeBytes $ Wallet.unXPrv a

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -114,8 +114,9 @@ parseCBORObject :: Parser CBORObject
 parseCBORObject = asum
   [ CBORBlockByron <$> option auto
       (  long "byron-block"
-      <> (help $  "The CBOR file is a byron era block."
-               <> " Enter the number of slots in an epoch. The default value is 21600")
+      <> help
+          (   "The CBOR file is a byron era block."
+          <>  " Enter the number of slots in an epoch. The default value is 21600")
       <> metavar "INT"
       <> value (EpochSlots 21600)
       )
@@ -652,12 +653,12 @@ parseFractionWithDefault
   -> Double
   -> Parser Rational
 parseFractionWithDefault optname desc w =
-  toRational <$> ( option readDouble
-                 $ long optname
-                <> metavar "DOUBLE"
-                <> help desc
-                <> value w
-                )
+  toRational <$> option readDouble
+    ( long optname
+    <> metavar "DOUBLE"
+    <> help desc
+    <> value w
+    )
 
 pNetworkId :: Parser Typed.NetworkId
 pNetworkId =

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -24,11 +24,11 @@ import           Ouroboros.Network.Block
 import           Cardano.Api.LocalChainSync (getLocalTip)
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
 import           Cardano.CLI.Types (SocketPath (..))
-import           Cardano.Tracing.Render (renderHeaderHash, renderSlotNo) -- TODO: This forces us to import "cardano-node". Fix this.
+import           Cardano.Tracing.Render (renderHeaderHash, renderSlotNo)
 
+{- HLINT ignore "Reduce duplication" -}
 
-data ByronQueryError
-  = ByronQueryEnvVarSocketErr !EnvSocketError
+newtype ByronQueryError = ByronQueryEnvVarSocketErr EnvSocketError
   deriving Show
 
 renderByronQueryError :: ByronQueryError -> Text
@@ -42,7 +42,7 @@ renderByronQueryError err =
 
 runGetLocalNodeTip :: NetworkId -> ExceptT ByronQueryError IO ()
 runGetLocalNodeTip networkId = do
-    SocketPath sockPath <- firstExceptT ByronQueryEnvVarSocketErr $
+    SocketPath sockPath <- firstExceptT ByronQueryEnvVarSocketErr
                            readEnvSocketPath
     let connctInfo =
           LocalNodeConnectInfo {
@@ -57,7 +57,7 @@ runGetLocalNodeTip networkId = do
       putTextLn (getTipOutput tip)
   where
     getTipOutput :: forall blk. ConvertRawHash blk => Tip blk -> Text
-    getTipOutput (TipGenesis) = "Current tip: genesis (origin)"
+    getTipOutput TipGenesis = "Current tip: genesis (origin)"
     getTipOutput (Tip slotNo headerHash (BlockNo blkNo)) =
       Text.unlines
         [ "\n"

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -46,16 +46,14 @@ import qualified Cardano.Crypto.Signing as Crypto
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
-import           Ouroboros.Consensus.Cardano (SecurityParam(..))
-import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
-                   (GenTx(DegenGenTx))
+import           Ouroboros.Consensus.Cardano (SecurityParam (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (GenTx (DegenGenTx))
 
-import           Cardano.Api.Typed
-                   (NetworkId, LocalNodeConnectInfo(..), NodeConsensusMode(..),
-                    submitTxToNodeLocal, toByronProtocolMagicId)
+import           Cardano.Api.Typed (LocalNodeConnectInfo (..), NetworkId, NodeConsensusMode (..),
+                     submitTxToNodeLocal, toByronProtocolMagicId)
 import           Cardano.CLI.Environment
 import           Cardano.CLI.Helpers (textShow)
-import           Cardano.CLI.Types (SocketPath(..))
+import           Cardano.CLI.Types (SocketPath (..))
 
 data ByronTxError
   = TxDeserialisationFailed !FilePath !Binary.DecoderError
@@ -145,7 +143,7 @@ genesisUTxOTxIn gc vk genAddr =
     handleMissingAddr :: Maybe UTxO.TxIn -> UTxO.TxIn
     handleMissingAddr  = fromMaybe . error
       $  "\nGenesis UTxO has no address\n"
-      <> (T.unpack $ prettyAddress genAddr)
+      <> T.unpack (prettyAddress genAddr)
       <> "\n\nIt has the following, though:\n\n"
       <> Cardano.Prelude.concat (T.unpack . prettyAddress <$> Map.keys initialUtxo)
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -45,13 +45,13 @@ data ByronVoteError
 renderByronVoteError :: ByronVoteError -> Text
 renderByronVoteError bVerr =
   case bVerr of
-    ByronVoteDecodingError decoderErr -> "Error decoding Byron vote: " <> (Text.pack $ show decoderErr)
-    ByronVoteGenesisReadError genErr -> "Error reading the genesis file:" <> (Text.pack $ show genErr)
+    ByronVoteDecodingError decoderErr -> "Error decoding Byron vote: " <> Text.pack (show decoderErr)
+    ByronVoteGenesisReadError genErr -> "Error reading the genesis file:" <> Text.pack (show genErr)
     ByronVoteReadFileFailure fp err -> "Error reading Byron vote at " <> Text.pack fp <> " Error: " <> err
-    ByronVoteTxSubmissionError txErr -> "Error submitting the transaction: " <> (Text.pack $ show txErr)
-    ByronVoteUpdateProposalFailure err -> "Error reading the update proposal: " <> (Text.pack $ show err)
-    ByronVoteUpdateHelperError err ->"Error creating the vote: " <> (Text.pack $ show err)
-    ByronVoteKeyReadFailure err -> "Error reading the signing key: " <> (Text.pack $ show err)
+    ByronVoteTxSubmissionError txErr -> "Error submitting the transaction: " <> Text.pack (show txErr)
+    ByronVoteUpdateProposalFailure err -> "Error reading the update proposal: " <> Text.pack (show err)
+    ByronVoteUpdateHelperError err ->"Error creating the vote: " <> Text.pack (show err)
+    ByronVoteKeyReadFailure err -> "Error reading the signing key: " <> Text.pack (show err)
 
 
 runVoteCreation

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -17,8 +17,7 @@ import           System.Environment (lookupEnv)
 import           Cardano.CLI.Helpers (textShow)
 import           Cardano.CLI.Types (SocketPath (..))
 
-data EnvSocketError
-  = CliEnvVarLookup !Text deriving Show
+newtype EnvSocketError = CliEnvVarLookup Text deriving Show
 
 renderEnvSocketError :: EnvSocketError -> Text
 renderEnvSocketError err =

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -43,10 +43,10 @@ renderHelpersError :: HelpersError -> Text
 renderHelpersError err =
   case err of
     OutputMustNotAlreadyExist fp -> "Output file/directory must not already exist: " <> Text.pack fp
-    ReadCBORFileFailure fp err' -> "CBOR read failure at: " <> Text.pack fp <> (Text.pack $ show err')
-    CBORPrettyPrintError err' -> "Error with CBOR decoding: " <> (Text.pack $ show err')
-    CBORDecodingError err' -> "Error with CBOR decoding: " <> (Text.pack $ show err')
-    IOError' fp ioE -> "Error at: " <> (Text.pack fp) <> " Error: " <> (Text.pack $ show ioE)
+    ReadCBORFileFailure fp err' -> "CBOR read failure at: " <> Text.pack fp <> Text.pack (show err')
+    CBORPrettyPrintError err' -> "Error with CBOR decoding: " <> Text.pack (show err')
+    CBORDecodingError err' -> "Error with CBOR decoding: " <> Text.pack (show err')
+    IOError' fp ioE -> "Error at: " <> Text.pack fp <> " Error: " <> Text.pack (show ioE)
 
 decodeCBOR
   :: LByteString
@@ -85,23 +85,23 @@ validateCBOR :: CBORObject -> LByteString -> Either HelpersError Text
 validateCBOR cborObject bs =
   case cborObject of
     CBORBlockByron epochSlots -> do
-      (const () ) <$> decodeCBOR bs (fromCBORABlockOrBoundary epochSlots)
+      () <$ decodeCBOR bs (fromCBORABlockOrBoundary epochSlots)
       Right "Valid Byron block."
 
     CBORDelegationCertificateByron -> do
-      (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s Delegation.Certificate)
+      () <$ decodeCBOR bs (fromCBOR :: Decoder s Delegation.Certificate)
       Right "Valid Byron delegation certificate."
 
     CBORTxByron -> do
-      (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s UTxO.Tx)
+      () <$ decodeCBOR bs (fromCBOR :: Decoder s UTxO.Tx)
       Right "Valid Byron Tx."
 
     CBORUpdateProposalByron -> do
-      (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s Update.Proposal)
+      () <$ decodeCBOR bs (fromCBOR :: Decoder s Update.Proposal)
       Right "Valid Byron update proposal."
 
     CBORVoteByron -> do
-      (const () ) <$> decodeCBOR bs (fromCBOR :: Decoder s Update.Vote)
+      () <$ decodeCBOR bs (fromCBOR :: Decoder s Update.Vote)
       Right "Valid Byron vote."
 
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -178,15 +178,12 @@ pPaymentVerificationKeyFile =
     )
 
 pScript :: Parser ScriptFile
-pScript =
-  ScriptFile <$>
-    ( Opt.strOption
-        (  Opt.long "script-file"
-        <> Opt.metavar "FILE"
-        <> Opt.help "Filepath of the script."
-        <> Opt.completer (Opt.bashCompleter "file")
-        )
-    )
+pScript = ScriptFile <$> Opt.strOption
+  (  Opt.long "script-file"
+  <> Opt.metavar "FILE"
+  <> Opt.help "Filepath of the script."
+  <> Opt.completer (Opt.bashCompleter "file")
+  )
 
 pStakeAddress :: Parser StakeAddressCmd
 pStakeAddress =
@@ -344,7 +341,7 @@ pKeyCmd =
         Opt.strOption
           (  Opt.long "byron-signing-key-file"
           <> Opt.metavar "FILE"
-          <> Opt.help ("Input filepath of the Byron-format signing key.")
+          <> Opt.help "Input filepath of the Byron-format signing key."
           <> Opt.completer (Opt.bashCompleter "file")
           )
 
@@ -354,7 +351,7 @@ pKeyCmd =
         Opt.strOption
           (  Opt.long "byron-verification-key-file"
           <> Opt.metavar "FILE"
-          <> Opt.help ("Input filepath of the Byron-format verification key.")
+          <> Opt.help "Input filepath of the Byron-format verification key."
           <> Opt.completer (Opt.bashCompleter "file")
           )
 
@@ -954,7 +951,7 @@ pSomeSigningKeyFiles =
       Opt.strOption
       (  Opt.long "signing-key-file"
       <> Opt.metavar "FILE"
-      <> Opt.help ("Input filepath of the signing key (one or more).")
+      <> Opt.help "Input filepath of the signing key (one or more)."
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
@@ -969,15 +966,12 @@ pSigningKeyFile fdir =
       )
 
 pWitnessSigningKeyFile :: Parser SigningKeyFile
-pWitnessSigningKeyFile =
-  SigningKeyFile <$>
-    ( Opt.strOption
-        (  Opt.long "witness-signing-key-file"
-        <> Opt.metavar "FILE"
-        <> Opt.help "Filepath of the witness signing key."
-        <> Opt.completer (Opt.bashCompleter "file")
-        )
-    )
+pWitnessSigningKeyFile = SigningKeyFile <$> Opt.strOption
+  (  Opt.long "witness-signing-key-file"
+  <> Opt.metavar "FILE"
+  <> Opt.help "Filepath of the witness signing key."
+  <> Opt.completer (Opt.bashCompleter "file")
+  )
 
 pKesPeriod :: Parser KESPeriod
 pKesPeriod =
@@ -1072,7 +1066,7 @@ pColdVerificationKeyFile =
     ( Opt.strOption
         (  Opt.long "cold-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help ("Filepath of the cold verification key.")
+        <> Opt.help "Filepath of the cold verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1226,7 +1220,7 @@ pWitnessFile =
     Opt.strOption
       (  Opt.long "witness-file"
       <> Opt.metavar "FILE"
-      <> Opt.help ("Filepath of the witness.")
+      <> Opt.help "Filepath of the witness."
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
@@ -1349,7 +1343,7 @@ pStakeVerificationKeyFile =
     ( Opt.strOption
         (  Opt.long "stake-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help ("Filepath of the staking verification key.")
+        <> Opt.help "Filepath of the staking verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1366,7 +1360,7 @@ pPoolStakeVerificationKeyFile =
     (  Opt.strOption
          (  Opt.long "cold-verification-key-file"
          <> Opt.metavar "FILE"
-         <> Opt.help ("Filepath of the stake pool verification key.")
+         <> Opt.help "Filepath of the stake pool verification key."
          <> Opt.completer (Opt.bashCompleter "file")
          )
     <|>
@@ -1411,7 +1405,7 @@ pVRFVerificationKeyFile =
     Opt.strOption
       (  Opt.long "vrf-verification-key-file"
       <> Opt.metavar "FILE"
-      <> Opt.help ("Filepath of the VRF verification key.")
+      <> Opt.help "Filepath of the VRF verification key."
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
@@ -1421,7 +1415,7 @@ pRewardAcctVerificationKeyFile =
     ( Opt.strOption
         (  Opt.long "pool-reward-account-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help ("Filepath of the reward account staking verification key.")
+        <> Opt.help "Filepath of the reward account staking verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1438,7 +1432,7 @@ pPoolOwner =
     ( Opt.strOption
         (  Opt.long "pool-owner-stake-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help ("Filepath of the pool owner staking verification key.")
+        <> Opt.help "Filepath of the pool owner staking verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1518,7 +1512,7 @@ pSingleHostAddress = singleHostAddress
   singleHostAddress ipv4 ipv6 port =
     case (ipv4, ipv6) of
       (Nothing, Nothing) ->
-        panic $ "Please enter either an IPv4 or IPv6 address for the pool relay"
+        panic "Please enter either an IPv4 or IPv6 address for the pool relay"
       (Just i4, Nothing) ->
         StakePoolRelayIp (Just i4) Nothing (Just port)
       (Nothing, Just i6) ->
@@ -1758,7 +1752,7 @@ pExtraEntropy =
   where
     parseEntropyBytes :: Atto.Parser ByteString
     parseEntropyBytes =
-      (fst . Base16.decode) <$> Atto.takeWhile1 Char.isHexDigit
+      fst . Base16.decode <$> Atto.takeWhile1 Char.isHexDigit
 
 
 pProtocol :: Parser Protocol

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -186,8 +186,7 @@ readAddressVerificationKeyFile (VerificationKeyFile vkfile) =
 --
 
 runAddressBuildMultiSig :: ExceptT ShelleyAddressCmdError IO ()
-runAddressBuildMultiSig =
-    liftIO $ putStrLn ("runAddressBuildMultiSig: TODO")
+runAddressBuildMultiSig = liftIO $ putStrLn "runAddressBuildMultiSig: TODO"
 
 --
 -- Script addresses

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
@@ -4,22 +4,18 @@ module Cardano.CLI.Shelley.Run.Address.Info
   , ShelleyAddressInfoError(..)
   ) where
 
+import           Cardano.Api.Typed
+import           Cardano.CLI.Shelley.Parsers (OutputFile (..))
 import           Cardano.Prelude
-
-import           Data.Aeson (ToJSON (..), object, (.=))
-import           Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.ByteString.Lazy.Char8 as LBS
-
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (left)
+import           Data.Aeson (ToJSON (..), object, (.=))
+import           Data.Aeson.Encode.Pretty (encodePretty)
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Text.Encoding as Text
 
-import           Cardano.Api.Typed
-
-import           Cardano.CLI.Shelley.Parsers (OutputFile (..))
-
-
-data ShelleyAddressInfoError = ShelleyAddressInvalid Text
+newtype ShelleyAddressInfoError = ShelleyAddressInvalid Text
   deriving Show
 
 instance Error ShelleyAddressInfoError where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -48,6 +48,8 @@ import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Parsers (renderTxIn)
 import           Cardano.CLI.Types
 
+{- HLINT ignore "Reduce duplication" -}
+
 data ShelleyGenesisCmdError
   = ShelleyGenesisCmdReadGenesisAesonDecodeError !FilePath !Text
   | ShelleyGenesisCmdReadGenesisIOError !FilePath !IOException

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -4,22 +4,19 @@ module Cardano.CLI.Shelley.Run.Node
   , runNodeCmd
   ) where
 
+import           Cardano.Api.TextView (TextViewDescription (..))
+import           Cardano.Api.Typed
+import           Cardano.CLI.Shelley.Commands
+import           Cardano.CLI.Types (SigningKeyFile (..), VerificationKeyFile (..))
 import           Cardano.Prelude
-import           Prelude (id)
-
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
+import           Prelude (id)
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as Text
 
-import           Cardano.Api.Typed
-
-import           Cardano.Api.TextView (TextViewDescription (..))
-
-import           Cardano.CLI.Shelley.Commands
-import           Cardano.CLI.Types (SigningKeyFile (..), VerificationKeyFile(..))
-
+{- HLINT ignore "Reduce duplication" -}
 
 data ShelleyNodeCmdError
   = ShelleyNodeReadFileError !(FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -76,7 +76,7 @@ runStakePoolRegistrationCert
   -- ^ Pool owner stake verification key(s).
   -> [StakePoolRelay]
   -- ^ Stake pool relays.
-  -> (Maybe StakePoolMetadataReference)
+  -> Maybe StakePoolMetadataReference
   -- ^ Stake pool metadata.
   -> NetworkId
   -> OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -126,7 +126,7 @@ runQueryProtocolParameters protocol network mOutFile = do
     SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr
                            readEnvSocketPath
     pparams <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
-               withlocalNodeConnectInfo protocol network sockPath $
+               withlocalNodeConnectInfo protocol network sockPath
                  queryPParamsFromLocalState
     writeProtocolParameters mOutFile pparams
 
@@ -305,7 +305,7 @@ printStakeDistribution (PoolDistr stakeDist) = do
     putStrLn $ replicate (Text.length title + 2) '-'
     sequence_
       [ putStrLn $ showStakeDistr (StakePoolKeyHash poolId) stakeFraction (VrfKeyHash vrfKeyId)
-      | (poolId, (IndividualPoolStake stakeFraction vrfKeyId)) <- Map.toList stakeDist ]
+      | (poolId, IndividualPoolStake stakeFraction vrfKeyId) <- Map.toList stakeDist ]
   where
     title :: Text
     title =
@@ -550,7 +550,7 @@ queryDelegationsAndRewardsFromLocalState stakeaddrs
           )
       case result of
         QueryResultEraMismatch err -> throwError (EraMismatchError err)
-        QueryResultSuccess drs -> return $ (uncurry toDelegsAndRwds) drs
+        QueryResultSuccess drs -> return $ uncurry toDelegsAndRwds drs
   where
     toDelegsAndRwds
       :: Map (Ledger.Credential Ledger.Staking TPraosStandardCrypto)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
@@ -21,7 +21,7 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 data ShelleyTextViewFileError
-  = ShelleyTextViewReadFileError ((FileError TextEnvelopeError))
+  = ShelleyTextViewReadFileError (FileError TextEnvelopeError)
   | ShelleyTextViewCBORPrettyPrintError !HelpersError
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -13,9 +13,9 @@ import           Cardano.Prelude
 import           Prelude (String)
 
 import qualified Data.Aeson as Aeson
-import qualified Data.Text as Text
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as Text
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
@@ -209,7 +209,7 @@ runTxSign (TxBodyFile txbodyFile) skFiles mnw (TxFile txFile) = do
 runTxSubmit :: Protocol -> NetworkId -> FilePath
             -> ExceptT ShelleyTxCmdError IO ()
 runTxSubmit protocol network txFile = do
-    SocketPath sockPath <- firstExceptT ShelleyTxSocketEnvError $ readEnvSocketPath
+    SocketPath sockPath <- firstExceptT ShelleyTxSocketEnvError readEnvSocketPath
     tx <- firstExceptT ShelleyTxReadFileError
       . newExceptT
       $ Api.readFileTextEnvelopeAnyOf

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -46,7 +46,7 @@ newtype GenesisFile = GenesisFile
 instance FromJSON GenesisFile where
   parseJSON (String genFp) = pure . GenesisFile $ Text.unpack genFp
   parseJSON invalid = panic $ "Parsing of GenesisFile failed due to type mismatch. "
-                           <> "Encountered: " <> (Text.pack $ show invalid)
+                           <> "Encountered: " <> Text.pack (show invalid)
 
 -- | The desired output format.
 data OutputFormat

--- a/cardano-cli/test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/Test/Cli/ITN.hs
@@ -13,6 +13,8 @@ import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.ByteString.Base16 as Base16
 import qualified Hedgehog as H
 
+{- HLINT ignore "Reduce duplication" -}
+
 -- | Bech32 verification key
 itnVerKey :: Text
 itnVerKey = "ed25519_pk1demeytzdadayd4qrqeg2raadp2eceg3mrdmefxyfxx73q60hg4xsjjyzyq"

--- a/cardano-cli/test/Test/Golden/Byron/TextEnvelope/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Byron/TextEnvelope/PaymentKeys.hs
@@ -5,9 +5,9 @@ module Test.Golden.Byron.TextEnvelope.PaymentKeys
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair

--- a/cardano-cli/test/Test/Golden/Byron/TextEnvelope/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Byron/TextEnvelope/Tx.hs
@@ -5,9 +5,9 @@ module Test.Golden.Byron.TextEnvelope.Tx
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
 
 golden_byronTx :: Property
 golden_byronTx = panic "TODO"

--- a/cardano-cli/test/Test/Golden/Byron/TextEnvelope/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Byron/TextEnvelope/TxBody.hs
@@ -5,9 +5,9 @@ module Test.Golden.Byron.TextEnvelope.TxBody
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
 
 golden_byronTxBody :: Property
 golden_byronTxBody = panic "TODO"

--- a/cardano-cli/test/Test/Golden/Byron/TextEnvelope/Witness.hs
+++ b/cardano-cli/test/Test/Golden/Byron/TextEnvelope/Witness.hs
@@ -5,9 +5,9 @@ module Test.Golden.Byron.TextEnvelope.Witness
   ) where
 
 import           Cardano.Prelude
-
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
 
 golden_byronWitness :: Property
 golden_byronWitness = panic "TODO"

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -23,6 +23,7 @@ import qualified Hedgehog.Range as R
 import qualified System.Directory as IO
 
 {- HLINT ignore "Use camelCase" -}
+{- HLINT ignore "Reduce duplication" -}
 
 parseMaxLovelaceSupply :: J.Value -> J.Parser Int
 parseMaxLovelaceSupply = J.withObject "Object" $ \o -> o J..: "maxLovelaceSupply"
@@ -31,7 +32,7 @@ parseSystemStart :: J.Value -> J.Parser String
 parseSystemStart = J.withObject "Object" $ \o -> o J..: "systemStart"
 
 parseHashMap :: J.Value -> J.Parser (HM.HashMap String J.Value)
-parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first T.unpack) (HM.toList (hm))
+parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first T.unpack) (HM.toList hm)
 parseHashMap v = J.typeMismatch "Object" v
 
 parseDelegateCount :: J.Value -> J.Parser Int

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -23,12 +23,12 @@ golden_shelleyGenesisKeyGenDelegate = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
     ]
 
-  assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ verificationKeyFile
-  assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ signingKeyFile
-  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ operationalCertificateIssueCounterFile
+  assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" verificationKeyFile
+  assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" signingKeyFile
+  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" operationalCertificateIssueCounterFile
 
-  assertFileOccurences 1 "Genesis delegate operator key" $ verificationKeyFile
-  assertFileOccurences 1 "Genesis delegate operator key" $ signingKeyFile
+  assertFileOccurences 1 "Genesis delegate operator key" verificationKeyFile
+  assertFileOccurences 1 "Genesis delegate operator key" signingKeyFile
 
   assertEndsWithSingleNewline verificationKeyFile
   assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -21,8 +21,8 @@ golden_shelleyGenesisKeyGenGenesis = propertyOnce . moduleWorkspace "tmp" $ \tem
     , "--signing-key-file", signingKeyFile
     ]
 
-  assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ verificationKeyFile
-  assertFileOccurences 1 "GenesisSigningKey_ed25519" $ signingKeyFile
+  assertFileOccurences 1 "GenesisVerificationKey_ed25519" verificationKeyFile
+  assertFileOccurences 1 "GenesisSigningKey_ed25519" signingKeyFile
 
   assertEndsWithSingleNewline verificationKeyFile
   assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -21,8 +21,8 @@ golden_shelleyGenesisKeyGenUtxo = propertyOnce . moduleWorkspace "tmp" $ \tempDi
     , "--signing-key-file", utxoSigningKeyFile
     ]
 
-  assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" $ utxoVerificationKeyFile
-  assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ utxoSigningKeyFile
+  assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" utxoVerificationKeyFile
+  assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" utxoSigningKeyFile
 
   assertEndsWithSingleNewline utxoVerificationKeyFile
   assertEndsWithSingleNewline utxoSigningKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -8,6 +8,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
+{- HLINT ignore "Use camelCase" -}
+
 golden_stakePoolMetadataHash :: Property
 golden_stakePoolMetadataHash = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
   referenceStakePoolMetaData <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"

--- a/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -37,8 +37,8 @@ golden_shelleyNodeIssueOpCert = propertyOnce . moduleWorkspace "tmp" $ \tempDir 
     , "--out-file", operationalCertFile
     ]
 
-  assertFileOccurences 1 "NodeOperationalCertificate" $ operationalCertFile
-  assertFileOccurences 1 "Next certificate issue number: 1" $ operationalCertificateIssueCounterFile
+  assertFileOccurences 1 "NodeOperationalCertificate" operationalCertFile
+  assertFileOccurences 1 "Next certificate issue number: 1" operationalCertificateIssueCounterFile
 
   assertEndsWithSingleNewline operationalCertFile
   assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
@@ -23,9 +23,9 @@ golden_shelleyNodeKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     , "--operational-certificate-issue-counter", opCertCounterFile
     ]
 
-  assertFileOccurences 1 "StakePoolVerificationKey_ed25519" $ verificationKeyFile
-  assertFileOccurences 1 "StakePoolSigningKey_ed25519" $ signingKeyFile
-  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ opCertCounterFile
+  assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
+  assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
+  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
 
   assertEndsWithSingleNewline verificationKeyFile
   assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisDelegationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisDelegationCertificate.hs
@@ -7,5 +7,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisDelegation
 import           Cardano.Prelude
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
+
 golden_shelleyGenesisDelegationCertificate :: Property
 golden_shelleyGenesisDelegationCertificate = panic "TODO"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate stake key pair
 --   2. Create MIR certificate
 --   s. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Create KES key pair.
 --   2. Create cold keys.
 --   3. Create operational certificate.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Create cold key pair.
 --   2. Create stake key pair.
 --   3. Create VRF key pair.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair & operational certificate counter file
 --   2. Check for the existence of the key pair & counter file
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. Generate a key pair
 --   2. Create tx body
 --   3. Sign tx body

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+{- HLINT ignore "Use camelCase" -}
+
 -- | 1. We create a 'TxBody Shelley' file.
 --   2. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTxBody :: Property

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
@@ -7,5 +7,7 @@ module Test.Golden.Shelley.TextEnvelope.Tx.Witness
 import           Cardano.Prelude
 import           Hedgehog (Property)
 
+{- HLINT ignore "Use camelCase" -}
+
 golden_shelleyWitness :: Property
 golden_shelleyWitness = panic "TODO"

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -265,7 +265,7 @@ failDiffCustom cS x y =
     Nothing ->
       withFrozenCallStack $
         failWithCustom cS Nothing $
-        Prelude.unlines $ [
+        Prelude.unlines [
             "Failed"
           , "━━ lhs ━━"
           , showPretty x

--- a/cardano-node-chairman/src/Chairman/Process.hs
+++ b/cardano-node-chairman/src/Chairman/Process.hs
@@ -93,7 +93,7 @@ execFlex pkgBin envBin arguments = GHC.withFrozenCallStack $ do
   maybeEnvBin <- liftIO $ IO.lookupEnv envBin
   (actualBin, actualArguments) <- case maybeEnvBin of
     Just envBin' -> return (envBin', arguments)
-    Nothing -> return ("cabal", ("exec":"--":pkgBin:arguments))
+    Nothing -> return ("cabal", "exec":"--":pkgBin:arguments)
   H.annotate $ "Command: " <> actualBin <> " " <> L.unwords actualArguments
   (exitResult, stdout, stderr) <- H.evalM . liftIO $ IO.readProcessWithExitCode actualBin actualArguments ""
   case exitResult of

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman.hs
@@ -73,18 +73,17 @@ prop_spawnOneNode = H.propertyOnce . H.workspace "temp/chairman" $ \tempDir -> d
     hNodeStderr <- H.evalM . liftIO $ IO.openFile nodeStderrFile IO.WriteMode
 
     (Just hIn, _mOut, _mErr, hProcess, _) <- H.createProcess =<<
-      ( ( H.procNode
-          [ "run"
-          , "--database-path", dbDir
-          , "--socket-path", socketDir <> "/node-" <> si <> "-socket"
-          , "--port", "300" <> si <> ""
-          , "--topology", tempDir <> "/topology-node-" <> si <> ".json"
-          , "--config", tempDir <> "/config-" <> si <> ".yaml"
-          , "--signing-key", tempDir <> "/genesis/delegate-keys.00" <> si <> ".key"
-          , "--delegation-certificate", tempDir <> "/genesis/delegation-cert.00" <> si <> ".json"
-          , "--shutdown-ipc", "0"
-          ]
-        ) <&>
+      ( H.procNode
+        [ "run"
+        , "--database-path", dbDir
+        , "--socket-path", socketDir <> "/node-" <> si <> "-socket"
+        , "--port", "300" <> si <> ""
+        , "--topology", tempDir <> "/topology-node-" <> si <> ".json"
+        , "--config", tempDir <> "/config-" <> si <> ".yaml"
+        , "--signing-key", tempDir <> "/genesis/delegate-keys.00" <> si <> ".key"
+        , "--delegation-certificate", tempDir <> "/genesis/delegation-cert.00" <> si <> ".json"
+        , "--shutdown-ipc", "0"
+        ] <&>
         ( \cp -> cp
           { IO.std_in = IO.CreatePipe
           , IO.std_out = IO.UseHandle hNodeStdout

--- a/cardano-node/chairman/Cardano/Chairman.hs
+++ b/cardano-node/chairman/Cardano/Chairman.hs
@@ -87,7 +87,7 @@ chairmanTest tracer slotLength securityParam runningTime optionalProgressThresho
     traceWith tracer ("Will observe nodes for " ++ show runningTime)
     traceWith tracer ("Will require chain growth of " ++ show progressThreshold)
 
-    SomeNodeClientProtocol (p :: ProtocolClient blk (BlockProtocol blk)) <- return $ someNodeClientProtocol
+    SomeNodeClientProtocol (p :: ProtocolClient blk (BlockProtocol blk)) <- return someNodeClientProtocol
 
     -- Run the chairman and get the final snapshot of the chain from each node.
     chainsSnapshot <- runChairman
@@ -98,7 +98,7 @@ chairmanTest tracer slotLength securityParam runningTime optionalProgressThresho
                         runningTime
                         socketPaths
 
-    traceWith tracer ("================== chairman results ==================")
+    traceWith tracer "================== chairman results =================="
 
     -- Test if we achieved consensus
     consensusSuccess <- either throwIO return $
@@ -111,7 +111,7 @@ chairmanTest tracer slotLength securityParam runningTime optionalProgressThresho
                          progressCondition progressThreshold consensusSuccess
 
     traceWith tracer (show progressSuccess)
-    traceWith tracer ("================== chairman results ==================")
+    traceWith tracer "================== chairman results =================="
 
   where
     progressThreshold = deriveProgressThreshold
@@ -240,9 +240,7 @@ consensusCondition (SecurityParam securityParam) chains =
           - fromWithOrigin 0 (AF.anchorToBlockNo intersection)
 
 
-data ProgressSuccess =
-     ProgressSuccess
-       BlockNo
+newtype ProgressSuccess = ProgressSuccess BlockNo
   deriving Show
 
 data ProgressFailure blk =

--- a/cardano-node/chairman/chairman.hs
+++ b/cardano-node/chairman/chairman.hs
@@ -94,7 +94,7 @@ parseSocketPath :: Text -> Parser SocketPath
 parseSocketPath helpMessage =
   SocketPath <$> strOption
     ( long "socket-path"
-        <> (help $ toS helpMessage)
+        <> help (toS helpMessage)
         <> completer (bashCompleter "file")
         <> metavar "FILEPATH"
     )
@@ -148,8 +148,8 @@ parseChairmanArgs =
     ChairmanArgs
       <$> parseRunningTime
       <*> optional parseProgress
-      <*> (some $ parseSocketPath "Path to a cardano-node socket")
-      <*> (ConfigYamlFilePath <$> parseConfigFile)
+      <*> some (parseSocketPath "Path to a cardano-node socket")
+      <*> fmap ConfigYamlFilePath parseConfigFile
       <*> parseSlotLength
       <*> parseSecurityParam
       <*> parseTestnetMagic

--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -165,7 +165,7 @@ maybeSpawnOnSlotSyncedShutdownHandler cli sfds trace registry chaindb =
   case (shutdownOnSlotSynced cli, sfds) of
     (MaxSlotNo maxSlot, InternalShutdown _sl sd) -> do
       traceWith (trTransformer MaximalVerbosity $ severityNotice trace)
-        ("will terminate upon reaching " <> (pack $ show maxSlot) :: Text)
+        ("will terminate upon reaching " <> pack (show maxSlot))
       spawnSlotLimitTerminator maxSlot sd
     (MaxSlotNo{}, _) -> panic
       "internal error: slot-limited shutdown requested, but no proper ShutdownFDs passed."

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -22,7 +22,7 @@ instance FromJSON TracingVerbosity where
     err -> panic $ "Parsing of TracingVerbosity failed, "
                  <> err <> " is not a valid TracingVerbosity"
   parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                             <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
 
 deriving instance Show TracingVerbosity
 
@@ -30,4 +30,4 @@ instance FromJSON Update.ApplicationName where
   parseJSON (String x) = pure $ Update.ApplicationName x
   parseJSON invalid  =
     panic $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+    <> "Encountered: " <> Text.pack (Prelude.show invalid)

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -78,7 +78,7 @@ parseSocketPath :: Text -> Parser SocketPath
 parseSocketPath helpMessage =
   SocketPath <$> strOption
     ( long "socket-path"
-        <> (help $ toS helpMessage)
+        <> help (toS helpMessage)
         <> completer (bashCompleter "file")
         <> metavar "FILEPATH"
     )

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -216,11 +216,11 @@ renderByronProtocolInstantiationError pie =
     DelegationCertificateFilepathNotSpecified -> "Delegation certificate filepath not specified"
     --TODO: Implement configuration error render function in cardano-ledger
     GenesisConfigurationError fp genesisConfigError -> "Genesis configuration error in: " <> toS fp
-                                                       <> " Error: " <> (Text.pack $ show genesisConfigError)
+                                                       <> " Error: " <> Text.pack (show genesisConfigError)
     GenesisReadError fp err ->  "There was an error parsing the genesis file: " <> toS fp
-                                <> " Error: " <> (Text.pack $ show err)
+                                <> " Error: " <> Text.pack (show err)
     -- TODO: Implement ByronLeaderCredentialsError render function in ouroboros-network
-    CredentialsError byronLeaderCredentialsError -> "Byron leader credentials error: " <> (Text.pack $ show byronLeaderCredentialsError)
+    CredentialsError byronLeaderCredentialsError -> "Byron leader credentials error: " <> Text.pack (show byronLeaderCredentialsError)
     SigningKeyDeserialiseFailure fp deserialiseFailure -> "Signing key deserialisation error in: " <> toS fp
-                                                           <> " Error: " <> (Text.pack $ show deserialiseFailure)
+                                                           <> " Error: " <> Text.pack (show deserialiseFailure)
     SigningKeyFilepathNotSpecified -> "Signing key filepath not specified"

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -203,7 +203,7 @@ renderShelleyProtocolInstantiationError pie =
   case pie of
     GenesisReadError fp err ->
         "There was an error reading the genesis file: "
-     <> toS fp <> " Error: " <> (T.pack $ show err)
+     <> toS fp <> " Error: " <> T.pack (show err)
 
     GenesisHashMismatch actual expected ->
         "Wrong Shelley genesis file: the actual hash is " <> show actual
@@ -212,7 +212,7 @@ renderShelleyProtocolInstantiationError pie =
 
     GenesisDecodeError fp err ->
         "There was an error parsing the genesis file: "
-     <> toS fp <> " Error: " <> (T.pack $ show err)
+     <> toS fp <> " Error: " <> T.pack (show err)
 
     FileError fileErr -> T.pack $ displayError fileErr
 

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -166,9 +166,9 @@ logTracingVerbosity nc tracer =
     TracingOff -> return ()
     TracingOn traceConf ->
       case traceVerbosity traceConf of
-        NormalVerbosity -> traceWith tracer $ "tracing verbosity = normal verbosity "
-        MinimalVerbosity -> traceWith tracer $ "tracing verbosity = minimal verbosity "
-        MaximalVerbosity -> traceWith tracer $ "tracing verbosity = maximal verbosity "
+        NormalVerbosity -> traceWith tracer "tracing verbosity = normal verbosity "
+        MinimalVerbosity -> traceWith tracer "tracing verbosity = minimal verbosity "
+        MaximalVerbosity -> traceWith tracer "tracing verbosity = maximal verbosity "
 
 -- | Add the application name and unqualified hostname to the logging
 -- layer basic trace.

--- a/cardano-node/src/Cardano/Node/TUI/Drawing.hs
+++ b/cardano-node/src/Cardano/Node/TUI/Drawing.hs
@@ -333,14 +333,14 @@ systemStatsW p =
                                  , (mempoolToDoAttr, progressIncompleteAttr)
                                  ]
                  ) $ bar mempoolLabel (lvsMempoolPerc p)
-    mempoolLabel = Just $ (show . lvsMempool $ p)
+    mempoolLabel = Just . show $ lvsMempool p
     memPoolBytesBar :: forall n. Widget n
     memPoolBytesBar = updateAttrMap
                  (A.mapAttrNames [ (mempoolDoneAttr, progressCompleteAttr)
                                  , (mempoolToDoAttr, progressIncompleteAttr)
                                  ]
                  ) $ bar mempoolBytesLabel (lvsMempoolBytesPerc p)
-    mempoolBytesLabel = Just $ (show . lvsMempoolBytes $ p)
+    mempoolBytesLabel = Just . show $ lvsMempoolBytes p
     memUsageBar :: forall n. Widget n
     memUsageBar = updateAttrMap
                   (A.mapAttrNames [ (memDoneAttr, progressCompleteAttr)
@@ -463,42 +463,42 @@ bold a = Vty.withStyle a Vty.bold
 
 lightThemeAttributes :: [(A.AttrName, Vty.Attr)]
 lightThemeAttributes =
-    [ (cardanoAttr,       bold $ fg Vty.black)
-    , (releaseAttr,       bold $ fg Vty.blue)
-    , (nodeIdAttr,        bold $ fg Vty.blue)
-    , (valueAttr,         bold $ fg Vty.black)
-    , (keyAttr,           bold $ fg Vty.magenta)
-    , (barValueAttr,      bold $ fg Vty.black)
-    , (mempoolDoneAttr,   bold $ progressDoneColorLFG `on` progressDoneColorLBG)
-    , (mempoolToDoAttr,   bold $ progressToDoColorLFG `on` progressToDoColorLBG)
-    , (memDoneAttr,       bold $ progressDoneColorLFG `on` progressDoneColorLBG)
-    , (memToDoAttr,       bold $ progressToDoColorLFG `on` progressToDoColorLBG)
-    , (cpuDoneAttr,       bold $ progressDoneColorLFG `on` progressDoneColorLBG)
-    , (cpuToDoAttr,       bold $ progressToDoColorLFG `on` progressToDoColorLBG)
-    , (diskIODoneAttr,    bold $ progressDoneColorLFG `on` progressDoneColorLBG)
-    , (diskIOToDoAttr,    bold $ progressToDoColorLFG `on` progressToDoColorLBG)
-    , (networkIODoneAttr, bold $ progressDoneColorLFG `on` progressDoneColorLBG)
-    , (networkIOToDoAttr, bold $ progressToDoColorLFG `on` progressToDoColorLBG)
+    [ (cardanoAttr,       bold (fg Vty.black))
+    , (releaseAttr,       bold (fg Vty.blue))
+    , (nodeIdAttr,        bold (fg Vty.blue))
+    , (valueAttr,         bold (fg Vty.black))
+    , (keyAttr,           bold (fg Vty.magenta))
+    , (barValueAttr,      bold (fg Vty.black))
+    , (mempoolDoneAttr,   bold (progressDoneColorLFG `on` progressDoneColorLBG))
+    , (mempoolToDoAttr,   bold (progressToDoColorLFG `on` progressToDoColorLBG))
+    , (memDoneAttr,       bold (progressDoneColorLFG `on` progressDoneColorLBG))
+    , (memToDoAttr,       bold (progressToDoColorLFG `on` progressToDoColorLBG))
+    , (cpuDoneAttr,       bold (progressDoneColorLFG `on` progressDoneColorLBG))
+    , (cpuToDoAttr,       bold (progressToDoColorLFG `on` progressToDoColorLBG))
+    , (diskIODoneAttr,    bold (progressDoneColorLFG `on` progressDoneColorLBG))
+    , (diskIOToDoAttr,    bold (progressToDoColorLFG `on` progressToDoColorLBG))
+    , (networkIODoneAttr, bold (progressDoneColorLFG `on` progressDoneColorLBG))
+    , (networkIOToDoAttr, bold (progressToDoColorLFG `on` progressToDoColorLBG))
     ]
 
 darkThemeAttributes :: [(A.AttrName, Vty.Attr)]
 darkThemeAttributes =
-    [ (cardanoAttr,       bold $ fg Vty.white)
-    , (releaseAttr,       bold $ fg Vty.cyan)
-    , (nodeIdAttr,        bold $ fg Vty.cyan)
-    , (valueAttr,         bold $ fg Vty.white)
-    , (keyAttr,           bold $ fg Vty.white)
-    , (barValueAttr,      bold $ fg Vty.white)
-    , (mempoolDoneAttr,   bold $ progressDoneColorDFG `on` progressDoneColorDBG)
-    , (mempoolToDoAttr,   bold $ progressToDoColorDFG `on` progressToDoColorDBG)
-    , (memDoneAttr,       bold $ progressDoneColorDFG `on` progressDoneColorDBG)
-    , (memToDoAttr,       bold $ progressToDoColorDFG `on` progressToDoColorDBG)
-    , (cpuDoneAttr,       bold $ progressDoneColorDFG `on` progressDoneColorDBG)
-    , (cpuToDoAttr,       bold $ progressToDoColorDFG `on` progressToDoColorDBG)
-    , (diskIODoneAttr,    bold $ progressDoneColorDFG `on` progressDoneColorDBG)
-    , (diskIOToDoAttr,    bold $ progressToDoColorDFG `on` progressToDoColorDBG)
-    , (networkIODoneAttr, bold $ progressDoneColorDFG `on` progressDoneColorDBG)
-    , (networkIOToDoAttr, bold $ progressToDoColorDFG `on` progressToDoColorDBG)
+    [ (cardanoAttr,       bold (fg Vty.white))
+    , (releaseAttr,       bold (fg Vty.cyan))
+    , (nodeIdAttr,        bold (fg Vty.cyan))
+    , (valueAttr,         bold (fg Vty.white))
+    , (keyAttr,           bold (fg Vty.white))
+    , (barValueAttr,      bold (fg Vty.white))
+    , (mempoolDoneAttr,   bold (progressDoneColorDFG `on` progressDoneColorDBG))
+    , (mempoolToDoAttr,   bold (progressToDoColorDFG `on` progressToDoColorDBG))
+    , (memDoneAttr,       bold (progressDoneColorDFG `on` progressDoneColorDBG))
+    , (memToDoAttr,       bold (progressToDoColorDFG `on` progressToDoColorDBG))
+    , (cpuDoneAttr,       bold (progressDoneColorDFG `on` progressDoneColorDBG))
+    , (cpuToDoAttr,       bold (progressToDoColorDFG `on` progressToDoColorDBG))
+    , (diskIODoneAttr,    bold (progressDoneColorDFG `on` progressDoneColorDBG))
+    , (diskIOToDoAttr,    bold (progressToDoColorDFG `on` progressToDoColorDBG))
+    , (networkIODoneAttr, bold (progressDoneColorDFG `on` progressDoneColorDBG))
+    , (networkIOToDoAttr, bold (progressToDoColorDFG `on` progressToDoColorDBG))
     ]
 
 lightTheme :: Theme

--- a/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
+++ b/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
@@ -114,8 +114,8 @@ instance IsEffectuator (LiveViewBackend blk) Text where
 
                     LogValue "Stat.utime" (PureI ticks) ->
                         modifyMVar_ (getbe lvbe) $ \lvs -> do
-                            let !tdiff      = max 1 $ (fromIntegral (currentTimeInNs - lvsCPUUsageNs lvs)) / 1000000000 :: Float
-                                !cpuperc    = (fromIntegral (ticks - lvsCPUUsageLast lvs)) / (fromIntegral clktck) / tdiff
+                            let !tdiff      = max 1 $ fromIntegral (currentTimeInNs - lvsCPUUsageNs lvs) / 1000000000 :: Float
+                                !cpuperc    = fromIntegral (ticks - lvsCPUUsageLast lvs) / fromIntegral clktck / tdiff
                                 !uptime     = diffUTCTime (tstamp meta) (lvsStartTime lvs)
 
                             checkForUnexpectedThunks ["Stat.utime LiveViewBackend"] lvs
@@ -128,7 +128,7 @@ instance IsEffectuator (LiveViewBackend blk) Text where
 
                     LogValue "Sys.SysUserTime" (Nanoseconds nsecs) ->   -- Darwin, Windows
                         modifyMVar_ (getbe lvbe) $ \lvs -> do
-                            let !tdiff      = max 1 $ (fromIntegral (currentTimeInNs - lvsCPUUsageNs lvs)) :: Float
+                            let !tdiff      = max 1 $ fromIntegral (currentTimeInNs - lvsCPUUsageNs lvs) :: Float
                                 !deltacpu   = fromIntegral nsecs - fromIntegral (lvsCPUUsageLast lvs) :: Float
                                 !cpuperc    = deltacpu * 10 / tdiff
                                 !uptime     = diffUTCTime (tstamp meta) (lvsStartTime lvs)

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -52,8 +52,7 @@ import           Ouroboros.Network.Block (MaxSlotNo (..))
 -- use records with named fields in the CLI code.
 
 -- | Errors for the cardano-config module.
-data ConfigError
-    = ConfigErrorFileNotFound !FilePath
+newtype ConfigError = ConfigErrorFileNotFound FilePath
     deriving Show
 
 -- | Filepath of the configuration yaml file. This file determines
@@ -75,7 +74,7 @@ newtype GenesisFile = GenesisFile
 instance FromJSON GenesisFile where
   parseJSON (String genFp) = pure . GenesisFile $ Text.unpack genFp
   parseJSON invalid = panic $ "Parsing of GenesisFile failed due to type mismatch. "
-                           <> "Encountered: " <> (Text.pack $ show invalid)
+                           <> "Encountered: " <> Text.pack (show invalid)
 
 -- Node can be run in two modes.
 data ViewMode = LiveView    -- Live mode with TUI
@@ -90,7 +89,7 @@ instance FromJSON ViewMode where
                                           <> view <> " failed. "
                                           <> view <> " is not a valid view mode"
   parseJSON invalid = panic $ "Parsing of ViewMode failed due to type mismatch. "
-                            <> "Encountered: " <> (Text.pack $ show invalid)
+                            <> "Encountered: " <> Text.pack (show invalid)
 
 newtype MaxConcurrencyBulkSync = MaxConcurrencyBulkSync
   { unMaxConcurrencyBulkSync :: Word }
@@ -137,12 +136,12 @@ instance FromJSON NodeHostAddress where
       Nothing -> panic $ "Parsing of IP failed: " <> ipStr
   parseJSON Null = pure $ NodeHostAddress Nothing
   parseJSON invalid = panic $ "Parsing of IP failed due to type mismatch. "
-                            <> "Encountered: " <> (Text.pack $ show invalid) <> "\n"
+                            <> "Encountered: " <> Text.pack (show invalid) <> "\n"
 
 instance ToJSON NodeHostAddress where
   toJSON mha =
     case unNodeHostAddress mha of
-      Just ip -> String (Text.pack $ show ip)
+      Just ip -> String (Text.pack (show ip))
       Nothing -> Null
 
 data NodeCLI = NodeCLI

--- a/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
+++ b/cardano-node/src/Cardano/Tracing/MicroBenchmarking.hs
@@ -136,10 +136,10 @@ instance (Monad m, HasTxId (GenTx blk)) => Outcome m (MeasureTxs blk) where
     computeOutcomeMetric _ xs ys = pure . computeFinalValues $ computeIntermediateValues xsTxId ysTxId
       where
         --xsTxId :: [(GenTxId blk, Time)]
-        xsTxId = map (\(genTx, _time) -> (txId genTx, _time)) xs
+        xsTxId = map (first txId) xs
 
         --ysTxId :: [(GenTxId blk, Time)]
-        ysTxId = map (\(genTx, _time) -> (txId genTx, _time)) ys
+        ysTxId = map (first txId) ys
 
         -- | Here we filter and match all the transactions that made it into
         -- a block.
@@ -196,7 +196,7 @@ instance (Monad m, MonadTime m) => Outcome m (TraceForgeEvent blk) where
 
     --computeOutcomeMetric   :: a -> IntermediateValue a -> IntermediateValue a -> m (OutcomeMetric a)
     computeOutcomeMetric _ (startSlot, absTimeStart, _) (stopSlot, absTimeStop, mempoolSize)
-        | startSlot == stopSlot = pure $ Just (startSlot, (diffTime absTimeStop absTimeStart), mempoolSize)
+        | startSlot == stopSlot = pure $ Just (startSlot, diffTime absTimeStop absTimeStart, mempoolSize)
         | otherwise             = pure Nothing
 
 instance HasPrivacyAnnotation (Either

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -34,7 +34,7 @@ import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
 import           Cardano.Chain.Delegation (delegateVK)
 import           Cardano.Crypto.Signing (VerificationKey)
 
-
+{- HLINT ignore "Use :" -}
 
 --
 -- | instances of @ToObject@
@@ -65,14 +65,14 @@ instance ToObject ApplyMempoolPayloadErr where
 
 instance ToObject ByronLedgerUpdate where
   toObject verb (ByronUpdatedProtocolUpdates protocolUpdates) =
-    mkObject $
+    mkObject
       [ "kind"            .= String "ByronUpdatedProtocolUpdates"
       , "protocolUpdates" .= map (toObject verb) protocolUpdates
       ]
 
 instance ToObject ProtocolUpdate where
   toObject verb (ProtocolUpdate updateVersion updateState) =
-    mkObject $
+    mkObject
       [ "kind"                  .= String "ProtocolUpdate"
       , "protocolUpdateVersion" .= updateVersion
       , "protocolUpdateState"   .= toObject verb updateState

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -81,21 +81,20 @@ instance FromJSON TracingVerbosity where
     err -> panic $ "Parsing of TracingVerbosity failed, "
                  <> err <> " is not a valid TracingVerbosity"
   parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                             <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
 
 instance FromJSON PortNumber where
   parseJSON (Number portNum) = case readMaybe . show $ coefficient portNum of
-                                 Just port -> pure port
-                                 Nothing -> panic $ (show portNum)
-                                                  <> " is not a valid port number."
+    Just port -> pure port
+    Nothing -> panic $ show portNum <> " is not a valid port number."
   parseJSON invalid  = panic $ "Parsing of port number failed due to type mismatch. "
-                             <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
 
 instance FromJSON Update.ApplicationName where
   parseJSON (String x) = pure $ Update.ApplicationName x
   parseJSON invalid  =
     panic $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> (Text.pack $ Prelude.show invalid)
+    <> "Encountered: " <> Text.pack (Prelude.show invalid)
 
 instance ToJSON (HeaderHash blk) => ToJSON (Tip blk) where
   toJSON TipGenesis = object [ "genesis" .= True ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -59,7 +59,8 @@ import           Ouroboros.Network.Point (withOrigin)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 
-
+{- HLINT ignore "Use const" -}
+{- HLINT ignore "Use record patterns" -}
 
 instance ConvertRawHash blk => ConvertRawHash (Header blk) where
   toShortRawHash _ h = toShortRawHash (Proxy @blk) h
@@ -552,8 +553,7 @@ instance (Show (PBFT.PBftVerKeyHash c))
 
 instance ConvertRawHash blk
       => ToObject (RealPoint blk) where
-  toObject verb p =
-    mkObject $
+  toObject verb p = mkObject
         [ "kind" .= String "Point"
         , "slot" .= unSlotNo (realPointSlot p)
         , "hash" .= renderHeaderHashForVerbosity (Proxy @blk) verb (realPointHash p) ]
@@ -645,8 +645,8 @@ instance ( ConvertRawHash blk
                , "block" .= toObject verb pt ]
    where
      addedHdrsNewChain
-       :: (AF.AnchoredFragment (Header blk))
-       -> (AF.AnchoredFragment (Header blk))
+       :: AF.AnchoredFragment (Header blk)
+       -> AF.AnchoredFragment (Header blk)
        -> [Header blk]
      addedHdrsNewChain fro to_ =
        case AF.intersect fro to_ of
@@ -762,20 +762,24 @@ instance ConvertRawHash blk
   toObject verb ev = case ev of
     TraceChainSyncServerRead tip (AddBlock hdr) ->
       mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock"
-               , "tip" .= (String (renderTipForVerbosity verb tip))
-               , "addedBlock" .= (String (renderPointForVerbosity verb hdr)) ]
+               , "tip" .= String (renderTipForVerbosity verb tip)
+               , "addedBlock" .= String (renderPointForVerbosity verb hdr)
+               ]
     TraceChainSyncServerRead tip (RollBack pt) ->
       mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.RollBack"
-               , "tip" .= (String (renderTipForVerbosity verb tip))
-               , "rolledBackBlock" .= (String (renderPointForVerbosity verb pt)) ]
+               , "tip" .= String (renderTipForVerbosity verb tip)
+               , "rolledBackBlock" .= String (renderPointForVerbosity verb pt)
+               ]
     TraceChainSyncServerReadBlocked tip (AddBlock hdr) ->
       mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock"
-               , "tip" .= (String (renderTipForVerbosity verb tip))
-               , "addedBlock" .= (String (renderPointForVerbosity verb hdr)) ]
+               , "tip" .= String (renderTipForVerbosity verb tip)
+               , "addedBlock" .= String (renderPointForVerbosity verb hdr)
+               ]
     TraceChainSyncServerReadBlocked tip (RollBack pt) ->
       mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.RollBack"
-               , "tip" .= (String (renderTipForVerbosity verb tip))
-               , "rolledBackBlock" .= (String (renderPointForVerbosity verb pt)) ]
+               , "tip" .= String (renderTipForVerbosity verb tip)
+               , "rolledBackBlock" .= String (renderPointForVerbosity verb pt)
+               ]
 
 
 instance ( Show (ApplyTxErr blk), ToObject (ApplyTxErr blk), ToObject (GenTx blk),
@@ -837,11 +841,10 @@ instance ( tx ~ GenTx blk
     mkObject
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
-      , "blockHash" .=
-          (renderHeaderHashForVerbosity
-            (Proxy @blk)
-            MaximalVerbosity
-            (blockHash blk))
+      , "blockHash" .= renderHeaderHashForVerbosity
+          (Proxy @blk)
+          MaximalVerbosity
+          (blockHash blk)
       , "blockSize" .= toJSON (nodeBlockFetchSize (getHeader blk))
       , "txIds" .= toJSON (map (show . txId) txs)
       ]
@@ -849,11 +852,10 @@ instance ( tx ~ GenTx blk
     mkObject
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
-      , "blockHash" .=
-          (renderHeaderHashForVerbosity
-            (Proxy @blk)
-            verb
-            (blockHash blk))
+      , "blockHash" .= renderHeaderHashForVerbosity
+          (Proxy @blk)
+          verb
+          (blockHash blk)
       , "blockSize" .= toJSON (nodeBlockFetchSize (getHeader blk))
       ]
   toObject _verb (TraceBlockFromFuture currentSlot tip) =

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -51,6 +51,7 @@ import           Ouroboros.Network.Subscription (ConnectResult (..), DnsTrace (.
 import           Ouroboros.Network.TxSubmission.Inbound (TraceTxSubmissionInbound (..))
 import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound (..))
 
+{- HLINT ignore "Use record patterns" -}
 
 --
 -- * instances of @HasPrivacyAnnotation@ and @HasSeverityAnnotation@
@@ -454,10 +455,12 @@ instance ToObject (AnyMessage (ChainSync blk tip)) where
 instance ToObject (FetchDecision [Point header]) where
   toObject _verb (Left decline) =
     mkObject [ "kind" .= String "FetchDecision declined"
-             , "declined" .= String (pack $ show $ decline) ]
+             , "declined" .= String (pack (show decline))
+             ]
   toObject _verb (Right results) =
     mkObject [ "kind" .= String "FetchDecision results"
-             , "length" .= String (pack $ show $ length results) ]
+             , "length" .= String (pack $ show $ length results)
+             ]
 
 
 instance ToObject NtC.HandshakeTr where
@@ -536,17 +539,17 @@ instance ToObject SlotNo where
 
 
 instance ToObject (TraceFetchClientState header) where
-  toObject _verb (AddedFetchRequest {}) =
+  toObject _verb AddedFetchRequest {} =
     mkObject [ "kind" .= String "AddedFetchRequest" ]
-  toObject _verb (AcknowledgedFetchRequest {}) =
+  toObject _verb AcknowledgedFetchRequest {} =
     mkObject [ "kind" .= String "AcknowledgedFetchRequest" ]
-  toObject _verb (CompletedBlockFetch {}) =
+  toObject _verb CompletedBlockFetch {} =
     mkObject [ "kind" .= String "CompletedBlockFetch" ]
-  toObject _verb (CompletedFetchBatch {}) =
+  toObject _verb CompletedFetchBatch {} =
     mkObject [ "kind" .= String "CompletedFetchBatch" ]
-  toObject _verb (StartedFetchBatch {}) =
+  toObject _verb StartedFetchBatch {} =
     mkObject [ "kind" .= String "StartedFetchBatch" ]
-  toObject _verb (RejectedFetchBatch {}) =
+  toObject _verb RejectedFetchBatch {} =
     mkObject [ "kind" .= String "RejectedFetchBatch" ]
 
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -80,6 +80,7 @@ import           Shelley.Spec.Ledger.STS.Updn
 import           Shelley.Spec.Ledger.STS.Utxo
 import           Shelley.Spec.Ledger.TxData (MIRPot (..), TxId (..), TxIn (..), TxOut (..))
 
+{- HLINT ignore "Use :" -}
 
 --
 -- | instances of @ToObject@
@@ -96,8 +97,7 @@ instance ToJSON (SupportsMempool.TxId (GenTx (ShelleyBlock c))) where
   toJSON i = toJSON (condense i)
 
 instance Crypto c => ToObject (Header (ShelleyBlock c)) where
-  toObject _verb b =
-    mkObject $
+  toObject _verb b = mkObject
         [ "kind" .= String "ShelleyBlock"
         , "hash" .= condense (blockHash b)
         , "slotNo" .= condense (blockSlot b)
@@ -125,7 +125,7 @@ instance ToObject (TPraosCannotForge c) where
 deriving newtype instance ToJSON KESPeriod
 
 instance ToObject HotKey.KESInfo where
-  toObject _verb (HotKey.KESInfo { kesStartPeriod, kesEndPeriod, kesEvolution }) =
+  toObject _verb HotKey.KESInfo { kesStartPeriod, kesEndPeriod, kesEvolution } =
     mkObject
       [ "kind" .= String "KESInfo"
       , "startPeriod" .= kesStartPeriod
@@ -204,8 +204,8 @@ instance Crypto c => ToObject (PrtlSeqFailure c) where
              ]
   toObject _verb (WrongBlockSequencePrtclSeq lastAppliedHash currentHash) =
     mkObject [ "kind" .= String "WrongBlockSequence"
-             , "lastAppliedBlockHash" .= (String $ textShow lastAppliedHash)
-             , "currentBlockHash" .= (String $ textShow currentHash)
+             , "lastAppliedBlockHash" .= String (textShow lastAppliedHash)
+             , "currentBlockHash" .= String (textShow currentHash)
              ]
 
 instance Crypto c =>  ToObject (PredicateFailure (BBODY c)) where
@@ -508,21 +508,21 @@ instance Crypto c => ToObject (PredicateFailure (PRTCL c)) where
 instance Crypto c => ToObject (PredicateFailure (OVERLAY c)) where
   toObject _verb (UnknownGenesisKeyOVERLAY (KeyHash genKeyHash)) =
     mkObject [ "kind" .= String "UnknownGenesisKeyOVERLAY"
-             , "unknownKeyHash" .= (String $ textShow genKeyHash)
+             , "unknownKeyHash" .= String (textShow genKeyHash)
              ]
   toObject _verb (VRFKeyBadLeaderValue seedNonce (SlotNo currSlotNo) prevHashNonce leaderElecVal) =
     mkObject [ "kind" .= String "VRFKeyBadLeaderValueOVERLAY"
-             , "seedNonce" .= (String $ textShow seedNonce)
-             , "currentSlot" .= (String $ textShow currSlotNo)
-             , "previousHashAsNonce" .= (String $ textShow prevHashNonce)
-             , "leaderElectionValue" .= (String $ textShow leaderElecVal)
+             , "seedNonce" .= String (textShow seedNonce)
+             , "currentSlot" .= String (textShow currSlotNo)
+             , "previousHashAsNonce" .= String (textShow prevHashNonce)
+             , "leaderElectionValue" .= String (textShow leaderElecVal)
              ]
   toObject _verb (VRFKeyBadNonce seedNonce (SlotNo currSlotNo) prevHashNonce blockNonce) =
     mkObject [ "kind" .= String "VRFKeyBadNonceOVERLAY"
-             , "seedNonce" .= (String $ textShow seedNonce)
-             , "currentSlot" .= (String $ textShow currSlotNo)
-             , "previousHashAsNonce" .= (String $ textShow prevHashNonce)
-             , "blockNonce" .= (String $ textShow blockNonce)
+             , "seedNonce" .= String (textShow seedNonce)
+             , "currentSlot" .= String (textShow currSlotNo)
+             , "previousHashAsNonce" .= String (textShow prevHashNonce)
+             , "blockNonce" .= String (textShow blockNonce)
              ]
   toObject _verb (VRFKeyWrongVRFKey issuerHash regVRFKeyHash unregVRFKeyHash) =
     mkObject [ "kind" .= String "VRFKeyWrongVRFKeyOVERLAY"
@@ -533,18 +533,18 @@ instance Crypto c => ToObject (PredicateFailure (OVERLAY c)) where
   --TODO: Pipe slot number with VRFKeyUnknown
   toObject _verb (VRFKeyUnknown (KeyHash kHash)) =
     mkObject [ "kind" .= String "VRFKeyUnknownOVERLAY"
-             , "keyHash" .= (String $ textShow kHash)
+             , "keyHash" .= String (textShow kHash)
              ]
   toObject _verb (VRFLeaderValueTooBig leadElecVal weightOfDelegPool actSlotCoefff) =
     mkObject [ "kind" .= String "VRFLeaderValueTooBigOVERLAY"
-             , "leaderElectionValue" .= (String $ textShow leadElecVal)
-             , "delegationPoolWeight" .= (String $ textShow weightOfDelegPool)
-             , "activeSlotCoefficient" .= (String $ textShow actSlotCoefff)
+             , "leaderElectionValue" .= String (textShow leadElecVal)
+             , "delegationPoolWeight" .= String (textShow weightOfDelegPool)
+             , "activeSlotCoefficient" .= String (textShow actSlotCoefff)
              ]
   toObject _verb (NotActiveSlotOVERLAY notActiveSlotNo) =
     -- TODO: Elaborate on NotActiveSlot error
     mkObject [ "kind" .= String "NotActiveSlotOVERLAY"
-             , "slot" .= (String $ textShow notActiveSlotNo)
+             , "slot" .= String (textShow notActiveSlotNo)
              ]
   toObject _verb (WrongGenesisColdKeyOVERLAY actual expected) =
     mkObject [ "kind" .= String "WrongGenesisColdKeyOVERLAY"

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -49,9 +49,8 @@ import           Cardano.BM.ElidingTracer
 import           Cardano.BM.Trace (appendName, traceNamedObject)
 import           Cardano.BM.Tracing
 
-import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge,
-                     ConvertRawHash, ForgeStateInfo, ForgeStateUpdateError,
-                     Header, realPointSlot)
+import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ConvertRawHash,
+                     ForgeStateInfo, ForgeStateUpdateError, Header, realPointSlot)
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..),
                      TraceBlockchainTimeEvent (..))
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
@@ -93,6 +92,8 @@ import           Cardano.Tracing.Queries
 import           Cardano.Node.Protocol.Byron ()
 import           Cardano.Node.Protocol.Shelley ()
 
+{- HLINT ignore "Redundant bracket" -}
+{- HLINT ignore "Use record patterns" -}
 
 data Tracers peer localPeer blk = Tracers
   { -- | Trace the ChainDB
@@ -205,10 +206,10 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
   doelide (WithSeverity _ (ChainDB.TraceCopyToImmDBEvent _)) = True
   doelide _ = False
   conteliding _tverb _tr _ (Nothing, _count) = return (Nothing, 0)
-  conteliding tverb tr ev@(WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.AddedToCurrentChain{}))) (_old, oldt) = do
+  conteliding tverb tr ev@(WithSeverity _ (ChainDB.TraceAddBlockEvent ChainDB.AddedToCurrentChain{})) (_old, oldt) = do
       tnow <- fromIntegral <$> getMonotonicTimeNSec
       let deltat = tnow - oldt
-      if (deltat > 1250000000)  -- report at most every 1250 ms
+      if deltat > 1250000000 -- report at most every 1250 ms
         then do
           traceWith (toLogObject' tverb tr) ev
           return (Just ev, tnow)
@@ -226,7 +227,7 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
           progress :: Double = (fromInteger slotno * 100.0) / fromInteger (max slotno endslot)
       when (count > 0 && (slotno - startslot) `mod` 1000 == 0) $ do  -- report every 1000th slot
           meta <- mkLOMeta (getSeverityAnnotation ev) (getPrivacyAnnotation ev)
-          traceNamedObject tr (meta, LogValue "block replay progress (%)" (PureD $ (fromInteger $ round (progress * 10.0)) / 10.0))
+          traceNamedObject tr (meta, LogValue "block replay progress (%)" (PureD (fromInteger (round (progress * 10.0)) / 10.0)))
       return (Just ev, fromInteger startslot)
   conteliding _ _ _ _ = return (Nothing, 0)
 
@@ -470,18 +471,18 @@ mkConsensusTracers trSel verb tr nodeKern bcCounters = do
      staticMeta <- mkLOMeta Critical Confidential
      let name :: LoggerName = "metrics.Forge"
      ForgeTracers
-       <$> (counting $ liftCounting staticMeta name "forged" tr)
-       <*> (counting $ liftCounting staticMeta name "forge-about-to-lead" tr)
-       <*> (counting $ liftCounting staticMeta name "could-not-forge" tr)
-       <*> (counting $ liftCounting staticMeta name "adopted" tr)
-       <*> (counting $ liftCounting staticMeta name "didnt-adopt" tr)
-       <*> (counting $ liftCounting staticMeta name "forged-invalid" tr)
-       <*> (counting $ liftCounting staticMeta name "node-not-leader" tr)
-       <*> (counting $ liftCounting staticMeta name "cannot-forge" tr)
-       <*> (counting $ liftCounting staticMeta name "forge-state-update-error" tr)
-       <*> (counting $ liftCounting staticMeta name "block-from-future" tr)
-       <*> (counting $ liftCounting staticMeta name "slot-is-immutable" tr)
-       <*> (counting $ liftCounting staticMeta name "node-is-leader" tr)
+       <$> counting (liftCounting staticMeta name "forged" tr)
+       <*> counting (liftCounting staticMeta name "forge-about-to-lead" tr)
+       <*> counting (liftCounting staticMeta name "could-not-forge" tr)
+       <*> counting (liftCounting staticMeta name "adopted" tr)
+       <*> counting (liftCounting staticMeta name "didnt-adopt" tr)
+       <*> counting (liftCounting staticMeta name "forged-invalid" tr)
+       <*> counting (liftCounting staticMeta name "node-not-leader" tr)
+       <*> counting (liftCounting staticMeta name "cannot-forge" tr)
+       <*> counting (liftCounting staticMeta name "forge-state-update-error" tr)
+       <*> counting (liftCounting staticMeta name "block-from-future" tr)
+       <*> counting (liftCounting staticMeta name "slot-is-immutable" tr)
+       <*> counting (liftCounting staticMeta name "node-is-leader" tr)
 
 teeForge ::
   forall blk


### PR DESCRIPTION
Enable the following default `hlint` rules:

* Move brackets to avoid $
* Redundant bracket
* Redundant flip
* Use camelCase
* Use newtype instead of data
* Redundant $
* Reduce duplication
* Use first
* Use record patterns
* Use :
* Use const

In some cases, I've selectively re-enabled the rule on a file-by-file bases by adding `HLINT ignore` pragmas to the file.  I did this in cases where it seemed stylistically sensible to relax those rules in those circumstances.  For example we break the camelCase rule in function names of property tests.