### PR TITLE
Apply test magic argument

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -16,17 +16,17 @@ library
   hs-source-dirs:       src
 
   exposed-modules:      Cardano.Api.Protocol
-                        Cardano.Api.Protocol.Types
+                        Cardano.Api.LocalChainSync
+                        Cardano.Api.MetaData
                         Cardano.Api.Protocol.Byron
                         Cardano.Api.Protocol.Cardano
                         Cardano.Api.Protocol.Shelley
+                        Cardano.Api.Protocol.Types
                         Cardano.Api.Shelley.Genesis
                         Cardano.Api.Shelley.ITN
                         Cardano.Api.TextView
-                        Cardano.Api.Typed
-                        Cardano.Api.LocalChainSync
-                        Cardano.Api.MetaData
                         Cardano.Api.TxSubmit
+                        Cardano.Api.Typed
 
   other-modules:        Cardano.Api.TxSubmit.ErrorRender
                         Cardano.Api.TxSubmit.Types

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -302,6 +302,7 @@ module Cardano.Api.Typed (
     toByronProtocolMagicId,
     toByronRequiresNetworkMagic,
     toShelleyNetwork,
+    toNetworkMagic,
   ) where
 
 import           Prelude
@@ -785,7 +786,7 @@ toShelleyNetwork  Mainnet    = Shelley.Mainnet
 toShelleyNetwork (Testnet _) = Shelley.Testnet
 
 toNetworkMagic :: NetworkId -> NetworkMagic
-toNetworkMagic  Mainnet     = NetworkMagic 764824073
+toNetworkMagic Mainnet      = NetworkMagic (Byron.unProtocolMagicId Byron.mainnetProtocolMagicId)
 toNetworkMagic (Testnet nm) = nm
 
 toShelleyAddr :: Address era -> Shelley.Addr ShelleyCrypto


### PR DESCRIPTION
Before:

```
$ cardano-cli shelley genesis create --genesis-dir testnet --testnet-magic 142
$ grep networkM testnet/* 2> /dev/null
testnet/genesis.json:    "networkMagic": 42,
testnet/genesis.spec.json:    "networkMagic": 42,

$ cardano-cli shelley genesis create --genesis-dir mainnet --mainnet
$ grep networkM mainnet/* 2> /dev/null
mainnet/genesis.json:    "networkMagic": 42,
mainnet/genesis.spec.json:    "networkMagic": 42,
```

After:
```
$ cardano-cli shelley genesis create --genesis-dir testnet --testnet-magic 142
$ grep networkM testnet/* 2> /dev/null
testnet/genesis.json:    "networkMagic": 142,
testnet/genesis.spec.json:    "networkMagic": 142,

$ cardano-cli shelley genesis create --genesis-dir mainnet --mainnet
$ grep networkM mainnet/* 2> /dev/null
mainnet/genesis.json:    "networkMagic": 764824073,
mainnet/genesis.spec.json:    "networkMagic": 764824073,
```