### PR TITLE
Properly render genesis file hash without quotes in shelley genesis hash command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -576,4 +576,4 @@ runGenesisHashFile (GenesisFile fpath) = do
               BS.readFile fpath
    let gh :: Crypto.Hash Crypto.Blake2b_256 ByteString
        gh = Crypto.hashWith id content
-   liftIO $ print gh
+   liftIO $ Text.putStrLn (Crypto.hashToTextAsHex gh)


### PR DESCRIPTION
Closes #1713 