### PR TITLE
Fix build for cabal users that don't have systemd

### DIFF
--- a/scripts/gen-cabal-nosystemd.sh
+++ b/scripts/gen-cabal-nosystemd.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# force systemd off until there's a solution to
+# https://github.com/haskell/cabal/issues/5444
+
+set -eux
+
+root="$(dirname "$(dirname "$(realpath "$0")")")"
+
+cd "${root}"
+
+perl -00 -ne 'print if not /.*scribe-systemd.*/' cabal.project > cabal.nosystemd.project
+echo "" >> cabal.nosystemd.project
+echo "flags: -systemd" >> cabal.nosystemd.project
+
+if [ -e cabal.project.freeze ] ; then
+    cp cabal.project.freeze cabal.nosystemd.project.freeze
+fi


### PR DESCRIPTION
This is mainly due to a cabal bug and should be removed in
the future: https://github.com/haskell/cabal/issues/5444

There are various distros, where installing development files
of libsystemd won't be an option:

- Alpine (doesn't have systemd at all)
- Gentoo (not installable when eudev is installed)
- Exherbo (not installable when eudev is installed)

Users are expected to run the script and then execute cabal like so:

  cabal build --project-file=cabal.nosystemd.project all

----

related:
- https://github.com/input-output-hk/cardano-node/pull/1666
- https://github.com/input-output-hk/cardano-node/issues/1200

This has also been discussed on slack.

Instructions for this edge case should probably be added to the wiki?