### PR TITLE
Fix the --treasury flag for MIR certs

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -655,7 +655,7 @@ pGovernanceCmd =
             (  Opt.long "reserves"
             <> Opt.help "Use the reserves pot."
             )
-      <|> Opt.flag' Shelley.ReservesMIR
+      <|> Opt.flag' Shelley.TreasuryMIR
             (  Opt.long "treasury"
             <> Opt.help "Use the treasury pot."
             )


### PR DESCRIPTION
It was accidentally referring to the reserves too.