### PR TITLE
Audit compliance with CIP5: common bech32 prefixes

### DIFF
--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -684,10 +684,9 @@ instance SerialiseAsRawBytes StakeAddress where
 instance SerialiseAsBech32 (Address Shelley) where
     bech32PrefixFor (ShelleyAddress Shelley.Mainnet _ _) = "addr"
     bech32PrefixFor (ShelleyAddress Shelley.Testnet _ _) = "addr_test"
-    bech32PrefixFor (ByronAddress _)                     = "addr_bootstrap"
+    bech32PrefixFor (ByronAddress _)                     = "addr"
 
-    bech32PrefixesPermitted AsShelleyAddress = ["addr", "addr_test",
-                                                "addr_bootstrap"]
+    bech32PrefixesPermitted AsShelleyAddress = ["addr", "addr_test"]
 
 
 instance SerialiseAsBech32 StakeAddress where


### PR DESCRIPTION
Fix one minor oddity which is not covered in CIP5: the prefix for bech32
rendering of Byron addresses, which we don't expect to use anyway. The
change makes it use the same as the wallet backend for this corner case.