### PR TITLE
Shelley testnet in haskell

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -16,6 +16,7 @@ library
                       , aeson
                       , async
                       , bytestring
+                      , deepseq
                       , directory
                       , hedgehog
                       , mmorph
@@ -27,8 +28,10 @@ library
                       , text
                       , time
                       , unliftio
+                      , unordered-containers
                       , Win32-network
-  exposed-modules:      Chairman.Base
+  exposed-modules:      Chairman.Aeson
+                        Chairman.Base
                         Chairman.IO.File
                         Chairman.IO.Network.NamedPipe
                         Chairman.IO.Network.Socket
@@ -37,6 +40,7 @@ library
                         Chairman.OS
                         Chairman.Plan
                         Chairman.Process
+                        Chairman.String
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude
   ghc-options:          -Wall
@@ -54,6 +58,7 @@ test-suite tests
                       , aeson
                       , async
                       , cardano-node-chairman
+                      , containers
                       , directory
                       , filepath
                       , hedgehog
@@ -63,9 +68,12 @@ test-suite tests
                       , random
                       , resourcet
                       , temporary
+                      , text
                       , time
                       , unliftio
+                      , unordered-containers
   other-modules:        Test.Cardano.Node.Chairman.Byron
+                        Test.Cardano.Node.Chairman.Shelley
                         Test.Common.NetworkSpec
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-node-chairman/src/Chairman/Aeson.hs
+++ b/cardano-node-chairman/src/Chairman/Aeson.hs
@@ -1,0 +1,11 @@
+module Chairman.Aeson
+  ( rewriteObject
+  ) where
+
+import           Data.Aeson
+import           Data.HashMap.Lazy
+import           Data.Text
+
+rewriteObject :: (HashMap Text Value -> HashMap Text Value) -> Value -> Value
+rewriteObject f (Object hm) = Object (f hm)
+rewriteObject _ v = v

--- a/cardano-node-chairman/src/Chairman/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Base.hs
@@ -9,23 +9,35 @@ module Chairman.Base
   , moduleWorkspace
   , createDirectoryIfMissing
   , copyFile
+  , createFileLink
   , noteShow
+  , noteShow_
   , noteShowM
+  , noteShowM_
   , noteShowIO
+  , noteShowIO_
   , noteTempFile
   , assertByDeadlineIO
   , showUTCTimeSeconds
   , listDirectory
+  , readFile
   , writeFile
+  , lbsReadFile
+  , lbsWriteFile
+  , rewriteJson
   , assertM
   , assertIO
   , Integration
+  , forceM
+  , release
   ) where
 
+import           Control.DeepSeq
 import           Control.Monad
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Morph (hoist)
-import           Control.Monad.Trans.Resource (ResourceT, runResourceT)
+import           Control.Monad.Trans.Resource (ReleaseKey, ResourceT, runResourceT)
+import           Data.Aeson
 import           Data.Bool
 import           Data.Either (Either (..))
 import           Data.Eq
@@ -47,6 +59,8 @@ import           System.IO (FilePath, IO)
 import           Text.Show
 
 import qualified Control.Concurrent as IO
+import qualified Control.Monad.Trans.Resource as IO
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Time.Clock as DTC
 import qualified Data.Time.Clock.POSIX as DTC
 import qualified GHC.Stack as GHC
@@ -100,19 +114,14 @@ moduleWorkspace prefixPath f = GHC.withFrozenCallStack $ do
   let srcModule = maybe "UnknownModule"  (GHC.srcLocModule . snd) (listToMaybe (getCallStack callStack))
   workspace (prefixPath <> "/" <> srcModule) f
 
-createDirectoryIfMissing :: HasCallStack => FilePath -> Integration ()
-createDirectoryIfMissing filePath = H.evalM . liftIO $ IO.createDirectoryIfMissing True filePath
-
-copyFile :: HasCallStack => FilePath -> FilePath -> Integration ()
-copyFile src dst = GHC.withFrozenCallStack $ do
-  H.annotate $ "Copy from " <> show src <> " to " <> show dst
-  H.evalM . liftIO $ IO.copyFile src dst
-
 noteShow :: (HasCallStack, Show a) => a -> Integration a
 noteShow a = GHC.withFrozenCallStack $ do
   !b <- H.eval a
   H.annotateShow b
   return b
+
+noteShow_ :: (HasCallStack, Show a) => a -> Integration ()
+noteShow_ = void . noteShow
 
 noteShowM :: (HasCallStack, Show a) => Integration a -> Integration a
 noteShowM a = GHC.withFrozenCallStack $ do
@@ -120,11 +129,17 @@ noteShowM a = GHC.withFrozenCallStack $ do
   H.annotateShow b
   return b
 
+noteShowM_ :: (HasCallStack, Show a) => Integration a -> Integration ()
+noteShowM_ = void . noteShowM
+
 noteShowIO :: (HasCallStack, Show a) => IO a -> Integration a
 noteShowIO a = GHC.withFrozenCallStack $ do
   !b <- H.evalM . liftIO $ a
   H.annotateShow b
   return b
+
+noteShowIO_ :: (HasCallStack, Show a) => IO a -> Integration ()
+noteShowIO_ = void . noteShowIO
 
 -- | Return the test file path after annotating it relative to the project root directory
 noteTempFile :: (Monad m, HasCallStack) => FilePath -> FilePath -> H.PropertyT m FilePath
@@ -153,14 +168,62 @@ assertByDeadlineIO deadline f = GHC.withFrozenCallStack $ do
 showUTCTimeSeconds :: UTCTime -> String
 showUTCTimeSeconds time = show @Int64 (floor (DTC.utcTimeToPOSIXSeconds time))
 
+createDirectoryIfMissing :: HasCallStack => FilePath -> Integration ()
+createDirectoryIfMissing filePath = GHC.withFrozenCallStack $ do
+  H.annotate $ "Creating directory if missing: " <> filePath
+  H.evalIO $ IO.createDirectoryIfMissing True filePath
+
+copyFile :: HasCallStack => FilePath -> FilePath -> Integration ()
+copyFile src dst = GHC.withFrozenCallStack $ do
+  H.annotate $ "Copying from " <> show src <> " to " <> show dst
+  H.evalM . liftIO $ IO.copyFile src dst
+
+createFileLink :: HasCallStack => FilePath -> FilePath -> Integration ()
+createFileLink src dst = GHC.withFrozenCallStack $ do
+  H.annotate $ "Creating link from " <> show dst <> " to " <> show src
+  H.evalM . liftIO $ IO.copyFile src dst
+
 listDirectory :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m [FilePath]
-listDirectory = GHC.withFrozenCallStack . H.evalIO . IO.listDirectory
+listDirectory p = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Listing directory: " <> p
+  H.evalIO $ IO.listDirectory p
 
 writeFile :: (MonadIO m, HasCallStack) => FilePath -> String -> H.PropertyT m ()
-writeFile filePath contents = GHC.withFrozenCallStack . H.evalIO $ IO.writeFile filePath contents
+writeFile filePath contents = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Writing file: " <> filePath
+  H.evalIO $ IO.writeFile filePath contents
+
+readFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m String
+readFile filePath = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Reading file: " <> filePath
+  H.evalIO $ IO.readFile filePath
+
+lbsWriteFile :: (MonadIO m, HasCallStack) => FilePath -> LBS.ByteString -> H.PropertyT m ()
+lbsWriteFile filePath contents = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Writing file: " <> filePath
+  H.evalIO $ LBS.writeFile filePath contents
+
+lbsReadFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m LBS.ByteString
+lbsReadFile filePath = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Reading file: " <> filePath
+  H.evalIO $ LBS.readFile filePath
+
+rewriteJson :: (MonadIO m, HasCallStack) => FilePath -> (Value -> Value) -> H.PropertyT m ()
+rewriteJson filePath f = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Rewriting JSON file: " <> filePath
+  lbs <- forceM $ lbsReadFile filePath
+  case eitherDecode lbs of
+    Right iv -> lbsWriteFile filePath (encode (f iv))
+    Left msg -> failWithCustom GHC.callStack Nothing msg
 
 assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
 assertM = (>>= H.assert)
 
 assertIO :: (MonadIO m, HasCallStack) => IO Bool -> H.PropertyT m ()
 assertIO f = H.evalIO f >>= H.assert
+
+forceM :: (Monad m, NFData a) => m a -> m a
+forceM = (force <$!>)
+
+release :: MonadIO m => ReleaseKey -> H.PropertyT m ()
+release = H.evalIO . IO.release

--- a/cardano-node-chairman/src/Chairman/String.hs
+++ b/cardano-node-chairman/src/Chairman/String.hs
@@ -1,0 +1,11 @@
+module Chairman.String
+  ( strip
+  ) where
+
+import           Data.Function
+import           Data.String
+
+import qualified Data.Text as T
+
+strip :: String -> String
+strip = T.unpack . T.strip . T.pack

--- a/cardano-node-chairman/test/Main.hs
+++ b/cardano-node-chairman/test/Main.hs
@@ -6,10 +6,12 @@ import           Hedgehog.Main (defaultMain)
 import           System.IO (IO)
 
 import qualified Test.Cardano.Node.Chairman.Byron
+import qualified Test.Cardano.Node.Chairman.Shelley
 import qualified Test.Common.NetworkSpec
 
 main :: IO ()
 main = defaultMain
-    [ Test.Cardano.Node.Chairman.Byron.tests
-    , Test.Common.NetworkSpec.tests
-    ]
+  [ Test.Cardano.Node.Chairman.Byron.tests
+  , Test.Cardano.Node.Chairman.Shelley.tests
+  , Test.Common.NetworkSpec.tests
+  ]

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -1,0 +1,417 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+
+module Test.Cardano.Node.Chairman.Shelley
+  ( tests
+  ) where
+
+import           Chairman.Aeson
+import           Chairman.IO.Network.Sprocket (Sprocket (..))
+import           Control.Concurrent.Async
+import           Control.Monad
+import           Control.Monad.IO.Class (liftIO)
+import           Data.Aeson
+import           Data.Bool
+import           Data.Char
+import           Data.Either
+import           Data.Function
+import           Data.Functor
+import           Data.HashMap.Lazy (HashMap)
+import           Data.Int
+import           Data.Map (Map)
+import           Data.Maybe
+import           Data.Ord
+import           Data.Semigroup
+import           Data.String (String)
+import           Data.Text (Text)
+import           GHC.Float
+import           GHC.Num
+import           Hedgehog (Property, discover, (===))
+import           System.Exit (ExitCode (..))
+import           System.IO (IO)
+import           Text.Read
+import           Text.Show
+
+import qualified Chairman.Base as H
+import qualified Chairman.IO.File as IO
+import qualified Chairman.IO.Network.Socket as IO
+import qualified Chairman.IO.Network.Sprocket as IO
+import qualified Chairman.Process as H
+import qualified Chairman.String as S
+import qualified Data.HashMap.Lazy as HM
+import qualified Data.List as L
+import qualified Data.Map.Lazy as M
+import qualified Data.Time.Clock as DTC
+import qualified Hedgehog as H
+import qualified System.Directory as IO
+import qualified System.Environment as IO
+import qualified System.FilePath.Posix as FP
+import qualified System.IO as IO
+import qualified System.Process as IO
+
+{- HLINT ignore "Redundant <&>" -}
+{- HLINT ignore "Redundant flip" -}
+
+rewriteConfiguration :: String -> String
+rewriteConfiguration "Protocol: RealPBFT" = "Protocol: TPraos"
+rewriteConfiguration "minSeverity: Info" = "minSeverity: Debug"
+rewriteConfiguration "TraceBlockchainTime: False" = "TraceBlockchainTime: True"
+rewriteConfiguration s = s
+
+rewriteGenesisSpec :: Int -> Value -> Value
+rewriteGenesisSpec supply =
+  rewriteObject
+    $ HM.insert "activeSlotsCoeff" (toJSON @Double 0.1)
+    . HM.insert "securityParam" (toJSON @Int 10)
+    . HM.insert "epochLength" (toJSON @Int 1500)
+    . HM.insert "maxLovelaceSupply" (toJSON supply)
+    . flip HM.adjust "protocolParams"
+      ( rewriteObject (HM.insert "decentralisationParam" (toJSON @Double 0.7))
+      )
+
+prop_spawnShelleyCluster :: Property
+prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
+  tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
+  tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath
+  base <- H.noteShowM H.getProjectBase
+  baseConfig <- H.noteShow $ base <> "/configuration/chairman/defaults/simpleview"
+  currentTime <- H.noteShowIO DTC.getCurrentTime
+  startTime <- H.noteShow $ DTC.addUTCTime 10 currentTime -- 10 seconds into the future
+  socketDir <- H.noteShow $ tempRelPath <> "/socket"
+  env <- H.evalIO IO.getEnvironment
+
+  let bftNodes = ["node-bft1", "node-bft2"] :: [String]
+  let bftNodesN = ["1", "2"] :: [String]
+  let poolNodes = ["node-pool1"] :: [String]
+  let allNodes = bftNodes <> poolNodes :: [String]
+  let numBftNodes = 3 :: Int
+
+  let userAddrs = ["user1"]
+  let poolAddrs = ["pool-owner1"]
+  let addrs = userAddrs <> poolAddrs
+
+  H.writeFile (tempAbsPath <> "/configuration.yaml") . L.unlines . fmap rewriteConfiguration . L.lines =<<
+    H.evalIO (IO.readFile (base <> "/configuration/defaults/byron-mainnet/configuration.yaml"))
+
+  -- Set up our template
+  void $ H.execCli
+    [ "shelley", "genesis", "create"
+    , "--testnet-magic", "42"
+    , "--genesis-dir", tempAbsPath
+    ]
+
+  -- Then edit the genesis.spec.json ...
+  let supply = 1000000000
+
+  -- We're going to use really quick epochs (300 seconds), by using short slots 0.2s
+  -- and K=10, but we'll keep long KES periods so we don't have to bother
+  -- cycling KES keys
+  H.rewriteJson (tempAbsPath <> "/genesis.spec.json") (rewriteGenesisSpec supply)
+
+  _ <- H.noteShowM . H.evalM $ eitherDecode @Value <$> H.lbsReadFile (tempAbsPath <> "/genesis.spec.json")
+
+  -- Now generate for real
+  void $ H.execCli
+    [ "shelley", "genesis", "create"
+    , "--testnet-magic", "42"
+    , "--genesis-dir", tempAbsPath
+    , "--gen-genesis-keys", show numBftNodes
+    , "--gen-utxo-keys", "1"
+    ]
+
+  forM_ allNodes $ \p -> H.createDirectoryIfMissing $ tempAbsPath <> "/" <> p
+
+  -- Make the pool operator cold keys
+  -- This was done already for the BFT nodes as part of the genesis creation
+  forM_ poolNodes $ \n -> do
+    void $ H.execCli
+      [ "shelley", "node", "key-gen"
+      , "--cold-verification-key-file", tempAbsPath <> "/" <> n <> "/operator.vkey"
+      , "--cold-signing-key-file", tempAbsPath <> "/" <> n <> "/operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath <> "/" <> n <> "/operator.counter"
+      ]
+
+    void $ H.execCli
+      [ "shelley", "node", "key-gen-VRF"
+      , "--verification-key-file", tempAbsPath <> "/" <> n <> "/vrf.vkey"
+      , "--signing-key-file", tempAbsPath <> "/" <> n <> "/vrf.skey"
+      ]
+
+  -- Symlink the BFT operator keys from the genesis delegates, for uniformity
+  forM_ bftNodesN $ \n -> do
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".skey") (tempAbsPath <> "/node-bft" <> n <> "/operator.skey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vkey") (tempAbsPath <> "/node-bft" <> n <> "/operator.vkey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".counter") (tempAbsPath <> "/node-bft" <> n <> "/operator.counter")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.vkey") (tempAbsPath <> "/node-bft" <> n <> "/vrf.vkey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.skey") (tempAbsPath <> "/node-bft" <> n <> "/vrf.skey")
+
+  --  Make hot keys and for all nodes
+  forM_ allNodes $ \node -> do
+    void $ H.execCli
+      [ "shelley", "node", "key-gen-KES"
+      , "--verification-key-file", tempAbsPath <> "/" <> node <> "/kes.vkey"
+      , "--signing-key-file", tempAbsPath <> "/" <> node <> "/kes.skey"
+      ]
+
+    void $ H.execCli
+      [ "shelley", "node", "issue-op-cert"
+      , "--kes-period", "0"
+      , "--kes-verification-key-file", tempAbsPath <> "/" <> node <> "/kes.vkey"
+      , "--cold-signing-key-file", tempAbsPath <> "/" <> node <> "/operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath <> "/" <> node <> "/operator.counter"
+      , "--out-file", tempAbsPath <> "/" <> node <> "/node.cert"
+      ]
+
+
+  -- Make topology files
+  -- TODO generalise this over the N BFT nodes and pool nodes
+  H.writeFile (tempAbsPath <> "/node-bft1/topology.json") "\
+    \{ \"Producers\":\
+    \  [ { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3002\
+    \    , \"valency\": 1\
+    \    }\
+    \  , { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3003\
+    \    , \"valency\": 1\
+    \    }\
+    \  ]\
+    \}"
+  H.writeFile (tempAbsPath <> "/node-bft1/port") "3001"
+
+  H.writeFile (tempAbsPath <> "/node-bft2/topology.json") "\
+    \{ \"Producers\":\
+    \  [ { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3001\
+    \    , \"valency\": 1\
+    \    }\
+    \  , { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3003\
+    \    , \"valency\": 1\
+    \    }\
+    \  ]\
+    \}"
+  H.writeFile (tempAbsPath <> "/node-bft2/port") "3002"
+
+  H.writeFile (tempAbsPath <> "/node-pool1/topology.json") "\
+    \{ \"Producers\":\
+    \  [ { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3001\
+    \    , \"valency\": 1\
+    \    }\
+    \  , { \"addr\": \"127.0.0.1\"\
+    \    , \"port\": 3002\
+    \    , \"valency\": 1\
+    \    }\
+    \  ]\
+    \}"
+  H.writeFile (tempAbsPath <> "/node-pool1/port") "3003"
+
+  -- Generated node operator keys (cold, hot) and operational certs
+  forM_ allNodes $ \n -> H.noteShowM_ . H.listDirectory $ tempAbsPath <> "/" <> n
+
+  -- Make some payment and stake addresses
+  -- user1..n:       will own all the funds in the system, we'll set this up from
+  --                 initial utxo the
+  -- pool-owner1..n: will be the owner of the pools and we'll use their reward
+  --                 account for pool rewards
+  H.createDirectoryIfMissing $ tempAbsPath <> "/addresses"
+
+  forM_ addrs $ \addr -> do
+    -- Payment address keys
+    void $ H.execCli
+      [ "shelley", "address", "key-gen"
+      , "--verification-key-file", tempAbsPath <> "/addresses/" <> addr <> ".vkey"
+      , "--signing-key-file", tempAbsPath <> "/addresses/" <> addr <> ".skey"
+      ]
+
+    -- Stake address keys
+    void $ H.execCli
+      [ "shelley", "stake-address", "key-gen"
+      , "--verification-key-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.vkey"
+      , "--signing-key-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.skey"
+      ]
+
+    -- Payment addresses
+    void $ H.execCli
+      [ "shelley", "address", "build"
+      , "--payment-verification-key-file", tempAbsPath <> "/addresses/" <> addr <> ".vkey"
+      , "--stake-verification-key-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.vkey"
+      , "--testnet-magic", "42"
+      , "--out-file", tempAbsPath <> "/addresses/" <> addr <> ".addr"
+      ]
+
+    -- Stake addresses
+    void $ H.execCli
+      [ "shelley", "stake-address", "build"
+      , "--stake-verification-key-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.vkey"
+      , "--testnet-magic", "42"
+      , "--out-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.addr"
+      ]
+
+    -- Stake addresses registration certs
+    void $ H.execCli
+      [ "shelley", "stake-address", "registration-certificate"
+      , "--stake-verification-key-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.vkey"
+      , "--out-file", tempAbsPath <> "/addresses/" <> addr <> "-stake.reg.cert"
+      ]
+
+  -- User N will delegate to pool N
+  let userPoolN = ["1"]
+
+  forM_ userPoolN $ \n -> do
+    -- Stake address delegation certs
+    void $ H.execCli
+      [ "shelley", "stake-address", "delegation-certificate"
+      , "--stake-verification-key-file", tempAbsPath <> "/addresses/user" <> n <> "-stake.vkey"
+      , "--cold-verification-key-file", tempAbsPath <> "/node-pool" <> n <> "/operator.vkey"
+      , "--out-file", tempAbsPath <> "/addresses/user" <> n <> "-stake.deleg.cert"
+      ]
+
+    H.createFileLink (tempAbsPath <> "/addresses/pool-owner" <> n <> "-stake.vkey") (tempAbsPath <> "/node-pool" <> n <> "/owner.vkey")
+    H.createFileLink (tempAbsPath <> "/addresses/pool-owner" <> n <> "-stake.skey") (tempAbsPath <> "/node-pool" <> n <> "/owner.skey")
+
+  -- Generated payment address keys, stake address keys,
+  -- stake address regitration certs, and stake address delegatation certs
+  H.noteShowM_ . H.listDirectory $ tempAbsPath <> "/addresses"
+
+  -- Next is to make the stake pool registration cert
+  forM_ poolNodes $ \node -> do
+    void $ H.execCli
+      [ "shelley", "stake-pool", "registration-certificate"
+      , "--testnet-magic", "42"
+      , "--pool-pledge", "0"
+      , "--pool-cost", "0"
+      , "--pool-margin", "0"
+      , "--cold-verification-key-file", tempAbsPath <> "/" <> node <> "/operator.vkey"
+      , "--vrf-verification-key-file", tempAbsPath <> "/" <> node <> "/vrf.vkey"
+      , "--reward-account-verification-key-file", tempAbsPath <> "/" <> node <> "/owner.vkey"
+      , "--pool-owner-stake-verification-key-file", tempAbsPath <> "/" <> node <> "/owner.vkey"
+      , "--out-file", tempAbsPath <> "/" <> node <> "/registration.cert"
+      ]
+
+  -- Generated stake pool registration certs:
+  forM_ poolNodes $ \node -> H.assertIO . IO.doesFileExist $ tempAbsPath <> "/" <> node <> "/registration.cert"
+
+  -- Now we'll construct one whopper of a transaction that does everything
+  -- just to show off that we can, and to make the script shorter
+
+  -- We'll transfer all the funds to the user1, which delegates to pool1
+  -- We'll register certs to:
+  --  1. register the pool-owner1 stake address
+  --  2. register the stake pool 1
+  --  3. register the user1 stake address
+  --  4. delegate from the user1 stake address to the stake pool
+  genesisTxinResult <- H.noteShowM $ S.strip <$> H.execCli
+    [ "shelley", "genesis", "initial-txin"
+    , "--testnet-magic", "42"
+    , "--verification-key-file", tempAbsPath <> "/utxo-keys/utxo1.vkey"
+    ]
+
+  user1Addr <- H.readFile $ tempAbsPath <> "/addresses/user1.addr"
+
+  void $ H.execCli
+    [ "shelley", "transaction", "build-raw"
+    , "--ttl", "1000"
+    , "--fee", "0"
+    , "--tx-in", genesisTxinResult
+    , "--tx-out", user1Addr <> "+" <> show supply
+    , "--certificate-file", tempAbsPath <> "/addresses/pool-owner1-stake.reg.cert"
+    , "--certificate-file", tempAbsPath <> "/node-pool1/registration.cert"
+    , "--certificate-file", tempAbsPath <> "/addresses/user1-stake.reg.cert"
+    , "--certificate-file", tempAbsPath <> "/addresses/user1-stake.deleg.cert"
+    , "--out-file", tempAbsPath <> "/tx1.txbody"
+    ]
+
+  -- So we'll need to sign this with a bunch of keys:
+  -- 1. the initial utxo spending key, for the funds
+  -- 2. the user1 stake address key, due to the delegatation cert
+  -- 3. the pool1 owner key, due to the pool registration cert
+  -- 3. the pool1 operator key, due to the pool registration cert
+
+  void $ H.execCli
+    [ "shelley", "transaction", "sign"
+    , "--signing-key-file", tempAbsPath <> "/utxo-keys/utxo1.skey"
+    , "--signing-key-file", tempAbsPath <> "/addresses/user1-stake.skey"
+    , "--signing-key-file", tempAbsPath <> "/node-pool1/owner.skey"
+    , "--signing-key-file", tempAbsPath <> "/node-pool1/operator.skey"
+    , "--testnet-magic", "42"
+    , "--tx-body-file", tempAbsPath <> "/tx1.txbody"
+    , "--out-file", tempAbsPath <> "/tx1.tx"
+    ]
+
+  -- Generated a signed 'do it all' transaction:
+  H.assertIO . IO.doesFileExist $ tempAbsPath <> "/tx1.tx"
+
+  --------------------------------
+  -- Launch cluster of three nodes
+
+  logDir <- H.noteTempFile tempAbsPath "/logs"
+
+  H.createDirectoryIfMissing logDir
+
+  forM_ allNodes $ \node -> do
+    dbDir <- H.noteShow $ tempAbsPath <> "/db/" <> node
+    nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"
+    nodeStderrFile <- H.noteTempFile logDir $ node <> ".stderr.log"
+    sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir <> "/" <> node)
+
+    H.createDirectoryIfMissing dbDir
+    H.createDirectoryIfMissing $ tempBaseAbsPath <> "/" <> socketDir
+
+    hNodeStdout <- H.evalM . liftIO $ IO.openFile nodeStdoutFile IO.WriteMode
+    hNodeStderr <- H.evalM . liftIO $ IO.openFile nodeStderrFile IO.WriteMode
+
+    H.diff (L.length (IO.sprocketArgumentName sprocket)) (<=) IO.maxSprocketArgumentNameLength
+
+    portString <- H.readFile $ tempAbsPath <> "/" <> node <> "/port"
+
+    void $ H.createProcess =<<
+      ( H.procNode
+        [ "run"
+        , "--config", tempAbsPath <> "/configuration.yaml"
+        , "--topology", tempAbsPath <> "/" <> node <> "/topology.json"
+        , "--database-path", tempAbsPath <> "/" <> node <> "/db"
+        , "--shelley-kes-key", tempAbsPath <> "/" <> node <> "/kes.skey"
+        , "--shelley-vrf-key", tempAbsPath <> "/" <> node <> "/vrf.skey"
+        , "--shelley-operational-certificate" , tempAbsPath <> "/" <> node <> "/node.cert"
+        , "--port", portString
+        , "--socket-path", IO.sprocketArgumentName sprocket
+        ] <&>
+        ( \cp -> cp
+          { IO.std_in = IO.CreatePipe
+          , IO.std_out = IO.UseHandle hNodeStdout
+          , IO.std_err = IO.UseHandle hNodeStderr
+          , IO.cwd = Just tempBaseAbsPath
+          }
+        )
+      )
+
+  H.noteShowIO_ DTC.getCurrentTime
+
+  deadline <- H.noteShowIO $ DTC.addUTCTime 60 <$> DTC.getCurrentTime -- 60 seconds from now
+
+  forM_ allNodes $ \node -> do
+    portString <- H.noteShowM . H.readFile $ tempAbsPath <> "/" <> node <> "/port"
+    H.assertByDeadlineIO deadline $ IO.isPortOpen (read portString)
+
+  forM_ allNodes $ \node -> do
+    sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir <> "/" <> node)
+    _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
+    H.assertIO $ IO.doesSprocketExist sprocket
+
+  forM_ allNodes $ \node -> do
+    nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"
+    H.assertByDeadlineIO deadline $ IO.fileContains "until genesis start time at" nodeStdoutFile
+    H.assertByDeadlineIO deadline $ IO.fileContains "Chain extended, new tip" nodeStdoutFile
+
+  H.noteShowIO_ DTC.getCurrentTime
+
+tests :: IO Bool
+tests = H.checkParallel $$discover

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -58,12 +58,6 @@ import qualified System.Process as IO
 {- HLINT ignore "Redundant <&>" -}
 {- HLINT ignore "Redundant flip" -}
 
-rewriteConfiguration :: String -> String
-rewriteConfiguration "Protocol: RealPBFT" = "Protocol: TPraos"
-rewriteConfiguration "minSeverity: Info" = "minSeverity: Debug"
-rewriteConfiguration "TraceBlockchainTime: False" = "TraceBlockchainTime: True"
-rewriteConfiguration s = s
-
 rewriteGenesisSpec :: Int -> Value -> Value
 rewriteGenesisSpec supply =
   rewriteObject
@@ -96,8 +90,9 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
   let poolAddrs = ["pool-owner1"]
   let addrs = userAddrs <> poolAddrs
 
-  H.writeFile (tempAbsPath <> "/configuration.yaml") . L.unlines . fmap rewriteConfiguration . L.lines =<<
-    H.evalIO (IO.readFile (base <> "/configuration/defaults/byron-mainnet/configuration.yaml"))
+  H.copyFile
+    (base <> "/configuration/chairman/shelly-only/configuration.yaml")
+    (tempAbsPath <> "/configuration.yaml")
 
   -- Set up our template
   void $ H.execCli

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -86,11 +86,11 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
   socketDir <- H.noteShow $ tempRelPath <> "/socket"
   env <- H.evalIO IO.getEnvironment
 
-  let bftNodes = ["node-bft1", "node-bft2"] :: [String]
-  let bftNodesN = ["1", "2"] :: [String]
+  let praosNodes = ["node-praos1", "node-praos2"] :: [String]
+  let praosNodesN = ["1", "2"] :: [String]
   let poolNodes = ["node-pool1"] :: [String]
-  let allNodes = bftNodes <> poolNodes :: [String]
-  let numBftNodes = 3 :: Int
+  let allNodes = praosNodes <> poolNodes :: [String]
+  let numPraosNodes = 3 :: Int
 
   let userAddrs = ["user1"]
   let poolAddrs = ["pool-owner1"]
@@ -121,7 +121,7 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
     [ "shelley", "genesis", "create"
     , "--testnet-magic", "42"
     , "--genesis-dir", tempAbsPath
-    , "--gen-genesis-keys", show numBftNodes
+    , "--gen-genesis-keys", show numPraosNodes
     , "--gen-utxo-keys", "1"
     ]
 
@@ -144,12 +144,12 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
       ]
 
   -- Symlink the BFT operator keys from the genesis delegates, for uniformity
-  forM_ bftNodesN $ \n -> do
-    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".skey") (tempAbsPath <> "/node-bft" <> n <> "/operator.skey")
-    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vkey") (tempAbsPath <> "/node-bft" <> n <> "/operator.vkey")
-    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".counter") (tempAbsPath <> "/node-bft" <> n <> "/operator.counter")
-    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.vkey") (tempAbsPath <> "/node-bft" <> n <> "/vrf.vkey")
-    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.skey") (tempAbsPath <> "/node-bft" <> n <> "/vrf.skey")
+  forM_ praosNodesN $ \n -> do
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".skey") (tempAbsPath <> "/node-praos" <> n <> "/operator.skey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vkey") (tempAbsPath <> "/node-praos" <> n <> "/operator.vkey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".counter") (tempAbsPath <> "/node-praos" <> n <> "/operator.counter")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.vkey") (tempAbsPath <> "/node-praos" <> n <> "/vrf.vkey")
+    H.createFileLink (tempAbsPath <> "/delegate-keys/delegate" <> n <> ".vrf.skey") (tempAbsPath <> "/node-praos" <> n <> "/vrf.skey")
 
   --  Make hot keys and for all nodes
   forM_ allNodes $ \node -> do
@@ -171,7 +171,7 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
 
   -- Make topology files
   -- TODO generalise this over the N BFT nodes and pool nodes
-  H.writeFile (tempAbsPath <> "/node-bft1/topology.json") "\
+  H.writeFile (tempAbsPath <> "/node-praos1/topology.json") "\
     \{ \"Producers\":\
     \  [ { \"addr\": \"127.0.0.1\"\
     \    , \"port\": 3002\
@@ -183,9 +183,9 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
     \    }\
     \  ]\
     \}"
-  H.writeFile (tempAbsPath <> "/node-bft1/port") "3001"
+  H.writeFile (tempAbsPath <> "/node-praos1/port") "3001"
 
-  H.writeFile (tempAbsPath <> "/node-bft2/topology.json") "\
+  H.writeFile (tempAbsPath <> "/node-praos2/topology.json") "\
     \{ \"Producers\":\
     \  [ { \"addr\": \"127.0.0.1\"\
     \    , \"port\": 3001\
@@ -197,7 +197,7 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
     \    }\
     \  ]\
     \}"
-  H.writeFile (tempAbsPath <> "/node-bft2/port") "3002"
+  H.writeFile (tempAbsPath <> "/node-praos2/port") "3002"
 
   H.writeFile (tempAbsPath <> "/node-pool1/topology.json") "\
     \{ \"Producers\":\

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -1,0 +1,292 @@
+##########################################################
+###############          Mainnet                 #########
+############### Cardano Byron Node Configuration #########
+##########################################################
+
+
+##### Locations #####
+
+GenesisFile: genesis.json
+SocketPath: db/node.socket
+
+##### Blockfetch Protocol
+
+# The maximum number of used peers during bulk sync.
+MaxConcurrencyBulkSync: 1
+# The maximum number of used peers when fetching newly forged blocks.
+MaxConcurrencyDeadline: 2
+
+#TODO: These parameters cannot yet be used in the config file, only on the CLI:
+#DatabasePath: db/
+#Topology: configuration/mainnet-topology.json
+#Port 7776
+
+##### Core protocol parameters #####
+
+# This is the instance of the Ouroboros family that we are running.
+# "RealPBFT" is the real (permissive) OBFT protocol, which is what we use on
+# mainnet in Byron era.
+Protocol: TPraos
+
+# The mainnet does not include the network magic into addresses. Testnets do.
+RequiresNetworkMagic: RequiresNoMagic
+
+
+##### Update system parameters #####
+
+# This protocol version number gets used by by block producing nodes as part
+# part of the system for agreeing on and synchronising protocol updates.
+LastKnownBlockVersion-Major: 0
+LastKnownBlockVersion-Minor: 2
+LastKnownBlockVersion-Alt: 0
+
+# In the Byron era some software versions are also published on the chain.
+# We do this only for Byron compatibility now.
+ApplicationName: cardano-sl
+ApplicationVersion: 1
+
+
+##### Logging configuration #####
+
+# The node can run in either the SimpleView or LiveView. The SimpleView just
+# uses standard output, optionally with log output. The LiveView is a text
+# console on Linux and Mac OSX with a live view of various node metrics.
+# When LiveView is used logging output to 'stdout' is automatically disabled.
+ViewMode: SimpleView
+#ViewMode: LiveView
+
+# Enble or disable logging overall
+TurnOnLogging: True
+
+# Enable the collection of various OS metrics such as memory and CPU use.
+# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# be directed to the logs or monitoring backends.
+TurnOnLogMetrics: True
+
+# Global logging severity filter. Messages must have at least this severity to
+# pass. Typical values would be Warning, Notice, Info or Debug.
+minSeverity: Debug
+
+# Log items can be rendered with more or less verbose detail.
+# Verbosity ranges from MinimalVerbosity, NormalVerbosity to MaximalVerbosity
+TracingVerbosity: NormalVerbosity
+
+# The system supports a number of backends for logging and monitoring.
+# This setting lists the the backends that will be available to use in the
+# configuration below. The logging backend is called Katip.
+setupBackends:
+  - KatipBK
+
+# This specifies the default backends that trace output is sent to if it
+# is not specifically configured to be sent to other backends.
+defaultBackends:
+  - KatipBK
+
+# EKG is a simple metrics monitoring system. Uncomment the following to enable
+# this backend and listen on the given local port and point your web browser to
+# http://localhost:12788/
+# hasEKG: 12788
+
+# The Prometheus monitoring system exports EKG metrics. Uncomment the following
+# to listen on the given port. Output is provided on
+# http://localhost:12789/metrics
+# hasPrometheus:
+#   - "127.0.0.1"
+#   - 12789
+
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
+# traceForwardTo:
+#   tag: RemoteSocket
+#   contents:
+#     - "127.0.0.1"
+#     - "2997"
+
+# For the Katip logging backend we must set up outputs (called scribes)
+# The available types of scribe are:
+#   FileSK for files
+#   StdoutSK/StderrSK for stdout/stderr
+#   JournalSK for systemd's journal system
+#   DevNullSK ignores all output
+# The scribe output format can be ScText or ScJson. Log rotation settings can
+# be specified in the defaults below or overidden on a per-scribe basis here.
+setupScribes:
+  - scKind: FileSK
+    scName: "logs/mainnet.log"
+    scFormat: ScText
+
+  - scKind: StdoutSK
+    scName: stdout
+    scFormat: ScText
+
+# For the Katip logging backend this specifies the default scribes that trace
+# output is sent to if it is not configured to be sent to other scribes.
+defaultScribes:
+  - - FileSK
+    - "logs/mainnet.log"
+  - - StdoutSK
+    - stdout
+
+# The default file rotation settings for katip scribes, unless overridden
+# in the setupScribes above for specific scribes.
+rotation:
+  rpLogLimitBytes: 5000000
+  rpKeepFilesNum:  3
+  rpMaxAgeHours:   24
+
+
+##### Coarse grained logging control #####
+
+# Trace output from whole subsystems can be enabled/disabled using the following
+# settings. This provides fairly coarse grained control, but it is relatively
+# efficient at filtering out unwanted trace output.
+
+# Trace BlockFetch client.
+TraceBlockFetchClient: False
+
+# Trace BlockFetch decisions made by the BlockFetch client.
+# needed to display "peers" and their block height in LiveView
+TraceBlockFetchDecisions: False
+
+# Trace BlockFetch protocol messages.
+TraceBlockFetchProtocol: False
+
+# Serialised Trace BlockFetch protocol messages.
+TraceBlockFetchProtocolSerialised: False
+
+# Trace BlockFetch server.
+TraceBlockFetchServer: False
+
+# Trace BlockchainTime.
+TraceBlockchainTime: True
+
+# Verbose tracer of ChainDB
+TraceChainDb: True
+
+# Trace ChainSync client.
+TraceChainSyncClient: False
+
+# Trace ChainSync server (blocks).
+TraceChainSyncBlockServer: False
+
+# Trace ChainSync server (headers)
+TraceChainSyncHeaderServer: False
+
+# Trace ChainSync protocol messages.
+TraceChainSyncProtocol: False
+
+# Trace DNS Resolver messages.
+TraceDNSResolver: True
+
+# Trace DNS Subscription messages.
+TraceDNSSubscription: True
+
+# Trace error policy resolution.
+TraceErrorPolicy: True
+
+# Trace local error policy resolution.
+TraceLocalErrorPolicy: True
+
+# Trace block forging.
+TraceForge: True
+
+# Trace Handshake protocol messages.
+TraceHandshake: False
+
+# Trace IP Subscription messages.
+TraceIpSubscription: True
+
+# Trace local ChainSync protocol messages.
+TraceLocalChainSyncProtocol: False
+
+# Trace local Handshake protocol messages.
+TraceLocalHandshake: False
+
+# Trace local TxSubmission protocol messages.
+TraceLocalTxSubmissionProtocol: False
+
+# Trace local TxSubmission server.
+TraceLocalTxSubmissionServer: False
+
+# Trace mempool.
+TraceMempool: True
+
+# Trace Mux Events
+TraceMux: False
+
+# Trace TxSubmission server (inbound transactions).
+TraceTxInbound: False
+
+# Trace TxSubmission client (outbound transactions).
+TraceTxOutbound: False
+
+# Trace TxSubmission protocol messages.
+TraceTxSubmissionProtocol: False
+
+
+##### Fine grained logging control #####
+
+# It is also possible to have more fine grained control over filtering of
+# trace output, and to match and route trace output to particular backends.
+# This is less efficient than the coarse trace filters above but provides
+# much more precise control.
+
+options:
+
+  # This routes metrics matching specific names to particular backends.
+  # This overrides the 'defaultBackends' listed above. And note that it is
+  # an override and not an extension so anything matched here will not
+  # go to the default backend, only to the explicitly listed backends.
+  mapBackends:
+    cardano.node.BlockFetchDecision.peers:
+      - TraceForwarderBK
+      - EKGViewBK
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.ChainDB.metrics:
+      - TraceForwarderBK
+      - EKGViewBK
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.metrics:
+      - TraceForwarderBK
+      - EKGViewBK  
+      - kind: UserDefinedBK
+        name: LiveViewBackend
+    cardano.node.Forge.metrics:
+      - EKGViewBK
+    cardano.node.release:
+      - TraceForwarderBK
+      - KatipBK
+    cardano.node.version:
+      - TraceForwarderBK
+      - KatipBK
+    cardano.node.commit:
+      - TraceForwarderBK
+      - KatipBK
+
+  # redirects traced values to a specific scribe which is identified by its
+  # type and its name, separated by "::":
+  mapScribes:
+    cardano.node-metrics:
+      - "FileSK::logs/mainnet.log"
+
+  # apply a filter on message severity on messages in a specific named context.
+  # this filter is applied additionally to the global 'minSeverity' and thus
+  # needs to be at least as high.
+  mapSeverity:
+    cardano.node.ChainDB: Notice
+    cardano.node.DnsSubscription: Debug
+


### PR DESCRIPTION
This PR extends https://github.com/input-output-hk/cardano-node/pull/1786

New Shelley-only chairman test.  The test makes the following assertions:

* It opens the correct port
* It creates a socket file
* The text "until genesis start time at" appears in the log output
* The text "Chain extended, new tip" appears in the log output

Additional changes:

* New `createFileLink` function for creating symbolic links in tests
* New `noteShow_`, `noteShowM_`, `noteShowIO_` functions, which are `()` returning equivalents
* New `readFile`, `writeFile`, `lbsReadFile`, `lbsWriteFile` functions for reading and writing files
* New `rewriteJson` functions for rewriting JSON configuration files
* New `forceM` function for forcing the return values of computations.  It is used for reading of files (which is lazy by default).
* New `release` function for releasing resources early.  Used to shutdown the node process early.
* New `fileContains` function for testing if a file contains a string.  For making assertions on the log file output.
* New `strip` function, which is `String` version of standard `Text` function.
* Existing file IO related test functions now annotate the filename that is involved.

## Testing

Run `cabal test cardano-node-chairman --test-show-details=direct`.

You can see more detailed test output by making it fail, which is done by adding `H.failure` to the end of the test.