### PR TITLE
Add TraceBlockchainTime to config files

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -29,12 +29,13 @@ library
                       , unliftio
                       , Win32-network
   exposed-modules:      Chairman.Base
-                        Chairman.Plan
-                        Chairman.OS
+                        Chairman.IO.File
                         Chairman.IO.Network.NamedPipe
                         Chairman.IO.Network.Socket
                         Chairman.IO.Network.Sprocket
                         Chairman.Network
+                        Chairman.OS
+                        Chairman.Plan
                         Chairman.Process
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-node-chairman/src/Chairman/IO/File.hs
+++ b/cardano-node-chairman/src/Chairman/IO/File.hs
@@ -1,0 +1,15 @@
+module Chairman.IO.File
+  ( fileContains
+  ) where
+
+import           Data.Bool
+import           Data.Functor
+import           Data.String (String)
+import           System.IO (FilePath, IO)
+
+import qualified Data.List as L
+import qualified System.IO as IO
+
+-- | Determine if the given string is found in the given file.
+fileContains :: String -> FilePath -> IO Bool
+fileContains text path = (text `L.isInfixOf`) <$> IO.readFile path

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -147,6 +147,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -146,6 +146,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -152,6 +152,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -169,6 +169,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: False
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -142,6 +142,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: False
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -142,6 +142,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: False
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/liveview/config-0.yaml
+++ b/configuration/defaults/liveview/config-0.yaml
@@ -146,6 +146,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/liveview/config-1.yaml
+++ b/configuration/defaults/liveview/config-1.yaml
@@ -140,6 +140,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/liveview/config-2.yaml
+++ b/configuration/defaults/liveview/config-2.yaml
@@ -146,6 +146,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -137,6 +137,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: False
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: True
 

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -147,6 +147,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -146,6 +146,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -152,6 +152,9 @@ TraceBlockFetchProtocolSerialised: False
 # Trace BlockFetch server.
 TraceBlockFetchServer: True
 
+# Trace BlockchainTime.
+TraceBlockchainTime: False
+
 # Verbose tracer of ChainDB
 TraceChainDb: False
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -211,6 +211,7 @@ Also enable the EKG backend if you want to use the EKG or Prometheus monitoring 
 	  "TraceBlockFetchProtocol": false,
 	  "TraceBlockFetchProtocolSerialised": false,
 	  "TraceBlockFetchServer": false,
+	  "TraceBlockchainTime": false,
 	  "TraceChainDb": true,
 	  "TraceChainSyncBlockServer": false,
 	  "TraceChainSyncClient": false,

--- a/doc/reference/shelley-genesis.md
+++ b/doc/reference/shelley-genesis.md
@@ -965,8 +965,9 @@ $ cp cardano-node/configuration/defaults/byron-mainnet/configuration.yaml \
 and make a couple tweaks
 
 ```
-$ sed -i 's/Protocol: RealPBFT/Protocol: TPraos/' example/configuration.yaml
-$ sed -i 's/minSeverity: Info/minSeverity: Debug/' example/configuration.yaml
+$ sed -i 's/^Protocol: RealPBFT/Protocol: TPraos/' example/configuration.yaml
+$ sed -i 's/^minSeverity: Info/minSeverity: Debug/' example/configuration.yaml
+$ sed -i 's/^TraceBlockchainTime: False/TraceBlockchainTime: True/' example/configuration.yaml
 ```
 
 We will share this `configuration.yaml` file between both nodes we run.

--- a/scripts/lite/shelley-testnet-2.sh
+++ b/scripts/lite/shelley-testnet-2.sh
@@ -25,8 +25,9 @@ cardano_node="$(cabal exec -- which cardano-node)"
 # copy and tweak the configuration
 cp configuration/defaults/byron-mainnet/configuration.yaml ${ROOT}/
 sed -i ${ROOT}/configuration.yaml \
-    -e 's/Protocol: RealPBFT/Protocol: TPraos/' \
-    -e 's/minSeverity: Info/minSeverity: Debug/'
+    -e 's/^Protocol: RealPBFT/Protocol: TPraos/' \
+    -e 's/^minSeverity: Info/minSeverity: Debug/' \
+    -e 's/^TraceBlockchainTime: False/TraceBlockchainTime: True/'
 
 # Set up our template
 $cardano_cli shelley genesis create --testnet-magic 42 --genesis-dir ${ROOT}


### PR DESCRIPTION
`TraceBlockchainTime` is a configuration that was added back in June, but was not mentioned in documentation or in config files found within the project.

This setting must be set to `True` in order to see the "until genesis start time at" when the start time is set to the future.

This PR makes those additions.

Additionally, the `Byron` chairman test now asserts that the text "until genesis start time at" appears in the log file when the start time is in the future.