### PR TITLE
Disable selection of rdrand in cryptonite

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,6 +22,11 @@ package cardano-node
 package cardano-node-chairman
   ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
 
+package cryptonite
+  -- Using RDRAND instead of /dev/urandom as an entropy source for key
+  -- generation is dubious. Set the flag so we use /dev/urandom by default.
+  flags: -support_rdrand
+
 -- ---------------------------------------------------------
 -- Disable all tests by default
 


### PR DESCRIPTION
It is better to use /dev/urandom as the primary entropy source (which on
some systems will use RDRAND as a contribuytory source) rather than
using RDRAND from user space as the sole source.

Change the build flag for cryptonite to avoid the rdrand entropy
backend.