### PR TITLE
rework JSON conversions for transaction metadata

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -53,7 +53,7 @@
 # Ignore some builtin hints
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
-
+- ignore: {name: "Use lambda-case"}
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -99,6 +99,7 @@ test-suite cardano-api-test
   build-depends:
                         base >=4.12 && <5
                       , aeson
+                      , base16-bytestring
                       , bytestring
                       , cardano-api
                       , cardano-binary

--- a/cardano-api/test/Test/Cardano/Api/MetaData.hs
+++ b/cardano-api/test/Test/Cardano/Api/MetaData.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
 module Test.Cardano.Api.MetaData
   ( tests
   ) where
@@ -7,80 +7,287 @@ module Test.Cardano.Api.MetaData
 import           Cardano.Prelude hiding (MetaData)
 
 import           Cardano.Api.MetaData
-import           Cardano.Api.Typed
 
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.List as List
+import           Data.Aeson (ToJSON (..))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 
-import           Hedgehog (Gen, Property, discover)
+import           Hedgehog (Gen, Property, discover, property, (===))
 import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog.Range (Range)
+import qualified Hedgehog.Internal.Gen as Gen
 import qualified Hedgehog.Range as Range
 
--- This test is fragile to changes in the way Metadata is converted to/from JSON.
-prop_round_trip_json_metadatum :: Property
-prop_round_trip_json_metadatum = do
-  Hedgehog.withTests 1000 . Hedgehog.property $ do
-    md <- Hedgehog.forAll genMetaData
-    Hedgehog.tripping md jsonFromMetadata jsonToMetadata
 
--- -----------------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- Golden / unit tests
+--
 
--- Generate 'TxMetadata' that will round trip correctly.
--- The only valid value that is known to not round trip correctly is a list of
--- lists where all the sub-lists are of length 2.
--- The reason this does not round trip is because when decoding the JSON, a list
--- of pairs is assumed to be a map.
-genMetaData :: Gen TxMetadata
-genMetaData = do
-  idxs <- List.nub <$> Gen.list (Range.linear 1 5) (Gen.word64 Range.constantBounded)
-  makeTransactionMetadata . Map.fromList <$> mapM (\i -> (i,) <$> genTxMetadataValue) idxs
+prop_golden_1 :: Property
+prop_golden_1 = matchMetadata
+                  "{\"0\": 1}"
+                  (TxMetadata (Map.fromList [(0, TxMetaNumber 1)]))
+
+prop_golden_2 :: Property
+prop_golden_2 = matchMetadata
+                  "{\"0\": \"deadbeef\"}"
+                  (txMetadataSingleton 0 (TxMetaText "deadbeef"))
+
+prop_golden_3 :: Property
+prop_golden_3 = matchMetadata
+                  "{\"0\": \"0xDEADBEEF\"}"
+                  (txMetadataSingleton 0 (TxMetaText "0xDEADBEEF"))
+
+prop_golden_4 :: Property
+prop_golden_4 = matchMetadata
+                  "{\"0\": \"0xdeadbeef\"}"
+                  (txMetadataSingleton 0 (TxMetaBytes "\xde\xad\xbe\xef"))
+
+prop_golden_5 :: Property
+prop_golden_5 = matchMetadata
+                  "{\"0\": [] }"
+                  (txMetadataSingleton 0 (TxMetaList []))
+
+prop_golden_6 :: Property
+prop_golden_6 = matchMetadata
+                  "{\"0\": [1, \"a\", \"0x42\"] }"
+                  (txMetadataSingleton 0
+                    (TxMetaList [TxMetaNumber 1
+                                ,TxMetaText "a"
+                                ,TxMetaBytes "\x42"]))
+
+prop_golden_7 :: Property
+prop_golden_7 = matchMetadata
+                  "{\"0\": {} }"
+                  (txMetadataSingleton 0 (TxMetaMap []))
+
+prop_golden_8 :: Property
+prop_golden_8 = matchMetadata
+                  "{\"0\": { \"0x41\": \"0x42\", \"1\": 2, \"a\" : \"b\" }}"
+                  (txMetadataSingleton 0
+                    (TxMetaMap [(TxMetaBytes "\x41", TxMetaBytes "\x42")
+                               ,(TxMetaNumber 1,     TxMetaNumber 2)
+                               ,(TxMetaText  "a",    TxMetaText "b")]))
+
+txMetadataSingleton :: Word64 -> TxMetadataValue -> TxMetadata
+txMetadataSingleton n v = TxMetadata (Map.fromList [(n, v)])
+
+matchMetadata :: ByteString -> TxMetadata -> Property
+matchMetadata jsonStr metadata =
+  Hedgehog.withTests 1 $ Hedgehog.property $ Hedgehog.test $
+    case Aeson.decodeStrict' jsonStr of
+      Nothing -> Hedgehog.failure
+      Just json -> do
+        Hedgehog.annotateShow json
+        metadataFromJson TxMetadataJsonNoSchema json === Right metadata
+
+
+-- ----------------------------------------------------------------------------
+-- Round trip properties
+--
+
+-- | Any JSON (within the supported subset) can be converted to tx metadata and
+-- back, to give the same original JSON.
+--
+-- This uses the \"no schema\" mapping. Note that with this mapping it is /not/
+-- the case that any tx metadata can be converted to JSON and back to give the
+-- original value.
+--
+prop_noschema_json_roundtrip_via_metadata :: Property
+prop_noschema_json_roundtrip_via_metadata = Hedgehog.property $ do
+    json <- Hedgehog.forAll (genJsonForTxMetadata TxMetadataJsonNoSchema)
+    Right json === (fmap (metadataToJson   TxMetadataJsonNoSchema)
+                        . metadataFromJson TxMetadataJsonNoSchema) json
+
+-- | Any JSON (fitting the detailed schema) can be converted to tx metadata and
+-- back, to give the same original JSON.
+--
+prop_schema_json_roundtrip_via_metadata :: Property
+prop_schema_json_roundtrip_via_metadata = Hedgehog.property $ do
+    json <- Hedgehog.forAll (genJsonForTxMetadata TxMetadataJsonDetailedSchema)
+    Right json === (fmap (metadataToJson   TxMetadataJsonDetailedSchema)
+                        . metadataFromJson TxMetadataJsonDetailedSchema) json
+
+
+-- | Any tx metadata can be converted to JSON (using the detailed schema) and
+-- back, to give the same original tx metadata.
+--
+prop_metadata_roundtrip_via_schema_json :: Property
+prop_metadata_roundtrip_via_schema_json = Hedgehog.property $ do
+    md <- Hedgehog.forAll genTxMetadata
+    Right md === (metadataFromJson TxMetadataJsonDetailedSchema
+                . metadataToJson   TxMetadataJsonDetailedSchema) md
+
+
+-- ----------------------------------------------------------------------------
+-- Generators
+--
+
+genJsonForTxMetadata :: TxMetadataJsonSchema -> Gen Aeson.Value
+genJsonForTxMetadata mapping =
+    Gen.sized $ \sz ->
+      Aeson.object <$>
+      Gen.list (Range.linear 0 (fromIntegral sz))
+               ((,) <$> (Text.pack . show <$> Gen.word64 Range.constantBounded)
+                    <*> genJsonForTxMetadataValue mapping)
+
+genJsonForTxMetadataValue :: TxMetadataJsonSchema -> Gen Aeson.Value
+genJsonForTxMetadataValue TxMetadataJsonNoSchema = genJsonValue
+  where
+    genJsonValue :: Gen Aeson.Value
+    genJsonValue =
+      Gen.sized $ \sz ->
+        Gen.frequency
+          [ (1,         Aeson.toJSON <$> genJsonNumber)
+          , (2,         Aeson.toJSON <$> genJsonText)
+          , (fromIntegral (signum sz),
+                        Aeson.toJSON <$> Gen.scale (`div` 2) genJsonList)
+          , (fromIntegral (signum sz),
+                        Aeson.object <$> Gen.scale (`div` 2) genJsonMap)
+          ]
+
+    genJsonNumber :: Gen Integer
+    genJsonNumber = Gen.integral
+                      (Range.linear
+                        (-fromIntegral (maxBound :: Word64) :: Integer)
+                        ( fromIntegral (maxBound :: Word64) :: Integer))
+
+    genJsonText  :: Gen Text
+    genJsonText = Gen.choice
+                    [ Gen.ensure validText (genText 64)
+                    , Gen.ensure validText ((bytesPrefix <>) <$> genText 62)
+                    , genBytes
+                    , Text.pack . show <$> genJsonNumber
+                    ]
+      where
+        validText t = BS.length (Text.encodeUtf8 t) <= 64
+        bytesPrefix = "0x"
+        genText sz  = Text.pack <$> Gen.list (Range.linear 0 sz) Gen.alphaNum
+        genBytes    = (bytesPrefix <>)
+                    . Text.decodeUtf8
+                    . Base16.encode
+                    . BS.pack
+                  <$> Gen.list (Range.linear 0 64)
+                               (Gen.word8 Range.constantBounded)
+
+    genJsonList :: Gen [Aeson.Value]
+    genJsonList = Gen.sized $ \sz ->
+                    Gen.list (Range.linear 0 (fromIntegral sz)) genJsonValue
+
+    genJsonMap :: Gen [(Text, Aeson.Value)]
+    genJsonMap = Gen.sized $ \sz ->
+                   Gen.list (Range.linear 0 (fromIntegral sz)) $
+                     (,) <$> genJsonText <*> genJsonValue
+
+
+genJsonForTxMetadataValue TxMetadataJsonDetailedSchema = genJsonValue
+  where
+    genJsonValue :: Gen Aeson.Value
+    genJsonValue =
+      Gen.sized $ \sz ->
+        Gen.frequency
+          [ (1,         singleFieldObject "int"    <$> genJsonNumber)
+          , (1,         singleFieldObject "bytes"  <$> genJsonBytes)
+          , (1,         singleFieldObject "string" <$> genJsonText)
+          , (fromIntegral (signum sz),
+                        singleFieldObject "list" <$>
+                          Gen.scale (`div` 2) genJsonList)
+          , (fromIntegral (signum sz),
+                        singleFieldObject "map" <$>
+                          Gen.scale (`div` 2) genJsonMap)
+          ]
+
+    singleFieldObject name v = Aeson.object [(name, v)]
+
+    genJsonNumber :: Gen Aeson.Value
+    genJsonNumber = toJSON <$>
+                    Gen.integral
+                      (Range.linear
+                        (-fromIntegral (maxBound :: Word64) :: Integer)
+                        ( fromIntegral (maxBound :: Word64) :: Integer))
+
+    genJsonBytes :: Gen Aeson.Value
+    genJsonBytes = toJSON
+                 . Text.decodeLatin1
+                 . Base16.encode
+                 . BS.pack
+               <$> Gen.list (Range.linear 0 64)
+                            (Gen.word8 Range.constantBounded)
+
+    genJsonText  :: Gen Aeson.Value
+    genJsonText = fmap toJSON $
+                    Gen.ensure validText $
+                      Text.pack <$> Gen.list (Range.linear 0 64) Gen.alphaNum
+      where
+        validText t = BS.length (Text.encodeUtf8 t) <= 64
+
+    genJsonList :: Gen Aeson.Value
+    genJsonList = fmap toJSON $
+                    Gen.sized $ \sz ->
+                      Gen.list (Range.linear 0 (fromIntegral sz)) genJsonValue
+
+    genJsonMap :: Gen Aeson.Value
+    genJsonMap = fmap toJSON $
+                   Gen.sized $ \sz ->
+                     Gen.list (Range.linear 0 (fromIntegral sz)) $
+                       mkKVPair <$> genJsonValue <*> genJsonValue
+      where
+        mkKVPair :: Aeson.Value -> Aeson.Value -> Aeson.Value
+        mkKVPair k v = Aeson.object [ ("k", k), ("v", v) ]
+
+
+genTxMetadata :: Gen TxMetadata
+genTxMetadata =
+    Gen.sized $ \sz ->
+      TxMetadata . Map.fromList <$>
+      Gen.list (Range.linear 0 (fromIntegral sz))
+               ((,) <$> Gen.word64 Range.constantBounded
+                    <*> genTxMetadataValue)
 
 genTxMetadataValue :: Gen TxMetadataValue
 genTxMetadataValue =
-  -- This shrinks towards the head of the list, so have TxMetaMap at the end.
-  Gen.choice
-    [ TxMetaNumber <$> Gen.integral (Range.linear 0 10000)
-    , TxMetaBytes <$> genByteString
-    , TxMetaText <$> genText
-    -- Only generate list of flat values to avoid generating a valid HashMap.
-    , TxMetaList <$> Gen.list (Range.linear 1 8) genFlatTxMetadataValue
-    , TxMetaMap <$> genPairList (Range.linear 1 8)
-    ]
+    Gen.sized $ \sz ->
+      Gen.frequency
+        [ (1,         TxMetaNumber <$> genTxMetaNumber)
+        , (1,         TxMetaBytes  <$> genTxMetaBytes)
+        , (1,         TxMetaText   <$> genTxMetaText)
+        , (fromIntegral (signum sz),
+                      TxMetaList   <$> Gen.scale (`div` 2) genTxMetaList)
+        , (fromIntegral (signum sz),
+                      TxMetaMap    <$> Gen.scale (`div` 2) genTxMetaMap)
+        ]
+  where
+    genTxMetaNumber :: Gen Integer
+    genTxMetaNumber = Gen.integral
+                        (Range.linear
+                          (-fromIntegral (maxBound :: Word64) :: Integer)
+                          ( fromIntegral (maxBound :: Word64) :: Integer))
 
--- As above, but without nested values (List and Map).
-genFlatTxMetadataValue :: Gen TxMetadataValue
-genFlatTxMetadataValue =
-  Gen.choice
-    [ TxMetaNumber <$> Gen.integral (Range.linear 0 10000)
-    , TxMetaBytes <$> genByteString
-    , TxMetaText <$> genText
-    ]
+    genTxMetaBytes :: Gen ByteString
+    genTxMetaBytes = BS.pack <$> Gen.list (Range.linear 0 64)
+                                          (Gen.word8 Range.constantBounded)
 
-genPairList :: Range Int -> Gen [(TxMetadataValue, TxMetadataValue)]
-genPairList len = do
-  keys <- Gen.list len $
-            Gen.frequency
-              [ (3, TxMetaText <$> genText)
-              , (2, TxMetaBytes <$> genByteString)
-              , (1, genFlatTxMetadataValue)
-              ]
-  -- Keys need to be unique and sorted.
-  -- They need to be unique because they are inserted into a HashMap and they
-  -- need to be sorted so they round trip correctly.
-  mapM (\k -> (k,) <$> genTxMetadataValue) (List.sort $ List.nub keys)
+    genTxMetaText  :: Gen Text
+    genTxMetaText = Text.pack <$> Gen.list (Range.linear 0 64) Gen.alphaNum
 
-genByteString :: Gen ByteString
-genByteString = BS.pack <$> Gen.list (Range.linear 0 64) Gen.latin1
+    genTxMetaList :: Gen [TxMetadataValue]
+    genTxMetaList = Gen.sized $ \sz ->
+                      Gen.list (Range.linear 0 (fromIntegral sz))
+                               genTxMetadataValue
 
-genText :: Gen Text
-genText = Text.pack <$> Gen.list (Range.linear 0 64) Gen.alphaNum
+    genTxMetaMap  :: Gen [(TxMetadataValue, TxMetadataValue)]
+    genTxMetaMap = Gen.sized $ \sz ->
+                      Gen.list (Range.linear 0 (fromIntegral sz)) $
+                        (,) <$> genTxMetadataValue <*> genTxMetadataValue
 
--- -----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Automagically collecting all the tests
+--
 
 tests :: IO Bool
-tests =
-  Hedgehog.checkParallel $$discover
+tests = Hedgehog.checkParallel $$discover

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -48,6 +48,7 @@ module Cardano.CLI.Shelley.Commands
 import           Data.Text (Text)
 import           Prelude
 
+import           Cardano.Api.MetaData
 import           Cardano.Api.Protocol (Protocol)
 import           Cardano.Api.Typed hiding (PoolId)
 
@@ -160,6 +161,7 @@ data TransactionCmd
       Lovelace
       [CertificateFile]
       [(StakeAddress, Lovelace)]
+      TxMetadataJsonSchema
       [MetaDataFile]
       (Maybe UpdateProposalFile)
       TxBodyFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -14,6 +14,7 @@ module Cardano.CLI.Shelley.Parsers
 import           Cardano.Prelude hiding (option)
 import           Prelude (String)
 
+import           Cardano.Api.MetaData
 import           Cardano.Api.Protocol (Protocol (..))
 import           Cardano.Api.Typed hiding (PoolId)
 import           Cardano.Chain.Slotting (EpochSlots (..))
@@ -468,6 +469,7 @@ pTransaction =
                                    <*> pTxFee
                                    <*> many pCertificateFile
                                    <*> many pWithdrawal
+                                   <*> pTxMetadataJsonSchema
                                    <*> many pMetaDataFile
                                    <*> optional pUpdateProposalFile
                                    <*> pTxBodyFile Output
@@ -906,6 +908,25 @@ pPoolMetaDataFile =
       <> Opt.help "Filepath of the pool metadata."
       <> Opt.completer (Opt.bashCompleter "file")
       )
+
+pTxMetadataJsonSchema :: Parser TxMetadataJsonSchema
+pTxMetadataJsonSchema =
+    (  Opt.flag' ()
+        (  Opt.long "--json-metadata-no-schema"
+        <> Opt.help "Use the \"no schema\" conversion from JSON to tx metadata."
+        )
+    *> pure TxMetadataJsonNoSchema
+    )
+  <|>
+    (  Opt.flag' ()
+        (  Opt.long "--json-metadata-detailed-schema"
+        <> Opt.help "Use the \"detailed schema\" conversion from JSON to tx metadata."
+        )
+    *> pure TxMetadataJsonDetailedSchema
+    )
+  <|>
+    -- Default to the no-schema conversion.
+    pure TxMetadataJsonNoSchema
 
 pMetaDataFile :: Parser MetaDataFile
 pMetaDataFile =


### PR DESCRIPTION
  a. Encode JSON as CBOR considering only the following "optimizations"
  b. Hexadecimal sequences starting with 0x are encoded as CBOR bytestring.
  c. JSON keys that are numbers are encoded as CBOR numbers.
  d. CBOR is shown as JSON when possible, or as a string representing JSON-encoded data when not (i.e. when map keys aren't numbers or strings).
  e. CBOR bytestrings are represented as hexadecimal strings prefixed with 0x

  - we expect are that we can round trip any JSON without constraints (modulo null and boolean values)
  - for CBOR, we should be able to round trip a subset with some simple-ish constraints.