### PR TITLE
Fix typos in configuration

### DIFF
--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -150,7 +150,7 @@ TraceBlockFetchServer: True
 # Trace BlockchainTime.
 TraceBlockchainTime: False
 
-# Verbose tracer of ChainDB
+# Verbose tracer of ChainDB.
 TraceChainDb: False
 
 # Trace ChainSync client.
@@ -159,7 +159,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -201,7 +201,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -158,7 +158,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -200,7 +200,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -155,7 +155,7 @@ TraceBlockFetchServer: True
 # Trace BlockchainTime.
 TraceBlockchainTime: False
 
-# Verbose tracer of ChainDB
+# Verbose tracer of ChainDB.
 TraceChainDb: False
 
 # Trace ChainSync client.
@@ -164,7 +164,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -206,7 +206,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -34,8 +34,8 @@ RequiresNetworkMagic: RequiresNoMagic
 
 ##### Update system parameters #####
 
-# This protocol version number gets used by by block producing nodes as part
-# part of the system for agreeing on and synchronising protocol updates.
+# This protocol version number gets used by block producing nodes as part
+# of the system for agreeing on and synchronising protocol updates.
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
@@ -181,7 +181,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -223,7 +223,7 @@ TraceLocalTxSubmissionServer: False
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -27,8 +27,8 @@ RequiresNetworkMagic: RequiresNoMagic
 
 ##### Update system parameters #####
 
-# This protocol version number gets used by by block producing nodes as part
-# part of the system for agreeing on and synchronising protocol updates.
+# This protocol version number gets used by block producing nodes as part
+# of the system for agreeing on and synchronising protocol updates.
 LastKnownBlockVersion-Major: 1
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
@@ -154,7 +154,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -196,7 +196,7 @@ TraceLocalTxSubmissionServer: False
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).
@@ -220,7 +220,7 @@ options:
 
   # This routes metrics matching specific names to particular backends.
   # This overrides the defaultBackends listed above. And note that it is
-  # and override and not an extension so anything matched here will not
+  # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.ChainDB.metrics:

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -27,8 +27,8 @@ RequiresNetworkMagic: RequiresMagic
 
 ##### Update system parameters #####
 
-# This protocol version number gets used by by block producing nodes as part
-# part of the system for agreeing on and synchronising protocol updates.
+# This protocol version number gets used by block producing nodes as part
+# of the system for agreeing on and synchronising protocol updates.
 LastKnownBlockVersion-Major: 1
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
@@ -154,7 +154,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -196,7 +196,7 @@ TraceLocalTxSubmissionServer: False
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).
@@ -220,7 +220,7 @@ options:
 
   # This routes metrics matching specific names to particular backends.
   # This overrides the defaultBackends listed above. And note that it is
-  # and override and not an extension so anything matched here will not
+  # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.ChainDB.metrics:

--- a/configuration/defaults/liveview/config-0.yaml
+++ b/configuration/defaults/liveview/config-0.yaml
@@ -149,7 +149,7 @@ TraceBlockFetchServer: True
 # Trace BlockchainTime.
 TraceBlockchainTime: False
 
-# Verbose tracer of ChainDB
+# Verbose tracer of ChainDB.
 TraceChainDb: True
 
 # Trace ChainSync client.
@@ -158,7 +158,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -200,7 +200,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/liveview/config-1.yaml
+++ b/configuration/defaults/liveview/config-1.yaml
@@ -143,7 +143,7 @@ TraceBlockFetchServer: True
 # Trace BlockchainTime.
 TraceBlockchainTime: False
 
-# Verbose tracer of ChainDB
+# Verbose tracer of ChainDB.
 TraceChainDb: True
 
 # Trace ChainSync client.
@@ -152,7 +152,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -194,7 +194,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/liveview/config-2.yaml
+++ b/configuration/defaults/liveview/config-2.yaml
@@ -149,7 +149,7 @@ TraceBlockFetchServer: True
 # Trace BlockchainTime.
 TraceBlockchainTime: False
 
-# Verbose tracer of ChainDB
+# Verbose tracer of ChainDB.
 TraceChainDb: True
 
 # Trace ChainSync client.
@@ -158,7 +158,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -200,7 +200,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -25,8 +25,8 @@ RequiresNetworkMagic: RequiresNoMagic
 
 ##### Update system parameters #####
 
-# This protocol version number gets used by by block producing nodes as part
-# part of the system for agreeing on and synchronising protocol updates.
+# This protocol version number gets used by block producing nodes as part
+# of the system for agreeing on and synchronising protocol updates.
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
@@ -149,7 +149,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -191,7 +191,7 @@ TraceLocalTxSubmissionServer: False
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).
@@ -215,7 +215,7 @@ options:
 
   # This routes metrics matching specific names to particular backends.
   # This overrides the defaultBackends listed above. And note that it is
-  # and override and not an extension so anything matched here will not
+  # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.ChainDB.metrics:

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -159,7 +159,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -201,7 +201,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -158,7 +158,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -200,7 +200,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -164,7 +164,7 @@ TraceChainSyncClient: False
 # Trace ChainSync server (blocks).
 TraceChainSyncBlockServer: False
 
-# Trace ChainSync server (headers)
+# Trace ChainSync server (headers).
 TraceChainSyncHeaderServer: False
 
 # Trace ChainSync protocol messages.
@@ -206,7 +206,7 @@ TraceLocalTxSubmissionServer: True
 # Trace mempool.
 TraceMempool: True
 
-# Trace Mux Events
+# Trace Mux Events.
 TraceMux: False
 
 # Trace TxSubmission server (inbound transactions).


### PR DESCRIPTION
* Replace `by by` with `by`
* Replace `part part` with `part`
* Add terminating period to be in line with rest of file.