### PR TITLE
Improve cardano-cli shelley errors

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -39,18 +39,20 @@ data ClientCommand =
 
 data ClientCommandErrors
   = ByronClientError ByronClientCmdError
-  | ShelleyClientError ShelleyClientCmdError
+  | ShelleyClientError ShelleyCommand ShelleyClientCmdError
   deriving Show
   --TODO: We should include an AgnosticClientError
 
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()
-runClientCommand (ByronCommand   c) = firstExceptT ByronClientError $ runByronClientCommand c
-runClientCommand (ShelleyCommand c) = firstExceptT ShelleyClientError $ runShelleyClientCommand c
-runClientCommand DisplayVersion     = runDisplayVersion
+runClientCommand (ByronCommand c) = firstExceptT ByronClientError $ runByronClientCommand c
+runClientCommand (ShelleyCommand c) = firstExceptT (ShelleyClientError c) $ runShelleyClientCommand c
+runClientCommand DisplayVersion = runDisplayVersion
 
 renderClientCommandError :: ClientCommandErrors -> Text
-renderClientCommandError (ByronClientError err) = renderByronClientCmdError err
-renderClientCommandError (ShelleyClientError err) = renderShelleyClientCmdError err
+renderClientCommandError (ByronClientError err) =
+  renderByronClientCmdError err
+renderClientCommandError (ShelleyClientError cmd err) =
+  runIdentity $ renderShelleyClientCmdError cmd err
 
 runDisplayVersion :: ExceptT ClientCommandErrors IO ()
 runDisplayVersion = do

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -52,7 +52,7 @@ renderClientCommandError :: ClientCommandErrors -> Text
 renderClientCommandError (ByronClientError err) =
   renderByronClientCmdError err
 renderClientCommandError (ShelleyClientError cmd err) =
-  runIdentity $ renderShelleyClientCmdError cmd err
+  renderShelleyClientCmdError cmd err
 
 runDisplayVersion :: ExceptT ClientCommandErrors IO ()
 runDisplayVersion = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -16,6 +16,7 @@ module Cardano.CLI.Shelley.Commands
   , GovernanceCmd (..)
   , GenesisCmd (..)
   , TextViewCmd (..)
+  , renderShelleyCommand
 
     -- * CLI flag types
   , AddressKeyType (..)
@@ -74,6 +75,19 @@ data ShelleyCommand
   | TextViewCmd     TextViewCmd
   deriving (Eq, Show)
 
+renderShelleyCommand :: ShelleyCommand -> Text
+renderShelleyCommand sc =
+  case sc of
+    AddressCmd cmd -> renderAddressCmd cmd
+    StakeAddressCmd cmd -> renderStakeAddressCmd cmd
+    KeyCmd cmd -> renderKeyCmd cmd
+    TransactionCmd cmd -> renderTransactionCmd cmd
+    NodeCmd cmd -> renderNodeCmd cmd
+    PoolCmd cmd -> renderPoolCmd cmd
+    QueryCmd cmd -> renderQueryCmd cmd
+    GovernanceCmd cmd -> renderGovernanceCmd cmd
+    GenesisCmd cmd -> renderGenesisCmd cmd
+    TextViewCmd cmd -> renderTextViewCmd cmd
 
 data AddressCmd
   = AddressKeyGen AddressKeyType VerificationKeyFile SigningKeyFile
@@ -84,6 +98,17 @@ data AddressCmd
   | AddressInfo Text (Maybe OutputFile)
   deriving (Eq, Show)
 
+
+renderAddressCmd :: AddressCmd -> Text
+renderAddressCmd cmd =
+  case cmd of
+    AddressKeyGen {} -> "address key-gen"
+    AddressKeyHash {} -> "address key-hash"
+    AddressBuild {} -> "address build"
+    AddressBuildMultiSig {} -> "address build-multisig"
+    AddressInfo {} -> "address info"
+    AddressBuildScript {} -> "address build-script"
+
 data StakeAddressCmd
   = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
   | StakeAddressKeyHash VerificationKeyFile (Maybe OutputFile)
@@ -92,6 +117,16 @@ data StakeAddressCmd
   | StakeKeyDelegationCert VerificationKeyFile StakePoolVerificationKeyHashOrFile OutputFile
   | StakeKeyDeRegistrationCert VerificationKeyFile OutputFile
   deriving (Eq, Show)
+
+renderStakeAddressCmd :: StakeAddressCmd -> Text
+renderStakeAddressCmd cmd =
+  case cmd of
+    StakeAddressKeyGen {} -> "stake-address key-gen"
+    StakeAddressKeyHash {} -> "stake-address key-hash"
+    StakeAddressBuild {} -> "stake-address build"
+    StakeKeyRegistrationCert {} -> "stake-address registration-certificate"
+    StakeKeyDelegationCert {} -> "stake-address delegation-certificate"
+    StakeKeyDeRegistrationCert {} -> "stake-address deregistration-certificate"
 
 data KeyCmd
   = KeyGetVerificationKey SigningKeyFile VerificationKeyFile
@@ -102,6 +137,17 @@ data KeyCmd
   | KeyConvertITNExtendedToStakeKey SomeKeyFile OutputFile
   | KeyConvertITNBip32ToStakeKey SomeKeyFile OutputFile
   deriving (Eq, Show)
+
+renderKeyCmd :: KeyCmd -> Text
+renderKeyCmd cmd =
+  case cmd of
+    KeyGetVerificationKey {} -> "key verification-key"
+    KeyNonExtendedKey {} -> "key non-extended-key"
+    KeyConvertByronKey {} -> "key convert-byron-key"
+    KeyConvertByronGenesisVKey {} -> "key convert-byron-genesis-key"
+    KeyConvertITNStakeKey {} -> "key convert-itn-key"
+    KeyConvertITNExtendedToStakeKey {} -> "key convert-itn-extended-key"
+    KeyConvertITNBip32ToStakeKey {} -> "key convert-itn-bip32-key"
 
 data TransactionCmd
   = TxBuildRaw
@@ -129,6 +175,16 @@ data TransactionCmd
   | TxGetTxId TxBodyFile
   deriving (Eq, Show)
 
+renderTransactionCmd :: TransactionCmd -> Text
+renderTransactionCmd cmd =
+  case cmd of
+    TxBuildRaw {} -> "transaction build-raw"
+    TxSign {} -> "transaction sign"
+    TxWitness {} -> "transaction witness"
+    TxSignWitness {} -> "transaction sign-witness"
+    TxSubmit {} -> "transaction submit"
+    TxCalculateMinFee {} -> "transaction calculate-min-fee"
+    TxGetTxId {} -> "transaction txid"
 
 data NodeCmd
   = NodeKeyGenCold VerificationKeyFile SigningKeyFile OpCertCounterFile
@@ -139,6 +195,17 @@ data NodeCmd
   | NodeIssueOpCert VerificationKeyFile SigningKeyFile OpCertCounterFile
                     KESPeriod OutputFile
   deriving (Eq, Show)
+
+renderNodeCmd :: NodeCmd -> Text
+renderNodeCmd cmd = do
+  case cmd of
+    NodeKeyGenCold {} -> "node key-gen"
+    NodeKeyGenKES {} -> "node key-gen-KES"
+    NodeKeyGenVRF {} -> "node key-gen-VRF"
+    NodeKeyHashVRF {} -> "node key-hash-VRF"
+    NodeNewCounter {} -> "node new-counter"
+    NodeIssueOpCert{} -> "node issue-op-cert"
+
 
 data PoolCmd
   = PoolRegistrationCert
@@ -166,12 +233,19 @@ data PoolCmd
       VerificationKeyFile
       -- ^ Stake pool verification key.
       EpochNo
-      -- ^ Epoch in which to retire the stake pool. --TODO: Double check this
+      -- ^ Epoch in which to retire the stake pool.
       OutputFile
   | PoolGetId VerificationKeyFile OutputFormat
   | PoolMetaDataHash PoolMetaDataFile (Maybe OutputFile)
   deriving (Eq, Show)
 
+renderPoolCmd :: PoolCmd -> Text
+renderPoolCmd cmd =
+  case cmd of
+    PoolRegistrationCert {} -> "stake-pool registration-certificate"
+    PoolRetirementCert {} -> "stake-pool deregistration-certificate"
+    PoolGetId {} -> "stake-pool id"
+    PoolMetaDataHash {} -> "stake-pool metadata-hash"
 
 data QueryCmd =
     QueryProtocolParameters Protocol NetworkId (Maybe OutputFile)
@@ -181,6 +255,16 @@ data QueryCmd =
   | QueryUTxO Protocol QueryFilter NetworkId (Maybe OutputFile)
   | QueryLedgerState Protocol NetworkId (Maybe OutputFile)
   deriving (Eq, Show)
+
+renderQueryCmd :: QueryCmd -> Text
+renderQueryCmd cmd =
+  case cmd of
+    QueryProtocolParameters {} -> "query protocol-parameters "
+    QueryTip {} -> "query tip"
+    QueryStakeDistribution {} -> "query stake-distribution"
+    QueryStakeAddressInfo {} -> "query stake-address-info"
+    QueryUTxO {} -> "query utxo"
+    QueryLedgerState {} -> "query ledger-state"
 
 data GovernanceCmd
   = GovernanceMIRCertificate MIRPot [VerificationKeyFile] [Lovelace] OutputFile
@@ -194,10 +278,20 @@ data GovernanceCmd
                              ProtocolParametersUpdate
   deriving (Eq, Show)
 
+renderGovernanceCmd :: GovernanceCmd -> Text
+renderGovernanceCmd cmd =
+  case cmd of
+    GovernanceGenesisKeyDelegationCertificate {} -> "governance create-genesis-key-delegation-certificate"
+    GovernanceMIRCertificate {} -> "governance create-mir-certificate"
+    GovernanceUpdateProposal {} -> "governance create-update-proposal"
 
 data TextViewCmd
   = TextViewInfo !FilePath (Maybe OutputFile)
   deriving (Eq, Show)
+
+
+renderTextViewCmd :: TextViewCmd -> Text
+renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"
 
 data GenesisCmd
   = GenesisCreate GenesisDir Word Word (Maybe SystemStart) (Maybe Lovelace) NetworkId
@@ -210,6 +304,19 @@ data GenesisCmd
   | GenesisAddr VerificationKeyFile NetworkId (Maybe OutputFile)
   | GenesisHashFile GenesisFile
   deriving (Eq, Show)
+
+renderGenesisCmd :: GenesisCmd -> Text
+renderGenesisCmd cmd =
+  case cmd of
+    GenesisCreate {} -> "genesis create"
+    GenesisKeyGenGenesis {} -> "genesis key-gen-genesis"
+    GenesisKeyGenDelegate {} -> "genesis key-gen-delegate"
+    GenesisKeyGenUTxO {} -> "genesis key-gen-utxo"
+    GenesisCmdKeyHash {} -> "genesis key-hash"
+    GenesisVerKey {} -> "genesis get-ver-key"
+    GenesisTxIn {} -> "genesis initial-txin"
+    GenesisAddr {} -> "genesis initial-addr"
+    GenesisHashFile {} -> "genesis hash"
 
 --
 -- Shelley CLI flag/option data types

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -26,7 +26,7 @@ import           Cardano.CLI.Shelley.Run.TextView
 data ShelleyClientCmdError
   = ShelleyCmdAddressError !ShelleyAddressCmdError
   | ShelleyCmdGenesisError !ShelleyGenesisCmdError
-  | ShelleyCmdGovernanceError !ShelleyGovernanceError
+  | ShelleyCmdGovernanceError !ShelleyGovernanceCmdError
   | ShelleyCmdNodeError !ShelleyNodeCmdError
   | ShelleyCmdPoolError !ShelleyPoolCmdError
   | ShelleyCmdStakeAddressError !ShelleyStakeAddressCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -36,19 +36,36 @@ data ShelleyClientCmdError
   | ShelleyCmdKeyError !ShelleyKeyCmdError
   deriving Show
 
-renderShelleyClientCmdError :: ShelleyClientCmdError -> Text
-renderShelleyClientCmdError err =
-  case err of
-    ShelleyCmdAddressError addrCmdErr -> renderShelleyAddressCmdError addrCmdErr
-    ShelleyCmdGenesisError genesisCmdErr -> renderShelleyGenesisCmdError genesisCmdErr
-    ShelleyCmdGovernanceError govCmdErr -> renderShelleyGovernanceError govCmdErr
-    ShelleyCmdNodeError nodeCmdErr -> renderShelleyNodeCmdError nodeCmdErr
-    ShelleyCmdPoolError poolCmdErr -> renderShelleyPoolCmdError poolCmdErr
-    ShelleyCmdStakeAddressError stakeAddrCmdErr -> renderShelleyStakeAddressCmdError stakeAddrCmdErr
-    ShelleyCmdTextViewError txtViewErr -> renderShelleyTextViewFileError txtViewErr
-    ShelleyCmdTransactionError txErr -> renderShelleyTxCmdError txErr
-    ShelleyCmdQueryError queryErr -> renderShelleyQueryCmdError queryErr
-    ShelleyCmdKeyError keyErr -> renderShelleyKeyCmdError keyErr
+-- Identity monad is used to avoid boilerplate
+renderShelleyClientCmdError :: ShelleyCommand -> ShelleyClientCmdError -> Identity Text
+renderShelleyClientCmdError cmd err = do
+  cmdError <- case err of
+                ShelleyCmdAddressError addrCmdErr ->
+                  return $ renderShelleyAddressCmdError addrCmdErr
+                ShelleyCmdGenesisError genesisCmdErr ->
+                  return $ renderShelleyGenesisCmdError genesisCmdErr
+                ShelleyCmdGovernanceError govCmdErr ->
+                  return $ renderShelleyGovernanceError govCmdErr
+                ShelleyCmdNodeError nodeCmdErr ->
+                  return $ renderShelleyNodeCmdError nodeCmdErr
+                ShelleyCmdPoolError poolCmdErr ->
+                  return $ renderShelleyPoolCmdError poolCmdErr
+                ShelleyCmdStakeAddressError stakeAddrCmdErr ->
+                  return $ renderShelleyStakeAddressCmdError stakeAddrCmdErr
+                ShelleyCmdTextViewError txtViewErr ->
+                  return $ renderShelleyTextViewFileError txtViewErr
+                ShelleyCmdTransactionError txErr ->
+                  return $ renderShelleyTxCmdError txErr
+                ShelleyCmdQueryError queryErr ->
+                  return $ renderShelleyQueryCmdError queryErr
+                ShelleyCmdKeyError keyErr ->
+                  return $ renderShelleyKeyCmdError keyErr
+
+  return $ "Shelley command failed: "
+         <> renderShelleyCommand cmd
+         <> "  Error: "
+         <> cmdError
+
 
 --
 -- CLI shelley command dispatch

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -36,35 +36,37 @@ data ShelleyClientCmdError
   | ShelleyCmdKeyError !ShelleyKeyCmdError
   deriving Show
 
--- Identity monad is used to avoid boilerplate
-renderShelleyClientCmdError :: ShelleyCommand -> ShelleyClientCmdError -> Identity Text
-renderShelleyClientCmdError cmd err = do
-  cmdError <- case err of
-                ShelleyCmdAddressError addrCmdErr ->
-                  return $ renderShelleyAddressCmdError addrCmdErr
-                ShelleyCmdGenesisError genesisCmdErr ->
-                  return $ renderShelleyGenesisCmdError genesisCmdErr
-                ShelleyCmdGovernanceError govCmdErr ->
-                  return $ renderShelleyGovernanceError govCmdErr
-                ShelleyCmdNodeError nodeCmdErr ->
-                  return $ renderShelleyNodeCmdError nodeCmdErr
-                ShelleyCmdPoolError poolCmdErr ->
-                  return $ renderShelleyPoolCmdError poolCmdErr
-                ShelleyCmdStakeAddressError stakeAddrCmdErr ->
-                  return $ renderShelleyStakeAddressCmdError stakeAddrCmdErr
-                ShelleyCmdTextViewError txtViewErr ->
-                  return $ renderShelleyTextViewFileError txtViewErr
-                ShelleyCmdTransactionError txErr ->
-                  return $ renderShelleyTxCmdError txErr
-                ShelleyCmdQueryError queryErr ->
-                  return $ renderShelleyQueryCmdError queryErr
-                ShelleyCmdKeyError keyErr ->
-                  return $ renderShelleyKeyCmdError keyErr
-
-  return $ "Shelley command failed: "
-         <> renderShelleyCommand cmd
-         <> "  Error: "
-         <> cmdError
+renderShelleyClientCmdError :: ShelleyCommand -> ShelleyClientCmdError -> Text
+renderShelleyClientCmdError cmd err =
+  case err of
+    ShelleyCmdAddressError addrCmdErr ->
+       renderError cmd renderShelleyAddressCmdError addrCmdErr
+    ShelleyCmdGenesisError genesisCmdErr ->
+       renderError cmd renderShelleyGenesisCmdError genesisCmdErr
+    ShelleyCmdGovernanceError govCmdErr ->
+       renderError cmd renderShelleyGovernanceError govCmdErr
+    ShelleyCmdNodeError nodeCmdErr ->
+       renderError cmd renderShelleyNodeCmdError nodeCmdErr
+    ShelleyCmdPoolError poolCmdErr ->
+       renderError cmd renderShelleyPoolCmdError poolCmdErr
+    ShelleyCmdStakeAddressError stakeAddrCmdErr ->
+       renderError cmd renderShelleyStakeAddressCmdError stakeAddrCmdErr
+    ShelleyCmdTextViewError txtViewErr ->
+       renderError cmd renderShelleyTextViewFileError txtViewErr
+    ShelleyCmdTransactionError txErr ->
+       renderError cmd renderShelleyTxCmdError txErr
+    ShelleyCmdQueryError queryErr ->
+       renderError cmd renderShelleyQueryCmdError queryErr
+    ShelleyCmdKeyError keyErr ->
+       renderError cmd renderShelleyKeyCmdError keyErr
+ where
+   renderError :: ShelleyCommand -> (a -> Text) -> a -> Text
+   renderError shelleyCmd renderer shelCliCmdErr =
+      mconcat [ "Shelley command failed: "
+              , renderShelleyCommand shelleyCmd
+              , "  Error: "
+              , renderer shelCliCmdErr
+              ]
 
 
 --

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -1,5 +1,5 @@
 module Cardano.CLI.Shelley.Run.Governance
-  ( ShelleyGovernanceError
+  ( ShelleyGovernanceCmdError
   , renderShelleyGovernanceError
   , runGovernanceCmd
   ) where
@@ -21,11 +21,11 @@ import           Cardano.CLI.Types
 import qualified Shelley.Spec.Ledger.TxData as Shelley
 
 
-data ShelleyGovernanceError
-  = GovernanceReadFileError !(FileError TextEnvelopeError)
-  | GovernanceWriteFileError !(FileError ())
-  | GovernanceEmptyUpdateProposalError
-  | GovernanceMIRCertificateKeyRewardMistmach
+data ShelleyGovernanceCmdError
+  = ShelleyGovernanceCmdTextEnvReadError !(FileError TextEnvelopeError)
+  | ShelleyGovernanceCmdTextEnvWriteError !(FileError ())
+  | ShelleyGovernanceCmdEmptyUpdateProposalError
+  | ShelleyGovernanceCmdMIRCertificateKeyRewardMistmach
       !FilePath
       !Int
       -- ^ Number of stake verification keys
@@ -33,15 +33,15 @@ data ShelleyGovernanceError
       -- ^ Number of reward amounts
   deriving Show
 
-renderShelleyGovernanceError :: ShelleyGovernanceError -> Text
+renderShelleyGovernanceError :: ShelleyGovernanceCmdError -> Text
 renderShelleyGovernanceError err =
   case err of
-    GovernanceReadFileError fileErr -> Text.pack (displayError fileErr)
-    GovernanceWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyGovernanceCmdTextEnvReadError fileErr -> Text.pack (displayError fileErr)
+    ShelleyGovernanceCmdTextEnvWriteError fileErr -> Text.pack (displayError fileErr)
     -- TODO: The equality check is still not working for empty update proposals.
-    GovernanceEmptyUpdateProposalError ->
+    ShelleyGovernanceCmdEmptyUpdateProposalError ->
       "Empty update proposals are not allowed"
-    GovernanceMIRCertificateKeyRewardMistmach fp numVKeys numRwdAmts ->
+    ShelleyGovernanceCmdMIRCertificateKeyRewardMistmach fp numVKeys numRwdAmts ->
        "Error creating the MIR certificate at: " <> textShow fp
        <> " The number of staking keys: " <> textShow numVKeys
        <> " and the number of reward amounts: " <> textShow numRwdAmts
@@ -49,7 +49,7 @@ renderShelleyGovernanceError err =
 
 
 
-runGovernanceCmd :: GovernanceCmd -> ExceptT ShelleyGovernanceError IO ()
+runGovernanceCmd :: GovernanceCmd -> ExceptT ShelleyGovernanceCmdError IO ()
 runGovernanceCmd (GovernanceMIRCertificate mirpot vKeys rewards out) =
   runGovernanceMIRCertificate mirpot vKeys rewards out
 runGovernanceCmd (GovernanceGenesisKeyDelegationCertificate genVk genDelegVk vrfVk out) =
@@ -64,7 +64,7 @@ runGovernanceMIRCertificate
   -> [Lovelace]
   -- ^ Reward amounts
   -> OutputFile
-  -> ExceptT ShelleyGovernanceError IO ()
+  -> ExceptT ShelleyGovernanceCmdError IO ()
 runGovernanceMIRCertificate mirPot vKeys rwdAmts (OutputFile oFp) = do
     sCreds <- mapM readStakeKeyToCred vKeys
 
@@ -72,23 +72,23 @@ runGovernanceMIRCertificate mirPot vKeys rwdAmts (OutputFile oFp) = do
 
     let mirCert = makeMIRCertificate mirPot (zip sCreds rwdAmts)
 
-    firstExceptT GovernanceWriteFileError
+    firstExceptT ShelleyGovernanceCmdTextEnvWriteError
       . newExceptT
       $ writeFileTextEnvelope oFp (Just mirCertDesc) mirCert
   where
     mirCertDesc :: TextViewDescription
     mirCertDesc = TextViewDescription "Move Instantaneous Rewards Certificate"
 
-    checkEqualKeyRewards :: [VerificationKeyFile] -> [Lovelace] -> ExceptT ShelleyGovernanceError IO ()
+    checkEqualKeyRewards :: [VerificationKeyFile] -> [Lovelace] -> ExceptT ShelleyGovernanceCmdError IO ()
     checkEqualKeyRewards keys rwds = do
        let numVKeys = length keys
            numRwdAmts = length rwds
        if numVKeys == numRwdAmts
-       then return () else left $ GovernanceMIRCertificateKeyRewardMistmach oFp numVKeys numRwdAmts
+       then return () else left $ ShelleyGovernanceCmdMIRCertificateKeyRewardMistmach oFp numVKeys numRwdAmts
 
-    readStakeKeyToCred :: VerificationKeyFile -> ExceptT ShelleyGovernanceError IO StakeCredential
+    readStakeKeyToCred :: VerificationKeyFile -> ExceptT ShelleyGovernanceCmdError IO StakeCredential
     readStakeKeyToCred (VerificationKeyFile stVKey) = do
-      stakeVkey <- firstExceptT GovernanceReadFileError
+      stakeVkey <- firstExceptT ShelleyGovernanceCmdTextEnvReadError
         . newExceptT
         $ readFileTextEnvelope (AsVerificationKey AsStakeKey) stVKey
       right . StakeCredentialByKey $ verificationKeyHash stakeVkey
@@ -98,21 +98,21 @@ runGovernanceGenesisKeyDelegationCertificate
   -> VerificationKeyOrHashOrFile GenesisDelegateKey
   -> VerificationKeyOrHashOrFile VrfKey
   -> OutputFile
-  -> ExceptT ShelleyGovernanceError IO ()
+  -> ExceptT ShelleyGovernanceCmdError IO ()
 runGovernanceGenesisKeyDelegationCertificate genVkOrHashOrFp
                                              genDelVkOrHashOrFp
                                              vrfVkOrHashOrFp
                                              (OutputFile oFp) = do
-    genesisVkHash <- firstExceptT GovernanceReadFileError
+    genesisVkHash <- firstExceptT ShelleyGovernanceCmdTextEnvReadError
       . newExceptT
       $ readVerificationKeyOrHashOrFile AsGenesisKey genVkOrHashOrFp
-    genesisDelVkHash <-firstExceptT GovernanceReadFileError
+    genesisDelVkHash <-firstExceptT ShelleyGovernanceCmdTextEnvReadError
       . newExceptT
       $ readVerificationKeyOrHashOrFile AsGenesisDelegateKey genDelVkOrHashOrFp
-    vrfVkHash <- firstExceptT GovernanceReadFileError
+    vrfVkHash <- firstExceptT ShelleyGovernanceCmdTextEnvReadError
       . newExceptT
       $ readVerificationKeyOrHashOrFile AsVrfKey vrfVkOrHashOrFp
-    firstExceptT GovernanceWriteFileError
+    firstExceptT ShelleyGovernanceCmdTextEnvWriteError
       . newExceptT
       $ writeFileTextEnvelope oFp (Just genKeyDelegCertDesc)
       $ makeGenesisKeyDelegationCertificate genesisVkHash genesisDelVkHash vrfVkHash
@@ -126,18 +126,18 @@ runGovernanceUpdateProposal
   -> [VerificationKeyFile]
   -- ^ Genesis verification keys
   -> ProtocolParametersUpdate
-  -> ExceptT ShelleyGovernanceError IO ()
+  -> ExceptT ShelleyGovernanceCmdError IO ()
 runGovernanceUpdateProposal (OutputFile upFile) eNo genVerKeyFiles upPprams = do
-    when (upPprams == mempty) $ left GovernanceEmptyUpdateProposalError
+    when (upPprams == mempty) $ left ShelleyGovernanceCmdEmptyUpdateProposalError
     genVKeys <- sequence
-                  [ firstExceptT GovernanceReadFileError . newExceptT $
+                  [ firstExceptT ShelleyGovernanceCmdTextEnvReadError . newExceptT $
                       readFileTextEnvelope
                         (AsVerificationKey AsGenesisKey)
                         vkeyFile
                   | VerificationKeyFile vkeyFile <- genVerKeyFiles ]
     let genKeyHashes = map verificationKeyHash genVKeys
         upProp = makeShelleyUpdateProposal upPprams genKeyHashes eNo
-    firstExceptT GovernanceWriteFileError . newExceptT $
+    firstExceptT ShelleyGovernanceCmdTextEnvWriteError . newExceptT $
       writeFileTextEnvelope upFile Nothing upProp
 
 -- | Read a verification key or verification key hash or verification key file

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -62,7 +62,7 @@ renderShelleyKeyCmdError err =
     ShelleyKeyCmdByronKeyParseError errTxt -> errTxt
     ShelleyKeyCmdItnKeyConvError convErr -> renderConversionError convErr
     ShelleyKeyCmdWrongKeyTypeError -> Text.pack "Please use a signing key file \
-                                                \when converting ITN BIP32 or Extended keys"
+                                   \when converting ITN BIP32 or Extended keys"
 
 runKeyCmd :: KeyCmd -> ExceptT ShelleyKeyCmdError IO ()
 runKeyCmd cmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -19,19 +19,19 @@ import qualified Data.Text as Text
 {- HLINT ignore "Reduce duplication" -}
 
 data ShelleyNodeCmdError
-  = ShelleyNodeReadFileError !(FileError TextEnvelopeError)
-  | ShelleyNodeWriteFileError !(FileError ())
-  | ShelleyNodeOperationalCertificateIssueError !OperationalCertIssueError
+  = ShelleyNodeCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyNodeCmdWriteFileError !(FileError ())
+  | ShelleyNodeCmdOperationalCertificateIssueError !OperationalCertIssueError
   deriving Show
 
 renderShelleyNodeCmdError :: ShelleyNodeCmdError -> Text
 renderShelleyNodeCmdError err =
   case err of
-    ShelleyNodeReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyNodeCmdReadFileError fileErr -> Text.pack (displayError fileErr)
 
-    ShelleyNodeWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyNodeCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
 
-    ShelleyNodeOperationalCertificateIssueError issueErr ->
+    ShelleyNodeCmdOperationalCertificateIssueError issueErr ->
       Text.pack (displayError issueErr)
 
 
@@ -58,13 +58,13 @@ runNodeKeyGenCold (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath)
                   (OpCertCounterFile ocertCtrPath) = do
     skey <- liftIO $ generateSigningKey AsStakePoolKey
     let vkey = getVerificationKey skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope skeyPath (Just skeyDesc) skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope vkeyPath (Just vkeyDesc) vkey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope ocertCtrPath (Just ocertCtrDesc)
       $ OperationalCertificateIssueCounter initialCounter vkey
@@ -84,10 +84,10 @@ runNodeKeyGenKES :: VerificationKeyFile
 runNodeKeyGenKES (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     skey <- liftIO $ generateSigningKey AsKesKey
     let vkey = getVerificationKey skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope skeyPath (Just skeyDesc) skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope vkeyPath (Just vkeyDesc) vkey
   where
@@ -101,10 +101,10 @@ runNodeKeyGenVRF :: VerificationKeyFile -> SigningKeyFile
 runNodeKeyGenVRF (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     skey <- liftIO $ generateSigningKey AsVrfKey
     let vkey = getVerificationKey skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope skeyPath (Just skeyDesc) skey
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope vkeyPath (Just vkeyDesc) vkey
   where
@@ -115,7 +115,7 @@ runNodeKeyGenVRF (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
 runNodeKeyHashVRF :: VerificationKeyFile -> Maybe OutputFile
                   -> ExceptT ShelleyNodeCmdError IO ()
 runNodeKeyHashVRF (VerificationKeyFile vkeyPath) mOutputFp = do
-  vkey <- firstExceptT ShelleyNodeReadFileError
+  vkey <- firstExceptT ShelleyNodeCmdReadFileError
     . newExceptT
     $ readFileTextEnvelope (AsVerificationKey AsVrfKey) vkeyPath
 
@@ -133,7 +133,7 @@ runNodeNewCounter :: VerificationKeyFile
 runNodeNewCounter (VerificationKeyFile vkeyPath) counter
                   (OpCertCounterFile ocertCtrPath) = do
 
-    vkey <- firstExceptT ShelleyNodeReadFileError . newExceptT $
+    vkey <- firstExceptT ShelleyNodeCmdReadFileError . newExceptT $
               readFileTextEnvelopeAnyOf
                 [ FromSomeType (AsVerificationKey AsStakePoolKey) id
                 , FromSomeType (AsVerificationKey AsGenesisDelegateKey)
@@ -144,7 +144,7 @@ runNodeNewCounter (VerificationKeyFile vkeyPath) counter
     let ocertIssueCounter =
           OperationalCertificateIssueCounter (fromIntegral counter) vkey
 
-    firstExceptT ShelleyNodeWriteFileError . newExceptT $
+    firstExceptT ShelleyNodeCmdWriteFileError . newExceptT $
       writeFileTextEnvelope ocertCtrPath Nothing ocertIssueCounter
 
 
@@ -165,20 +165,20 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKesPath)
                    kesPeriod
                    (OutputFile certFile) = do
 
-    ocertIssueCounter <- firstExceptT ShelleyNodeReadFileError
+    ocertIssueCounter <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
       $ readFileTextEnvelope AsOperationalCertificateIssueCounter ocertCtrPath
 
-    verKeyKes <- firstExceptT ShelleyNodeReadFileError
+    verKeyKes <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
       $ readFileTextEnvelope (AsVerificationKey AsKesKey) vkeyKesPath
 
-    signKey <- firstExceptT ShelleyNodeReadFileError
+    signKey <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
       $ readFileTextEnvelopeAnyOf possibleBlockIssuers skeyStakePoolPath
 
     (ocert, nextOcertCtr) <-
-      firstExceptT ShelleyNodeOperationalCertificateIssueError
+      firstExceptT ShelleyNodeCmdOperationalCertificateIssueError
         . hoistEither
         $ issueOperationalCertificate
             verKeyKes
@@ -188,14 +188,14 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKesPath)
 
     -- Write the counter first, to reduce the chance of ending up with
     -- a new cert but without updating the counter.
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope
         ocertCtrPath
         (Just $ ocertCtrDesc $ getCounter nextOcertCtr)
         nextOcertCtr
 
-    firstExceptT ShelleyNodeWriteFileError
+    firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
       $ writeFileTextEnvelope certFile Nothing ocert
   where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -113,7 +113,7 @@ runQueryProtocolParameters protocol network mOutFile = do
     SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr
                            readEnvSocketPath
     pparams <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
-               withlocalNodeConnectInfo protocol network sockPath $
+               withlocalNodeConnectInfo protocol network sockPath
                  queryPParamsFromLocalState
     writeProtocolParameters mOutFile pparams
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -73,32 +73,19 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQu
 
 
 data ShelleyQueryCmdError
-  = ShelleyQueryEnvVarSocketErr !EnvSocketError
-  | ShelleyQueryNodeLocalStateQueryError !LocalStateQueryError
-  | ShelleyQueryWriteProtocolParamsError !FilePath !IOException
-  | ShelleyQueryWriteFilteredUTxOsError !FilePath !IOException
-  | ShelleyQueryWriteStakeDistributionError !FilePath !IOException
-  | ShelleyQueryWriteLedgerStateError !FilePath !IOException
-  | ShelleyQueryWriteStakeAddressInfoError !FilePath !IOException
-  | ShelleyHelpersError !HelpersError
+  = ShelleyQueryCmdEnvVarSocketErr !EnvSocketError
+  | ShelleyQueryCmdLocalStateQueryError !ShelleyQueryCmdLocalStateQueryError
+  | ShelleyQueryCmdWriteFileError !(FileError ())
+  | ShelleyQueryCmdHelpersError !HelpersError
   deriving Show
 
 renderShelleyQueryCmdError :: ShelleyQueryCmdError -> Text
 renderShelleyQueryCmdError err =
   case err of
-    ShelleyQueryEnvVarSocketErr envSockErr -> renderEnvSocketError envSockErr
-    ShelleyQueryNodeLocalStateQueryError lsqErr -> renderLocalStateQueryError lsqErr
-    ShelleyQueryWriteProtocolParamsError fp ioException ->
-      "Error writing protocol parameters at: " <> show fp <> " Error: " <> show ioException
-    ShelleyQueryWriteFilteredUTxOsError fp ioException ->
-      "Error writing filtered UTxOs at: " <> show fp <> " Error: " <> show ioException
-    ShelleyQueryWriteStakeDistributionError fp ioException ->
-      "Error writing stake distribution at: " <> show fp <> " Error: " <> show ioException
-    ShelleyQueryWriteLedgerStateError fp ioException ->
-      "Error writing ledger state at: " <> show fp <> " Error: " <> show ioException
-    ShelleyQueryWriteStakeAddressInfoError fp ioException ->
-      "Error writing stake address info at: " <> show fp <> " Error: " <> show ioException
-    ShelleyHelpersError helpersErr -> renderHelpersError helpersErr
+    ShelleyQueryCmdEnvVarSocketErr envSockErr -> renderEnvSocketError envSockErr
+    ShelleyQueryCmdLocalStateQueryError lsqErr -> renderLocalStateQueryError lsqErr
+    ShelleyQueryCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyQueryCmdHelpersError helpersErr -> renderHelpersError helpersErr
 
 runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmd cmd =
@@ -123,10 +110,10 @@ runQueryProtocolParameters
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryProtocolParameters protocol network mOutFile = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr
+    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr
                            readEnvSocketPath
-    pparams <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
-               withlocalNodeConnectInfo protocol network sockPath
+    pparams <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
+               withlocalNodeConnectInfo protocol network sockPath $
                  queryPParamsFromLocalState
     writeProtocolParameters mOutFile pparams
 
@@ -135,7 +122,7 @@ writeProtocolParameters mOutFile pparams =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty pparams)
     Just (OutputFile fpath) ->
-      handleIOExceptT (ShelleyQueryWriteProtocolParamsError fpath) $
+      handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $
         LBS.writeFile fpath (encodePretty pparams)
 
 runQueryTip
@@ -144,9 +131,9 @@ runQueryTip
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryTip protocol network mOutFile = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
+    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
     output <-
-      firstExceptT ShelleyQueryNodeLocalStateQueryError $
+      firstExceptT ShelleyQueryCmdLocalStateQueryError $
       withlocalNodeConnectInfo protocol network sockPath $ \connectInfo -> do
         tip <- liftIO $ getLocalTip connectInfo
         let output = case localNodeConsensusMode connectInfo of
@@ -166,8 +153,8 @@ runQueryUTxO
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryUTxO protocol qfilter network mOutFile = do
-  SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  filteredUtxo <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  filteredUtxo <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
     withlocalNodeConnectInfo protocol network sockPath (queryUTxOFromLocalState qfilter)
   writeFilteredUTxOs mOutFile filteredUtxo
 
@@ -177,14 +164,14 @@ runQueryLedgerState
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryLedgerState protocol network mOutFile = do
-  SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  els <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  els <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
     withlocalNodeConnectInfo protocol network sockPath queryLocalLedgerState
   case els of
     Right lstate -> writeLedgerState mOutFile lstate
     Left lbs -> do
       liftIO $ putTextLn "Version mismatch between node and consensus, so dumping this as generic CBOR."
-      firstExceptT ShelleyHelpersError $ pPrintCBOR lbs
+      firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR lbs
 
 runQueryStakeAddressInfo
   :: Protocol
@@ -193,8 +180,8 @@ runQueryStakeAddressInfo
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryStakeAddressInfo protocol addr network mOutFile = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-    delegsAndRwds <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
+    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+    delegsAndRwds <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
       withlocalNodeConnectInfo
         protocol
         network
@@ -205,7 +192,7 @@ runQueryStakeAddressInfo protocol addr network mOutFile = do
 -- -------------------------------------------------------------------------------------------------
 
 -- | An error that can occur while querying a node's local state.
-data LocalStateQueryError
+data ShelleyQueryCmdLocalStateQueryError
   = AcquireFailureError !LocalStateQuery.AcquireFailure
   | EraMismatchError !EraMismatch
   -- ^ A query from a certain era was applied to a ledger from a different
@@ -214,7 +201,7 @@ data LocalStateQueryError
   -- ^ The query does not support the Byron protocol.
   deriving (Eq, Show)
 
-renderLocalStateQueryError :: LocalStateQueryError -> Text
+renderLocalStateQueryError :: ShelleyQueryCmdLocalStateQueryError -> Text
 renderLocalStateQueryError lsqErr =
   case lsqErr of
     AcquireFailureError err -> "Local state query acquire failure: " <> show err
@@ -231,7 +218,7 @@ writeStakeAddressInfo mOutFile dr@(DelegationsAndRewards _ _delegsAndRwds) =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty dr)
     Just (OutputFile fpath) ->
-      handleIOExceptT (ShelleyQueryWriteStakeAddressInfoError fpath)
+      handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath (encodePretty dr)
 
 writeLedgerState :: Maybe OutputFile -> EpochState StandardShelley -> ExceptT ShelleyQueryCmdError IO ()
@@ -239,7 +226,7 @@ writeLedgerState mOutFile lstate =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty lstate)
     Just (OutputFile fpath) ->
-      handleIOExceptT (ShelleyQueryWriteLedgerStateError fpath)
+      handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath (encodePretty lstate)
 
 writeFilteredUTxOs :: Maybe OutputFile -> Ledger.UTxO StandardShelley -> ExceptT ShelleyQueryCmdError IO ()
@@ -247,7 +234,7 @@ writeFilteredUTxOs mOutFile utxo =
     case mOutFile of
       Nothing -> liftIO $ printFilteredUTxOs utxo
       Just (OutputFile fpath) ->
-        handleIOExceptT (ShelleyQueryWriteFilteredUTxOsError fpath) $ LBS.writeFile fpath (encodePretty utxo)
+        handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $ LBS.writeFile fpath (encodePretty utxo)
 
 printFilteredUTxOs :: Ledger.UTxO StandardShelley -> IO ()
 printFilteredUTxOs (Ledger.UTxO utxo) = do
@@ -280,8 +267,8 @@ runQueryStakeDistribution
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
 runQueryStakeDistribution protocol network mOutFile = do
-  SocketPath sockPath <- firstExceptT ShelleyQueryEnvVarSocketErr readEnvSocketPath
-  stakeDist <- firstExceptT ShelleyQueryNodeLocalStateQueryError $
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  stakeDist <- firstExceptT ShelleyQueryCmdLocalStateQueryError $
       withlocalNodeConnectInfo
         protocol
         network
@@ -293,7 +280,7 @@ writeStakeDistribution :: Maybe OutputFile
                        -> PoolDistr StandardShelley
                        -> ExceptT ShelleyQueryCmdError IO ()
 writeStakeDistribution (Just (OutputFile outFile)) (PoolDistr stakeDist) =
-    handleIOExceptT (ShelleyQueryWriteStakeDistributionError outFile) $
+    handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError outFile) $
       LBS.writeFile outFile (encodePretty stakeDist)
 
 writeStakeDistribution Nothing stakeDist =
@@ -335,7 +322,7 @@ printStakeDistribution (PoolDistr stakeDist) = do
 queryUTxOFromLocalState
   :: QueryFilter
   -> LocalNodeConnectInfo mode block
-  -> ExceptT LocalStateQueryError IO (Ledger.UTxO StandardShelley)
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO (Ledger.UTxO StandardShelley)
 queryUTxOFromLocalState qFilter connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
   case localNodeConsensusMode of
     ByronMode{} -> throwError ByronProtocolNotSupportedError
@@ -409,7 +396,7 @@ instance ToJSON DelegationsAndRewards where
 --
 queryPParamsFromLocalState
   :: LocalNodeConnectInfo mode block
-  -> ExceptT LocalStateQueryError IO PParams
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO PParams
 queryPParamsFromLocalState LocalNodeConnectInfo{
                              localNodeConsensusMode = ByronMode{}
                            } =
@@ -445,7 +432,7 @@ queryPParamsFromLocalState connectInfo@LocalNodeConnectInfo{
 --
 queryStakeDistributionFromLocalState
   :: LocalNodeConnectInfo mode block
-  -> ExceptT LocalStateQueryError IO (PoolDistr StandardShelley)
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO (PoolDistr StandardShelley)
 queryStakeDistributionFromLocalState LocalNodeConnectInfo{
                                        localNodeConsensusMode = ByronMode{}
                                      } =
@@ -475,7 +462,7 @@ queryStakeDistributionFromLocalState connectInfo@LocalNodeConnectInfo{
 
 queryLocalLedgerState
   :: LocalNodeConnectInfo mode blk
-  -> ExceptT LocalStateQueryError IO
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO
              (Either LByteString (Ledger.EpochState StandardShelley))
 queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
   case localNodeConsensusMode of
@@ -516,7 +503,7 @@ queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
 queryDelegationsAndRewardsFromLocalState
   :: Set StakeAddress
   -> LocalNodeConnectInfo mode block
-  -> ExceptT LocalStateQueryError IO DelegationsAndRewards
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO DelegationsAndRewards
 queryDelegationsAndRewardsFromLocalState stakeaddrs
                                          connectInfo@LocalNodeConnectInfo{
                                            localNodeNetworkId,

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
@@ -21,15 +21,15 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 data ShelleyTextViewFileError
-  = ShelleyTextViewReadFileError (FileError TextEnvelopeError)
-  | ShelleyTextViewCBORPrettyPrintError !HelpersError
+  = TextViewReadFileError (FileError TextEnvelopeError)
+  | TextViewCBORPrettyPrintError !HelpersError
   deriving Show
 
 renderShelleyTextViewFileError :: ShelleyTextViewFileError -> Text
 renderShelleyTextViewFileError err =
   case err of
-    ShelleyTextViewReadFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyTextViewCBORPrettyPrintError hlprsErr ->
+    TextViewReadFileError fileErr -> Text.pack (displayError fileErr)
+    TextViewCBORPrettyPrintError hlprsErr ->
       "Error pretty printing CBOR: " <> renderHelpersError hlprsErr
 
 
@@ -40,8 +40,8 @@ runTextViewCmd cmd =
 
 runTextViewInfo :: FilePath -> Maybe OutputFile -> ExceptT ShelleyTextViewFileError IO ()
 runTextViewInfo fpath mOutFile = do
-  tv <- firstExceptT ShelleyTextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
+  tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
   let lbCBOR = LBS.fromStrict (tvRawCBOR tv)
   case mOutFile of
     Just (OutputFile oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
-    Nothing -> firstExceptT ShelleyTextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR
+    Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -193,7 +193,7 @@ runTxSign (TxBodyFile txbodyFile) skFiles mnw (TxFile txFile) = do
 runTxSubmit :: Protocol -> NetworkId -> FilePath
             -> ExceptT ShelleyTxCmdError IO ()
 runTxSubmit protocol network txFile = do
-    SocketPath sockPath <- firstExceptT ShelleyTxCmdSocketEnvError $ readEnvSocketPath
+    SocketPath sockPath <- firstExceptT ShelleyTxCmdSocketEnvError readEnvSocketPath
     tx <- firstExceptT ShelleyTxCmdReadTextViewFileError
       . newExceptT
       $ Api.readFileTextEnvelopeAnyOf

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -43,70 +43,49 @@ import           Cardano.Api.Protocol
 import           Cardano.Api.TxSubmit as Api
 import           Cardano.Api.Typed as Api
 
-
 data ShelleyTxCmdError
-  = ShelleyTxAesonDecodeProtocolParamsError !FilePath !Text
-  | ShelleyTxMetaDataFileError !FilePath !IOException
-  | ShelleyTxMetaDataConversionError !FilePath !MetaDataJsonConversionError
-  | ShelleyTxMetaDecodeError !FilePath !CBOR.DecoderError
+  = ShelleyTxCmdAesonDecodeProtocolParamsError !FilePath !Text
+  | ShelleyTxCmdReadFileError !(FileError ())
+  | ShelleyTxCmdReadTextViewFileError !(FileError TextEnvelopeError)
+  | ShelleyTxCmdWriteFileError !(FileError ())
+  | ShelleyTxCmdMetaDataConversionError !FilePath !MetaDataJsonConversionError
   | ShelleyTxMetaValidationError !FilePath !TxMetadataValidationError
-  | ShelleyTxMissingNetworkId
-  | ShelleyTxSocketEnvError !EnvSocketError
-  | ShelleyTxReadProtocolParamsError !FilePath !IOException
-  | ShelleyTxReadUpdateError !(Api.FileError Api.TextEnvelopeError)
-  | ShelleyTxReadUnsignedTxError !(Api.FileError Api.TextEnvelopeError)
-  | ShelleyTxCertReadError !(Api.FileError Api.TextEnvelopeError)
-  | ShelleyTxWriteSignedTxError !(Api.FileError ())
-  | ShelleyTxWriteUnsignedTxError !(Api.FileError ())
-  | ShelleyTxSubmitErrorByron   !(ApplyTxErr ByronBlock)
-  | ShelleyTxSubmitErrorShelley !(ApplyTxErr (ShelleyBlock StandardShelley))
-  | ShelleyTxSubmitErrorEraMismatch !EraMismatch
-  | ShelleyTxReadFileError !(Api.FileError Api.TextEnvelopeError)
-  | ShelleyTxWriteFileError !(Api.FileError ())
+  | ShelleyTxCmdMetaDecodeError !FilePath !CBOR.DecoderError
+  | ShelleyTxCmdMissingNetworkId
+  | ShelleyTxCmdSocketEnvError !EnvSocketError
+  | ShelleyTxCmdTxSubmitErrorByron !(ApplyTxErr ByronBlock)
+  | ShelleyTxCmdTxSubmitErrorShelley !(ApplyTxErr (ShelleyBlock StandardShelley))
+  | ShelleyTxCmdTxSubmitErrorEraMismatch !EraMismatch
   deriving Show
 
 renderShelleyTxCmdError :: ShelleyTxCmdError -> Text
 renderShelleyTxCmdError err =
   case err of
-    ShelleyTxReadProtocolParamsError fp ioException ->
-      "Error while reading protocol parameters at: " <> show fp
-                                       <> " Error: " <> show ioException
-    ShelleyTxMetaDataFileError fp ioException ->
-       "Error reading metadata at: " <> show fp <> " Error: " <> show ioException
-    ShelleyTxMetaDataConversionError fp metaDataErr ->
+    ShelleyTxCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdReadTextViewFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdMetaDataConversionError fp metaDataErr ->
        "Error reading metadata at: " <> show fp
                        <> " Error: " <> renderMetaDataJsonConversionError metaDataErr
-    ShelleyTxMetaDecodeError fp metaDataErr ->
+    ShelleyTxCmdMetaDecodeError fp metaDataErr ->
        "Error decoding CBOR metadata at: " <> show fp
                              <> " Error: " <> show metaDataErr
     ShelleyTxMetaValidationError fp valErr ->
       "Error validating transaction metadata at: " <> show fp
                                      <> " Error: " <> renderTxMetadataValidationError valErr
-    ShelleyTxReadUnsignedTxError err' ->
-      "Error while reading unsigned shelley tx: " <> Text.pack (Api.displayError err')
-    ShelleyTxReadUpdateError apiError ->
-      "Error while reading shelley update proposal: " <> Text.pack (Api.displayError apiError)
-    ShelleyTxSocketEnvError envSockErr -> renderEnvSocketError envSockErr
-    ShelleyTxAesonDecodeProtocolParamsError fp decErr ->
+    ShelleyTxCmdSocketEnvError envSockErr -> renderEnvSocketError envSockErr
+    ShelleyTxCmdAesonDecodeProtocolParamsError fp decErr ->
       "Error while decoding the protocol parameters at: " <> show fp
                                             <> " Error: " <> show decErr
-    ShelleyTxCertReadError err' ->
-      "Error reading shelley certificate at: " <> Text.pack (Api.displayError err')
-    ShelleyTxWriteSignedTxError err' ->
-      "Error while writing signed shelley tx: " <> Text.pack (Api.displayError err')
-    ShelleyTxWriteUnsignedTxError err' ->
-      "Error while writing unsigned shelley tx: " <> Text.pack (Api.displayError err')
-    ShelleyTxSubmitErrorByron res ->
+    ShelleyTxCmdTxSubmitErrorByron res ->
       "Error while submitting tx: " <> Text.pack (show res)
-    ShelleyTxSubmitErrorShelley res ->
+    ShelleyTxCmdTxSubmitErrorShelley res ->
       "Error while submitting tx: " <> Text.pack (show res)
-    ShelleyTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
+    ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
       "The era of the node and the tx do not match. " <>
       "The node is running in the " <> ledgerEraName <>
       " era, but the transaction is for the " <> otherEraName <> " era."
-    ShelleyTxReadFileError fileErr -> Text.pack (Api.displayError fileErr)
-    ShelleyTxWriteFileError fileErr -> Text.pack (Api.displayError fileErr)
-    ShelleyTxMissingNetworkId -> "Please enter network id with your byron transaction"
+    ShelleyTxCmdMissingNetworkId -> "Please enter network id with your byron transaction"
 
 runTransactionCmd :: TransactionCmd -> ExceptT ShelleyTxCmdError IO ()
 runTransactionCmd cmd =
@@ -144,7 +123,7 @@ runTxBuildRaw txins txouts ttl fee
               (TxBodyFile fpath) = do
 
     certs <- sequence
-               [ firstExceptT ShelleyTxCertReadError . newExceptT $
+               [ firstExceptT ShelleyTxCmdReadTextViewFileError . newExceptT $
                    Api.readFileTextEnvelope Api.AsCertificate certFile
                | CertificateFile certFile <- certFiles ]
 
@@ -159,7 +138,7 @@ runTxBuildRaw txins txouts ttl fee
       case mUpdatePropFile of
         Nothing                        -> return Nothing
         Just (UpdateProposalFile file) ->
-          fmap Just <$> firstExceptT ShelleyTxReadUpdateError $ newExceptT $
+          fmap Just <$> firstExceptT ShelleyTxCmdReadTextViewFileError $ newExceptT $
             Api.readFileTextEnvelope Api.AsUpdateProposal file
 
     let txBody = Api.makeShelleyTransaction
@@ -174,7 +153,7 @@ runTxBuildRaw txins txouts ttl fee
                    txins
                    txouts
 
-    firstExceptT ShelleyTxWriteUnsignedTxError
+    firstExceptT ShelleyTxCmdWriteFileError
       . newExceptT
       $ Api.writeFileTextEnvelope fpath Nothing txBody
 
@@ -185,9 +164,9 @@ runTxSign :: TxBodyFile
           -> TxFile
           -> ExceptT ShelleyTxCmdError IO ()
 runTxSign (TxBodyFile txbodyFile) skFiles mnw (TxFile txFile) = do
-    txbody <- firstExceptT ShelleyTxReadUnsignedTxError . newExceptT $
+    txbody <- firstExceptT ShelleyTxCmdReadTextViewFileError . newExceptT $
                 Api.readFileTextEnvelope Api.AsShelleyTxBody txbodyFile
-    sks    <- firstExceptT ShelleyTxReadFileError $
+    sks    <- firstExceptT ShelleyTxCmdReadTextViewFileError $
                 mapM readSigningKeyFile skFiles
 
     -- We have to handle Byron and Shelley key witnesses slightly differently
@@ -197,7 +176,7 @@ runTxSign (TxBodyFile txbodyFile) skFiles mnw (TxFile txFile) = do
     witnessesByron <-
       case (sksByron, mnw) of
         ([], Nothing) -> return []
-        (_,  Nothing) -> throwError ShelleyTxMissingNetworkId
+        (_,  Nothing) -> throwError ShelleyTxCmdMissingNetworkId
         (_,  Just nw) ->
           return $ map (Api.makeShelleyBootstrapWitness nw txbody) sksByron
 
@@ -208,14 +187,14 @@ runTxSign (TxBodyFile txbodyFile) skFiles mnw (TxFile txFile) = do
         tx        :: Api.Tx Api.Shelley
         tx        = Api.makeSignedTransaction witnesses txbody
 
-    firstExceptT ShelleyTxWriteSignedTxError . newExceptT $
+    firstExceptT ShelleyTxCmdWriteFileError . newExceptT $
       Api.writeFileTextEnvelope txFile Nothing tx
 
 runTxSubmit :: Protocol -> NetworkId -> FilePath
             -> ExceptT ShelleyTxCmdError IO ()
 runTxSubmit protocol network txFile = do
-    SocketPath sockPath <- firstExceptT ShelleyTxSocketEnvError readEnvSocketPath
-    tx <- firstExceptT ShelleyTxReadFileError
+    SocketPath sockPath <- firstExceptT ShelleyTxCmdSocketEnvError $ readEnvSocketPath
+    tx <- firstExceptT ShelleyTxCmdReadTextViewFileError
       . newExceptT
       $ Api.readFileTextEnvelopeAnyOf
           [ Api.FromSomeType Api.AsByronTx   Left
@@ -229,10 +208,10 @@ runTxSubmit protocol network txFile = do
           case result of
             TxSubmitSuccess -> return ()
             TxSubmitFailureByronMode err ->
-              left (ShelleyTxSubmitErrorByron err)
+              left (ShelleyTxCmdTxSubmitErrorByron err)
 
         (ByronMode{}, Right{}) ->
-          left $ ShelleyTxSubmitErrorEraMismatch EraMismatch {
+          left $ ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch {
                    ledgerEraName = "Byron",
                    otherEraName  = "Shelley"
                  }
@@ -242,10 +221,10 @@ runTxSubmit protocol network txFile = do
           case result of
             TxSubmitSuccess -> return ()
             TxSubmitFailureShelleyMode err ->
-              left (ShelleyTxSubmitErrorShelley err)
+              left (ShelleyTxCmdTxSubmitErrorShelley err)
 
         (ShelleyMode{}, Left{}) ->
-          left $ ShelleyTxSubmitErrorEraMismatch EraMismatch {
+          left $ ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch {
                    ledgerEraName = "Shelley",
                    otherEraName  = "Byron"
                  }
@@ -255,11 +234,11 @@ runTxSubmit protocol network txFile = do
           case result of
             TxSubmitSuccess -> return ()
             TxSubmitFailureCardanoMode (ApplyTxErrByron err) ->
-              left (ShelleyTxSubmitErrorByron err)
+              left (ShelleyTxCmdTxSubmitErrorByron err)
             TxSubmitFailureCardanoMode (ApplyTxErrShelley err) ->
-              left (ShelleyTxSubmitErrorShelley err)
+              left (ShelleyTxCmdTxSubmitErrorShelley err)
             TxSubmitFailureCardanoMode (ApplyTxErrWrongEra mismatch) ->
-              left (ShelleyTxSubmitErrorEraMismatch mismatch)
+              left (ShelleyTxCmdTxSubmitErrorEraMismatch mismatch)
 
 
 runTxCalculateMinFee
@@ -276,7 +255,7 @@ runTxCalculateMinFee (TxBodyFile txbodyFile) nw pParamsFile
                      (TxShelleyWitnessCount nShelleyKeyWitnesses)
                      (TxByronWitnessCount nByronKeyWitnesses) = do
 
-    txbody <- firstExceptT ShelleyTxReadUnsignedTxError . newExceptT $
+    txbody <- firstExceptT ShelleyTxCmdReadTextViewFileError . newExceptT $
                 Api.readFileTextEnvelope Api.AsShelleyTxBody txbodyFile
 
     pparams <- readProtocolParameters pParamsFile
@@ -297,8 +276,8 @@ runTxCalculateMinFee (TxBodyFile txbodyFile) nw pParamsFile
 readProtocolParameters :: ProtocolParamsFile
                        -> ExceptT ShelleyTxCmdError IO Shelley.PParams
 readProtocolParameters (ProtocolParamsFile fpath) = do
-  pparams <- handleIOExceptT (ShelleyTxReadProtocolParamsError fpath) $ LBS.readFile fpath
-  firstExceptT (ShelleyTxAesonDecodeProtocolParamsError fpath . Text.pack) . hoistEither $
+  pparams <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fpath) $ LBS.readFile fpath
+  firstExceptT (ShelleyTxCmdAesonDecodeProtocolParamsError fpath . Text.pack) . hoistEither $
     Aeson.eitherDecode' pparams
 
 data SomeWitnessSigningKey
@@ -367,7 +346,7 @@ categoriseWitnessSigningKey swsk =
 
 runTxGetTxId :: TxBodyFile -> ExceptT ShelleyTxCmdError IO ()
 runTxGetTxId (TxBodyFile txbodyFile) = do
-  txbody <- firstExceptT ShelleyTxReadUnsignedTxError . newExceptT $
+  txbody <- firstExceptT ShelleyTxCmdReadTextViewFileError . newExceptT $
               Api.readFileTextEnvelope Api.AsShelleyTxBody txbodyFile
   liftIO $ BS.putStrLn $ Api.serialiseToRawBytesHex (Api.getTxId txbody)
 
@@ -378,30 +357,30 @@ runTxWitness
   -> OutputFile
   -> ExceptT ShelleyTxCmdError IO ()
 runTxWitness (TxBodyFile txbodyFile) witSignKeyFile mbNw (OutputFile oFile) = do
-  txbody <- firstExceptT ShelleyTxReadFileError . newExceptT $
+  txbody <- firstExceptT ShelleyTxCmdReadTextViewFileError . newExceptT $
               Api.readFileTextEnvelope Api.AsShelleyTxBody txbodyFile
-  someWitSignKey <- firstExceptT ShelleyTxReadFileError $ readSigningKeyFile witSignKeyFile
+  someWitSignKey <- firstExceptT ShelleyTxCmdReadTextViewFileError $ readSigningKeyFile witSignKeyFile
 
   witness <-
     case (categoriseWitnessSigningKey someWitSignKey, mbNw) of
       -- Byron witnesses require the network ID.
-      (Left _, Nothing) -> throwError ShelleyTxMissingNetworkId
+      (Left _, Nothing) -> throwError ShelleyTxCmdMissingNetworkId
       (Left byronSk, Just nw) -> pure $ makeShelleyBootstrapWitness nw txbody byronSk
       (Right shelleySk, _) -> pure $ makeShelleyKeyWitness txbody shelleySk
 
-  firstExceptT ShelleyTxWriteFileError
+  firstExceptT ShelleyTxCmdWriteFileError
     . newExceptT
     $ Api.writeFileTextEnvelope oFile Nothing witness
 
 runTxSignWitness :: TxBodyFile -> [WitnessFile] -> OutputFile -> ExceptT ShelleyTxCmdError IO ()
 runTxSignWitness (TxBodyFile txBodyFile) witnessFiles (OutputFile oFp) = do
-    txBody <- firstExceptT ShelleyTxReadFileError
+    txBody <- firstExceptT ShelleyTxCmdReadTextViewFileError
       . newExceptT
       $ Api.readFileTextEnvelope Api.AsShelleyTxBody txBodyFile
-    witnesses <- firstExceptT ShelleyTxReadFileError
+    witnesses <- firstExceptT ShelleyTxCmdReadTextViewFileError
       $ mapM readWitnessFile witnessFiles
     let tx = Api.makeSignedTransaction witnesses txBody
-    firstExceptT ShelleyTxWriteFileError
+    firstExceptT ShelleyTxCmdWriteFileError
       . newExceptT
       $ Api.writeFileTextEnvelope oFp Nothing tx
   where
@@ -418,17 +397,17 @@ runTxSignWitness (TxBodyFile txBodyFile) witnessFiles (OutputFile oFp) = do
 readFileTxMetaData :: MetaDataFile
                    -> ExceptT ShelleyTxCmdError IO Api.TxMetadata
 readFileTxMetaData (MetaDataFileJSON fp) = do
-    bs <- handleIOExceptT (ShelleyTxMetaDataFileError fp) $
+    bs <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fp) $
           LBS.readFile fp
-    v  <- firstExceptT (ShelleyTxMetaDataConversionError fp . ConversionErrDecodeJSON) $
+    v  <- firstExceptT (ShelleyTxCmdMetaDataConversionError fp . ConversionErrDecodeJSON) $
           hoistEither $
             Aeson.eitherDecode' bs
-    firstExceptT (ShelleyTxMetaDataConversionError fp) $ hoistEither $
+    firstExceptT (ShelleyTxCmdMetaDataConversionError fp) $ hoistEither $
       jsonToMetadata v
 readFileTxMetaData (MetaDataFileCBOR fp) = do
-    bs <- handleIOExceptT (ShelleyTxMetaDataFileError fp) $
+    bs <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fp) $
           BS.readFile fp
-    txMetadata <- firstExceptT (ShelleyTxMetaDecodeError fp) $ hoistEither $
+    txMetadata <- firstExceptT (ShelleyTxCmdMetaDecodeError fp) $ hoistEither $
       Api.deserialiseFromCBOR Api.AsTxMetadata bs
     firstExceptT (ShelleyTxMetaValidationError fp . NE.head) $ hoistEither $
       validateTxMetadata txMetadata


### PR DESCRIPTION
Shelley `cardano-cli` commands now fail in this format: `Shelley command failed: $failedcommand Error: $error`

Example
```
Shelley command failed: node issue-op-cert  Error: node-bft1/kes.vkey: node-bft1/kes.vkey: openBinaryFile: does not exist (No such file or directory)
```