### PR TITLE
CAD-1765 stack on 1.19.1

### DIFF
--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -3,6 +3,6 @@ with import ./. {};
 
 haskell.lib.buildStackProject {
   name = "stack-env";
-  buildInputs = with pkgs; [ zlib openssl gmp libffi git systemd haskellPackages.happy ];
+  buildInputs = with pkgs; [ zlib openssl gmp libffi libsodium pkg-config git systemd haskellPackages.happy ];
   ghc = (import ../shell.nix {inherit pkgs;}).ghc;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/71ea865408f2e03e6d6832359423546699730849/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0c5b0a6619fadf22f4d62a12154e181a6d035c1c/snapshot.yaml
 compiler: ghc-8.6.5
 
 packages:
@@ -12,29 +12,31 @@ ghc-options:
   cardano-config:       -Wall -fwarn-redundant-constraints
   cardano-node:         -Wall -fwarn-redundant-constraints
 
-allow-newer: true
-
 extra-deps:
   - QuickCheck-2.12.6.1
-  - quickcheck-instances-0.3.19
+  - Unique-0.4.7.6
+  - aeson-1.4.7.1
+  - assoc-1.0.1
   - base58-bytestring-0.1.0
   - base64-0.4.2
-  - bech32-1.0.2
-  - brick-0.47
-  - binary-0.8.7.0
+  - bech32-1.1.0
+  - bifunctors-5.5.7
   - bimap-0.4.0
+  - binary-0.8.7.0
+  - brick-0.47
   - canonical-json-0.6.0.0
   - cborg-0.2.4.0
   - clock-0.8
   - config-ini-0.2.4.0
   - containers-0.5.11.0
   - data-clist-0.1.2.2
+  - directory-1.3.6.1
+  - esqueleto-3.2.2
   - generic-monoid-0.1.0.0
+  - generics-sop-0.5.1.0
   - ghc-byteorder-4.11.0.0.10
   - gray-code-0.3.1
   - hedgehog-1.0.2
-  - hedgehog-corpus-0.2.0
-  - hedgehog-quickcheck-0.1.1
   - hspec-2.7.0
   - hspec-core-2.7.0
   - hspec-discover-2.7.0
@@ -43,33 +45,51 @@ extra-deps:
   - micro-recursion-schemes-5.0.2.2
   - moo-1.2
   - network-3.1.1.1
+  - persistent-2.10.5.1
+  - persistent-postgresql-2.10.1.2
+  - persistent-template-2.8.2.3
+  - pipes-safe-2.3.2
+  - primitive-0.7.1.0
+  - process-1.6.8.2
+  - protolude-0.3.0
   - quiet-0.2
+  - quickcheck-instances-0.3.19
+  - serialise-0.2.3.0
   - snap-core-1.0.4.1
   - snap-server-1.1.1.1
+  - sop-core-0.5.0.1
   - statistics-linreg-0.3
   - streaming-binary-0.3.0.1
   - systemd-2.3.0
   - tasty-hedgehog-1.0.0.2
   - text-1.2.4.0
-  - text-ansi-0.1.0
   - text-zipper-0.10.1
+  - th-abstraction-0.3.2.0
+  - th-lift-0.8.1
   - th-lift-instances-0.1.14
+  - these-1.1
+  - time-1.8.0.4
+  - time-compat-1.9.3
   - time-units-1.0.0
   - transformers-except-0.1.1
-  - Unique-0.4.7.6
-  - word-wrap-0.4.1
+  - typerep-map-0.3.3.0
+  - unix-2.7.2.2
+  - webdriver-0.9.0.1
   - websockets-0.12.6.1
+  - Win32-2.8.5.0
+  - word-wrap-0.4.1
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
     commit: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
     subdirs:
       # small-steps
       - semantics/executable-spec
+      - semantics/small-steps-test
       # cs-ledger
       - byron/ledger/executable-spec
       - byron/ledger/impl
-      - byron/crypto
       - byron/ledger/impl/test
+      - byron/crypto
       - byron/crypto/test
       # cs-blockchain
       - byron/chain/executable-spec
@@ -92,8 +112,8 @@ extra-deps:
       - binary
       - binary/test
       - cardano-crypto-class
+      - cardano-crypto-praos
       - slotting
-
 
     # Needed for `cardano-ledger-specs`
   - git: https://github.com/input-output-hk/goblins
@@ -116,8 +136,6 @@ extra-deps:
   - prometheus-2.1.2
   - libsystemd-journal-1.4.4
   - katip-0.8.4.0
-
-    #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
     commit: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac


### PR DESCRIPTION
stack compiles Release 1.19.1 again

```
$ stack exec cardano-node -- --version
cardano-node 1.19.1 - linux-x86_64 - ghc-8.6
git rev 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
```