### PR TITLE
Run chairman in chairman tests

### DIFF
--- a/cardano-node-chairman/app/Cardano/Chairman/Options.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Options.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Chairman.Options
+  ( mkNodeClientProtocol
+  , ChairmanArgs(..)
+  , parseChairmanArgs
+  , opts
+  ) where
+
+import           Cardano.Api.Protocol.Byron
+import           Cardano.Api.Protocol.Cardano
+import           Cardano.Api.Protocol.Shelley
+import           Cardano.Api.Protocol.Types
+import           Cardano.Api.Typed (NetworkMagic (..))
+import           Cardano.Chain.Slotting (EpochSlots (..))
+import           Cardano.Node.Protocol.Types (Protocol (..))
+import           Cardano.Node.Types
+import           Cardano.Prelude hiding (option)
+import           Control.Applicative (some)
+import           Control.Monad.Class.MonadTime (DiffTime)
+import           Options.Applicative
+import           Ouroboros.Consensus.BlockchainTime (SlotLength, slotLengthFromSec)
+import           Ouroboros.Consensus.Cardano (SecurityParam (..))
+import           Ouroboros.Network.Block (BlockNo)
+
+import qualified Options.Applicative as Opt
+
+--TODO: replace this with the new stuff from Cardano.Api.Protocol
+mkNodeClientProtocol :: Protocol -> SomeNodeClientProtocol
+mkNodeClientProtocol protocol =
+  case protocol of
+    ByronProtocol ->
+      mkSomeNodeClientProtocolByron
+        (EpochSlots 21600) (SecurityParam 2160)
+
+    ShelleyProtocol ->
+      mkSomeNodeClientProtocolShelley
+
+    CardanoProtocol ->
+      mkSomeNodeClientProtocolCardano
+        (EpochSlots 21600) (SecurityParam 2160)
+
+data ChairmanArgs = ChairmanArgs
+    -- | Stop the test after given number of seconds. The chairman will
+    -- observe only for the given period of time, and check the consensus
+    -- and progress conditions at the end.
+    --
+  { caRunningTime :: !DiffTime
+    -- | Expect this amount of progress (chain growth) by the end of the test.
+  , caMinProgress :: !(Maybe BlockNo)
+  , caSocketPaths :: ![SocketPath]
+  , caConfigYaml :: !ConfigYamlFilePath
+  , caSlotLength :: !SlotLength
+  , caSecurityParam :: !SecurityParam
+  , caNetworkMagic :: !NetworkMagic
+  }
+
+parseConfigFile :: Parser FilePath
+parseConfigFile =
+  strOption
+    ( long "config"
+    <> metavar "NODE-CONFIGURATION"
+    <> help "Configuration file for the cardano-node"
+    <> completer (bashCompleter "file")
+    )
+
+parseSocketPath :: Text -> Parser SocketPath
+parseSocketPath helpMessage =
+  SocketPath <$> strOption
+    ( long "socket-path"
+    <> help (toS helpMessage)
+    <> completer (bashCompleter "file")
+    <> metavar "FILEPATH"
+    )
+
+parseRunningTime :: Parser DiffTime
+parseRunningTime =
+  option ((fromIntegral :: Int -> DiffTime) <$> auto)
+    (  long "timeout"
+    <> short 't'
+    <> metavar "Time"
+    <> help "Run the chairman for this length of time in seconds."
+    )
+
+parseSlotLength :: Parser SlotLength
+parseSlotLength =
+  option (slotLengthFromSec <$> Opt.auto)
+    ( long "slot-length"
+    <> metavar "INT"
+    <> help "Slot length in seconds."
+    )
+
+parseSecurityParam :: Parser SecurityParam
+parseSecurityParam =
+  option (SecurityParam <$> Opt.auto)
+    ( long "security-parameter"
+    <> metavar "INT"
+    <> help "Security parameter"
+    )
+
+
+parseTestnetMagic :: Parser NetworkMagic
+parseTestnetMagic =
+  NetworkMagic <$>
+    Opt.option Opt.auto
+      (  Opt.long "testnet-magic"
+      <> Opt.metavar "INT"
+      <> Opt.help "The testnet network magic number"
+      )
+
+parseProgress :: Parser BlockNo
+parseProgress =
+  option ((fromIntegral :: Int -> BlockNo) <$> auto)
+    (  long "require-progress"
+    <> short 'p'
+    <> metavar "Blocks"
+    <> help "Require this much chain-growth progress, in blocks."
+  )
+
+parseChairmanArgs :: Parser ChairmanArgs
+parseChairmanArgs =
+  ChairmanArgs
+  <$> parseRunningTime
+  <*> optional parseProgress
+  <*> some (parseSocketPath "Path to a cardano-node socket")
+  <*> fmap ConfigYamlFilePath parseConfigFile
+  <*> parseSlotLength
+  <*> parseSecurityParam
+  <*> parseTestnetMagic
+
+opts :: ParserInfo ChairmanArgs
+opts = info (parseChairmanArgs <**> helper)
+  ( fullDesc
+  <> progDesc "Chairman checks Cardano clusters for progress and consensus."
+  <> header "Chairman sits in a room full of Shelley nodes, and checks \
+            \if they are all behaving ...")

--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -3,26 +3,12 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import           Cardano.Prelude hiding (option)
-
-import           Cardano.Api.Protocol.Byron
-import           Cardano.Api.Protocol.Cardano
-import           Cardano.Api.Protocol.Shelley
-import           Cardano.Api.Protocol.Types
-import           Cardano.Api.Typed (NetworkMagic (..))
-import           Cardano.Chain.Slotting (EpochSlots (..))
 import           Cardano.Chairman (chairmanTest)
-import           Cardano.Node.Protocol.Types (Protocol (..))
+import           Cardano.Chairman.Options
 import           Cardano.Node.Types
-import           Control.Applicative (some)
-import           Control.Monad.Class.MonadTime (DiffTime)
+import           Cardano.Prelude hiding (option)
 import           Control.Tracer (stdoutTracer)
 import           Options.Applicative
-import           Ouroboros.Consensus.BlockchainTime (SlotLength, slotLengthFromSec)
-import           Ouroboros.Consensus.Cardano (SecurityParam (..))
-import           Ouroboros.Network.Block (BlockNo)
-
-import qualified Options.Applicative as Opt
 
 main :: IO ()
 main = do
@@ -49,113 +35,3 @@ main = do
     caSocketPaths
     someNodeClientProtocol
     caNetworkMagic
-
---TODO: replace this with the new stuff from Cardano.Api.Protocol
-mkNodeClientProtocol :: Protocol -> SomeNodeClientProtocol
-mkNodeClientProtocol protocol =
-    case protocol of
-      ByronProtocol ->
-        mkSomeNodeClientProtocolByron
-          (EpochSlots 21600) (SecurityParam 2160)
-
-      ShelleyProtocol ->
-        mkSomeNodeClientProtocolShelley
-
-      CardanoProtocol ->
-        mkSomeNodeClientProtocolCardano
-          (EpochSlots 21600) (SecurityParam 2160)
-
-data ChairmanArgs = ChairmanArgs {
-      -- | Stop the test after given number of seconds. The chairman will
-      -- observe only for the given period of time, and check the consensus
-      -- and progress conditions at the end.
-      --
-      caRunningTime :: !DiffTime
-      -- | Expect this amount of progress (chain growth) by the end of the test.
-    , caMinProgress :: !(Maybe BlockNo)
-    , caSocketPaths :: ![SocketPath]
-    , caConfigYaml :: !ConfigYamlFilePath
-    , caSlotLength :: !SlotLength
-    , caSecurityParam :: !SecurityParam
-    , caNetworkMagic :: !NetworkMagic
-    }
-
-parseConfigFile :: Parser FilePath
-parseConfigFile =
-  strOption
-    ( long "config"
-    <> metavar "NODE-CONFIGURATION"
-    <> help "Configuration file for the cardano-node"
-    <> completer (bashCompleter "file")
-    )
-
-parseSocketPath :: Text -> Parser SocketPath
-parseSocketPath helpMessage =
-  SocketPath <$> strOption
-    ( long "socket-path"
-    <> help (toS helpMessage)
-    <> completer (bashCompleter "file")
-    <> metavar "FILEPATH"
-    )
-
-parseRunningTime :: Parser DiffTime
-parseRunningTime =
-      option ((fromIntegral :: Int -> DiffTime) <$> auto)
-        (  long "timeout"
-        <> short 't'
-        <> metavar "Time"
-        <> help "Run the chairman for this length of time in seconds."
-      )
-
-parseSlotLength :: Parser SlotLength
-parseSlotLength =
-  option (slotLengthFromSec <$> Opt.auto)
-    ( long "slot-length"
-    <> metavar "INT"
-    <> help "Slot length in seconds."
-    )
-
-parseSecurityParam :: Parser SecurityParam
-parseSecurityParam =
-  option (SecurityParam <$> Opt.auto)
-    ( long "security-parameter"
-    <> metavar "INT"
-    <> help "Security parameter"
-    )
-
-
-parseTestnetMagic :: Parser NetworkMagic
-parseTestnetMagic =
-  NetworkMagic <$>
-    Opt.option Opt.auto
-      (  Opt.long "testnet-magic"
-      <> Opt.metavar "INT"
-      <> Opt.help "The testnet network magic number"
-      )
-
-parseProgress :: Parser BlockNo
-parseProgress =
-  option ((fromIntegral :: Int -> BlockNo) <$> auto)
-    (  long "require-progress"
-    <> short 'p'
-    <> metavar "Blocks"
-    <> help "Require this much chain-growth progress, in blocks."
-  )
-
-parseChairmanArgs :: Parser ChairmanArgs
-parseChairmanArgs =
-  ChairmanArgs
-  <$> parseRunningTime
-  <*> optional parseProgress
-  <*> some (parseSocketPath "Path to a cardano-node socket")
-  <*> fmap ConfigYamlFilePath parseConfigFile
-  <*> parseSlotLength
-  <*> parseSecurityParam
-  <*> parseTestnetMagic
-
-opts :: ParserInfo ChairmanArgs
-opts = info (parseChairmanArgs <**> helper)
-  ( fullDesc
-  <> progDesc "Chairman checks Cardano clusters for progress and consensus."
-  <> header "Chairman sits in a room full of Shelley nodes, and checks \
-            \if they are all behaving ...")

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -55,6 +55,7 @@ executable cardano-node-chairman
   hs-source-dirs:      app
   main-is:             cardano-node-chairman.hs
   other-modules:       Cardano.Chairman
+                       Cardano.Chairman.Options
                        Paths_cardano_node_chairman
   default-language:    Haskell2010
   ghc-options:         -threaded

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -36,6 +36,7 @@ library
                         Chairman.IO.Network.NamedPipe
                         Chairman.IO.Network.Socket
                         Chairman.IO.Network.Sprocket
+                        Chairman.IO.Process
                         Chairman.Network
                         Chairman.OS
                         Chairman.Plan

--- a/cardano-node-chairman/src/Chairman/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Base.hs
@@ -24,6 +24,7 @@ module Chairman.Base
   , writeFile
   , lbsReadFile
   , lbsWriteFile
+  , cat
   , rewriteJson
   , assertM
   , assertIO
@@ -61,6 +62,7 @@ import           Text.Show
 import qualified Control.Concurrent as IO
 import qualified Control.Monad.Trans.Resource as IO
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Data.Time.Clock.POSIX as DTC
 import qualified GHC.Stack as GHC
@@ -215,6 +217,15 @@ rewriteJson filePath f = GHC.withFrozenCallStack $ do
   case eitherDecode lbs of
     Right iv -> lbsWriteFile filePath (encode (f iv))
     Left msg -> failWithCustom GHC.callStack Nothing msg
+
+cat :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+cat filePath = GHC.withFrozenCallStack $ do
+  contents <- readFile filePath
+  void . H.annotate $ L.unlines
+    [ "━━━━ File: " <> filePath <> " ━━━━"
+    , contents
+    ]
+  return ()
 
 assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
 assertM = (>>= H.assert)

--- a/cardano-node-chairman/src/Chairman/IO/Process.hs
+++ b/cardano-node-chairman/src/Chairman/IO/Process.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Chairman.IO.Process
+  ( maybeWaitForProcess
+  , waitSecondsForProcess
+  , TimedOut(..)
+  ) where
+
+import           Control.Concurrent.Async
+import           Control.Exception
+import           Control.Monad
+import           Data.Either
+import           Data.Function
+import           Data.Int
+import           Data.Maybe
+import           GHC.Num
+import           System.Exit
+import           System.IO
+import           System.Process
+
+import qualified Control.Concurrent as IO
+import qualified Control.Concurrent.Async as IO
+import qualified System.Process as IO
+
+
+data TimedOut = TimedOut
+
+maybeWaitForProcess
+  :: ProcessHandle
+  -> IO (Maybe ExitCode)
+maybeWaitForProcess hProcess =
+  catch (fmap Just (IO.waitForProcess hProcess)) $ \(_ :: AsyncCancelled) -> return Nothing
+
+waitSecondsForProcess
+  :: Int
+  -> ProcessHandle
+  -> IO (Either TimedOut (Maybe ExitCode))
+waitSecondsForProcess seconds hProcess = IO.race
+  (IO.threadDelay (seconds * 1000000) >> return TimedOut)
+  (maybeWaitForProcess hProcess)

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -55,6 +55,7 @@ import qualified System.FilePath.Posix as FP
 import qualified System.IO as IO
 import qualified System.Process as IO
 
+{- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
 {- HLINT ignore "Redundant flip" -}
 
@@ -411,20 +412,14 @@ prop_spawnShelleyCluster = H.propertyOnce . H.workspace "chairman" $ \tempAbsPat
 
   -- Run chairman
   forM_ (L.take 1 allNodes) $ \node -> do
-    dbDir <- H.noteShow $ tempAbsPath <> "/db/" <> node
     nodeStdoutFile <- H.noteTempFile logDir $ "chairman-" <> node <> ".stdout.log"
     nodeStderrFile <- H.noteTempFile logDir $ "chairman-" <> node <> ".stderr.log"
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir <> "/" <> node)
 
-    H.createDirectoryIfMissing dbDir
     H.createDirectoryIfMissing $ tempBaseAbsPath <> "/" <> socketDir
 
     hNodeStdout <- H.evalM . liftIO $ IO.openFile nodeStdoutFile IO.WriteMode
     hNodeStderr <- H.evalM . liftIO $ IO.openFile nodeStderrFile IO.WriteMode
-
-    H.diff (L.length (IO.sprocketArgumentName sprocket)) (<=) IO.maxSprocketArgumentNameLength
-
-    portString <- H.readFile $ tempAbsPath <> "/" <> node <> "/port"
 
     (_, _, _, hProcess, _) <- H.createProcess =<<
       ( H.procChairman

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -104,6 +104,7 @@ let
         packages.cardano-node-chairman.preCheck = "
           export CARDANO_CLI=${pkgSet.cardano-cli.components.exes.cardano-cli}/bin/cardano-cli
           export CARDANO_NODE=${pkgSet.cardano-node.components.exes.cardano-node}/bin/cardano-node
+          export CARDANO_NODE_CHAIRMAN=${pkgSet.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman
           export CARDANO_NODE_SRC=${ ./.. }
         ";
       }


### PR DESCRIPTION
* Moved option parsing to its own module to keep the main module clean.
* Invoke the chairman executable from the chairman tests.
* New `waitSecondsForProcess` function which waits for a process to exit by a deadline.
* New `cat` function to print contents of a file.
* New `procChairman` for invoking `cardano-node-chairman` process.
* Replace magic constant `42` with `testnetMagic` constant