### PR TITLE
Force evaluation in assertIO

### DIFF
--- a/cardano-node-chairman/src/Chairman/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Base.hs
@@ -231,7 +231,7 @@ assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
 assertM = (>>= H.assert)
 
 assertIO :: (MonadIO m, HasCallStack) => IO Bool -> H.PropertyT m ()
-assertIO f = H.evalIO f >>= H.assert
+assertIO f = H.evalIO (forceM f) >>= H.assert
 
 forceM :: (Monad m, NFData a) => m a -> m a
 forceM = (force <$!>)


### PR DESCRIPTION
Trying to fix this problem:

https://hydra.iohk.io/build/4032130/nixlog/16

My suspicion is `doesSocketExist` throws an exception lazily when the returned `Bool` is evaluated which would allow the exception to evade `hedgehog`.  Forcing the return value to be evaluated should ensure the exception is thrown within `evalIO` which will allow `hedgehog` to catch it and print the error.