### PR TITLE
Update register_stakepool.md

### DIFF
--- a/doc/stake-pool-operations/register_stakepool.md
+++ b/doc/stake-pool-operations/register_stakepool.md
@@ -179,7 +179,7 @@ All amounts in Lovelace
 
 Get Pool ID
 
-    cardano-cli shelley stake-pool id --verification-key-file cold.vkey
+    cardano-cli shelley stake-pool id --verification-key-file cold.vkey --output-format "hex"
 
 Check for the presence of your poolID in the network ledger state, with:
 


### PR DESCRIPTION
Running Cardano 1.19.0 the command instructions "Get Pool ID" was generating output in format bech32 which the succeeding command to verify you PoolID does not use. 

Setting output format to --output-format "hex" resolved this issue.

Available options:
  --verification-key-file FILE
                           Output filepath of the verification key.
  --output-format STRING   Optional output format. Accepted output formats are
                           "hex" and "bech32" (default is "bech32").