### PR TITLE
Tidy up and bug fixes

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -31,17 +31,20 @@ library
                       , unordered-containers
                       , Win32-network
   exposed-modules:      Chairman.Aeson
-                        Chairman.Base
+                        Chairman.Hedgehog.Base
+                        Chairman.Hedgehog.File
+                        Chairman.Hedgehog.Network
+                        Chairman.Hedgehog.Process
                         Chairman.IO.File
                         Chairman.IO.Network.NamedPipe
                         Chairman.IO.Network.Socket
                         Chairman.IO.Network.Sprocket
                         Chairman.IO.Process
-                        Chairman.Network
+                        Chairman.Monad
                         Chairman.OS
                         Chairman.Plan
-                        Chairman.Process
                         Chairman.String
+                        Chairman.Time
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude
   ghc-options:          -Wall

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE TypeApplications #-}
 
-module Chairman.Base
+module Chairman.Hedgehog.Base
   ( propertyOnce
-  , failWithCustom
+
   , threadDelay
+
   , workspace
   , moduleWorkspace
-  , createDirectoryIfMissing
-  , copyFile
-  , createFileLink
+
   , noteShow
   , noteShow_
   , noteShowM
@@ -17,28 +15,23 @@ module Chairman.Base
   , noteShowIO
   , noteShowIO_
   , noteTempFile
+
+  , failWithCustom
+  , failMessage
+
   , assertByDeadlineIO
-  , showUTCTimeSeconds
-  , listDirectory
-  , readFile
-  , writeFile
-  , lbsReadFile
-  , lbsWriteFile
-  , cat
-  , rewriteJson
   , assertM
   , assertIO
+
   , Integration
-  , forceM
   , release
   ) where
 
-import           Control.DeepSeq
+import           Chairman.Monad
 import           Control.Monad
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans.Resource (ReleaseKey, ResourceT, runResourceT)
-import           Data.Aeson
 import           Data.Bool
 import           Data.Either (Either (..))
 import           Data.Eq
@@ -51,26 +44,21 @@ import           Data.Semigroup (Semigroup (..))
 import           Data.String (String)
 import           Data.Time.Clock (UTCTime)
 import           Data.Tuple
-import           GHC.Stack (CallStack, HasCallStack, callStack, getCallStack)
+import           GHC.Stack (CallStack, HasCallStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Internal.Property (Diff, liftTest, mkTest)
 import           Hedgehog.Internal.Source (getCaller)
-import           Prelude (floor)
 import           System.IO (FilePath, IO)
 import           Text.Show
 
 import qualified Control.Concurrent as IO
 import qualified Control.Monad.Trans.Resource as IO
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
-import qualified Data.Time.Clock.POSIX as DTC
 import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
 import qualified System.Directory as IO
 import qualified System.Info as IO
-import qualified System.IO as IO
 import qualified System.IO.Temp as IO
 
 type Integration a = H.PropertyT (ResourceT IO) a
@@ -85,6 +73,10 @@ threadDelay = H.evalM . liftIO . IO.threadDelay
 failWithCustom :: MonadTest m => CallStack -> Maybe Diff -> String -> m a
 failWithCustom cs mdiff msg = liftTest $ mkTest (Left $ H.Failure (getCaller cs) msg mdiff, mempty)
 
+-- | Takes a 'CallStack' so the error can be rendered at the appropriate call site.
+failMessage :: MonadTest m => CallStack -> String -> m a
+failMessage cs = failWithCustom cs Nothing
+
 -- | Create a workspace directory which will exist for at least the duration of
 -- the supplied block.
 --
@@ -95,7 +87,7 @@ failWithCustom cs mdiff msg = liftTest $ mkTest (Left $ H.Failure (getCaller cs)
 -- the block fails.
 workspace :: HasCallStack => FilePath -> (FilePath -> Integration ()) -> Integration ()
 workspace prefixPath f = GHC.withFrozenCallStack $ do
-  systemTemp <- H.evalM . liftIO $ IO.getCanonicalTemporaryDirectory
+  systemTemp <- H.evalIO IO.getCanonicalTemporaryDirectory
   let systemPrefixPath = systemTemp <> "/" <> prefixPath
   H.evalM . liftIO $ IO.createDirectoryIfMissing True systemPrefixPath
   ws <- H.evalM . liftIO $ IO.createTempDirectory systemPrefixPath "test"
@@ -113,35 +105,44 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
 -- the block fails.
 moduleWorkspace :: HasCallStack => FilePath -> (FilePath -> Integration ()) -> Integration ()
 moduleWorkspace prefixPath f = GHC.withFrozenCallStack $ do
-  let srcModule = maybe "UnknownModule"  (GHC.srcLocModule . snd) (listToMaybe (getCallStack callStack))
+  let srcModule = maybe "UnknownModule" (GHC.srcLocModule . snd) (listToMaybe (GHC.getCallStack GHC.callStack))
   workspace (prefixPath <> "/" <> srcModule) f
+
+noteWithCallstack :: MonadTest m => CallStack -> String -> m ()
+noteWithCallstack cs a = H.writeLog $ H.Annotation (getCaller cs) a
 
 noteShow :: (HasCallStack, Show a) => a -> Integration a
 noteShow a = GHC.withFrozenCallStack $ do
   !b <- H.eval a
-  H.annotateShow b
+  noteWithCallstack GHC.callStack (show b)
   return b
 
 noteShow_ :: (HasCallStack, Show a) => a -> Integration ()
-noteShow_ = void . noteShow
+noteShow_ a = GHC.withFrozenCallStack $ noteWithCallstack GHC.callStack (show a)
 
 noteShowM :: (HasCallStack, Show a) => Integration a -> Integration a
 noteShowM a = GHC.withFrozenCallStack $ do
   !b <- H.evalM a
-  H.annotateShow b
+  noteWithCallstack GHC.callStack (show b)
   return b
 
 noteShowM_ :: (HasCallStack, Show a) => Integration a -> Integration ()
-noteShowM_ = void . noteShowM
+noteShowM_ a = GHC.withFrozenCallStack $ do
+  !b <- H.evalM a
+  noteWithCallstack GHC.callStack (show b)
+  return ()
 
 noteShowIO :: (HasCallStack, Show a) => IO a -> Integration a
-noteShowIO a = GHC.withFrozenCallStack $ do
-  !b <- H.evalM . liftIO $ a
-  H.annotateShow b
-  return b
+noteShowIO f = GHC.withFrozenCallStack $ do
+  !a <- H.evalM . liftIO $ f
+  noteWithCallstack GHC.callStack (show a)
+  return a
 
 noteShowIO_ :: (HasCallStack, Show a) => IO a -> Integration ()
-noteShowIO_ = void . noteShowIO
+noteShowIO_ f = GHC.withFrozenCallStack $ do
+  !a <- H.evalM . liftIO $ f
+  noteWithCallstack GHC.callStack (show a)
+  return ()
 
 -- | Return the test file path after annotating it relative to the project root directory
 noteTempFile :: (Monad m, HasCallStack) => FilePath -> FilePath -> H.PropertyT m FilePath
@@ -164,77 +165,13 @@ assertByDeadlineIO deadline f = GHC.withFrozenCallStack $ do
         assertByDeadlineIO deadline f
       else do
         H.annotateShow currentTime
-        failWithCustom GHC.callStack Nothing "Condition not met by deadline"
-
--- | Show 'UTCTime' in seconds since epoch
-showUTCTimeSeconds :: UTCTime -> String
-showUTCTimeSeconds time = show @Int64 (floor (DTC.utcTimeToPOSIXSeconds time))
-
-createDirectoryIfMissing :: HasCallStack => FilePath -> Integration ()
-createDirectoryIfMissing filePath = GHC.withFrozenCallStack $ do
-  H.annotate $ "Creating directory if missing: " <> filePath
-  H.evalIO $ IO.createDirectoryIfMissing True filePath
-
-copyFile :: HasCallStack => FilePath -> FilePath -> Integration ()
-copyFile src dst = GHC.withFrozenCallStack $ do
-  H.annotate $ "Copying from " <> show src <> " to " <> show dst
-  H.evalM . liftIO $ IO.copyFile src dst
-
-createFileLink :: HasCallStack => FilePath -> FilePath -> Integration ()
-createFileLink src dst = GHC.withFrozenCallStack $ do
-  H.annotate $ "Creating link from " <> show dst <> " to " <> show src
-  H.evalM . liftIO $ IO.copyFile src dst
-
-listDirectory :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m [FilePath]
-listDirectory p = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Listing directory: " <> p
-  H.evalIO $ IO.listDirectory p
-
-writeFile :: (MonadIO m, HasCallStack) => FilePath -> String -> H.PropertyT m ()
-writeFile filePath contents = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Writing file: " <> filePath
-  H.evalIO $ IO.writeFile filePath contents
-
-readFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m String
-readFile filePath = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Reading file: " <> filePath
-  H.evalIO $ IO.readFile filePath
-
-lbsWriteFile :: (MonadIO m, HasCallStack) => FilePath -> LBS.ByteString -> H.PropertyT m ()
-lbsWriteFile filePath contents = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Writing file: " <> filePath
-  H.evalIO $ LBS.writeFile filePath contents
-
-lbsReadFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m LBS.ByteString
-lbsReadFile filePath = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Reading file: " <> filePath
-  H.evalIO $ LBS.readFile filePath
-
-rewriteJson :: (MonadIO m, HasCallStack) => FilePath -> (Value -> Value) -> H.PropertyT m ()
-rewriteJson filePath f = GHC.withFrozenCallStack $ do
-  void . H.annotate $ "Rewriting JSON file: " <> filePath
-  lbs <- forceM $ lbsReadFile filePath
-  case eitherDecode lbs of
-    Right iv -> lbsWriteFile filePath (encode (f iv))
-    Left msg -> failWithCustom GHC.callStack Nothing msg
-
-cat :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
-cat filePath = GHC.withFrozenCallStack $ do
-  contents <- readFile filePath
-  void . H.annotate $ L.unlines
-    [ "━━━━ File: " <> filePath <> " ━━━━"
-    , contents
-    ]
-  return ()
+        failMessage GHC.callStack "Condition not met by deadline"
 
 assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
 assertM = (>>= H.assert)
 
 assertIO :: (MonadIO m, HasCallStack) => IO Bool -> H.PropertyT m ()
 assertIO f = H.evalIO (forceM f) >>= H.assert
-
-forceM :: (Monad m, NFData a) => m a -> m a
-forceM = (force <$!>)
 
 release :: MonadIO m => ReleaseKey -> H.PropertyT m ()
 release = H.evalIO . IO.release

--- a/cardano-node-chairman/src/Chairman/Hedgehog/File.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/File.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Chairman.Hedgehog.File
+  ( createDirectoryIfMissing
+  , copyFile
+  , createFileLink
+  , listDirectory
+
+  , writeFile
+  , openFile
+  , readFile
+  , lbsWriteFile
+  , lbsReadFile
+
+  , readJsonFile
+  , rewriteJson
+
+  , cat
+
+  , assertIsJsonFile
+  ) where
+
+import           Chairman.Hedgehog.Base (Integration)
+import           Chairman.Monad
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import           Data.Bool
+import           Data.Either
+import           Data.Function
+import           Data.Functor
+import           Data.Semigroup
+import           Data.String
+import           GHC.Stack (HasCallStack)
+import           System.IO (FilePath, Handle, IOMode)
+import           Text.Show
+
+import qualified Chairman.Hedgehog.Base as H
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List as L
+import qualified GHC.Stack as GHC
+import qualified Hedgehog as H
+import qualified System.Directory as IO
+import qualified System.IO as IO
+
+
+createDirectoryIfMissing :: HasCallStack => FilePath -> Integration ()
+createDirectoryIfMissing filePath = GHC.withFrozenCallStack $ do
+  H.annotate $ "Creating directory if missing: " <> filePath
+  H.evalIO $ IO.createDirectoryIfMissing True filePath
+
+copyFile :: HasCallStack => FilePath -> FilePath -> Integration ()
+copyFile src dst = GHC.withFrozenCallStack $ do
+  H.annotate $ "Copying from " <> show src <> " to " <> show dst
+  H.evalM . liftIO $ IO.copyFile src dst
+
+createFileLink :: HasCallStack => FilePath -> FilePath -> Integration ()
+createFileLink src dst = GHC.withFrozenCallStack $ do
+  H.annotate $ "Creating link from " <> show dst <> " to " <> show src
+  H.evalM . liftIO $ IO.copyFile src dst
+
+listDirectory :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m [FilePath]
+listDirectory p = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Listing directory: " <> p
+  H.evalIO $ IO.listDirectory p
+
+writeFile :: (MonadIO m, HasCallStack) => FilePath -> String -> H.PropertyT m ()
+writeFile filePath contents = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Writing file: " <> filePath
+  H.evalIO $ IO.writeFile filePath contents
+
+openFile :: (MonadIO m, HasCallStack) => FilePath -> IOMode -> H.PropertyT m Handle
+openFile filePath mode = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Opening file: " <> filePath
+  H.evalIO $ IO.openFile filePath mode
+
+readFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m String
+readFile filePath = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Reading file: " <> filePath
+  H.evalIO $ IO.readFile filePath
+
+lbsWriteFile :: (MonadIO m, HasCallStack) => FilePath -> LBS.ByteString -> H.PropertyT m ()
+lbsWriteFile filePath contents = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Writing file: " <> filePath
+  H.evalIO $ LBS.writeFile filePath contents
+
+lbsReadFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m LBS.ByteString
+lbsReadFile filePath = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Reading file: " <> filePath
+  H.evalIO $ LBS.readFile filePath
+
+readJsonFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m (Either String Value)
+readJsonFile filePath = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Reading JSON file: " <> filePath
+  H.evalIO $ eitherDecode @Value <$> LBS.readFile filePath
+
+rewriteJson :: (MonadIO m, HasCallStack) => FilePath -> (Value -> Value) -> H.PropertyT m ()
+rewriteJson filePath f = GHC.withFrozenCallStack $ do
+  void . H.annotate $ "Rewriting JSON file: " <> filePath
+  lbs <- forceM $ lbsReadFile filePath
+  case eitherDecode lbs of
+    Right iv -> lbsWriteFile filePath (encode (f iv))
+    Left msg -> H.failMessage GHC.callStack msg
+
+cat :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+cat filePath = GHC.withFrozenCallStack $ do
+  contents <- readFile filePath
+  void . H.annotate $ L.unlines
+    [ "━━━━ File: " <> filePath <> " ━━━━"
+    , contents
+    ]
+  return ()
+
+assertIsJsonFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+assertIsJsonFile fp = GHC.withFrozenCallStack $ do
+  jsonResult <- readJsonFile fp
+  case jsonResult of
+    Right _ -> return ()
+    Left msg -> H.failMessage GHC.callStack msg

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Network.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Network.hs
@@ -1,4 +1,4 @@
-module Chairman.Network
+module Chairman.Hedgehog.Network
   ( doesFileExists
   , isPortOpen
   , doesSocketExist
@@ -14,7 +14,7 @@ import           Data.Int
 import           GHC.Stack (HasCallStack)
 import           System.IO (FilePath)
 
-import qualified Chairman.Base as H
+import qualified Chairman.Hedgehog.Base as H
 import qualified Chairman.IO.Network.Socket as IO
 import qualified GHC.Stack as GHC
 import qualified Hedgehog as H

--- a/cardano-node-chairman/src/Chairman/Monad.hs
+++ b/cardano-node-chairman/src/Chairman/Monad.hs
@@ -1,0 +1,9 @@
+module Chairman.Monad
+  ( forceM
+  ) where
+
+import           Control.DeepSeq (NFData, force)
+import           Control.Monad
+
+forceM :: (Monad m, NFData a) => m a -> m a
+forceM = (force <$!>)

--- a/cardano-node-chairman/src/Chairman/String.hs
+++ b/cardano-node-chairman/src/Chairman/String.hs
@@ -1,11 +1,17 @@
 module Chairman.String
   ( strip
+  , lastLine
   ) where
 
 import           Data.Function
 import           Data.String
 
+import qualified Data.List as L
 import qualified Data.Text as T
 
 strip :: String -> String
 strip = T.unpack . T.strip . T.pack
+
+-- | Get the last line in the string
+lastLine :: String -> String
+lastLine =  L.unlines . L.reverse . L.take 1 . L.reverse . L.lines

--- a/cardano-node-chairman/src/Chairman/Time.hs
+++ b/cardano-node-chairman/src/Chairman/Time.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Chairman.Time
+  ( showUTCTimeSeconds
+  ) where
+
+import           Data.Int
+import           Data.String
+import           Data.Time.Clock (UTCTime)
+import           Prelude (floor)
+import           Text.Show
+
+import qualified Data.Time.Clock.POSIX as DTC
+
+-- | Show 'UTCTime' in seconds since epoch
+showUTCTimeSeconds :: UTCTime -> String
+showUTCTimeSeconds time = show @Int64 (floor (DTC.utcTimeToPOSIXSeconds time))

--- a/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
+++ b/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
@@ -19,9 +19,9 @@ import           Network.Socket (Socket)
 import           Prelude (error)
 import           System.IO (IO)
 
-import qualified Chairman.Base as H
+import qualified Chairman.Hedgehog.Base as H
+import qualified Chairman.Hedgehog.Network as H
 import qualified Chairman.IO.Network.Socket as IO
-import qualified Chairman.Network as H
 import qualified Control.Monad.Trans.Resource as IO
 import qualified Data.List as L
 import qualified Hedgehog as H


### PR DESCRIPTION
* Reorganise modules with more structure.
  * Replace:
    * Chairman.Base
    * Chairman.Network
    * Chairman.Process
  * With:
    * Chairman.Hedgehog.Base
    * Chairman.Hedgehog.File
    * Chairman.Hedgehog.Network
    * Chairman.Hedgehog.Process
    * Chairman.Monad
    * Chairman.String
    * Chairman.Time
* Refactor `H.evalM . liftIO` to `H.evalIO`
* Ensure that all the `note` functions annotate in the caller's context.  This ensures the annotations appear in the body of the tests and not in the annotation functions.
* New `assertIsJsonFile`, replacing exist assertion that didn't really work.
* New `lastLine` function for extracting the last line in a `String`
* Remove `-Wno-unused-imports` `-Wno-unused-local-binds` `-Wno-unused-matches`