### PR TITLE
More reliable random port allocation in Shelly-only chairman tests

### DIFF
--- a/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
@@ -67,7 +67,7 @@ propertyOnce :: HasCallStack => Integration () -> H.Property
 propertyOnce = H.withTests 1 . H.property . hoist runResourceT
 
 threadDelay :: Int -> Integration ()
-threadDelay = H.evalM . liftIO . IO.threadDelay
+threadDelay n = GHC.withFrozenCallStack . H.evalM . liftIO $ IO.threadDelay n
 
 -- | Takes a 'CallStack' so the error can be rendered at the appropriate call site.
 failWithCustom :: MonadTest m => CallStack -> Maybe Diff -> String -> m a
@@ -168,10 +168,10 @@ assertByDeadlineIO deadline f = GHC.withFrozenCallStack $ do
         failMessage GHC.callStack "Condition not met by deadline"
 
 assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
-assertM = (>>= H.assert)
+assertM f = GHC.withFrozenCallStack $ f >>= H.assert
 
 assertIO :: (MonadIO m, HasCallStack) => IO Bool -> H.PropertyT m ()
-assertIO f = H.evalIO (forceM f) >>= H.assert
+assertIO f = GHC.withFrozenCallStack $ H.evalIO (forceM f) >>= H.assert
 
 release :: MonadIO m => ReleaseKey -> H.PropertyT m ()
-release = H.evalIO . IO.release
+release k = GHC.withFrozenCallStack . H.evalIO $ IO.release k

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -21,7 +21,6 @@ import           Data.Ord
 import           Data.Semigroup
 import           Data.String (String)
 import           GHC.Float
-import           GHC.Num
 import           Hedgehog (Property, discover)
 import           System.IO (IO)
 import           Text.Read
@@ -44,7 +43,6 @@ import qualified System.Directory as IO
 import qualified System.FilePath.Posix as FP
 import qualified System.IO as IO
 import qualified System.Process as IO
-import qualified System.Random as IO
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
@@ -74,8 +72,7 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
   let allNodes = praosNodes <> poolNodes :: [String]
   let numPraosNodes = L.length allNodes :: Int
 
-  portBase <- H.noteShowIO $ IO.randomRIO (3000, 50000)
-  allPorts <- H.noteShow ((+ portBase) <$> [1..numPraosNodes])
+  allPorts <- H.noteShowIO $ IO.allocateRandomPorts numPraosNodes
   nodeToPort <- H.noteShow (M.fromList (L.zip allNodes allPorts))
 
   let userAddrs = ["user1"]


### PR DESCRIPTION
Getting the system to allocate the ports to reduce the chance that already bound ports get allocated.

Also fixed the annotations on some functions.