### PR TITLE
Report module name in temporary test directory

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -31,6 +31,7 @@ library
                       , unordered-containers
                       , Win32-network
   exposed-modules:      Chairman.Aeson
+                        Chairman.CallStack
                         Chairman.Hedgehog.Base
                         Chairman.Hedgehog.File
                         Chairman.Hedgehog.Network

--- a/cardano-node-chairman/src/Chairman/CallStack.hs
+++ b/cardano-node-chairman/src/Chairman/CallStack.hs
@@ -1,0 +1,12 @@
+module Chairman.CallStack
+  ( callerModuleName
+  ) where
+
+import           Data.Function
+import           Data.Maybe
+import           Data.String
+import           Data.Tuple
+import           GHC.Stack (HasCallStack, callStack, getCallStack, srcLocModule)
+
+callerModuleName :: HasCallStack => String
+callerModuleName = maybe "<no-module>" (srcLocModule . snd) (listToMaybe (getCallStack callStack))

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
@@ -27,6 +27,7 @@ module Chairman.Hedgehog.Base
   , release
   ) where
 
+import           Chairman.CallStack
 import           Chairman.Monad
 import           Control.Monad
 import           Control.Monad.IO.Class (MonadIO, liftIO)
@@ -59,6 +60,7 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
 import qualified System.Directory as IO
 import qualified System.Info as IO
+import qualified System.IO as IO
 import qualified System.IO.Temp as IO
 
 type Integration a = H.PropertyT (ResourceT IO) a
@@ -92,6 +94,7 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
   H.evalM . liftIO $ IO.createDirectoryIfMissing True systemPrefixPath
   ws <- H.evalM . liftIO $ IO.createTempDirectory systemPrefixPath "test"
   H.annotate $ "Workspace: " <> ws
+  liftIO $ IO.writeFile (ws <> "/module") callerModuleName
   f ws
   when (IO.os /= "mingw32") . H.evalM . liftIO $ IO.removeDirectoryRecursive ws
 


### PR DESCRIPTION
This will make it easier to match temporary test directories to tests, which is important because we now have multiple tests.

```
$ find /private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman -name module
/private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman/test-f9937747964f8055/module
/private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman/test-df9c801866990e43/module
/private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman/test-16030a33a4e54a05/module
$ cat /private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman/test-16030a33a4e54a05/module
Test.Cardano.Node.Chairman.Shelley
```