### PR TITLE
Update dependency on ouroboros-network

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -122,78 +122,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package
@@ -274,85 +274,85 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: a61301de950b4f587431a42d9c6511ef8a4a6a27
-  --sha256: 0anncgsbaqmnbcj1l8vvnsckrsn1jbqcgayz7yq9xj8yvvfcv190
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: Win32-network
 
 constraints:

--- a/cardano-api/src/Cardano/Api/Protocol.hs
+++ b/cardano-api/src/Cardano/Api/Protocol.hs
@@ -24,13 +24,12 @@ import           Cardano.Chain.Slotting (EpochSlots (..))
 
 import           Cardano.Api.Typed
 
-import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 
-data Protocol = ByronProtocol !EpochSlots !Consensus.SecurityParam
+data Protocol = ByronProtocol !EpochSlots
               | ShelleyProtocol
-              | CardanoProtocol !EpochSlots !Consensus.SecurityParam
+              | CardanoProtocol !EpochSlots
   deriving (Eq, Show)
 
 data LocalNodeConnectInfoForSomeMode where
@@ -59,11 +58,11 @@ localNodeConnectInfo :: Protocol
 localNodeConnectInfo protocol network socketPath =
     case protocol of
 
-      ByronProtocol epSlots secParam ->
+      ByronProtocol epSlots ->
         LocalNodeConnectInfoForSomeMode $
           LocalNodeConnectInfo
             socketPath network
-            (ByronMode epSlots secParam)
+            (ByronMode epSlots)
 
       ShelleyProtocol ->
         LocalNodeConnectInfoForSomeMode $
@@ -71,9 +70,8 @@ localNodeConnectInfo protocol network socketPath =
             socketPath network
             ShelleyMode
 
-      CardanoProtocol epSlots secParam ->
+      CardanoProtocol epSlots ->
         LocalNodeConnectInfoForSomeMode $
           LocalNodeConnectInfo
             socketPath network
-            (CardanoMode epSlots secParam)
-
+            (CardanoMode epSlots)

--- a/cardano-api/src/Cardano/Api/Protocol/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Byron.hs
@@ -8,18 +8,15 @@ module Cardano.Api.Protocol.Byron
 
 import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
 import           Cardano.Chain.Slotting (EpochSlots)
-import           Ouroboros.Consensus.Cardano (ProtocolByron, ProtocolClient (ProtocolClientByron),
-                     SecurityParam)
+import           Ouroboros.Consensus.Cardano (ProtocolByron, ProtocolClient (ProtocolClientByron))
 import           Ouroboros.Consensus.Cardano.ByronHFC
 
 mkNodeClientProtocolByron :: EpochSlots
-                          -> SecurityParam
                           -> ProtocolClient ByronBlockHFC ProtocolByron
 mkNodeClientProtocolByron = ProtocolClientByron
 
 mkSomeNodeClientProtocolByron :: EpochSlots
-                              -> SecurityParam
                               -> SomeNodeClientProtocol
-mkSomeNodeClientProtocolByron epochSlots securityParam =
+mkSomeNodeClientProtocolByron epochSlots =
     SomeNodeClientProtocol
-      (mkNodeClientProtocolByron epochSlots securityParam)
+      (mkNodeClientProtocolByron epochSlots)

--- a/cardano-api/src/Cardano/Api/Protocol/Cardano.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Cardano.hs
@@ -9,19 +9,17 @@ module Cardano.Api.Protocol.Cardano
 import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
 import           Cardano.Chain.Slotting (EpochSlots)
 import           Ouroboros.Consensus.Cardano (ProtocolCardano,
-                     ProtocolClient (ProtocolClientCardano), SecurityParam)
+                     ProtocolClient (ProtocolClientCardano))
 import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
 
 mkNodeClientProtocolCardano :: EpochSlots
-                            -> SecurityParam
                             -> ProtocolClient (CardanoBlock StandardCrypto)
                                               ProtocolCardano
 mkNodeClientProtocolCardano = ProtocolClientCardano
 
 mkSomeNodeClientProtocolCardano :: EpochSlots
-                                -> SecurityParam
                                 -> SomeNodeClientProtocol
-mkSomeNodeClientProtocolCardano epochSlots securityParam =
+mkSomeNodeClientProtocolCardano epochSlots =
     SomeNodeClientProtocol
-      (mkNodeClientProtocolCardano epochSlots securityParam)
+      (mkNodeClientProtocolCardano epochSlots)

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -385,7 +385,7 @@ import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
 
 -- TODO: it'd be nice if the consensus imports needed were a bit more coherent
 import           Ouroboros.Consensus.Block (BlockProtocol)
-import           Ouroboros.Consensus.Cardano (ProtocolClient, SecurityParam, protocolClientInfo)
+import           Ouroboros.Consensus.Cardano (ProtocolClient, protocolClientInfo)
 import           Ouroboros.Consensus.Ledger.Abstract (Query)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
 import           Ouroboros.Consensus.Network.NodeToClient (Codecs' (..), clientCodecs)
@@ -2514,7 +2514,6 @@ data NodeConsensusMode mode block where
 
      ByronMode
        :: Byron.EpochSlots
-       -> SecurityParam
        -> NodeConsensusMode ByronMode ByronBlockHFC
 
      ShelleyMode
@@ -2522,7 +2521,6 @@ data NodeConsensusMode mode block where
 
      CardanoMode
        :: Byron.EpochSlots
-       -> SecurityParam
        -> NodeConsensusMode CardanoMode (CardanoBlock StandardCrypto)
 
 
@@ -2532,13 +2530,13 @@ withNodeProtocolClient
           SupportedNetworkProtocolVersion block)
       => ProtocolClient block (BlockProtocol block) -> a)
   -> a
-withNodeProtocolClient (ByronMode epochSlots securityParam) f =
-    f (mkNodeClientProtocolByron epochSlots securityParam)
+withNodeProtocolClient (ByronMode epochSlots) f =
+    f (mkNodeClientProtocolByron epochSlots)
 
 withNodeProtocolClient ShelleyMode f = f mkNodeClientProtocolShelley
 
-withNodeProtocolClient (CardanoMode epochSlots securityParam) f =
-    f (mkNodeClientProtocolCardano epochSlots securityParam)
+withNodeProtocolClient (CardanoMode epochSlots) f =
+    f (mkNodeClientProtocolCardano epochSlots)
 
 data LocalNodeClientProtocols block =
      LocalNodeClientProtocols {

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -18,7 +18,6 @@ import qualified Data.Text as Text
 import           Cardano.Api.Typed
 import           Cardano.Chain.Slotting (EpochSlots (..))
 import           Ouroboros.Consensus.Block (ConvertRawHash (..))
-import           Ouroboros.Consensus.Cardano (SecurityParam (..))
 import           Ouroboros.Network.Block
 
 import           Cardano.Api.LocalChainSync (getLocalTip)
@@ -48,9 +47,7 @@ runGetLocalNodeTip networkId = do
           LocalNodeConnectInfo {
             localNodeSocketPath    = sockPath,
             localNodeNetworkId     = networkId,
-            localNodeConsensusMode = ByronMode
-                                       (EpochSlots 21600)
-                                       (SecurityParam 2160)
+            localNodeConsensusMode = ByronMode (EpochSlots 21600)
           }
     liftIO $ do
       tip <- getLocalTip connctInfo

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -46,7 +46,6 @@ import qualified Cardano.Crypto.Signing as Crypto
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
-import           Ouroboros.Consensus.Cardano (SecurityParam (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (GenTx (DegenGenTx))
 
 import           Cardano.Api.Typed (LocalNodeConnectInfo (..), NetworkId, NodeConsensusMode (..),
@@ -197,9 +196,7 @@ nodeSubmitTx network gentx = do
           LocalNodeConnectInfo {
             localNodeSocketPath    = socketPath,
             localNodeNetworkId     = network,
-            localNodeConsensusMode = ByronMode
-                                       (EpochSlots 21600)
-                                       (SecurityParam 2160)
+            localNodeConsensusMode = ByronMode (EpochSlots 21600)
           }
     _res <- liftIO $ submitTxToNodeLocal connctInfo (DegenGenTx gentx)
     --TODO: print failures

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -35,7 +35,6 @@ import           Cardano.Chain.Slotting (EpochSlots (..))
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
-import           Ouroboros.Consensus.Cardano (SecurityParam (..))
 
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.TxData as Shelley
@@ -1928,17 +1927,16 @@ pProtocol =
     -- Default to the Cardano protocol.
     pure
       (CardanoProtocol
-        (EpochSlots defaultByronEpochSlots)
-        (SecurityParam defaultSecurityParam))
+        (EpochSlots defaultByronEpochSlots))
   where
     pByron :: Parser Protocol
-    pByron = ByronProtocol <$> pEpochSlots <*> pSecurityParam
+    pByron = ByronProtocol <$> pEpochSlots
 
     pShelley :: Parser Protocol
     pShelley = pure ShelleyProtocol
 
     pCardano :: Parser Protocol
-    pCardano = CardanoProtocol <$> pEpochSlots <*> pSecurityParam
+    pCardano = CardanoProtocol <$> pEpochSlots
 
     pEpochSlots :: Parser EpochSlots
     pEpochSlots =
@@ -1951,22 +1949,8 @@ pProtocol =
           <> Opt.showDefault
           )
 
-    pSecurityParam :: Parser SecurityParam
-    pSecurityParam =
-      SecurityParam <$>
-        Opt.option Opt.auto
-          (  Opt.long "security-param"
-          <> Opt.metavar "NATURAL"
-          <> Opt.help "The security parameter."
-          <> Opt.value defaultSecurityParam -- Default to the mainnet value.
-          <> Opt.showDefault
-          )
-
     defaultByronEpochSlots :: Word64
     defaultByronEpochSlots = 21600
-
-    defaultSecurityParam :: Word64
-    defaultSecurityParam = 2160
 
 pProtocolVersion :: Parser (Natural, Natural)
 pProtocolVersion =

--- a/cardano-node-chairman/app/Cardano/Chairman/Options.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Options.hs
@@ -33,14 +33,14 @@ mkNodeClientProtocol protocol =
   case protocol of
     ByronProtocol ->
       mkSomeNodeClientProtocolByron
-        (EpochSlots 21600) (SecurityParam 2160)
+        (EpochSlots 21600)
 
     ShelleyProtocol ->
       mkSomeNodeClientProtocolShelley
 
     CardanoProtocol ->
       mkSomeNodeClientProtocolCardano
-        (EpochSlots 21600) (SecurityParam 2160)
+        (EpochSlots 21600)
 
 data ChairmanArgs = ChairmanArgs
     -- | Stop the test after given number of seconds. The chairman will

--- a/cardano-node/chairman/chairman.hs
+++ b/cardano-node/chairman/chairman.hs
@@ -57,14 +57,14 @@ mkNodeClientProtocol protocol =
     case protocol of
       ByronProtocol ->
         mkSomeNodeClientProtocolByron
-          (EpochSlots 21600) (SecurityParam 2160)
+          (EpochSlots 21600)
 
       ShelleyProtocol ->
         mkSomeNodeClientProtocolShelley
 
       CardanoProtocol ->
         mkSomeNodeClientProtocolCardano
-          (EpochSlots 21600) (SecurityParam 2160)
+          (EpochSlots 21600)
 
 data ChairmanArgs = ChairmanArgs {
       -- | Stop the test after given number of seconds. The chairman will

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -151,7 +151,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         (Shelley.genesisHashToPraosNonce shelleyGenesisHash)
         (Shelley.ProtVer npcShelleySupportedProtocolVersionMajor
                          npcShelleySupportedProtocolVersionMinor)
-        npcShelleyMaxSupportedProtocolVersion
+        (MaxMajorProtVer npcShelleyMaxSupportedProtocolVersion)
         shelleyLeaderCredentials
 
         -- Hard fork parameters

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -37,8 +37,8 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Cardano.ShelleyHFC
 
-import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ShelleyGenesis,
-                     TPraosLeaderCredentials (..))
+import           Ouroboros.Consensus.Shelley.Node (MaxMajorProtVer (..), Nonce (..),
+                     ShelleyGenesis, TPraosLeaderCredentials (..))
 import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley, TPraosCanBeLeader (..))
 
 import           Shelley.Spec.Ledger.Genesis (ValidationErr (..), describeValidationErr,
@@ -109,7 +109,7 @@ mkConsensusProtocolShelley NodeShelleyProtocolConfiguration {
         (genesisHashToPraosNonce genesisHash)
         (ProtVer npcShelleySupportedProtocolVersionMajor
                  npcShelleySupportedProtocolVersionMinor)
-        npcShelleyMaxSupportedProtocolVersion
+        (MaxMajorProtVer npcShelleyMaxSupportedProtocolVersion)
         optionalLeaderCredentials
 
 genesisHashToPraosNonce :: GenesisHash -> Nonce

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ extra-deps:
   - websockets-0.12.6.1
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 2b5f688fb1823f8280ed12df110c7aa68f59363b
+    commit: 2ae53965017e18b6a02988762e5e80f07e7709ed
     subdirs:
       # small-steps
       - semantics/executable-spec
@@ -120,7 +120,7 @@ extra-deps:
     #Ouroboros-network dependencies
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: a61301de950b4f587431a42d9c6511ef8a4a6a27
+    commit: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
WARNING: this breaks binary compatibility of Byron and Shelley ledger
snapshots. The ledger will have to be replayed from genesis!

* `Protocol(Client)Info` no longer needs the `SecurityParam`.
* New `TraceForgeEvent` messages were added. The constructors have been sorted
  to match the order in which they're defined in
  `Ouroboros.Consensus.Node.Tracers`.