### PR TITLE
Better error message for --tx-in argument parsing

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1260,7 +1260,7 @@ renderTxIn (TxIn txid (TxIx txix)) =
     ]
 
 parseTxId :: Atto.Parser TxId
-parseTxId = (<?> "Tansaction ID (hexadecimal)") $ do
+parseTxId = (<?> "Transaction ID (hexadecimal)") $ do
   bstr <- Atto.takeWhile1 Char.isHexDigit
   case deserialiseFromRawBytesHex AsTxId bstr of
     Just addr -> return addr


### PR DESCRIPTION
Before:

```
option --tx-in: Failed reading: takeWhile1
```

After:

```
option --tx-in: Tansaction ID (hexadecimal): Failed reading: takeWhile1
```