### PR TITLE
Tidy up chairman tests

### DIFF
--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -194,7 +194,7 @@ formatIso8601 = DT.formatTime DT.defaultTimeLocale (DT.iso8601DateFormat (Just "
 
 -- | Assert the file contains the given number of occurrences of the given string
 readFile :: HasCallStack => FilePath -> H.PropertyT IO String
-readFile filename = withFrozenCallStack $ H.evalM . liftIO $ E.evaluate . CSD.force =<< IO.readFile filename
+readFile filename = withFrozenCallStack $ H.evalIO $ E.evaluate . CSD.force =<< IO.readFile filename
 
 -- | Checks if all files gives exists. If this fails, all files are deleted.
 assertFilesExist :: HasCallStack => [FilePath] -> H.PropertyT IO ()
@@ -208,14 +208,14 @@ assertFilesExist (file:rest) = do
 -- | Assert the file contains the given number of occurrences of the given string
 assertFileOccurences :: HasCallStack => Int -> String -> FilePath -> H.PropertyT IO ()
 assertFileOccurences n s fp = withFrozenCallStack $ do
-  contents <- H.evalM . liftIO $ IO.readFile fp
+  contents <- H.evalIO $ IO.readFile fp
 
   length (filter (s `L.isInfixOf`) (L.lines contents)) H.=== n
 
 -- | Assert the file contains the given number of occurrences of the given string
 assertFileLines :: HasCallStack => (Int -> Bool) -> FilePath -> H.PropertyT IO ()
 assertFileLines p fp = withFrozenCallStack $ do
-  contents <- H.evalM . liftIO $ IO.readFile fp
+  contents <- H.evalIO $ IO.readFile fp
 
   let lines = L.lines contents
 
@@ -229,7 +229,7 @@ assertFileLines p fp = withFrozenCallStack $ do
 -- | Assert the file contains the given number of occurrences of the given string
 assertEndsWithSingleNewline :: HasCallStack => FilePath -> H.PropertyT IO ()
 assertEndsWithSingleNewline fp = withFrozenCallStack $ do
-  contents <- H.evalM . liftIO $ IO.readFile fp
+  contents <- H.evalIO $ IO.readFile fp
 
   case reverse contents of
     '\n':'\n':_ -> failWithCustom callStack Nothing (fp <> " ends with too many newlines.")

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -18,6 +18,7 @@ library
                       , bytestring
                       , deepseq
                       , directory
+                      , exceptions
                       , hedgehog
                       , mmorph
                       , network
@@ -32,7 +33,9 @@ library
                       , Win32-network
   exposed-modules:      Chairman.Aeson
                         Chairman.CallStack
+                        Chairman.Cli
                         Chairman.Hedgehog.Base
+                        Chairman.Hedgehog.Concurrent
                         Chairman.Hedgehog.File
                         Chairman.Hedgehog.Network
                         Chairman.Hedgehog.Process

--- a/cardano-node-chairman/src/Chairman/Aeson.hs
+++ b/cardano-node-chairman/src/Chairman/Aeson.hs
@@ -6,6 +6,9 @@ import           Data.Aeson
 import           Data.HashMap.Lazy
 import           Data.Text
 
+-- | Rewrite a JSON object to another JSON object using the function 'f'.
+--
+-- All other JSON values are preserved.
 rewriteObject :: (HashMap Text Value -> HashMap Text Value) -> Value -> Value
 rewriteObject f (Object hm) = Object (f hm)
 rewriteObject _ v = v

--- a/cardano-node-chairman/src/Chairman/CallStack.hs
+++ b/cardano-node-chairman/src/Chairman/CallStack.hs
@@ -8,5 +8,6 @@ import           Data.String
 import           Data.Tuple
 import           GHC.Stack (HasCallStack, callStack, getCallStack, srcLocModule)
 
+-- | Get the module name of the caller.
 callerModuleName :: HasCallStack => String
 callerModuleName = maybe "<no-module>" (srcLocModule . snd) (listToMaybe (getCallStack callStack))

--- a/cardano-node-chairman/src/Chairman/Cli.hs
+++ b/cardano-node-chairman/src/Chairman/Cli.hs
@@ -1,0 +1,28 @@
+module Chairman.Cli
+  ( argQuote
+  ) where
+
+import           Data.Bool
+import           Data.Semigroup
+import           Data.String
+
+import qualified Data.List as L
+
+-- | Format argument for a shell CLI command.
+--
+-- This includes automatically embedding string in double quotes if necessary, including any necessary escaping.
+--
+-- Note, this function does not cover all the edge cases for shell processing, so avoid use in production code.
+argQuote :: String -> String
+argQuote arg = if ' ' `L.elem` arg || '"' `L.elem` arg || '$' `L.elem` arg
+  then "\"" <> escape arg <> "\""
+  else arg
+  where escape :: String -> String
+        escape ('"':xs) = '\\':'"':escape xs
+        escape ('\\':xs) = '\\':'\\':escape xs
+        escape ('\n':xs) = '\\':'n':escape xs
+        escape ('\r':xs) = '\\':'r':escape xs
+        escape ('\t':xs) = '\\':'t':escape xs
+        escape ('$':xs) = '\\':'$':escape xs
+        escape (x:xs) = x:escape xs
+        escape "" = ""

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Base.hs
@@ -3,8 +3,6 @@
 module Chairman.Hedgehog.Base
   ( propertyOnce
 
-  , threadDelay
-
   , workspace
   , moduleWorkspace
 
@@ -46,6 +44,7 @@ module Chairman.Hedgehog.Base
 import           Chairman.CallStack
 import           Chairman.Monad
 import           Control.Monad
+import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans.Resource (ReleaseKey, ResourceT, runResourceT)
@@ -54,7 +53,6 @@ import           Data.Either (Either (..))
 import           Data.Eq
 import           Data.Foldable
 import           Data.Function (($), (.))
-import           Data.Int
 import           Data.Maybe (Maybe (..), listToMaybe, maybe)
 import           Data.Monoid (Monoid (..))
 import           Data.Ord
@@ -83,11 +81,10 @@ import qualified System.IO.Temp as IO
 
 type Integration a = H.PropertyT (ResourceT IO) a
 
+-- | Run a property with only one test.  This is intended for allowing hedgehog
+-- to run unit tests.
 propertyOnce :: HasCallStack => Integration () -> H.Property
 propertyOnce = H.withTests 1 . H.property . hoist runResourceT
-
-threadDelay :: Int -> Integration ()
-threadDelay n = GHC.withFrozenCallStack . H.evalIO $ IO.threadDelay n
 
 -- | Takes a 'CallStack' so the error can be rendered at the appropriate call site.
 failWithCustom :: MonadTest m => CallStack -> Maybe Diff -> String -> m a
@@ -105,7 +102,7 @@ failMessage cs = failWithCustom cs Nothing
 --
 -- The directory will be deleted if the block succeeds, but left behind if
 -- the block fails.
-workspace :: HasCallStack => FilePath -> (FilePath -> Integration ()) -> Integration ()
+workspace :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> (FilePath -> m ()) -> m ()
 workspace prefixPath f = GHC.withFrozenCallStack $ do
   systemTemp <- H.evalIO IO.getCanonicalTemporaryDirectory
   let systemPrefixPath = systemTemp <> "/" <> prefixPath
@@ -124,112 +121,131 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
 --
 -- The directory will be deleted if the block succeeds, but left behind if
 -- the block fails.
-moduleWorkspace :: HasCallStack => FilePath -> (FilePath -> Integration ()) -> Integration ()
+moduleWorkspace :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> (FilePath -> m ()) -> m ()
 moduleWorkspace prefixPath f = GHC.withFrozenCallStack $ do
   let srcModule = maybe "UnknownModule" (GHC.srcLocModule . snd) (listToMaybe (GHC.getCallStack GHC.callStack))
   workspace (prefixPath <> "/" <> srcModule) f
 
+-- | Annotate the given string at the context supplied by the callstack.
 noteWithCallstack :: MonadTest m => CallStack -> String -> m ()
 noteWithCallstack cs a = H.writeLog $ H.Annotation (getCaller cs) a
 
-note :: HasCallStack => String -> Integration String
+-- | Annotate with the given string.
+note :: (MonadTest m, HasCallStack) => String -> m String
 note a = GHC.withFrozenCallStack $ do
   !b <- H.eval a
   noteWithCallstack GHC.callStack b
   return b
 
-note_ :: HasCallStack => String -> Integration ()
+-- | Annotate the given string returning unit.
+note_ :: (MonadTest m, HasCallStack) => String -> m ()
 note_ a = GHC.withFrozenCallStack $ noteWithCallstack GHC.callStack a
 
-noteM :: HasCallStack => Integration String -> Integration String
+-- | Annotate the given string in a monadic context.
+noteM :: (MonadTest m, MonadCatch m, HasCallStack) => m String -> m String
 noteM a = GHC.withFrozenCallStack $ do
   !b <- H.evalM a
   noteWithCallstack GHC.callStack b
   return b
 
-noteM_ :: HasCallStack => Integration String -> Integration ()
+-- | Annotate the given string in a monadic context returning unit.
+noteM_ :: (MonadTest m, MonadCatch m, HasCallStack) => m String -> m ()
 noteM_ a = GHC.withFrozenCallStack $ do
   !b <- H.evalM a
   noteWithCallstack GHC.callStack b
   return ()
 
-noteIO :: HasCallStack => IO String -> Integration String
+-- | Annotate the given string in IO.
+noteIO :: (MonadTest m, MonadIO m, HasCallStack) => IO String -> m String
 noteIO f = GHC.withFrozenCallStack $ do
   !a <- H.evalIO f
   noteWithCallstack GHC.callStack a
   return a
 
-noteIO_ :: HasCallStack => IO String -> Integration ()
+-- | Annotate the given string in IO returning unit.
+noteIO_ :: (MonadTest m, MonadIO m, HasCallStack) => IO String -> m ()
 noteIO_ f = GHC.withFrozenCallStack $ do
   !a <- H.evalIO f
   noteWithCallstack GHC.callStack a
   return ()
 
-noteShow :: (HasCallStack, Show a) => a -> Integration a
+-- | Annotate the given value.
+noteShow :: (MonadTest m, HasCallStack, Show a) => a -> m a
 noteShow a = GHC.withFrozenCallStack $ do
   !b <- H.eval a
   noteWithCallstack GHC.callStack (show b)
   return b
 
-noteShow_ :: (HasCallStack, Show a) => a -> Integration ()
+-- | Annotate the given value returning unit.
+noteShow_ :: (MonadTest m, HasCallStack, Show a) => a -> m ()
 noteShow_ a = GHC.withFrozenCallStack $ noteWithCallstack GHC.callStack (show a)
 
-noteShowM :: (HasCallStack, Show a) => Integration a -> Integration a
+-- | Annotate the given value in a monadic context.
+noteShowM :: (MonadTest m, MonadCatch m, HasCallStack, Show a) => m a -> m a
 noteShowM a = GHC.withFrozenCallStack $ do
   !b <- H.evalM a
   noteWithCallstack GHC.callStack (show b)
   return b
 
-noteShowM_ :: (HasCallStack, Show a) => Integration a -> Integration ()
+-- | Annotate the given value in a monadic context returning unit.
+noteShowM_ :: (MonadTest m, MonadCatch m, HasCallStack, Show a) => m a -> m ()
 noteShowM_ a = GHC.withFrozenCallStack $ do
   !b <- H.evalM a
   noteWithCallstack GHC.callStack (show b)
   return ()
 
-noteShowIO :: (HasCallStack, Show a) => IO a -> Integration a
+-- | Annotate the given value in IO.
+noteShowIO :: (MonadTest m, MonadIO m, HasCallStack, Show a) => IO a -> m a
 noteShowIO f = GHC.withFrozenCallStack $ do
   !a <- H.evalIO f
   noteWithCallstack GHC.callStack (show a)
   return a
 
-noteShowIO_ :: (HasCallStack, Show a) => IO a -> Integration ()
+-- | Annotate the given value in IO returning unit.
+noteShowIO_ :: (MonadTest m, MonadIO m, HasCallStack, Show a) => IO a -> m ()
 noteShowIO_ f = GHC.withFrozenCallStack $ do
   !a <- H.evalIO f
   noteWithCallstack GHC.callStack (show a)
   return ()
 
-noteEach :: (HasCallStack, Show a, Traversable f) => f a -> Integration (f a)
+-- | Annotate the each value in the given traversable.
+noteEach :: (MonadTest m, HasCallStack, Show a, Traversable f) => f a -> m (f a)
 noteEach as = GHC.withFrozenCallStack $ do
   for_ as $ noteWithCallstack GHC.callStack . show
   return as
 
-noteEach_ :: (HasCallStack, Show a, Traversable f) => f a -> Integration ()
+-- | Annotate the each value in the given traversable returning unit.
+noteEach_ :: (MonadTest m, HasCallStack, Show a, Traversable f) => f a -> m ()
 noteEach_ as = GHC.withFrozenCallStack $ for_ as $ noteWithCallstack GHC.callStack . show
 
-noteEachM :: (HasCallStack, Show a, Traversable f) => Integration (f a) -> Integration (f a)
+-- | Annotate the each value in the given traversable in a monadic context.
+noteEachM :: (MonadTest m, HasCallStack, Show a, Traversable f) => m (f a) -> m (f a)
 noteEachM f = GHC.withFrozenCallStack $ do
   !as <- f
   for_ as $ noteWithCallstack GHC.callStack . show
   return as
 
-noteEachM_ :: (HasCallStack, Show a, Traversable f) => Integration (f a) -> Integration ()
+-- | Annotate the each value in the given traversable in a monadic context returning unit.
+noteEachM_ :: (MonadTest m, HasCallStack, Show a, Traversable f) => m (f a) -> m ()
 noteEachM_ f = GHC.withFrozenCallStack $ do
   !as <- f
   for_ as $ noteWithCallstack GHC.callStack . show
 
-noteEachIO :: (HasCallStack, Show a, Traversable f) => IO (f a) -> Integration (f a)
+-- | Annotate the each value in the given traversable in IO.
+noteEachIO :: (MonadTest m, MonadIO m, HasCallStack, Show a, Traversable f) => IO (f a) -> m (f a)
 noteEachIO f = GHC.withFrozenCallStack $ do
   !as <- H.evalIO f
   for_ as $ noteWithCallstack GHC.callStack . show
   return as
 
-noteEachIO_ :: (HasCallStack, Show a, Traversable f) => IO (f a) -> Integration ()
+-- | Annotate the each value in the given traversable in IO returning unit.
+noteEachIO_ :: (MonadTest m, MonadIO m, HasCallStack, Show a, Traversable f) => IO (f a) -> m ()
 noteEachIO_ f = GHC.withFrozenCallStack $ do
   !as <- H.evalIO f
   for_ as $ noteWithCallstack GHC.callStack . show
 
 -- | Return the test file path after annotating it relative to the project root directory
-noteTempFile :: (Monad m, HasCallStack) => FilePath -> FilePath -> H.PropertyT m FilePath
+noteTempFile :: (MonadTest m, HasCallStack) => FilePath -> FilePath -> m FilePath
 noteTempFile tempDir filePath = GHC.withFrozenCallStack $ do
   let relPath = tempDir <> "/" <> filePath
   H.annotate relPath
@@ -238,7 +254,7 @@ noteTempFile tempDir filePath = GHC.withFrozenCallStack $ do
 -- | Run the operation 'f' once a second until it returns 'True' or the deadline expires.
 --
 -- Expiration of the deadline results in an assertion failure
-assertByDeadlineIO :: (MonadIO m, HasCallStack) => UTCTime -> IO Bool -> H.PropertyT m ()
+assertByDeadlineIO :: (MonadTest m, MonadIO m, HasCallStack) => UTCTime -> IO Bool -> m ()
 assertByDeadlineIO deadline f = GHC.withFrozenCallStack $ do
   success <- liftIO f
   unless success $ do
@@ -253,8 +269,11 @@ assertByDeadlineIO deadline f = GHC.withFrozenCallStack $ do
 
 -- | Run the operation 'f' once a second until it returns 'True' or the deadline expires.
 --
+-- The action 'g' is run after expiration of the deadline, but before failure allowing for
+-- additional annotations to be presented.
+--
 -- Expiration of the deadline results in an assertion failure
-assertByDeadlineIOFinally :: (MonadIO m, HasCallStack) => UTCTime -> IO Bool -> H.PropertyT m () -> H.PropertyT m ()
+assertByDeadlineIOFinally :: (MonadTest m, MonadIO m, HasCallStack) => UTCTime -> IO Bool -> m () -> m ()
 assertByDeadlineIOFinally deadline f g = GHC.withFrozenCallStack $ do
   success <- liftIO f
   unless success $ do
@@ -268,11 +287,14 @@ assertByDeadlineIOFinally deadline f g = GHC.withFrozenCallStack $ do
         g
         failMessage GHC.callStack "Condition not met by deadline"
 
-assertM :: (MonadIO m, HasCallStack) => H.PropertyT m Bool -> H.PropertyT m ()
+-- | Run the monadic action 'f' and assert the return value is 'True'.
+assertM :: (MonadTest m, HasCallStack) => m Bool -> m ()
 assertM f = GHC.withFrozenCallStack $ f >>= H.assert
 
-assertIO :: (MonadIO m, HasCallStack) => IO Bool -> H.PropertyT m ()
+-- | Run the IO action 'f' and assert the return value is 'True'.
+assertIO :: (MonadTest m, MonadIO m, HasCallStack) => IO Bool -> m ()
 assertIO f = GHC.withFrozenCallStack $ H.evalIO (forceM f) >>= H.assert
 
-release :: MonadIO m => ReleaseKey -> H.PropertyT m ()
+-- | Release the given release key.
+release :: (MonadTest m, MonadIO m) => ReleaseKey -> m ()
 release k = GHC.withFrozenCallStack . H.evalIO $ IO.release k

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Concurrent.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Concurrent.hs
@@ -1,0 +1,16 @@
+module Chairman.Hedgehog.Concurrent
+  ( threadDelay
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO)
+import           Data.Function (($), (.))
+import           Data.Int
+import           Hedgehog (MonadTest)
+
+import qualified Control.Concurrent as IO
+import qualified GHC.Stack as GHC
+import qualified Hedgehog as H
+
+-- Delay the thread by 'n' milliseconds.
+threadDelay :: (MonadTest m, MonadIO m) => Int -> m ()
+threadDelay n = GHC.withFrozenCallStack . H.evalIO $ IO.threadDelay n

--- a/cardano-node-chairman/src/Chairman/Hedgehog/File.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/File.hs
@@ -21,8 +21,8 @@ module Chairman.Hedgehog.File
   , assertIsJsonFile
   ) where
 
-import           Chairman.Hedgehog.Base (Integration)
 import           Chairman.Monad
+import           Chairman.OS
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson
@@ -33,6 +33,7 @@ import           Data.Functor
 import           Data.Semigroup
 import           Data.String
 import           GHC.Stack (HasCallStack)
+import           Hedgehog (MonadTest)
 import           System.IO (FilePath, Handle, IOMode)
 import           Text.Show
 
@@ -44,63 +45,76 @@ import qualified Hedgehog as H
 import qualified System.Directory as IO
 import qualified System.IO as IO
 
-
-createDirectoryIfMissing :: HasCallStack => FilePath -> Integration ()
+-- | Create the 'filePath' directory if it is missing.
+createDirectoryIfMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 createDirectoryIfMissing filePath = GHC.withFrozenCallStack $ do
   H.annotate $ "Creating directory if missing: " <> filePath
   H.evalIO $ IO.createDirectoryIfMissing True filePath
 
-copyFile :: HasCallStack => FilePath -> FilePath -> Integration ()
+-- | Copy the contents of the 'src' file to the 'dst' file.
+copyFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> FilePath -> m ()
 copyFile src dst = GHC.withFrozenCallStack $ do
   H.annotate $ "Copying from " <> show src <> " to " <> show dst
-  H.evalM . liftIO $ IO.copyFile src dst
+  H.evalIO $ IO.copyFile src dst
 
-renameFile :: HasCallStack => FilePath -> FilePath -> Integration ()
+-- | Rename the 'src' file to 'dst'.
+renameFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> FilePath -> m ()
 renameFile src dst = GHC.withFrozenCallStack $ do
   H.annotate $ "Copying from " <> show src <> " to " <> show dst
-  H.evalM . liftIO $ IO.renameFile src dst
+  H.evalIO $ IO.renameFile src dst
 
-createFileLink :: HasCallStack => FilePath -> FilePath -> Integration ()
+-- | Create a symbolic link from 'dst' to 'src'.
+createFileLink :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> FilePath -> m ()
 createFileLink src dst = GHC.withFrozenCallStack $ do
   H.annotate $ "Creating link from " <> show dst <> " to " <> show src
-  H.evalM . liftIO $ IO.copyFile src dst
+  if isWin32
+    then H.evalIO $ IO.copyFile src dst
+    else H.evalIO $ IO.createFileLink src dst
 
-listDirectory :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m [FilePath]
+-- | List 'p' directory.
+listDirectory :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m [FilePath]
 listDirectory p = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Listing directory: " <> p
   H.evalIO $ IO.listDirectory p
 
-writeFile :: (MonadIO m, HasCallStack) => FilePath -> String -> H.PropertyT m ()
+-- | Write 'contents' to the 'filePath' file.
+writeFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> String -> m ()
 writeFile filePath contents = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Writing file: " <> filePath
   H.evalIO $ IO.writeFile filePath contents
 
-openFile :: (MonadIO m, HasCallStack) => FilePath -> IOMode -> H.PropertyT m Handle
+-- | Open a handle to the 'filePath' file.
+openFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> IOMode -> m Handle
 openFile filePath mode = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Opening file: " <> filePath
   H.evalIO $ IO.openFile filePath mode
 
-readFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m String
+-- | Read the contents of the 'filePath' file.
+readFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m String
 readFile filePath = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Reading file: " <> filePath
   H.evalIO $ IO.readFile filePath
 
-lbsWriteFile :: (MonadIO m, HasCallStack) => FilePath -> LBS.ByteString -> H.PropertyT m ()
+-- | Write 'contents' to the 'filePath' file.
+lbsWriteFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> LBS.ByteString -> m ()
 lbsWriteFile filePath contents = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Writing file: " <> filePath
   H.evalIO $ LBS.writeFile filePath contents
 
-lbsReadFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m LBS.ByteString
+-- | Read the contents of the 'filePath' file.
+lbsReadFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m LBS.ByteString
 lbsReadFile filePath = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Reading file: " <> filePath
   H.evalIO $ LBS.readFile filePath
 
-readJsonFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m (Either String Value)
+-- | Read the 'filePath' file as JSON.
+readJsonFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m (Either String Value)
 readJsonFile filePath = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Reading JSON file: " <> filePath
   H.evalIO $ eitherDecode @Value <$> LBS.readFile filePath
 
-rewriteJson :: (MonadIO m, HasCallStack) => FilePath -> (Value -> Value) -> H.PropertyT m ()
+-- | Rewrite the 'filePath' JSON file using the function 'f'.
+rewriteJson :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> (Value -> Value) -> m ()
 rewriteJson filePath f = GHC.withFrozenCallStack $ do
   void . H.annotate $ "Rewriting JSON file: " <> filePath
   lbs <- forceM $ lbsReadFile filePath
@@ -108,7 +122,8 @@ rewriteJson filePath f = GHC.withFrozenCallStack $ do
     Right iv -> lbsWriteFile filePath (encode (f iv))
     Left msg -> H.failMessage GHC.callStack msg
 
-cat :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+-- | Annotate the contents of the 'filePath' file.
+cat :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 cat filePath = GHC.withFrozenCallStack $ do
   contents <- readFile filePath
   void . H.annotate $ L.unlines
@@ -117,7 +132,8 @@ cat filePath = GHC.withFrozenCallStack $ do
     ]
   return ()
 
-assertIsJsonFile :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+-- | Assert the 'filePath' can be parsed as JSON.
+assertIsJsonFile :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertIsJsonFile fp = GHC.withFrozenCallStack $ do
   jsonResult <- readJsonFile fp
   case jsonResult of

--- a/cardano-node-chairman/src/Chairman/Hedgehog/Network.hs
+++ b/cardano-node-chairman/src/Chairman/Hedgehog/Network.hs
@@ -12,6 +12,7 @@ import           Data.Bool
 import           Data.Function
 import           Data.Int
 import           GHC.Stack (HasCallStack)
+import           Hedgehog (MonadTest)
 import           System.IO (FilePath)
 
 import qualified Chairman.Hedgehog.Base as H
@@ -20,20 +21,26 @@ import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
 import qualified System.Directory as IO
 
-doesFileExists :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m Bool
+-- | Test if a file exists
+doesFileExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m Bool
 doesFileExists = GHC.withFrozenCallStack . H.evalIO . IO.doesFileExist
 
-isPortOpen :: (MonadIO m, HasCallStack) => Int -> H.PropertyT m Bool
+-- | Test if a port is open
+isPortOpen :: (MonadTest m, MonadIO m, HasCallStack) => Int -> m Bool
 isPortOpen = GHC.withFrozenCallStack . H.evalIO . IO.isPortOpen
 
-doesSocketExist :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m Bool
+-- | Test if a socket file exists
+doesSocketExist :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m Bool
 doesSocketExist = GHC.withFrozenCallStack . H.evalIO . IO.doesSocketExist
 
-assertFileExists :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+-- | Assert that a file exists
+assertFileExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertFileExists = H.assertM . doesFileExists
 
-assertPortOpen :: (MonadIO m, HasCallStack) => Int -> H.PropertyT m ()
+-- | Assert that a port is open
+assertPortOpen :: (MonadTest m, MonadIO m, HasCallStack) => Int -> m ()
 assertPortOpen = H.assertM . isPortOpen
 
-assertSocketExists :: (MonadIO m, HasCallStack) => FilePath -> H.PropertyT m ()
+-- | Assert that a socket file exists is open
+assertSocketExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertSocketExists = H.assertM . doesSocketExist

--- a/cardano-node-chairman/src/Chairman/IO/Process.hs
+++ b/cardano-node-chairman/src/Chairman/IO/Process.hs
@@ -10,6 +10,7 @@ import           Control.Concurrent.Async
 import           Control.Exception
 import           Control.Monad
 import           Data.Either
+import           Data.Eq
 import           Data.Function
 import           Data.Int
 import           Data.Maybe
@@ -17,13 +18,13 @@ import           GHC.Num
 import           System.Exit
 import           System.IO
 import           System.Process
+import           Text.Show
 
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.Async as IO
 import qualified System.Process as IO
 
-
-data TimedOut = TimedOut
+data TimedOut = TimedOut deriving (Eq, Show)
 
 maybeWaitForProcess
   :: ProcessHandle

--- a/cardano-node-chairman/src/Chairman/Monad.hs
+++ b/cardano-node-chairman/src/Chairman/Monad.hs
@@ -5,5 +5,6 @@ module Chairman.Monad
 import           Control.DeepSeq (NFData, force)
 import           Control.Monad
 
+-- | Force the evaluation of the return value in a monadic computation.
 forceM :: (Monad m, NFData a) => m a -> m a
 forceM = (force <$!>)

--- a/cardano-node-chairman/src/Chairman/OS.hs
+++ b/cardano-node-chairman/src/Chairman/OS.hs
@@ -6,6 +6,7 @@ import           Data.Bool
 import           Data.Eq
 import           System.Info
 
+-- | Determine if the operating system is Windows.
 isWin32 :: Bool
 isWin32 = os == "mingw32"
 {-# INLINE isWin32 #-}

--- a/cardano-node-chairman/src/Chairman/String.hs
+++ b/cardano-node-chairman/src/Chairman/String.hs
@@ -10,6 +10,7 @@ import           Data.String
 import qualified Data.List as L
 import qualified Data.Text as T
 
+-- | Strip whitepsace from the beginning and end of the string.
 strip :: String -> String
 strip = T.unpack . T.strip . T.pack
 

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Byron.hs
@@ -33,6 +33,7 @@ import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
 import qualified System.FilePath.Posix as FP
+import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
 
@@ -45,6 +46,7 @@ rewriteConfiguration s = s
 
 prop_chairman :: Property
 prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
+  void $ H.note OS.os
   let nodeCount = 3
   tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
   tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
@@ -54,6 +54,7 @@ import qualified Hedgehog as H
 import qualified System.Directory as IO
 import qualified System.Environment as IO
 import qualified System.FilePath.Posix as FP
+import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified System.Random as IO
@@ -64,6 +65,7 @@ import qualified System.Random as IO
 
 prop_chairman :: Property
 prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
+  void $ H.note OS.os
   tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
   tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath
   base <- H.noteShowM H.getProjectBase

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
@@ -36,6 +36,7 @@ import           Text.Show
 
 import qualified Chairman.Aeson as J
 import qualified Chairman.Hedgehog.Base as H
+import qualified Chairman.Hedgehog.Concurrent as H
 import qualified Chairman.Hedgehog.File as H
 import qualified Chairman.Hedgehog.Process as H
 import qualified Chairman.IO.File as IO

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
@@ -15,6 +15,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson ((.=))
 import           Data.Bool
+import           Data.Either
 import           Data.Eq
 import           Data.Function
 import           Data.Functor
@@ -27,7 +28,7 @@ import           Data.String
 import           GHC.Float
 import           GHC.Num
 import           GHC.Real
-import           Hedgehog (Property, discover)
+import           Hedgehog (Property, discover, (===))
 import           System.Exit (ExitCode (..))
 import           System.FilePath.Posix ((</>))
 import           System.IO (IO)
@@ -648,10 +649,13 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
         )
       )
 
-    void $ H.waitSecondsForProcess 110 hProcess
+    chairmanResult <- H.waitSecondsForProcess 110 hProcess
 
     H.cat nodeStdoutFile
     H.cat nodeStderrFile
+
+
+    chairmanResult === Right ExitSuccess
 
 tests :: IO Bool
 tests = H.checkParallel $$discover

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -12,6 +12,7 @@ import           Chairman.IO.Network.Sprocket (Sprocket (..))
 import           Control.Monad
 import           Data.Aeson
 import           Data.Bool
+import           Data.Either
 import           Data.Function
 import           Data.Functor
 import           Data.Int
@@ -21,7 +22,8 @@ import           Data.Ord
 import           Data.Semigroup
 import           Data.String (String)
 import           GHC.Float
-import           Hedgehog (Property, discover)
+import           Hedgehog (Property, discover, (===))
+import           System.Exit (ExitCode (..))
 import           System.IO (IO)
 import           Text.Read
 import           Text.Show
@@ -398,10 +400,12 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
         )
       )
 
-    void $ H.waitSecondsForProcess 110 hProcess
+    chairmanResult <- H.waitSecondsForProcess 110 hProcess
 
     H.cat nodeStdoutFile
     H.cat nodeStderrFile
+
+    chairmanResult === Right ExitSuccess
 
 tests :: IO Bool
 tests = H.checkParallel $$discover

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -43,6 +43,7 @@ import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
 import qualified System.Directory as IO
 import qualified System.FilePath.Posix as FP
+import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
 
@@ -63,6 +64,7 @@ rewriteGenesisSpec supply =
 
 prop_chairman :: Property
 prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
+  void $ H.note OS.os
   tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
   tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath
   base <- H.noteShowM H.getProjectBase

--- a/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
+++ b/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
@@ -34,7 +34,7 @@ prop_isPortOpen_False = H.propertyOnce . H.workspace "temp/network" $ \_ -> do
   -- Check multiple random ports and assert that one is closed.
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program
-  ports <- H.evalM . liftIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
+  ports <- H.evalIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
   results <- forM ports H.isPortOpen
   H.assert (False `L.elem` results)
 
@@ -43,7 +43,7 @@ prop_isPortOpen_True = H.propertyOnce . H.workspace "temp/network" $ \_ -> do
   -- Check first random port from multiple possible ports to be successfully bound is open
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program
-  ports <- H.evalM . liftIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
+  ports <- H.evalIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
   (socket, port) <- liftIO $ openOnePortFrom ports
   void $ IO.register $ IO.close socket
   result <- H.isPortOpen port


### PR DESCRIPTION
Tidy up chairman tests support code.  Assert that chairman exits successfully.

* Replace `evalM . liftIO` with `evalIO`
* Add function documentation for many functions
* Move `argQuote` quote into its own module because it didn't fit in with the rest of the module
* Move `threadDelay` to `Concurrent` module.
* Modify function signatures to abstract type to maximise re-use.
* Modify `createFileLink` to create a symbolic link on posix systems.
* Simplify type for `waitForProcess` and `waitSecondsForProcess` to not use `Maybe`