### PR TITLE
Increase test code re-use by moving test support code into separate common library

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ packages:
     cardano-config
     cardano-node
     cardano-node-chairman
+    hedgehog-extras
 
 package cardano-api
   ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -165,7 +165,9 @@ test-suite cardano-cli-test
                       , containers
                       , deepseq
                       , directory
+                      , exceptions
                       , hedgehog
+                      , hedgehog-extras
                       , lifted-base
                       , optparse-applicative
                       , process
@@ -193,8 +195,6 @@ test-suite cardano-cli-test
                         -Wcompat
                         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
-  build-tool-depends:   cardano-cli:cardano-cli
-
 test-suite cardano-cli-golden
   hs-source-dirs:       test
   main-is:              cardano-cli-golden.hs
@@ -211,7 +211,9 @@ test-suite cardano-cli-golden
                       , containers
                       , deepseq
                       , directory
+                      , exceptions
                       , hedgehog
+                      , hedgehog-extras
                       , lifted-base
                       , optparse-applicative
                       , process
@@ -280,5 +282,3 @@ test-suite cardano-cli-golden
                         -Wpartial-fields
                         -Wcompat
                         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
-
-  build-tool-depends:   cardano-cli:cardano-cli

--- a/cardano-cli/test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/Test/Cli/ITN.hs
@@ -12,6 +12,8 @@ import           Test.OptParse
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.ByteString.Base16 as Base16
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -26,7 +28,7 @@ itnSignKey = "ed25519_sk1yhnetcmla9pskrvp5z5ff2v8gkenhmluy736jd6nrxrlxcgn70zsy94
 -- | 1. Convert a bech32 ITN key pair to a haskell stake verification key and signing key
 --   2. Derive the haskell verification key from the haskell signing key.
 prop_convertITNKeys :: Property
-prop_convertITNKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_convertITNKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- ITN input file paths
   itnVerKeyFp <- noteTempFile tempDir "itnVerKey.key"
   itnSignKeyFp <- noteTempFile tempDir "itnSignKey.key"
@@ -38,7 +40,7 @@ prop_convertITNKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
   -- Write ITN keys to disk
   liftIO $ writeFile itnVerKeyFp itnVerKey
   liftIO $ writeFile itnSignKeyFp itnSignKey
-  assertFilesExist [itnVerKeyFp, itnSignKeyFp]
+  H.assertFilesExist [itnVerKeyFp, itnSignKeyFp]
 
   -- Generate haskell stake verification key
   void $ execCardanoCLI
@@ -54,11 +56,11 @@ prop_convertITNKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     ]
 
   -- Check for existence of the converted ITN keys
-  assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
+  H.assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
 
 -- | 1. Convert a bech32 ITN extended signing key to a haskell stake signing key
 prop_convertITNExtendedSigningKey :: Property
-prop_convertITNExtendedSigningKey = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_convertITNExtendedSigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   let itnExtendedSignKey = "\
     \ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj\
     \f38hkyn0shcycyaha4k9tmjy6xgvzaz7stw5t7rqjadyjcwfyx6k"
@@ -71,7 +73,7 @@ prop_convertITNExtendedSigningKey = propertyOnce . moduleWorkspace "tmp" $ \temp
 
   -- Write ITN keys to disk
   liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
-  assertFilesExist [itnSignKeyFp]
+  H.assertFilesExist [itnSignKeyFp]
 
   -- Generate haskell signing key
   void $ execCardanoCLI
@@ -81,11 +83,11 @@ prop_convertITNExtendedSigningKey = propertyOnce . moduleWorkspace "tmp" $ \temp
     ]
 
   -- Check for existence of the converted ITN keys
-  assertFilesExist [outputHaskellSignKeyFp]
+  H.assertFilesExist [outputHaskellSignKeyFp]
 
 -- | 1. Convert a bech32 ITN BIP32 signing key to a haskell stake signing key
 prop_convertITNBIP32SigningKey :: Property
-prop_convertITNBIP32SigningKey = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_convertITNBIP32SigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   let itnExtendedSignKey = "\
     \xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka\
     \jcza9ud848ckdqf48md9njzc5pkujfxwu2j8wdvtxkx02n3s2qa\
@@ -100,7 +102,7 @@ prop_convertITNBIP32SigningKey = propertyOnce . moduleWorkspace "tmp" $ \tempDir
   -- Write ITN keys to disk
   liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
 
-  assertFilesExist [itnSignKeyFp]
+  H.assertFilesExist [itnSignKeyFp]
 
   -- Generate haskell signing key
   void $ execCardanoCLI
@@ -110,7 +112,7 @@ prop_convertITNBIP32SigningKey = propertyOnce . moduleWorkspace "tmp" $ \tempDir
     ]
 
   -- Check for existence of the converted ITN keys
-  assertFilesExist [outputHaskellSignKeyFp]
+  H.assertFilesExist [outputHaskellSignKeyFp]
 
 -- | We check our 'decodeBech32' outputs against https://slowli.github.io/bech32-buffer/
 -- using 'itnVerKey' & 'itnSignKey' as inputs.

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise1.hs
@@ -9,12 +9,14 @@ import           Hedgehog (Property)
 import           Test.OptParse
 
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. We use the generated verification key to build a shelley payment address.
 prop_buildShelleyPaymentAddress :: Property
-prop_buildShelleyPaymentAddress = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_buildShelleyPaymentAddress = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Key filepaths
   verKey <- noteTempFile tempDir "payment-verification-key-file"
   signKey <- noteTempFile tempDir "payment-signing-key-file"
@@ -26,7 +28,7 @@ prop_buildShelleyPaymentAddress = propertyOnce . moduleWorkspace "tmp" $ \tempDi
     , "--signing-key-file", signKey
     ]
 
-  assertFilesExist [verKey, signKey]
+  H.assertFilesExist [verKey, signKey]
 
   -- Build shelley payment address
   void $ execCardanoCLI
@@ -41,7 +43,7 @@ prop_buildShelleyPaymentAddress = propertyOnce . moduleWorkspace "tmp" $ \tempDi
 --   3. We use the payment verification key & staking verification key
 --      to build a shelley stake address.
 prop_buildShelleyStakeAddress :: Property
-prop_buildShelleyStakeAddress = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_buildShelleyStakeAddress = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Key filepaths
   stakeVerKey <- noteTempFile tempDir "stake-verification-key-file"
   stakeSignKey <- noteTempFile tempDir "stake-signing-key-file"
@@ -62,7 +64,7 @@ prop_buildShelleyStakeAddress = propertyOnce . moduleWorkspace "tmp" $ \tempDir 
     , "--signing-key-file", stakeSignKey
     ]
 
-  assertFilesExist [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
+  H.assertFilesExist [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
 
   -- Build shelley stake address
   void $ execCardanoCLI

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise2.hs
@@ -9,12 +9,14 @@ import           Hedgehog (Property)
 import           Test.OptParse
 
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 -- | 1. We generate a payment signing key
 --   2. We create a tx body
 --   3. We sign the tx body with the generated payment signing key
 prop_createTransaction :: Property
-prop_createTransaction = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_createTransaction = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Key filepaths
   paymentVerKey <- noteTempFile tempDir "payment-verification-key-file"
   paymentSignKey <- noteTempFile tempDir "payment-signing-key-file"
@@ -28,7 +30,7 @@ prop_createTransaction = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     , "--signing-key-file", paymentSignKey
     ]
 
-  assertFilesExist [paymentVerKey, paymentSignKey]
+  H.assertFilesExist [paymentVerKey, paymentSignKey]
 
   -- Create transaction body
   void $ execCardanoCLI
@@ -40,7 +42,7 @@ prop_createTransaction = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     , "--out-file", transactionBodyFile
     ]
 
-  assertFilesExist [transactionBodyFile]
+  H.assertFilesExist [transactionBodyFile]
 
   -- Sign transaction
   void $ execCardanoCLI
@@ -51,7 +53,7 @@ prop_createTransaction = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     , "--out-file", transactionFile
     ]
 
-  assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]
+  H.assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise3.hs
@@ -9,13 +9,15 @@ import           Hedgehog (Property)
 import           Test.OptParse
 
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 -- | 1. Create KES key pair.
 --   2. Create cold keys.
 --   3. Create operational certificate.
 --   4. Create VRF key pair.
 prop_createOperationalCertificate :: Property
-prop_createOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_createOperationalCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Key filepaths
   kesVerKey <- noteTempFile tempDir "KES-verification-key-file"
   kesSignKey <- noteTempFile tempDir "KES-signing-key-file"
@@ -31,7 +33,7 @@ prop_createOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \temp
     , "--signing-key-file", kesSignKey
     ]
 
-  assertFilesExist [kesSignKey, kesVerKey]
+  H.assertFilesExist [kesSignKey, kesVerKey]
 
   -- Create cold key pair
   void $ execCardanoCLI
@@ -41,7 +43,7 @@ prop_createOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \temp
     , "--operational-certificate-issue-counter", operationalCertCounter
     ]
 
-  assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
+  H.assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
 
   -- Create operational certificate
   void $ execCardanoCLI
@@ -53,7 +55,7 @@ prop_createOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \temp
     , "--out-file", operationalCert
     ]
 
-  assertFilesExist [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]
+  H.assertFilesExist [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise4.hs
@@ -9,11 +9,13 @@ import           Hedgehog (Property)
 import           Test.OptParse
 
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 prop_createStakeAddressRegistrationCertificate :: Property
-prop_createStakeAddressRegistrationCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+prop_createStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"
   signKey <- noteTempFile tempDir "stake-signing-key-file"
@@ -25,7 +27,7 @@ prop_createStakeAddressRegistrationCertificate = propertyOnce . moduleWorkspace 
     , "--verification-key-file", verKey
     , "--signing-key-file", signKey
     ]
-  assertFilesExist [verKey, signKey]
+  H.assertFilesExist [verKey, signKey]
 
   -- Create stake address registration certificate
   void $ execCardanoCLI
@@ -34,7 +36,7 @@ prop_createStakeAddressRegistrationCertificate = propertyOnce . moduleWorkspace 
     , "--out-file", stakeRegCert
     ]
 
-  assertFilesExist [verKey, signKey, stakeRegCert]
+  H.assertFilesExist [verKey, signKey, stakeRegCert]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/test/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/Build.hs
@@ -8,12 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
-import qualified System.IO as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressBuild :: Property
-golden_shelleyAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- noteInputFile "test/data/golden/shelley/keys/payment_keys/verification_key"
   addressSKeyFile <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
   goldenStakingAddressHexFile <- noteInputFile "test/data/golden/shelley/addresses/staking-address.hex"
@@ -21,7 +22,7 @@ golden_shelleyAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> 
   stakingAddressHexFile <- noteTempFile tempDir "staking-address.hex"
   enterpriseAddressHexFile <- noteTempFile tempDir "enterprise-address.hex"
 
-  void $ OP.readFile addressVKeyFile
+  void $ H.readFile addressVKeyFile
 
   stakingAddressText <- execCardanoCLI
     [ "shelley","address","build"
@@ -30,13 +31,13 @@ golden_shelleyAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> 
     , "--staking-verification-key-file", addressSKeyFile
     ]
 
-  goldenStakingAddressHex <- OP.readFile goldenStakingAddressHexFile
+  goldenStakingAddressHex <- H.readFile goldenStakingAddressHexFile
 
-  liftIO $ IO.writeFile stakingAddressHexFile stakingAddressText
+  H.writeFile stakingAddressHexFile stakingAddressText
 
   equivalence stakingAddressText goldenStakingAddressHex
 
-  void $ OP.readFile addressSKeyFile
+  void $ H.readFile addressSKeyFile
 
   enterpriseAddressText <- execCardanoCLI
     [ "shelley","address","build"
@@ -45,8 +46,8 @@ golden_shelleyAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> 
     , "--staking-verification-key-file", addressSKeyFile
     ]
 
-  goldenEnterpriseAddressHex <- OP.readFile goldenEnterpriseAddressHexFile
+  goldenEnterpriseAddressHex <- H.readFile goldenEnterpriseAddressHexFile
 
-  liftIO $ IO.writeFile enterpriseAddressHexFile enterpriseAddressText
+  H.writeFile enterpriseAddressHexFile enterpriseAddressText
 
   equivalence enterpriseAddressText goldenEnterpriseAddressHex

--- a/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
@@ -8,12 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
-import qualified Test.OptParse as OP
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAddressKeyGen :: Property
-golden_shelleyAddressKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- noteTempFile tempDir "address.vkey"
   addressSKeyFile <- noteTempFile tempDir "address.skey"
 
@@ -23,11 +24,11 @@ golden_shelleyAddressKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir ->
     , "--signing-key-file", addressSKeyFile
     ]
 
-  void $ OP.readFile addressVKeyFile
-  void $ OP.readFile addressSKeyFile
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
 
-  assertFileOccurences 1 "PaymentVerificationKeyShelley" addressVKeyFile
-  assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
+  H.assertFileOccurences 1 "PaymentVerificationKeyShelley" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
 
-  assertEndsWithSingleNewline addressVKeyFile
-  assertEndsWithSingleNewline addressSKeyFile
+  H.assertEndsWithSingleNewline addressVKeyFile
+  H.assertEndsWithSingleNewline addressSKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -18,6 +18,9 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Time.Clock as DT
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.Time as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Gen as G
 import qualified Hedgehog.Range as R
 import qualified System.Directory as IO
@@ -60,7 +63,7 @@ parseTotalSupply = J.withObject "Object" $ \ o -> do
 
 golden_shelleyGenesisCreate :: Property
 golden_shelleyGenesisCreate = propertyOnce $ do
-  moduleWorkspace "tmp" $ \tempDir -> do
+  H.moduleWorkspace "tmp" $ \tempDir -> do
     sourceGenesisSpecFile <- noteInputFile "test/data/golden/shelley/genesis/genesis.spec.json"
     genesisSpecFile <- noteTempFile tempDir "genesis.spec.json"
 
@@ -68,7 +71,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap OP.formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap H.formatIso8601 $ liftIO DT.getCurrentTime
 
     (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
@@ -85,7 +88,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
       , "--genesis-dir", tempDir
       ]
 
-    assertFilesExist [genesisFile]
+    H.assertFilesExist [genesisFile]
 
     genesisContents <- liftIO $ LBS.readFile genesisFile
 
@@ -113,32 +116,32 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     for_ [1 .. delegateCount] $ \i -> do
       -- Check Genesis keys
-      assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
-      assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       -- Check delegate keys
-      assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       -- Check utxo keys
-      assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
-      assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
-  moduleWorkspace "tmp" $ \tempDir -> do
+  H.moduleWorkspace "tmp" $ \tempDir -> do
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap OP.formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap H.formatIso8601 $ liftIO DT.getCurrentTime
 
     (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
@@ -155,7 +158,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
         , "--genesis-dir", tempDir
         ]
 
-    assertFilesExist [genesisFile]
+    H.assertFilesExist [genesisFile]
 
     genesisContents <- liftIO $ LBS.readFile genesisFile
 
@@ -183,24 +186,24 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     for_ [1 .. delegateCount] $ \i -> do
       -- Check Genesis keys
-      assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
-      assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       -- Check delegate keys
-      assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       -- Check utxo keys
-      assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
-      assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -8,13 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
-import qualified System.IO as IO
-import qualified Test.OptParse as OP
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisInitialTxIn :: Property
-golden_shelleyGenesisInitialTxIn = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisInitialTxIn = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteInputFile "test/data/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
   goldenUtxoHashFile <- noteInputFile "test/data/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
   utxoHashFile <- noteTempFile tempDir "utxo_hash"
@@ -25,8 +25,8 @@ golden_shelleyGenesisInitialTxIn = propertyOnce . moduleWorkspace "tmp" $ \tempD
     , "--verification-key-file", verificationKeyFile
     ]
 
-  liftIO $ IO.writeFile utxoHashFile utxoHash
+  H.writeFile utxoHashFile utxoHash
 
-  goldenUtxoHash <- OP.readFile goldenUtxoHashFile
+  goldenUtxoHash <- H.readFile goldenUtxoHashFile
 
   equivalence utxoHash goldenUtxoHash

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenDelegate :: Property
-golden_shelleyGenesisKeyGenDelegate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisKeyGenDelegate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   operationalCertificateIssueCounterFile <- noteTempFile tempDir "op-cert.counter"
@@ -23,13 +26,13 @@ golden_shelleyGenesisKeyGenDelegate = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
     ]
 
-  assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" verificationKeyFile
-  assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" signingKeyFile
-  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" operationalCertificateIssueCounterFile
+  H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" operationalCertificateIssueCounterFile
 
-  assertFileOccurences 1 "Genesis delegate operator key" verificationKeyFile
-  assertFileOccurences 1 "Genesis delegate operator key" signingKeyFile
+  H.assertFileOccurences 1 "Genesis delegate operator key" verificationKeyFile
+  H.assertFileOccurences 1 "Genesis delegate operator key" signingKeyFile
 
-  assertEndsWithSingleNewline verificationKeyFile
-  assertEndsWithSingleNewline signingKeyFile
-  assertEndsWithSingleNewline operationalCertificateIssueCounterFile
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenGenesis :: Property
-golden_shelleyGenesisKeyGenGenesis = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisKeyGenGenesis = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
@@ -21,8 +24,8 @@ golden_shelleyGenesisKeyGenGenesis = propertyOnce . moduleWorkspace "tmp" $ \tem
     , "--signing-key-file", signingKeyFile
     ]
 
-  assertFileOccurences 1 "GenesisVerificationKey_ed25519" verificationKeyFile
-  assertFileOccurences 1 "GenesisSigningKey_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "GenesisSigningKey_ed25519" signingKeyFile
 
-  assertEndsWithSingleNewline verificationKeyFile
-  assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyGenUtxo :: Property
-golden_shelleyGenesisKeyGenUtxo = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisKeyGenUtxo = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   utxoVerificationKeyFile <- noteTempFile tempDir "utxo.vkey"
   utxoSigningKeyFile <- noteTempFile tempDir "utxo.skey"
 
@@ -21,8 +24,8 @@ golden_shelleyGenesisKeyGenUtxo = propertyOnce . moduleWorkspace "tmp" $ \tempDi
     , "--signing-key-file", utxoSigningKeyFile
     ]
 
-  assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" utxoVerificationKeyFile
-  assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" utxoSigningKeyFile
+  H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" utxoVerificationKeyFile
+  H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" utxoSigningKeyFile
 
-  assertEndsWithSingleNewline utxoVerificationKeyFile
-  assertEndsWithSingleNewline utxoSigningKeyFile
+  H.assertEndsWithSingleNewline utxoVerificationKeyFile
+  H.assertEndsWithSingleNewline utxoSigningKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -8,12 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property, (===))
 import           Test.OptParse as OP
 
-import qualified System.IO as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyHash :: Property
-golden_shelleyGenesisKeyHash = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisKeyHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   referenceVerificationKey <- noteInputFile "test/data/golden/shelley/keys/genesis_keys/verification_key"
   goldenGenesisVerificationKeyHashFile <- noteInputFile "test/data/golden/shelley/keys/genesis_keys/verification_key.key-hash"
   genesisVerificationKeyHashFile <- noteTempFile tempDir "key-hash.hex"
@@ -23,8 +24,8 @@ golden_shelleyGenesisKeyHash = propertyOnce . moduleWorkspace "tmp" $ \tempDir -
     , "--verification-key-file", referenceVerificationKey
     ]
 
-  liftIO $ IO.writeFile genesisVerificationKeyHashFile genesisVerificationKeyHash
+  H.writeFile genesisVerificationKeyHashFile genesisVerificationKeyHash
 
-  goldenGenesisVerificationKeyHash <- OP.readFile goldenGenesisVerificationKeyHashFile
+  goldenGenesisVerificationKeyHash <- H.readFile goldenGenesisVerificationKeyHashFile
 
   genesisVerificationKeyHash === goldenGenesisVerificationKeyHash

--- a/cardano-cli/test/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -8,10 +8,11 @@ module Test.Golden.Shelley.Key.ConvertCardanoAddressKey
   ) where
 
 import           Cardano.Prelude hiding (readFile)
-
 import           Hedgehog (Property, (===))
-
 import           Test.OptParse
+
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -43,7 +44,7 @@ exampleShelleySigningKey =
 -- expected result.
 golden_convertCardanoAddressByronSigningKey :: Property
 golden_convertCardanoAddressByronSigningKey =
-  propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
     -- `cardano-address` signing key filepath
     signingKeyFp <- noteTempFile tempDir "cardano-address-byron.skey"
@@ -53,8 +54,8 @@ golden_convertCardanoAddressByronSigningKey =
       noteTempFile tempDir "converted-cardano-address-byron.skey"
 
     -- Write `cardano-address` signing key to disk
-    liftIO $ writeFile signingKeyFp exampleByronSigningKey
-    assertFilesExist [signingKeyFp]
+    H.textWriteFile signingKeyFp exampleByronSigningKey
+    H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
     void $ execCardanoCLI
@@ -65,13 +66,13 @@ golden_convertCardanoAddressByronSigningKey =
       ]
 
     -- Check for existence of the converted signing key file
-    assertFilesExist [convertedSigningKeyFp]
+    H.assertFilesExist [convertedSigningKeyFp]
 
     -- Check that the contents of the converted signing key file match that of
     -- the golden file.
-    actualConvertedSigningKey <- readFile convertedSigningKeyFp
+    actualConvertedSigningKey <- H.readFile convertedSigningKeyFp
     expectedConvertedSigningKey <-
-      readFile $
+      H.readFile $
         "test/data/golden/shelley/keys/converted_cardano-address_keys/"
           <> "byron_signing_key"
     expectedConvertedSigningKey === actualConvertedSigningKey
@@ -80,18 +81,18 @@ golden_convertCardanoAddressByronSigningKey =
 -- expected result.
 golden_convertCardanoAddressIcarusSigningKey :: Property
 golden_convertCardanoAddressIcarusSigningKey =
-  propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
     -- `cardano-address` signing key filepath
-    signingKeyFp <- noteTempFile tempDir "cardano-address-icarus.skey"
+    signingKeyFp <- H.noteTempFile tempDir "cardano-address-icarus.skey"
 
     -- Converted signing key filepath
     convertedSigningKeyFp <-
       noteTempFile tempDir "converted-cardano-address-icarus.skey"
 
     -- Write `cardano-address` signing key to disk
-    liftIO $ writeFile signingKeyFp exampleIcarusSigningKey
-    assertFilesExist [signingKeyFp]
+    H.textWriteFile signingKeyFp exampleIcarusSigningKey
+    H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
     void $ execCardanoCLI
@@ -102,13 +103,13 @@ golden_convertCardanoAddressIcarusSigningKey =
       ]
 
     -- Check for existence of the converted signing key file
-    assertFilesExist [convertedSigningKeyFp]
+    H.assertFilesExist [convertedSigningKeyFp]
 
     -- Check that the contents of the converted signing key file match that of
     -- the golden file.
-    actualConvertedSigningKey <- readFile convertedSigningKeyFp
+    actualConvertedSigningKey <- H.readFile convertedSigningKeyFp
     expectedConvertedSigningKey <-
-      readFile $
+      H.readFile $
         "test/data/golden/shelley/keys/converted_cardano-address_keys/"
           <> "icarus_signing_key"
     expectedConvertedSigningKey === actualConvertedSigningKey
@@ -117,7 +118,7 @@ golden_convertCardanoAddressIcarusSigningKey =
 -- yields the expected result.
 golden_convertCardanoAddressShelleyPaymentSigningKey :: Property
 golden_convertCardanoAddressShelleyPaymentSigningKey =
-  propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
     -- `cardano-address` signing key filepath
     signingKeyFp <-
@@ -128,8 +129,8 @@ golden_convertCardanoAddressShelleyPaymentSigningKey =
       noteTempFile tempDir "converted-cardano-address-shelley-payment.skey"
 
     -- Write `cardano-address` signing key to disk
-    liftIO $ writeFile signingKeyFp exampleShelleySigningKey
-    assertFilesExist [signingKeyFp]
+    H.textWriteFile signingKeyFp exampleShelleySigningKey
+    H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
     void $ execCardanoCLI
@@ -140,13 +141,13 @@ golden_convertCardanoAddressShelleyPaymentSigningKey =
       ]
 
     -- Check for existence of the converted signing key file
-    assertFilesExist [convertedSigningKeyFp]
+    H.assertFilesExist [convertedSigningKeyFp]
 
     -- Check that the contents of the converted signing key file match that of
     -- the golden file.
-    actualConvertedSigningKey <- readFile convertedSigningKeyFp
+    actualConvertedSigningKey <- H.readFile convertedSigningKeyFp
     expectedConvertedSigningKey <-
-      readFile $
+      H.readFile $
         "test/data/golden/shelley/keys/converted_cardano-address_keys/"
           <> "shelley_payment_signing_key"
     expectedConvertedSigningKey === actualConvertedSigningKey
@@ -155,7 +156,7 @@ golden_convertCardanoAddressShelleyPaymentSigningKey =
 -- the expected result.
 golden_convertCardanoAddressShelleyStakeSigningKey :: Property
 golden_convertCardanoAddressShelleyStakeSigningKey =
-  propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
     -- `cardano-address` signing key filepath
     signingKeyFp <-
@@ -163,11 +164,11 @@ golden_convertCardanoAddressShelleyStakeSigningKey =
 
     -- Converted signing key filepath
     convertedSigningKeyFp <-
-      noteTempFile tempDir "converted-cardano-address-shelley-stake.skey"
+      H.noteTempFile tempDir "converted-cardano-address-shelley-stake.skey"
 
     -- Write `cardano-address` signing key to disk
-    liftIO $ writeFile signingKeyFp exampleShelleySigningKey
-    assertFilesExist [signingKeyFp]
+    H.textWriteFile signingKeyFp exampleShelleySigningKey
+    H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
     void $ execCardanoCLI
@@ -178,13 +179,13 @@ golden_convertCardanoAddressShelleyStakeSigningKey =
       ]
 
     -- Check for existence of the converted signing key file
-    assertFilesExist [convertedSigningKeyFp]
+    H.assertFilesExist [convertedSigningKeyFp]
 
     -- Check that the contents of the converted signing key file match that of
     -- the golden file.
-    actualConvertedSigningKey <- readFile convertedSigningKeyFp
+    actualConvertedSigningKey <- H.readFile convertedSigningKeyFp
     expectedConvertedSigningKey <-
-      readFile $
+      H.readFile $
         "test/data/golden/shelley/keys/converted_cardano-address_keys/"
           <> "shelley_stake_signing_key"
     expectedConvertedSigningKey === actualConvertedSigningKey

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_stakePoolMetadataHash :: Property
-golden_stakePoolMetadataHash = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   referenceStakePoolMetaData <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"
 
   stakePoolMetadataFile <- noteTempFile tempDir "stake-pool-metadata.json"
@@ -28,8 +31,8 @@ golden_stakePoolMetadataHash = propertyOnce . moduleWorkspace "tmp" $ \tempDir -
     ]
 
   -- Check that the stake pool metadata hash file content is correct.
-  expectedStakePoolMetadataHash <- OP.readFile referenceStakePoolMetaData
-  actualStakePoolMetadataHash <- OP.readFile outputStakePoolMetadataHashFp
+  expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetaData
+  actualStakePoolMetadataHash <- H.readFile outputStakePoolMetadataHashFp
 
   equivalence expectedStakePoolMetadataHash actualStakePoolMetadataHash
   where

--- a/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
@@ -10,10 +10,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyAllMultiSigAddressBuild :: Property
-golden_shelleyAllMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \_ -> do
+golden_shelleyAllMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   allMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/all"
 
   allMultiSigAddress <- execCardanoCLI
@@ -24,12 +27,12 @@ golden_shelleyAllMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \
 
   goldenAllMultiSigAddrFp <- noteInputFile "test/data/golden/shelley/multisig/addresses/all"
 
-  goldenAllMs <- OP.readFile goldenAllMultiSigAddrFp
+  goldenAllMs <- H.readFile goldenAllMultiSigAddrFp
 
   equivalence allMultiSigAddress goldenAllMs
 
 golden_shelleyAnyMultiSigAddressBuild :: Property
-golden_shelleyAnyMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \_ -> do
+golden_shelleyAnyMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   anyMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/any"
 
   anyMultiSigAddress <- execCardanoCLI
@@ -40,12 +43,12 @@ golden_shelleyAnyMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \
 
   goldenAnyMultiSigAddrFp <- noteInputFile "test/data/golden/shelley/multisig/addresses/any"
 
-  goldenAnyMs <- OP.readFile goldenAnyMultiSigAddrFp
+  goldenAnyMs <- H.readFile goldenAnyMultiSigAddrFp
 
   equivalence anyMultiSigAddress goldenAnyMs
 
 golden_shelleyAtLeastMultiSigAddressBuild :: Property
-golden_shelleyAtLeastMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \_ -> do
+golden_shelleyAtLeastMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   atLeastMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/atleast"
 
   atLeastMultiSigAddress <- execCardanoCLI
@@ -56,6 +59,6 @@ golden_shelleyAtLeastMultiSigAddressBuild = propertyOnce . moduleWorkspace "tmp"
 
   goldenAtLeastMultiSigAddrFp <- noteInputFile "test/data/golden/shelley/multisig/addresses/atleast"
 
-  goldenAtLeastMs <- OP.readFile goldenAtLeastMultiSigAddrFp
+  goldenAtLeastMs <- H.readFile goldenAtLeastMultiSigAddrFp
 
   equivalence atLeastMultiSigAddress goldenAtLeastMs

--- a/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -8,12 +8,14 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 import qualified System.Directory as IO
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeIssueOpCert :: Property
-golden_shelleyNodeIssueOpCert = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyNodeIssueOpCert = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   hotKesVerificationKeyFile <- noteInputFile "test/data/golden/shelley/keys/kes_keys/verification_key"
   coldSigningKeyFile <- noteInputFile "test/data/golden/shelley/keys/genesis_delegate_keys/signing_key"
   originalOperationalCertificateIssueCounterFile <- noteInputFile "test/data/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
@@ -37,8 +39,8 @@ golden_shelleyNodeIssueOpCert = propertyOnce . moduleWorkspace "tmp" $ \tempDir 
     , "--out-file", operationalCertFile
     ]
 
-  assertFileOccurences 1 "NodeOperationalCertificate" operationalCertFile
-  assertFileOccurences 1 "Next certificate issue number: 1" operationalCertificateIssueCounterFile
+  H.assertFileOccurences 1 "NodeOperationalCertificate" operationalCertFile
+  H.assertFileOccurences 1 "Next certificate issue number: 1" operationalCertificateIssueCounterFile
 
-  assertEndsWithSingleNewline operationalCertFile
-  assertEndsWithSingleNewline operationalCertificateIssueCounterFile
+  H.assertEndsWithSingleNewline operationalCertFile
+  H.assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGen :: Property
-golden_shelleyNodeKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyNodeKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
@@ -23,10 +26,10 @@ golden_shelleyNodeKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
     , "--operational-certificate-issue-counter", opCertCounterFile
     ]
 
-  assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
-  assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
-  assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+  H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
 
-  assertEndsWithSingleNewline verificationKeyFile
-  assertEndsWithSingleNewline signingKeyFile
-  assertEndsWithSingleNewline opCertCounterFile
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline opCertCounterFile

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGenKes :: Property
-golden_shelleyNodeKeyGenKes = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyNodeKeyGenKes = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -21,8 +24,8 @@ golden_shelleyNodeKeyGenKes = propertyOnce . moduleWorkspace "tmp" $ \tempDir ->
     , "--signing-key-file", signingKey
     ]
 
-  assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
-  assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+  H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
+  H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
 
-  assertEndsWithSingleNewline verificationKey
-  assertEndsWithSingleNewline signingKey
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyNodeKeyGenVrf :: Property
-golden_shelleyNodeKeyGenVrf = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyNodeKeyGenVrf = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
@@ -21,8 +24,8 @@ golden_shelleyNodeKeyGenVrf = propertyOnce . moduleWorkspace "tmp" $ \tempDir ->
     , "--signing-key-file", signingKey
     ]
 
-  assertFileOccurences 1 "VRF Verification Key" verificationKey
-  assertFileOccurences 1 "VRF Signing Key" signingKey
+  H.assertFileOccurences 1 "VRF Verification Key" verificationKey
+  H.assertFileOccurences 1 "VRF Signing Key" signingKey
 
-  assertEndsWithSingleNewline verificationKey
-  assertEndsWithSingleNewline signingKey
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressBuild :: Property
-golden_shelleyStakeAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \_ -> do
+golden_shelleyStakeAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   verificationKeyFile <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
   goldenRewardAddressFile <- noteInputFile "test/data/golden/shelley/keys/stake_keys/reward_address"
 
@@ -21,6 +24,6 @@ golden_shelleyStakeAddressBuild = propertyOnce . moduleWorkspace "tmp" $ \_ -> d
     , "--staking-verification-key-file", verificationKeyFile
     ]
 
-  goldenRewardsAddress <- OP.readFile goldenRewardAddressFile
+  goldenRewardsAddress <- H.readFile goldenRewardAddressFile
 
   equivalence rewardAddress goldenRewardsAddress

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressDeregistrationCertificate :: Property
-golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
   deregistrationCertFile <- noteTempFile tempDir "deregistrationCertFile"
 
@@ -21,6 +24,6 @@ golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . moduleWorks
     , "--out-file", deregistrationCertFile
     ]
 
-  assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
+  H.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
 
-  assertEndsWithSingleNewline deregistrationCertFile
+  H.assertEndsWithSingleNewline deregistrationCertFile

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressKeyGen :: Property
-golden_shelleyStakeAddressKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakeAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   verificationKeyFile <- noteTempFile tempDir "kes.vkey"
   signingKeyFile <- noteTempFile tempDir "kes.skey"
 
@@ -21,8 +24,8 @@ golden_shelleyStakeAddressKeyGen = propertyOnce . moduleWorkspace "tmp" $ \tempD
     , "--signing-key-file", signingKeyFile
     ]
 
-  assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
-  assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
 
-  assertEndsWithSingleNewline verificationKeyFile
-  assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakeAddressRegistrationCertificate :: Property
-golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   keyGenStakingVerificationKeyFile <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
 
@@ -21,6 +24,6 @@ golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . moduleWorkspa
     , "--out-file", registrationCertFile
     ]
 
-  assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
+  H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
-  assertEndsWithSingleNewline registrationCertFile
+  H.assertEndsWithSingleNewline registrationCertFile

--- a/cardano-cli/test/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyStakePoolRegistrationCertificate :: Property
-golden_shelleyStakePoolRegistrationCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakePoolRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   operatorVerificationKeyFile <- noteInputFile "test/data/golden/shelley/node-pool/operator.vkey"
   vrfVerificationKeyFile <- noteInputFile "test/data/golden/shelley/node-pool/vrf.vkey"
   ownerVerificationKeyFile <- noteInputFile "test/data/golden/shelley/node-pool/owner.vkey"
@@ -30,6 +33,6 @@ golden_shelleyStakePoolRegistrationCertificate = propertyOnce . moduleWorkspace 
     , "--out-file", registrationCertFile
     ]
 
-  assertFileOccurences 1 "Stake Pool Registration Certificate" registrationCertFile
+  H.assertFileOccurences 1 "Stake Pool Registration Certificate" registrationCertFile
 
-  assertEndsWithSingleNewline registrationCertFile
+  H.assertEndsWithSingleNewline registrationCertFile

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
@@ -4,19 +4,19 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertifi
   ( golden_shelleyGenesisKeyDelegationCertificate
   ) where
 
-import           Cardano.Prelude
-
-import           Hedgehog (Property)
-
 import           Cardano.Api.Typed (AsType (..), HasTextEnvelope (..))
-
+import           Cardano.Prelude
+import           Hedgehog (Property)
 import           Test.OptParse
+
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyGenesisKeyDelegationCertificate :: Property
 golden_shelleyGenesisKeyDelegationCertificate =
-  propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     -- Reference certificate
     referenceCertificateFilePath <-
       noteInputFile $
@@ -54,7 +54,7 @@ golden_shelleyGenesisKeyDelegationCertificate =
       , "--signing-key-file", "/dev/null"
       ]
 
-    assertFilesExist
+    H.assertFilesExist
       [ genesisVerKeyFilePath
       , genesisDelegVerKeyFilePath
       , vrfVerKeyFilePath
@@ -69,7 +69,7 @@ golden_shelleyGenesisKeyDelegationCertificate =
       , "--out-file", genesisKeyDelegCertFilePath
       ]
 
-    assertFilesExist [genesisKeyDelegCertFilePath]
+    H.assertFilesExist [genesisKeyDelegCertFilePath]
 
     let certificateType = textEnvelopeType AsCertificate
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
@@ -9,13 +9,16 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate stake key pair
 --   2. Create MIR certificate
 --   s. Check the TextEnvelope serialization format has not changed.
 golden_shelleyMIRCertificate :: Property
-golden_shelleyMIRCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceMIRCertificate <- noteInputFile "test/data/golden/shelley/certificates/mir_certificate"
 
@@ -31,7 +34,7 @@ golden_shelleyMIRCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -
     , "--signing-key-file", signKey
     ]
 
-  assertFilesExist [verKey, signKey]
+  H.assertFilesExist [verKey, signKey]
 
   -- Create MIR certificate
   void $ execCardanoCLI
@@ -42,7 +45,7 @@ golden_shelleyMIRCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -
     , "--out-file", mirCertificate
     ]
 
-  assertFilesExist [mirCertificate]
+  H.assertFilesExist [mirCertificate]
 
   let registrationCertificateType = textEnvelopeType AsCertificate
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
@@ -9,6 +9,9 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Create KES key pair.
@@ -16,7 +19,7 @@ import           Test.OptParse
 --   3. Create operational certificate.
 --   4. Check the TextEnvelope serialization format has not changed.
 golden_shelleyOperationalCertificate :: Property
-golden_shelleyOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyOperationalCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceOperationalCertificate <- noteInputFile "test/data/golden/shelley/certificates/operational_certificate"
 
@@ -35,7 +38,7 @@ golden_shelleyOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \t
     , "--signing-key-file", kesSignKey
     ]
 
-  assertFilesExist [kesSignKey, kesVerKey]
+  H.assertFilesExist [kesSignKey, kesVerKey]
 
   -- Create cold key pair
   void $ execCardanoCLI
@@ -45,7 +48,7 @@ golden_shelleyOperationalCertificate = propertyOnce . moduleWorkspace "tmp" $ \t
     , "--operational-certificate-issue-counter", operationalCertCounter
     ]
 
-  assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
+  H.assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
 
   -- Create operational certificate
   void $ execCardanoCLI

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -9,13 +9,16 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeAddressCertificates :: Property
-golden_shelleyStakeAddressCertificates = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference files
   referenceRegistrationCertificate <- noteInputFile "test/data/golden/shelley/certificates/stake_address_registration_certificate"
   referenceDeregistrationCertificate <- noteInputFile "test/data/golden/shelley/certificates/stake_address_deregistration_certificate"
@@ -33,7 +36,7 @@ golden_shelleyStakeAddressCertificates = propertyOnce . moduleWorkspace "tmp" $ 
     , "--signing-key-file", signKey
     ]
 
-  assertFilesExist [verKey, signKey]
+  H.assertFilesExist [verKey, signKey]
 
   -- Create stake address registration certificate
   void $ execCardanoCLI

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
@@ -9,6 +9,9 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Create cold key pair.
@@ -18,7 +21,7 @@ import           Test.OptParse
 --   5. Create stake pool deregistration/retirement certificate.
 --   6. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakePoolCertificates :: Property
-golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference files
   referenceRegistrationCertificate <- noteInputFile "test/data/golden/shelley/certificates/stake_pool_registration_certificate"
   referenceDeregistrationCertificate <- noteInputFile "test/data/golden/shelley/certificates/stake_pool_deregistration_certificate"
@@ -42,7 +45,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--operational-certificate-issue-counter", operationalCertCounter
     ]
 
-  assertFilesExist [coldSignKey, coldVerKey, operationalCertCounter]
+  H.assertFilesExist [coldSignKey, coldVerKey, operationalCertCounter]
 
   -- Generate stake key pair
   void $ execCardanoCLI
@@ -51,7 +54,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--signing-key-file", poolRewardAccountSignKey
     ]
 
-  assertFilesExist [poolRewardAccountAndOwnerVerKey, poolRewardAccountSignKey]
+  H.assertFilesExist [poolRewardAccountAndOwnerVerKey, poolRewardAccountSignKey]
 
   -- Generate vrf verification key
   void $ execCardanoCLI
@@ -61,7 +64,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \te
     ]
 
 
-  assertFilesExist [vrfSignKey, vrfVerKey]
+  H.assertFilesExist [vrfSignKey, vrfVerKey]
 
   -- Create stake pool registration certificate
   void $ execCardanoCLI
@@ -77,7 +80,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--out-file", registrationCertificate
     ]
 
-  assertFilesExist [registrationCertificate]
+  H.assertFilesExist [registrationCertificate]
 
   let registrationCertificateType = textEnvelopeType AsCertificate
 
@@ -93,7 +96,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . moduleWorkspace "tmp" $ \te
     , "--out-file", deregistrationCertificate
     ]
 
-  assertFilesExist [deregistrationCertificate]
+  H.assertFilesExist [deregistrationCertificate]
 
   -- Check the newly created files have not deviated from the
   -- golden files

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyExtendedPaymentKeys :: Property
-golden_shelleyExtendedPaymentKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair & operational certificate counter file
 --   2. Check for the existence of the key pair & counter file
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisDelegateKeys :: Property
-golden_shelleyGenesisDelegateKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisDelegateKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/genesis_delegate_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/genesis_delegate_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed
 golden_shelleyGenesisKeys :: Property
-golden_shelleyGenesisKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/genesis_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/genesis_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyGenesisUTxOKeys :: Property
-golden_shelleyGenesisUTxOKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyGenesisUTxOKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/genesis_utxo_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/genesis_utxo_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyKESKeys :: Property
-golden_shelleyKESKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyPaymentKeys :: Property
-golden_shelleyPaymentKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyStakeKeys :: Property
-golden_shelleyStakeKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -9,13 +9,15 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
-golden_shelleyVRFKeys = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -9,6 +9,8 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. Generate a key pair
@@ -16,7 +18,7 @@ import           Test.OptParse
 --   3. Sign tx body
 --   4. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTx :: Property
-golden_shelleyTx = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   let referenceTx = "test/data/golden/shelley/tx/tx"
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -9,12 +9,14 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+
 {- HLINT ignore "Use camelCase" -}
 
 -- | 1. We create a 'TxBody Shelley' file.
 --   2. Check the TextEnvelope serialization format has not changed.
 golden_shelleyTxBody :: Property
-golden_shelleyTxBody = propertyOnce . moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTxBody = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
   referenceTxBody <- noteInputFile "test/data/golden/shelley/tx/txbody"
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -8,12 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
-import qualified System.IO as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTextViewDecodeCbor :: Property
-golden_shelleyTextViewDecodeCbor = propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTextViewDecodeCbor = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   unsignedTxFile <- noteInputFile "test/data/golden/shelley/tx/unsigned.tx"
   decodedTxtFile <- noteTempFile tempDir "decoded.txt"
 
@@ -24,11 +25,11 @@ golden_shelleyTextViewDecodeCbor = propertyOnce $ moduleWorkspace "tmp" $ \tempD
     , "--file", unsignedTxFile
     ]
 
-  liftIO $ IO.writeFile decodedTxtFile decodedTxt
+  H.writeFile decodedTxtFile decodedTxt
 
-  assertFileOccurences 1 "# int(4999998000)" decodedTxtFile
-  assertFileOccurences 1 "# int(2000)" decodedTxtFile
-  assertFileOccurences 1 "# int(1000)" decodedTxtFile
+  H.assertFileOccurences 1 "# int(4999998000)" decodedTxtFile
+  H.assertFileOccurences 1 "# int(2000)" decodedTxtFile
+  H.assertFileOccurences 1 "# int(1000)" decodedTxtFile
 
-  assertEndsWithSingleNewline decodedTxtFile
-  assertFileLines (>= 10) decodedTxtFile
+  H.assertEndsWithSingleNewline decodedTxtFile
+  H.assertFileLines (>= 10) decodedTxtFile

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionBuild :: Property
-golden_shelleyTransactionBuild = propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTransactionBuild = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Use the same (faked) TxIn for both transactions.
   let txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
 
@@ -29,6 +32,6 @@ golden_shelleyTransactionBuild = propertyOnce $ moduleWorkspace "tmp" $ \tempDir
     , "--tx-body-file", txBodyOutFile
     ]
 
-  assertFileOccurences 1 "TxUnsignedShelley" txBodyOutFile
+  H.assertFileOccurences 1 "TxUnsignedShelley" txBodyOutFile
 
-  assertEndsWithSingleNewline txBodyOutFile
+  H.assertEndsWithSingleNewline txBodyOutFile

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -8,12 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
-import qualified System.IO as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionCalculateMinFee :: Property
-golden_shelleyTransactionCalculateMinFee = propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTransactionCalculateMinFee = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   protocolParamsJsonFile <- noteInputFile "test/data/golden/shelley/transaction-calculate-min-fee/protocol-params.json"
   txBodyFile <- noteInputFile "test/data/golden/shelley/transaction-calculate-min-fee/tx-body-file"
   minFeeTxtFile <- noteTempFile tempDir "min-fee.txt"
@@ -29,8 +30,8 @@ golden_shelleyTransactionCalculateMinFee = propertyOnce $ moduleWorkspace "tmp" 
     , "--tx-body-file", txBodyFile
     ]
 
-  liftIO $ IO.writeFile minFeeTxtFile minFeeTxt
+  H.writeFile minFeeTxtFile minFeeTxt
 
-  assertFileOccurences 1 "2541502" minFeeTxtFile
-  assertFileLines (== 1) minFeeTxtFile
-  assertEndsWithSingleNewline minFeeTxtFile
+  H.assertFileOccurences 1 "2541502" minFeeTxtFile
+  H.assertFileLines (== 1) minFeeTxtFile
+  H.assertEndsWithSingleNewline minFeeTxtFile

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Sign.hs
@@ -8,10 +8,13 @@ import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyTransactionSign :: Property
-golden_shelleyTransactionSign = propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+golden_shelleyTransactionSign = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyFile <- noteInputFile "test/data/golden/shelley/transaction-sign/tx-body-file"
   initialUtxo1SigningKeyFile <- noteInputFile "test/data/golden/shelley/transaction-sign/initial-utxo1.skey"
   initialUtxo2SigningKeyFile <- noteInputFile "test/data/golden/shelley/transaction-sign/initial-utxo2.skey"
@@ -31,8 +34,8 @@ golden_shelleyTransactionSign = propertyOnce $ moduleWorkspace "tmp" $ \tempDir 
     , "--tx-file", signedTransactionFile
     ]
 
-  assertFileOccurences 1 "TxSignedShelley" signedTransactionFile
-  assertEndsWithSingleNewline signedTransactionFile
+  H.assertFileOccurences 1 "TxSignedShelley" signedTransactionFile
+  H.assertEndsWithSingleNewline signedTransactionFile
 
   -- Sign for a testnet with a testnet network magic of 11, but use two signing keys
 
@@ -45,8 +48,8 @@ golden_shelleyTransactionSign = propertyOnce $ moduleWorkspace "tmp" $ \tempDir 
     , "--tx-file", signedTransactionFile
     ]
 
-  assertFileOccurences 1 "TxSignedShelley" signedTransactionFile
-  assertEndsWithSingleNewline signedTransactionFile
+  H.assertFileOccurences 1 "TxSignedShelley" signedTransactionFile
+  H.assertEndsWithSingleNewline signedTransactionFile
 
   -- Sign a pool registration transaction.
   -- TODO: This needs to use an unsigned tx with a registration certificate
@@ -61,5 +64,5 @@ golden_shelleyTransactionSign = propertyOnce $ moduleWorkspace "tmp" $ \tempDir 
     , "--tx-file", transactionPoolRegSignedFile
     ]
 
-  assertFileOccurences 1 "TxSignedShelley" transactionPoolRegSignedFile
-  assertEndsWithSingleNewline transactionPoolRegSignedFile
+  H.assertFileOccurences 1 "TxSignedShelley" transactionPoolRegSignedFile
+  H.assertEndsWithSingleNewline transactionPoolRegSignedFile

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -1,108 +1,47 @@
-{-# LANGUAGE TypeApplications #-}
-
 module Test.OptParse
   ( checkTextEnvelopeFormat
-  , assertEndsWithSingleNewline
-  , assertFileLines
-  , assertFileOccurences
-  , assertFilesExist
   , equivalence
   , execCardanoCLI
-  , formatIso8601
   , propertyOnce
-  , workspace
-  , moduleWorkspace
   , withSnd
-  , newFileWithContents
-  , noteEval
-  , noteEvalM
   , noteInputFile
   , noteTempFile
-  , readFile
   ) where
 
 import           Cardano.Api.TextView (TextView (..), TextViewError, TextViewType (..))
 import           Cardano.Api.Typed (FileError, displayError, readTextEnvelopeOfTypeFromFile)
 import           Cardano.Prelude hiding (lines, readFile, stderr, stdout)
+import           Control.Monad.Catch
 import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
 import           Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
 import           Hedgehog.Internal.Source (getCaller)
 import           Prelude (String)
-import           System.Directory (doesFileExist)
 
-import qualified Control.DeepSeq as CSD
-import qualified Control.Exception as E
-import qualified Data.List as L
-import qualified Data.Maybe as M
-import qualified Data.Time.Clock as DT
-import qualified Data.Time.Format as DT
 import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Process as H
 import qualified Hedgehog.Internal.Property as H
 import qualified Prelude
-import qualified System.Directory as IO
-import qualified System.Environment as IO
-import qualified System.Exit as IO
-import qualified System.IO as IO
-import qualified System.IO.Temp as IO
-import qualified System.Process as IO
-
--- | Format argument for a shell CLI command.
---
--- This includes automatically embedding string in double quotes if necessary, including any necessary escaping.
---
--- Note, this function does not cover all the edge cases for shell processing, so avoid use in production code.
-argQuote :: String -> String
-argQuote arg = if ' ' `elem` arg || '"' `elem` arg || '$' `elem` arg
-  then "\"" <> escape arg <> "\""
-  else arg
-  where escape :: String -> String
-        escape ('"':xs) = '\\':'"':escape xs
-        escape ('\\':xs) = '\\':'\\':escape xs
-        escape ('\n':xs) = '\\':'n':escape xs
-        escape ('\r':xs) = '\\':'r':escape xs
-        escape ('\t':xs) = '\\':'t':escape xs
-        escape ('$':xs) = '\\':'$':escape xs
-        escape (x:xs) = x:escape xs
-        escape "" = ""
 
 -- | Execute cardano-cli via the command line.
 --
 -- Waits for the process to finish and returns the stdout.
 execCardanoCLI
-  :: HasCallStack
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => [String]
   -- ^ Arguments to the CLI command
-  -> H.PropertyT IO String
+  -> m String
   -- ^ Captured stdout
-execCardanoCLI arguments = do
-  maybeCardanoCli <- liftIO $ IO.lookupEnv "CARDANO_CLI"
-  (exitResult, stdout, stderr) <- case maybeCardanoCli of
-    Just cardanoCli -> liftIO $ IO.readProcessWithExitCode cardanoCli arguments ""
-    Nothing -> liftIO $ IO.readProcessWithExitCode "cabal" ("exec":"--":"cardano-cli":arguments) ""
-  case exitResult of
-    IO.ExitFailure exitCode -> failWithCustom callStack Nothing . Prelude.unlines $
-      [ "Process exited with non-zero exit-code"
-      , "━━━━ command ━━━━"
-      , "cardano-cli " <> intercalate " " (fmap argQuote arguments)
-      , "━━━━ stdout ━━━━"
-      , stdout
-      , "━━━━ stderr ━━━━"
-      , stderr
-      , "━━━━ exit code ━━━━"
-      , show @Int exitCode
-      ]
-    IO.ExitSuccess -> return stdout
+execCardanoCLI = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI"
 
 -- | Checks that the 'tvType' and 'tvDescription' are equivalent between two files.
 checkTextEnvelopeFormat
-  :: HasCallStack
+  :: (MonadTest m, MonadIO m, HasCallStack)
   => TextViewType
   -> FilePath
   -> FilePath
-  -> H.PropertyT IO ()
+  -> m ()
 checkTextEnvelopeFormat tve reference created = do
-
   eRefTextEnvelope <- liftIO $ readTextEnvelopeOfTypeFromFile tve reference
   refTextEnvelope <- handleTextEnvelope eRefTextEnvelope
 
@@ -111,11 +50,11 @@ checkTextEnvelopeFormat tve reference created = do
 
   typeTitleEquivalence refTextEnvelope createdTextEnvelope
  where
-   handleTextEnvelope :: Either (FileError TextViewError) TextView -> H.PropertyT IO TextView
+   handleTextEnvelope :: MonadTest m => Either (FileError TextViewError) TextView -> m TextView
    handleTextEnvelope (Right refTextEnvelope) = return refTextEnvelope
    handleTextEnvelope (Left fileErr) = failWithCustom callStack Nothing . displayError $ fileErr
 
-   typeTitleEquivalence :: TextView -> TextView -> H.PropertyT IO ()
+   typeTitleEquivalence :: MonadTest m => TextView -> TextView -> m ()
    typeTitleEquivalence (TextView refType refTitle _) (TextView createdType createdTitle _) = do
      equivalence refType createdType
      equivalence refTitle createdTitle
@@ -127,114 +66,22 @@ checkTextEnvelopeFormat tve reference created = do
 cardanoCliPath :: FilePath
 cardanoCliPath = "cardano-cli"
 
--- | Evaluate the value 'f' and annotate the value returned.
-noteEval :: (Show a, Monad m, HasCallStack) => a -> H.PropertyT m a
-noteEval a = withFrozenCallStack (H.annotateShow a >> pure a)
-
--- | Run the computation 'f' and annotate the value returned.
-noteEvalM :: (Show a, Monad m, HasCallStack) => H.PropertyT m a -> H.PropertyT m a
-noteEvalM f = withFrozenCallStack $ do
-  a <- f
-  H.annotateShow a
-  return a
-
 -- | Return the input file path after annotating it relative to the project root directory
-noteInputFile :: (Monad m, HasCallStack) => FilePath -> H.PropertyT m FilePath
+noteInputFile :: (MonadTest m, HasCallStack) => FilePath -> m FilePath
 noteInputFile filePath = withFrozenCallStack $ do
   H.annotate $ cardanoCliPath <> "/" <> filePath
   return filePath
 
 -- | Return the test file path after annotating it relative to the project root directory
-noteTempFile :: (Monad m, HasCallStack) => FilePath -> FilePath -> H.PropertyT m FilePath
+noteTempFile :: (MonadTest m, HasCallStack) => FilePath -> FilePath -> m FilePath
 noteTempFile tempDir filePath = withFrozenCallStack $ do
   let relPath = tempDir <> "/" <> filePath
   H.annotate $ cardanoCliPath <> "/" <> relPath
   return relPath
 
--- | Create a new file with the given text contents at the specified path
-newFileWithContents :: MonadIO m => FilePath -> String -> m FilePath
-newFileWithContents filePath contents = liftIO $ IO.writeFile filePath contents >> return filePath
-
--- | Create a workspace directory which will exist for at least the duration of
--- the supplied block.
---
--- The directory will have the supplied prefix but contain a generated random
--- suffix to prevent interference between tests
---
--- The directory will be deleted if the block succeeds, but left behind if
--- the block fails.
-workspace :: HasCallStack => FilePath -> (FilePath -> H.PropertyT IO ()) -> H.PropertyT IO ()
-workspace prefixPath f = withFrozenCallStack $ do
-  liftIO $ IO.createDirectoryIfMissing True prefixPath
-  ws <- liftIO $ IO.createTempDirectory prefixPath "test"
-  H.annotate $ "Workspace: " <> cardanoCliPath <> "/" <> ws
-  f ws
-  liftIO $ IO.removeDirectoryRecursive ws
-
--- | Create a workspace directory which will exist for at least the duration of
--- the supplied block.
---
--- The directory will have the prefix as "$prefixPath/$moduleName" but contain a generated random
--- suffix to prevent interference between tests
---
--- The directory will be deleted if the block succeeds, but left behind if
--- the block fails.
-moduleWorkspace :: HasCallStack => FilePath -> (FilePath -> H.PropertyT IO ()) -> H.PropertyT IO ()
-moduleWorkspace prefixPath f = withFrozenCallStack $ do
-  let srcModule = M.fromMaybe "UnknownModule" (fmap (GHC.srcLocModule . snd) (M.listToMaybe (getCallStack callStack)))
-  workspace (prefixPath <> "/" <> srcModule) f
-
 -- | Return the supply value with the result of the supplied function as a tuple
 withSnd :: (a -> b) -> a -> (a, b)
 withSnd f a = (a, f a)
-
--- | Format the given time as an ISO 8601 date-time string
-formatIso8601 :: DT.UTCTime -> String
-formatIso8601 = DT.formatTime DT.defaultTimeLocale (DT.iso8601DateFormat (Just "%H:%M:%SZ"))
-
--- | Assert the file contains the given number of occurrences of the given string
-readFile :: HasCallStack => FilePath -> H.PropertyT IO String
-readFile filename = withFrozenCallStack $ H.evalIO $ E.evaluate . CSD.force =<< IO.readFile filename
-
--- | Checks if all files gives exists. If this fails, all files are deleted.
-assertFilesExist :: HasCallStack => [FilePath] -> H.PropertyT IO ()
-assertFilesExist [] = return ()
-assertFilesExist (file:rest) = do
-  exists <- liftIO $ doesFileExist file
-  if exists == True
-    then withFrozenCallStack $ assertFilesExist rest
-    else failWithCustom callStack Nothing (file <> " has not been successfully created.")
-
--- | Assert the file contains the given number of occurrences of the given string
-assertFileOccurences :: HasCallStack => Int -> String -> FilePath -> H.PropertyT IO ()
-assertFileOccurences n s fp = withFrozenCallStack $ do
-  contents <- H.evalIO $ IO.readFile fp
-
-  length (filter (s `L.isInfixOf`) (L.lines contents)) H.=== n
-
--- | Assert the file contains the given number of occurrences of the given string
-assertFileLines :: HasCallStack => (Int -> Bool) -> FilePath -> H.PropertyT IO ()
-assertFileLines p fp = withFrozenCallStack $ do
-  contents <- H.evalIO $ IO.readFile fp
-
-  let lines = L.lines contents
-
-  let len = case reverse lines of
-        "":xs -> length xs
-        xs -> length xs
-
-  when (not (p len)) $ do
-    failWithCustom callStack Nothing (fp <> " has an unexpected number of lines")
-
--- | Assert the file contains the given number of occurrences of the given string
-assertEndsWithSingleNewline :: HasCallStack => FilePath -> H.PropertyT IO ()
-assertEndsWithSingleNewline fp = withFrozenCallStack $ do
-  contents <- H.evalIO $ IO.readFile fp
-
-  case reverse contents of
-    '\n':'\n':_ -> failWithCustom callStack Nothing (fp <> " ends with too many newlines.")
-    '\n':_ -> return ()
-    _ -> failWithCustom callStack Nothing (fp <> " must end with newline.")
 
 -- These were lifted from hedgehog and slightly modified
 
@@ -243,10 +90,10 @@ propertyOnce =  H.withTests 1 . H.property
 
 -- | Check for equivalence between two types and perform a file cleanup on failure.
 equivalence
-  :: (Eq a, Show a, HasCallStack)
+  :: (MonadTest m, Eq a, Show a, HasCallStack)
   => a
   -> a
-  -> H.PropertyT IO ()
+  -> m ()
 equivalence x y = do
   ok <- H.eval (x == y)
   if ok
@@ -259,7 +106,7 @@ failWithCustom cs mdiff msg =
   liftTest $ mkTest (Left $ H.Failure (getCaller cs) msg mdiff, mempty)
 
 -- | Fails with an error that shows the difference between two values.
-failDiffCustom :: Show a => CallStack -> a -> a -> H.PropertyT IO ()
+failDiffCustom :: (MonadTest m, Show a) => CallStack -> a -> a -> m ()
 failDiffCustom cS x y =
   case valueDiff <$> mkValue x <*> mkValue y of
     Nothing ->

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -10,55 +10,6 @@ license-files:          LICENSE
                         NOTICE
 build-type:             Simple
 
-library
-  hs-source-dirs:       src
-  build-depends:        base >= 4.12 && < 5
-                      , aeson
-                      , async
-                      , bytestring
-                      , deepseq
-                      , directory
-                      , exceptions
-                      , hedgehog
-                      , mmorph
-                      , network
-                      , process
-                      , random
-                      , resourcet
-                      , temporary
-                      , text
-                      , time
-                      , unliftio
-                      , unordered-containers
-                      , Win32-network
-  exposed-modules:      Chairman.Aeson
-                        Chairman.CallStack
-                        Chairman.Cli
-                        Chairman.Hedgehog.Base
-                        Chairman.Hedgehog.Concurrent
-                        Chairman.Hedgehog.File
-                        Chairman.Hedgehog.Network
-                        Chairman.Hedgehog.Process
-                        Chairman.IO.File
-                        Chairman.IO.Network.NamedPipe
-                        Chairman.IO.Network.Socket
-                        Chairman.IO.Network.Sprocket
-                        Chairman.IO.Process
-                        Chairman.Monad
-                        Chairman.OS
-                        Chairman.Plan
-                        Chairman.String
-                        Chairman.Time
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-
-
 executable cardano-node-chairman
   hs-source-dirs:      app
   main-is:             cardano-node-chairman.hs
@@ -107,11 +58,12 @@ test-suite tests
   build-depends:        base >= 4.12 && < 5
                       , aeson
                       , async
-                      , cardano-node-chairman
                       , containers
                       , directory
+                      , exceptions
                       , filepath
                       , hedgehog
+                      , hedgehog-extras
                       , mmorph
                       , network
                       , process
@@ -125,6 +77,7 @@ test-suite tests
   other-modules:        Test.Cardano.Node.Chairman.Byron
                         Test.Cardano.Node.Chairman.ByronShelley
                         Test.Cardano.Node.Chairman.Shelley
+                        Test.Cardano.Process
                         Test.Common.NetworkSpec
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Byron.hs
@@ -6,8 +6,6 @@ module Test.Cardano.Node.Chairman.Byron
   ( tests
   ) where
 
-import           Chairman.IO.Network.Sprocket (Sprocket (..))
-import           Chairman.Time
 import           Control.Monad
 import           Data.Bool
 import           Data.Function
@@ -19,23 +17,26 @@ import           Data.Semigroup
 import           Data.String (String)
 import           GHC.Num
 import           Hedgehog (Property, discover)
+import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
+import           Hedgehog.Extras.Stock.Time
 import           System.IO (IO)
 import           Text.Show
 
-import qualified Chairman.Hedgehog.Base as H
-import qualified Chairman.Hedgehog.File as H
-import qualified Chairman.Hedgehog.Process as H
-import qualified Chairman.IO.File as IO
-import qualified Chairman.IO.Network.Socket as IO
-import qualified Chairman.IO.Network.Sprocket as IO
-import qualified Chairman.String as S
 import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.File as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Stock.String as S
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.FilePath.Posix as FP
 import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
+import qualified Test.Cardano.Process as H
 
 {- HLINT ignore "Redundant <&>" -}
 
@@ -136,7 +137,7 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
     si <- H.noteShow $ show @Int i
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir <> "/node-" <> si)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.assertIO $ IO.doesSprocketExist sprocket
+    H.assertByDeadlineIO deadline $ IO.doesSprocketExist sprocket
 
   forM_ nodeIndexes $ \i -> do
     si <- H.noteShow $ show @Int i

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/ByronShelley.hs
@@ -9,8 +9,6 @@ module Test.Cardano.Node.Chairman.ByronShelley
   ( tests
   ) where
 
-import           Chairman.IO.Network.Sprocket (Sprocket (..))
-import           Chairman.Time
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson ((.=))
@@ -29,28 +27,30 @@ import           GHC.Float
 import           GHC.Num
 import           GHC.Real
 import           Hedgehog (Property, discover, (===))
+import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
+import           Hedgehog.Extras.Stock.Time
 import           System.Exit (ExitCode (..))
 import           System.FilePath.Posix ((</>))
 import           System.IO (IO)
 import           Text.Read
 import           Text.Show
 
-import qualified Chairman.Aeson as J
-import qualified Chairman.Hedgehog.Base as H
-import qualified Chairman.Hedgehog.Concurrent as H
-import qualified Chairman.Hedgehog.File as H
-import qualified Chairman.Hedgehog.Process as H
-import qualified Chairman.IO.File as IO
-import qualified Chairman.IO.Network.Socket as IO
-import qualified Chairman.IO.Network.Sprocket as IO
-import qualified Chairman.OS as OS
-import qualified Chairman.String as S
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.Aeson as J
+import qualified Hedgehog.Extras.Stock.IO.File as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Stock.OS as OS
+import qualified Hedgehog.Extras.Stock.String as S
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Concurrent as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Environment as IO
 import qualified System.FilePath.Posix as FP
@@ -58,6 +58,7 @@ import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified System.Random as IO
+import qualified Test.Cardano.Process as H
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
@@ -613,7 +614,7 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
   forM_ allNodes $ \node -> do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.assertIO $ IO.doesSprocketExist sprocket
+    H.assertByDeadlineIO deadline $ IO.doesSprocketExist sprocket
 
   forM_ allNodes $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"

--- a/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Node/Chairman/Shelley.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Node.Chairman.Shelley
   ( tests
   ) where
 
-import           Chairman.Aeson
-import           Chairman.IO.Network.Sprocket (Sprocket (..))
 import           Control.Monad
 import           Data.Aeson
 import           Data.Bool
@@ -23,29 +21,32 @@ import           Data.Semigroup
 import           Data.String (String)
 import           GHC.Float
 import           Hedgehog (Property, discover, (===))
+import           Hedgehog.Extras.Stock.Aeson
+import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           System.Exit (ExitCode (..))
 import           System.IO (IO)
 import           Text.Read
 import           Text.Show
 
-import qualified Chairman.Hedgehog.Base as H
-import qualified Chairman.Hedgehog.File as H
-import qualified Chairman.Hedgehog.Process as H
-import qualified Chairman.IO.File as IO
-import qualified Chairman.IO.Network.Socket as IO
-import qualified Chairman.IO.Network.Sprocket as IO
-import qualified Chairman.String as S
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.File as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Stock.String as S
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.FilePath.Posix as FP
 import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
+import qualified Test.Cardano.Process as H
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
@@ -364,7 +365,7 @@ prop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
   forM_ allNodes $ \node -> do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir <> "/" <> node)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.assertIO $ IO.doesSprocketExist sprocket
+    H.assertByDeadlineIO deadline $ IO.doesSprocketExist sprocket
 
   forM_ allNodes $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"

--- a/cardano-node-chairman/test/Test/Cardano/Process.hs
+++ b/cardano-node-chairman/test/Test/Cardano/Process.hs
@@ -1,0 +1,54 @@
+module Test.Cardano.Process
+  ( execCli
+  , procCli
+  , procNode
+  , procChairman
+  ) where
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.IO.Class (MonadIO)
+import           Data.Function
+import           Data.String
+import           GHC.Stack (HasCallStack)
+import           Hedgehog (MonadTest)
+import           System.Process (CreateProcess)
+
+import qualified GHC.Stack as GHC
+import qualified Hedgehog.Extras.Test.Process as H
+
+-- | Run cardano-cli, returning the stdout
+execCli
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [String]
+  -> m String
+execCli = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI"
+
+-- | Create a 'CreateProcess' describing how to start the cardano-cli process
+-- and an argument list.
+procCli
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [String]
+  -- ^ Arguments to the CLI command
+  -> m CreateProcess
+  -- ^ Captured stdout
+procCli = GHC.withFrozenCallStack $ H.procFlex "cardano-cli" "CARDANO_CLI"
+
+-- | Create a 'CreateProcess' describing how to start the cardano-node process
+-- and an argument list.
+procNode
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [String]
+  -- ^ Arguments to the CLI command
+  -> m CreateProcess
+  -- ^ Captured stdout
+procNode = GHC.withFrozenCallStack $ H.procFlex "cardano-node" "CARDANO_NODE"
+
+-- | Create a 'CreateProcess' describing how to start the cardano-node-chairman process
+-- and an argument list.
+procChairman
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [String]
+  -- ^ Arguments to the CLI command
+  -> m CreateProcess
+  -- ^ Captured stdout
+procChairman = GHC.withFrozenCallStack $ H.procFlex "cardano-node-chairman" "CARDANO_NODE_CHAIRMAN"

--- a/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
+++ b/cardano-node-chairman/test/Test/Common/NetworkSpec.hs
@@ -19,12 +19,12 @@ import           Network.Socket (Socket)
 import           Prelude (error)
 import           System.IO (IO)
 
-import qualified Chairman.Hedgehog.Base as H
-import qualified Chairman.Hedgehog.Network as H
-import qualified Chairman.IO.Network.Socket as IO
 import qualified Control.Monad.Trans.Resource as IO
 import qualified Data.List as L
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Network as H
 import qualified Network.Socket as IO
 import qualified System.Random as IO
 import qualified UnliftIO.Exception as IO

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -86,6 +86,7 @@ library
                      , containers
                      , directory
                      , filepath
+                     , hedgehog-extras
                      , hostname
                      , iproute
                      , io-sim-classes

--- a/hedgehog-extras/LICENSE
+++ b/hedgehog-extras/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hedgehog-extras/NOTICE
+++ b/hedgehog-extras/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2020 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/hedgehog-extras/hedgehog-extras.cabal
+++ b/hedgehog-extras/hedgehog-extras.cabal
@@ -1,0 +1,59 @@
+cabal-version: 2.4
+
+name:                   hedgehog-extras
+version:                1.19.1
+description:            The cardano full node
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+
+library
+  hs-source-dirs:       src
+  build-depends:        base >= 4.12 && < 5
+                      , aeson
+                      , async
+                      , bytestring
+                      , deepseq
+                      , directory
+                      , exceptions
+                      , hedgehog
+                      , mmorph
+                      , network
+                      , process
+                      , random
+                      , resourcet
+                      , temporary
+                      , text
+                      , time
+                      , unliftio
+                      , unordered-containers
+                      , Win32-network
+  exposed-modules:      Hedgehog.Extras.Internal.Cli
+                        Hedgehog.Extras.Internal.Plan
+                        Hedgehog.Extras.Stock.Aeson
+                        Hedgehog.Extras.Stock.CallStack
+                        Hedgehog.Extras.Stock.IO.File
+                        Hedgehog.Extras.Stock.IO.Network.NamedPipe
+                        Hedgehog.Extras.Stock.IO.Network.Socket
+                        Hedgehog.Extras.Stock.IO.Network.Sprocket
+                        Hedgehog.Extras.Stock.IO.Process
+                        Hedgehog.Extras.Stock.Monad
+                        Hedgehog.Extras.Stock.OS
+                        Hedgehog.Extras.Stock.String
+                        Hedgehog.Extras.Stock.Time
+                        Hedgehog.Extras.Test.Base
+                        Hedgehog.Extras.Test.Concurrent
+                        Hedgehog.Extras.Test.File
+                        Hedgehog.Extras.Test.Network
+                        Hedgehog.Extras.Test.Process
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat

--- a/hedgehog-extras/src/Hedgehog/Extras/Internal/Cli.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Internal/Cli.hs
@@ -1,4 +1,4 @@
-module Chairman.Cli
+module Hedgehog.Extras.Internal.Cli
   ( argQuote
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Internal/Plan.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Internal/Plan.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Chairman.Plan
+module Hedgehog.Extras.Internal.Plan
   ( Plan(..)
   , Component(..)
   ) where

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/Aeson.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/Aeson.hs
@@ -1,4 +1,4 @@
-module Chairman.Aeson
+module Hedgehog.Extras.Stock.Aeson
   ( rewriteObject
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/CallStack.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/CallStack.hs
@@ -1,4 +1,4 @@
-module Chairman.CallStack
+module Hedgehog.Extras.Stock.CallStack
   ( callerModuleName
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/File.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/File.hs
@@ -1,4 +1,4 @@
-module Chairman.IO.File
+module Hedgehog.Extras.Stock.IO.File
   ( fileContains
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/NamedPipe.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/NamedPipe.hs
@@ -3,7 +3,7 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 
-module Chairman.IO.Network.NamedPipe
+module Hedgehog.Extras.Stock.IO.Network.NamedPipe
   ( doesNamedPipeExist
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/Socket.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/Socket.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Chairman.IO.Network.Socket
+module Hedgehog.Extras.Stock.IO.Network.Socket
   ( doesSocketExist
   , isPortOpen
   , canConnect

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/Sprocket.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Network/Sprocket.hs
@@ -1,4 +1,4 @@
-module Chairman.IO.Network.Sprocket
+module Hedgehog.Extras.Stock.IO.Network.Sprocket
   ( Sprocket(..)
   , doesSprocketExist
   , sprocketArgumentName
@@ -6,7 +6,6 @@ module Chairman.IO.Network.Sprocket
   , maxSprocketArgumentNameLength
   ) where
 
-import           Chairman.OS
 import           Data.Bool
 import           Data.Char
 import           Data.Eq
@@ -14,11 +13,12 @@ import           Data.Functor
 import           Data.Int
 import           Data.Semigroup
 import           Data.String (String)
+import           Hedgehog.Extras.Stock.OS
 import           System.IO (FilePath, IO)
 import           Text.Show
 
-import qualified Chairman.IO.Network.NamedPipe as IO
-import qualified Chairman.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.NamedPipe as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
 
 -- | Socket emulation.  On Posix it represents a socket.  On Windows it represents a named pipe.
 data Sprocket = Sprocket

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Process.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/IO/Process.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Chairman.IO.Process
+module Hedgehog.Extras.Stock.IO.Process
   ( maybeWaitForProcess
   , waitSecondsForProcess
   , TimedOut(..)

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/Monad.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/Monad.hs
@@ -1,4 +1,4 @@
-module Chairman.Monad
+module Hedgehog.Extras.Stock.Monad
   ( forceM
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/OS.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/OS.hs
@@ -1,4 +1,4 @@
-module Chairman.OS
+module Hedgehog.Extras.Stock.OS
   ( isWin32
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/String.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/String.hs
@@ -1,4 +1,4 @@
-module Chairman.String
+module Hedgehog.Extras.Stock.String
   ( strip
   , lastLine
   , firstLine

--- a/hedgehog-extras/src/Hedgehog/Extras/Stock/Time.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Stock/Time.hs
@@ -1,17 +1,24 @@
 {-# LANGUAGE TypeApplications #-}
 
-module Chairman.Time
+module Hedgehog.Extras.Stock.Time
   ( showUTCTimeSeconds
+  , formatIso8601
   ) where
 
 import           Data.Int
+import           Data.Maybe
 import           Data.String
 import           Data.Time.Clock (UTCTime)
 import           Prelude (floor)
 import           Text.Show
 
 import qualified Data.Time.Clock.POSIX as DTC
+import qualified Data.Time.Format as DT
 
 -- | Show 'UTCTime' in seconds since epoch
 showUTCTimeSeconds :: UTCTime -> String
 showUTCTimeSeconds time = show @Int64 (floor (DTC.utcTimeToPOSIXSeconds time))
+
+-- | Format the given time as an ISO 8601 date-time string
+formatIso8601 :: UTCTime -> String
+formatIso8601 = DT.formatTime DT.defaultTimeLocale (DT.iso8601DateFormat (Just "%H:%M:%SZ"))

--- a/hedgehog-extras/src/Hedgehog/Extras/Test/Base.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Test/Base.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Chairman.Hedgehog.Base
+module Hedgehog.Extras.Test.Base
   ( propertyOnce
 
   , workspace
@@ -41,8 +41,6 @@ module Chairman.Hedgehog.Base
   , release
   ) where
 
-import           Chairman.CallStack
-import           Chairman.Monad
 import           Control.Monad
 import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
@@ -63,6 +61,8 @@ import           Data.Traversable
 import           Data.Tuple
 import           GHC.Stack (CallStack, HasCallStack)
 import           Hedgehog (MonadTest)
+import           Hedgehog.Extras.Stock.CallStack
+import           Hedgehog.Extras.Stock.Monad
 import           Hedgehog.Internal.Property (Diff, liftTest, mkTest)
 import           Hedgehog.Internal.Source (getCaller)
 import           System.IO (FilePath, IO)

--- a/hedgehog-extras/src/Hedgehog/Extras/Test/Concurrent.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Test/Concurrent.hs
@@ -1,4 +1,4 @@
-module Chairman.Hedgehog.Concurrent
+module Hedgehog.Extras.Test.Concurrent
   ( threadDelay
   ) where
 

--- a/hedgehog-extras/src/Hedgehog/Extras/Test/Network.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Test/Network.hs
@@ -1,4 +1,4 @@
-module Chairman.Hedgehog.Network
+module Hedgehog.Extras.Test.Network
   ( doesFileExists
   , isPortOpen
   , doesSocketExist
@@ -15,10 +15,10 @@ import           GHC.Stack (HasCallStack)
 import           Hedgehog (MonadTest)
 import           System.IO (FilePath)
 
-import qualified Chairman.Hedgehog.Base as H
-import qualified Chairman.IO.Network.Socket as IO
 import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
+import qualified Hedgehog.Extras.Test.Base as H
 import qualified System.Directory as IO
 
 -- | Test if a file exists


### PR DESCRIPTION
Increase test code re-use by moving test support code into separate common `hedgehog-extras` library.

* Move generic test code into the new `hedgehog-extras` library with a module structure consistent with its genericity.
* Both `cardano-node-chairman` and `cardano-cli` modified to use the new library
* Avoid using `System.IO` libraries directly in `cardano-cli` because exceptions cause test annotations to show making tests difficult.  Instead use equivalent functions from `hedgehog-extras`
* Re-implement `execCardanoCLI` in terms of `execFlex` which has the advantage of not depending on `cabal exec` which occasionally causes problems in terms of pollution of `stdout`