### PR TITLE
Implement partial options monoid configuration technique in cardano-node

### DIFF
--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -5,7 +5,7 @@
 
 import           Cardano.Chairman (chairmanTest)
 import           Cardano.Chairman.Options
-import           Cardano.Node.Types
+import           Cardano.Node.Configuration.POM (parseNodeConfigurationFP, pncProtocol)
 import           Cardano.Prelude hiding (option)
 import           Control.Tracer (stdoutTracer)
 import           Options.Applicative
@@ -22,9 +22,13 @@ main = do
     , caNetworkMagic
     } <- execParser opts
 
-  nc <- liftIO $ parseNodeConfigurationFP caConfigYaml
+  partialNc <- liftIO . parseNodeConfigurationFP $ Just caConfigYaml
 
-  let someNodeClientProtocol = mkNodeClientProtocol $ ncProtocol nc
+  ptcl <- case pncProtocol partialNc of
+            Left err -> panic $ "Chairman error: " <> err
+            Right protocol -> return protocol
+
+  let someNodeClientProtocol = mkNodeClientProtocol ptcl
 
   chairmanTest
     stdoutTracer

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -16,12 +16,11 @@ import           Data.Version (showVersion)
 import           Paths_cardano_node (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
 
-import           Cardano.Node.Configuration.Logging (createLoggingLayer)
+import           Cardano.Node.Configuration.POM (PartialNodeConfiguration)
 import           Cardano.Node.Handlers.TopLevel
 import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
                      renderHelpDoc)
 import           Cardano.Node.Run (runNode)
-import           Cardano.Node.Types (NodeCLI (..))
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
@@ -56,7 +55,7 @@ main = toplevelExceptionHandler $ do
         <$$> parserHelpOptions nodeCLIParser
 
 
-data Command = RunCmd NodeCLI
+data Command = RunCmd PartialNodeConfiguration
              | VersionCmd
 
 -- Yes! A --version flag or version command. Either guess is right!
@@ -91,18 +90,8 @@ runVersionCommand =
     renderVersion = Text.pack . showVersion
 
 
-runRunCommand :: NodeCLI -> IO ()
-runRunCommand npm = do
-
-  eLoggingLayer <- runExceptT $ createLoggingLayer
-                     (Text.pack (showVersion version))
-                     npm
-
-  loggingLayer <- case eLoggingLayer of
-                    Left err -> putTextLn (show err) >> exitFailure
-                    Right res -> return res
-
-  liftIO $ runNode loggingLayer npm
+runRunCommand :: PartialNodeConfiguration -> IO ()
+runRunCommand pnc = liftIO $ runNode pnc
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -32,8 +32,9 @@ library
 
   hs-source-dirs:      src
 
-  exposed-modules:     Cardano.Node.Configuration.Topology
-                       Cardano.Node.Configuration.Logging
+  exposed-modules:     Cardano.Node.Configuration.Logging
+                       Cardano.Node.Configuration.POM
+                       Cardano.Node.Configuration.Topology
                        Cardano.Node.Handlers.Shutdown
                        Cardano.Node.Handlers.TopLevel
                        Cardano.Node.Orphans
@@ -86,6 +87,7 @@ library
                      , containers
                      , directory
                      , filepath
+                     , generic-data
                      , hedgehog-extras
                      , hostname
                      , iproute
@@ -145,7 +147,8 @@ library cardano-node-config
 
   hs-source-dirs:      src
 
-  exposed-modules:     Cardano.Node.Orphans
+  exposed-modules:     Cardano.Node.Configuration.POM
+                       Cardano.Node.Orphans
                        Cardano.Node.Protocol.Types
                        Cardano.Node.Types
                        Cardano.Tracing.Config
@@ -168,9 +171,11 @@ library cardano-node-config
                      , cardano-slotting
                      , containers
                      , filepath
+                     , generic-data
                      , iohk-monitoring
                      , iproute
                      , network
+                     , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-cardano
                      , ouroboros-consensus-byron

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -304,6 +304,7 @@ test-suite cardano-node-test
 
   other-modules:        Test.Cardano.Node.Gen
                         Test.Cardano.Node.Json
+                        Test.Cardano.Node.POM
 
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-node/chairman/chairman.hs
+++ b/cardano-node/chairman/chairman.hs
@@ -23,6 +23,7 @@ import           Cardano.Api.Protocol.Shelley
 import           Cardano.Api.Protocol.Types
 import           Cardano.Api.Typed (NetworkMagic (..))
 import           Cardano.Chairman (chairmanTest)
+import           Cardano.Node.Configuration.POM (parseNodeConfigurationFP, pncProtocol)
 import           Cardano.Node.Protocol.Types (Protocol (..))
 import           Cardano.Node.Types
 
@@ -37,9 +38,13 @@ main = do
                  , caNetworkMagic
                  } <- execParser opts
 
-    nc <- liftIO $ parseNodeConfigurationFP caConfigYaml
+    partialNc <- liftIO . parseNodeConfigurationFP $ Just caConfigYaml
 
-    let someNodeClientProtocol = mkNodeClientProtocol $ ncProtocol nc
+    ptcl <- case pncProtocol partialNc of
+              Left err -> panic $ "Chairman error: " <> err
+              Right protocol -> return protocol
+
+    let someNodeClientProtocol = mkNodeClientProtocol ptcl
 
     chairmanTest
       stdoutTracer

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -64,6 +64,7 @@ import           Cardano.BM.Trace (Trace, appendName, traceNamedObject)
 import qualified Cardano.BM.Trace as Trace
 
 import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
 import           Cardano.Node.Types
 
 --------------------------------
@@ -124,21 +125,18 @@ loggingCLIConfiguration = maybe emptyConfig readConfig
 -- | Create logging feature for `cardano-node`
 createLoggingLayer
   :: Text
-  -> NodeCLI
+  -> NodeConfiguration
   -> ExceptT ConfigError IO LoggingLayer
-createLoggingLayer ver nodecli@NodeCLI{configFile} = do
-
-  -- TODO:  we shouldn't be parsing configuration multiple times!
-  nodeConfig <- liftIO $ parseNodeConfiguration nodecli
+createLoggingLayer ver nodeConfig' = do
 
   logConfig <- loggingCLIConfiguration $
-    if ncLoggingSwitch nodeConfig
+    if ncLoggingSwitch nodeConfig'
     -- Re-interpret node config again, as logging 'Configuration':
-    then Just $ unConfigPath configFile
+    then Just . unConfigPath $ ncConfigFile nodeConfig'
     else Nothing
 
   -- adapt logging configuration before setup
-  liftIO $ adaptLogConfig nodeConfig logConfig
+  liftIO $ adaptLogConfig nodeConfig' logConfig
 
   -- These have to be set before the switchboard is set up.
   liftIO $ do
@@ -148,14 +146,14 @@ createLoggingLayer ver nodecli@NodeCLI{configFile} = do
   (baseTrace, switchBoard) <- liftIO $ setupTrace_ logConfig "cardano"
 
   let loggingEnabled :: Bool
-      loggingEnabled = ncLoggingSwitch nodeConfig
+      loggingEnabled = ncLoggingSwitch nodeConfig'
       trace :: Trace IO Text
       trace = if loggingEnabled
               then baseTrace
               else Trace.nullTracer
 
   when loggingEnabled $ liftIO $
-    loggingPreInit nodeConfig logConfig switchBoard trace
+    loggingPreInit nodeConfig' logConfig switchBoard trace
 
   pure $ mkLogLayer logConfig switchBoard trace
  where

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -65,7 +65,7 @@ data NodeConfiguration
        , ncLoggingSwitch  :: !Bool
        , ncLogMetrics     :: !Bool
        , ncTraceConfig    :: !TraceOptions
-       } deriving Show
+       } deriving (Eq, Show)
 
 
 data PartialNodeConfiguration

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -1,0 +1,315 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+{-# OPTIONS_GHC -Wno-noncanonical-monoid-instances #-}
+
+module Cardano.Node.Configuration.POM
+  ( NodeConfiguration (..)
+  , PartialNodeConfiguration(..)
+  , defaultPartialNodeConfiguration
+  , lastOption
+  , makeNodeConfiguration
+  , parseNodeConfigurationFP
+  , pncProtocol
+  , ncProtocol
+  )
+where
+
+import           Cardano.Prelude
+import           Prelude (String)
+
+import           Control.Monad (fail)
+import           Data.Aeson
+import           Data.Semigroup (Semigroup (..))
+import           Data.Yaml (decodeFileThrow)
+import           Generic.Data (gmappend)
+import           Generic.Data.Orphans ()
+import           Options.Applicative
+import           System.FilePath (takeDirectory, (</>))
+import           System.Posix.Types (Fd (..))
+
+import qualified Cardano.Chain.Update as Byron
+import           Cardano.Crypto (RequiresNetworkMagic (..))
+import           Cardano.Node.Protocol.Types (Protocol (..))
+import           Cardano.Node.Types
+import           Cardano.Tracing.Config
+import           Ouroboros.Network.Block (MaxSlotNo (..))
+
+data NodeConfiguration
+  = NodeConfiguration
+      {  ncNodeAddr        :: !(Maybe NodeAddress)
+          -- | Filepath of the configuration yaml file. This file determines
+          -- all the configuration settings required for the cardano node
+          -- (logging, tracing, protocol, slot length etc)
+       , ncConfigFile      :: !ConfigYamlFilePath
+       , ncTopologyFile    :: !TopologyFile
+       , ncDatabaseFile    :: !DbFile
+       , ncProtocolFiles   :: !ProtocolFilepaths
+       , ncValidateDB      :: !Bool
+       , ncShutdownIPC     :: !(Maybe Fd)
+       , ncShutdownOnSlotSynced :: !MaxSlotNo
+
+        -- Protocol-specific parameters:
+       , ncProtocolConfig :: !NodeProtocolConfiguration
+
+         -- Node parameters, not protocol-specific:
+       , ncSocketPath     :: !(Maybe SocketPath)
+
+         -- BlockFetch configuration
+       , ncMaxConcurrencyBulkSync :: !(Maybe MaxConcurrencyBulkSync)
+       , ncMaxConcurrencyDeadline :: !(Maybe MaxConcurrencyDeadline)
+
+         -- Logging parameters:
+       , ncViewMode       :: !ViewMode
+       , ncLoggingSwitch  :: !Bool
+       , ncLogMetrics     :: !Bool
+       , ncTraceConfig    :: !TraceOptions
+       } deriving Show
+
+
+data PartialNodeConfiguration
+  = PartialNodeConfiguration
+      {  pncNodeAddr        :: !(Last NodeAddress)
+         -- | Filepath of the configuration yaml file. This file determines
+         -- all the configuration settings required for the cardano node
+         -- (logging, tracing, protocol, slot length etc)
+       , pncConfigFile      :: !(Last ConfigYamlFilePath)
+       , pncTopologyFile    :: !(Last TopologyFile)
+       , pncDatabaseFile    :: !(Last DbFile)
+       , pncProtocolFiles   :: !(Last ProtocolFilepaths)
+       , pncValidateDB      :: !(Last Bool)
+       , pncShutdownIPC     :: !(Last (Maybe Fd))
+       , pncShutdownOnSlotSynced :: !(Last MaxSlotNo)
+
+          -- Protocol-specific parameters:
+       , pncProtocolConfig :: !(Last NodeProtocolConfiguration)
+
+         -- Node parameters, not protocol-specific:
+       , pncSocketPath     :: !(Last SocketPath)
+
+         -- BlockFetch configuration
+       , pncMaxConcurrencyBulkSync :: !(Last MaxConcurrencyBulkSync)
+       , pncMaxConcurrencyDeadline :: !(Last MaxConcurrencyDeadline)
+
+         -- Logging parameters:
+       , pncViewMode       :: !(Last ViewMode)
+       , pncLoggingSwitch  :: !(Last Bool)
+       , pncLogMetrics     :: !(Last Bool)
+       , pncTraceConfig    :: !(Last TraceOptions)
+       } deriving (Eq, Generic, Show)
+
+instance AdjustFilePaths PartialNodeConfiguration where
+  adjustFilePaths f x =
+    x { pncProtocolConfig = adjustFilePaths f (pncProtocolConfig x)
+      , pncSocketPath     = adjustFilePaths f (pncSocketPath x)
+      }
+
+instance Semigroup PartialNodeConfiguration where
+  (<>) = gmappend
+
+instance FromJSON PartialNodeConfiguration where
+  parseJSON =
+    withObject "PartialNodeConfiguration" $ \v -> do
+
+      -- Node parameters, not protocol-specific
+      pncSocketPath' <- Last <$> v .:? "SocketPath"
+
+      -- Blockfetch parameters
+      pncMaxConcurrencyBulkSync' <- Last <$> v .:? "MaxConcurrencyBulkSync"
+      pncMaxConcurrencyDeadline' <- Last <$> v .:? "MaxConcurrencyDeadline"
+
+      -- Logging parameters
+      pncViewMode'      <- Last <$> v .:? "ViewMode"
+      pncLoggingSwitch' <- v .:? "TurnOnLogging" .!= True
+      pncLogMetrics'    <- Last <$> v .:? "TurnOnLogMetrics"
+      pncTraceConfig'   <- if pncLoggingSwitch'
+                           then Last . Just <$> traceConfigParser v
+                           else return . Last $ Just TracingOff
+
+      -- Protocol parameters
+      protocol <-  v .:? "Protocol" .!= ByronProtocol
+      pncProtocolConfig' <-
+        case protocol of
+          ByronProtocol ->
+            Last . Just . NodeProtocolConfigurationByron <$> parseByronProtocol v
+
+          ShelleyProtocol ->
+            Last . Just . NodeProtocolConfigurationShelley <$> parseShelleyProtocol v
+
+          CardanoProtocol ->
+            Last . Just  <$> (NodeProtocolConfigurationCardano <$> parseByronProtocol v
+                                                               <*> parseShelleyProtocol v
+                                                               <*> parseHardForkProtocol v)
+      pure PartialNodeConfiguration {
+             pncProtocolConfig = pncProtocolConfig'
+           , pncSocketPath = pncSocketPath'
+           , pncMaxConcurrencyBulkSync = pncMaxConcurrencyBulkSync'
+           , pncMaxConcurrencyDeadline = pncMaxConcurrencyDeadline'
+           , pncViewMode = pncViewMode'
+           , pncLoggingSwitch = Last $ Just pncLoggingSwitch'
+           , pncLogMetrics = pncLogMetrics'
+           , pncTraceConfig = pncTraceConfig'
+           , pncNodeAddr = mempty
+           , pncConfigFile = mempty
+           , pncTopologyFile = mempty
+           , pncDatabaseFile = mempty
+           , pncProtocolFiles = mempty
+           , pncValidateDB = mempty
+           , pncShutdownIPC = mempty
+           , pncShutdownOnSlotSynced = mempty
+           }
+    where
+      parseByronProtocol v = do
+        primary   <- v .:? "ByronGenesisFile"
+        secondary <- v .:? "GenesisFile"
+        npcByronGenesisFile <-
+          case (primary, secondary) of
+            (Just g, Nothing)  -> return g
+            (Nothing, Just g)  -> return g
+            (Nothing, Nothing) -> fail $ "Missing required field, either "
+                                      ++ "ByronGenesisFile or GenesisFile"
+            (Just _, Just _)   -> fail $ "Specify either ByronGenesisFile"
+                                      ++ "or GenesisFile, but not both"
+        npcByronGenesisFileHash <- v .:? "ByronGenesisHash"
+
+        npcByronReqNetworkMagic     <- v .:? "RequiresNetworkMagic"
+                                         .!= RequiresNoMagic
+        npcByronPbftSignatureThresh <- v .:? "PBftSignatureThreshold"
+        npcByronApplicationName     <- v .:? "ApplicationName"
+                                         .!= Byron.ApplicationName "cardano-sl"
+        npcByronApplicationVersion  <- v .:? "ApplicationVersion" .!= 1
+        protVerMajor                <- v .: "LastKnownBlockVersion-Major"
+        protVerMinor                <- v .: "LastKnownBlockVersion-Minor"
+        protVerAlt                  <- v .: "LastKnownBlockVersion-Alt" .!= 0
+
+        pure NodeByronProtocolConfiguration {
+               npcByronGenesisFile
+             , npcByronGenesisFileHash
+             , npcByronReqNetworkMagic
+             , npcByronPbftSignatureThresh
+             , npcByronApplicationName
+             , npcByronApplicationVersion
+             , npcByronSupportedProtocolVersionMajor = protVerMajor
+             , npcByronSupportedProtocolVersionMinor = protVerMinor
+             , npcByronSupportedProtocolVersionAlt   = protVerAlt
+             }
+
+      parseShelleyProtocol v = do
+        primary   <- v .:? "ShelleyGenesisFile"
+        secondary <- v .:? "GenesisFile"
+        npcShelleyGenesisFile <-
+          case (primary, secondary) of
+            (Just g, Nothing)  -> return g
+            (Nothing, Just g)  -> return g
+            (Nothing, Nothing) -> fail $ "Missing required field, either "
+                                      ++ "ShelleyGenesisFile or GenesisFile"
+            (Just _, Just _)   -> fail $ "Specify either ShelleyGenesisFile"
+                                      ++ "or GenesisFile, but not both"
+        npcShelleyGenesisFileHash <- v .:? "ShelleyGenesisHash"
+
+        --TODO: these are silly names, allow better aliases:
+        protVerMajor    <- v .:  "LastKnownBlockVersion-Major"
+        protVerMinor    <- v .:  "LastKnownBlockVersion-Minor"
+        protVerMajroMax <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
+
+        pure NodeShelleyProtocolConfiguration {
+               npcShelleyGenesisFile
+             , npcShelleyGenesisFileHash
+             , npcShelleySupportedProtocolVersionMajor = protVerMajor
+             , npcShelleySupportedProtocolVersionMinor = protVerMinor
+             , npcShelleyMaxSupportedProtocolVersion   = protVerMajroMax
+             }
+
+      parseHardForkProtocol v = do
+        npcTestShelleyHardForkAtEpoch   <- v .:? "TestShelleyHardForkAtEpoch"
+        npcTestShelleyHardForkAtVersion <- v .:? "TestShelleyHardForkAtVersion"
+        npcShelleyHardForkNotBeforeEpoch <- v .:? "ShelleyHardForkNotBeforeEpoch"
+        pure NodeHardForkProtocolConfiguration {
+               npcTestShelleyHardForkAtEpoch,
+               npcTestShelleyHardForkAtVersion,
+               npcShelleyHardForkNotBeforeEpoch
+             }
+
+-- | Default configuration is mainnet
+defaultPartialNodeConfiguration :: PartialNodeConfiguration
+defaultPartialNodeConfiguration =
+  PartialNodeConfiguration
+    { pncConfigFile = Last . Just $ ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
+    , pncDatabaseFile = Last . Just $ DbFile "mainnet/db/"
+    , pncLoggingSwitch = Last $ Just True
+    , pncSocketPath = Last $ Just "mainnet/socket/nodesocket"
+    , pncTopologyFile = Last . Just $ TopologyFile "configuration/cardano/mainnet-topology.json"
+    , pncViewMode = Last $ Just SimpleView
+    , pncNodeAddr = mempty
+    , pncProtocolFiles = mempty
+    , pncValidateDB = mempty
+    , pncShutdownIPC = mempty
+    , pncShutdownOnSlotSynced = mempty
+    , pncProtocolConfig = mempty
+    , pncMaxConcurrencyBulkSync = mempty
+    , pncMaxConcurrencyDeadline = mempty
+    , pncLogMetrics = mempty
+    , pncTraceConfig = mempty
+    }
+
+lastOption :: Parser a -> Parser (Last a)
+lastOption = fmap Last . optional
+
+lastToEither :: String -> Last a -> Either String a
+lastToEither errMsg (Last x) = maybe (Left errMsg) Right x
+
+makeNodeConfiguration :: PartialNodeConfiguration -> Either String NodeConfiguration
+makeNodeConfiguration pnc = do
+  configFile <- lastToEither "Missing YAML config file" $ pncConfigFile pnc
+  topologyFile <- lastToEither "Missing TopologyFile" $ pncTopologyFile pnc
+  databaseFile <- lastToEither "Missing DatabaseFile" $ pncDatabaseFile pnc
+  protocolFiles <- lastToEither "Missing ProtocolFiles" $ pncProtocolFiles pnc
+  validateDB <- lastToEither "Missing ValidateDB" $ pncValidateDB pnc
+  shutdownIPC <- lastToEither "Missing ShutdownIPC" $ pncShutdownIPC pnc
+  shutdownOnSlotSynced <- lastToEither "Missing ShutdownOnSlotSynced" $ pncShutdownOnSlotSynced pnc
+  protocolConfig <- lastToEither "Missing ProtocolConfig" $ pncProtocolConfig pnc
+  viewMode <- lastToEither "Missing ViewMode" $ pncViewMode pnc
+  loggingSwitch <- lastToEither "Missing LoggingSwitch" $ pncLoggingSwitch pnc
+  logMetrics <- lastToEither "Missing LogMetrics" $ pncLogMetrics pnc
+  traceConfig <- lastToEither "Missing TraceConfig" $ pncTraceConfig pnc
+  return $ NodeConfiguration
+             { ncNodeAddr = getLast $ pncNodeAddr pnc
+             , ncConfigFile = configFile
+             , ncTopologyFile = topologyFile
+             , ncDatabaseFile = databaseFile
+             , ncProtocolFiles = protocolFiles
+             , ncValidateDB = validateDB
+             , ncShutdownIPC = shutdownIPC
+             , ncShutdownOnSlotSynced = shutdownOnSlotSynced
+             , ncProtocolConfig = protocolConfig
+             , ncSocketPath = getLast $ pncSocketPath pnc
+             , ncMaxConcurrencyBulkSync = getLast $ pncMaxConcurrencyBulkSync pnc
+             , ncMaxConcurrencyDeadline = getLast $ pncMaxConcurrencyDeadline pnc
+             , ncViewMode = viewMode
+             , ncLoggingSwitch = loggingSwitch
+             , ncLogMetrics = logMetrics
+             , ncTraceConfig = traceConfig
+             }
+
+ncProtocol :: NodeConfiguration -> Protocol
+ncProtocol nc =
+  case ncProtocolConfig nc of
+    NodeProtocolConfigurationByron{}   -> ByronProtocol
+    NodeProtocolConfigurationShelley{} -> ShelleyProtocol
+    NodeProtocolConfigurationCardano{} -> CardanoProtocol
+
+pncProtocol :: PartialNodeConfiguration -> Either Text Protocol
+pncProtocol pnc =
+  case pncProtocolConfig pnc of
+    Last Nothing -> Left "Node protocol configuration not found"
+    Last (Just NodeProtocolConfigurationByron{})   -> Right ByronProtocol
+    Last (Just NodeProtocolConfigurationShelley{}) -> Right ShelleyProtocol
+    Last (Just NodeProtocolConfigurationCardano{}) -> Right CardanoProtocol
+
+parseNodeConfigurationFP :: Maybe ConfigYamlFilePath -> IO PartialNodeConfiguration
+parseNodeConfigurationFP Nothing = parseNodeConfigurationFP . getLast $ pncConfigFile defaultPartialNodeConfiguration
+parseNodeConfigurationFP (Just (ConfigYamlFilePath fp)) = do
+    nc <- decodeFileThrow fp
+    -- Make all the files be relative to the location of the config file.
+    pure $ adjustFilePaths (takeDirectory fp </>) nc

--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -25,6 +25,7 @@ import qualified Data.Text as Text
 import           Network.Socket (PortNumber, SockAddr (..))
 import           Text.Read (readMaybe)
 
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
 import           Cardano.Node.Types
 
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
@@ -128,9 +129,9 @@ instance ToJSON NetworkTopology where
 -- | Read the `NetworkTopology` configuration from the specified file.
 -- While running a real protocol, this gives your node its own address and
 -- other remote peers it will attempt to connect to.
-readTopologyFile :: NodeCLI -> IO (Either Text NetworkTopology)
-readTopologyFile ncli = do
-  eBs <- Exception.try $ BS.readFile (unTopology $ topologyFile ncli)
+readTopologyFile :: NodeConfiguration -> IO (Either Text NetworkTopology)
+readTopologyFile nc = do
+  eBs <- Exception.try $ BS.readFile (unTopology $ ncTopologyFile nc)
 
   case eBs of
     Left e -> return . Left $ handler e

--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -39,7 +39,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Consensus.Util.STM (onEachChange)
 import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo, pointSlot)
 
-import           Cardano.Node.Types
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
 
 -- | 'ShutdownFDs' mediate the graceful shutdown requests,
 -- either external or internal to the process.
@@ -131,18 +131,18 @@ triggerShutdown (ShutdownDoorbell (Fd shutFd)) trace reason = do
 -- external or internal, as requested by configuration in 'NodeCLI',
 -- while allocating corresponding 'ShutdownFDs', and providing them to the 'action'.
 withShutdownHandling
-  :: NodeCLI
+  :: NodeConfiguration
   -> Trace IO Text
   -> (ShutdownFDs -> IO ())
   -> IO ()
-withShutdownHandling cli trace action = do
-  sfds <- decideShutdownFds cli
+withShutdownHandling nc trace action = do
+  sfds <- decideShutdownFds nc
   withShutdownHandler (sfdsListener sfds) trace (action sfds)
  where
-   decideShutdownFds :: NodeCLI -> IO ShutdownFDs
-   decideShutdownFds NodeCLI{shutdownIPC = Just fd} =
+   decideShutdownFds :: NodeConfiguration -> IO ShutdownFDs
+   decideShutdownFds NodeConfiguration{ncShutdownIPC = Just fd} =
      pure $ ExternalShutdown (ShutdownListener fd)
-   decideShutdownFds NodeCLI{shutdownOnSlotSynced = MaxSlotNo{}} =
+   decideShutdownFds NodeConfiguration{ncShutdownOnSlotSynced = MaxSlotNo{}} =
      mkInternalShutdown
    decideShutdownFds _ = pure NoShutdownFDs
 
@@ -155,14 +155,14 @@ withShutdownHandling cli trace action = do
 -- spawn a thread that would cause node to shutdown upon ChainDB reaching the
 -- configuration-defined slot.
 maybeSpawnOnSlotSyncedShutdownHandler
-  :: NodeCLI
+  :: NodeConfiguration
   -> ShutdownFDs
   -> Trace IO Text
   -> ResourceRegistry IO
   -> ChainDB.ChainDB IO blk
   -> IO ()
-maybeSpawnOnSlotSyncedShutdownHandler cli sfds trace registry chaindb =
-  case (shutdownOnSlotSynced cli, sfds) of
+maybeSpawnOnSlotSyncedShutdownHandler nc sfds trace registry chaindb =
+  case (ncShutdownOnSlotSynced nc, sfds) of
     (MaxSlotNo maxSlot, InternalShutdown _sl sd) -> do
       traceWith (trTransformer MaximalVerbosity $ severityNotice trace)
         ("will terminate upon reaching " <> pack (show maxSlot))

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -12,6 +12,7 @@ import           Cardano.Prelude
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
 import           Cardano.Node.Types
 
 import           Cardano.Node.Protocol.Byron
@@ -25,18 +26,17 @@ import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 
 mkConsensusProtocol
   :: NodeConfiguration
-  -> Maybe ProtocolFilepaths
   -> ExceptT ProtocolInstantiationError IO SomeConsensusProtocol
-mkConsensusProtocol NodeConfiguration{ncProtocolConfig} files =
+mkConsensusProtocol NodeConfiguration{ncProtocolConfig, ncProtocolFiles} =
     case ncProtocolConfig of
 
       NodeProtocolConfigurationByron config ->
         firstExceptT ByronProtocolInstantiationError $
-          mkSomeConsensusProtocolByron config files
+          mkSomeConsensusProtocolByron config (Just ncProtocolFiles)
 
       NodeProtocolConfigurationShelley config ->
         firstExceptT ShelleyProtocolInstantiationError $
-          mkSomeConsensusProtocolShelley config files
+          mkSomeConsensusProtocolShelley config (Just ncProtocolFiles)
 
       NodeProtocolConfigurationCardano byronConfig
                                        shelleyConfig
@@ -46,7 +46,7 @@ mkConsensusProtocol NodeConfiguration{ncProtocolConfig} files =
             byronConfig
             shelleyConfig
             hardForkConfig
-            files
+            (Just ncProtocolFiles)
 
 ------------------------------------------------------------------------------
 -- Errors

--- a/cardano-node/src/Cardano/Node/TUI/Run.hs
+++ b/cardano-node/src/Cardano/Node/TUI/Run.hs
@@ -34,11 +34,12 @@ import           Cardano.Node.TUI.Drawing (LiveViewState (..), LiveViewThread (.
 import           Cardano.Node.TUI.EventHandler (LiveViewBackend (..))
 import           Cardano.Tracing.Peer (Peer (..))
 
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Types
 
 -- | Change a few fields in the LiveViewState after it has been initialized above.
-liveViewPostSetup :: NFData a => LiveViewBackend blk a -> NodeCLI -> NodeConfiguration-> IO ()
-liveViewPostSetup lvbe ncli nc = do
+liveViewPostSetup :: NFData a => LiveViewBackend blk a -> NodeConfiguration-> IO ()
+liveViewPostSetup lvbe nc = do
     modifyMVar_ (getbe lvbe) $ \lvs ->
       pure lvs
             { lvsNodeId = nodeId
@@ -50,7 +51,7 @@ liveViewPostSetup lvbe ncli nc = do
     -- an ID. We don't even have a port number that we know if we're given our
     -- listening socket via systemd socket activation.
     nodeId :: Text
-    nodeId = Text.pack $ "Port: " <> maybe "-" show (naPort <$> nodeAddr ncli)
+    nodeId = Text.pack $ "Port: " <> maybe "-" show (naPort <$> ncNodeAddr nc)
 
 setNodeThread :: NFData a => LiveViewBackend blk a -> Async.Async () -> IO ()
 setNodeThread lvbe nodeThr =

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -4,12 +4,11 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Node.Types
-  ( ConfigError(..)
+  ( AdjustFilePaths(..)
+  , ConfigError(..)
   , ConfigYamlFilePath(..)
   , DbFile(..)
   , GenesisFile(..)
-  , NodeCLI(..)
-  , NodeConfiguration(..)
   , ProtocolFilepaths (..)
   , GenesisHash(..)
   , MaxConcurrencyBulkSync(..)
@@ -23,32 +22,22 @@ module Cardano.Node.Types
   , SocketPath(..)
   , TopologyFile(..)
   , ViewMode(..)
-  , ncProtocol
-  , parseNodeConfiguration
-  , parseNodeConfigurationFP
   , protocolName
   ) where
 
 import           Cardano.Prelude
 import           Prelude (String)
 
-import           Control.Monad (fail)
 import           Data.Aeson
 import           Data.IP (IP)
 import qualified Data.Text as Text
-import           Data.Yaml (decodeFileThrow)
 import           Network.Socket (PortNumber)
-import           System.FilePath (takeDirectory, (</>))
-import           System.Posix.Types (Fd)
 
 import           Cardano.Api.Typed (EpochNo)
 import qualified Cardano.Chain.Update as Byron
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Node.Protocol.Types (Protocol (..))
-import           Cardano.Tracing.Config (TraceOptions (..), traceConfigParser)
-import           Ouroboros.Network.Block (MaxSlotNo (..))
-
 --TODO: things will probably be clearer if we don't use these newtype wrappers and instead
 -- use records with named fields in the CLI code.
 
@@ -65,7 +54,7 @@ newtype ConfigYamlFilePath = ConfigYamlFilePath
 
 newtype DbFile = DbFile
   { unDB :: FilePath }
-  deriving newtype Show
+  deriving newtype (Eq, Show)
 
 newtype GenesisFile = GenesisFile
   { unGenesisFile :: FilePath }
@@ -145,167 +134,9 @@ instance ToJSON NodeHostAddress where
       Just ip -> String (Text.pack (show ip))
       Nothing -> Null
 
-data NodeCLI = NodeCLI
-  { nodeAddr        :: !(Maybe NodeAddress)
-    -- | Filepath of the configuration yaml file. This file determines
-    -- all the configuration settings required for the cardano node
-    -- (logging, tracing, protocol, slot length etc)
-  , configFile      :: !ConfigYamlFilePath
-  , topologyFile    :: !TopologyFile
-  , databaseFile    :: !DbFile
-  , socketFile      :: !(Maybe SocketPath)
-  , protocolFiles   :: !ProtocolFilepaths
-  , validateDB      :: !Bool
-  , shutdownIPC     :: !(Maybe Fd)
-  , shutdownOnSlotSynced :: !MaxSlotNo
-  }
-
-data NodeConfiguration
-  = NodeConfiguration
-      { -- Protocol-specific parameters:
-         ncProtocolConfig :: NodeProtocolConfiguration
-
-         -- Node parameters, not protocol-specific:
-       , ncSocketPath     :: Maybe SocketPath
-
-         -- BlockFetch configuration
-       , ncMaxConcurrencyBulkSync :: Maybe MaxConcurrencyBulkSync
-       , ncMaxConcurrencyDeadline :: Maybe MaxConcurrencyDeadline
-
-         -- Logging parameters:
-       , ncViewMode       :: ViewMode
-       , ncLoggingSwitch  :: Bool
-       , ncLogMetrics     :: Bool
-       , ncTraceConfig    :: TraceOptions
-       } deriving Show
-
 class AdjustFilePaths a where
   adjustFilePaths :: (FilePath -> FilePath) -> a -> a
 
-instance AdjustFilePaths NodeConfiguration where
-  adjustFilePaths f x@NodeConfiguration {
-                        ncProtocolConfig,
-                        ncSocketPath
-                      } =
-    x {
-      ncProtocolConfig = adjustFilePaths f ncProtocolConfig,
-      ncSocketPath     = adjustFilePaths f ncSocketPath
-    }
-
-instance FromJSON NodeConfiguration where
-  parseJSON =
-    withObject "NodeConfiguration" $ \v -> do
-
-      -- Node parameters, not protocol-specific
-      ncSocketPath <- v .:? "SocketPath"
-
-      -- Blockfetch parameters
-      ncMaxConcurrencyBulkSync <- v .:? "MaxConcurrencyBulkSync"
-      ncMaxConcurrencyDeadline <- v .:? "MaxConcurrencyDeadline"
-
-      -- Logging parameters
-      ncViewMode      <- v .:? "ViewMode"         .!= SimpleView
-      ncLoggingSwitch <- v .:? "TurnOnLogging"    .!= True
-      ncLogMetrics    <- v .:? "TurnOnLogMetrics" .!= True
-      ncTraceConfig   <- if ncLoggingSwitch
-                           then traceConfigParser v
-                           else return TracingOff
-
-      -- Protocol parameters
-      protocol <- v .: "Protocol" .!= ByronProtocol
-      ncProtocolConfig <-
-        case protocol of
-          ByronProtocol ->
-            NodeProtocolConfigurationByron <$> parseByronProtocol v
-
-          ShelleyProtocol ->
-            NodeProtocolConfigurationShelley <$> parseShelleyProtocol v
-
-          CardanoProtocol ->
-            NodeProtocolConfigurationCardano <$> parseByronProtocol v
-                                             <*> parseShelleyProtocol v
-                                             <*> parseHardForkProtocol v
-      pure NodeConfiguration {
-             ncProtocolConfig
-           , ncSocketPath
-           , ncMaxConcurrencyBulkSync
-           , ncMaxConcurrencyDeadline
-           , ncViewMode
-           , ncLoggingSwitch
-           , ncLogMetrics
-           , ncTraceConfig
-           }
-    where
-      parseByronProtocol v = do
-        primary   <- v .:? "ByronGenesisFile"
-        secondary <- v .:? "GenesisFile"
-        npcByronGenesisFile <-
-          case (primary, secondary) of
-            (Just g, Nothing)  -> return g
-            (Nothing, Just g)  -> return g
-            (Nothing, Nothing) -> fail $ "Missing required field, either "
-                                      ++ "ByronGenesisFile or GenesisFile"
-            (Just _, Just _)   -> fail $ "Specify either ByronGenesisFile"
-                                      ++ "or GenesisFile, but not both"
-        npcByronGenesisFileHash <- v .:? "ByronGenesisHash"
-
-        npcByronReqNetworkMagic     <- v .:? "RequiresNetworkMagic"
-                                         .!= RequiresNoMagic
-        npcByronPbftSignatureThresh <- v .:? "PBftSignatureThreshold"
-        npcByronApplicationName     <- v .:? "ApplicationName"
-                                         .!= Byron.ApplicationName "cardano-sl"
-        npcByronApplicationVersion  <- v .:? "ApplicationVersion" .!= 1
-        protVerMajor                <- v .: "LastKnownBlockVersion-Major"
-        protVerMinor                <- v .: "LastKnownBlockVersion-Minor"
-        protVerAlt                  <- v .: "LastKnownBlockVersion-Alt" .!= 0
-
-        pure NodeByronProtocolConfiguration {
-               npcByronGenesisFile
-             , npcByronGenesisFileHash
-             , npcByronReqNetworkMagic
-             , npcByronPbftSignatureThresh
-             , npcByronApplicationName
-             , npcByronApplicationVersion
-             , npcByronSupportedProtocolVersionMajor = protVerMajor
-             , npcByronSupportedProtocolVersionMinor = protVerMinor
-             , npcByronSupportedProtocolVersionAlt   = protVerAlt
-             }
-
-      parseShelleyProtocol v = do
-        primary   <- v .:? "ShelleyGenesisFile"
-        secondary <- v .:? "GenesisFile"
-        npcShelleyGenesisFile <-
-          case (primary, secondary) of
-            (Just g, Nothing)  -> return g
-            (Nothing, Just g)  -> return g
-            (Nothing, Nothing) -> fail $ "Missing required field, either "
-                                      ++ "ShelleyGenesisFile or GenesisFile"
-            (Just _, Just _)   -> fail $ "Specify either ShelleyGenesisFile"
-                                      ++ "or GenesisFile, but not both"
-        npcShelleyGenesisFileHash <- v .:? "ShelleyGenesisHash"
-
-        --TODO: these are silly names, allow better aliases:
-        protVerMajor    <- v .:  "LastKnownBlockVersion-Major"
-        protVerMinor    <- v .:  "LastKnownBlockVersion-Minor"
-        protVerMajroMax <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
-
-        pure NodeShelleyProtocolConfiguration {
-               npcShelleyGenesisFile
-             , npcShelleyGenesisFileHash
-             , npcShelleySupportedProtocolVersionMajor = protVerMajor
-             , npcShelleySupportedProtocolVersionMinor = protVerMinor
-             , npcShelleyMaxSupportedProtocolVersion   = protVerMajroMax
-             }
-
-      parseHardForkProtocol v = do
-        npcTestShelleyHardForkAtEpoch   <- v .:? "TestShelleyHardForkAtEpoch"
-        npcTestShelleyHardForkAtVersion <- v .:? "TestShelleyHardForkAtVersion"
-        npcShelleyHardForkNotBeforeEpoch <- v .:? "ShelleyHardForkNotBeforeEpoch"
-        pure NodeHardForkProtocolConfiguration {
-               npcTestShelleyHardForkAtEpoch,
-               npcTestShelleyHardForkAtVersion,
-               npcShelleyHardForkNotBeforeEpoch
-             }
 
 data ProtocolFilepaths =
      ProtocolFilepaths {
@@ -314,7 +145,7 @@ data ProtocolFilepaths =
      , shelleyKESFile  :: !(Maybe FilePath)
      , shelleyVRFFile  :: !(Maybe FilePath)
      , shelleyCertFile :: !(Maybe FilePath)
-     }
+     } deriving (Eq, Show)
 
 newtype GenesisHash = GenesisHash (Crypto.Hash Crypto.Blake2b_256 ByteString)
   deriving newtype (Eq, Show, ToJSON, FromJSON)
@@ -325,7 +156,7 @@ data NodeProtocolConfiguration =
      | NodeProtocolConfigurationCardano NodeByronProtocolConfiguration
                                         NodeShelleyProtocolConfiguration
                                         NodeHardForkProtocolConfiguration
-  deriving Show
+  deriving (Eq, Show)
 
 data NodeShelleyProtocolConfiguration =
      NodeShelleyProtocolConfiguration {
@@ -347,7 +178,7 @@ data NodeShelleyProtocolConfiguration =
        -- will stop with an appropriate error message.
      , npcShelleyMaxSupportedProtocolVersion :: !Natural
      }
-  deriving Show
+  deriving (Eq, Show)
 
 data NodeByronProtocolConfiguration =
      NodeByronProtocolConfiguration {
@@ -373,7 +204,7 @@ data NodeByronProtocolConfiguration =
      , npcByronSupportedProtocolVersionMinor :: !Word16
      , npcByronSupportedProtocolVersionAlt   :: !Word8
      }
-  deriving Show
+  deriving (Eq, Show)
 
 -- | Configuration relating to a hard forks themselves, not the specific eras.
 --
@@ -404,7 +235,7 @@ data NodeHardForkProtocolConfiguration =
        --
      , npcTestShelleyHardForkAtVersion :: Maybe Word
      }
-  deriving Show
+  deriving (Eq, Show)
 
 newtype SocketPath = SocketPath
   { unSocketPath :: FilePath }
@@ -413,7 +244,7 @@ newtype SocketPath = SocketPath
 
 newtype TopologyFile = TopologyFile
   { unTopology :: FilePath }
-  deriving newtype Show
+  deriving newtype (Show, Eq)
 
 instance AdjustFilePaths NodeProtocolConfiguration where
 
@@ -449,21 +280,6 @@ instance AdjustFilePaths GenesisFile where
 instance AdjustFilePaths a => AdjustFilePaths (Maybe a) where
   adjustFilePaths f = fmap (adjustFilePaths f)
 
-ncProtocol :: NodeConfiguration -> Protocol
-ncProtocol nc =
-    case ncProtocolConfig nc of
-      NodeProtocolConfigurationByron{}   -> ByronProtocol
-      NodeProtocolConfigurationShelley{} -> ShelleyProtocol
-      NodeProtocolConfigurationCardano{} -> CardanoProtocol
-
-parseNodeConfiguration :: NodeCLI -> IO NodeConfiguration
-parseNodeConfiguration NodeCLI{configFile} = parseNodeConfigurationFP configFile
-
-parseNodeConfigurationFP :: ConfigYamlFilePath -> IO NodeConfiguration
-parseNodeConfigurationFP (ConfigYamlFilePath fp) = do
-    nc <- decodeFileThrow fp
-    -- Make all the files be relative to the location of the config file.
-    pure $ adjustFilePaths (takeDirectory fp </>) nc
 
 instance AdjustFilePaths (Last NodeProtocolConfiguration) where
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
@@ -463,6 +464,24 @@ parseNodeConfigurationFP (ConfigYamlFilePath fp) = do
     nc <- decodeFileThrow fp
     -- Make all the files be relative to the location of the config file.
     pure $ adjustFilePaths (takeDirectory fp </>) nc
+
+instance AdjustFilePaths (Last NodeProtocolConfiguration) where
+
+  adjustFilePaths f (Last (Just (NodeProtocolConfigurationByron pc))) =
+    Last . Just $ NodeProtocolConfigurationByron (adjustFilePaths f pc)
+
+  adjustFilePaths f (Last (Just (NodeProtocolConfigurationShelley pc))) =
+    Last . Just $ NodeProtocolConfigurationShelley (adjustFilePaths f pc)
+
+  adjustFilePaths f (Last (Just (NodeProtocolConfigurationCardano pcb pcs pch))) =
+    Last . Just $ NodeProtocolConfigurationCardano (adjustFilePaths f pcb)
+                                                   (adjustFilePaths f pcs)
+                                                   pch
+  adjustFilePaths _ (Last Nothing) = Last Nothing
+
+instance AdjustFilePaths (Last SocketPath) where
+  adjustFilePaths f (Last (Just (SocketPath p))) = Last . Just $ SocketPath (f p)
+  adjustFilePaths _ (Last Nothing) = Last Nothing
 
 -- | A human readable name for the protocol
 --

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -20,7 +20,7 @@ import           Cardano.Node.Orphans ()
 data TraceOptions
   = TracingOff
   | TracingOn TraceSelection
-  deriving Show
+  deriving (Eq, Show)
 
 data TraceSelection
   = TraceSelection

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Node.POM
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import           Cardano.Node.Configuration.POM
+import           Cardano.Node.Types
+import           Cardano.Tracing.Config (TraceOptions (..))
+import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo (..))
+
+import           Hedgehog (Property, discover, (===))
+import qualified Hedgehog
+import           Hedgehog.Internal.Property (failWith)
+
+
+-- This is a simple test to check that the POM technique is working as intended.
+-- What is entered on the command line via the cli takes precedence and this is
+-- tested in the property below.
+-- See: https://medium.com/@jonathangfischoff/the-partial-options-monoid-pattern-31914a71fc67
+
+prop_sanityCheck_POM :: Property
+prop_sanityCheck_POM =
+  Hedgehog.property $ do
+    let combinedPartials = defaultPartialNodeConfiguration
+                             <> testPartialYamlConfig
+                             <> testPartialCliConfig
+        nc = makeNodeConfiguration combinedPartials
+    case nc of
+      Left err -> failWith Nothing $ "Partial Options Monoid sanity check failure: " <> err
+      Right config -> config === expectedConfig
+
+-- | Example partial configuration theoretically created from a
+-- config yaml file.
+testPartialYamlConfig :: PartialNodeConfiguration
+testPartialYamlConfig =
+  PartialNodeConfiguration
+    { pncProtocolConfig = Last . Just . NodeProtocolConfigurationShelley
+                                          $ NodeShelleyProtocolConfiguration
+                                          (GenesisFile "dummmy-genesis-file") Nothing 1 2 3
+    , pncSocketPath = Last Nothing
+    , pncMaxConcurrencyBulkSync = Last Nothing
+    , pncMaxConcurrencyDeadline = Last Nothing
+    , pncViewMode = Last $ Just LiveView
+    , pncLoggingSwitch = Last $ Just True
+    , pncLogMetrics = Last $ Just True
+    , pncTraceConfig = Last $ Just TracingOff
+    , pncNodeAddr = mempty
+    , pncConfigFile = mempty
+    , pncTopologyFile = mempty
+    , pncDatabaseFile = mempty
+    , pncProtocolFiles = mempty
+    , pncValidateDB = mempty
+    , pncShutdownIPC = mempty
+    , pncShutdownOnSlotSynced = mempty
+    }
+
+-- | Example partial configuration theoretically created
+-- from what was parsed on the command line.
+testPartialCliConfig :: PartialNodeConfiguration
+testPartialCliConfig =
+  PartialNodeConfiguration
+    { pncNodeAddr     = mempty
+    , pncConfigFile   = mempty
+    , pncTopologyFile = mempty
+    , pncDatabaseFile = mempty
+    , pncSocketPath   = mempty
+    , pncProtocolFiles = Last . Just $ ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing
+    , pncValidateDB = Last $ Just True
+    , pncShutdownIPC = Last $ Just Nothing
+    , pncShutdownOnSlotSynced = Last . Just . MaxSlotNo $ SlotNo 42
+    , pncProtocolConfig = mempty
+    , pncMaxConcurrencyBulkSync = mempty
+    , pncMaxConcurrencyDeadline = mempty
+    , pncViewMode = Last $ Just SimpleView
+    , pncLoggingSwitch = mempty
+    , pncLogMetrics = mempty
+    , pncTraceConfig = mempty
+    }
+
+-- | Expected final NodeConfiguration
+expectedConfig :: NodeConfiguration
+expectedConfig =
+  NodeConfiguration
+    { ncNodeAddr = Nothing
+    , ncConfigFile = ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
+    , ncTopologyFile = TopologyFile "configuration/cardano/mainnet-topology.json"
+    , ncDatabaseFile = DbFile "mainnet/db/"
+    , ncProtocolFiles = ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing
+    , ncValidateDB = True
+    , ncShutdownIPC = Nothing
+    , ncShutdownOnSlotSynced = MaxSlotNo $ SlotNo 42
+    , ncProtocolConfig = NodeProtocolConfigurationShelley
+                           $ NodeShelleyProtocolConfiguration
+                             (GenesisFile "dummmy-genesis-file") Nothing 1 2 3
+    , ncSocketPath = Just "mainnet/socket/nodesocket"
+    , ncMaxConcurrencyBulkSync = Nothing
+    , ncMaxConcurrencyDeadline = Nothing
+    , ncViewMode = SimpleView
+    , ncLoggingSwitch = True
+    , ncLogMetrics = True
+    , ncTraceConfig = TracingOff
+    }
+
+-- -----------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  Hedgehog.checkParallel $$discover

--- a/cardano-node/test/cardano-node-test.hs
+++ b/cardano-node/test/cardano-node-test.hs
@@ -3,8 +3,10 @@ import           Cardano.Prelude
 import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Cardano.Node.Json
+import qualified Test.Cardano.Node.POM
 
 main :: IO ()
 main = defaultMain
     [ Test.Cardano.Node.Json.tests
+    , Test.Cardano.Node.POM.tests
     ]

--- a/scripts/lite/mainnet.sh
+++ b/scripts/lite/mainnet.sh
@@ -5,7 +5,7 @@
 ROOT="$(realpath "$(dirname "$0")/../..")"
 configuration="${ROOT}/configuration/cardano"
 
-data_dir=mainnet
+data_dir=mainnetsingle
 mkdir -p "${data_dir}"
 db_dir="${data_dir}/db/node"
 mkdir -p "${db_dir}"


### PR DESCRIPTION
POI: https://medium.com/@jonathangfischoff/the-partial-options-monoid-pattern-31914a71fc67

This allows us to combine configuration options from the command line and from the config yaml file in a seamless way. The default configuration will connect to mainnet. I.E running `cabal exec cardano-node run` in the top level `cardano-node` dir will connect the node to mainnet.