### PR TITLE
Add CLI support for accepting Bech32 and hex-encoded verification keys as input

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Shelley CLI command types
@@ -42,7 +41,6 @@ module Cardano.CLI.Shelley.Commands
   , PoolMetaDataFile (..)
   , PrivKeyFile (..)
   , BlockId (..)
-  , VerificationKeyOrHashOrFile (..)
   , WitnessSigningData (..)
   ) where
 
@@ -55,6 +53,7 @@ import           Cardano.Api.Typed hiding (PoolId)
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrHashOrFile)
 import           Cardano.CLI.Types
 
 import           Shelley.Spec.Ledger.TxBody (MIRPot)
@@ -431,24 +430,6 @@ newtype TxFile
 newtype VerificationKeyBase64
   = VerificationKeyBase64 String
   deriving (Eq, Show)
-
--- | Either a verification key, verification key hash, or path to a
--- verification key file.
-data VerificationKeyOrHashOrFile keyrole
-  = VerificationKeyValue !(VerificationKey keyrole)
-  -- ^ A verification key.
-  | VerificationKeyHash !(Hash keyrole)
-  -- ^ A verification key hash.
-  | VerificationKeyFilePath !VerificationKeyFile
-  -- ^ A path to a verification key file.
-  -- Note that this file hasn't been validated at all (whether it exists,
-  -- contains a key of the correct type, etc.)
-
-deriving instance (Show (VerificationKey keyrole), Show (Hash keyrole))
-  => Show (VerificationKeyOrHashOrFile keyrole)
-
-deriving instance (Eq (VerificationKey keyrole), Eq (Hash keyrole))
-  => Eq (VerificationKeyOrHashOrFile keyrole)
 
 -- | Data required to construct a witness.
 data WitnessSigningData

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -53,7 +53,7 @@ import           Cardano.Api.Typed hiding (PoolId)
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 
-import           Cardano.CLI.Shelley.Key (VerificationKeyOrHashOrFile)
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, VerificationKeyOrHashOrFile)
 import           Cardano.CLI.Types
 
 import           Shelley.Spec.Ledger.TxBody (MIRPot)
@@ -111,11 +111,14 @@ renderAddressCmd cmd =
 
 data StakeAddressCmd
   = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
-  | StakeAddressKeyHash VerificationKeyFile (Maybe OutputFile)
-  | StakeAddressBuild VerificationKeyFile NetworkId (Maybe OutputFile)
-  | StakeKeyRegistrationCert VerificationKeyFile OutputFile
-  | StakeKeyDelegationCert VerificationKeyFile StakePoolVerificationKeyHashOrFile OutputFile
-  | StakeKeyDeRegistrationCert VerificationKeyFile OutputFile
+  | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe OutputFile)
+  | StakeAddressBuild (VerificationKeyOrFile StakeKey) NetworkId (Maybe OutputFile)
+  | StakeKeyRegistrationCert (VerificationKeyOrFile StakeKey) OutputFile
+  | StakeKeyDelegationCert
+      (VerificationKeyOrFile StakeKey)
+      (VerificationKeyOrHashOrFile StakePoolKey)
+      OutputFile
+  | StakeKeyDeRegistrationCert (VerificationKeyOrFile StakeKey) OutputFile
   deriving (Eq, Show)
 
 renderStakeAddressCmd :: StakeAddressCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -54,7 +54,8 @@ import           Cardano.Api.Typed hiding (PoolId)
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 
-import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, VerificationKeyOrHashOrFile)
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, VerificationKeyOrHashOrFile,
+                     VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
 import           Shelley.Spec.Ledger.TxBody (MIRPot)
@@ -94,8 +95,12 @@ renderShelleyCommand sc =
 
 data AddressCmd
   = AddressKeyGen AddressKeyType VerificationKeyFile SigningKeyFile
-  | AddressKeyHash VerificationKeyFile (Maybe OutputFile)
-  | AddressBuild VerificationKeyFile (Maybe VerificationKeyFile) NetworkId (Maybe OutputFile)
+  | AddressKeyHash VerificationKeyTextOrFile (Maybe OutputFile)
+  | AddressBuild
+      VerificationKeyTextOrFile
+      (Maybe (VerificationKeyOrFile StakeKey))
+      NetworkId
+      (Maybe OutputFile)
   | AddressBuildMultiSig ScriptFile NetworkId (Maybe OutputFile)
   | AddressInfo Text (Maybe OutputFile)
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -42,6 +42,7 @@ module Cardano.CLI.Shelley.Commands
   , PrivKeyFile (..)
   , BlockId (..)
   , WitnessSigningData (..)
+  , ColdVerificationKeyOrFile (..)
   ) where
 
 import           Data.Text (Text)
@@ -196,9 +197,9 @@ data NodeCmd
   = NodeKeyGenCold VerificationKeyFile SigningKeyFile OpCertCounterFile
   | NodeKeyGenKES  VerificationKeyFile SigningKeyFile
   | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
-  | NodeKeyHashVRF  VerificationKeyFile (Maybe OutputFile)
-  | NodeNewCounter  VerificationKeyFile Word OpCertCounterFile
-  | NodeIssueOpCert VerificationKeyFile SigningKeyFile OpCertCounterFile
+  | NodeKeyHashVRF  (VerificationKeyOrFile VrfKey) (Maybe OutputFile)
+  | NodeNewCounter ColdVerificationKeyOrFile Word OpCertCounterFile
+  | NodeIssueOpCert (VerificationKeyOrFile KesKey) SigningKeyFile OpCertCounterFile
                     KESPeriod OutputFile
   deriving (Eq, Show)
 
@@ -445,4 +446,17 @@ data WitnessSigningData
       -- If specified, both the network ID and derivation path are extracted
       -- from the address and used in the construction of the Byron witness.
   | ScriptWitnessSigningData !ScriptFile
+  deriving (Eq, Show)
+
+-- | Either a stake pool verification key, genesis delegate verification key,
+-- or a path to a cold verification key file.
+--
+-- Note that a "cold verification key" refers to either a stake pool or
+-- genesis delegate verification key.
+--
+-- TODO: A genesis delegate extended key should also be valid here.
+data ColdVerificationKeyOrFile
+  = ColdStakePoolVerificationKey !(VerificationKey StakePoolKey)
+  | ColdGenesisDelegateVerificationKey !(VerificationKey GenesisDelegateKey)
+  | ColdVerificationKeyFile !VerificationKeyFile
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -221,9 +221,9 @@ renderNodeCmd cmd = do
 
 data PoolCmd
   = PoolRegistrationCert
-      VerificationKeyFile
+      (VerificationKeyOrFile StakePoolKey)
       -- ^ Stake pool verification key.
-      VerificationKeyFile
+      (VerificationKeyOrFile VrfKey)
       -- ^ VRF Verification key.
       Lovelace
       -- ^ Pool pledge.
@@ -231,9 +231,9 @@ data PoolCmd
       -- ^ Pool cost.
       Rational
       -- ^ Pool margin.
-      VerificationKeyFile
+      (VerificationKeyOrFile StakeKey)
       -- ^ Reward account verification staking key.
-      [VerificationKeyFile]
+      [VerificationKeyOrFile StakeKey]
       -- ^ Pool owner verification staking key(s).
       [StakePoolRelay]
       -- ^ Stake pool relays.
@@ -242,12 +242,12 @@ data PoolCmd
       NetworkId
       OutputFile
   | PoolRetirementCert
-      VerificationKeyFile
+      (VerificationKeyOrFile StakePoolKey)
       -- ^ Stake pool verification key.
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
       OutputFile
-  | PoolGetId VerificationKeyFile OutputFormat
+  | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
   | PoolMetaDataHash PoolMetaDataFile (Maybe OutputFile)
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -1,50 +1,296 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Shelley CLI option data types and functions for cryptographic keys.
 module Cardano.CLI.Shelley.Key
-  ( SigningKeyDecodeError (..)
+  ( InputFormat (..)
+  , InputDecodeError (..)
+  , deserialiseInput
+  , deserialiseInputAnyOf
+  , renderInputDecodeError
+
+  , readKeyFile
+  , readKeyFileAnyOf
+  , readKeyFileTextEnvelope
+
   , readSigningKeyFile
   , readSigningKeyFileAnyOf
+
+  , VerificationKeyOrFile (..)
+  , readVerificationKeyOrFile
+  , readVerificationKeyOrTextEnvFile
+
+  , VerificationKeyTextOrFile (..)
+  , VerificationKeyTextOrFileError (..)
+  , readVerificationKeyTextOrFileAnyOf
+  , renderVerificationKeyTextOrFileError
+
+  , VerificationKeyOrHashOrFile (..)
+  , readVerificationKeyOrHashOrFile
+  , readVerificationKeyOrHashOrTextEnvFile
   ) where
 
 import           Cardano.Prelude
 
-import           Control.Monad.Trans.Except.Extra (handleIOExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
 
 import           Cardano.Api.TextView (TextViewError (..))
 import           Cardano.Api.Typed
 
 import           Cardano.CLI.Types
 
--- | Signing key decoding error.
-data SigningKeyDecodeError
-  = SigningKeyTextEnvelopeError !TextEnvelopeError
+------------------------------------------------------------------------------
+-- Formatted/encoded input deserialisation
+------------------------------------------------------------------------------
+
+-- | Input format/encoding.
+data InputFormat a where
+  -- | Bech32 encoding.
+  InputFormatBech32 :: SerialiseAsBech32 a => InputFormat a
+
+  -- | Hex/Base16 encoding.
+  InputFormatHex :: SerialiseAsRawBytes a => InputFormat a
+
+  -- | Text envelope format.
+  InputFormatTextEnvelope :: HasTextEnvelope a => InputFormat a
+
+-- | Input decoding error.
+data InputDecodeError
+  = InputTextEnvelopeError !TextEnvelopeError
   -- ^ The provided data seems to be a valid text envelope, but some error
-  -- occurred in extracting a valid signing key from it.
-  | SigningKeyBech32DecodeError !Bech32DecodeError
+  -- occurred in deserialising it.
+  | InputBech32DecodeError !Bech32DecodeError
   -- ^ The provided data is valid Bech32, but some error occurred in
-  -- deserializing it to a signing key.
-  | SigningKeyInvalidError
-  -- ^ The provided data does not represent a valid signing key.
+  -- deserialising it.
+  | InputInvalidError
+  -- ^ The provided data does not represent a valid value of the provided
+  -- type.
   deriving (Eq, Show)
 
--- | Render an error message for a 'SigningKeyDecodeError'.
-renderSigningKeyDecodeError :: SigningKeyDecodeError -> Text
-renderSigningKeyDecodeError err =
-  case err of
-    SigningKeyTextEnvelopeError textEnvErr ->
-      Text.pack (displayError textEnvErr)
-    SigningKeyBech32DecodeError decodeErr ->
-      Text.pack (displayError decodeErr)
-    SigningKeyInvalidError -> "Invalid signing key."
+instance Error InputDecodeError where
+  displayError = Text.unpack . renderInputDecodeError
 
-instance Error SigningKeyDecodeError where
-  displayError = Text.unpack . renderSigningKeyDecodeError
+-- | Render an error message for a 'InputDecodeError'.
+renderInputDecodeError :: InputDecodeError -> Text
+renderInputDecodeError err =
+  case err of
+    InputTextEnvelopeError textEnvErr ->
+      Text.pack (displayError textEnvErr)
+    InputBech32DecodeError decodeErr ->
+      Text.pack (displayError decodeErr)
+    InputInvalidError -> "Invalid key."
+
+-- | The result of a deserialisation function.
+--
+-- Note that this type isn't intended to be exported, but only used as a
+-- helper within the 'deserialiseInput' function.
+data DeserialiseInputResult a
+  = DeserialiseInputSuccess !a
+  -- ^ Input successfully deserialised.
+  | DeserialiseInputError !InputDecodeError
+  -- ^ The provided data is of the expected format/encoding, but an error
+  -- occurred in deserializing it.
+  | DeserialiseInputErrorFormatMismatch
+  -- ^ The provided data's formatting/encoding does not match that which was
+  -- expected. This error is an indication that one could attempt to
+  -- deserialise the input again, but instead expecting a different format.
+
+-- | Deserialise an input of some type that is formatted in some way.
+deserialiseInput
+  :: forall a.
+     AsType a
+  -> NonEmpty (InputFormat a)
+  -> ByteString
+  -> Either InputDecodeError a
+deserialiseInput asType acceptedFormats inputBs =
+    go (NE.toList acceptedFormats)
+  where
+    inputText :: Text
+    inputText = Text.decodeUtf8 inputBs
+
+    go :: [InputFormat a] -> Either InputDecodeError a
+    go [] = Left InputInvalidError
+    go (kf:kfs) =
+      let res =
+            case kf of
+              InputFormatBech32 -> deserialiseBech32
+              InputFormatHex -> deserialiseHex
+              InputFormatTextEnvelope -> deserialiseTextEnvelope
+      in case res of
+        DeserialiseInputSuccess a -> Right a
+        DeserialiseInputError err -> Left err
+        DeserialiseInputErrorFormatMismatch -> go kfs
+
+    deserialiseTextEnvelope :: HasTextEnvelope a => DeserialiseInputResult a
+    deserialiseTextEnvelope = do
+      let textEnvRes :: Either TextEnvelopeError a
+          textEnvRes =
+            deserialiseFromTextEnvelope asType
+              =<< first TextViewAesonDecodeError (Aeson.eitherDecodeStrict' inputBs)
+      case textEnvRes of
+        Right res -> DeserialiseInputSuccess res
+
+        -- The input was valid a text envelope, but there was a type mismatch
+        -- error.
+        Left err@(TextViewTypeError _ _) ->
+          DeserialiseInputError (InputTextEnvelopeError err)
+
+        -- The input was not valid a text envelope.
+        Left _ -> DeserialiseInputErrorFormatMismatch
+
+    deserialiseBech32 :: SerialiseAsBech32 a => DeserialiseInputResult a
+    deserialiseBech32 =
+      case deserialiseFromBech32 asType inputText of
+        Right res -> DeserialiseInputSuccess res
+
+        -- The input was not valid Bech32.
+        Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+
+        -- The input was valid Bech32, but some other error occurred.
+        Left err -> DeserialiseInputError $ InputBech32DecodeError err
+
+    deserialiseHex :: SerialiseAsRawBytes a => DeserialiseInputResult a
+    deserialiseHex
+      | isValidHex inputBs =
+          maybe
+            (DeserialiseInputError InputInvalidError)
+            DeserialiseInputSuccess
+            (deserialiseFromRawBytesHex asType inputBs)
+      | otherwise = DeserialiseInputErrorFormatMismatch
+
+    isValidHex :: ByteString -> Bool
+    isValidHex x =
+      all (`elem` hexAlpha) (toLower <$> BSC.unpack x)
+        && even (BSC.length x)
+      where
+        hexAlpha :: [Char]
+        hexAlpha = "0123456789abcdef"
+
+-- | Deserialise an input of some type that is formatted in some way.
+--
+-- The provided 'ByteString' can either be Bech32-encoded or in the text
+-- envelope format.
+deserialiseInputAnyOf
+  :: forall b.
+     [FromSomeType SerialiseAsBech32 b]
+  -> [FromSomeType HasTextEnvelope b]
+  -> ByteString
+  -> Either InputDecodeError b
+deserialiseInputAnyOf bech32Types textEnvTypes inputBs =
+    case deserialiseBech32 `orTry` deserialiseTextEnvelope of
+      DeserialiseInputSuccess res -> Right res
+      DeserialiseInputError err -> Left err
+      DeserialiseInputErrorFormatMismatch -> Left InputInvalidError
+  where
+    inputText :: Text
+    inputText = Text.decodeUtf8 inputBs
+
+    orTry
+      :: DeserialiseInputResult b
+      -> DeserialiseInputResult b
+      -> DeserialiseInputResult b
+    orTry x y =
+      case x of
+        DeserialiseInputSuccess _ -> x
+        DeserialiseInputError _ -> x
+        DeserialiseInputErrorFormatMismatch -> y
+
+    deserialiseTextEnvelope :: DeserialiseInputResult b
+    deserialiseTextEnvelope = do
+      let textEnvRes :: Either TextEnvelopeError b
+          textEnvRes =
+            deserialiseFromTextEnvelopeAnyOf textEnvTypes
+              =<< first TextViewAesonDecodeError (Aeson.eitherDecodeStrict' inputBs)
+      case textEnvRes of
+        Right res -> DeserialiseInputSuccess res
+
+        -- The input was valid a text envelope, but there was a type mismatch
+        -- error.
+        Left err@(TextViewTypeError _ _) ->
+          DeserialiseInputError (InputTextEnvelopeError err)
+
+        -- The input was not valid a text envelope.
+        Left _ -> DeserialiseInputErrorFormatMismatch
+
+    deserialiseBech32 :: DeserialiseInputResult b
+    deserialiseBech32 =
+      case deserialiseAnyOfFromBech32 bech32Types inputText of
+        Right res -> DeserialiseInputSuccess res
+
+        -- The input was not valid Bech32.
+        Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+
+        -- The input was valid Bech32, but some other error occurred.
+        Left err -> DeserialiseInputError $ InputBech32DecodeError err
+
+------------------------------------------------------------------------------
+-- Cryptographic key deserialisation
+------------------------------------------------------------------------------
+
+-- | Read a cryptographic key from a file.
+--
+-- The contents of the file can either be Bech32-encoded, hex-encoded, or in
+-- the text envelope format.
+readKeyFile
+  :: AsType a
+  -> NonEmpty (InputFormat a)
+  -> FilePath
+  -> IO (Either (FileError InputDecodeError) a)
+readKeyFile asType acceptedFormats path =
+  runExceptT $ do
+    content <- handleIOExceptT (FileIOError path) $ BS.readFile path
+    firstExceptT (FileError path) $ hoistEither $
+      deserialiseInput asType acceptedFormats content
+
+-- | Read a cryptographic key from a file.
+--
+-- The contents of the file must be in the text envelope format.
+readKeyFileTextEnvelope
+  :: HasTextEnvelope a
+  => AsType a
+  -> FilePath
+  -> IO (Either (FileError InputDecodeError) a)
+readKeyFileTextEnvelope asType fp =
+    first toInputDecodeError <$> readFileTextEnvelope asType fp
+  where
+    toInputDecodeError
+      :: FileError TextEnvelopeError
+      -> FileError InputDecodeError
+    toInputDecodeError err =
+      case err of
+        FileIOError path ex -> FileIOError path ex
+        FileError path textEnvErr ->
+          FileError path (InputTextEnvelopeError textEnvErr)
+
+-- | Read a cryptographic key from a file given that it is one of the provided
+-- types.
+--
+-- The contents of the file can either be Bech32-encoded or in the text
+-- envelope format.
+readKeyFileAnyOf
+  :: forall b.
+     [FromSomeType SerialiseAsBech32 b]
+  -> [FromSomeType HasTextEnvelope b]
+  -> FilePath
+  -> IO (Either (FileError InputDecodeError) b)
+readKeyFileAnyOf bech32Types textEnvTypes path =
+  runExceptT $ do
+    content <- handleIOExceptT (FileIOError path) $ BS.readFile path
+    firstExceptT (FileError path) $ hoistEither $
+      deserialiseInputAnyOf bech32Types textEnvTypes content
+
+------------------------------------------------------------------------------
+-- Signing key deserialisation
+------------------------------------------------------------------------------
 
 -- | Read a signing key from a file.
 --
@@ -57,56 +303,12 @@ readSigningKeyFile
      )
   => AsType keyrole
   -> SigningKeyFile
-  -> IO (Either (FileError SigningKeyDecodeError) (SigningKey keyrole))
+  -> IO (Either (FileError InputDecodeError) (SigningKey keyrole))
 readSigningKeyFile asType (SigningKeyFile fp) =
-    tryReadTextEnvelope (tryDeserialiseBech32 tryDeserialiseHex)
-  where
-    tryReadTextEnvelope
-      :: (Text -> Either SigningKeyDecodeError (SigningKey keyrole))
-      -> IO (Either (FileError SigningKeyDecodeError) (SigningKey keyrole))
-    tryReadTextEnvelope tryBech32 = do
-      readTextEnvRes <- readFileTextEnvelope (AsSigningKey asType) fp
-      case readTextEnvRes of
-        Right res -> pure (Right res)
-
-        -- If there was an IO exception, return the error.
-        Left (FileIOError _ ioEx) -> pure $ Left $ FileIOError fp ioEx
-
-        Left (FileError _ textEnvErr) ->
-          case textEnvErr of
-            -- The input was valid text envelope, but there was a type mismatch
-            -- error.
-            TextViewTypeError _ _ ->
-              pure $ Left $ FileError fp (SigningKeyTextEnvelopeError textEnvErr)
-
-            _ -> do
-              content <- runExceptT . handleIOExceptT (FileIOError fp)
-                $ Text.readFile fp
-              case content of
-                Left err -> pure (Left err)
-                Right c' -> pure $ first (FileError fp) (tryBech32 c')
-
-    tryDeserialiseBech32
-      :: (ByteString -> Either SigningKeyDecodeError (SigningKey keyrole))
-      -> Text
-      -> Either SigningKeyDecodeError (SigningKey keyrole)
-    tryDeserialiseBech32 tryHex content =
-      case deserialiseFromBech32 (AsSigningKey asType) content of
-        Right res -> Right res
-
-        -- The input was not valid Bech32. Attempt to deserialize it as hex.
-        Left (Bech32DecodingError _) -> tryHex (Text.encodeUtf8 content)
-
-        -- The input was valid Bech32, but some other error occurred.
-        Left err -> Left $ SigningKeyBech32DecodeError err
-
-    tryDeserialiseHex
-      :: ByteString
-      -> Either SigningKeyDecodeError (SigningKey keyrole)
-    tryDeserialiseHex content =
-      case deserialiseFromRawBytesHex (AsSigningKey asType) content of
-        Just res -> Right res
-        Nothing -> Left SigningKeyInvalidError
+  readKeyFile
+    (AsSigningKey asType)
+    (NE.fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
+    fp
 
 -- | Read a signing key from a file given that it is one of the provided types
 -- of signing key.
@@ -115,47 +317,154 @@ readSigningKeyFile asType (SigningKeyFile fp) =
 -- envelope format.
 readSigningKeyFileAnyOf
   :: forall b.
-     [FromSomeType HasTextEnvelope b]
-  -> [FromSomeType SerialiseAsBech32 b]
+     [FromSomeType SerialiseAsBech32 b]
+  -> [FromSomeType HasTextEnvelope b]
   -> SigningKeyFile
-  -> IO (Either (FileError SigningKeyDecodeError) b)
-readSigningKeyFileAnyOf textEnvTypes bech32Types (SigningKeyFile fp) =
-    tryReadTextEnvelope tryDeserialiseBech32
-  where
-    tryReadTextEnvelope
-      :: (Text -> Either SigningKeyDecodeError b)
-      -> IO (Either (FileError SigningKeyDecodeError) b)
-    tryReadTextEnvelope tryBech32 = do
-      readTextEnvRes <- readFileTextEnvelopeAnyOf textEnvTypes fp
-      case readTextEnvRes of
-        Right res -> pure (Right res)
+  -> IO (Either (FileError InputDecodeError) b)
+readSigningKeyFileAnyOf bech32Types textEnvTypes (SigningKeyFile fp) =
+  readKeyFileAnyOf bech32Types textEnvTypes fp
 
-        -- If there was an IO exception, return the error.
-        Left (FileIOError _ ioEx) -> pure $ Left $ FileIOError fp ioEx
+------------------------------------------------------------------------------
+-- Verification key deserialisation
+------------------------------------------------------------------------------
 
-        Left (FileError _ textEnvErr) ->
-          case textEnvErr of
-            -- The input was valid text envelope, but there was a type mismatch
-            -- error.
-            TextViewTypeError _ _ ->
-              pure $ Left $ FileError fp (SigningKeyTextEnvelopeError textEnvErr)
+-- | Either a verification key or path to a verification key file.
+data VerificationKeyOrFile keyrole
+  = VerificationKeyValue !(VerificationKey keyrole)
+  -- ^ A verification key.
+  | VerificationKeyFilePath !VerificationKeyFile
+  -- ^ A path to a verification key file.
+  -- Note that this file hasn't been validated at all (whether it exists,
+  -- contains a key of the correct type, etc.)
 
-            _ -> do
-              content <- runExceptT . handleIOExceptT (FileIOError fp)
-                $ Text.readFile fp
-              case content of
-                Left err -> pure (Left err)
-                Right c' -> pure $ first (FileError fp) (tryBech32 c')
+deriving instance Show (VerificationKey keyrole)
+  => Show (VerificationKeyOrFile keyrole)
 
-    tryDeserialiseBech32
-      :: Text
-      -> Either SigningKeyDecodeError b
-    tryDeserialiseBech32 content =
-      case deserialiseAnyOfFromBech32 bech32Types content of
-        Right res -> Right res
+deriving instance Eq (VerificationKey keyrole)
+  => Eq (VerificationKeyOrFile keyrole)
 
-        -- The input was not valid Bech32.
-        Left (Bech32DecodingError _) -> Left SigningKeyInvalidError
+-- | Read a verification key or verification key file and return a
+-- verification key.
+--
+-- If a filepath is provided, the file can either be formatted as Bech32, hex,
+-- or text envelope.
+readVerificationKeyOrFile
+  :: ( HasTextEnvelope (VerificationKey keyrole)
+     , SerialiseAsBech32 (VerificationKey keyrole)
+     )
+  => AsType keyrole
+  -> VerificationKeyOrFile keyrole
+  -> IO (Either (FileError InputDecodeError) (VerificationKey keyrole))
+readVerificationKeyOrFile asType verKeyOrFile =
+  case verKeyOrFile of
+    VerificationKeyValue vk -> pure (Right vk)
+    VerificationKeyFilePath (VerificationKeyFile fp) ->
+      readKeyFile
+        (AsVerificationKey asType)
+        (NE.fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
+        fp
 
-        -- The input was valid Bech32, but some other error occurred.
-        Left err -> Left $ SigningKeyBech32DecodeError err
+-- | Read a verification key or verification key file and return a
+-- verification key.
+--
+-- If a filepath is provided, it will be interpreted as a text envelope
+-- formatted file.
+readVerificationKeyOrTextEnvFile
+  :: HasTextEnvelope (VerificationKey keyrole)
+  => AsType keyrole
+  -> VerificationKeyOrFile keyrole
+  -> IO (Either (FileError InputDecodeError) (VerificationKey keyrole))
+readVerificationKeyOrTextEnvFile asType verKeyOrFile =
+  case verKeyOrFile of
+    VerificationKeyValue vk -> pure (Right vk)
+    VerificationKeyFilePath (VerificationKeyFile fp) ->
+      readKeyFileTextEnvelope (AsVerificationKey asType) fp
+
+-- | Either an unvalidated text representation of a verification key or a path
+-- to a verification key file.
+data VerificationKeyTextOrFile
+  = VktofVerificationKeyText !Text
+  | VktofVerificationKeyFile !VerificationKeyFile
+  deriving (Eq, Show)
+
+-- | An error in deserializing a 'VerificationKeyTextOrFile' to a
+-- 'VerificationKey'.
+data VerificationKeyTextOrFileError
+  = VerificationKeyTextError !InputDecodeError
+  | VerificationKeyFileError !(FileError InputDecodeError)
+  deriving Show
+
+-- | Render an error message for a 'VerificationKeyTextOrFileError'.
+renderVerificationKeyTextOrFileError :: VerificationKeyTextOrFileError -> Text
+renderVerificationKeyTextOrFileError vkTextOrFileErr =
+  case vkTextOrFileErr of
+    VerificationKeyTextError err -> renderInputDecodeError err
+    VerificationKeyFileError err -> Text.pack (displayError err)
+
+-- | Deserialise a verification key from text or a verification key file given
+-- that it is one of the provided types.
+--
+-- If a filepath is provided, the file can either be formatted as Bech32, hex,
+-- or text envelope.
+readVerificationKeyTextOrFileAnyOf
+  :: forall b.
+     [FromSomeType SerialiseAsBech32 b]
+  -> [FromSomeType HasTextEnvelope b]
+  -> VerificationKeyTextOrFile
+  -> IO (Either VerificationKeyTextOrFileError b)
+readVerificationKeyTextOrFileAnyOf bech32Types textEnvTypes verKeyTextOrFile =
+  case verKeyTextOrFile of
+    VktofVerificationKeyText vkText ->
+      pure $ first VerificationKeyTextError $
+        deserialiseInputAnyOf bech32Types textEnvTypes (Text.encodeUtf8 vkText)
+    VktofVerificationKeyFile (VerificationKeyFile fp) ->
+      first VerificationKeyFileError
+        <$> readKeyFileAnyOf bech32Types textEnvTypes fp
+
+-- | Verification key, verification key hash, or path to a verification key
+-- file.
+data VerificationKeyOrHashOrFile keyrole
+  = VerificationKeyOrFile !(VerificationKeyOrFile keyrole)
+  -- ^ Either a verification key or path to a verification key file.
+  | VerificationKeyHash !(Hash keyrole)
+  -- ^ A verification key hash.
+
+deriving instance (Show (VerificationKeyOrFile keyrole), Show (Hash keyrole))
+  => Show (VerificationKeyOrHashOrFile keyrole)
+
+deriving instance (Eq (VerificationKeyOrFile keyrole), Eq (Hash keyrole))
+  => Eq (VerificationKeyOrHashOrFile keyrole)
+
+-- | Read a verification key or verification key hash or verification key file
+-- and return a verification key hash.
+--
+-- If a filepath is provided, the file can either be formatted as Bech32, hex,
+-- or text envelope.
+readVerificationKeyOrHashOrFile
+  :: (Key keyrole, SerialiseAsBech32 (VerificationKey keyrole))
+  => AsType keyrole
+  -> VerificationKeyOrHashOrFile keyrole
+  -> IO (Either (FileError InputDecodeError) (Hash keyrole))
+readVerificationKeyOrHashOrFile asType verKeyOrHashOrFile =
+  case verKeyOrHashOrFile of
+    VerificationKeyOrFile vkOrFile -> do
+      eitherVk <- readVerificationKeyOrFile asType vkOrFile
+      pure (verificationKeyHash <$> eitherVk)
+    VerificationKeyHash vkHash -> pure (Right vkHash)
+
+-- | Read a verification key or verification key hash or verification key file
+-- and return a verification key hash.
+--
+-- If a filepath is provided, it will be interpreted as a text envelope
+-- formatted file.
+readVerificationKeyOrHashOrTextEnvFile
+  :: Key keyrole
+  => AsType keyrole
+  -> VerificationKeyOrHashOrFile keyrole
+  -> IO (Either (FileError InputDecodeError) (Hash keyrole))
+readVerificationKeyOrHashOrTextEnvFile asType verKeyOrHashOrFile =
+  case verKeyOrHashOrFile of
+    VerificationKeyOrFile vkOrFile -> do
+      eitherVk <- readVerificationKeyOrTextEnvFile asType vkOrFile
+      pure (verificationKeyHash <$> eitherVk)
+    VerificationKeyHash vkHash -> pure (Right vkHash)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -22,7 +22,8 @@ import           Cardano.Api.Typed hiding (PoolId)
 import           Cardano.Chain.Slotting (EpochSlots (..))
 import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Key (InputFormat (..), VerificationKeyOrFile (..),
-                     VerificationKeyOrHashOrFile (..), deserialiseInput, renderInputDecodeError)
+                     VerificationKeyOrHashOrFile (..), VerificationKeyTextOrFile (..),
+                     deserialiseInput, renderInputDecodeError)
 import           Cardano.CLI.Types
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import           Control.Monad.Fail (fail)
@@ -135,13 +136,16 @@ pAddressCmd =
                                    <*> pSigningKeyFile Output
 
     pAddressKeyHash :: Parser AddressCmd
-    pAddressKeyHash = AddressKeyHash <$> pPaymentVerificationKeyFile <*> pMaybeOutputFile
+    pAddressKeyHash =
+      AddressKeyHash
+        <$> pPaymentVerificationKeyTextOrFile
+        <*> pMaybeOutputFile
 
     pAddressBuild :: Parser AddressCmd
     pAddressBuild =
       AddressBuild
-        <$> pPaymentVerificationKeyFile
-        <*> Opt.optional pStakeVerificationKeyFile
+        <$> pPaymentVerificationKeyTextOrFile
+        <*> Opt.optional pStakeVerificationKeyOrFile
         <*> pNetworkId
         <*> pMaybeOutputFile
 
@@ -153,6 +157,20 @@ pAddressCmd =
 
     pAddressInfo :: Parser AddressCmd
     pAddressInfo = AddressInfo <$> pAddress <*> pMaybeOutputFile
+
+pPaymentVerificationKeyTextOrFile :: Parser VerificationKeyTextOrFile
+pPaymentVerificationKeyTextOrFile =
+  VktofVerificationKeyText <$> pPaymentVerificationKeyText
+    <|> VktofVerificationKeyFile <$> pPaymentVerificationKeyFile
+
+pPaymentVerificationKeyText :: Parser Text
+pPaymentVerificationKeyText =
+  Text.pack <$>
+    Opt.strOption
+      (  Opt.long "payment-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Payment verification key (Bech32-encoded)"
+      )
 
 pPaymentVerificationKeyFile :: Parser VerificationKeyFile
 pPaymentVerificationKeyFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -626,7 +626,7 @@ pPoolCmd =
       ]
   where
     pId :: Parser PoolCmd
-    pId = PoolGetId <$> pVerificationKeyFile Output <*> pOutputFormat
+    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pOutputFormat
 
     pPoolMetaDataHashSubCmd :: Parser PoolCmd
     pPoolMetaDataHashSubCmd = PoolMetaDataHash <$> pPoolMetaDataFile <*> pMaybeOutputFile
@@ -1715,24 +1715,15 @@ pStakePoolVerificationKey =
     asType :: AsType (VerificationKey StakePoolKey)
     asType = AsVerificationKey AsStakePoolKey
 
+    keyFormats :: NonEmpty (InputFormat (VerificationKey StakePoolKey))
+    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+
     deserialiseFromBech32OrHex
       :: String
       -> Either String (VerificationKey StakePoolKey)
     deserialiseFromBech32OrHex str =
-      case deserialiseFromBech32 asType (Text.pack str) of
-        Right res -> Right res
-
-        -- The input was valid Bech32, but some other error occurred.
-        Left err@(Bech32UnexpectedPrefix _ _) -> Left (displayError err)
-        Left err@(Bech32DataPartToBytesError _) -> Left (displayError err)
-        Left err@(Bech32DeserialiseFromBytesError _) -> Left (displayError err)
-        Left err@(Bech32WrongPrefix _ _) -> Left (displayError err)
-
-        -- The input was not valid Bech32. Attempt to deserialize it as hex.
-        Left (Bech32DecodingError _) ->
-          case deserialiseFromRawBytesHex asType (BSC.pack str) of
-            Just res' -> Right res'
-            Nothing -> Left "Invalid stake pool verification key."
+      first (Text.unpack . renderInputDecodeError) $
+        deserialiseInput asType keyFormats (BSC.pack str)
 
 pStakePoolVerificationKeyOrFile
   :: Parser (VerificationKeyOrFile StakePoolKey)
@@ -1809,7 +1800,7 @@ pRewardAcctVerificationKeyFile =
     ( Opt.strOption
         (  Opt.long "pool-reward-account-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help "Filepath of the reward account staking verification key."
+        <> Opt.help "Filepath of the reward account stake verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1819,14 +1810,40 @@ pRewardAcctVerificationKeyFile =
         )
     )
 
+pRewardAcctVerificationKey :: Parser (VerificationKey StakeKey)
+pRewardAcctVerificationKey =
+    Opt.option
+      (Opt.eitherReader deserialiseFromBech32OrHex)
+        (  Opt.long "pool-reward-account-verification-key"
+        <> Opt.metavar "STRING"
+        <> Opt.help "Reward account stake verification key (Bech32 or hex-encoded)."
+        )
+  where
+    asType :: AsType (VerificationKey StakeKey)
+    asType = AsVerificationKey AsStakeKey
 
-pPoolOwner :: Parser VerificationKeyFile
-pPoolOwner =
+    keyFormats :: NonEmpty (InputFormat (VerificationKey StakeKey))
+    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+
+    deserialiseFromBech32OrHex
+      :: String
+      -> Either String (VerificationKey StakeKey)
+    deserialiseFromBech32OrHex str =
+      first (Text.unpack . renderInputDecodeError) $
+        deserialiseInput asType keyFormats (BSC.pack str)
+
+pRewardAcctVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
+pRewardAcctVerificationKeyOrFile =
+  VerificationKeyValue <$> pRewardAcctVerificationKey
+    <|> VerificationKeyFilePath <$> pRewardAcctVerificationKeyFile
+
+pPoolOwnerVerificationKeyFile :: Parser VerificationKeyFile
+pPoolOwnerVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
         (  Opt.long "pool-owner-stake-verification-key-file"
         <> Opt.metavar "FILE"
-        <> Opt.help "Filepath of the pool owner staking verification key."
+        <> Opt.help "Filepath of the pool owner stake verification key."
         <> Opt.completer (Opt.bashCompleter "file")
         )
     <|>
@@ -1836,6 +1853,32 @@ pPoolOwner =
           )
     )
 
+pPoolOwnerVerificationKey :: Parser (VerificationKey StakeKey)
+pPoolOwnerVerificationKey =
+    Opt.option
+      (Opt.eitherReader deserialiseFromBech32OrHex)
+        (  Opt.long "pool-owner-verification-key"
+        <> Opt.metavar "STRING"
+        <> Opt.help "Pool owner stake verification key (Bech32 or hex-encoded)."
+        )
+  where
+    asType :: AsType (VerificationKey StakeKey)
+    asType = AsVerificationKey AsStakeKey
+
+    keyFormats :: NonEmpty (InputFormat (VerificationKey StakeKey))
+    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+
+    deserialiseFromBech32OrHex
+      :: String
+      -> Either String (VerificationKey StakeKey)
+    deserialiseFromBech32OrHex str =
+      first (Text.unpack . renderInputDecodeError) $
+        deserialiseInput asType keyFormats (BSC.pack str)
+
+pPoolOwnerVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
+pPoolOwnerVerificationKeyOrFile =
+  VerificationKeyValue <$> pPoolOwnerVerificationKey
+    <|> VerificationKeyFilePath <$> pPoolOwnerVerificationKeyFile
 
 pPoolPledge :: Parser Lovelace
 pPoolPledge =
@@ -1969,23 +2012,23 @@ pStakePoolMetadataHash =
 
 pStakePoolRegistrationCert :: Parser PoolCmd
 pStakePoolRegistrationCert =
- PoolRegistrationCert
-  <$> pStakePoolVerificationKeyFile
-  <*> pVrfVerificationKeyFile
-  <*> pPoolPledge
-  <*> pPoolCost
-  <*> pPoolMargin
-  <*> pRewardAcctVerificationKeyFile
-  <*> some pPoolOwner
-  <*> many pPoolRelay
-  <*> pStakePoolMetadataReference
-  <*> pNetworkId
-  <*> pOutputFile
+  PoolRegistrationCert
+    <$> pStakePoolVerificationKeyOrFile
+    <*> pVrfVerificationKeyOrFile
+    <*> pPoolPledge
+    <*> pPoolCost
+    <*> pPoolMargin
+    <*> pRewardAcctVerificationKeyOrFile
+    <*> some pPoolOwnerVerificationKeyOrFile
+    <*> many pPoolRelay
+    <*> pStakePoolMetadataReference
+    <*> pNetworkId
+    <*> pOutputFile
 
 pStakePoolRetirementCert :: Parser PoolCmd
 pStakePoolRetirementCert =
   PoolRetirementCert
-    <$> pStakePoolVerificationKeyFile
+    <$> pStakePoolVerificationKeyOrFile
     <*> pEpochNo
     <*> pOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Shelley.Parsers
   ( -- * CLI command parser
@@ -565,11 +567,11 @@ pNodeCmd =
 
     pKeyHashVRF :: Parser NodeCmd
     pKeyHashVRF =
-      NodeKeyHashVRF <$> pVerificationKeyFile Input <*> pMaybeOutputFile
+      NodeKeyHashVRF <$> pVerificationKeyOrFile AsVrfKey <*> pMaybeOutputFile
 
     pNewCounter :: Parser NodeCmd
     pNewCounter =
-      NodeNewCounter <$> pColdVerificationKeyFile
+      NodeNewCounter <$> pColdVerificationKeyOrFile
                      <*> pCounterValue
                      <*> pOperatorCertIssueCounterFile
 
@@ -583,7 +585,7 @@ pNodeCmd =
 
     pIssueOpCert :: Parser NodeCmd
     pIssueOpCert =
-      NodeIssueOpCert <$> pKESVerificationKeyFile
+      NodeIssueOpCert <$> pKesVerificationKeyOrFile
                       <*> pColdSigningKeyFile
                       <*> pOperatorCertIssueCounterFile
                       <*> pKesPeriod
@@ -1145,6 +1147,12 @@ pOutputFile =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
+pColdVerificationKeyOrFile :: Parser ColdVerificationKeyOrFile
+pColdVerificationKeyOrFile =
+  ColdStakePoolVerificationKey <$> pStakePoolVerificationKey
+    <|> ColdGenesisDelegateVerificationKey <$> pGenesisDelegateVerificationKey
+    <|> ColdVerificationKeyFile <$> pColdVerificationKeyFile
+
 pColdVerificationKeyFile :: Parser VerificationKeyFile
 pColdVerificationKeyFile =
   VerificationKeyFile <$>
@@ -1160,6 +1168,36 @@ pColdVerificationKeyFile =
         <> Opt.internal
         )
     )
+
+pVerificationKey
+  :: forall keyrole. SerialiseAsBech32 (VerificationKey keyrole)
+  => AsType keyrole
+  -> Parser (VerificationKey keyrole)
+pVerificationKey asType =
+    Opt.option
+      (Opt.eitherReader deserialiseFromBech32OrHex)
+        (  Opt.long "verification-key"
+        <> Opt.metavar "STRING"
+        <> Opt.help "Verification key (Bech32 or hex-encoded)."
+        )
+  where
+    keyFormats :: NonEmpty (InputFormat (VerificationKey keyrole))
+    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+
+    deserialiseFromBech32OrHex
+      :: String
+      -> Either String (VerificationKey keyrole)
+    deserialiseFromBech32OrHex str =
+      first (Text.unpack . renderInputDecodeError) $
+        deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
+
+pVerificationKeyOrFile
+  :: SerialiseAsBech32 (VerificationKey keyrole)
+  => AsType keyrole
+  -> Parser (VerificationKeyOrFile keyrole)
+pVerificationKeyOrFile asType =
+  VerificationKeyValue <$> pVerificationKey asType
+    <|> VerificationKeyFilePath <$> pVerificationKeyFile Input
 
 pVerificationKeyFile :: FileDirection -> Parser VerificationKeyFile
 pVerificationKeyFile fdir =
@@ -1285,8 +1323,42 @@ pGenesisDelegateVerificationKeyOrHashOrFile =
   VerificationKeyOrFile <$> pGenesisDelegateVerificationKeyOrFile
     <|> VerificationKeyHash <$> pGenesisDelegateVerificationKeyHash
 
-pKESVerificationKeyFile :: Parser VerificationKeyFile
-pKESVerificationKeyFile =
+pKesVerificationKeyOrFile :: Parser (VerificationKeyOrFile KesKey)
+pKesVerificationKeyOrFile =
+  VerificationKeyValue <$> pKesVerificationKey
+    <|> VerificationKeyFilePath <$> pKesVerificationKeyFile
+
+pKesVerificationKey :: Parser (VerificationKey KesKey)
+pKesVerificationKey =
+    Opt.option
+      (Opt.eitherReader deserialiseVerKey)
+        (  Opt.long "kes-verification-key"
+        <> Opt.metavar "STRING"
+        <> Opt.help "A Bech32 or hex-encoded hot KES verification key."
+        )
+  where
+    asType :: AsType (VerificationKey KesKey)
+    asType = AsVerificationKey AsKesKey
+
+    deserialiseVerKey :: String -> Either String (VerificationKey KesKey)
+    deserialiseVerKey str =
+      case deserialiseFromBech32 asType (Text.pack str) of
+        Right res -> Right res
+
+        -- The input was valid Bech32, but some other error occurred.
+        Left err@(Bech32UnexpectedPrefix _ _) -> Left (displayError err)
+        Left err@(Bech32DataPartToBytesError _) -> Left (displayError err)
+        Left err@(Bech32DeserialiseFromBytesError _) -> Left (displayError err)
+        Left err@(Bech32WrongPrefix _ _) -> Left (displayError err)
+
+        -- The input was not valid Bech32. Attempt to deserialize it as hex.
+        Left (Bech32DecodingError _) ->
+          case deserialiseFromRawBytesHex asType (BSC.pack str) of
+            Just res' -> Right res'
+            Nothing -> Left "Invalid stake pool verification key."
+
+pKesVerificationKeyFile :: Parser VerificationKeyFile
+pKesVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
         (  Opt.long "kes-verification-key-file"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1192,22 +1192,12 @@ pVerificationKey
   => AsType keyrole
   -> Parser (VerificationKey keyrole)
 pVerificationKey asType =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "Verification key (Bech32 or hex-encoded)."
-        )
-  where
-    keyFormats :: NonEmpty (InputFormat (VerificationKey keyrole))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey keyrole)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey asType)
+      (  Opt.long "verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Verification key (Bech32 or hex-encoded)."
+      )
 
 pVerificationKeyOrFile
   :: SerialiseAsBech32 (VerificationKey keyrole)
@@ -1626,25 +1616,12 @@ pStakeVerificationKeyOrFile =
 
 pStakeVerificationKey :: Parser (VerificationKey StakeKey)
 pStakeVerificationKey =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "stake-verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "Stake verification key (Bech32 or hex-encoded)."
-        )
-  where
-    asType :: AsType (VerificationKey StakeKey)
-    asType = AsVerificationKey AsStakeKey
-
-    keyFormats :: NonEmpty (InputFormat (VerificationKey StakeKey))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey StakeKey)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput asType keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey AsStakeKey)
+      (  Opt.long "stake-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Stake verification key (Bech32 or hex-encoded)."
+      )
 
 pStakeVerificationKeyFile :: Parser VerificationKeyFile
 pStakeVerificationKeyFile =
@@ -1705,25 +1682,12 @@ pStakePoolVerificationKeyHash =
 
 pStakePoolVerificationKey :: Parser (VerificationKey StakePoolKey)
 pStakePoolVerificationKey =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "stake-pool-verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
-        )
-  where
-    asType :: AsType (VerificationKey StakePoolKey)
-    asType = AsVerificationKey AsStakePoolKey
-
-    keyFormats :: NonEmpty (InputFormat (VerificationKey StakePoolKey))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey StakePoolKey)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput asType keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey AsStakePoolKey)
+      (  Opt.long "stake-pool-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
+      )
 
 pStakePoolVerificationKeyOrFile
   :: Parser (VerificationKeyOrFile StakePoolKey)
@@ -1764,25 +1728,12 @@ pVrfVerificationKeyHash =
 
 pVrfVerificationKey :: Parser (VerificationKey VrfKey)
 pVrfVerificationKey =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "vrf-verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "VRF verification key (Bech32 or hex-encoded)."
-        )
-  where
-    asType :: AsType (VerificationKey VrfKey)
-    asType = AsVerificationKey AsVrfKey
-
-    keyFormats :: NonEmpty (InputFormat (VerificationKey VrfKey))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey VrfKey)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput asType keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey AsVrfKey)
+      (  Opt.long "vrf-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "VRF verification key (Bech32 or hex-encoded)."
+      )
 
 pVrfVerificationKeyOrFile :: Parser (VerificationKeyOrFile VrfKey)
 pVrfVerificationKeyOrFile =
@@ -1812,25 +1763,12 @@ pRewardAcctVerificationKeyFile =
 
 pRewardAcctVerificationKey :: Parser (VerificationKey StakeKey)
 pRewardAcctVerificationKey =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "pool-reward-account-verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "Reward account stake verification key (Bech32 or hex-encoded)."
-        )
-  where
-    asType :: AsType (VerificationKey StakeKey)
-    asType = AsVerificationKey AsStakeKey
-
-    keyFormats :: NonEmpty (InputFormat (VerificationKey StakeKey))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey StakeKey)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput asType keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey AsStakeKey)
+      (  Opt.long "pool-reward-account-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Reward account stake verification key (Bech32 or hex-encoded)."
+      )
 
 pRewardAcctVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
 pRewardAcctVerificationKeyOrFile =
@@ -1855,25 +1793,12 @@ pPoolOwnerVerificationKeyFile =
 
 pPoolOwnerVerificationKey :: Parser (VerificationKey StakeKey)
 pPoolOwnerVerificationKey =
-    Opt.option
-      (Opt.eitherReader deserialiseFromBech32OrHex)
-        (  Opt.long "pool-owner-verification-key"
-        <> Opt.metavar "STRING"
-        <> Opt.help "Pool owner stake verification key (Bech32 or hex-encoded)."
-        )
-  where
-    asType :: AsType (VerificationKey StakeKey)
-    asType = AsVerificationKey AsStakeKey
-
-    keyFormats :: NonEmpty (InputFormat (VerificationKey StakeKey))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
-
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey StakeKey)
-    deserialiseFromBech32OrHex str =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput asType keyFormats (BSC.pack str)
+  Opt.option
+    (readVerificationKey AsStakeKey)
+      (  Opt.long "pool-owner-verification-key"
+      <> Opt.metavar "STRING"
+      <> Opt.help "Pool owner stake verification key (Bech32 or hex-encoded)."
+      )
 
 pPoolOwnerVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
 pPoolOwnerVerificationKeyOrFile =
@@ -2297,6 +2222,24 @@ lexPlausibleAddressString =
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
+
+-- | Read a Bech32 or hex-encoded verification key.
+readVerificationKey
+  :: forall keyrole. SerialiseAsBech32 (VerificationKey keyrole)
+  => AsType keyrole
+  -> Opt.ReadM (VerificationKey keyrole)
+readVerificationKey asType =
+    Opt.eitherReader deserialiseFromBech32OrHex
+  where
+    keyFormats :: NonEmpty (InputFormat (VerificationKey keyrole))
+    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+
+    deserialiseFromBech32OrHex
+      :: String
+      -> Either String (VerificationKey keyrole)
+    deserialiseFromBech32OrHex str =
+      first (Text.unpack . renderInputDecodeError) $
+        deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
 
 readOutputFormat :: Opt.ReadM OutputFormat
 readOutputFormat = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -7,7 +7,7 @@ module Cardano.CLI.Shelley.Run.Node
 import           Cardano.Api.TextView (TextViewDescription (..))
 import           Cardano.Api.Typed
 import           Cardano.CLI.Shelley.Commands
-import           Cardano.CLI.Shelley.Key (SigningKeyDecodeError (..), readSigningKeyFileAnyOf)
+import           Cardano.CLI.Shelley.Key (InputDecodeError (..), readSigningKeyFileAnyOf)
 import           Cardano.CLI.Types (SigningKeyFile (..), VerificationKeyFile (..))
 import           Cardano.Prelude
 import           Control.Monad.Trans.Except (ExceptT)
@@ -21,7 +21,7 @@ import qualified Data.Text as Text
 
 data ShelleyNodeCmdError
   = ShelleyNodeCmdReadFileError !(FileError TextEnvelopeError)
-  | ShelleyNodeCmdReadSigningKeyFileError !(FileError SigningKeyDecodeError)
+  | ShelleyNodeCmdReadKeyFileError !(FileError InputDecodeError)
   | ShelleyNodeCmdWriteFileError !(FileError ())
   | ShelleyNodeCmdOperationalCertificateIssueError !OperationalCertIssueError
   deriving Show
@@ -31,7 +31,7 @@ renderShelleyNodeCmdError err =
   case err of
     ShelleyNodeCmdReadFileError fileErr -> Text.pack (displayError fileErr)
 
-    ShelleyNodeCmdReadSigningKeyFileError fileErr ->
+    ShelleyNodeCmdReadKeyFileError fileErr ->
       Text.pack (displayError fileErr)
 
     ShelleyNodeCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
@@ -178,11 +178,11 @@ runNodeIssueOpCert (VerificationKeyFile vkeyKesPath)
       . newExceptT
       $ readFileTextEnvelope (AsVerificationKey AsKesKey) vkeyKesPath
 
-    signKey <- firstExceptT ShelleyNodeCmdReadSigningKeyFileError
+    signKey <- firstExceptT ShelleyNodeCmdReadKeyFileError
       . newExceptT
       $ readSigningKeyFileAnyOf
-          textEnvPossibleBlockIssuers
           bech32PossibleBlockIssuers
+          textEnvPossibleBlockIssuers
           stakePoolSKeyFile
 
     (ocert, nextOcertCtr) <-

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardShelley)
 
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
-import           Cardano.CLI.Shelley.Key (SigningKeyDecodeError (..), readSigningKeyFileAnyOf)
+import           Cardano.CLI.Shelley.Key (InputDecodeError, readSigningKeyFileAnyOf)
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Types
 
@@ -313,8 +313,7 @@ instance Error ScriptJsonDecodeError where
 
 -- | Error reading the data required to construct a key witness.
 data ReadWitnessSigningDataError
-  = ReadWitnessSigningDataSigningKeyDecodeError
-      !(FileError SigningKeyDecodeError)
+  = ReadWitnessSigningDataSigningKeyDecodeError !(FileError InputDecodeError)
   | ReadWitnessSigningDataScriptError !(FileError ScriptJsonDecodeError)
   | ReadWitnessSigningDataSigningKeyAndAddressMismatch
   -- ^ A Byron address was specified alongside a non-Byron signing key.
@@ -346,7 +345,7 @@ readWitnessSigningData (ScriptWitnessSigningData (ScriptFile fp)) = do
 readWitnessSigningData (KeyWitnessSigningData skFile mbByronAddr) = do
     res <- firstExceptT ReadWitnessSigningDataSigningKeyDecodeError
       . newExceptT
-      $ readSigningKeyFileAnyOf textEnvFileTypes bech32FileTypes skFile
+      $ readSigningKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
     case (res, mbByronAddr) of
       (AByronSigningKey _ _, Just _) -> pure res
       (AByronSigningKey _ _, Nothing) -> pure res

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.Types
   , SigningKeyFile (..)
   , SigningKeyOrScriptFile (..)
   , SocketPath (..)
-  , StakePoolVerificationKeyHashOrFile (..)
   , ScriptFile (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
@@ -67,12 +66,6 @@ newtype SigningKeyFile = SigningKeyFile
   deriving newtype (IsString, Show)
 
 newtype SocketPath = SocketPath { unSocketPath :: FilePath }
-
--- | Either a stake pool verification key hash or verification key file.
-data StakePoolVerificationKeyHashOrFile
-  = StakePoolVerificationKeyHash !(Hash StakePoolKey)
-  | StakePoolVerificationKeyFile !VerificationKeyFile
-  deriving (Eq, Show)
 
 newtype UpdateProposalFile = UpdateProposalFile { unUpdateProposalFile :: FilePath }
                              deriving newtype (Eq, Show)


### PR DESCRIPTION
At the moment, `cardano-cli` commands only accept verification keys as "text envelope" formatted files.

This PR allows verification keys to be specified as both files and CLI arg strings containing other data formats such as Bech32 and hex.