### PR TITLE
Remove dependency on cardano-config

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -41,7 +41,7 @@ library
                        Cardano.CLI.Byron.Query
                        Cardano.CLI.Byron.UpdateProposal
                        Cardano.CLI.Byron.Vote
-
+                       Cardano.CLI.GitRev
                        Cardano.CLI.Shelley.Commands
                        Cardano.CLI.Shelley.Key
                        Cardano.CLI.Shelley.Orphans
@@ -89,6 +89,7 @@ library
                      , directory
                      , filepath
                      , formatting
+                     , gitrev
                      , io-sim-classes
                      , iproute
                      , memory

--- a/cardano-cli/src/Cardano/CLI/GitRev.hs
+++ b/cardano-cli/src/Cardano/CLI/GitRev.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.CLI.GitRev
+  ( gitRev
+  ) where
+
+import           Data.Text (Text)
+
+import qualified Data.Text as T
+import qualified Development.GitRev as GR
+
+gitRev :: Text
+gitRev = T.pack $(GR.gitHash)

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -20,7 +20,7 @@ import           Cardano.CLI.Shelley.Commands (ShelleyCommand)
 import           Cardano.CLI.Shelley.Run (ShelleyClientCmdError, renderShelleyClientCmdError,
                      runShelleyClientCommand)
 
-import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.CLI.GitRev (gitRev)
 import           Data.Version (showVersion)
 import           Paths_cardano_cli (version)
 import           System.Info (arch, compilerName, compilerVersion, os)

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -11,7 +11,7 @@ import           Options.Applicative
 import qualified Options.Applicative as Opt
 import           Options.Applicative.Help ((<$$>))
 
-import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.Node.GitRev (gitRev)
 import           Data.Version (showVersion)
 import           Paths_cardano_node (version)
 import           System.Info (arch, compilerName, compilerVersion, os)

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -34,6 +34,7 @@ library
 
   exposed-modules:     Cardano.Node.Configuration.Topology
                        Cardano.Node.Configuration.Logging
+                       Cardano.Node.GitRev
                        Cardano.Node.Handlers.Shutdown
                        Cardano.Node.Handlers.TopLevel
                        Cardano.Node.Orphans
@@ -86,6 +87,7 @@ library
                      , containers
                      , directory
                      , filepath
+                     , gitrev
                      , hedgehog-extras
                      , hostname
                      , iproute

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -63,7 +63,7 @@ import           Cardano.BM.Setup (setupTrace_, shutdown)
 import           Cardano.BM.Trace (Trace, appendName, traceNamedObject)
 import qualified Cardano.BM.Trace as Trace
 
-import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.Node.GitRev (gitRev)
 import           Cardano.Node.Types
 
 --------------------------------

--- a/cardano-node/src/Cardano/Node/GitRev.hs
+++ b/cardano-node/src/Cardano/Node/GitRev.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.Node.GitRev
+  ( gitRev
+  ) where
+
+import           Data.Text (Text)
+
+import qualified Data.Text as T
+import qualified Development.GitRev as GR
+
+gitRev :: Text
+gitRev = T.pack $(GR.gitHash)

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -44,9 +44,9 @@ import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..)
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
 
-import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.Logging (LoggingLayer (..), Severity (..),
                      shutdownLoggingLayer)
+import           Cardano.Node.GitRev (gitRev)
 import           Cardano.Node.Types
 import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 

--- a/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
+++ b/cardano-node/src/Cardano/Node/TUI/EventHandler.hs
@@ -26,7 +26,7 @@ import           Cardano.BM.Data.Aggregated (Measurable (..))
 import           Cardano.BM.Data.Backend (BackendKind (..), IsBackend (..), IsEffectuator (..))
 import           Cardano.BM.Data.Counter (Platform (..))
 import           Cardano.BM.Data.LogItem (LOContent (..), LOMeta (..), LogObject (..), utc2ns)
-import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.Node.GitRev (gitRev)
 import           Cardano.Node.Protocol.Types (Protocol (..))
 import           Cardano.Node.TUI.Drawing (ColorTheme (..), LiveViewState (..), LiveViewThread (..),
                      Screen (..), darkTheme, drawUI, lightTheme)

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -122,6 +122,7 @@ let
       }
       (lib.optionalAttrs stdenv.hostPlatform.isLinux {
         # systemd can't be statically linked
+        packages.hedghog-extras.flags.systemd = !stdenv.hostPlatform.isMusl;
         packages.cardano-config.flags.systemd = !stdenv.hostPlatform.isMusl;
         packages.cardano-node.flags.systemd = !stdenv.hostPlatform.isMusl;
       })


### PR DESCRIPTION
Remove the dependency on `cardano-config` without actually removing it.  Hopefully this gets us closer to actually removing it in a way that doesn't break CI and we can debug CI issues separately.

This PR is based on https://github.com/input-output-hk/cardano-node/pull/1829