### PR TITLE
Correct a mistake in the name of the metadata schema flags

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -912,14 +912,14 @@ pPoolMetaDataFile =
 pTxMetadataJsonSchema :: Parser TxMetadataJsonSchema
 pTxMetadataJsonSchema =
     (  Opt.flag' ()
-        (  Opt.long "--json-metadata-no-schema"
+        (  Opt.long "json-metadata-no-schema"
         <> Opt.help "Use the \"no schema\" conversion from JSON to tx metadata."
         )
     *> pure TxMetadataJsonNoSchema
     )
   <|>
     (  Opt.flag' ()
-        (  Opt.long "--json-metadata-detailed-schema"
+        (  Opt.long "json-metadata-detailed-schema"
         <> Opt.help "Use the \"detailed schema\" conversion from JSON to tx metadata."
         )
     *> pure TxMetadataJsonDetailedSchema


### PR DESCRIPTION
I accidentally included extra "--" in the flag names.