### PR TITLE
CAD-1866: Prepared TraceForwarderBK in defaut configs.

### DIFF
--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -79,11 +79,13 @@ TracingVerbosity: NormalVerbosity
 # configuration below. The logging backend is called Katip.
 setupBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to enable
 # this backend and listen on the given local port and point your web browser to
@@ -260,30 +262,31 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK  
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.Forge.metrics:
+      # - TraceForwarderBK
       - EKGViewBK
     cardano.node.release:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.version:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.commit:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
@@ -69,10 +70,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -81,10 +88,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -93,7 +104,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2997'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12782
@@ -69,10 +70,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -81,10 +88,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -93,7 +104,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2998'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12783
@@ -74,10 +75,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -86,10 +93,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -98,7 +109,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2999'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -76,11 +76,13 @@ TracingVerbosity: NormalVerbosity
 # configuration below. The logging backend is called Katip.
 setupBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to enable
 # this backend and listen on the given local port and point your web browser to
@@ -251,30 +253,31 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK  
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.Forge.metrics:
+      # - TraceForwarderBK
       - EKGViewBK
     cardano.node.release:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.version:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.commit:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -76,11 +76,13 @@ TracingVerbosity: NormalVerbosity
 # configuration below. The logging backend is called Katip.
 setupBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to enable
 # this backend and listen on the given local port and point your web browser to
@@ -251,30 +253,30 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.metrics:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - EKGViewBK  
       - kind: UserDefinedBK
         name: LiveViewBackend
     cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.version:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
     cardano.node.commit:
-      - TraceForwarderBK
+      # - TraceForwarderBK
       - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -76,6 +76,7 @@ setupBackends:
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to listen
 # on the given local port and point your web browser to http://localhost:12788/
@@ -225,6 +226,8 @@ options:
   mapBackends:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
+    # Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+    # - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK  
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
@@ -266,8 +269,20 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
 
-# If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
-# to remote socket '127.0.0.1:2997'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -76,6 +76,7 @@ setupBackends:
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to listen
 # on the given local port and point your web browser to http://localhost:12788/
@@ -225,6 +226,8 @@ options:
   mapBackends:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
+    # Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+    # - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK  
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
@@ -266,8 +269,20 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
 
-# If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
-# to remote socket '127.0.0.1:2997'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/liveview/config-0.yaml
+++ b/configuration/defaults/liveview/config-0.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
@@ -68,10 +69,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -80,10 +87,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -92,7 +103,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2997'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/liveview/config-1.yaml
+++ b/configuration/defaults/liveview/config-1.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12782
@@ -63,10 +64,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -75,10 +82,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -87,7 +98,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2998'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/liveview/config-2.yaml
+++ b/configuration/defaults/liveview/config-2.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12783
@@ -68,10 +69,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -80,10 +87,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -92,7 +103,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2999'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -66,11 +66,13 @@ TracingVerbosity: NormalVerbosity
 setupBackends:
   - KatipBK
 # - EKGViewBK
+# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # EKG is a simple metrics monitoring system. Uncomment the following to listen
 # on the given local port and point your web browser to http://localhost:12788/
@@ -220,10 +222,13 @@ options:
   mapBackends:
     cardano.node.ChainDB.metrics:
       - EKGViewBK
+    # - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
+    # - TraceForwarderBK
     cardano.node-metrics:
       - EKGViewBK
+    # - TraceForwarderBK
 
   # This section is more expressive still, and needs to be properly documented.
   mapSubtrace:
@@ -251,3 +256,23 @@ options:
       # Change the `subtrace` value to `Neutral` in order to log
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
+
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
+# traceForwardTo:
+#   tag: RemoteSocket
+#   contents:
+#     - "127.0.0.1"
+#     - "2997"

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12781
@@ -69,10 +70,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -81,10 +88,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -93,7 +104,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2997'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12782
@@ -69,10 +70,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -81,10 +88,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -93,7 +104,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2998'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -17,6 +17,7 @@ setupBackends:
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK
+# - TraceForwarderBK
 
 # if wanted, the EKG interface is listening on this port:
 #hasEKG: 12783
@@ -74,10 +75,16 @@ options:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.ChainDB.metrics' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Forge:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Forge' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics.Mempool:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.metrics.Mempool' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.metrics:
       - EKGViewBK
       - kind: UserDefinedBK
@@ -86,10 +93,14 @@ options:
 #     - TraceForwarderBK
     cardano.node.peers:
       - EKGViewBK
+# Uncomment it to send 'cardano.node.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
     cardano.node.BlockFetchDecision.peers:
       - EKGViewBK
       - kind: UserDefinedBK
         name: LiveViewBackend
+# Uncomment it to send 'cardano.node.BlockFetchDecision.peers' to 'TraceForwarderBK' as well.
+#     - TraceForwarderBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK
@@ -98,7 +109,20 @@ options:
 #    cardano.node.commit:
 #      - TraceForwarderBK
 
-# Uncomment it to forward node's metrics to remote socket '127.0.0.1:2999'.
+# To enable the 'TraceForwarder' backend, uncomment the following setting. Log
+# items are then forwarded based on an entry in 'mapBackends' to a separate
+# process running a 'TraceAcceptor'.
+# Example using UNIX pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "logs/pipe"
+# 
+# Example using Windows named pipes:
+# traceForwardTo:
+#   tag: RemotePipe
+#   contents: "\\\\.\\pipe\\acceptor"
+#
+# Example using network socket:
 # traceForwardTo:
 #   tag: RemoteSocket
 #   contents:


### PR DESCRIPTION
1. Now the default configs of the node already contain metric forwarding to `TraceForwarderBK`
2. The `TraceForwarderBK` can be commented out in the default backends section (this makes it easy for someone to turn on `RTView`).

_Please note that this PR doesn't touch any code, only configuration files_.