### PR TITLE
Fix trace severity for things wrapped in TraceLabelPeer

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -87,7 +87,8 @@ instance HasSeverityAnnotation (TraceSendRecv a) where
 
 
 instance HasPrivacyAnnotation a => HasPrivacyAnnotation (TraceLabelPeer peer a)
-instance HasSeverityAnnotation a => HasSeverityAnnotation (TraceLabelPeer peer a)
+instance HasSeverityAnnotation a => HasSeverityAnnotation (TraceLabelPeer peer a) where
+  getSeverityAnnotation (TraceLabelPeer _p a) = getSeverityAnnotation a
 
 
 instance HasPrivacyAnnotation [TraceLabelPeer peer (FetchDecision [Point header])]


### PR DESCRIPTION
It should be the severity of the contained thing. This explains why we
were seeing various protocol tracers with debug severity.