### PR TITLE
Fix severity level for TraceLabelPeer.

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -85,8 +85,8 @@ instance HasSeverityAnnotation (TraceSendRecv a) where
 
 
 instance HasPrivacyAnnotation a => HasPrivacyAnnotation (TraceLabelPeer peer a)
-instance HasSeverityAnnotation a => HasSeverityAnnotation (TraceLabelPeer peer a)
-
+instance HasSeverityAnnotation a => HasSeverityAnnotation (TraceLabelPeer peer a) where
+  getSeverityAnnotation (TraceLabelPeer _p a) = getSeverityAnnotation a
 
 instance HasPrivacyAnnotation [TraceLabelPeer peer (FetchDecision [Point header])]
 instance HasSeverityAnnotation [TraceLabelPeer peer (FetchDecision [Point header])] where


### PR DESCRIPTION
Before this all TraceBlockFetch messages was at Debug level rather than
the expected Info level.