### PR TITLE
Report all log files on any test failure

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -51,6 +51,7 @@ executable cardano-node-chairman
                       , HUnit
                       , io-sim-classes
                       , mmorph
+                      , mtl
                       , network
                       , network-mux
                       , optparse-applicative
@@ -66,6 +67,7 @@ executable cardano-node-chairman
                       , temporary
                       , text
                       , time
+                      , transformers
                       , transformers-except
                       , typed-protocols
                       , unliftio
@@ -96,6 +98,7 @@ test-suite chairman-tests
                       , hspec
                       , HUnit
                       , mmorph
+                      , mtl
                       , network
                       , process
                       , random
@@ -105,6 +108,7 @@ test-suite chairman-tests
                       , temporary
                       , text
                       , time
+                      , transformers
                       , unliftio
                       , unordered-containers
   other-modules:        Spec.Chairman.Chairman

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -10,13 +10,38 @@ license-files:         LICENSE
                        NOTICE
 build-type:            Simple
 
-library
+common common-modules
   hs-source-dirs:       src
-  build-depends:        base >= 4.12 && < 5
+  other-modules:        Test.Process
+                        Test.Base
+                        Testnet.ByronShelley
+                        Testnet.Conf
+                        Testnet.Shelley
+
+executable cardano-node-chairman
+  hs-source-dirs:       app
+  main-is:              cardano-node-chairman.hs
+  other-modules:        Cardano.Chairman
+                        Cardano.Chairman.Options
+                        Paths_cardano_node_chairman
+  default-language:     Haskell2010
+  ghc-options:          -threaded
+                        -Wall
+                        -rtsopts
+                        "-with-rtsopts=-T"
+                        -Wno-unticked-promoted-constructors
+  build-depends:        base >=4.12 && <5
                       , aeson
                       , async
+                      , bytestring
                       , call-stack
+                      , cardano-api
+                      , cardano-config
+                      , cardano-ledger
+                      , cardano-node
+                      , cardano-prelude
                       , containers
+                      , contra-tracer
                       , directory
                       , exceptions
                       , filepath
@@ -24,8 +49,15 @@ library
                       , hedgehog-extras
                       , hspec
                       , HUnit
+                      , io-sim-classes
                       , mmorph
                       , network
+                      , network-mux
+                      , optparse-applicative
+                      , ouroboros-consensus
+                      , ouroboros-consensus-cardano
+                      , ouroboros-network
+                      , ouroboros-network-framework
                       , process
                       , random
                       , resourcet
@@ -34,64 +66,20 @@ library
                       , temporary
                       , text
                       , time
+                      , transformers-except
+                      , typed-protocols
                       , unliftio
                       , unordered-containers
-  exposed-modules:      Test.Process
-                        Test.Base
-                        Testnet.ByronShelley
-                        Testnet.Conf
-                        Testnet.Shelley
-  default-language:     Haskell2010
+
   default-extensions:   NoImplicitPrelude
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-
-executable cardano-node-chairman
-  hs-source-dirs:      app
-  main-is:             cardano-node-chairman.hs
-  other-modules:       Cardano.Chairman
-                       Cardano.Chairman.Options
-                       Paths_cardano_node_chairman
-  default-language:    Haskell2010
-  ghc-options:         -threaded
-                       -Wall
-                       -rtsopts
-                       "-with-rtsopts=-T"
-                       -Wno-unticked-promoted-constructors
-  build-depends:       base >=4.12 && <5
-                     , async
-                     , bytestring
-                     , cardano-api
-                     , cardano-config
-                     , cardano-ledger
-                     , cardano-node
-                     , cardano-prelude
-                     , cardano-prelude
-                     , containers
-                     , contra-tracer
-                     , io-sim-classes
-                     , network-mux
-                     , optparse-applicative
-                     , ouroboros-consensus
-                     , ouroboros-consensus-cardano
-                     , ouroboros-network
-                     , ouroboros-network-framework
-                     , text
-                     , transformers-except
-                     , typed-protocols
-
-  default-extensions:  NoImplicitPrelude
 
   if os(windows)
-     build-depends:    Win32
+     build-depends:     Win32
   else
-     build-depends:    unix
+     build-depends:     unix
 
 test-suite chairman-tests
+  import:               common-modules
   hs-source-dirs:       test
   main-is:              Spec.hs
   type:                 exitcode-stdio-1.0
@@ -99,7 +87,6 @@ test-suite chairman-tests
                       , aeson
                       , async
                       , call-stack
-                      , cardano-node-chairman
                       , containers
                       , directory
                       , exceptions
@@ -125,6 +112,7 @@ test-suite chairman-tests
                         Spec.Chairman.ByronShelley
                         Spec.Chairman.Shelley
                         Spec.Network
+                        
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude
   ghc-options:          -Wall
@@ -140,6 +128,7 @@ test-suite chairman-tests
                       , cardano-node-chairman:cardano-node-chairman
 
 executable cardano-testnet
+  import:               common-modules
   hs-source-dirs:       testnet
   main-is:              Main.hs
   build-depends:        base >= 4.12 && < 5
@@ -147,7 +136,6 @@ executable cardano-testnet
                       , ansi-terminal
                       , async
                       , call-stack
-                      , cardano-node-chairman
                       , containers
                       , directory
                       , exceptions

--- a/cardano-node-chairman/test/Spec/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Byron.hs
@@ -44,7 +44,7 @@ rewriteConfiguration "TraceBlockchainTime: False" = "TraceBlockchainTime: True"
 rewriteConfiguration s = s
 
 hprop_chairman :: Property
-hprop_chairman = H.propertyOnce . H.workspace "chairman" $ \tempAbsPath -> do
+hprop_chairman = H.propertyOnce . H.runFinallies . H.workspace "chairman" $ \tempAbsPath -> do
   void $ H.note OS.os
   let nodeCount = 3
   tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath

--- a/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
@@ -19,7 +19,7 @@ import qualified Testnet.Conf as H
 {- HLINT ignore "Redundant flip" -}
 
 hprop_chairman :: H.Property
-hprop_chairman = H.integration . H.workspace "chairman" $ \tempAbsPath' -> do
+hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
   conf@H.Conf {..} <- H.mkConf tempAbsPath' 42
 
   allNodes <- H.testnet conf

--- a/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
@@ -19,7 +19,7 @@ import qualified Testnet.Shelley as H
 {- HLINT ignore "Redundant flip" -}
 
 hprop_chairman :: H.Property
-hprop_chairman = H.integration . H.workspace "chairman" $ \tempAbsPath' -> do
+hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
   conf@H.Conf {..} <- H.mkConf tempAbsPath' 42
 
   allNodes <- H.testnet conf

--- a/cardano-node-chairman/test/Spec/Network.hs
+++ b/cardano-node-chairman/test/Spec/Network.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Spec.Network
   ( hprop_isPortOpen_False

--- a/cardano-node-chairman/testnet/Main.hs
+++ b/cardano-node-chairman/testnet/Main.hs
@@ -23,7 +23,7 @@ import qualified Testnet.Conf as H
 import qualified Testnet.ByronShelley
 
 testnetProperty :: (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty tn = H.integration . H.workspace "chairman" $ \tempAbsPath' -> do
+testnetProperty tn = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
   conf@H.Conf {..} <- H.mkConf tempAbsPath' 42
 
   -- Fork a thread to keep alive indefinitely any resources allocated by testnet.

--- a/hedgehog-extras/hedgehog-extras.cabal
+++ b/hedgehog-extras/hedgehog-extras.cabal
@@ -21,19 +21,23 @@ library
                       , exceptions
                       , hedgehog
                       , mmorph
+                      , mtl
                       , network
                       , filepath
                       , process
                       , random
                       , resourcet
+                      , stm
                       , temporary
                       , text
                       , time
+                      , transformers
                       , unliftio
                       , unordered-containers
                       , Win32-network
   exposed-modules:      Hedgehog.Extras.Internal.Cli
                         Hedgehog.Extras.Internal.Plan
+                        Hedgehog.Extras.Internal.Test.Integration
                         Hedgehog.Extras.Stock.Aeson
                         Hedgehog.Extras.Stock.CallStack
                         Hedgehog.Extras.Stock.IO.File
@@ -48,6 +52,7 @@ library
                         Hedgehog.Extras.Test.Base
                         Hedgehog.Extras.Test.Concurrent
                         Hedgehog.Extras.Test.File
+                        Hedgehog.Extras.Test.MonadAssertion
                         Hedgehog.Extras.Test.Network
                         Hedgehog.Extras.Test.Process
   default-language:     Haskell2010

--- a/hedgehog-extras/src/Hedgehog/Extras/Internal/Test/Integration.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Internal/Test/Integration.hs
@@ -1,0 +1,33 @@
+
+module Hedgehog.Extras.Internal.Test.Integration
+  ( Integration
+  , IntegrationState(..)
+  , newIntegrationStateIO
+  , newIntegrationStateM
+  , runIntegrationReaderT
+  ) where
+
+import           Control.Monad.Reader
+import           Control.Monad.Trans.Resource (ResourceT)
+import           Data.Functor
+import           System.IO (IO)
+
+import qualified Control.Concurrent.STM as STM
+import qualified Hedgehog as H
+
+newtype IntegrationState = IntegrationState
+  { integrationStateFinals :: STM.TVar [Integration ()]
+  }
+
+type Integration a = H.PropertyT (ReaderT IntegrationState (ResourceT IO)) a
+
+newIntegrationStateIO :: IO IntegrationState
+newIntegrationStateIO = IntegrationState <$> STM.newTVarIO []
+
+newIntegrationStateM :: MonadIO m => m IntegrationState
+newIntegrationStateM = liftIO newIntegrationStateIO
+
+runIntegrationReaderT :: MonadIO m => ReaderT IntegrationState m a -> m a
+runIntegrationReaderT f = do
+  s <- newIntegrationStateM
+  runReaderT f s

--- a/hedgehog-extras/src/Hedgehog/Extras/Test/MonadAssertion.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Test/MonadAssertion.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Hedgehog.Extras.Test.MonadAssertion
+  ( MonadAssertion(..)
+  ) where
+
+import           Control.Monad
+import           Control.Monad.Trans.Class
+import           Data.Either
+import           Data.Function
+import           Data.Monoid (mempty)
+
+import qualified Control.Monad.Trans.Except as E
+import qualified Control.Monad.Trans.Resource as IO
+import qualified Control.Monad.Trans.Resource.Internal as IO
+import qualified Hedgehog as H
+import qualified Hedgehog.Internal.Property as H
+
+class Monad m => MonadAssertion m where
+  throwAssertion :: H.Failure -> m a
+  catchAssertion :: m a -> (H.Failure -> m a) -> m a
+
+instance Monad m => MonadAssertion (H.TestT m) where
+  throwAssertion f = H.liftTest $ H.mkTest (Left f, mempty)
+  catchAssertion g h = H.TestT $ E.catchE (H.unTest g) (H.unTest . h)
+
+instance MonadAssertion m => MonadAssertion (IO.ResourceT m) where
+  throwAssertion = lift . throwAssertion
+  catchAssertion r h = IO.ResourceT $ \i -> IO.unResourceT r i `catchAssertion` \e -> IO.unResourceT (h e) i
+
+deriving instance Monad m => MonadAssertion (H.PropertyT m)


### PR DESCRIPTION
This is to get more visibility over what is happening with flaky test failures.

Previously log files were not written to the output consistently, so the cause of failures weren't clear.

This PR introduces new test functions that allows for actions to be run on test failure.  This is useful because the best time to capture log files is when they are fully written, which is right at the point of failure.