### PR TITLE
cardano-api: Fix haddock build

### DIFF
--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -1,3 +1,7 @@
+-- | This module provides a library interface that is intended to be the complete API
+-- for Byron covering everything, including exposing constructors for the lower level types.
+--
+
 module Cardano.Api.Byron
   ( module Cardano.Api.Protocol.Byron
   , module Cardano.Api.Protocol.Cardano
@@ -8,10 +12,6 @@ module Cardano.Api.Byron
   , module Ouroboros.Consensus.HardFork.Combinator.Degenerate
   , module Ouroboros.Network.Block
   ) where
-
--- | This module provides a library interface that is intended to be the complete API
--- for Byron covering everything, including exposing constructors for the lower level types.
---
 
 import           Cardano.Api.Protocol.Byron (mkSomeNodeClientProtocolByron)
 import           Cardano.Api.Protocol.Cardano (mkSomeNodeClientProtocolCardano)
@@ -25,4 +25,3 @@ import           Ouroboros.Consensus.Block (ConvertRawHash (..))
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (ByronTx), byronIdTx)
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (GenTx (DegenGenTx))
 import           Ouroboros.Network.Block (BlockNo (BlockNo), Tip (Tip, TipGenesis))
-

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -1,3 +1,7 @@
+-- | This module provides a library interface that is intended to be the complete API
+-- for Shelley covering everything, including exposing constructors for the lower level types.
+--
+
 module Cardano.Api.Shelley
   ( module Cardano.Api.LocalChainSync
   , module Cardano.Api.MetaData
@@ -31,10 +35,6 @@ module Cardano.Api.Shelley
   , module Shelley.Spec.Ledger.Genesis
   , module Shelley.Spec.Ledger.OCert
   ) where
-
--- | This module provides a library interface that is intended to be the complete API
--- for Shelley covering everything, including exposing constructors for the lower level types.
---
 
 import           Cardano.Api.LocalChainSync (getLocalTip)
 import           Cardano.Api.MetaData (TxMetadata (..), TxMetadataJsonError (..),
@@ -91,5 +91,3 @@ import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (LocalTxSubmission)
 import           Shelley.Spec.Ledger.Genesis (ShelleyGenesis (..))
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
-
-


### PR DESCRIPTION
I get the following from the haddock build of 1.21.1:

    src/Cardano/Api/Byron.hs:16:1: error: parse error on input `import'
       |
    16 | import           Cardano.Api.Protocol.Byron (mkSomeNodeClientProtocolByron)
       | ^^^^^^
