### PR TITLE
Create VRF signing key file with correct permissions

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,8 @@ library
                       , contra-tracer
                       , containers
                       , cryptonite
+                      , directory
+                      , filepath
                       , formatting
                       , io-sim-classes
                       , iohk-monitoring

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -191,6 +191,7 @@ module Cardano.API (
     deserialiseFromTextEnvelope,
     readFileTextEnvelope,
     writeFileTextEnvelope,
+    writeFileTextEnvelopeWithOwnerPermissions,
     readTextEnvelopeFromFile,
     readTextEnvelopeOfTypeFromFile,
     -- *** Reading one of several key types
@@ -199,7 +200,7 @@ module Cardano.API (
     readFileTextEnvelopeAnyOf,
 
     -- * Errors
-    Error,
+    Error(..),
     throwErrorAsException,
     FileError,
 

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
 
 import           Cardano.Prelude hiding (option)
 
@@ -9,13 +14,17 @@ import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
 import qualified Cardano.Crypto.Libsodium as Crypto
-
+#ifdef UNIX
+import           System.Posix.Files
+#endif
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
   -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
   Crypto.sodiumInit
-
+#ifdef UNIX
+  _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
+#endif
   co <- Opt.customExecParser pref opts
 
   orDie renderClientCommandError $ runClientCommand co

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -139,11 +139,15 @@ executable cardano-cli
                        -Wall
                        -rtsopts
                        "-with-rtsopts=-T"
+  if !os(windows)
+     build-depends:    unix
+
   build-depends:       base >=4.12 && <5
                      , cardano-cli
                      , cardano-config
                      , cardano-crypto-class
                      , cardano-prelude
+                     , directory
                      , optparse-applicative
                      , text
                      , transformers-except
@@ -161,6 +165,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , cardano-api
                       , cardano-cli
+                      , cardano-node
                       , cardano-prelude
                       , containers
                       , deepseq
@@ -177,7 +182,8 @@ test-suite cardano-cli-test
                       , transformers-except
                       , unordered-containers
 
-  other-modules:        Test.Cli.ITN
+  other-modules:        Test.Cli.FilePermissions
+                        Test.Cli.ITN
                         Test.Cli.Pioneers.Exercise1
                         Test.Cli.Pioneers.Exercise2
                         Test.Cli.Pioneers.Exercise3

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -270,6 +270,8 @@ readKeyFileTextEnvelope asType fp =
         FileIOError path ex -> FileIOError path ex
         FileError path textEnvErr ->
           FileError path (InputTextEnvelopeError textEnvErr)
+        FileErrorTempFile targetP tempP h ->
+          FileErrorTempFile targetP tempP h
 
 -- | Read a cryptographic key from a file given that it is one of the provided
 -- types.

--- a/cardano-cli/test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/Test/Cli/FilePermissions.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cli.FilePermissions
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+
+import           Cardano.Node.Run (checkVRFFilePermissions)
+import           Hedgehog (Property, discover, success)
+import qualified Hedgehog
+import qualified Hedgehog.Extras.Test.Base as H
+import           Hedgehog.Internal.Property (failWith)
+
+import           Test.OptParse (execCardanoCLI)
+
+-- | This property ensures that the VRF signing key file is created only with owner permissions
+prop_createVRFSigningKeyFilePermissions :: Property
+prop_createVRFSigningKeyFilePermissions =
+  H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    -- Key filepaths
+    vrfVerKey <- H.noteTempFile tempDir "VRF-verification-key-file"
+
+    vrfSignKey <- H.noteTempFile tempDir "VRF-signing-key-file"
+
+    -- Create VRF key pair
+    void $ execCardanoCLI
+      [ "shelley", "node", "key-gen-VRF"
+      , "--verification-key-file", vrfVerKey
+      , "--signing-key-file", vrfSignKey
+      ]
+
+    result <- liftIO . runExceptT $ checkVRFFilePermissions vrfSignKey
+    case result of
+      Left err ->
+        failWith Nothing
+          $ "key-gen-VRF cli command created a VRF signing key \
+            \file with the wrong permissions: " <> show err
+      Right () -> success
+
+-- -----------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  Hedgehog.checkParallel $$discover

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
@@ -32,26 +32,35 @@ golden_shelleyGenesisKeyDelegationCertificate =
     genesisKeyDelegCertFilePath <-
       noteTempFile tempDir "genesis-key-delegation-certificate-file"
 
+    -- Signing Key filepaths
+    genesisSignKeyFilePath <- noteTempFile tempDir "genesis-signing-key-file"
+    genesisDelegSignKeyFilePath <- noteTempFile tempDir "genesis-delegate-signing-key-file"
+    vrfSignKeyFilePath <- noteTempFile tempDir "vrf-signing-key-file"
+
+    genesisDelegOpCertCounterFilePath <- noteTempFile tempDir "genesis-delegate-opcert-counter"
+
+
     -- Generate genesis key pair
     void $ execCardanoCLI
       [ "shelley","genesis","key-gen-genesis"
       , "--verification-key-file", genesisVerKeyFilePath
-      , "--signing-key-file", "/dev/null"
+      , "--signing-key-file", genesisSignKeyFilePath
       ]
 
     -- Generate genesis delegate key pair
     void $ execCardanoCLI
       [ "shelley","genesis","key-gen-delegate"
       , "--verification-key-file", genesisDelegVerKeyFilePath
-      , "--signing-key-file", "/dev/null"
-      , "--operational-certificate-issue-counter-file", "/dev/null"
+      , "--signing-key-file", genesisDelegSignKeyFilePath
+      , "--operational-certificate-issue-counter-file"
+      , genesisDelegOpCertCounterFilePath
       ]
 
     -- Generate VRF key pair
     void $ execCardanoCLI
       [ "shelley","node","key-gen-VRF"
       , "--verification-key-file", vrfVerKeyFilePath
-      , "--signing-key-file", "/dev/null"
+      , "--signing-key-file", vrfSignKeyFilePath
       ]
 
     H.assertFilesExist

--- a/cardano-cli/test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test.hs
@@ -2,6 +2,7 @@ import           Cardano.Prelude
 
 import           Hedgehog.Main (defaultMain)
 
+import qualified Test.Cli.FilePermissions
 import qualified Test.Cli.ITN
 import qualified Test.Cli.Pioneers.Exercise1
 import qualified Test.Cli.Pioneers.Exercise2
@@ -11,9 +12,11 @@ import qualified Test.Cli.Pioneers.Exercise4
 main :: IO ()
 main =
   defaultMain
-    [ Test.Cli.ITN.tests
+    [ Test.Cli.FilePermissions.tests
+    , Test.Cli.ITN.tests
     , Test.Cli.Pioneers.Exercise1.tests
     , Test.Cli.Pioneers.Exercise2.tests
     , Test.Cli.Pioneers.Exercise3.tests
     , Test.Cli.Pioneers.Exercise4.tests
     ]
+

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -182,13 +182,13 @@ test-suite cardano-node-test
 
   if !os(windows)
       build-depends:     unix
-      other-modules:     Test.Cardano.Node.FilePermissions
 
   build-depends:
                         base >= 4.12 && < 5
                       , aeson
                       , async
                       , bytestring
+                      , cardano-api
                       , cardano-config
                       , cardano-crypto-class
                       , cardano-crypto-test
@@ -217,7 +217,8 @@ test-suite cardano-node-test
                       , time
                       , unliftio
 
-  other-modules:        Test.Cardano.Node.Gen
+  other-modules:        Test.Cardano.Node.FilePermissions
+                        Test.Cardano.Node.Gen
                         Test.Cardano.Node.Json
                         Test.Cardano.Node.POM
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -451,6 +451,7 @@ protocolName CardanoProtocol = "Byron; Shelley"
 data VRFPrivateKeyFilePermissionError
   = OtherPermissionsExist FilePath
   | GroupPermissionsExist FilePath
+  | GenericPermissionsExist FilePath
   deriving Show
 
 renderVRFPrivateKeyFilePermissionError :: VRFPrivateKeyFilePermissionError -> Text
@@ -463,3 +464,6 @@ renderVRFPrivateKeyFilePermissionError err =
     GroupPermissionsExist fp ->
       "VRF private key file at: " <> Text.pack fp
       <> "has \"group\" file permissions. Please remove all \"group\" file permissions."
+    GenericPermissionsExist fp ->
+      "VRF private key file at: " <> Text.pack fp
+      <> "has \"generic\" file permissions. Please remove all \"generic\" file permissions."

--- a/scripts/lite/shelley-testnet.sh
+++ b/scripts/lite/shelley-testnet.sh
@@ -75,7 +75,7 @@ for i in 1 2 3; do
 
   # Generate a KES keys
   mkdir -p "${data_dir}/node-$i"
-  cardano-cli shelley node key-gen-KES \
+  cabal run exe:cardano-cli -- shelley node key-gen-KES \
     --verification-key-file "${data_dir}/node-$i/kes.vkey" \
     --signing-key-file      "${data_dir}/node-$i/kes.skey"
 
@@ -93,7 +93,7 @@ for i in 1 2 3; do
   chmod u+r "${data_dir}/node-$i/vrf.skey"
 
   # Issue an operational certificate:
-  cardano-cli shelley node issue-op-cert \
+  cabal run exe:cardano-cli -- shelley node issue-op-cert \
       --kes-period 0 \
       --kes-verification-key-file                  "${data_dir}/node-$i/kes.vkey"  \
       --cold-signing-key-file                      "${data_dir}/node-$i/hotkey.skey" \


### PR DESCRIPTION
Since we are now checking that the VRF signing key file has the correct owner read/write permissions, it makes sense to create the VRF signing key file with the correct permissions in `cardano-cli`.
- Related to #1936 
