### PR TITLE
Adjust chairman logging configuration

### DIFF
--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -189,7 +189,7 @@ PBftSignatureThreshold: 0.6
 TraceDNSResolver: True
 
 # Trace DNS Subscription messages.
-TraceDNSSubscription: True
+TraceDNSSubscription: False
 
 # Trace error policy resolution.
 TraceErrorPolicy: True
@@ -201,7 +201,7 @@ TraceLocalErrorPolicy: True
 TraceForge: True
 
 # Trace Handshake protocol messages.
-TraceHandshake: False
+TraceHandshake: True
 
 # Trace IP Subscription messages.
 TraceIpSubscription: True
@@ -224,7 +224,7 @@ TraceLocalTxSubmissionServer: False
 TraceMempool: True
 
 # Trace Mux Events.
-TraceMux: False
+TraceMux: True
 
 # Trace TxSubmission server (inbound transactions).
 TraceTxInbound: False
@@ -284,5 +284,8 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
+    cardano.node.TraceIpSubscription: Info
+    cardano.node.TraceMux: Info
+    cardano.node.Handshake: Debug
 
 TestShelleyHardForkAtEpoch: 1

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -183,7 +183,7 @@ TraceChainSyncProtocol: False
 TraceDNSResolver: True
 
 # Trace DNS Subscription messages.
-TraceDNSSubscription: True
+TraceDNSSubscription: False
 
 # Trace error policy resolution.
 TraceErrorPolicy: True
@@ -195,7 +195,7 @@ TraceLocalErrorPolicy: True
 TraceForge: True
 
 # Trace Handshake protocol messages.
-TraceHandshake: False
+TraceHandshake: True
 
 # Trace IP Subscription messages.
 TraceIpSubscription: True
@@ -216,7 +216,7 @@ TraceLocalTxSubmissionServer: False
 TraceMempool: True
 
 # Trace Mux Events
-TraceMux: False
+TraceMux: True
 
 # Trace TxSubmission server (inbound transactions).
 TraceTxInbound: False
@@ -275,4 +275,7 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
+    cardano.node.TraceIpSubscription: Info
+    cardano.node.TraceMux: Info
+    cardano.node.Handshake: Debug
 


### PR DESCRIPTION
Adjust chairman logging configuration as per the following:

```
TraceIpSubscription at Info level
TraceMux at Info level (Debug would be too noisy)
DnsSubscription can be turned off as the test is not using dns addresses
Handshake cat be used at Debug level
```