### PR TITLE
Add the upcoming Allegra and Mary eras to CardanoBlock

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -88,43 +88,43 @@ package io-sim-classes
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: cardano-crypto-tests
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f786c9d0d78d404cd4bad0ddadbbe92870dba872
-  --sha256: 0ndq2vb8ngms5d3g41vhqny8gmnv0mya2al33pgiwkciylq5a64i
+  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
+  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
   subdir: cardano-crypto-praos
 
 source-repository-package
@@ -136,91 +136,91 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
+  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: e74fa90e33a5a1ac5815c5286a2347ed9e1988b4
-  --sha256: 020bzlaaxzjf75scc43jbxdblc9pv6cfw8f6s66q64cvndfspx98
+  tag: 53f963be6c4b19a6bb710f9fa5e34db1c5a33a01
+  --sha256: 06d21hbl800k018rpf9i8r83d7wjzfgsp3qj23k1mqr2031f55cc
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: e74fa90e33a5a1ac5815c5286a2347ed9e1988b4
-  --sha256: 020bzlaaxzjf75scc43jbxdblc9pv6cfw8f6s66q64cvndfspx98
+  tag: 53f963be6c4b19a6bb710f9fa5e34db1c5a33a01
+  --sha256: 06d21hbl800k018rpf9i8r83d7wjzfgsp3qj23k1mqr2031f55cc
   subdir: test
 
 source-repository-package
@@ -288,85 +288,85 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
-  --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
+  tag: 6a2b8922856460cccdc7015d33a14ebd28696d14
+  --sha256: 01sxmgm65i8lspzh600vvyn5pfwhny4bx215ksxh9lpz8kjp1lc5
   subdir: Win32-network
 
 constraints:
@@ -378,9 +378,6 @@ constraints:
     -- systemd-2.3.0 requires at least network 3.1.1.0 but it doesn't declare
     -- that dependency
   , network >= 3.1.1.0
-    -- We need this constaint until we have updated to a version of
-    -- cardano-prelude that includes #126.
-  , base16-bytestring < 1
 
 package comonad
   flags: -test-doctests

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library
                       , network
                       , network-mux
                       , network-uri
+                      , nothunks
                       , ouroboros-consensus
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano

--- a/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
+++ b/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
@@ -25,6 +25,7 @@ import           Data.ByteArray as BA (ByteArrayAccess, ScrubbedBytes, convert)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks, InspectHeap (..))
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Crypto.Wallet as CC
@@ -41,6 +42,17 @@ data Ed25519Bip32DSIGN
 
 instance DSIGNAlgorithm Ed25519Bip32DSIGN where
 
+    type SeedSizeDSIGN    Ed25519Bip32DSIGN = 32
+
+    -- | BIP32-Ed25519 extended verification key size is 64 octets.
+    type SizeVerKeyDSIGN  Ed25519Bip32DSIGN = 64
+
+    -- | BIP32-Ed25519 extended signing key size is 96 octets.
+    type SizeSignKeyDSIGN Ed25519Bip32DSIGN = 96
+
+    -- | BIP32-Ed25519 extended signature size is 64 octets.
+    type SizeSigDSIGN     Ed25519Bip32DSIGN = 64
+
     --
     -- Key and signature types
     --
@@ -48,16 +60,16 @@ instance DSIGNAlgorithm Ed25519Bip32DSIGN where
     newtype VerKeyDSIGN Ed25519Bip32DSIGN = VerKeyEd25519Bip32DSIGN CC.XPub
         deriving (Show, Eq, Generic)
         deriving newtype NFData
-        deriving NoUnexpectedThunks via UseIsNormalForm CC.XPub
+        deriving NoThunks via InspectHeap CC.XPub
 
     newtype SignKeyDSIGN Ed25519Bip32DSIGN = SignKeyEd25519Bip32DSIGN CC.XPrv
         deriving (Generic, ByteArrayAccess)
         deriving newtype NFData
-        deriving NoUnexpectedThunks via UseIsNormalForm CC.XPrv
+        deriving NoThunks via InspectHeap CC.XPrv
 
     newtype SigDSIGN Ed25519Bip32DSIGN = SigEd25519Bip32DSIGN CC.XSignature
         deriving (Show, Eq, Generic, ByteArrayAccess)
-        deriving NoUnexpectedThunks via UseIsNormalForm CC.XSignature
+        deriving NoThunks via InspectHeap CC.XSignature
 
     --
     -- Metadata and basic key operations
@@ -87,8 +99,6 @@ instance DSIGNAlgorithm Ed25519Bip32DSIGN where
     -- Key generation
     --
 
-    seedSizeDSIGN _  = 32
-
     genKeyDSIGN seed =
       SignKeyEd25519Bip32DSIGN $
         CC.generateNew
@@ -99,15 +109,6 @@ instance DSIGNAlgorithm Ed25519Bip32DSIGN where
     --
     -- raw serialise/deserialise
     --
-
-    -- | BIP32-Ed25519 extended verification key size is 64 octets.
-    sizeVerKeyDSIGN  _ = 64
-
-    -- | BIP32-Ed25519 extended signing key size is 96 octets.
-    sizeSignKeyDSIGN _ = 96
-
-    -- | BIP32-Ed25519 extended signature size is 64 octets.
-    sizeSigDSIGN     _ = 64
 
     rawSerialiseVerKeyDSIGN (VerKeyEd25519Bip32DSIGN vk) = CC.unXPub vk
     rawSerialiseSignKeyDSIGN (SignKeyEd25519Bip32DSIGN sk) = xPrvToBytes sk

--- a/cardano-api/src/Cardano/Api/Protocol/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Shelley.hs
@@ -11,7 +11,7 @@ import           Ouroboros.Consensus.Cardano (ProtocolClient (ProtocolClientShel
                      ProtocolShelley)
 import           Ouroboros.Consensus.Cardano.ShelleyHFC
 
-import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
 import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
 

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -23,10 +23,11 @@ import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Cardano.Block (CardanoApplyTxErr,
                      GenTx (GenTxByron, GenTxShelley),
-                     HardForkApplyTxErr (ApplyTxErrByron, ApplyTxErrShelley, ApplyTxErrWrongEra))
+                     HardForkApplyTxErr (ApplyTxErrAllegra, ApplyTxErrByron, ApplyTxErrMary, ApplyTxErrShelley, ApplyTxErrWrongEra))
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock, mkShelleyTx)
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto, StandardShelley)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
 
 import           Cardano.Api.TxSubmit.ErrorRender
 import           Cardano.Api.Typed
@@ -120,6 +121,12 @@ renderTxSubmitResult res =
     TxSubmitFailureCardanoMode (ApplyTxErrShelley err) ->
       -- TODO: Write render function for Shelley tx submission errors.
       "Failed to submit Shelley transaction: " <> show err
+
+    TxSubmitFailureCardanoMode (ApplyTxErrMary err) ->
+      "Failed to submit Mary transaction: " <> show err
+
+    TxSubmitFailureCardanoMode (ApplyTxErrAllegra err) ->
+      "Failed to submit Allegra transaction: " <> show err
 
     TxSubmitFailureCardanoMode (ApplyTxErrWrongEra mismatch) ->
       "Failed to submit transaction due to era mismatch: " <> show mismatch

--- a/cardano-api/test/Test/Cardano/Api/Crypto.hs
+++ b/cardano-api/test/Test/Cardano/Api/Crypto.hs
@@ -121,9 +121,9 @@ testDSIGNAlgorithm _ n =
       ]
 
     , testGroup "NoUnexpectedThunks"
-      [ testProperty "VerKey"  $ prop_no_unexpected_thunks @(VerKeyDSIGN v)
-      , testProperty "SignKey" $ prop_no_unexpected_thunks @(SignKeyDSIGN v)
-      , testProperty "Sig"     $ prop_no_unexpected_thunks @(SigDSIGN v)
+      [ testProperty "VerKey"  $ prop_no_thunks @(VerKeyDSIGN v)
+      , testProperty "SignKey" $ prop_no_thunks @(SignKeyDSIGN v)
+      , testProperty "Sig"     $ prop_no_thunks @(SigDSIGN v)
       ]
     ]
 

--- a/cardano-api/test/Test/Cardano/Api/Examples.hs
+++ b/cardano-api/test/Test/Cardano/Api/Examples.hs
@@ -22,7 +22,7 @@ import           Cardano.Api.Typed (MultiSigScript (..))
 import qualified Cardano.Api.Typed as Api
 import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.Shelley.Node (emptyGenesisStaking)
-import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Consensus.Util.Time
 
 import           Shelley.Spec.Ledger.Address (Addr (..))

--- a/cardano-api/test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/Test/Cardano/Api/Ledger.hs
@@ -14,7 +14,7 @@ import           Hedgehog (Property, discover)
 import qualified Hedgehog
 import           Test.Tasty (TestTree)
 
-import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
 import           Test.Shelley.Spec.Ledger.Serialisation.Generators.Genesis (genAddress)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
@@ -12,6 +12,7 @@ import           Cardano.Prelude
 import           Cardano.Api.Typed
 import           Cardano.Crypto.Hash hiding (Hash)
 import           Cardano.Crypto.KES
+import           Cardano.Crypto.Libsodium (SodiumHashAlgorithm)
 
 import           Test.Cardano.Crypto.Orphans ()
 
@@ -28,5 +29,8 @@ deriving instance Eq (SigningKey KesKey)
 deriving instance Eq (SigningKey VrfKey)
 
 
-instance (HashAlgorithm h, KESAlgorithm d) => Eq (SignKeyKES (SumKES h d)) where
+instance ( KESAlgorithm d
+         , SodiumHashAlgorithm h
+         , SizeHash h ~ SeedSizeKES d
+         ) => Eq (SignKeyKES (SumKES h d)) where
   k1 == k2 = rawSerialiseSignKeyKES k1 == rawSerialiseSignKeyKES k2

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -1,4 +1,5 @@
 
+import           Cardano.Crypto.Libsodium (sodiumInit)
 import           Cardano.Prelude
 
 import           Test.Tasty (TestTree, defaultMain, testGroup)
@@ -13,7 +14,9 @@ import qualified Test.Cardano.Api.Typed.MultiSigScript
 import qualified Test.Cardano.Api.Typed.RawBytes
 
 main :: IO ()
-main =
+main = do
+  -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
+  sodiumInit
   defaultMain tests
 
 tests :: TestTree

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -8,10 +8,13 @@ import qualified Options.Applicative as Opt
 import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
+import qualified Cardano.Crypto.Libsodium as Crypto
 
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
+  -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
+  Crypto.sodiumInit
 
   co <- Opt.customExecParser pref opts
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -143,6 +143,7 @@ executable cardano-cli
   build-depends:       base >=4.12 && <5
                      , cardano-cli
                      , cardano-config
+                     , cardano-crypto-class
                      , cardano-prelude
                      , optparse-applicative
                      , text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -28,7 +28,7 @@ import           Cardano.Crypto.Hash.Class as Crypto
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash (..))
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Tip (..))
 
 import           Cardano.Ledger.Era (Era)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -37,7 +37,7 @@ import           Cardano.Api.TextView (TextViewDescription (..))
 import           Cardano.Api.Typed
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
-import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
 import qualified Shelley.Spec.Ledger.Address as Ledger
 import qualified Shelley.Spec.Ledger.Coin as Ledger

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -50,7 +50,7 @@ import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import           Ouroboros.Consensus.Cardano.Block (Either (..), EraMismatch (..), Query (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (Either (DegenQueryResult),
                      Query (DegenQuery))
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Network.Block (Serialised (..), getTipPoint)
 
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -28,11 +28,10 @@ import qualified Cardano.Binary as CBOR
 import qualified Shelley.Spec.Ledger.PParams as Shelley
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..),
-                     HardForkApplyTxErr (ApplyTxErrByron, ApplyTxErrShelley, ApplyTxErrWrongEra))
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..), HardForkApplyTxErr (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardShelley)
 
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
 import           Cardano.CLI.Shelley.Key (InputDecodeError, readSigningKeyFileAnyOf)
@@ -245,6 +244,10 @@ runTxSubmit protocol network txFile = do
             TxSubmitFailureCardanoMode (ApplyTxErrByron err) ->
               left (ShelleyTxCmdTxSubmitErrorByron err)
             TxSubmitFailureCardanoMode (ApplyTxErrShelley err) ->
+              left (ShelleyTxCmdTxSubmitErrorShelley err)
+            TxSubmitFailureCardanoMode (ApplyTxErrAllegra err) ->
+              left (ShelleyTxCmdTxSubmitErrorShelley err)
+            TxSubmitFailureCardanoMode (ApplyTxErrMary err) ->
               left (ShelleyTxCmdTxSubmitErrorShelley err)
             TxSubmitFailureCardanoMode (ApplyTxErrWrongEra mismatch) ->
               left (ShelleyTxCmdTxSubmitErrorEraMismatch mismatch)

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -100,6 +100,7 @@ library
                      , lobemo-backend-trace-forwarder
                      , network
                      , network-mux
+                     , nothunks
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-byron

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -223,24 +223,39 @@ instance FromJSON PartialNodeConfiguration where
         --TODO: these are silly names, allow better aliases:
         protVerMajor    <- v .:  "LastKnownBlockVersion-Major"
         protVerMinor    <- v .:  "LastKnownBlockVersion-Minor"
-        protVerMajroMax <- v .:? "MaxKnownMajorProtocolVersion" .!= 1
 
         pure NodeShelleyProtocolConfiguration {
                npcShelleyGenesisFile
              , npcShelleyGenesisFileHash
              , npcShelleySupportedProtocolVersionMajor = protVerMajor
              , npcShelleySupportedProtocolVersionMinor = protVerMinor
-             , npcShelleyMaxSupportedProtocolVersion   = protVerMajroMax
              }
 
       parseHardForkProtocol v = do
         npcTestShelleyHardForkAtEpoch   <- v .:? "TestShelleyHardForkAtEpoch"
         npcTestShelleyHardForkAtVersion <- v .:? "TestShelleyHardForkAtVersion"
         npcShelleyHardForkNotBeforeEpoch <- v .:? "ShelleyHardForkNotBeforeEpoch"
+
+        npcTestAllegraHardForkAtEpoch   <- v .:? "TestAllegraHardForkAtEpoch"
+        npcTestAllegraHardForkAtVersion <- v .:? "TestAllegraHardForkAtVersion"
+        npcAllegraHardForkNotBeforeEpoch <- v .:? "AllegraHardForkNotBeforeEpoch"
+
+        npcTestMaryHardForkAtEpoch   <- v .:? "TestMaryHardForkAtEpoch"
+        npcTestMaryHardForkAtVersion <- v .:? "TestMaryHardForkAtVersion"
+        npcMaryHardForkNotBeforeEpoch <- v .:? "MaryHardForkNotBeforeEpoch"
+
         pure NodeHardForkProtocolConfiguration {
                npcTestShelleyHardForkAtEpoch,
                npcTestShelleyHardForkAtVersion,
-               npcShelleyHardForkNotBeforeEpoch
+               npcShelleyHardForkNotBeforeEpoch,
+
+               npcTestAllegraHardForkAtEpoch,
+               npcTestAllegraHardForkAtVersion,
+               npcAllegraHardForkNotBeforeEpoch,
+
+               npcTestMaryHardForkAtEpoch,
+               npcTestMaryHardForkAtVersion,
+               npcMaryHardForkNotBeforeEpoch
              }
 
 -- | Default configuration is mainnet

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -100,16 +100,22 @@ mkConsensusProtocolByron NodeByronProtocolConfiguration {
     optionalLeaderCredentials <- readLeaderCredentials genesisConfig files
 
     return $
-      Consensus.ProtocolByron
-        genesisConfig
-        (PBftSignatureThreshold <$> npcByronPbftSignatureThresh)
-        (Update.ProtocolVersion npcByronSupportedProtocolVersionMajor
-                                npcByronSupportedProtocolVersionMinor
-                                npcByronSupportedProtocolVersionAlt)
-        (Update.SoftwareVersion npcByronApplicationName
-                                npcByronApplicationVersion)
-        (maybeToList optionalLeaderCredentials)
-
+      Consensus.ProtocolByron $ Consensus.ProtocolParamsByron {
+        byronGenesis = genesisConfig,
+        byronPbftSignatureThreshold =
+          PBftSignatureThreshold <$> npcByronPbftSignatureThresh,
+        byronProtocolVersion =
+          Update.ProtocolVersion
+            npcByronSupportedProtocolVersionMajor
+            npcByronSupportedProtocolVersionMinor
+            npcByronSupportedProtocolVersionAlt,
+        byronSoftwareVersion =
+          Update.SoftwareVersion
+            npcByronApplicationName
+            npcByronApplicationVersion,
+        byronLeaderCredentials =
+          optionalLeaderCredentials
+        }
 
 readGenesis :: GenesisFile
             -> Maybe GenesisHash

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -16,6 +16,7 @@ import           Cardano.Prelude
 
 import           Control.Monad.Fail (fail)
 import           Data.Aeson
+import           NoThunks.Class (NoThunks)
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import qualified Ouroboros.Consensus.Cardano as Consensus (Protocol)
@@ -30,7 +31,7 @@ data Protocol = ByronProtocol
   deriving (Eq, Show, Generic)
 
 deriving instance NFData Protocol
-deriving instance NoUnexpectedThunks Protocol
+deriving instance NoThunks Protocol
 
 instance FromJSON Protocol where
   parseJSON =

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -55,6 +55,8 @@ import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..)
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
 
+import qualified Cardano.Crypto.Libsodium as Crypto
+
 import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.Logging (LoggingLayer (..), Severity (..),
                      createLoggingLayer, shutdownLoggingLayer)
@@ -106,6 +108,8 @@ runNode
   :: PartialNodeConfiguration
   -> IO ()
 runNode cmdPc = do
+    -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
+    Crypto.sodiumInit
 
     configYamlPc <- parseNodeConfigurationFP . getLast $ pncConfigFile cmdPc
 

--- a/cardano-node/src/Cardano/Node/TUI/Drawing.hs
+++ b/cardano-node/src/Cardano/Node/TUI/Drawing.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.Node.TUI.Drawing
@@ -36,6 +37,7 @@ import           Data.Time.Calendar (Day (..))
 import           Data.Time.Clock (NominalDiffTime, UTCTime (..), addUTCTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified Graphics.Vty as Vty
+import           NoThunks.Class (NoThunks, AllowThunk (..))
 import           Numeric (showFFloat)
 import           Text.Printf (printf)
 
@@ -45,7 +47,7 @@ import           Cardano.Tracing.Peer (Peer (..), ppPeer)
 data ColorTheme
   = DarkTheme
   | LightTheme
-  deriving (Eq, Generic, NoUnexpectedThunks, NFData)
+  deriving (Eq, Generic, NoThunks, NFData)
 
 data LiveViewState blk a = LiveViewState
   { lvsScreen               :: !Screen
@@ -109,15 +111,13 @@ data LiveViewState blk a = LiveViewState
   , lvsNodeThread           :: !LiveViewThread
   , lvsPeers                :: [Peer blk]
   , lvsColorTheme           :: !ColorTheme
-  } deriving (Generic, NFData, NoUnexpectedThunks)
+  } deriving (Generic, NFData, NoThunks)
 
 -- | Type wrapper to simplify derivations.
 newtype LiveViewThread = LiveViewThread
     { getLVThread :: Maybe (Async.Async ())
     } deriving (Eq, Generic)
-
-instance NoUnexpectedThunks LiveViewThread where
-    whnfNoUnexpectedThunks _ _ = pure NoUnexpectedThunks
+  deriving NoThunks via AllowThunk LiveViewThread
 
 instance NFData LiveViewThread where
     rnf = rwhnf
@@ -125,7 +125,7 @@ instance NFData LiveViewThread where
 data Screen
   = MainView
   | Peers
-  deriving (Generic, NoUnexpectedThunks, NFData)
+  deriving (Generic, NoThunks, NFData)
 
 -------------------------------------------------------------------------------
 -- UI drawing

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -57,8 +57,8 @@ import qualified Data.IP as IP
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import           Network.Socket (PortNumber, SockAddr (..))
 import qualified Network.DNS as DNS (Domain)
+import           Network.Socket (PortNumber, SockAddr (..))
 
 import           Cardano.Api.Typed (EpochNo)
 import qualified Cardano.Chain.Update as Byron
@@ -293,11 +293,6 @@ data NodeShelleyProtocolConfiguration =
        --
      , npcShelleySupportedProtocolVersionMajor :: !Natural
      , npcShelleySupportedProtocolVersionMinor :: !Natural
-
-       -- | The maximum major version of the protocol this node supports.
-       -- If the actual version ever goes higher than this then the node
-       -- will stop with an appropriate error message.
-     , npcShelleyMaxSupportedProtocolVersion :: !Natural
      }
   deriving (Eq, Show)
 
@@ -355,6 +350,48 @@ data NodeHardForkProtocolConfiguration =
        -- configured the same, or they will disagree.
        --
      , npcTestShelleyHardForkAtVersion :: Maybe Word
+
+       -- | If we have knowledge about when the Allegra hard fork is then we
+       -- have an opportunity to optimise the bulk sync slightly.
+       --
+     , npcAllegraHardForkNotBeforeEpoch :: Maybe EpochNo
+
+       -- | For testing purposes we support specifying that the hard fork
+       -- happens at an exact epoch number (ie the first epoch of the new era).
+       --
+       -- Obviously if this is used, all the nodes in the test cluster must be
+       -- configured the same, or they will disagree.
+       --
+     , npcTestAllegraHardForkAtEpoch :: Maybe EpochNo
+
+       -- | For testing purposes we support specifying that the hard fork
+       -- happens at a given major protocol version.
+       --
+       -- Obviously if this is used, all the nodes in the test cluster must be
+       -- configured the same, or they will disagree.
+       --
+     , npcTestAllegraHardForkAtVersion :: Maybe Word
+
+       -- | For testing purposes we support specifying that the hard fork
+       -- happens at an exact epoch number (ie the first epoch of the new era).
+       --
+       -- Obviously if this is used, all the nodes in the test cluster must be
+       -- configured the same, or they will disagree.
+       --
+     , npcTestMaryHardForkAtEpoch :: Maybe EpochNo
+
+       -- | For testing purposes we support specifying that the hard fork
+       -- happens at an exact epoch number (ie the first epoch of the new era).
+       --
+       -- Obviously if this is used, all the nodes in the test cluster must be
+       -- configured the same, or they will disagree.
+       --
+     , npcTestMaryHardForkAtVersion :: Maybe Word
+
+       -- | If we have knowledge about when the Shelley hard fork is then we
+       -- have an opportunity to optimise the bulk sync slightly.
+       --
+     , npcMaryHardForkNotBeforeEpoch :: Maybe EpochNo
      }
   deriving (Eq, Show)
 
@@ -443,4 +480,3 @@ renderVRFPrivateKeyFilePermissionError err =
     GroupPermissionsExist fp ->
       "VRF private key file at: " <> Text.pack fp
       <> "has \"group\" file permissions. Please remove all \"group\" file permissions."
-

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -442,8 +442,8 @@ instance ToObject (DelegPredicateFailure era) where
              ]
   toObject _verb WrongCertificateTypeDELEG =
     mkObject [ "kind" .= String "WrongCertificateTypeDELEG" ]
-  toObject _verb (GenesisKeyNotInpMappingDELEG (KeyHash genesisKeyHash)) =
-    mkObject [ "kind" .= String "GenesisKeyNotInpMappingDELEG"
+  toObject _verb (GenesisKeyNotInMappingDELEG (KeyHash genesisKeyHash)) =
+    mkObject [ "kind" .= String "GenesisKeyNotInMappingDELEG"
              , "unknownKeyHash" .= String (textShow genesisKeyHash)
              , "error" .= String "This genesis key is not in the delegation mapping"
              ]

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -19,6 +20,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Text.Printf (printf)
+import           NoThunks.Class (NoThunks, AllowThunk (..))
 
 import           Cardano.BM.Data.LogItem (LOContent (..), PrivacyAnnotation (..), mkLOMeta)
 import           Cardano.BM.Data.Tracer (emptyObject, mkObject)
@@ -47,9 +49,7 @@ data Peer blk =
   !(PeerFetchStatus (Header blk))
   !(PeerFetchInFlight (Header blk))
   deriving (Generic)
-
-instance NoUnexpectedThunks (Peer blk) where
-    whnfNoUnexpectedThunks _ _ = pure NoUnexpectedThunks
+  deriving NoThunks via AllowThunk (Peer blk)
 
 instance NFData (Peer blk) where
     rnf _ = ()

--- a/cardano-node/src/Cardano/Tracing/Queries.hs
+++ b/cardano-node/src/Cardano/Tracing/Queries.hs
@@ -49,4 +49,6 @@ instance LedgerQueries (Cardano.CardanoBlock c) where
   ledgerUtxoSize = \case
     Cardano.LedgerStateByron   ledgerByron   -> ledgerUtxoSize ledgerByron
     Cardano.LedgerStateShelley ledgerShelley -> ledgerUtxoSize ledgerShelley
+    Cardano.LedgerStateAllegra ledgerAllegra -> ledgerUtxoSize ledgerAllegra
+    Cardano.LedgerStateMary    ledgerMary    -> ledgerUtxoSize ledgerMary
     _ -> error "ledgerUtxoSize:  unhandled CardanoBlock case"

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -41,7 +41,7 @@ testPartialYamlConfig =
   PartialNodeConfiguration
     { pncProtocolConfig = Last . Just . NodeProtocolConfigurationShelley
                                           $ NodeShelleyProtocolConfiguration
-                                          (GenesisFile "dummmy-genesis-file") Nothing 1 2 3
+                                          (GenesisFile "dummmy-genesis-file") Nothing 1 2
     , pncSocketPath = Last Nothing
     , pncDiffusionMode = Last Nothing
     , pncMaxConcurrencyBulkSync = Last Nothing
@@ -104,7 +104,7 @@ expectedConfig =
     , ncShutdownOnSlotSynced = MaxSlotNo $ SlotNo 42
     , ncProtocolConfig = NodeProtocolConfigurationShelley
                            $ NodeShelleyProtocolConfiguration
-                             (GenesisFile "dummmy-genesis-file") Nothing 1 2 3
+                             (GenesisFile "dummmy-genesis-file") Nothing 1 2
     , ncSocketPath = Nothing
     , ncDiffusionMode = InitiatorAndResponderDiffusionMode
     , ncMaxConcurrencyBulkSync = Nothing


### PR DESCRIPTION
This propagates
<input-output-hk/ouroboros-network#2666>, extending
`CardanoEras` and `CardanoBlock` with the Allegra and Mary eras.

The Allegra and Mary eras, and even the future Goguen era, are all based on
`ShelleyBlock` (the name is unfortunate in hindsight). Concretely:

* A block from the Shelley era has the following type:
  `ShelleyBlock (ShelleyEra c)`
* A block from the Allegra era has the following type:
  `ShelleyBlock (AllegraEra c)`
* A block from the Mary era has the following type:
  `ShelleyBlock (MaryEra c)`

where `c` is the cryptography used. There are synonyms for when `c =
StandardCrypto`: `StandardShelley = ShelleyEra StandardCrypto`,
`StandardAllegra`, `StandardMary`.

We call `ShelleyEra`, `AllegraEra`, and `MaryEra` *era tags*.

A `CardanoBlock` can now be treated as the following "virtual" data type (thanks
to pattern synonyms):

```
data CardanoBlock c =
    BlockByron ByronBlock
  | BlockShelley (ShelleyBlock (ShelleyEra c))
  | BlockAllegra (ShelleyBlock (AllegraEra c))
  | BlockMary    (ShelleyBlock (MaryEra    c))
```

Similarly for the other types. See `Ouroboros.Consensus.Cardano.Block` for a
list of all the provided pattern synonyms.

IMPORTANT: at the moment: `ShelleyEra = AllegraEra = Mary`. In other words, the
Allegra and Mary eras are identical to the Shelley era. This means all code that
works with `ShelleyEra` also works the two other eras. However, this will change
in the future, as they will become different era tags. When that happens, such
code will have to be generalised to any Shelley `era` (e.g., `ShelleyBlock era`)
or different versions will have to be written for each era.

* This update also includes a change to the protocol arguments. The
  `ProtocolByron`, `ProtocolShelley` and `ProtocolCardano` constructors from
  consensus no longer take a whole bunch of parameters, but parameter records,
  i.e., `ProtocolParamsByron`, `ProtocolParamsShelley`, `ProtocolParamsAllegra`,
  `ProtocolParamsCardano`, `ProtocolParamsTransition`. Note that there doesn't
  exist `ProtocolParamsCardano`. Instead, `ProtocolCardano` takes
  `ProtocolParamsByron`, `ProtocolParamsShelley`, etc.

* This update also propagates
  <input-output-hk/cardano-prelude#124>, replacing
  `NoUnexpectedThunks` from `cardano-prelude` with `NoThunks`, from the
  `nothunks` package on Hackage.