### PR TITLE
CAD-1987: update iohk-monitoring dep.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -140,8 +140,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: d4bb653fcef181befe3883490c66faed46b6197d
-  --sha256: 0j859gyrcsdnnw3yflp8l70fvddlpca4x8y2l6kqzn0a9s1qvcb3
+  tag: 86f2dfc8db25133c95494318fe656155ac6a5754
+  --sha256: 0zbmpg5ircgy80ss57aa4nqfk0p0k01y3chdjqs41s52swiypss5
   subdir:
     contra-tracer
     iohk-monitoring


### PR DESCRIPTION
Update `iohk-monitoring` dependency, it solves CAD-1987 (less messages during `TraceForwarderBK` overflow).