### PR TITLE
Add CLI support for outputting Bech32 serialised keys

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -45,6 +45,7 @@ library
                         Cardano.Api.ChainSync.Client
                         Cardano.Api.ChainSync.ClientPipelined
                         Cardano.Api.Crypto.Ed25519Bip32
+                        Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.Shelley
                         -- TODO: Eliminate in the future when
                         -- we create wrapper types for the ledger types
@@ -59,7 +60,7 @@ library
                         Cardano.Api.Convenience.Constraints
                         Cardano.Api.Convenience.Construction
                         Cardano.Api.Convenience.Query
-                        Cardano.Api.DeserialiseAnyOf
+                        Cardano.Api.Protocol
                         Cardano.Api.Environment
                         Cardano.Api.EraCast
                         Cardano.Api.Eras

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -540,6 +540,8 @@ module Cardano.Api (
     writeFileTextEnvelope,
     readTextEnvelopeFromFile,
     readTextEnvelopeOfTypeFromFile,
+    readFileAnyOfInputFormats,
+    readFileTextEnvelope',
 
     -- ** Text envelope CDDL
     -- | Support for serialising values in the ledger's CDDL format.

--- a/cardano-api/src/Cardano/Api/Error.hs
+++ b/cardano-api/src/Cardano/Api/Error.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 -- | Class of errors used in the Api.
 --

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -28,7 +28,6 @@ module Cardano.Api.IO
 #ifdef UNIX
 import           Control.Exception (IOException, bracket, bracketOnError, try)
 import           System.Directory ()
-import           System.IO (hClose)
 import           System.Posix.Files (ownerModes, setFdOwnerAndGroup)
 import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
 import           System.Posix.User (getRealUserID)
@@ -36,7 +35,7 @@ import           System.Posix.User (getRealUserID)
 import           Control.Exception (bracketOnError)
 import           System.Directory (removeFile, renameFile)
 import           System.FilePath (splitFileName, (<.>))
-import           System.IO (hClose, openTempFile)
+import           System.IO (openTempFile)
 #endif
 
 import           Cardano.Api.Error (FileError (..))
@@ -54,7 +53,7 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
 import           GHC.Generics (Generic)
-import           System.IO (Handle)
+import           System.IO (Handle, hClose)
 
 handleFileForWritingWithOwnerPermission
   :: FilePath

--- a/cardano-api/src/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Compat.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Api.IO.Compat
+  ( writeLazyByteStringFileWithOwnerPermissions
+  ) where
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
+
+import           Cardano.Api.Error (FileError (..))
+
+import           Control.Monad.Except (runExceptT)
+import           Control.Monad.Trans.Except.Extra (handleIOExceptT)
+import qualified Data.ByteString.Lazy as LBS
+
+#ifdef UNIX
+import           Control.Exception (IOException, bracket, bracketOnError, try)
+import           System.Directory ()
+import           System.IO (hClose)
+import           System.Posix.Files (ownerModes, setFdOwnerAndGroup)
+import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
+import           System.Posix.User (getRealUserID)
+#else
+import           Control.Exception (bracketOnError)
+import           System.Directory (removeFile, renameFile)
+import           System.FilePath (splitFileName, (<.>))
+import           System.IO (hClose, openTempFile)
+#endif
+
+writeLazyByteStringFileWithOwnerPermissions
+  :: FilePath
+  -> LBS.ByteString
+  -> IO (Either (FileError ()) ())
+#ifdef UNIX
+-- On a unix based system, we grab a file descriptor and set ourselves as owner.
+-- Since we're holding the file descriptor at this point, we can be sure that
+-- what we're about to write to is owned by us if an error didn't occur.
+writeLazyByteStringFileWithOwnerPermissions path a = do
+    user <- getRealUserID
+    ownedFile <- try $
+      -- We only close the FD on error here, otherwise we let it leak out, since
+      -- it will be immediately turned into a Handle (which will be closed when
+      -- the Handle is closed)
+      bracketOnError
+        (openFd path WriteOnly (Just ownerModes) defaultFileFlags)
+        closeFd
+        (\fd -> setFdOwnerAndGroup fd user (-1) >> pure fd)
+    case ownedFile of
+      Left (err :: IOException) -> do
+        pure $ Left $ FileIOError path err
+      Right fd -> do
+        bracket
+          (fdToHandle fd)
+          hClose
+          (\handle -> runExceptT $ handleIOExceptT (FileIOError path) $ LBS.hPut handle a)
+#else
+-- On something other than unix, we make a _new_ file, and since we created it,
+-- we must own it. We then place it at the target location. Unfortunately this
+-- won't work correctly with pseudo-files.
+writeLazyByteStringFileWithOwnerPermissions targetPath a =
+    bracketOnError
+      (openTempFile targetDir $ targetFile <.> "tmp")
+      (\(tmpPath, fHandle) -> do
+        hClose fHandle >> removeFile tmpPath
+        return . Left $ FileErrorTempFile targetPath tmpPath fHandle)
+      (\(tmpPath, fHandle) -> do
+          LBS.hPut fHandle a
+          hClose fHandle
+          renameFile tmpPath targetPath
+          return $ Right ())
+  where
+    (targetDir, targetFile) = splitFileName targetPath
+#endif

--- a/cardano-api/src/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Compat.hs
@@ -58,7 +58,7 @@ handleFileForWritingWithOwnerPermission path f = do
 -- On something other than unix, we make a _new_ file, and since we created it,
 -- we must own it. We then place it at the target location. Unfortunately this
 -- won't work correctly with pseudo-files.
-handleFileForWritingWithOwnerPermission targetPath a =
+handleFileForWritingWithOwnerPermission targetPath f =
     bracketOnError
       (openTempFile targetDir $ targetFile <.> "tmp")
       (\(tmpPath, fHandle) -> do

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -243,6 +243,7 @@ test-suite cardano-cli-golden
                       , filepath
                       , hedgehog ^>= 1.2
                       , hedgehog-extras ^>= 0.4
+                      , regex-tdfa
                       , text
                       , time
                       , transformers

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -95,7 +95,7 @@ renderShelleyCommand sc =
     TextViewCmd cmd -> renderTextViewCmd cmd
 
 data AddressCmd
-  = AddressKeyGen AddressKeyType VerificationKeyFile SigningKeyFile
+  = AddressKeyGen KeyOutputFormat AddressKeyType VerificationKeyFile SigningKeyFile
   | AddressKeyHash VerificationKeyTextOrFile (Maybe OutputFile)
   | AddressBuild
       PaymentVerifier

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -332,7 +332,7 @@ data PoolCmd
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
       OutputFile
-  | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
+  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat
   | PoolMetadataHash PoolMetadataFile (Maybe OutputFile)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -52,7 +52,7 @@ import           Prelude
 
 import           Cardano.Api.Shelley
 
-import           Data.String(IsString)
+import           Data.String (IsString)
 import           Data.Text (Text)
 import           GHC.Generics (Generic)
 
@@ -115,7 +115,7 @@ renderAddressCmd cmd =
     AddressInfo {} -> "address info"
 
 data StakeAddressCmd
-  = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
+  = StakeAddressKeyGen KeyOutputFormat VerificationKeyFile SigningKeyFile
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe OutputFile)
   | StakeAddressBuild StakeVerifier NetworkId (Maybe OutputFile)
   | StakeRegistrationCert StakeIdentifier OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -289,9 +289,9 @@ renderTransactionCmd cmd =
     TxView {} -> "transaction view"
 
 data NodeCmd
-  = NodeKeyGenCold VerificationKeyFile SigningKeyFile OpCertCounterFile
-  | NodeKeyGenKES  VerificationKeyFile SigningKeyFile
-  | NodeKeyGenVRF  VerificationKeyFile SigningKeyFile
+  = NodeKeyGenCold KeyOutputFormat VerificationKeyFile SigningKeyFile OpCertCounterFile
+  | NodeKeyGenKES  KeyOutputFormat VerificationKeyFile SigningKeyFile
+  | NodeKeyGenVRF  KeyOutputFormat VerificationKeyFile SigningKeyFile
   | NodeKeyHashVRF  (VerificationKeyOrFile VrfKey) (Maybe OutputFile)
   | NodeNewCounter ColdVerificationKeyOrFile Word OpCertCounterFile
   | NodeIssueOpCert (VerificationKeyOrFile KesKey) SigningKeyFile OpCertCounterFile
@@ -441,9 +441,17 @@ renderTextViewCmd :: TextViewCmd -> Text
 renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"
 
 data GenesisCmd
-  = GenesisCreate GenesisDir Word Word (Maybe SystemStart) (Maybe Lovelace) NetworkId
+  = GenesisCreate
+      KeyOutputFormat
+      GenesisDir
+      Word
+      Word
+      (Maybe SystemStart)
+      (Maybe Lovelace)
+      NetworkId
   | GenesisCreateCardano GenesisDir Word Word (Maybe SystemStart) (Maybe Lovelace) BlockCount Word Rational NetworkId FilePath FilePath FilePath FilePath (Maybe FilePath)
   | GenesisCreateStaked
+      KeyOutputFormat
       GenesisDir
       Word
       Word

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Shelley CLI command types
@@ -49,7 +52,9 @@ import           Prelude
 
 import           Cardano.Api.Shelley
 
+import           Data.String(IsString)
 import           Data.Text (Text)
+import           GHC.Generics (Generic)
 
 import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeIdentifier, StakeVerifier,
                    VerificationKeyOrFile, VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
@@ -332,7 +337,7 @@ data PoolCmd
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
       OutputFile
-  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat
+  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat (Maybe OutputFile)
   | PoolMetadataHash PoolMetadataFile (Maybe OutputFile)
   deriving Show
 
@@ -516,7 +521,8 @@ data MetadataFile = MetadataFileJSON FilePath
 
 newtype PoolMetadataFile = PoolMetadataFile
   { unPoolMetadataFile :: FilePath }
-  deriving Show
+  deriving Generic
+  deriving newtype (Eq, Ord, Show, IsString)
 
 newtype GenesisDir
   = GenesisDir FilePath

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -37,8 +36,6 @@ module Cardano.CLI.Shelley.Key
   , generateKeyPair
   ) where
 
-import           Cardano.Api
-
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
@@ -46,6 +43,8 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+
+import           Cardano.Api
 
 import           Cardano.CLI.Types
 
@@ -66,7 +65,7 @@ readSigningKeyFile
   -> SigningKeyFile
   -> IO (Either (FileError InputDecodeError) (SigningKey keyrole))
 readSigningKeyFile asType (SigningKeyFile fp) =
-  readKeyFile
+  readFileAnyOfInputFormats
     (AsSigningKey asType)
     (NE.fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
     fp
@@ -106,7 +105,7 @@ readVerificationKeyOrFile asType verKeyOrFile =
   case verKeyOrFile of
     VerificationKeyValue vk -> pure (Right vk)
     VerificationKeyFilePath (VerificationKeyFile fp) ->
-      readKeyFile
+      readFileAnyOfInputFormats
         (AsVerificationKey asType)
         (NE.fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
         fp
@@ -125,7 +124,7 @@ readVerificationKeyOrTextEnvFile asType verKeyOrFile =
   case verKeyOrFile of
     VerificationKeyValue vk -> pure (Right vk)
     VerificationKeyFilePath (VerificationKeyFile fp) ->
-      readKeyFileTextEnvelope (AsVerificationKey asType) fp
+      readFileTextEnvelope' (AsVerificationKey asType) fp
 
 data PaymentVerifier
   = PaymentVerifierKey VerificationKeyTextOrFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -7,6 +7,17 @@
 -- | Shelley CLI option data types and functions for cryptographic keys.
 module Cardano.CLI.Shelley.Key
   ( VerificationKeyOrFile (..)
+  , InputFormat (..)
+  , InputDecodeError (..)
+  , deserialiseInput
+  , deserialiseInputAnyOf
+  , renderInputDecodeError
+
+  , readKeyFileAnyOf
+  , readKeyFileTextEnvelope
+
+  , readSigningKeyFile
+
   , readVerificationKeyOrFile
   , readVerificationKeyOrTextEnvFile
 
@@ -38,6 +49,27 @@ import qualified Data.Text.Encoding as Text
 
 import           Cardano.CLI.Types
 
+------------------------------------------------------------------------------
+-- Signing key deserialisation
+------------------------------------------------------------------------------
+
+-- | Read a signing key from a file.
+--
+-- The contents of the file can either be Bech32-encoded, hex-encoded, or in
+-- the text envelope format.
+readSigningKeyFile
+  :: forall keyrole.
+     ( HasTextEnvelope (SigningKey keyrole)
+     , SerialiseAsBech32 (SigningKey keyrole)
+     )
+  => AsType keyrole
+  -> SigningKeyFile
+  -> IO (Either (FileError InputDecodeError) (SigningKey keyrole))
+readSigningKeyFile asType (SigningKeyFile fp) =
+  readKeyFile
+    (AsSigningKey asType)
+    (NE.fromList [InputFormatBech32, InputFormatHex, InputFormatTextEnvelope])
+    fp
 
 ------------------------------------------------------------------------------
 -- Verification key deserialisation

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -145,9 +145,12 @@ pAddressCmd =
      ]
   where
     pAddressKeyGen :: Parser AddressCmd
-    pAddressKeyGen = AddressKeyGen <$> pAddressKeyType
-                                   <*> pVerificationKeyFile Output
-                                   <*> pSigningKeyFile Output
+    pAddressKeyGen =
+      AddressKeyGen
+        <$> pKeyOutputFormat
+        <*> pAddressKeyType
+        <*> pVerificationKeyFile Output
+        <*> pSigningKeyFile Output
 
     pAddressKeyHash :: Parser AddressCmd
     pAddressKeyHash =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -922,7 +922,7 @@ pPoolCmd =
       ]
   where
     pId :: Parser PoolCmd
-    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pOutputFormat
+    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat
 
     pPoolMetadataHashSubCmd :: Parser PoolCmd
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
@@ -1801,15 +1801,17 @@ pOperationalCertificateFile =
     <> Opt.completer (Opt.bashCompleter "file")
     )
 
-pOutputFormat :: Parser OutputFormat
-pOutputFormat =
-  Opt.option readOutputFormat
-    (  Opt.long "output-format"
-    <> Opt.metavar "STRING"
-    <> Opt.help "Optional output format. Accepted output formats are \"hex\" \
-                \and \"bech32\" (default is \"bech32\")."
-    <> Opt.value OutputFormatBech32
-    )
+pPoolIdOutputFormat :: Parser PoolIdOutputFormat
+pPoolIdOutputFormat =
+  Opt.option readPoolIdOutputFormat $ mconcat
+    [ Opt.long "output-format"
+    , Opt.metavar "STRING"
+    , Opt.help $ mconcat
+      [ "Optional pool id output format. Accepted output formats are \"hex\" "
+      , "and \"bech32\" (default is \"bech32\")."
+      ]
+    , Opt.value PoolIdOutputFormatBech32
+    ]
 
 pMaybeOutputFile :: Parser (Maybe OutputFile)
 pMaybeOutputFile =
@@ -3339,12 +3341,12 @@ readVerificationKey asType =
       first (Text.unpack . renderInputDecodeError) $
         deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
 
-readOutputFormat :: Opt.ReadM OutputFormat
-readOutputFormat = do
+readPoolIdOutputFormat :: Opt.ReadM PoolIdOutputFormat
+readPoolIdOutputFormat = do
   s <- Opt.str
   case s of
-    "hex" -> pure OutputFormatHex
-    "bech32" -> pure OutputFormatBech32
+    "hex" -> pure PoolIdOutputFormatHex
+    "bech32" -> pure PoolIdOutputFormatBech32
     _ ->
       fail $ "Invalid output format: \""
         <> s

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -381,9 +381,11 @@ pStakeAddressCmd =
       ]
   where
     pStakeAddressKeyGen :: Parser StakeAddressCmd
-    pStakeAddressKeyGen = StakeAddressKeyGen
-                            <$> pVerificationKeyFile Output
-                            <*> pSigningKeyFile Output
+    pStakeAddressKeyGen =
+      StakeAddressKeyGen
+        <$> pKeyOutputFormat
+        <*> pVerificationKeyFile Output
+        <*> pSigningKeyFile Output
 
     pStakeAddressKeyHash :: Parser StakeAddressCmd
     pStakeAddressKeyHash = StakeAddressKeyHash <$> pStakeVerificationKeyOrFile <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -922,7 +922,7 @@ pPoolCmd =
       ]
   where
     pId :: Parser PoolCmd
-    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat
+    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat <*> pMaybeOutputFile
 
     pPoolMetadataHashSubCmd :: Parser PoolCmd
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
@@ -3343,14 +3343,15 @@ readVerificationKey asType =
 
 readPoolIdOutputFormat :: Opt.ReadM PoolIdOutputFormat
 readPoolIdOutputFormat = do
-  s <- Opt.str
+  s <- Opt.str @String
   case s of
     "hex" -> pure PoolIdOutputFormatHex
     "bech32" -> pure PoolIdOutputFormatBech32
     _ ->
-      fail $ "Invalid output format: \""
-        <> s
-        <> "\". Accepted output formats are \"hex\" and \"bech32\"."
+      fail $ mconcat
+        [ "Invalid output format: " <> show s
+        , ". Accepted output formats are \"hex\" and \"bech32\"."
+        ]
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -220,10 +220,10 @@ runGenesisCmd (GenesisCmdKeyHash vk) = runGenesisKeyHash vk
 runGenesisCmd (GenesisVerKey vk sk) = runGenesisVerKey vk sk
 runGenesisCmd (GenesisTxIn vk nw mOutFile) = runGenesisTxIn vk nw mOutFile
 runGenesisCmd (GenesisAddr vk nw mOutFile) = runGenesisAddr vk nw mOutFile
-runGenesisCmd (GenesisCreate gd gn un ms am nw) = runGenesisCreate gd gn un ms am nw
+runGenesisCmd (GenesisCreate fmt gd gn un ms am nw) = runGenesisCreate fmt gd gn un ms am nw
 runGenesisCmd (GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg) = runGenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
-runGenesisCmd (GenesisCreateStaked gd gn gp gl un ms am ds nw bf bp su relayJsonFp) =
-  runGenesisCreateStaked gd gn gp gl un ms am ds nw bf bp su relayJsonFp
+runGenesisCmd (GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp) =
+  runGenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
 runGenesisCmd (GenesisHashFile gf) = runGenesisHashFile gf
 
 --
@@ -409,16 +409,20 @@ writeOutput Nothing                   = Text.putStrLn
 -- Create Genesis command implementation
 --
 
-runGenesisCreate :: GenesisDir
-                 -> Word  -- ^ num genesis & delegate keys to make
-                 -> Word  -- ^ num utxo keys to make
-                 -> Maybe SystemStart
-                 -> Maybe Lovelace
-                 -> NetworkId
-                 -> ExceptT ShelleyGenesisCmdError IO ()
-runGenesisCreate (GenesisDir rootdir)
-                 genNumGenesisKeys genNumUTxOKeys
-                 mStart mAmount network = do
+runGenesisCreate
+  :: KeyOutputFormat
+  -> GenesisDir
+  -> Word  -- ^ num genesis & delegate keys to make
+  -> Word  -- ^ num utxo keys to make
+  -> Maybe SystemStart
+  -> Maybe Lovelace
+  -> NetworkId
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runGenesisCreate
+    fmt (GenesisDir rootdir)
+    genNumGenesisKeys genNumUTxOKeys
+    mStart mAmount network = do
+
   liftIO $ do
     createDirectoryIfMissing False rootdir
     createDirectoryIfMissing False gendir
@@ -431,7 +435,7 @@ runGenesisCreate (GenesisDir rootdir)
 
   forM_ [ 1 .. genNumGenesisKeys ] $ \index -> do
     createGenesisKeys  gendir  index
-    createDelegateKeys deldir index
+    createDelegateKeys fmt deldir index
 
   forM_ [ 1 .. genNumUTxOKeys ] $ \index ->
     createUtxoKeys utxodir index
@@ -682,25 +686,27 @@ runGenesisCreateCardano (GenesisDir rootdir)
     dlgCertMap byronGenesis = Genesis.unGenesisDelegation $ Genesis.gdHeavyDelegation byronGenesis
 
 runGenesisCreateStaked
-  :: GenesisDir
-  -> Word           -- ^ num genesis & delegate keys to make
-  -> Word           -- ^ num utxo keys to make
-  -> Word           -- ^ num pools to make
-  -> Word           -- ^ num delegators to make
+  :: KeyOutputFormat    -- ^ key output format
+  -> GenesisDir
+  -> Word               -- ^ num genesis & delegate keys to make
+  -> Word               -- ^ num utxo keys to make
+  -> Word               -- ^ num pools to make
+  -> Word               -- ^ num delegators to make
   -> Maybe SystemStart
-  -> Maybe Lovelace -- ^ supply going to non-delegators
-  -> Lovelace       -- ^ supply going to delegators
+  -> Maybe Lovelace     -- ^ supply going to non-delegators
+  -> Lovelace           -- ^ supply going to delegators
   -> NetworkId
-  -> Word           -- ^ bulk credential files to write
-  -> Word           -- ^ pool credentials per bulk file
-  -> Word           -- ^ num stuffed UTxO entries
-  -> Maybe FilePath -- ^ Specified stake pool relays
+  -> Word               -- ^ bulk credential files to write
+  -> Word               -- ^ pool credentials per bulk file
+  -> Word               -- ^ num stuffed UTxO entries
+  -> Maybe FilePath     -- ^ Specified stake pool relays
   -> ExceptT ShelleyGenesisCmdError IO ()
-runGenesisCreateStaked (GenesisDir rootdir)
-                 genNumGenesisKeys genNumUTxOKeys genNumPools genNumStDelegs
-                 mStart mNonDlgAmount stDlgAmount network
-                 numBulkPoolCredFiles bulkPoolsPerFile numStuffedUtxo
-                 sPoolRelayFp = do
+runGenesisCreateStaked
+    fmt (GenesisDir rootdir)
+    genNumGenesisKeys genNumUTxOKeys genNumPools genNumStDelegs
+    mStart mNonDlgAmount stDlgAmount network
+    numBulkPoolCredFiles bulkPoolsPerFile numStuffedUtxo
+    sPoolRelayFp = do
   liftIO $ do
     createDirectoryIfMissing False rootdir
     createDirectoryIfMissing False gendir
@@ -715,7 +721,7 @@ runGenesisCreateStaked (GenesisDir rootdir)
 
   forM_ [ 1 .. genNumGenesisKeys ] $ \index -> do
     createGenesisKeys gendir index
-    createDelegateKeys deldir index
+    createDelegateKeys fmt deldir index
 
   forM_ [ 1 .. genNumUTxOKeys ] $ \index ->
     createUtxoKeys utxodir index
@@ -729,7 +735,7 @@ runGenesisCreateStaked (GenesisDir rootdir)
            . hoistEither $ Aeson.eitherDecode relaySpecJsonBs
 
   poolParams <- forM [ 1 .. genNumPools ] $ \index -> do
-    createPoolCredentials pooldir index
+    createPoolCredentials fmt pooldir index
     buildPoolParams network pooldir index (fromMaybe mempty mayStakePoolRelays)
 
   when (numBulkPoolCredFiles * bulkPoolsPerFile > genNumPools) $
@@ -826,8 +832,8 @@ runGenesisCreateStaked (GenesisDir rootdir)
 
 -- -------------------------------------------------------------------------------------------------
 
-createDelegateKeys :: FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
-createDelegateKeys dir index = do
+createDelegateKeys :: KeyOutputFormat -> FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
+createDelegateKeys fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   runGenesisKeyGenDelegate
         (VerificationKeyFile $ dir </> "delegate" ++ strIndex ++ ".vkey")
@@ -838,6 +844,7 @@ createDelegateKeys dir index = do
         (SigningKeyFile $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
+        fmt
         kesVK
         (SigningKeyFile $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
     runNodeIssueOpCert
@@ -869,17 +876,20 @@ createUtxoKeys dir index = do
         (VerificationKeyFile $ dir </> "utxo" ++ strIndex ++ ".vkey")
         (SigningKeyFile $ dir </> "utxo" ++ strIndex ++ ".skey")
 
-createPoolCredentials :: FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
-createPoolCredentials dir index = do
+createPoolCredentials :: KeyOutputFormat -> FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
+createPoolCredentials fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
+        fmt
         kesVK
         (SigningKeyFile $ dir </> "kes" ++ strIndex ++ ".skey")
     runNodeKeyGenVRF
+        fmt
         (VerificationKeyFile $ dir </> "vrf" ++ strIndex ++ ".vkey")
         (SigningKeyFile $ dir </> "vrf" ++ strIndex ++ ".skey")
     runNodeKeyGenCold
+        fmt
         (VerificationKeyFile $ dir </> "cold" ++ strIndex ++ ".vkey")
         coldSK
         opCertCtr

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -901,6 +901,7 @@ createPoolCredentials fmt dir index = do
         (OutputFile $ dir </> "opcert" ++ strIndex ++ ".cert")
   firstExceptT ShelleyGenesisCmdStakeAddressCmdError $
     runStakeAddressKeyGenToFile
+        fmt
         (VerificationKeyFile $ dir </> "staking-reward" ++ strIndex ++ ".vkey")
         (SigningKeyFile $ dir </> "staking-reward" ++ strIndex ++ ".skey")
  where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -14,7 +14,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
-import           Cardano.CLI.Types (OutputFormat (..))
+import           Cardano.CLI.Types (PoolIdOutputFormat (..))
 
 import qualified Cardano.Ledger.Slot as Shelley
 import           Control.Monad.IO.Class (MonadIO (..))
@@ -165,7 +165,7 @@ runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch (OutputFile outfp) 
 
 runPoolId
   :: VerificationKeyOrFile StakePoolKey
-  -> OutputFormat
+  -> PoolIdOutputFormat
   -> ExceptT ShelleyPoolCmdError IO ()
 runPoolId verKeyOrFile outputFormat = do
     stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
@@ -173,9 +173,9 @@ runPoolId verKeyOrFile outputFormat = do
       $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
     liftIO $
       case outputFormat of
-        OutputFormatHex ->
+        PoolIdOutputFormatHex ->
           BS.putStrLn $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
-        OutputFormatBech32 ->
+        PoolIdOutputFormatBech32 ->
           Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
 runPoolMetadataHash :: PoolMetadataFile -> Maybe OutputFile -> ExceptT ShelleyPoolCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -8,7 +8,6 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
                    newExceptT)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
@@ -44,7 +43,7 @@ runPoolCmd (PoolRegistrationCert sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerV
   runStakePoolRegistrationCert sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
 runPoolCmd (PoolRetirementCert sPvkeyFp retireEpoch outfp) =
   runStakePoolRetirementCert sPvkeyFp retireEpoch outfp
-runPoolCmd (PoolGetId sPvkey outputFormat) = runPoolId sPvkey outputFormat
+runPoolCmd (PoolGetId sPvkey outputFormat mOutFile) = runPoolId sPvkey outputFormat mOutFile
 runPoolCmd (PoolMetadataHash poolMdFile mOutFile) = runPoolMetadataHash poolMdFile mOutFile
 
 
@@ -166,17 +165,24 @@ runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch (OutputFile outfp) 
 runPoolId
   :: VerificationKeyOrFile StakePoolKey
   -> PoolIdOutputFormat
+  -> Maybe OutputFile
   -> ExceptT ShelleyPoolCmdError IO ()
-runPoolId verKeyOrFile outputFormat = do
-    stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
-      . newExceptT
-      $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
-    liftIO $
-      case outputFormat of
-        PoolIdOutputFormatHex ->
-          BS.putStrLn $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
-        PoolIdOutputFormatBech32 ->
-          Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
+runPoolId verKeyOrFile outputFormat mOutFile = do
+  stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
+    . newExceptT
+    $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
+
+  case outputFormat of
+    PoolIdOutputFormatHex ->
+      firstExceptT ShelleyPoolCmdWriteFileError
+        . newExceptT
+        $ writeByteStringOutput (unOutputFile <$> mOutFile)
+        $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
+    PoolIdOutputFormatBech32 ->
+      firstExceptT ShelleyPoolCmdWriteFileError
+        . newExceptT
+        $ writeTextOutput (unOutputFile <$> mOutFile)
+        $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
 runPoolMetadataHash :: PoolMetadataFile -> Maybe OutputFile -> ExceptT ShelleyPoolCmdError IO ()
 runPoolMetadataHash (PoolMetadataFile poolMDPath) mOutFile = do

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -17,7 +17,7 @@ module Cardano.CLI.Types
   , OpCertNodeAndOnDiskCounterInformation (..)
   , OpCertNodeStateCounter (..)
   , OpCertStartingKesPeriod (..)
-  , OutputFormat (..)
+  , PoolIdOutputFormat (..)
   , TxBuildOutputOptions(..)
   , ReferenceScriptAnyEra (..)
   , SigningKeyFile (..)
@@ -190,9 +190,9 @@ instance FromJSON GenesisFile where
                            <> "Encountered: " <> show invalid
 
 -- | The desired output format.
-data OutputFormat
-  = OutputFormatHex
-  | OutputFormatBech32
+data PoolIdOutputFormat
+  = PoolIdOutputFormatHex
+  | PoolIdOutputFormatBech32
   deriving (Eq, Show)
 
 data AllOrOnly a = All | Only a deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Types
   , CurrentKesPeriod (..)
   , EpochLeadershipSchedule (..)
   , GenesisFile (..)
+  , KeyOutputFormat(..)
   , OpCertEndingKesPeriod (..)
   , OpCertIntervalInformation (..)
   , OpCertOnDiskCounter (..)
@@ -193,6 +194,11 @@ instance FromJSON GenesisFile where
 data PoolIdOutputFormat
   = PoolIdOutputFormatHex
   | PoolIdOutputFormatBech32
+  deriving (Eq, Show)
+
+data KeyOutputFormat
+  = KeyOutputFormatTextEnvelope
+  | KeyOutputFormatBech32
   deriving (Eq, Show)
 
 data AllOrOnly a = All | Only a deriving (Eq, Show)

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -62,7 +62,8 @@ import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
                    (golden_shelleyGenesisUTxOKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys,
+                   golden_shelleyStakeKeys_bech32, golden_shelleyStakeKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
                    golden_shelleyVRFKeys_bech32, golden_shelleyVRFKeys_te)
 import           Test.Golden.Shelley.TextView.DecodeCbor (golden_shelleyTextViewDecodeCbor)
@@ -121,6 +122,8 @@ keyTests =
         , ("golden_shelleyStakeAddressKeyGen", golden_shelleyStakeAddressKeyGen)
         , ("golden_shelleyStakeAddressRegistrationCertificate", golden_shelleyStakeAddressRegistrationCertificate)
         , ("golden_shelleyStakeKeys", golden_shelleyStakeKeys)
+        , ("golden_shelleyStakeKeys_bech32", golden_shelleyStakeKeys_bech32)
+        , ("golden_shelleyStakeKeys_te", golden_shelleyStakeKeys_te)
         , ("golden_shelleyStakePoolRegistrationCertificate", golden_shelleyStakePoolRegistrationCertificate)
         , ("golden_shelleyTextViewDecodeCbor", golden_shelleyTextViewDecodeCbor)
         , ("golden_shelleyTransactionBuild", golden_shelleyTransactionBuild)

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -54,14 +54,16 @@ import           Test.Golden.Shelley.Metadata.StakePoolMetadata (golden_stakePoo
 import           Test.Golden.Shelley.MultiSig.Address (golden_shelleyAllMultiSigAddressBuild,
                    golden_shelleyAnyMultiSigAddressBuild, golden_shelleyAtLeastMultiSigAddressBuild)
 import           Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
-                   (golden_shelleyExtendedPaymentKeys)
+                   (golden_shelleyExtendedPaymentKeys, golden_shelleyExtendedPaymentKeys_bech32,
+                   golden_shelleyExtendedPaymentKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
                    (golden_shelleyGenesisDelegateKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys (golden_shelleyGenesisKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
                    (golden_shelleyGenesisUTxOKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys,
+                   golden_shelleyPaymentKeys_bech32, golden_shelleyPaymentKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys,
                    golden_shelleyStakeKeys_bech32, golden_shelleyStakeKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
@@ -96,6 +98,8 @@ keyTests =
         , ("golden_shelleyAddressExtendedKeyGen", golden_shelleyAddressExtendedKeyGen)
         , ("golden_shelleyAddressBuild", golden_shelleyAddressBuild)
         , ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
+        , ("golden_shelleyExtendedPaymentKeys_bech32", golden_shelleyExtendedPaymentKeys_bech32)
+        , ("golden_shelleyExtendedPaymentKeys_te", golden_shelleyExtendedPaymentKeys_te)
         , ("golden_shelleyGenesisCreate", golden_shelleyGenesisCreate)
         , ("golden_shelleyGenesisDelegateKeys", golden_shelleyGenesisDelegateKeys)
         , ("golden_shelleyGenesisInitialTxIn", golden_shelleyGenesisInitialTxIn)
@@ -117,6 +121,8 @@ keyTests =
         , ("golden_shelleyNodeKeyGenVrf_bech32", golden_shelleyNodeKeyGenVrf_bech32)
         , ("golden_shelleyNodeKeyGenVrf_te", golden_shelleyNodeKeyGenVrf_te)
         , ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
+        , ("golden_shelleyPaymentKeys_bech32", golden_shelleyPaymentKeys_bech32)
+        , ("golden_shelleyPaymentKeys_te", golden_shelleyPaymentKeys_te)
         , ("golden_shelleyStakeAddressBuild", golden_shelleyStakeAddressBuild)
         , ("golden_shelleyStakeAddressDeregistrationCertificate", golden_shelleyStakeAddressDeregistrationCertificate)
         , ("golden_shelleyStakeAddressKeyGen", golden_shelleyStakeAddressKeyGen)

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -11,7 +11,8 @@ module Test.Golden.Shelley
 
 import           Test.Golden.Shelley.Address.Build (golden_shelleyAddressBuild)
 import           Test.Golden.Shelley.Address.Info (golden_shelleyAddressInfo)
-import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressKeyGen)
+import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressExtendedKeyGen,
+                   golden_shelleyAddressKeyGen)
 import           Test.Golden.Shelley.Genesis.Create (golden_shelleyGenesisCreate)
 import           Test.Golden.Shelley.Genesis.InitialTxIn (golden_shelleyGenesisInitialTxIn)
 import           Test.Golden.Shelley.Genesis.KeyGenDelegate (golden_shelleyGenesisKeyGenDelegate)
@@ -24,9 +25,12 @@ import           Test.Golden.Shelley.Key.ConvertCardanoAddressKey
                    golden_convertCardanoAddressShelleyPaymentSigningKey,
                    golden_convertCardanoAddressShelleyStakeSigningKey)
 import           Test.Golden.Shelley.Node.IssueOpCert (golden_shelleyNodeIssueOpCert)
-import           Test.Golden.Shelley.Node.KeyGen (golden_shelleyNodeKeyGen)
-import           Test.Golden.Shelley.Node.KeyGenKes (golden_shelleyNodeKeyGenKes)
-import           Test.Golden.Shelley.Node.KeyGenVrf (golden_shelleyNodeKeyGenVrf)
+import           Test.Golden.Shelley.Node.KeyGen (golden_shelleyNodeKeyGen,
+                   golden_shelleyNodeKeyGen_bech32, golden_shelleyNodeKeyGen_te)
+import           Test.Golden.Shelley.Node.KeyGenKes (golden_shelleyNodeKeyGenKes,
+                   golden_shelleyNodeKeyGenKes_bech32, golden_shelleyNodeKeyGenKes_te)
+import           Test.Golden.Shelley.Node.KeyGenVrf (golden_shelleyNodeKeyGenVrf,
+                   golden_shelleyNodeKeyGenVrf_bech32, golden_shelleyNodeKeyGenVrf_te)
 import           Test.Golden.Shelley.StakeAddress.Build (golden_shelleyStakeAddressBuild)
 import           Test.Golden.Shelley.StakeAddress.DeregistrationCertificate
                    (golden_shelleyStakeAddressDeregistrationCertificate)
@@ -59,7 +63,8 @@ import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
+                   golden_shelleyVRFKeys_bech32, golden_shelleyVRFKeys_te)
 import           Test.Golden.Shelley.TextView.DecodeCbor (golden_shelleyTextViewDecodeCbor)
 import           Test.Golden.Shelley.Transaction.Assemble
                    (golden_shelleyTransactionAssembleWitness_SigningKey)
@@ -87,6 +92,7 @@ keyTests =
     $ H.Group "TextEnvelope Key Goldens"
         [ ("golden_shelleyAddressInfo", golden_shelleyAddressInfo)
         , ("golden_shelleyAddressKeyGen", golden_shelleyAddressKeyGen)
+        , ("golden_shelleyAddressExtendedKeyGen", golden_shelleyAddressExtendedKeyGen)
         , ("golden_shelleyAddressBuild", golden_shelleyAddressBuild)
         , ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
         , ("golden_shelleyGenesisCreate", golden_shelleyGenesisCreate)
@@ -101,8 +107,14 @@ keyTests =
         , ("golden_shelleyKESKeys", golden_shelleyKESKeys)
         , ("golden_shelleyNodeIssueOpCert", golden_shelleyNodeIssueOpCert)
         , ("golden_shelleyNodeKeyGen", golden_shelleyNodeKeyGen)
+        , ("golden_shelleyNodeKeyGen_bech32", golden_shelleyNodeKeyGen_bech32)
+        , ("golden_shelleyNodeKeyGen_te", golden_shelleyNodeKeyGen_te)
         , ("golden_shelleyNodeKeyGenKes", golden_shelleyNodeKeyGenKes)
+        , ("golden_shelleyNodeKeyGenKes_bech32", golden_shelleyNodeKeyGenKes_bech32)
+        , ("golden_shelleyNodeKeyGenKes_te", golden_shelleyNodeKeyGenKes_te)
         , ("golden_shelleyNodeKeyGenVrf", golden_shelleyNodeKeyGenVrf)
+        , ("golden_shelleyNodeKeyGenVrf_bech32", golden_shelleyNodeKeyGenVrf_bech32)
+        , ("golden_shelleyNodeKeyGenVrf_te", golden_shelleyNodeKeyGenVrf_te)
         , ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
         , ("golden_shelleyStakeAddressBuild", golden_shelleyStakeAddressBuild)
         , ("golden_shelleyStakeAddressDeregistrationCertificate", golden_shelleyStakeAddressDeregistrationCertificate)
@@ -119,6 +131,8 @@ keyTests =
         , ("golden_shelleyTransactionCalculateMinFee", golden_shelleyTransactionCalculateMinFee)
         , ("golden_shelleyTransactionSign", golden_shelleyTransactionSign)
         , ("golden_shelleyVRFKeys", golden_shelleyVRFKeys)
+        , ("golden_shelleyVRFKeys_bech32", golden_shelleyVRFKeys_bech32)
+        , ("golden_shelleyVRFKeys_te", golden_shelleyVRFKeys_te)
         , ("golden_version", golden_version)
         ]
 

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -12,7 +12,9 @@ module Test.Golden.Shelley
 import           Test.Golden.Shelley.Address.Build (golden_shelleyAddressBuild)
 import           Test.Golden.Shelley.Address.Info (golden_shelleyAddressInfo)
 import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressExtendedKeyGen,
-                   golden_shelleyAddressKeyGen)
+                   golden_shelleyAddressExtendedKeyGen_bech32,
+                   golden_shelleyAddressExtendedKeyGen_te, golden_shelleyAddressKeyGen,
+                   golden_shelleyAddressKeyGen_bech32, golden_shelleyAddressKeyGen_te)
 import           Test.Golden.Shelley.Genesis.Create (golden_shelleyGenesisCreate)
 import           Test.Golden.Shelley.Genesis.InitialTxIn (golden_shelleyGenesisInitialTxIn)
 import           Test.Golden.Shelley.Genesis.KeyGenDelegate (golden_shelleyGenesisKeyGenDelegate)
@@ -96,7 +98,11 @@ keyTests =
     $ H.Group "TextEnvelope Key Goldens"
         [ ("golden_shelleyAddressInfo", golden_shelleyAddressInfo)
         , ("golden_shelleyAddressKeyGen", golden_shelleyAddressKeyGen)
+        , ("golden_shelleyAddressKeyGen_bech32", golden_shelleyAddressKeyGen_bech32)
+        , ("golden_shelleyAddressKeyGen_te", golden_shelleyAddressKeyGen_te)
         , ("golden_shelleyAddressExtendedKeyGen", golden_shelleyAddressExtendedKeyGen)
+        , ("golden_shelleyAddressExtendedKeyGen_bech32", golden_shelleyAddressExtendedKeyGen_bech32)
+        , ("golden_shelleyAddressExtendedKeyGen_te", golden_shelleyAddressExtendedKeyGen_te)
         , ("golden_shelleyAddressBuild", golden_shelleyAddressBuild)
         , ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
         , ("golden_shelleyExtendedPaymentKeys_bech32", golden_shelleyExtendedPaymentKeys_bech32)

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -34,7 +34,8 @@ import           Test.Golden.Shelley.Node.KeyGenVrf (golden_shelleyNodeKeyGenVrf
 import           Test.Golden.Shelley.StakeAddress.Build (golden_shelleyStakeAddressBuild)
 import           Test.Golden.Shelley.StakeAddress.DeregistrationCertificate
                    (golden_shelleyStakeAddressDeregistrationCertificate)
-import           Test.Golden.Shelley.StakeAddress.KeyGen (golden_shelleyStakeAddressKeyGen)
+import           Test.Golden.Shelley.StakeAddress.KeyGen (golden_shelleyStakeAddressKeyGen,
+                   golden_shelleyStakeAddressKeyGen_bech32, golden_shelleyStakeAddressKeyGen_te)
 import           Test.Golden.Shelley.StakeAddress.RegistrationCertificate
                    (golden_shelleyStakeAddressRegistrationCertificate)
 import           Test.Golden.Shelley.StakePool.RegistrationCertificate
@@ -126,6 +127,8 @@ keyTests =
         , ("golden_shelleyStakeAddressBuild", golden_shelleyStakeAddressBuild)
         , ("golden_shelleyStakeAddressDeregistrationCertificate", golden_shelleyStakeAddressDeregistrationCertificate)
         , ("golden_shelleyStakeAddressKeyGen", golden_shelleyStakeAddressKeyGen)
+        , ("golden_shelleyStakeAddressKeyGen_bech32", golden_shelleyStakeAddressKeyGen_bech32)
+        , ("golden_shelleyStakeAddressKeyGen_te", golden_shelleyStakeAddressKeyGen_te)
         , ("golden_shelleyStakeAddressRegistrationCertificate", golden_shelleyStakeAddressRegistrationCertificate)
         , ("golden_shelleyStakeKeys", golden_shelleyStakeKeys)
         , ("golden_shelleyStakeKeys_bech32", golden_shelleyStakeKeys_bech32)

--- a/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
@@ -2,6 +2,7 @@
 
 module Test.Golden.Shelley.Address.KeyGen
   ( golden_shelleyAddressKeyGen
+  , golden_shelleyAddressExtendedKeyGen
   ) where
 
 import           Control.Monad (void)
@@ -27,8 +28,23 @@ golden_shelleyAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
   void $ H.readFile addressVKeyFile
   void $ H.readFile addressSKeyFile
 
-  H.assertFileOccurences 1 "PaymentVerificationKeyShelley" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentVerificationKeyShelley_ed25519" addressVKeyFile
   H.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
 
-  H.assertEndsWithSingleNewline addressVKeyFile
-  H.assertEndsWithSingleNewline addressSKeyFile
+golden_shelleyAddressExtendedKeyGen :: Property
+golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--extended-key"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "PaymentExtendedVerificationKeyShelley_ed25519_bip32" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentExtendedSigningKeyShelley_ed25519_bip32" addressSKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
@@ -2,7 +2,11 @@
 
 module Test.Golden.Shelley.Address.KeyGen
   ( golden_shelleyAddressKeyGen
+  , golden_shelleyAddressKeyGen_bech32
+  , golden_shelleyAddressKeyGen_te
   , golden_shelleyAddressExtendedKeyGen
+  , golden_shelleyAddressExtendedKeyGen_bech32
+  , golden_shelleyAddressExtendedKeyGen_te
   ) where
 
 import           Control.Monad (void)
@@ -31,6 +35,42 @@ golden_shelleyAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
   H.assertFileOccurences 1 "PaymentVerificationKeyShelley_ed25519" addressVKeyFile
   H.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
 
+golden_shelleyAddressKeyGen_te :: Property
+golden_shelleyAddressKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "PaymentVerificationKeyShelley_ed25519" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
+
+golden_shelleyAddressKeyGen_bech32 :: Property
+golden_shelleyAddressKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "addr_vk" addressVKeyFile
+  H.assertFileOccurences 1 "addr_sk" addressSKeyFile
+
 golden_shelleyAddressExtendedKeyGen :: Property
 golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   addressVKeyFile <- noteTempFile tempDir "address.vkey"
@@ -48,3 +88,41 @@ golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \
 
   H.assertFileOccurences 1 "PaymentExtendedVerificationKeyShelley_ed25519_bip32" addressVKeyFile
   H.assertFileOccurences 1 "PaymentExtendedSigningKeyShelley_ed25519_bip32" addressSKeyFile
+
+golden_shelleyAddressExtendedKeyGen_te :: Property
+golden_shelleyAddressExtendedKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--extended-key"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "PaymentExtendedVerificationKeyShelley_ed25519_bip32" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentExtendedSigningKeyShelley_ed25519_bip32" addressSKeyFile
+
+golden_shelleyAddressExtendedKeyGen_bech32 :: Property
+golden_shelleyAddressExtendedKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--extended-key"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "addr_xvk" addressVKeyFile
+  H.assertFileOccurences 1 "addr_xsk" addressSKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGen
   ( golden_shelleyNodeKeyGen
+  , golden_shelleyNodeKeyGen_bech32
+  , golden_shelleyNodeKeyGen_te
   ) where
 
 import           Control.Monad (void)
@@ -32,4 +34,45 @@ golden_shelleyNodeKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> 
 
   H.assertEndsWithSingleNewline verificationKeyFile
   H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline opCertCounterFile
+
+golden_shelleyNodeKeyGen_te :: Property
+golden_shelleyNodeKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- noteTempFile tempDir "key-gen.skey"
+  opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
+
+  void $ execCardanoCLI
+    [ "node","key-gen"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    , "--operational-certificate-issue-counter", opCertCounterFile
+    ]
+
+  H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline opCertCounterFile
+
+golden_shelleyNodeKeyGen_bech32 :: Property
+golden_shelleyNodeKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- noteTempFile tempDir "key-gen.skey"
+  opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
+
+  void $ execCardanoCLI
+    [ "node","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    , "--operational-certificate-issue-counter", opCertCounterFile
+    ]
+
+  H.assertFileOccurences 1 "pool_vk" verificationKeyFile
+  H.assertFileOccurences 1 "pool_sk" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+
   H.assertEndsWithSingleNewline opCertCounterFile

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGenKes
   ( golden_shelleyNodeKeyGenKes
+  , golden_shelleyNodeKeyGenKes_bech32
+  , golden_shelleyNodeKeyGenKes_te
   ) where
 
 import           Control.Monad (void)
@@ -29,3 +31,36 @@ golden_shelleyNodeKeyGenKes = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenKes_te :: Property
+golden_shelleyNodeKeyGenKes_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
+  H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenKes_bech32 :: Property
+golden_shelleyNodeKeyGenKes_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "kes_vk" verificationKey
+  H.assertFileOccurences 1 "kes_sk" signingKey

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGenVrf
   ( golden_shelleyNodeKeyGenVrf
+  , golden_shelleyNodeKeyGenVrf_bech32
+  , golden_shelleyNodeKeyGenVrf_te
   ) where
 
 import           Control.Monad (void)
@@ -29,3 +31,36 @@ golden_shelleyNodeKeyGenVrf = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenVrf_te :: Property
+golden_shelleyNodeKeyGenVrf_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "VRF Verification Key" verificationKey
+  H.assertFileOccurences 1 "VRF Signing Key" signingKey
+
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenVrf_bech32 :: Property
+golden_shelleyNodeKeyGenVrf_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "vrf_vk" verificationKey
+  H.assertFileOccurences 1 "vrf_sk" signingKey

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -26,6 +26,3 @@ golden_shelleyStakeAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tem
 
   H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
-
-  H.assertEndsWithSingleNewline verificationKeyFile
-  H.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.StakeAddress.KeyGen
   ( golden_shelleyStakeAddressKeyGen
+  , golden_shelleyStakeAddressKeyGen_bech32
+  , golden_shelleyStakeAddressKeyGen_te
   ) where
 
 import           Hedgehog (Property)
@@ -26,3 +28,32 @@ golden_shelleyStakeAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tem
 
   H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
+
+golden_shelleyStakeAddressKeyGen_te :: Property
+golden_shelleyStakeAddressKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "kes.vkey"
+  signingKeyFile <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    ]
+
+  H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
+
+golden_shelleyStakeAddressKeyGen_bech32 :: Property
+golden_shelleyStakeAddressKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "kes.vkey"
+  signingKeyFile <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    ]
+
+  H.assertFileOccurences 1 "stake_vk" verificationKeyFile
+  H.assertFileOccurences 1 "stake_sk" signingKeyFile

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
   ( golden_shelleyExtendedPaymentKeys
+  , golden_shelleyExtendedPaymentKeys_bech32
+  , golden_shelleyExtendedPaymentKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
+import           Text.Regex.TDFA ((=~))
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -41,3 +48,59 @@ golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \te
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyExtendedPaymentKeys_te :: Property
+golden_shelleyExtendedPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "extended-payment-verification-key-file"
+  signKey <- noteTempFile tempDir "extended-payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--extended-key"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyExtendedPaymentKeys_bech32 :: Property
+golden_shelleyExtendedPaymentKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "payment-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--extended-key"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "^addr_xvk[a-z0-9]{110}$"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "^addr_xsk[a-z0-9]{212}$"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys
   ( golden_shelleyKESKeys
+  , golden_shelleyKESKeys_bech32
+  , golden_shelleyKESKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +47,57 @@ golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyKESKeys_te :: Property
+golden_shelleyKESKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "kes-verification-key-file"
+  signKey <- noteTempFile tempDir "kes-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyKESKeys_bech32 :: Property
+golden_shelleyKESKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "kes-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "kes-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "kes_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "kes_sk[a-z0-9]{980}"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys
   ( golden_shelleyPaymentKeys
+  , golden_shelleyPaymentKeys_te
+  , golden_shelleyPaymentKeys_bech32
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
@@ -9,7 +12,10 @@ import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +46,57 @@ golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyPaymentKeys_te :: Property
+golden_shelleyPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "payment-verification-key-file"
+  signKey <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyPaymentKeys_bech32 :: Property
+golden_shelleyPaymentKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "payment-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "^addr_vk[a-z0-9]{59}$"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "^addr_sk[a-z0-9]{59}$"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys
   ( golden_shelleyStakeKeys
+  , golden_shelleyStakeKeys_bech32
+  , golden_shelleyStakeKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
@@ -9,7 +12,10 @@ import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +46,57 @@ golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> d
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyStakeKeys_te :: Property
+golden_shelleyStakeKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "stake-verification-key-file"
+  signKey <- noteTempFile tempDir "stake-signing-key-file"
+
+  -- Generate stake key pair
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyStakeKeys_bech32 :: Property
+golden_shelleyStakeKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "stake-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "stake-signing-key-file"
+
+  -- Generate stake key pair
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "stake_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "stake_sk[a-z0-9]{59}"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys
   ( golden_shelleyVRFKeys
+  , golden_shelleyVRFKeys_bech32
+  , golden_shelleyVRFKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -18,6 +25,8 @@ import qualified Hedgehog.Extras.Test.Base as H
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
 golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"
@@ -40,3 +49,59 @@ golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyVRFKeys_te :: Property
+golden_shelleyVRFKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "vrf-verification-key-file"
+  signKey <- noteTempFile tempDir "vrf-signing-key-file"
+
+  -- Generate vrf verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyVRFKeys_bech32 :: Property
+golden_shelleyVRFKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "vrf-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "vrf-signing-key-file"
+
+  -- Generate vrf verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "vrf_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "vrf_sk[a-z0-9]{110}"

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -25,8 +25,6 @@ import           Text.Regex.TDFA ((=~))
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
 golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  H.note_ tempDir
-
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"
@@ -55,8 +53,6 @@ golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys_te :: Property
 golden_shelleyVRFKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  H.note_ tempDir
-
   -- Reference keys
   referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
   referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"


### PR DESCRIPTION
This PR modifies CLI commands such that they now output Bech32-encoded keys.

Previous PRs have added CLI support for accepting keys in multiple formats: `TextEnvelope`, hex, and Bech32.

- https://github.com/input-output-hk/cardano-node/pull/1790
- https://github.com/input-output-hk/cardano-node/pull/1852