### PR TITLE
Publish chairman test artifacts

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -74,12 +74,9 @@ jobs:
       run: cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
     - uses: actions/cache@v2
-      if: matrix.os != 'macos-latest'
       name: Cache cabal store
       with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
         restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
 
@@ -93,4 +90,10 @@ jobs:
       run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror
 
     - name: Run tests
-      run: cabal test --builddir="$CABAL_BUILDDIR" cardano-node-chairman
+      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" cabal test --builddir="$CABAL_BUILDDIR" cardano-node-chairman
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: chairman-test-artifacts-${{ matrix.os }}
+        path: ${{ runner.temp }}/chairman/


### PR DESCRIPTION
This uploads test configuration and logs as artefacts so they are easy to get when things go wrong.

![image](https://user-images.githubusercontent.com/63014/96833918-e0893f00-148c-11eb-8c69-9011888bba73.png)
