### PR TITLE
disable clusterTests from default build. (still available from ./nix)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,8 +60,6 @@ let
 
     inherit (haskellPackages.cardano-node.identifier) version;
 
-    clusterTests = recRecurseIntoAttrs (import ./nix/supervisord-cluster/tests { inherit pkgs; });
-
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);
 
     # `tests` are the test suites which have been built.

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -57,6 +57,8 @@ pkgs: _: with pkgs;
   hfcCluster = callPackage ./supervisord-cluster/hfc {};
   cardanolib-py = callPackage ./cardanolib-py {};
 
+  clusterTests = import ./supervisord-cluster/tests { inherit pkgs; };
+
   inherit ((haskell-nix.hackage-package {
     name = "hlint";
     version = "3.1.6";


### PR DESCRIPTION
There are currently using too much for our CI workload capacity, and are deprecated in favor of cardano-node-tests.