### PR TITLE
Remove stdout and stderr from test output

### DIFF
--- a/cardano-node-chairman/src/Testnet/Byron.hs
+++ b/cardano-node-chairman/src/Testnet/Byron.hs
@@ -154,9 +154,6 @@ testnet H.Conf {..} = do
         )
       )
 
-    H.onFailure . H.noteM_ $ H.readFile nodeStdoutFile
-    H.onFailure . H.noteM_ $ H.readFile nodeStderrFile
-
     when (OS.os `L.elem` ["darwin", "linux"]) $ do
       H.onFailure . H.noteIO_ $ IO.readProcess "lsof" ["-iTCP:" <> portString, "-sTCP:LISTEN", "-n", "-P"] ""
 

--- a/cardano-node-chairman/src/Testnet/ByronShelley.hs
+++ b/cardano-node-chairman/src/Testnet/ByronShelley.hs
@@ -621,9 +621,6 @@ testnet H.Conf {..} = do
         )
       )
 
-    H.onFailure . H.noteM_ $ H.readFile nodeStdoutFile
-    H.onFailure . H.noteM_ $ H.readFile nodeStderrFile
-
     H.noteShowM_ $ H.getPid hProcess
 
     when (OS.os `L.elem` ["darwin", "linux"]) $ do
@@ -668,9 +665,6 @@ testnet H.Conf {..} = do
           }
         )
       )
-
-    H.onFailure . H.noteM_ $ H.readFile nodeStdoutFile
-    H.onFailure . H.noteM_ $ H.readFile nodeStderrFile
 
     when (OS.os `L.elem` ["darwin", "linux"]) $ do
       H.onFailure . H.noteIO_ $ IO.readProcess "lsof" ["-iTCP:" <> portString, "-sTCP:LISTEN", "-n", "-P"] ""

--- a/cardano-node-chairman/src/Testnet/Shelley.hs
+++ b/cardano-node-chairman/src/Testnet/Shelley.hs
@@ -376,9 +376,6 @@ testnet H.Conf {..} = do
         )
       )
 
-    H.onFailure . H.noteM_ $ H.readFile nodeStdoutFile
-    H.onFailure . H.noteM_ $ H.readFile nodeStderrFile
-
     when (OS.os `L.elem` ["darwin", "linux"]) $ do
       H.onFailure . H.noteIO_ $ IO.readProcess "lsof" ["-iTCP:" <> portString, "-sTCP:LISTEN", "-n", "-P"] ""
 

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -69,9 +69,6 @@ chairmanOver H.Conf {..} allNodes = do
       )
     )
 
-  H.onFailure . H.noteM_ $ H.readFile nodeStdoutFile
-  H.onFailure . H.noteM_ $ H.readFile nodeStderrFile
-
   chairmanResult <- H.waitSecondsForProcess 110 hProcess
 
   case chairmanResult of


### PR DESCRIPTION
Now that the chairman tests have their logs and config published as artifacts in Github Actions, we don't need them in the test output.

Having them in test output made the test output too long and too difficult to read.