### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -91,8 +91,8 @@ package io-sim-classes
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: af6675d6b6c618418c69c37d1307e3b0c97671cb
-  --sha256: 17bkgpdm39wcl8qfg41hs9xm6x6zmlxvfph1ysy6c4p7y9kkvix7
+  tag: 9e95b500486f59d6c34c97356e2a7b074b39d021
+  --sha256: 15k48xdqdclf9gipz7j58g3sxwn7888giwz2rpi6i60j265vix08
   subdir:
     binary
     binary/test
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5eaac6c4b21a8e69dc3a5503a72e3c3bfde648e
-  --sha256: 1lzwfi6bc7z995s345ij6aachsrmhmrgm71060z6rvk1w97b3jqk
+  tag: 1a2d7717682f8191cf818362df28ac20fac19b83
+  --sha256: 136pp0653w8chk53wnz6mlkdhf0ldglrb74p1i93d1xnf6ssvjhs
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -124,12 +124,13 @@ source-repository-package
     shelley/chain-and-ledger/dependencies/non-integer
     shelley/chain-and-ledger/executable-spec
     shelley/chain-and-ledger/shelley-spec-ledger-test
+    shelley-ma/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a5519e09958ad1605ed438d26dd7aad39167d0f9
-  --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
+  tag: bec71e48b027b2022e7be1fb7dd265bbbd80490b
+  --sha256: 0jnxa9m84ka799a3i863sqvlygzf18941pi00d88ar45qdmzkagm
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -158,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 4827c387a84c5cbd279d9a348368747051607cc0
-  --sha256: 1gfc5kvpndal9i9c7cgxbfs4zgrfysrxqswcyj8ws9law8yd9fc7
+  tag: 43080299637c24254774cd59d634e55be4844d4c
+  --sha256: 1k77y77k58rfxhnb4smw2kyci3xsswlcbxk2zicvdhkrifx09kpd
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -27,6 +27,7 @@ library
                         Cardano.Api.Protocol.Types
                         Cardano.Api.Shelley
                         Cardano.Api.Shelley.Genesis
+                        Cardano.Api.Shelley.Serialisation.Legacy
                         Cardano.Api.TextView
                         Cardano.Api.TxSubmit
                         Cardano.Api.Typed

--- a/cardano-api/src/Cardano/Api/LocalChainSync.hs
+++ b/cardano-api/src/Cardano/Api/LocalChainSync.hs
@@ -10,7 +10,7 @@ import           Cardano.Prelude hiding (atomically, catch)
 import           Cardano.Api.Typed
 import           Control.Concurrent.STM
 
-import           Ouroboros.Consensus.Ledger.Abstract (Query, ShowQuery)
+import           Ouroboros.Consensus.Ledger.Query (Query, ShowQuery)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Protocol.ChainSync.Client (ClientStIdle (..),

--- a/cardano-api/src/Cardano/Api/Shelley/Serialisation/Legacy.hs
+++ b/cardano-api/src/Cardano/Api/Shelley/Serialisation/Legacy.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Support for legacy serialisation formats that are no longer available in
+-- @cardano-ledger-specs@.
+module Cardano.Api.Shelley.Serialisation.Legacy
+  ( WrappedMultiSig (..)
+  ) where
+
+import           Cardano.Prelude
+
+import           Cardano.Binary
+import           Cardano.Ledger.Era (Era)
+import           NoThunks.Class (NoThunks (..))
+import           Shelley.Spec.Ledger.BaseTypes (invalidKey)
+import           Shelley.Spec.Ledger.Scripts (MultiSig)
+import           Shelley.Spec.Ledger.Serialization (decodeRecordSum)
+
+
+-- | Wrapper type for a 'MultiSig' script.
+--
+-- Used to support the old @Script@ binary serialization format from
+-- @cardano-ledger-specs@.
+newtype WrappedMultiSig era = WrappedMultiSig
+  { unWrappedMultiSig :: MultiSig era }
+  deriving newtype (Eq, Ord, Show, NoThunks)
+  deriving stock (Generic)
+
+instance (Era era, Typeable era) => FromCBOR (Annotator (WrappedMultiSig era)) where
+  fromCBOR = decodeRecordSum "WrappedMultiSig" $
+    \case
+      0 -> do
+        s <- fromCBOR
+        pure (2, WrappedMultiSig <$> s)
+      k -> invalidKey k
+
+instance Typeable era => ToCBOR (WrappedMultiSig era) where
+  toCBOR ms =
+    encodeListLen 2
+      <> toCBOR (0 :: Word8)
+      <> toCBOR (unWrappedMultiSig ms)

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -423,7 +424,7 @@ import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
 -- TODO: it'd be nice if the consensus imports needed were a bit more coherent
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Cardano (ProtocolClient, protocolClientInfo)
-import           Ouroboros.Consensus.Ledger.Abstract (Query, ShowQuery)
+import           Ouroboros.Consensus.Ledger.Query (Query, ShowQuery)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
 import           Ouroboros.Consensus.Network.NodeToClient (Codecs' (..), clientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToClientVersion,
@@ -873,7 +874,7 @@ toShelleyStakeReference  NoStakeAddress =
 -- Transaction Ids
 --
 
-newtype TxId = TxId (Shelley.Hash StandardShelley ())
+newtype TxId = TxId (Shelley.Hash StandardCrypto ())
   deriving stock (Eq, Ord, Show)
   deriving newtype (IsString)
                -- We use the Shelley representation and convert the Byron one
@@ -908,7 +909,7 @@ getTxId (ShelleyTxBody tx _) =
     TxId
   . Crypto.castHash
   . (\(Shelley.TxId txhash) -> txhash)
-  . Shelley.txid
+  . Shelley.txid @StandardShelley
   $ tx
 
 
@@ -1181,7 +1182,7 @@ data Witness era where
        -> Witness Shelley
 
      ShelleyKeyWitness
-       :: Shelley.WitVKey StandardShelley Shelley.Witness
+       :: Shelley.WitVKey Shelley.Witness StandardShelley
        -> Witness Shelley
 
      ShelleyScriptWitness
@@ -1269,7 +1270,7 @@ getTxWitnesses (ShelleyTx Shelley.Tx {
                      }) =
     map ShelleyBootstrapWitness (Set.elems bootWits)
  ++ map ShelleyKeyWitness       (Set.elems addrWits)
- ++ map (ShelleyScriptWitness . Shelley.MultiSigScript) (Map.elems msigWits)
+ ++ map ShelleyScriptWitness    (Map.elems msigWits)
 
 
 makeSignedTransaction :: [Witness era]
@@ -1296,8 +1297,7 @@ makeSignedTransaction witnesses (ShelleyTxBody txbody txmetadata) =
                                [ w | ShelleyKeyWitness w <- witnesses ],
           Shelley.msigWits = Map.fromList
                                [ (Shelley.hashMultiSigScript sw, sw)
-                               | ShelleyScriptWitness
-                                   (Shelley.MultiSigScript sw) <- witnesses ]
+                               | ShelleyScriptWitness sw <- witnesses ]
         }
         (maybeToStrictMaybe txmetadata)
 
@@ -1363,14 +1363,14 @@ makeShelleyBootstrapWitness nwOrAddr (ShelleyTxBody txbody _) (ByronSigningKey s
     -- now support extended signing keys for the Shelley too, we are able to
     -- reuse that here.
     --
-    signature :: Shelley.SignedDSIGN StandardShelley
-                  (Shelley.Hash StandardShelley (Shelley.TxBody StandardShelley))
+    signature :: Shelley.SignedDSIGN StandardCrypto
+                  (Shelley.Hash StandardCrypto (Shelley.TxBody StandardShelley))
     signature = makeShelleySignature
                   txhash
                   -- Make the signature with the extended key directly:
                   (ShelleyExtendedSigningKey (Byron.unSigningKey sk))
 
-    txhash :: Shelley.Hash StandardShelley (Shelley.TxBody StandardShelley)
+    txhash :: Shelley.Hash StandardCrypto (Shelley.TxBody StandardShelley)
     txhash = Crypto.hashWith CBOR.serialize' txbody
 
     -- And finally we need to provide the extra suffix bytes necessary to
@@ -1428,7 +1428,7 @@ makeShelleyKeyWitness :: TxBody Shelley
                       -> ShelleyWitnessSigningKey
                       -> Witness Shelley
 makeShelleyKeyWitness (ShelleyTxBody txbody _) =
-    let txhash :: Shelley.Hash StandardShelley (Shelley.TxBody StandardShelley)
+    let txhash :: Shelley.Hash StandardCrypto (Shelley.TxBody StandardShelley)
         txhash = Crypto.hashWith CBOR.serialize' txbody
 
         -- To allow sharing of the txhash computation across many signatures we
@@ -1445,7 +1445,7 @@ makeShelleyKeyWitness (ShelleyTxBody txbody _) =
 --
 data ShelleySigningKey =
        -- | A normal ed25519 signing key
-       ShelleyNormalSigningKey   (Shelley.SignKeyDSIGN StandardShelley)
+       ShelleyNormalSigningKey   (Shelley.SignKeyDSIGN StandardCrypto)
 
        -- | An extended ed25519 signing key
      | ShelleyExtendedSigningKey Crypto.HD.XPrv
@@ -1477,18 +1477,18 @@ toShelleySigningKey key = case key of
 
 getShelleyKeyWitnessVerificationKey
   :: ShelleySigningKey
-  -> Shelley.VKey Shelley.Witness StandardShelley
+  -> Shelley.VKey Shelley.Witness StandardCrypto
 getShelleyKeyWitnessVerificationKey (ShelleyNormalSigningKey sk) =
-      (Shelley.coerceKeyRole :: Shelley.VKey Shelley.Payment StandardShelley
-                             -> Shelley.VKey Shelley.Witness StandardShelley)
+      (Shelley.coerceKeyRole :: Shelley.VKey Shelley.Payment StandardCrypto
+                             -> Shelley.VKey Shelley.Witness StandardCrypto)
     . (\(PaymentVerificationKey vk) -> vk)
     . getVerificationKey
     . PaymentSigningKey
     $ sk
 
 getShelleyKeyWitnessVerificationKey (ShelleyExtendedSigningKey sk) =
-      (Shelley.coerceKeyRole :: Shelley.VKey Shelley.Payment StandardShelley
-                             -> Shelley.VKey Shelley.Witness StandardShelley)
+      (Shelley.coerceKeyRole :: Shelley.VKey Shelley.Payment StandardCrypto
+                             -> Shelley.VKey Shelley.Witness StandardCrypto)
     . (\(PaymentVerificationKey vk) -> vk)
     . (castVerificationKey :: VerificationKey PaymentExtendedKey
                            -> VerificationKey PaymentKey)
@@ -1501,7 +1501,7 @@ makeShelleySignature
   :: Crypto.SignableRepresentation tosign
   => tosign
   -> ShelleySigningKey
-  -> Shelley.SignedDSIGN StandardShelley tosign
+  -> Shelley.SignedDSIGN StandardCrypto tosign
 makeShelleySignature tosign (ShelleyNormalSigningKey sk) =
     Crypto.signedDSIGN () tosign sk
 
@@ -1513,7 +1513,7 @@ makeShelleySignature tosign (ShelleyExtendedSigningKey sk) =
         (Crypto.getSignableRepresentation tosign)
   where
     fromXSignature :: Crypto.HD.XSignature
-                   -> Shelley.SignedDSIGN StandardShelley b
+                   -> Shelley.SignedDSIGN StandardCrypto b
     fromXSignature =
         Crypto.SignedDSIGN
       . fromMaybe impossible
@@ -1749,16 +1749,14 @@ instance SerialiseAsCBOR Script where
 
 instance HasTextEnvelope Script where
     textEnvelopeType _ = "Script"
-    textEnvelopeDefaultDescr (Script script) =
-      case script of
-        Shelley.MultiSigScript {} -> "Multi-signature script"
+    textEnvelopeDefaultDescr (Script _) = "Multi-signature script"
 
 
 scriptHash :: Script -> Hash Script
 scriptHash (Script s) = ScriptHash (Shelley.hashAnyScript s)
 
 makeMultiSigScript :: MultiSigScript -> Script
-makeMultiSigScript = Script . Shelley.MultiSigScript . go
+makeMultiSigScript = Script . go
   where
     go :: MultiSigScript -> Shelley.MultiSig StandardShelley
     go (RequireSignature (PaymentKeyHash kh))
@@ -2011,7 +2009,7 @@ data StakePoolMetadata =
   deriving (Eq, Show)
 
 newtype instance Hash StakePoolMetadata =
-                 StakePoolMetadataHash (Shelley.Hash StandardShelley ByteString)
+                 StakePoolMetadataHash (Shelley.Hash StandardCrypto ByteString)
     deriving (Eq, Show)
 
 instance HasTypeProxy StakePoolMetadata where
@@ -2448,7 +2446,7 @@ toShelleyPParamsUpdate
 
 data OperationalCertificate =
      OperationalCertificate
-       !(Shelley.OCert StandardShelley)
+       !(Shelley.OCert StandardCrypto)
        !(VerificationKey StakePoolKey)
   deriving (Eq, Show)
   deriving anyclass SerialiseAsCBOR
@@ -2540,12 +2538,12 @@ issueOperationalCertificate (KesVerificationKey kesVKey)
                 . (castVerificationKey :: VerificationKey GenesisDelegateExtendedKey
                                        -> VerificationKey GenesisDelegateKey)
 
-    ocert     :: Shelley.OCert StandardShelley
+    ocert     :: Shelley.OCert StandardCrypto
     ocert     = Shelley.OCert kesVKey counter kesPeriod signature
 
     signature :: Shelley.SignedDSIGN
-                   StandardShelley
-                   (Shelley.OCertSignable StandardShelley)
+                   StandardCrypto
+                   (Shelley.OCertSignable StandardCrypto)
     signature = makeShelleySignature
                   (Shelley.OCertSignable kesVKey counter kesPeriod)
                   skey'
@@ -3335,14 +3333,14 @@ instance HasTypeProxy PaymentKey where
 instance Key PaymentKey where
 
     newtype VerificationKey PaymentKey =
-        PaymentVerificationKey (Shelley.VKey Shelley.Payment StandardShelley)
+        PaymentVerificationKey (Shelley.VKey Shelley.Payment StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey PaymentKey =
-        PaymentSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        PaymentSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -3390,7 +3388,7 @@ instance SerialiseAsBech32 (SigningKey PaymentKey) where
     bech32PrefixesPermitted _ = ["addr_sk"]
 
 newtype instance Hash PaymentKey =
-    PaymentKeyHash (Shelley.KeyHash Shelley.Payment StandardShelley)
+    PaymentKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash PaymentKey) where
@@ -3529,7 +3527,7 @@ instance SerialiseAsBech32 (SigningKey PaymentExtendedKey) where
 
 
 newtype instance Hash PaymentExtendedKey =
-    PaymentExtendedKeyHash (Shelley.KeyHash Shelley.Payment StandardShelley)
+    PaymentExtendedKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash PaymentExtendedKey) where
@@ -3571,14 +3569,14 @@ instance HasTypeProxy StakeKey where
 instance Key StakeKey where
 
     newtype VerificationKey StakeKey =
-        StakeVerificationKey (Shelley.VKey Shelley.Staking StandardShelley)
+        StakeVerificationKey (Shelley.VKey Shelley.Staking StandardCrypto)
       deriving stock (Eq)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakeKey)
 
     newtype SigningKey StakeKey =
-        StakeSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        StakeSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakeKey)
@@ -3628,7 +3626,7 @@ instance SerialiseAsBech32 (SigningKey StakeKey) where
 
 
 newtype instance Hash StakeKey =
-    StakeKeyHash (Shelley.KeyHash Shelley.Staking StandardShelley)
+    StakeKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash StakeKey) where
@@ -3767,7 +3765,7 @@ instance SerialiseAsBech32 (SigningKey StakeExtendedKey) where
 
 
 newtype instance Hash StakeExtendedKey =
-    StakeExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardShelley)
+    StakeExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash StakeExtendedKey) where
@@ -3809,14 +3807,14 @@ instance HasTypeProxy GenesisKey where
 instance Key GenesisKey where
 
     newtype VerificationKey GenesisKey =
-        GenesisVerificationKey (Shelley.VKey Shelley.Genesis StandardShelley)
+        GenesisVerificationKey (Shelley.VKey Shelley.Genesis StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey GenesisKey =
-        GenesisSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        GenesisSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -3858,7 +3856,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisKey) where
 
 
 newtype instance Hash GenesisKey =
-    GenesisKeyHash (Shelley.KeyHash Shelley.Genesis StandardShelley)
+    GenesisKeyHash (Shelley.KeyHash Shelley.Genesis StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash GenesisKey) where
@@ -3986,7 +3984,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisExtendedKey) where
 
 
 newtype instance Hash GenesisExtendedKey =
-    GenesisExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardShelley)
+    GenesisExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash GenesisExtendedKey) where
@@ -4029,14 +4027,14 @@ instance HasTypeProxy GenesisDelegateKey where
 instance Key GenesisDelegateKey where
 
     newtype VerificationKey GenesisDelegateKey =
-        GenesisDelegateVerificationKey (Shelley.VKey Shelley.GenesisDelegate StandardShelley)
+        GenesisDelegateVerificationKey (Shelley.VKey Shelley.GenesisDelegate StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisDelegateKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey GenesisDelegateKey =
-        GenesisDelegateSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        GenesisDelegateSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisDelegateKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -4078,7 +4076,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisDelegateKey) where
 
 
 newtype instance Hash GenesisDelegateKey =
-    GenesisDelegateKeyHash (Shelley.KeyHash Shelley.GenesisDelegate StandardShelley)
+    GenesisDelegateKeyHash (Shelley.KeyHash Shelley.GenesisDelegate StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash GenesisDelegateKey) where
@@ -4214,7 +4212,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisDelegateExtendedKey) where
 
 
 newtype instance Hash GenesisDelegateExtendedKey =
-    GenesisDelegateExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardShelley)
+    GenesisDelegateExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash GenesisDelegateExtendedKey) where
@@ -4257,14 +4255,14 @@ instance HasTypeProxy GenesisUTxOKey where
 instance Key GenesisUTxOKey where
 
     newtype VerificationKey GenesisUTxOKey =
-        GenesisUTxOVerificationKey (Shelley.VKey Shelley.Payment StandardShelley)
+        GenesisUTxOVerificationKey (Shelley.VKey Shelley.Payment StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisUTxOKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey GenesisUTxOKey =
-        GenesisUTxOSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        GenesisUTxOSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisUTxOKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -4306,7 +4304,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisUTxOKey) where
 
 
 newtype instance Hash GenesisUTxOKey =
-    GenesisUTxOKeyHash (Shelley.KeyHash Shelley.Payment StandardShelley)
+    GenesisUTxOKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash GenesisUTxOKey) where
@@ -4382,14 +4380,14 @@ instance HasTypeProxy StakePoolKey where
 instance Key StakePoolKey where
 
     newtype VerificationKey StakePoolKey =
-        StakePoolVerificationKey (Shelley.VKey Shelley.StakePool StandardShelley)
+        StakePoolVerificationKey (Shelley.VKey Shelley.StakePool StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakePoolKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey StakePoolKey =
-        StakePoolSigningKey (Shelley.SignKeyDSIGN StandardShelley)
+        StakePoolSigningKey (Shelley.SignKeyDSIGN StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakePoolKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -4437,7 +4435,7 @@ instance SerialiseAsBech32 (SigningKey StakePoolKey) where
     bech32PrefixesPermitted _ = ["pool_sk"]
 
 newtype instance Hash StakePoolKey =
-    StakePoolKeyHash (Shelley.KeyHash Shelley.StakePool StandardShelley)
+    StakePoolKeyHash (Shelley.KeyHash Shelley.StakePool StandardCrypto)
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash StakePoolKey) where
@@ -4482,14 +4480,14 @@ instance HasTypeProxy KesKey where
 instance Key KesKey where
 
     newtype VerificationKey KesKey =
-        KesVerificationKey (Shelley.VerKeyKES StandardShelley)
+        KesVerificationKey (Shelley.VerKeyKES StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey KesKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey KesKey =
-        KesSigningKey (Shelley.SignKeyKES StandardShelley)
+        KesSigningKey (Shelley.SignKeyKES StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey KesKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -4543,8 +4541,8 @@ instance SerialiseAsBech32 (SigningKey KesKey) where
 
 
 newtype instance Hash KesKey =
-    KesKeyHash (Shelley.Hash StandardShelley
-                             (Shelley.VerKeyKES StandardShelley))
+    KesKeyHash (Shelley.Hash StandardCrypto
+                             (Shelley.VerKeyKES StandardCrypto))
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash KesKey) where
@@ -4582,14 +4580,14 @@ instance HasTypeProxy VrfKey where
 instance Key VrfKey where
 
     newtype VerificationKey VrfKey =
-        VrfVerificationKey (Shelley.VerKeyVRF StandardShelley)
+        VrfVerificationKey (Shelley.VerKeyVRF StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey VrfKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
 
     newtype SigningKey VrfKey =
-        VrfSigningKey (Shelley.SignKeyVRF StandardShelley)
+        VrfSigningKey (Shelley.SignKeyVRF StandardCrypto)
       deriving (Show, IsString) via UsingRawBytesHex (SigningKey VrfKey)
       deriving newtype (ToCBOR, FromCBOR)
       deriving anyclass SerialiseAsCBOR
@@ -4636,8 +4634,8 @@ instance SerialiseAsBech32 (SigningKey VrfKey) where
     bech32PrefixesPermitted _ = ["vrf_sk"]
 
 newtype instance Hash VrfKey =
-    VrfKeyHash (Shelley.Hash StandardShelley
-                             (Shelley.VerKeyVRF StandardShelley))
+    VrfKeyHash (Shelley.Hash StandardCrypto
+                             (Shelley.VerKeyVRF StandardCrypto))
   deriving (Eq, Ord, Show)
 
 instance SerialiseAsRawBytes (Hash VrfKey) where

--- a/cardano-api/test/Test/Cardano/Api/Examples.hs
+++ b/cardano-api/test/Test/Cardano/Api/Examples.hs
@@ -22,7 +22,7 @@ import           Cardano.Api.Typed (MultiSigScript (..))
 import qualified Cardano.Api.Typed as Api
 import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.Shelley.Node (emptyGenesisStaking)
-import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto, StandardShelley)
 import           Ouroboros.Consensus.Util.Time
 
 import           Shelley.Spec.Ledger.Address (Addr (..))
@@ -121,12 +121,12 @@ exampleShelleyGenesis =
     }
  where
   -- hash of the genesis verification key
-  genesisVerKeyHash :: KeyHash Genesis StandardShelley
+  genesisVerKeyHash :: KeyHash Genesis StandardCrypto
   genesisVerKeyHash = KeyHash "23d51e91ae5adc7ae801e9de4cd54175fb7464ec2680b25686bbb194"
   -- hash of the delegators verification key
-  delegVerKeyHash :: KeyHash GenesisDelegate StandardShelley
+  delegVerKeyHash :: KeyHash GenesisDelegate StandardCrypto
   delegVerKeyHash = KeyHash "839b047f56e50654bdb504832186dc1ee0c73c8de2daec7ae6273827"
-  delegVrfKeyHash :: Hash StandardShelley (VerKeyVRF StandardShelley)
+  delegVrfKeyHash :: Hash StandardCrypto (VerKeyVRF StandardCrypto)
   delegVrfKeyHash = "231391e7ec1c450a8518134cf6fad1a8e0ed7ffd66d740f8e8271347a6de7bf2"
   initialFundedAddress :: Addr StandardShelley
   initialFundedAddress = Addr Testnet paymentCredential (StakeRefBase stakingCredential)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.Shelley.Orphans () where
 
 import           Cardano.Prelude
 
-import           Control.Iterate.SetAlgebra as SetAlgebra
+import           Control.SetAlgebra as SetAlgebra
 import           Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding as Aeson
@@ -28,10 +28,10 @@ import           Cardano.Crypto.Hash.Class as Crypto
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash (..))
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
-import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (ShelleyBasedEra, StandardCrypto, StandardShelley)
 import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Tip (..))
 
-import           Cardano.Ledger.Era (Era)
+import qualified Cardano.Ledger.Core as Core
 
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
 import           Shelley.Spec.Ledger.BlockChain (HashHeader (..))
@@ -46,10 +46,10 @@ import qualified Shelley.Spec.Ledger.Rewards as Ledger
 import           Shelley.Spec.Ledger.TxBody (TxId (..), TxIn (..), TxOut (..))
 import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 
-instance Era era => ToJSONKey (TxIn era) where
+instance ShelleyBasedEra era => ToJSONKey (TxIn era) where
   toJSONKey = ToJSONKeyText txInToText (Aeson.text . txInToText)
 
-txInToText :: Era era => TxIn era -> Text
+txInToText :: ShelleyBasedEra era => TxIn era -> Text
 txInToText (TxIn (TxId txidHash) ix) =
   hashToText txidHash
     <> Text.pack "#"
@@ -58,9 +58,9 @@ txInToText (TxIn (TxId txidHash) ix) =
 hashToText :: Hash crypto a -> Text
 hashToText = Text.decodeLatin1 . Crypto.hashToBytesAsHex
 
-deriving instance Era era => ToJSON (TxIn era)
+deriving instance ShelleyBasedEra era => ToJSON (TxIn era)
 
-instance Era era => ToJSON (TxOut era) where
+instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJSON (TxOut era) where
   toJSON (TxOut addr amount) =
     Aeson.object
       [ "address" .= addr
@@ -96,7 +96,7 @@ deriving newtype instance ToJSON BlockNo
 
 deriving newtype instance ToJSON (TxId era)
 
-deriving newtype instance Era era => ToJSON (UTxO era)
+deriving newtype instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJSON (UTxO era)
 
 deriving newtype instance ToJSON (ShelleyHash era)
 deriving newtype instance ToJSON (HashHeader era)
@@ -106,8 +106,8 @@ deriving newtype instance ToJSON Ledger.LogWeight
 deriving newtype instance ToJSON Ledger.Likelihood
 deriving newtype instance ToJSON (Ledger.Stake StandardShelley)
 
-deriving anyclass instance ToJSON (Ledger.GenDelegs StandardShelley)
-deriving anyclass instance ToJSON (Ledger.IndividualPoolStake StandardShelley)
+deriving anyclass instance ToJSON (Ledger.GenDelegs StandardCrypto)
+deriving anyclass instance ToJSON (Ledger.IndividualPoolStake StandardCrypto)
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates StandardShelley)
 deriving anyclass instance ToJSON (Ledger.PPUPState StandardShelley)
 
@@ -116,7 +116,7 @@ deriving instance ToJSON Ledger.AccountState
 
 deriving instance ToJSON (Ledger.DPState StandardShelley)
 deriving instance ToJSON (Ledger.DState StandardShelley)
-deriving instance ToJSON (Ledger.FutureGenDeleg StandardShelley)
+deriving instance ToJSON (Ledger.FutureGenDeleg StandardCrypto)
 deriving instance ToJSON (Ledger.InstantaneousRewards StandardShelley)
 deriving instance ToJSON (Ledger.SnapShot StandardShelley)
 deriving instance ToJSON (Ledger.SnapShots StandardShelley)
@@ -129,7 +129,7 @@ deriving instance ToJSON (Ledger.StakeReference StandardShelley)
 deriving instance ToJSON (Ledger.UTxOState StandardShelley)
 
 deriving instance ToJSONKey Ledger.Ptr
-deriving instance ToJSONKey (Ledger.FutureGenDeleg StandardShelley)
+deriving instance ToJSONKey (Ledger.FutureGenDeleg StandardCrypto)
 
 instance (ToJSONKey k, ToJSON v) => ToJSON (SetAlgebra.BiMap v k v) where
   toJSON = toJSON . SetAlgebra.forwards -- to normal Map

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -35,6 +35,7 @@ import qualified Cardano.Ledger.Core as Core
 
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
 import           Shelley.Spec.Ledger.BlockChain (HashHeader (..))
+import           Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import qualified Shelley.Spec.Ledger.Credential as Ledger
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as Ledger
 import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
@@ -105,11 +106,14 @@ deriving newtype instance ToJSON (MetaDataHash era)
 deriving newtype instance ToJSON Ledger.LogWeight
 deriving newtype instance ToJSON Ledger.Likelihood
 deriving newtype instance ToJSON (Ledger.Stake StandardShelley)
+deriving newtype instance ToJSON (Ledger.PoolDistr StandardCrypto)
+deriving newtype instance ToJSON DeltaCoin
 
 deriving anyclass instance ToJSON (Ledger.GenDelegs StandardCrypto)
 deriving anyclass instance ToJSON (Ledger.IndividualPoolStake StandardCrypto)
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates StandardShelley)
 deriving anyclass instance ToJSON (Ledger.PPUPState StandardShelley)
+deriving anyclass instance ToJSON (Ledger.BlocksMade StandardShelley)
 
 deriving instance ToJSON Ledger.Ptr
 deriving instance ToJSON Ledger.AccountState
@@ -123,6 +127,8 @@ deriving instance ToJSON (Ledger.SnapShots StandardShelley)
 deriving instance ToJSON (Ledger.NonMyopic StandardShelley)
 deriving instance ToJSON (Ledger.LedgerState StandardShelley)
 deriving instance ToJSON (Ledger.EpochState StandardShelley)
+deriving instance ToJSON (Ledger.RewardUpdate StandardShelley)
+deriving instance ToJSON (Ledger.NewEpochState StandardShelley)
 deriving instance ToJSON (Ledger.PParams' StrictMaybe StandardShelley)
 deriving instance ToJSON (Ledger.PState StandardShelley)
 deriving instance ToJSON (Ledger.StakeReference StandardShelley)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -61,6 +61,7 @@ import qualified Shelley.Spec.Ledger.TxBody as Ledger (TxId (..), TxIn (..), TxO
 import qualified Shelley.Spec.Ledger.UTxO as Ledger (UTxO (..))
 
 import           Ouroboros.Consensus.Shelley.Ledger
+import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
                      (AcquireFailure (..))
@@ -274,7 +275,7 @@ runQueryStakeDistribution protocol network mOutFile = do
   writeStakeDistribution mOutFile stakeDist
 
 writeStakeDistribution :: Maybe OutputFile
-                       -> PoolDistr StandardShelley
+                       -> PoolDistr StandardCrypto
                        -> ExceptT ShelleyQueryCmdError IO ()
 writeStakeDistribution (Just (OutputFile outFile)) (PoolDistr stakeDist) =
     handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError outFile) $
@@ -283,7 +284,7 @@ writeStakeDistribution (Just (OutputFile outFile)) (PoolDistr stakeDist) =
 writeStakeDistribution Nothing stakeDist =
    liftIO $ printStakeDistribution stakeDist
 
-printStakeDistribution :: PoolDistr StandardShelley -> IO ()
+printStakeDistribution :: PoolDistr StandardCrypto -> IO ()
 printStakeDistribution (PoolDistr stakeDist) = do
     Text.putStrLn title
     putStrLn $ replicate (Text.length title + 2) '-'
@@ -373,7 +374,7 @@ instance ToJSON DelegationsAndRewards where
         . map delegAndRwdToJson $ Map.toList delegsAndRwds
     where
       delegAndRwdToJson
-        :: (Ledger.Credential 'Ledger.Staking StandardShelley, (Maybe (Hash StakePoolKey), Coin))
+        :: (Ledger.Credential Ledger.Staking StandardShelley, (Maybe (Hash StakePoolKey), Coin))
         -> Aeson.Value
       delegAndRwdToJson (k, (d, r)) =
         Aeson.object
@@ -429,7 +430,7 @@ queryPParamsFromLocalState connectInfo@LocalNodeConnectInfo{
 --
 queryStakeDistributionFromLocalState
   :: LocalNodeConnectInfo mode block
-  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO (PoolDistr StandardShelley)
+  -> ExceptT ShelleyQueryCmdLocalStateQueryError IO (PoolDistr StandardCrypto)
 queryStakeDistributionFromLocalState LocalNodeConnectInfo{
                                        localNodeConsensusMode = ByronMode{}
                                      } =
@@ -460,7 +461,7 @@ queryStakeDistributionFromLocalState connectInfo@LocalNodeConnectInfo{
 queryLocalLedgerState
   :: LocalNodeConnectInfo mode blk
   -> ExceptT ShelleyQueryCmdLocalStateQueryError IO
-             (Either LByteString (Ledger.EpochState StandardShelley))
+             (Either LByteString (EpochState StandardShelley))
 queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
   case localNodeConsensusMode of
     ByronMode{} -> throwError ByronProtocolNotSupportedError
@@ -472,7 +473,7 @@ queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
             connectInfo
             ( getTipPoint tip
             , DegenQuery $
-                GetCBOR GetCurrentEpochState  -- Get CBOR-in-CBOR version
+                GetCBOR DebugEpochState  -- Get CBOR-in-CBOR version
             )
       return (decodeLedgerState result)
 
@@ -481,7 +482,7 @@ queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
       result <- firstExceptT AcquireFailureError . newExceptT $
         queryNodeLocalState
           connectInfo
-          (getTipPoint tip, QueryIfCurrentShelley (GetCBOR GetCurrentEpochState)) -- Get CBOR-in-CBOR version
+          (getTipPoint tip, QueryIfCurrentShelley (GetCBOR DebugEpochState)) -- Get CBOR-in-CBOR version
       case result of
         QueryResultEraMismatch err -> throwError (EraMismatchError err)
         QueryResultSuccess ls -> return (decodeLedgerState ls)
@@ -538,7 +539,7 @@ queryDelegationsAndRewardsFromLocalState stakeaddrs
   where
     toDelegsAndRwds
       :: Map (Ledger.Credential Ledger.Staking StandardShelley)
-             (Ledger.KeyHash Ledger.StakePool StandardShelley)
+             (Ledger.KeyHash Ledger.StakePool StandardCrypto)
       -> Ledger.RewardAccounts StandardShelley
       -> DelegationsAndRewards
     toDelegsAndRwds delegs rwdAcnts =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -54,7 +54,7 @@ import qualified Shelley.Spec.Ledger.Credential as Ledger
 import           Shelley.Spec.Ledger.Delegation.Certificates (IndividualPoolStake (..),
                      PoolDistr (..))
 import qualified Shelley.Spec.Ledger.Keys as Ledger
-import           Shelley.Spec.Ledger.LedgerState (EpochState)
+import           Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
 import           Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.TxBody as Ledger (TxId (..), TxIn (..), TxOut (..))
@@ -219,7 +219,7 @@ writeStakeAddressInfo mOutFile dr@(DelegationsAndRewards _ _delegsAndRwds) =
       handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath (encodePretty dr)
 
-writeLedgerState :: Maybe OutputFile -> EpochState StandardShelley -> ExceptT ShelleyQueryCmdError IO ()
+writeLedgerState :: Maybe OutputFile -> NewEpochState StandardShelley -> ExceptT ShelleyQueryCmdError IO ()
 writeLedgerState mOutFile lstate =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty lstate)
@@ -461,7 +461,7 @@ queryStakeDistributionFromLocalState connectInfo@LocalNodeConnectInfo{
 queryLocalLedgerState
   :: LocalNodeConnectInfo mode blk
   -> ExceptT ShelleyQueryCmdLocalStateQueryError IO
-             (Either LByteString (EpochState StandardShelley))
+             (Either LByteString (NewEpochState StandardShelley))
 queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
   case localNodeConsensusMode of
     ByronMode{} -> throwError ByronProtocolNotSupportedError
@@ -473,7 +473,7 @@ queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
             connectInfo
             ( getTipPoint tip
             , DegenQuery $
-                GetCBOR DebugEpochState  -- Get CBOR-in-CBOR version
+                GetCBOR DebugNewEpochState  -- Get CBOR-in-CBOR version
             )
       return (decodeLedgerState result)
 
@@ -482,7 +482,7 @@ queryLocalLedgerState connectInfo@LocalNodeConnectInfo{localNodeConsensusMode} =
       result <- firstExceptT AcquireFailureError . newExceptT $
         queryNodeLocalState
           connectInfo
-          (getTipPoint tip, QueryIfCurrentShelley (GetCBOR DebugEpochState)) -- Get CBOR-in-CBOR version
+          (getTipPoint tip, QueryIfCurrentShelley (GetCBOR DebugNewEpochState)) -- Get CBOR-in-CBOR version
       case result of
         QueryResultEraMismatch err -> throwError (EraMismatchError err)
         QueryResultSuccess ls -> return (decodeLedgerState ls)

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -38,7 +38,7 @@ import           Ouroboros.Consensus.Cardano.ShelleyHFC
 
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
                      ProtocolParamsShelley (..), ShelleyGenesis, TPraosLeaderCredentials (..))
-import           Ouroboros.Consensus.Shelley.Protocol (TPraosCanBeLeader (..))
+import           Ouroboros.Consensus.Shelley.Protocol (TPraosCanBeLeader (..), StandardCrypto)
 
 import           Shelley.Spec.Ledger.Genesis (ValidationErr (..), describeValidationErr,
                      validateGenesis)
@@ -140,7 +140,7 @@ readGenesis (GenesisFile file) mbExpectedGenesisHash = do
 
 readLeaderCredentials :: Maybe ProtocolFilepaths
                       -> ExceptT ShelleyProtocolInstantiationError IO
-                                 (Maybe (TPraosLeaderCredentials StandardShelley))
+                                 (Maybe (TPraosLeaderCredentials StandardCrypto))
 
 -- It's OK to supply none of the files
 readLeaderCredentials Nothing = return Nothing

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
-
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 module Cardano.Tracing.Kernel
   ( NodeKernelData (..)
   , mkNodeKernelData
@@ -33,9 +27,6 @@ newtype NodeKernelData blk =
   NodeKernelData
   { unNodeKernelData :: IORef (StrictMaybe (NodeKernel IO RemoteConnectionId LocalConnectionId blk))
   }
-
-deriving instance Foldable    StrictMaybe
-deriving instance Traversable StrictMaybe
 
 mkNodeKernelData :: IO (NodeKernelData blk)
 mkNodeKernelData = NodeKernelData <$> newIORef SNothing


### PR DESCRIPTION
Highlights:

* A bunch of Shelley types are now parameterised by the crypto instead of the
  era. This means the instantiation changes from `StandardShelley` to
  `StandardCrypto`. See https://github.com/input-output-hk/ouroboros-network/pull/2702

* Because of changes to the era parameterisation in the ledger, one should now
  use `ShelleyBasedEra` (from `Ouroboros.Consensus.Shelley.Eras`) as the
  constraint on `era` instead of `Era`. With the former you will be able to
  derive many more constraints.

* Consensus supports a bunch of new queries:
  + `GetGenesisConfig`: return the (compacted) genesis config used by the node.
  + `DebugEpochState`: was previously called `GetCurrentEpochState`.
  + `DebugNewEpochState`: this contains slightly more information than the
    former `DebugEpochState`. NOTE: in the second commit we start using this to
    query the ledger state.
  + `DebugChainDepState`: contains the epoch nonces, etc.
  + `GetCurrentEra`: use
    ```haskell
    eraIndexToInt :: EraIndex xs -> Int
    ```
    on its result to get the current era as index starting from 0.

  Note that some of these queries require a new network version. You don't have
  to do anything for this. You will only notice this when submitting one of the
  new queries to an older node that doesn't support it; you'll get a
  `ShelleyEncoderUnsupportedQuery` exception. Better to get such an exception
  when submitting the unsupported query than getting no response at all because
  the receiver fails to decode the request.

  See https://github.com/input-output-hk/ouroboros-network/pull/2694 for more details.