### PR TITLE
GHC version in artifact name

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -107,5 +107,5 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
-        name: chairman-test-artifacts-${{ matrix.os }}
+        name: chairman-test-artifacts-${{ matrix.os }}-${{ matrix.ghc }}
         path: ${{ runner.temp }}/chairman/


### PR DESCRIPTION
This is needed to prevent artifact from one GHC version clobbering another.