### PR TITLE
doco (retire.md) - Extracting current epoch is outdated for network type

### DIFF
--- a/doc/stake-pool-operations/retire_stakepool.md
+++ b/doc/stake-pool-operations/retire_stakepool.md
@@ -7,7 +7,7 @@ To retire a pool we need to:
 
 The deregistration certificate contains the _epoch_ in which we want to retire the pool. This epoch must be _after_ the current epoch and _not later than_ `eMax` epochs in the future, where `eMax` is a protocol parameter.
 
-So we first need to figure out the current epoch. For this, the easiest way to query epoch would be by querying using EKG port (part of node config). To query the current epoch , you can use the command (where jq is a command line tool for parsing JSON, part of EPEL package on linux):
+So we first need to figure out the current epoch. For this, the easiest way to query epoch would be by querying using EKG port (look for `hasEKG` variable in your node's config, or checkout sample config [here](https://github.com/input-output-hk/cardano-node/blob/master/configuration/cardano/mainnet-config.json) ). To query the current epoch , you can use the command below (where jq is a command line tool for parsing JSON, part of EPEL package on linux):
 
     curl -s -H 'Accept: application/json' http://127.0.0.1:12788/ | jq -r .cardano.node.ChainDB.metrics.epoch.int.val
     39

--- a/doc/stake-pool-operations/retire_stakepool.md
+++ b/doc/stake-pool-operations/retire_stakepool.md
@@ -7,22 +7,10 @@ To retire a pool we need to:
 
 The deregistration certificate contains the _epoch_ in which we want to retire the pool. This epoch must be _after_ the current epoch and _not later than_ `eMax` epochs in the future, where `eMax` is a protocol parameter.
 
-So we first need to figure out the current epoch. The number of _slots per epoch_ is recorded in the genesis file, and we can get it with
+So we first need to figure out the current epoch. For this, the easiest way to query epoch would be by querying using EKG port (part of node config). To query the current epoch , you can use the command (where jq is a command line tool for parsing JSON, part of EPEL package on linux):
 
-    cat mainnet-shelley-genesis.json | grep epoch
-    > "epochLength": 21600,
-
-So one epoch lasts for 21600 slots. We get the current slot by querying the tip:
-
-    export CARDANO_NODE_SOCKET_PATH=relay-db/node-socket
-    cardano-cli shelley query tip --mainnet
-
-    > Tip (SlotNo {unSlotNo = 856232}) ...
-
-This gives us
-
-    expr 856232 / 21600
-    > 39
+    curl -s -H 'Accept: application/json' http://127.0.0.1:12788/ | jq -r .cardano.node.ChainDB.metrics.epoch.int.val
+    39
 
 So we are currently in epoch 39.
 


### PR DESCRIPTION
For combinator networks, the slotsPerEpoch is different for Byron and Shelley eras. As such the method to simply divide current unSlot by slotsPerEpoch would only be valid for TPraos (or Byron) network. Suggest a change to query EKG instead