### PR TITLE
Add version command to cardano-testnet

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -152,6 +152,7 @@ executable cardano-testnet
                       , ansi-terminal
                       , async
                       , call-stack
+                      , cardano-config
                       , containers
                       , directory
                       , exceptions
@@ -174,10 +175,12 @@ executable cardano-testnet
                       , time
                       , unliftio
                       , unordered-containers
-  other-modules:        Testnet.Commands
+  other-modules:        Paths_cardano_node_chairman
+                        Testnet.Commands
                         Testnet.Commands.Byron
                         Testnet.Commands.ByronShelley
                         Testnet.Commands.Shelley
+                        Testnet.Commands.Version
                         Testnet.Run
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude

--- a/cardano-node-chairman/testnet/Testnet/Commands.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands.hs
@@ -7,15 +7,21 @@ import           System.IO (IO)
 import           Testnet.Commands.Byron
 import           Testnet.Commands.ByronShelley
 import           Testnet.Commands.Shelley
+import           Testnet.Commands.Version
 
 {- HLINT ignore "Monoid law, left identity" -}
 
 commands :: Parser (IO ())
-commands = commandsGeneral
+commands = commandsTestnet <|> commandsGeneral
 
-commandsGeneral :: Parser (IO ())
-commandsGeneral = subparser $ mempty
-  <>  commandGroup "Commands:"
+commandsTestnet :: Parser (IO ())
+commandsTestnet = subparser $ mempty
+  <>  commandGroup "Testnets:"
   <>  cmdByron
   <>  cmdByronShelley
   <>  cmdShelley
+
+commandsGeneral :: Parser (IO ())
+commandsGeneral = subparser $ mempty
+  <>  commandGroup "General:"
+  <>  cmdVersion

--- a/cardano-node-chairman/testnet/Testnet/Commands/Version.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands/Version.hs
@@ -1,0 +1,36 @@
+module Testnet.Commands.Version
+  ( VersionOptions(..)
+  , cmdVersion
+  , runVersionOptions
+  ) where
+
+import           Cardano.Config.Git.Rev (gitRev)
+import           Data.Eq
+import           Data.Function
+import           Data.Monoid
+import           Data.Version (showVersion)
+import           Options.Applicative
+import           Paths_cardano_node_chairman (version)
+import           System.Info (arch, compilerName, compilerVersion, os)
+import           System.IO (IO)
+import           Text.Show
+
+import qualified Data.Text as T
+import qualified System.IO as IO
+
+data VersionOptions = VersionOptions deriving (Eq, Show)
+
+optsVersion :: Parser VersionOptions
+optsVersion = pure VersionOptions
+
+runVersionOptions :: VersionOptions -> IO ()
+runVersionOptions VersionOptions = do
+  IO.putStrLn $ mconcat
+    [ "cardano-node ", showVersion version
+    , " - ", os, "-", arch
+    , " - ", compilerName, "-", showVersion compilerVersion
+    , "\ngit rev ", T.unpack gitRev
+    ]
+
+cmdVersion :: Mod CommandFields (IO ())
+cmdVersion = command "version" $ flip info idm $ runVersionOptions <$> optsVersion


### PR DESCRIPTION
This is to address https://github.com/input-output-hk/cardano-node/issues/1064

A separate PR will be made for the chairman executable.