### PR TITLE
Add version command to cardano-node-chairman

### DIFF
--- a/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
@@ -1,0 +1,15 @@
+module Cardano.Chairman.Commands where
+
+import           Cardano.Chairman.Commands.Run
+import           Cardano.Chairman.Commands.Version
+import           Data.Function
+import           Data.Monoid
+import           Options.Applicative
+import           System.IO (IO)
+
+{- HLINT ignore "Monoid law, left identity" -}
+
+commands :: Parser (IO ())
+commands = subparser $ mempty
+  <>  cmdRun
+  <>  cmdVersion

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
@@ -1,0 +1,36 @@
+module Cardano.Chairman.Commands.Version
+  ( VersionOptions(..)
+  , cmdVersion
+  , runVersionOptions
+  ) where
+
+import           Cardano.Config.Git.Rev (gitRev)
+import           Data.Eq
+import           Data.Function
+import           Data.Monoid
+import           Data.Version (showVersion)
+import           Options.Applicative
+import           Paths_cardano_node_chairman (version)
+import           System.Info (arch, compilerName, compilerVersion, os)
+import           System.IO (IO)
+import           Text.Show
+
+import qualified Data.Text as T
+import qualified System.IO as IO
+
+data VersionOptions = VersionOptions deriving (Eq, Show)
+
+optsVersion :: Parser VersionOptions
+optsVersion = pure VersionOptions
+
+runVersionOptions :: VersionOptions -> IO ()
+runVersionOptions VersionOptions = do
+  IO.putStrLn $ mconcat
+    [ "cardano-node ", showVersion version
+    , " - ", os, "-", arch
+    , " - ", compilerName, "-", showVersion compilerVersion
+    , "\ngit rev ", T.unpack gitRev
+    ]
+
+cmdVersion :: Mod CommandFields (IO ())
+cmdVersion = command "version" $ flip info idm $ runVersionOptions <$> optsVersion

--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -1,41 +1,20 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+module Main where
 
-import           Cardano.Chairman (chairmanTest)
-import           Cardano.Chairman.Options
-import           Cardano.Node.Configuration.POM (parseNodeConfigurationFP, pncProtocol)
-import           Cardano.Prelude hiding (option)
-import           Control.Tracer (stdoutTracer)
+import           Cardano.Chairman.Commands
+import           Control.Monad
+import           Data.Function
+import           Data.Semigroup
 import           Options.Applicative
+import           System.IO (IO)
 
 main :: IO ()
-main = do
-  ChairmanArgs
-    { caRunningTime
-    , caMinProgress
-    , caSocketPaths
-    , caConfigYaml
-    , caSlotLength
-    , caSecurityParam
-    , caNetworkMagic
-    } <- execParser opts
-
-  partialNc <- liftIO . parseNodeConfigurationFP $ Just caConfigYaml
-
-  ptcl <- case pncProtocol partialNc of
-            Left err -> panic $ "Chairman error: " <> err
-            Right protocol -> return protocol
-
-  let someNodeClientProtocol = mkNodeClientProtocol ptcl
-
-  chairmanTest
-    stdoutTracer
-    caSlotLength
-    caSecurityParam
-    caRunningTime
-    caMinProgress
-    caSocketPaths
-    someNodeClientProtocol
-    caNetworkMagic
+main = join
+  . customExecParser
+    ( prefs (showHelpOnEmpty <> showHelpOnError)
+    )
+  $ info (commands <**> helper)
+    (  fullDesc
+    <> progDesc "Chairman checks Cardano clusters for progress and consensus."
+    <> header "Chairman sits in a room full of Shelley nodes, and checks \
+              \if they are all behaving ..."
+    )

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -12,8 +12,8 @@ build-type:            Simple
 
 common common-modules
   hs-source-dirs:       src
-  other-modules:        Test.Process
-                        Test.Base
+  other-modules:        Test.Base
+                        Test.Process
                         Testnet.Byron
                         Testnet.ByronShelley
                         Testnet.Conf
@@ -23,7 +23,9 @@ executable cardano-node-chairman
   hs-source-dirs:       app
   main-is:              cardano-node-chairman.hs
   other-modules:        Cardano.Chairman
-                        Cardano.Chairman.Options
+                        Cardano.Chairman.Commands
+                        Cardano.Chairman.Commands.Version
+                        Cardano.Chairman.Commands.Run
                         Paths_cardano_node_chairman
   default-language:     Haskell2010
   ghc-options:          -threaded

--- a/cardano-node-chairman/src/Test/Process.hs
+++ b/cardano-node-chairman/src/Test/Process.hs
@@ -51,4 +51,4 @@ procChairman
   -- ^ Arguments to the CLI command
   -> m CreateProcess
   -- ^ Captured stdout
-procChairman = GHC.withFrozenCallStack $ H.procFlex "cardano-node-chairman" "CARDANO_NODE_CHAIRMAN"
+procChairman = GHC.withFrozenCallStack $ H.procFlex "cardano-node-chairman" "CARDANO_NODE_CHAIRMAN" . ("run":)


### PR DESCRIPTION
This is to address https://github.com/input-output-hk/cardano-node/issues/1064

Example usage output:

```
cabal run cardano-node-chairman:cardano-node-chairman
Up to date
Chairman sits in a room full of Shelley nodes, and checks if they are all
behaving ...

Usage: cardano-node-chairman COMMAND
  Chairman checks Cardano clusters for progress and consensus.

Available options:
  -h,--help                Show this help text

Available commands:
  run
  version
```