### PR TITLE
Start using the real Allegra and Mary eras

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2f70be61b04ca6a04aaa68c39288bdb5a762e40d
-  --sha256: 0wzjbwr8wyi45pnb8cw75yivf58xc7z6j54d8npnqzlzmplv65in
+  tag: 8d836e61bb88bda4a6a5c00694735928390067a1
+  --sha256: 0jpdz2294k5q8c90hbg7s808ypglar94j1rm2x81h69ilsp5g3j3
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7b02fb0db36ec9c649aecda524cc43d75a2342d5
-  --sha256: 19cfkfwgmm67hwj5ra5llmb98m37qasx2fpk4hi5yj2giwp4s2rm
+  tag: c1f326cd2c8df00d455370f9ecef02b2b6a5028f
+  --sha256: 0izjzxmc43g2jsdiipagqappz4fpz6cigvq7jcw5caaai4bm6mb6
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -338,6 +338,8 @@ module Cardano.Api.Typed (
     Shelley.PParamsUpdate,
     Shelley.VerKeyVRF,
     StandardShelley,
+    StandardAllegra,
+    StandardMary,
     Shelley.emptyPParams,
     Shelley.truncateUnitInterval,
     emptyGenesisStaking,
@@ -456,7 +458,7 @@ import qualified Cardano.Chain.UTxO as Byron
 --
 -- Shelley imports
 --
-import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardShelley, StandardMary)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
 
 import qualified Cardano.Ledger.Core as Shelley (Script)

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -79,6 +79,7 @@ library
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
+                     , cardano-ledger-shelley-ma
                      -- TODO: We shouldn't be forced to import "cardano-node". Fix this.
                      , cardano-node
                      , cardano-prelude

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -27,6 +27,7 @@ import qualified Cardano.Binary as CBOR
 import qualified Shelley.Spec.Ledger.PParams as Shelley
 --TODO: following import needed for orphan Eq Script instance
 import           Shelley.Spec.Ledger.Scripts ()
+import           Cardano.Ledger.ShelleyMA.TxBody ()
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..), HardForkApplyTxErr (..))
@@ -57,6 +58,8 @@ data ShelleyTxCmdError
   | ShelleyTxCmdSocketEnvError !EnvSocketError
   | ShelleyTxCmdTxSubmitErrorByron !(ApplyTxErr ByronBlock)
   | ShelleyTxCmdTxSubmitErrorShelley !(ApplyTxErr (ShelleyBlock StandardShelley))
+  | ShelleyTxCmdTxSubmitErrorAllegra !(ApplyTxErr (ShelleyBlock StandardAllegra))
+  | ShelleyTxCmdTxSubmitErrorMary !(ApplyTxErr (ShelleyBlock StandardMary))
   | ShelleyTxCmdTxSubmitErrorEraMismatch !EraMismatch
   deriving Show
 
@@ -87,6 +90,10 @@ renderShelleyTxCmdError err =
     ShelleyTxCmdTxSubmitErrorByron res ->
       "Error while submitting tx: " <> Text.pack (show res)
     ShelleyTxCmdTxSubmitErrorShelley res ->
+      "Error while submitting tx: " <> Text.pack (show res)
+    ShelleyTxCmdTxSubmitErrorAllegra res ->
+      "Error while submitting tx: " <> Text.pack (show res)
+    ShelleyTxCmdTxSubmitErrorMary res ->
       "Error while submitting tx: " <> Text.pack (show res)
     ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
       "The era of the node and the tx do not match. " <>
@@ -246,9 +253,9 @@ runTxSubmit protocol network txFile = do
             TxSubmitFailureCardanoMode (ApplyTxErrShelley err) ->
               left (ShelleyTxCmdTxSubmitErrorShelley err)
             TxSubmitFailureCardanoMode (ApplyTxErrAllegra err) ->
-              left (ShelleyTxCmdTxSubmitErrorShelley err)
+              left (ShelleyTxCmdTxSubmitErrorAllegra err)
             TxSubmitFailureCardanoMode (ApplyTxErrMary err) ->
-              left (ShelleyTxCmdTxSubmitErrorShelley err)
+              left (ShelleyTxCmdTxSubmitErrorMary err)
             TxSubmitFailureCardanoMode (ApplyTxErrWrongEra mismatch) ->
               left (ShelleyTxCmdTxSubmitErrorEraMismatch mismatch)
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -79,6 +79,7 @@ library
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
+                     , cardano-ledger-shelley-ma
                      , cardano-prelude
                      , cardano-slotting
                      , contra-tracer

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -393,13 +393,13 @@ instance ( ConvertRawHash blk
           "Replaying ledger from genesis"
         LedgerDB.ReplayFromSnapshot snap tip' _replayTo -> \_o ->
           "Replaying ledger from snapshot " <> showT snap <> " at " <>
-            renderPointAsPhrase tip'
+            renderRealPointAsPhrase tip'
         LedgerDB.ReplayedBlock pt _ledgerEvents replayTo -> \_o ->
           "Replayed block: slot " <> showT (realPointSlot pt) <> " of " <> showT (pointSlot replayTo)
       ChainDB.TraceLedgerEvent ev -> case ev of
         LedgerDB.TookSnapshot snap pt -> \_o ->
           "Took ledger snapshot " <> showT snap <>
-          " at " <> renderPointAsPhrase pt
+          " at " <> renderRealPointAsPhrase pt
         LedgerDB.DeletedSnapshot snap -> \_o ->
           "Deleted old snapshot " <> showT snap
         LedgerDB.InvalidSnapshot snap failure -> \_o ->


### PR DESCRIPTION
Up until now, the Allegra and Mary eras part of `CardanoBlock` were simply
aliases of the Shelley era.

We now switch them over to the real Allegra and Mary eras. This means that some
things will be different for the eras, e.g., `TxBody`, `Script`, `Value`,
`UtxoPredicateFailure`, etc.