### PR TITLE
Chairman simplify

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -52,11 +52,11 @@ chairmanOver H.Conf {..} allNodes = do
 
   (_, _, _, hProcess, _) <- H.createProcess =<<
     ( H.procChairman
-      ( [ "--timeout", "100"
+      ( [ "--timeout", "120"
         , "--config", tempAbsPath </> "configuration.yaml"
         , "--security-parameter", "2160"
         , "--testnet-magic", show @Int testnetMagic
-        , "--slot-length", "20"
+        , "--require-progress", "3"
         ]
       <> (sprockets >>= (\sprocket -> ["--socket-path", IO.sprocketArgumentName sprocket]))
       ) <&>
@@ -69,11 +69,12 @@ chairmanOver H.Conf {..} allNodes = do
       )
     )
 
-  chairmanResult <- H.waitSecondsForProcess 110 hProcess
+  chairmanResult <- H.waitSecondsForProcess 130 hProcess
 
   case chairmanResult of
     Right ExitSuccess -> return ()
     _ -> do
-      H.note_ $ "Failed with: " <> show chairmanResult
-      H.noteM_ $ H.noteTempFile logDir $ "chairman" <> ".stdout.log"
-      H.noteM_ $ H.noteTempFile logDir $ "chairman" <> ".stderr.log"
+      H.note_ $ "Chairman failed with: " <> show chairmanResult
+      H.cat nodeStdoutFile
+      H.cat nodeStderrFile
+      H.failure

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -60,8 +60,8 @@ import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
 import           Ouroboros.Consensus.Fragment.InFuture (defaultClockSkew)
 import           Ouroboros.Consensus.Node (DiffusionArguments (..), DiffusionTracers (..),
-                     DnsSubscriptionTarget (..), IPSubscriptionTarget (..), NodeArgs (..),
-                     RunNode, RunNodeArgs (..))
+                     DnsSubscriptionTarget (..), IPSubscriptionTarget (..), NodeArgs (..), RunNode,
+                     RunNodeArgs (..))
 import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo


### PR DESCRIPTION
This is a rebase of https://github.com/input-output-hk/cardano-node/pull/1331

> Pass the timeout and progress requirement, not the timeout and slot length.
>
> The slot length is only used to calculate the default progress
requirement and it's simpler to just pass that directly.
