### PR TITLE
Remove dist-newstyle -> dist hack

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -19,13 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Select build directory
-      run: |
-        CABAL_BUILDDIR=dist
-
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR"
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR" >> $GITHUB_ENV
-
     - name: Set cache version
       run: echo "CACHE_VERSION=UN37rUo" >> $GITHUB_ENV
 
@@ -63,7 +56,7 @@ jobs:
         mv cabal.project.tmp cabal.project
 
     - name: Cabal Configure
-      run: cabal configure --builddir="$CABAL_BUILDDIR" --write-ghc-environment-files=always
+      run: cabal configure --write-ghc-environment-files=always
 
     - name: Use cabal.project.local.github-pages
       run: |
@@ -84,12 +77,12 @@ jobs:
           cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Install dependencies
-      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+      run: cabal build all --only-dependencies
 
     - name: Build Haddock documentation 🔧
       run: |
         mkdir ./haddocks
-        ./scripts/haddocs.sh ./haddocks true "$CABAL_BUILDDIR"
+        ./scripts/haddocs.sh ./haddocks true
 
     - name: Upload documentation
       uses: actions/upload-artifact@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,13 +30,6 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ env.CABAL_VERSION }}
 
-    - name: Select build directory
-      run: |
-        CABAL_BUILDDIR=dist
-
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR"
-        echo "CABAL_BUILDDIR=$CABAL_BUILDDIR" >> $GITHUB_ENV
-
     - name: Set cache version
       run: echo "CACHE_VERSION=grFfw8r" >> $GITHUB_ENV
 
@@ -112,7 +105,7 @@ jobs:
         mv cabal.project.tmp cabal.project
 
     - name: Cabal Configure
-      run: retry 2 cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
+      run: retry 2 cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
     - name: Record dependencies
       run: |
@@ -128,25 +121,31 @@ jobs:
           cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Install dependencies
-      run: retry 2 cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+      run: retry 2 cabal build all --only-dependencies
 
     - name: Build
-      run: retry 2 cabal build cardano-node cardano-cli cardano-node-chairman --builddir="$CABAL_BUILDDIR"
+      run: retry 2 cabal build cardano-node cardano-cli cardano-node-chairman
 
     - name: Git clone
       run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror
 
     - name: Run tests
-      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 retry 2 cabal test --builddir="$CABAL_BUILDDIR" cardano-node-chairman
+      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 retry 2 cabal test cardano-node-chairman
 
     - name: Build & Test
       run: |
         mkdir -p artifacts
 
         for exe in $(cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(.style == "local" and (."component-name" | startswith("exe:"))) | ."bin-file"'); do
-          ( cd artifacts
-            tar -C "$(dirname $exe)" -czf "$(basename $exe).tar.gz" "$(basename $exe)"
-          )
+          if [ -f $exe ]; then
+            echo "Including artifact $exe"
+
+            ( cd artifacts
+              tar -C "$(dirname $exe)" -czf "$(basename $exe).tar.gz" "$(basename $exe)"
+            )
+          else
+            echo "Skipping artifact $exe"
+          fi
         done
 
     - name: Save Artifact


### PR DESCRIPTION
The hack is no longer needed because we have moved to `ghc-8.10.4`.

The hack was necessary because `ghc-8.6.5` suffered `MAX_PATH` issues for haskell source code.