### PR TITLE
CAD-2167: TraceForwarder with a callback.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -144,8 +144,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 86f2dfc8db25133c95494318fe656155ac6a5754
-  --sha256: 0zbmpg5ircgy80ss57aa4nqfk0p0k01y3chdjqs41s52swiypss5
+  tag: b5965e013fbcfb2a155582953d4a9a99eee22a8a
+  --sha256: 0c2xmf57rw2p1llm69x4b3cxzigxj0iyxa6cl0ivps92m9l2rv2n
   subdir:
     contra-tracer
     iohk-monitoring

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -62,9 +62,9 @@ import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
+import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.CanHardFork
-import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -6,6 +8,7 @@
 module Cardano.Node.Configuration.Logging
   ( LoggingLayer (..)
   , createLoggingLayer
+  , nodeBasicInfo
   , shutdownLoggingLayer
   -- re-exports
   , Trace
@@ -22,6 +25,10 @@ import           Cardano.Prelude hiding (trace)
 import qualified Control.Concurrent.Async as Async
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad.Trans.Except.Extra (catchIOExceptT)
+import           Data.List (nub)
+import           Data.Text (pack)
+import           Data.Time.Clock (UTCTime, getCurrentTime)
+import           Data.Version (showVersion)
 
 import           Cardano.BM.Backend.Aggregation (plugin)
 import           Cardano.BM.Backend.EKGView (plugin)
@@ -35,7 +42,7 @@ import qualified Cardano.BM.Configuration.Model as Config
 import           Cardano.BM.Counters (readCounters)
 import           Cardano.BM.Data.Backend (Backend, BackendKind)
 import           Cardano.BM.Data.Counter
-import           Cardano.BM.Data.LogItem (LOContent (..), LOMeta (..), LoggerName,
+import           Cardano.BM.Data.LogItem (LOContent (..), LOMeta (..), LogObject (..), LoggerName,
                      PrivacyAnnotation (..), mkLOMeta)
 import           Cardano.BM.Data.Observable
 import           Cardano.BM.Data.Severity (Severity (..))
@@ -50,9 +57,25 @@ import           Cardano.BM.Setup (setupTrace_, shutdown)
 import           Cardano.BM.Trace (Trace, appendName, traceNamedObject)
 import qualified Cardano.BM.Trace as Trace
 
+import qualified Cardano.Chain.Genesis as Gen
+import           Cardano.Slotting.Slot (EpochSize (..))
+import           Ouroboros.Consensus.Block (BlockProtocol)
+import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
+import           Ouroboros.Consensus.Byron.Ledger.Conversions
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.CanHardFork
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import qualified Ouroboros.Consensus.Config as Consensus
+import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Shelley.Ledger.Ledger
+import qualified Shelley.Spec.Ledger.API as SL
+
 import           Cardano.Config.Git.Rev (gitRev)
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Types
+import           Paths_cardano_node (version)
 
 --------------------------------
 -- Layer
@@ -113,8 +136,9 @@ loggingCLIConfiguration = maybe emptyConfig readConfig
 createLoggingLayer
   :: Text
   -> NodeConfiguration
+  -> Consensus.Protocol IO blk (BlockProtocol blk)
   -> ExceptT ConfigError IO LoggingLayer
-createLoggingLayer ver nodeConfig' = do
+createLoggingLayer ver nodeConfig' p = do
 
   logConfig <- loggingCLIConfiguration $
     if ncLoggingSwitch nodeConfig'
@@ -154,8 +178,13 @@ createLoggingLayer ver nodeConfig' = do
            >>= loadPlugin switchBoard
 
      Config.getForwardTo logConfig >>= \forwardTo ->
-       when (isJust forwardTo) $
-         Cardano.BM.Backend.TraceForwarder.plugin logConfig trace switchBoard "forwarderMinSeverity"
+       when (isJust forwardTo) $ do
+         nodeStartTime <- getCurrentTime
+         Cardano.BM.Backend.TraceForwarder.plugin logConfig
+                                                  trace
+                                                  switchBoard
+                                                  "forwarderMinSeverity"
+                                                  (nodeBasicInfo nodeConfig p nodeStartTime)
            >>= loadPlugin switchBoard
 
      Cardano.BM.Backend.Aggregation.plugin logConfig trace switchBoard
@@ -211,3 +240,51 @@ createLoggingLayer ver nodeConfig' = do
 
 shutdownLoggingLayer :: LoggingLayer -> IO ()
 shutdownLoggingLayer = shutdown . llSwitchboard
+
+-- The node provides the basic node's information for TraceForwarderBK.
+-- It will be sent once TraceForwarderBK is connected to an external process
+-- (for example, RTView).
+nodeBasicInfo :: NodeConfiguration
+              -> Consensus.Protocol IO blk (BlockProtocol blk)
+              -> UTCTime
+              -> IO [LogObject Text]
+nodeBasicInfo nc p nodeStartTime' = do
+  meta <- mkLOMeta Notice Public
+  let cfg = pInfoConfig $ Consensus.protocolInfo p
+      protocolDependentItems =
+        case p of
+          Consensus.ProtocolByron {} ->
+            let DegenLedgerConfig cfgByron = Consensus.configLedger cfg
+            in getGenesisValuesByron cfg cfgByron
+          Consensus.ProtocolShelley {} ->
+            let DegenLedgerConfig cfgShelley = Consensus.configLedger cfg
+            in getGenesisValues "Shelley" cfgShelley
+          Consensus.ProtocolCardano {} ->
+            let CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary = Consensus.configLedger cfg
+            in getGenesisValuesByron cfg cfgByron
+               ++ getGenesisValues "Shelley" cfgShelley
+               ++ getGenesisValues "Allegra" cfgAllegra
+               ++ getGenesisValues "Mary"    cfgMary
+      items = nub $
+        [ ("protocol",      pack . protocolName $ ncProtocol nc)
+        , ("version",       pack . showVersion $ version)
+        , ("commit",        gitRev)
+        , ("nodeStartTime", show nodeStartTime')
+        ] ++ protocolDependentItems
+      logObjects =
+        map (\(nm, msg) -> LogObject ("basicInfo." <> nm) meta (LogMessage msg)) items
+  return logObjects
+ where
+  getGenesisValuesByron cfg config =
+    let genesis = byronLedgerConfig config
+    in [ ("systemStartTime",  show (WCT.getSystemStart . getSystemStart $ Consensus.configBlock cfg))
+       , ("slotLengthByron",  show (WCT.getSlotLength . fromByronSlotLength $ genesisSlotLength genesis))
+       , ("epochLengthByron", show (unEpochSize . fromByronEpochSlots $ Gen.configEpochSlots genesis))
+       ]
+  getGenesisValues era config =
+    let genesis = shelleyLedgerGenesis $ shelleyLedgerConfig config
+    in [ ("systemStartTime",          show (SL.sgSystemStart genesis))
+       , ("slotLength" <> era,        show (WCT.getSlotLength . WCT.mkSlotLength $ SL.sgSlotLength genesis))
+       , ("epochLength" <> era,       show (unEpochSize . SL.sgEpochLength $ genesis))
+       , ("slotsPerKESPeriod" <> era, show (SL.sgSlotsPerKESPeriod genesis))
+       ]

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -77,8 +77,7 @@ import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                      gatherConfiguredSockets, getSocketOrSocketInfoAddr)
 import           Cardano.Node.Configuration.Topology
 import           Cardano.Node.Handlers.Shutdown
-import           Cardano.Node.Protocol (mkConsensusProtocol,
-                     renderProtocolInstantiationError)
+import           Cardano.Node.Protocol (mkConsensusProtocol, renderProtocolInstantiationError)
 import           Cardano.Node.Protocol.Types
 import           Cardano.Tracing.Kernel
 import           Cardano.Tracing.Peer

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -23,6 +23,7 @@ import           Control.Monad.Trans.Except.Extra (left)
 import           Control.Tracer
 import           Data.Text (breakOn, pack, take)
 import qualified Data.Text as Text
+import           Data.Time.Clock (getCurrentTime)
 import           Data.Version (showVersion)
 import           Network.HostName (getHostName)
 import           Network.Socket (AddrInfo, Socket)
@@ -35,7 +36,8 @@ import           System.Posix.Types (FileMode)
 import           System.Win32.File
 #endif
 
-import           Cardano.BM.Data.LogItem (LOContent (..), PrivacyAnnotation (..), mkLOMeta)
+import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
+                     mkLOMeta)
 import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
@@ -43,12 +45,11 @@ import           Paths_cardano_node (version)
 
 import qualified Cardano.Crypto.Libsodium as Crypto
 
-import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.Logging (LoggingLayer (..), Severity (..),
-                     createLoggingLayer, shutdownLoggingLayer)
+                     createLoggingLayer, nodeBasicInfo, shutdownLoggingLayer)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
                      PartialNodeConfiguration (..), defaultPartialNodeConfiguration,
-                     makeNodeConfiguration, ncProtocol, parseNodeConfigurationFP)
+                     makeNodeConfiguration, parseNodeConfigurationFP)
 import           Cardano.Node.Types
 import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 
@@ -76,8 +77,9 @@ import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                      gatherConfiguredSockets, getSocketOrSocketInfoAddr)
 import           Cardano.Node.Configuration.Topology
 import           Cardano.Node.Handlers.Shutdown
-import           Cardano.Node.Protocol (SomeConsensusProtocol (..), mkConsensusProtocol,
+import           Cardano.Node.Protocol (mkConsensusProtocol,
                      renderProtocolInstantiationError)
+import           Cardano.Node.Protocol.Types
 import           Cardano.Tracing.Kernel
 import           Cardano.Tracing.Peer
 import           Cardano.Tracing.Tracers
@@ -106,9 +108,17 @@ runNode cmdPc = do
                            pure ()
       Nothing -> pure ()
 
+    eitherSomeProtocol <- runExceptT $ mkConsensusProtocol nc
+
+    SomeConsensusProtocol (p :: Consensus.Protocol IO blk (BlockProtocol blk)) <-
+      case eitherSomeProtocol of
+        Left err -> putTextLn (renderProtocolInstantiationError err) >> exitFailure
+        Right (SomeConsensusProtocol p) -> pure $ SomeConsensusProtocol p
+
     eLoggingLayer <- runExceptT $ createLoggingLayer
                      (Text.pack (showVersion version))
                      nc
+                     p
 
     loggingLayer <- case eLoggingLayer of
                       Left err -> putTextLn (show err) >> exitFailure
@@ -117,15 +127,7 @@ runNode cmdPc = do
     !trace <- setupTrace loggingLayer
     let tracer = contramap pack $ toLogObject trace
 
-
     logTracingVerbosity nc tracer
-
-    eitherSomeProtocol <- runExceptT $ mkConsensusProtocol nc
-
-    SomeConsensusProtocol (p :: Consensus.Protocol IO blk (BlockProtocol blk)) <-
-      case eitherSomeProtocol of
-        Left err -> putTextLn (renderProtocolInstantiationError err) >> exitFailure
-        Right (SomeConsensusProtocol p) -> pure $ SomeConsensusProtocol p
 
     -- This IORef contains node kernel structure which holds node kernel.
     -- Used for ledger queries and peer connection status.
@@ -196,7 +198,7 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   let pInfo@ProtocolInfo{ pInfoConfig = cfg } = Consensus.protocolInfo p
       tracer = toLogObject trace
 
-  createTracers nc trace tracer cfg
+  createTracers nc trace tracer
 
   (publicIPv4SocketOrAddr
     , publicIPv6SocketOrAddr
@@ -314,25 +316,23 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
     :: NodeConfiguration
     -> Trace IO Text
     -> Tracer IO Text
-    -> Consensus.TopLevelConfig blk
     -> IO ()
   createTracers NodeConfiguration { ncValidateDB }
-                tr tracer cfg = do
+                tr tracer = do
+    let ProtocolInfo{ pInfoConfig = cfg } = Consensus.protocolInfo p
 
-         traceWith tracer $
-           "System started at " <> show (getSystemStart $ Consensus.configBlock cfg)
+    meta <- mkLOMeta Notice Public
+    traceNamedObject (appendName "networkMagic" tr)
+                     (meta, LogMessage ("NetworkMagic " <> show (unNetworkMagic . getNetworkMagic $ Consensus.configBlock cfg)))
 
-         meta <- mkLOMeta Notice Public
-         let rTr = appendName "release" tr
-             nTr = appendName "networkMagic" tr
-             vTr = appendName "version" tr
-             cTr = appendName "commit"  tr
-         traceNamedObject rTr (meta, LogMessage . Text.pack . protocolName $ ncProtocol nc)
-         traceNamedObject nTr (meta, LogMessage ("NetworkMagic " <> show (unNetworkMagic . getNetworkMagic $ Consensus.configBlock cfg)))
-         traceNamedObject vTr (meta, LogMessage . pack . showVersion $ version)
-         traceNamedObject cTr (meta, LogMessage gitRev)
+    traceNodeBasicInfo tr =<< nodeBasicInfo nc p =<< getCurrentTime
 
-         when ncValidateDB $ traceWith tracer "Performing DB validation"
+    when ncValidateDB $ traceWith tracer "Performing DB validation"
+
+  traceNodeBasicInfo :: Trace IO Text -> [LogObject Text] -> IO ()
+  traceNodeBasicInfo tr basicInfoItems =
+    forM_ basicInfoItems $ \(LogObject nm mt content) ->
+      traceNamedObject (appendName nm tr) (mt, content)
 
 --------------------------------------------------------------------------------
 -- Helper functions


### PR DESCRIPTION
The node has important information about itself:

1. Protocol
2. Version
3. Commit
4. Node start time
5. Slot length
6. Epoch length
7. KES period length
8. System start time

All this information should be traced to RTView (by `TraceForwarderBK` plugin) automatically, once after each connection with TraceAcceptorBK is established. Now `TraceForwarderBK` plugin provides a callback function for it.

_IMPORANT: Now it doesn't compile, I need help with Byron start time._