### PR TITLE
Reconfigure nodes for chairman tests and tweak chairman block expectations

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -17,6 +17,7 @@ common common-modules
                         Testnet.Byron
                         Testnet.ByronShelley
                         Testnet.Conf
+                        Testnet.List
                         Testnet.Shelley
 
 executable cardano-node-chairman

--- a/cardano-node-chairman/src/Testnet/Byron.hs
+++ b/cardano-node-chairman/src/Testnet/Byron.hs
@@ -9,7 +9,11 @@ module Testnet.Byron
   ) where
 
 import           Control.Monad
-import           Data.Aeson (Value, toJSON)
+import           Control.Monad.IO.Class
+import           Data.Aeson (Value, toJSON, (.=))
+import           Data.Bool
+import           Data.Either
+import           Data.Eq
 import           Data.Function
 import           Data.Functor
 import           Data.Int
@@ -24,11 +28,13 @@ import           Hedgehog.Extras.Stock.Time
 import           System.FilePath.Posix ((</>))
 import           Text.Show
 
+import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.File as IO
+import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Stock.String as S
 import qualified Hedgehog.Extras.Test.Base as H
@@ -40,10 +46,12 @@ import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified Test.Process as H
 import qualified Testnet.Conf as H
+import qualified Testnet.List as L
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
 {- HLINT ignore "Redundant flip" -}
+{- HLINT ignore "Use head" -}
 
 -- | Rewrite a line in the configuration file
 rewriteConfiguration :: String -> String
@@ -61,6 +69,7 @@ testnet H.Conf {..} = do
   baseConfig <- H.noteShow $ base </> "configuration/chairman/defaults/simpleview"
   currentTime <- H.noteShowIO DTC.getCurrentTime
   startTime <- H.noteShow $ DTC.addUTCTime 15 currentTime -- 15 seconds into the future
+  allPorts <- H.noteShowIO $ IO.allocateRandomPorts 3
 
   H.copyRewriteJsonFile
     (base </> "scripts/protocol-params.json")
@@ -103,7 +112,7 @@ testnet H.Conf {..} = do
     nodeStdoutFile <- H.noteTempFile tempAbsPath $ "cardano-node-" <> si <> ".stdout.log"
     nodeStderrFile <- H.noteTempFile tempAbsPath $ "cardano-node-" <> si <> ".stderr.log"
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> "node-" <> si)
-    portString <- H.noteShow $ "300" <> si <> ""
+    portString <- H.note $ show @Int (allPorts L.!! i)
     topologyFile <- H.noteShow $ tempAbsPath </> "topology-node-" <> si <> ".json"
     configFile <- H.noteShow $ tempAbsPath </> "config-" <> si <> ".yaml"
     signingKeyFile <- H.noteShow $ tempAbsPath </> "genesis/delegate-keys.00" <> si <> ".key"
@@ -112,7 +121,26 @@ testnet H.Conf {..} = do
     H.createDirectoryIfMissing dbDir
     H.createDirectoryIfMissing $ tempBaseAbsPath </> "" <> socketDir
 
-    H.copyFile (baseConfig </> "topology-node-" <> si <> ".json") (tempAbsPath </> "topology-node-" <> si <> ".json")
+    let otherPorts = L.dropNth i allPorts
+
+    H.lbsWriteFile (tempAbsPath </> "topology-node-" <> si <> ".json") $ J.encode $
+      J.object
+      [ ( "Producers"
+        , toJSON
+          [ J.object
+            [ ("addr", "127.0.0.1")
+            , ("valency", toJSON @Int 1)
+            , ("port", toJSON (otherPorts L.!! 0))
+            ]
+          , J.object
+            [ ("addr", "127.0.0.1")
+            , ("valency", toJSON @Int 1)
+            , ("port", toJSON (otherPorts L.!! 1))
+            ]
+          ]
+        )
+      ]
+
     H.writeFile (tempAbsPath </> "config-" <> si <> ".yaml") . L.unlines . fmap rewriteConfiguration . L.lines =<<
       H.readFile (baseConfig </> "config-" <> si <> ".yaml")
 

--- a/cardano-node-chairman/src/Testnet/ByronShelley.hs
+++ b/cardano-node-chairman/src/Testnet/ByronShelley.hs
@@ -31,6 +31,7 @@ import           Data.Maybe
 import           Data.Ord
 import           Data.Semigroup
 import           Data.String
+import           Data.Time
 import           GHC.Float
 import           GHC.Num
 import           GHC.Real
@@ -334,6 +335,7 @@ testnet H.Conf {..} = do
     . HM.insert "activeSlotsCoeff" (J.toJSON @Double 0.1)
     . HM.insert "securityParam" (J.toJSON @Int 10)
     . HM.insert "epochLength" (J.toJSON @Int 1500)
+    . HM.insert "slotLength" (J.toJSON @Double 0.2)
     . HM.insert "maxLovelaceSupply" (J.toJSON @Int maxSupply)
     . flip HM.adjust "protocolParams"
       ( J.rewriteObject (HM.insert "decentralisationParam" (J.toJSON @Double 0.7))
@@ -675,7 +677,7 @@ testnet H.Conf {..} = do
   forM_ allNodes $ \node -> do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.assertByDeadlineM deadline $ H.doesSprocketExist sprocket
+    H.waitByDeadlineM deadline $ H.doesSprocketExist sprocket
 
   forM_ allNodes $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"

--- a/cardano-node-chairman/src/Testnet/List.hs
+++ b/cardano-node-chairman/src/Testnet/List.hs
@@ -1,0 +1,12 @@
+module Testnet.List
+  ( dropNth
+  ) where
+
+import           Data.Int
+import           GHC.Num
+
+-- | Drop the zero-based n-th element from the list.
+dropNth :: Int -> [a] -> [a]
+dropNth _ [] = []
+dropNth 0 as = as
+dropNth i (a:as) = a:dropNth (i - 1) as

--- a/cardano-node-chairman/test/Spec/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Byron.hs
@@ -23,4 +23,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
   conf <- H.mkConf tempAbsPath' Nothing
   allNodes <- H.testnet conf
 
-  chairmanOver conf allNodes
+  chairmanOver 120 35 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
@@ -24,4 +24,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
 
   allNodes <- H.testnet conf
 
-  chairmanOver conf allNodes
+  chairmanOver 120 33 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -8,12 +8,14 @@ module Spec.Chairman.Chairman
 
 import           Control.Monad
 import           Data.Either
+import           Data.Eq
 import           Data.Function
 import           Data.Functor
 import           Data.Int
 import           Data.Maybe
 import           Data.Semigroup
 import           Data.String
+import           GHC.Num
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           Hedgehog.Extras.Test.Base (Integration)
 import           System.Exit (ExitCode (..))
@@ -26,6 +28,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
+import qualified System.Environment as IO
 import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified Test.Process as H
@@ -38,43 +41,46 @@ import qualified Testnet.Conf as H
 mkSprocket :: FilePath -> FilePath -> String -> Sprocket
 mkSprocket tempBaseAbsPath socketDir node = Sprocket tempBaseAbsPath (socketDir </> node)
 
-chairmanOver :: H.Conf -> [String] -> Integration ()
-chairmanOver H.Conf {..} allNodes = do
-  nodeStdoutFile <- H.noteTempFile logDir $ "chairman" <> ".stdout.log"
-  nodeStderrFile <- H.noteTempFile logDir $ "chairman" <> ".stderr.log"
+chairmanOver :: Int -> Int -> H.Conf -> [String] -> Integration ()
+chairmanOver timeoutSeconds requiredProgress H.Conf {..} allNodes = do
+  maybeChairman <- H.evalIO $ IO.lookupEnv "DISABLE_CHAIRMAN"
 
-  sprockets <- H.noteEach $ fmap (mkSprocket tempBaseAbsPath socketDir) allNodes
+  when (maybeChairman /= Just "1") $ do
+    nodeStdoutFile <- H.noteTempFile logDir $ "chairman" <> ".stdout.log"
+    nodeStderrFile <- H.noteTempFile logDir $ "chairman" <> ".stderr.log"
 
-  H.createDirectoryIfMissing $ tempBaseAbsPath </> socketDir
+    sprockets <- H.noteEach $ fmap (mkSprocket tempBaseAbsPath socketDir) allNodes
 
-  hNodeStdout <- H.evalIO $ IO.openFile nodeStdoutFile IO.WriteMode
-  hNodeStderr <- H.evalIO $ IO.openFile nodeStderrFile IO.WriteMode
+    H.createDirectoryIfMissing $ tempBaseAbsPath </> socketDir
 
-  (_, _, _, hProcess, _) <- H.createProcess =<<
-    ( H.procChairman
-      ( [ "--timeout", "120"
-        , "--config", tempAbsPath </> "configuration.yaml"
-        , "--security-parameter", "2160"
-        , "--testnet-magic", show @Int testnetMagic
-        , "--require-progress", "3"
-        ]
-      <> (sprockets >>= (\sprocket -> ["--socket-path", IO.sprocketArgumentName sprocket]))
-      ) <&>
-      ( \cp -> cp
-        { IO.std_in = IO.CreatePipe
-        , IO.std_out = IO.UseHandle hNodeStdout
-        , IO.std_err = IO.UseHandle hNodeStderr
-        , IO.cwd = Just tempBaseAbsPath
-        }
+    hNodeStdout <- H.evalIO $ IO.openFile nodeStdoutFile IO.WriteMode
+    hNodeStderr <- H.evalIO $ IO.openFile nodeStderrFile IO.WriteMode
+
+    (_, _, _, hProcess, _) <- H.createProcess =<<
+      ( H.procChairman
+        ( [ "--timeout", show @Int timeoutSeconds
+          , "--config", tempAbsPath </> "configuration.yaml"
+          , "--security-parameter", "2160"
+          , "--testnet-magic", show @Int testnetMagic
+          , "--require-progress", show @Int requiredProgress
+          ]
+        <> (sprockets >>= (\sprocket -> ["--socket-path", IO.sprocketArgumentName sprocket]))
+        ) <&>
+        ( \cp -> cp
+          { IO.std_in = IO.CreatePipe
+          , IO.std_out = IO.UseHandle hNodeStdout
+          , IO.std_err = IO.UseHandle hNodeStderr
+          , IO.cwd = Just tempBaseAbsPath
+          }
+        )
       )
-    )
 
-  chairmanResult <- H.waitSecondsForProcess 130 hProcess
+    chairmanResult <- H.waitSecondsForProcess (timeoutSeconds + 10) hProcess
 
-  case chairmanResult of
-    Right ExitSuccess -> return ()
-    _ -> do
-      H.note_ $ "Chairman failed with: " <> show chairmanResult
-      H.cat nodeStdoutFile
-      H.cat nodeStderrFile
-      H.failure
+    case chairmanResult of
+      Right ExitSuccess -> return ()
+      _ -> do
+        H.note_ $ "Chairman failed with: " <> show chairmanResult
+        H.cat nodeStdoutFile
+        H.cat nodeStderrFile
+        H.failure

--- a/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
@@ -24,4 +24,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
 
   allNodes <- H.testnet conf
 
-  chairmanOver conf allNodes
+  chairmanOver 120 21 conf allNodes

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -103,7 +103,7 @@ Protocol: RealPBFT
 GenesisFile: genesis/genesis.json
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold:
+PBftSignatureThreshold: 0.6
 TurnOnLogging: True
 TurnOnLogMetrics: True
 SocketPath:
@@ -144,7 +144,7 @@ TraceBlockFetchServer: True
 TraceBlockchainTime: False
 
 # Verbose tracer of ChainDB.
-TraceChainDb: False
+TraceChainDb: True
 
 # Trace ChainSync client.
 TraceChainSyncClient: False

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -102,7 +102,7 @@ Protocol: RealPBFT
 GenesisFile: genesis/genesis.json
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold:
+PBftSignatureThreshold: 0.6
 TurnOnLogging: True
 TurnOnLogMetrics: True
 SocketPath:
@@ -143,7 +143,7 @@ TraceBlockFetchServer: True
 TraceBlockchainTime: False
 
 # Verbose tracer of ChainDB
-TraceChainDb: False
+TraceChainDb: True
 
 # Trace ChainSync client.
 TraceChainSyncClient: False

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -108,7 +108,7 @@ Protocol: RealPBFT
 GenesisFile: genesis/genesis.json
 NumCoreNodes: 1
 RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold:
+PBftSignatureThreshold: 0.6
 TurnOnLogging: True
 TurnOnLogMetrics: True
 SocketPath:
@@ -149,7 +149,7 @@ TraceBlockFetchServer: True
 TraceBlockchainTime: False
 
 # Verbose tracer of ChainDB.
-TraceChainDb: False
+TraceChainDb: True
 
 # Trace ChainSync client.
 TraceChainSyncClient: False

--- a/hedgehog-extras/src/Hedgehog/Extras/Test/File.hs
+++ b/hedgehog-extras/src/Hedgehog/Extras/Test/File.hs
@@ -28,6 +28,8 @@ module Hedgehog.Extras.Test.File
   , assertFileOccurences
   , assertFileLines
   , assertEndsWithSingleNewline
+
+  , appendFileTimeDelta
   ) where
 
 import           Control.Monad
@@ -42,6 +44,7 @@ import           Data.Maybe
 import           Data.Semigroup
 import           Data.String (String)
 import           Data.Text (Text)
+import           Data.Time.Clock (UTCTime)
 import           GHC.Stack (HasCallStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Extras.Stock.OS
@@ -51,6 +54,7 @@ import           Text.Show
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as L
 import qualified Data.Text.IO as T
+import qualified Data.Time.Clock as DTC
 import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
@@ -218,3 +222,10 @@ assertEndsWithSingleNewline fp = GHC.withFrozenCallStack $ do
     '\n':'\n':_ -> H.failWithCustom GHC.callStack Nothing (fp <> " ends with too many newlines.")
     '\n':_ -> return ()
     _ -> H.failWithCustom GHC.callStack Nothing (fp <> " must end with newline.")
+
+-- | Write 'contents' to the 'filePath' file.
+appendFileTimeDelta :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> UTCTime ->  m ()
+appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
+  baseTime <- H.noteShowIO DTC.getCurrentTime
+  let delay = DTC.diffUTCTime baseTime offsetTime
+  appendFile filePath $ show @DTC.NominalDiffTime delay <> "\n"


### PR DESCRIPTION
Allow for the different testnets to have different expected number of blocks produced.

The new assertions are:

* `Spec.Chairman.Byron`: 35 Blocks
* `Spec.Chairman.ByronShelley`: 33 Blocks
* `Spec.Chairman.Shelley`: 21 Blocks
