### PR TITLE
CAD-2069 Tracing changes supporting K=1000

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -143,8 +143,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: b5965e013fbcfb2a155582953d4a9a99eee22a8a
-  --sha256: 0c2xmf57rw2p1llm69x4b3cxzigxj0iyxa6cl0ivps92m9l2rv2n
+  tag: 563e79f28c6da5c547463391d4c58a81442e48db
+  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
   subdir:
     contra-tracer
     iohk-monitoring

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -113,6 +113,7 @@ library
                      , safe-exceptions
                      , scientific
                      , shelley-spec-ledger
+                     , stm
                      , strict-concurrency
                      , text
                      , time

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -296,7 +296,7 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
 
     startTime <- getCurrentTime
     traceNodeBasicInfo tr =<< nodeBasicInfo nc p startTime
-    traceCounter "nodeStartTime" (ceiling $ utcTimeToPOSIXSeconds startTime) tr
+    traceCounter "nodeStartTime" tr (ceiling $ utcTimeToPOSIXSeconds startTime)
 
     when ncValidateDB $ traceWith tracer "Performing DB validation"
 

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE NamedFieldPuns #-}
 module Cardano.Tracing.Kernel
   ( NodeKernelData (..)
   , mkNodeKernelData
   , setNodeKernel
   , mapNodeKernelDataIO
+  , nkQueryLedger
+  , nkQueryChain
   -- * Re-exports
   , NodeKernel (..)
   , LocalConnectionId
@@ -11,14 +14,18 @@ module Cardano.Tracing.Kernel
   , fromSMaybe
   ) where
 
-import           Cardano.Prelude hiding (atomically)
+import           Cardano.Prelude
 
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), fromSMaybe)
 
+import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Orphans ()
 
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteConnectionId)
 
@@ -43,3 +50,17 @@ mapNodeKernelDataIO ::
   -> IO (StrictMaybe a)
 mapNodeKernelDataIO f (NodeKernelData ref) =
   readIORef ref >>= traverse f
+
+nkQueryLedger ::
+     (ExtLedgerState blk -> a)
+  -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
+  -> IO a
+nkQueryLedger f NodeKernel{getChainDB} =
+  f <$> atomically (ChainDB.getCurrentLedger getChainDB)
+
+nkQueryChain ::
+     (AF.AnchoredFragment (Header blk) -> a)
+  -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
+  -> IO a
+nkQueryChain f NodeKernel{getChainDB} =
+  f <$> atomically (ChainDB.getCurrentChain getChainDB)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -53,6 +56,7 @@ import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), Privac
                      mkLOMeta)
 import           Cardano.BM.Data.Tracer (HasTextFormatter (..), emptyObject, mkObject, trStructured,
                      trStructuredText)
+import           Cardano.BM.Stats
 import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
                      Severity (..), ToObject (..), Tracer (..), TracingVerbosity (..),
                      Transformable (..))
@@ -110,3 +114,15 @@ instance ToJSON (OneEraHash xs) where
 
 deriving newtype instance ToJSON ByronHash
 deriving newtype instance ToJSON BlockNo
+
+instance HasPrivacyAnnotation  ResourceStats
+instance HasSeverityAnnotation ResourceStats where
+  getSeverityAnnotation _ = Info
+instance Transformable Text IO ResourceStats where
+  trTransformer = trStructured
+
+instance ToObject ResourceStats where
+  toObject _verb stats =
+    case toJSON stats of
+      Object x -> x
+      _ -> mempty

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                      (TraceLocalTxSubmissionServerEvent (..))
 import           Ouroboros.Consensus.Node.Run (RunNode, estimateBlockSize)
 import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Protocol.BFT as BFT
 import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
@@ -326,6 +327,19 @@ instance ( tx ~ GenTx blk
 instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
   trTransformer = trStructured
 
+instance HasPrivacyAnnotation a => HasPrivacyAnnotation (Consensus.TraceLabelCreds a)
+instance HasSeverityAnnotation a => HasSeverityAnnotation (Consensus.TraceLabelCreds a) where
+  getSeverityAnnotation (Consensus.TraceLabelCreds _ a) = getSeverityAnnotation a
+
+instance ToObject a => ToObject (Consensus.TraceLabelCreds a) where
+  toObject verb (Consensus.TraceLabelCreds creds val) =
+    mkObject [ "credentials" .= toJSON creds
+             , "val"         .= toObject verb val
+             ]
+
+instance (HasPrivacyAnnotation a, HasSeverityAnnotation a, ToObject a)
+      => Transformable Text IO (Consensus.TraceLabelCreds a) where
+  trTransformer = trStructured
 
 instance ( ConvertRawHash blk
          , LedgerSupportsProtocol blk

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -394,7 +394,13 @@ instance ( ConvertTxId blk
          , HasTxs blk
          )
       => ToObject (AnyMessageAndAgency (BlockFetch blk (Point blk))) where
-  toObject MaximalVerbosity (AnyMessageAndAgency _ (MsgBlock blk)) =
+  toObject MinimalVerbosity (AnyMessageAndAgency _ (MsgBlock blk)) =
+    mkObject [ "kind" .= String "MsgBlock"
+             , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
+             , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
+             ]
+
+  toObject verb (AnyMessageAndAgency _ (MsgBlock blk)) =
     mkObject [ "kind" .= String "MsgBlock"
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
@@ -402,13 +408,8 @@ instance ( ConvertTxId blk
              ]
       where
         presentTx :: GenTx blk -> Value
-        presentTx =  String . renderTxIdForVerbosity MaximalVerbosity . txId
+        presentTx =  String . renderTxIdForVerbosity verb . txId
 
-  toObject _v (AnyMessageAndAgency _ (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
-             , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
-             , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
-             ]
   toObject _v (AnyMessageAndAgency _ MsgRequestRange{}) =
     mkObject [ "kind" .= String "MsgRequestRange" ]
   toObject _v (AnyMessageAndAgency _ MsgStartBatch{}) =

--- a/cardano-node/src/Cardano/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Tracing/Render.hs
@@ -156,5 +156,5 @@ trimHashTextForVerbosity :: TracingVerbosity -> Text -> Text
 trimHashTextForVerbosity verb =
   case verb of
     MinimalVerbosity -> Text.take 7
-    NormalVerbosity -> Text.take 7
+    NormalVerbosity -> id
     MaximalVerbosity -> id

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -10,6 +10,8 @@
 , compiler
 # Enable profiling
 , profiling ? false
+# Link with -eventlog
+, eventlog ? false
 # Enable asserts for given packages
 , assertedPackages ? []
 # Version info, to be passed when not building from a git work tree
@@ -114,6 +116,10 @@ let
         packages = lib.genAttrs projectPackages
           (name: { configureFlags = [ "--ghc-option=-Werror" ]; });
       }
+      (lib.optionalAttrs eventlog {
+        packages = lib.genAttrs ["cardano-node"]
+          (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
+      })
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
         packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -6,7 +6,7 @@
 with lib; with builtins;
 let
   cfg = config.services.cardano-node;
-  inherit (cfg.cardanoNodePkgs) commonLib cardano-node cardano-node-profiled cardano-node-asserted;
+  inherit (cfg.cardanoNodePkgs) commonLib cardano-node cardano-node-profiled cardano-node-eventlogged cardano-node-asserted;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: let
@@ -100,6 +100,11 @@ in {
         default = "none";
       };
 
+      eventlog = mkOption {
+        type = types.bool;
+        default = false;
+      };
+
       asserts = mkOption {
         type = types.bool;
         default = false;
@@ -123,6 +128,7 @@ in {
         type = types.package;
         default = if (cfg.profiling != "none")
           then cardano-node-profiled
+          else if cfg.eventlog then cardano-node-eventlogged
           else if cfg.asserts then cardano-node-asserted
           else cardano-node;
         defaultText = "cardano-node";

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -24,6 +24,17 @@ pkgs: _: with pkgs;
       ;
     profiling = true;
   };
+  cardanoNodeEventlogHaskellPackages = import ./haskell.nix {
+    inherit compiler
+      pkgs
+      lib
+      stdenv
+      haskell-nix
+      buildPackages
+      gitrev
+      ;
+    eventlog = true;
+  };
   cardanoNodeAssertedHaskellPackages = import ./haskell.nix {
     inherit config
       pkgs
@@ -48,6 +59,7 @@ pkgs: _: with pkgs;
   inherit (cardanoNodeHaskellPackages.cardano-cli.components.exes) cardano-cli;
   inherit (cardanoNodeHaskellPackages.bech32.components.exes) bech32;
   cardano-node-profiled = cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node;
+  cardano-node-evenlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node;
   cardano-node-asserted = cardanoNodeAssertedHaskellPackages.cardano-node.components.exes.cardano-node;
 
   # expose the db-converter from the ouroboros-network we depend on


### PR DESCRIPTION
1. update `iohk-monitoring` to `master`
1. make `NormalVerbosity` usable for benchmarking
1. compact & frequent reporting of process statistics
1. optional `.eventlog` collection, via specially-linked `cardano-node-eventlogged` Nix attribute & `eventlog` node NixOS service flag
1. chain density tracing in `TraceStartLeadershipCheck`