### PR TITLE
new CLI command to query the shelley protocol state

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -266,6 +266,7 @@ data QueryCmd =
   | QueryStakeAddressInfo Protocol StakeAddress NetworkId (Maybe OutputFile)
   | QueryUTxO Protocol QueryFilter NetworkId (Maybe OutputFile)
   | QueryLedgerState Protocol NetworkId (Maybe OutputFile)
+  | QueryProtocolState Protocol NetworkId (Maybe OutputFile)
   deriving (Eq, Show)
 
 renderQueryCmd :: QueryCmd -> Text
@@ -277,6 +278,7 @@ renderQueryCmd cmd =
     QueryStakeAddressInfo {} -> "query stake-address-info"
     QueryUTxO {} -> "query utxo"
     QueryLedgerState {} -> "query ledger-state"
+    QueryProtocolState {} -> "query protocol-state"
 
 data GovernanceCmd
   = GovernanceMIRCertificate MIRPot [VerificationKeyFile] [Lovelace] OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Tip (..))
 
 import qualified Cardano.Ledger.Core as Core
 
+import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe)
 import           Shelley.Spec.Ledger.BlockChain (HashHeader (..))
 import           Shelley.Spec.Ledger.Coin (DeltaCoin (..))
@@ -44,6 +45,8 @@ import qualified Shelley.Spec.Ledger.LedgerState as Ledger
 import           Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
 import qualified Shelley.Spec.Ledger.PParams as Ledger
 import qualified Shelley.Spec.Ledger.Rewards as Ledger
+import qualified Shelley.Spec.Ledger.STS.Prtcl as Ledger
+import qualified Shelley.Spec.Ledger.STS.Tickn as Ledger
 import           Shelley.Spec.Ledger.TxBody (TxId (..), TxIn (..), TxOut (..))
 import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 
@@ -133,6 +136,9 @@ deriving instance ToJSON (Ledger.PParams' StrictMaybe StandardShelley)
 deriving instance ToJSON (Ledger.PState StandardShelley)
 deriving instance ToJSON (Ledger.StakeReference StandardShelley)
 deriving instance ToJSON (Ledger.UTxOState StandardShelley)
+deriving instance ToJSON (Ledger.PrtclState StandardCrypto)
+deriving instance ToJSON Ledger.TicknState
+deriving instance ToJSON (Ledger.ChainDepState StandardCrypto)
 
 deriving instance ToJSONKey Ledger.Ptr
 deriving instance ToJSONKey (Ledger.FutureGenDeleg StandardCrypto)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -648,7 +648,9 @@ pQueryCmd =
           (Opt.info pQueryUTxO $ Opt.progDesc "Get the node's current UTxO with the option of \
                                               \filtering by address(es)")
       , Opt.command "ledger-state"
-          (Opt.info pQueryLedgerState $ Opt.progDesc "Dump the current state of the node")
+          (Opt.info pQueryLedgerState $ Opt.progDesc "Dump the current ledger state of the node")
+      , Opt.command "protocol-state"
+          (Opt.info pQueryProtocolState $ Opt.progDesc "Dump the current protocol state of the node")
       ]
   where
     pQueryProtocolParameters :: Parser QueryCmd
@@ -686,6 +688,9 @@ pQueryCmd =
 
     pQueryLedgerState :: Parser QueryCmd
     pQueryLedgerState = QueryLedgerState <$> pProtocol <*> pNetworkId <*> pMaybeOutputFile
+
+    pQueryProtocolState :: Parser QueryCmd
+    pQueryProtocolState = QueryProtocolState <$> pProtocol <*> pNetworkId <*> pMaybeOutputFile
 
 pGovernanceCmd :: Parser GovernanceCmd
 pGovernanceCmd =


### PR DESCRIPTION
I am adding a new CLI shelley query command to make use of the mini-protocol DebugChainDepState recently added to the ouroboros-network repository (see https://github.com/input-output-hk/ouroboros-network/pull/2694).

This command returns the operational certificate counters and the four nonces of interest to the protocol (epoch, last applied block, evolving, and candidate).

I'm open to different names if there is something better than "protocol state".