### PR TITLE
Update cardano-ledger-specs.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -91,8 +91,8 @@ package io-sim-classes
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 9e95b500486f59d6c34c97356e2a7b074b39d021
-  --sha256: 15k48xdqdclf9gipz7j58g3sxwn7888giwz2rpi6i60j265vix08
+  tag: acac87c7af2652b8d86d92c583b6c29234634866
+  --sha256: 1awxr663zgkn8dw13pjzzlzzz5y9y5l2fy14f87331gbrw6n2xdg
   subdir:
     binary
     binary/test
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d6179d72c52588460c1d57b932a2fd0724c5db32
-  --sha256: 0fwhnib6raiq2lisbabchdd45wmlj1kfd21a3zbdmgc468j16clw
+  tag: 2f70be61b04ca6a04aaa68c39288bdb5a762e40d
+  --sha256: 0wzjbwr8wyi45pnb8cw75yivf58xc7z6j54d8npnqzlzmplv65in
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95a7cd5be1cf565c3a15b2082b4ea5b7de82aefc
-  --sha256: 0czf50wscpg259841npgqscmmqqzg9kvikciryn4d08gxswswqky
+  tag: 7b02fb0db36ec9c649aecda524cc43d75a2342d5
+  --sha256: 19cfkfwgmm67hwj5ra5llmb98m37qasx2fpk4hi5yj2giwp4s2rm
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -486,6 +486,7 @@ import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.Coin as Shelley
 import qualified Shelley.Spec.Ledger.Credential as Shelley
 import qualified Shelley.Spec.Ledger.Genesis as Shelley
+import qualified Shelley.Spec.Ledger.Hashing as Shelley
 import qualified Shelley.Spec.Ledger.Keys as Shelley
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import qualified Shelley.Spec.Ledger.MetaData as Shelley
@@ -1446,8 +1447,8 @@ makeShelleyKeyWitness :: TxBody Shelley
                       -> ShelleyWitnessSigningKey
                       -> Witness Shelley
 makeShelleyKeyWitness (ShelleyTxBody txbody _) =
-    let txhash :: Shelley.Hash StandardCrypto (Shelley.TxBody StandardShelley)
-        txhash = Crypto.hashWith CBOR.serialize' txbody
+    let txhash :: Shelley.Hash StandardCrypto Shelley.EraIndependentTxBody
+        txhash = Shelley.hashAnnotated txbody
 
         -- To allow sharing of the txhash computation across many signatures we
         -- define and share the txhash outside the lambda for the signing key:


### PR DESCRIPTION
This also entails updates to cardano-base and ouroboros-network.

This update fixes #2050, and should also result in smaller ledger state
snapshots.

A change is also needed in Cardano/Api/Typed. We have made the minimal
change here, but further refactoring may be desirable.