### PR TITLE
Fix rewrite json

### DIFF
--- a/cardano-node-chairman/src/Testnet/ByronShelley.hs
+++ b/cardano-node-chairman/src/Testnet/ByronShelley.hs
@@ -329,7 +329,7 @@ testnet H.Conf {..} = do
   -- We're going to use really quick epochs (300 seconds), by using short slots 0.2s
   -- and K=10, but we'll keep long KES periods so we don't have to bother
   -- cycling KES keys
-  H.rewriteJson (tempAbsPath </> "shelley/genesis.spec.json") . J.rewriteObject
+  H.rewriteJsonFile (tempAbsPath </> "shelley/genesis.spec.json") . J.rewriteObject
     $ HM.insert "slotLength" (J.toJSON @Double 0.2)
     . HM.insert "activeSlotsCoeff" (J.toJSON @Double 0.1)
     . HM.insert "securityParam" (J.toJSON @Int 10)

--- a/cardano-node-chairman/src/Testnet/Shelley.hs
+++ b/cardano-node-chairman/src/Testnet/Shelley.hs
@@ -115,7 +115,7 @@ testnet H.Conf {..} = do
   -- We're going to use really quick epochs (300 seconds), by using short slots 0.2s
   -- and K=10, but we'll keep long KES periods so we don't have to bother
   -- cycling KES keys
-  H.rewriteJson (tempAbsPath </> "genesis.spec.json") (rewriteGenesisSpec supply)
+  H.rewriteJsonFile (tempAbsPath </> "genesis.spec.json") (rewriteGenesisSpec supply)
 
   H.assertIsJsonFile $ tempAbsPath </> "genesis.spec.json"
 


### PR DESCRIPTION
Introduce a new `copyRewriteJsonFile` function to work around [this issue in Hydra](https://hydra.iohk.io/build/4715512/nixlog/15).  It works by doing the copy and rewrite in one got rather than copy and in place rewrite the latter of which is not permitted.

Rename `rewriteJson` to `rewriteJsonFile` for clarity.