### PR TITLE
Initial lexer and parser for specifying Mary multi assets via the cli

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -59,6 +59,9 @@ library
                        Cardano.CLI.Shelley.Run.TextView
                        Cardano.CLI.Shelley.Run.Transaction
 
+                       Cardano.CLI.Mary.TxOutParser
+                       Cardano.CLI.Mary.ValueParser
+
                        Cardano.CLI.TopHandler
 
   other-modules:       Paths_cardano_cli
@@ -81,7 +84,6 @@ library
                      , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-shelley-ma
-                     -- TODO: We shouldn't be forced to import "cardano-node". Fix this.
                      , cardano-node
                      , cardano-prelude
                      , cardano-slotting
@@ -106,6 +108,7 @@ library
                      , ouroboros-consensus-shelley
                      , ouroboros-network
                      , primitive
+                     , parsec
                      , process
                      , scientific
                      , shelley-spec-ledger
@@ -170,6 +173,8 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , cardano-api
                       , cardano-cli
+                      , cardano-crypto-class
+                      , cardano-ledger-shelley-ma
                       , cardano-node
                       , cardano-prelude
                       , containers
@@ -180,7 +185,11 @@ test-suite cardano-cli-test
                       , hedgehog-extras
                       , lifted-base
                       , optparse-applicative
+                      , ouroboros-consensus-shelley
+                      , parsec
                       , process
+                      , shelley-spec-ledger
+                      , shelley-spec-ledger-test
                       , temporary
                       , text
                       , time
@@ -188,7 +197,9 @@ test-suite cardano-cli-test
                       , unordered-containers
 
   other-modules:        Test.Cli.FilePermissions
+                        -- Test.Cli.Gen
                         Test.Cli.ITN
+                        -- Test.Cli.MultiAssetParsing
                         Test.Cli.Pioneers.Exercise1
                         Test.Cli.Pioneers.Exercise2
                         Test.Cli.Pioneers.Exercise3

--- a/cardano-cli/src/Cardano/CLI/Mary/TxOutParser.hs
+++ b/cardano-cli/src/Cardano/CLI/Mary/TxOutParser.hs
@@ -1,0 +1,46 @@
+module Cardano.CLI.Mary.TxOutParser
+  ( parseTxOutAnyEra
+  ) where
+
+import           Prelude
+
+import           Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+import           Control.Applicative (some)
+import           Text.Parsec (satisfy, option, (<?>))
+import           Text.Parsec.Char (char, spaces)
+import           Text.Parsec.String (Parser)
+
+import           Cardano.API (AddressAny (..), AsType (..), deserialiseAddress)
+import           Cardano.CLI.Types (TxOutAnyEra (..))
+import           Cardano.CLI.Mary.ValueParser (parseValue)
+
+
+parseTxOutAnyEra :: Parser TxOutAnyEra
+parseTxOutAnyEra = do
+    addr <- parseAddressAny
+    spaces
+    -- Accept the old style of separating the address and value in a
+    -- transaction output:
+    option () (char '+' >> spaces)
+    TxOutAnyEra addr <$> parseValue
+
+parseAddressAny :: Parser AddressAny
+parseAddressAny = do
+  str <- plausibleAddressString <?> "address"
+  case deserialiseAddress AsAddressAny str of
+    Nothing -> fail "expecting valid address"
+    Just addr -> pure addr
+
+plausibleAddressString :: Parser Text
+plausibleAddressString =
+    Text.pack <$> some (satisfy isPlausibleAddressChar)
+  where
+    -- Covers both base58 and bech32 (with constrained prefixes)
+    isPlausibleAddressChar c =
+      isAsciiLower c
+        || isAsciiUpper c
+        || isDigit c
+        || c == '_'

--- a/cardano-cli/src/Cardano/CLI/Mary/ValueParser.hs
+++ b/cardano-cli/src/Cardano/CLI/Mary/ValueParser.hs
@@ -1,0 +1,166 @@
+module Cardano.CLI.Mary.ValueParser
+  ( parseValue
+  ) where
+
+import           Prelude
+
+import qualified Data.Char as Char
+import           Data.Functor (void, ($>))
+import           Data.List (foldl')
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Word (Word64)
+
+import           Control.Applicative (some, (<|>))
+
+import           Text.Parsec as Parsec (notFollowedBy, try, (<?>))
+import           Text.Parsec.Char (alphaNum, char, digit, hexDigit, space, spaces, string)
+import           Text.Parsec.Expr (Assoc (..), Operator (..), buildExpressionParser)
+import           Text.Parsec.String (Parser)
+import           Text.ParserCombinators.Parsec.Combinator (many1)
+
+import           Cardano.Api.Typed
+
+-- | Parse a 'Value' from its string representation.
+parseValue :: Parser Value
+parseValue = evalValueExpr <$> parseValueExpr
+
+-- | Evaluate a 'ValueExpr' and construct a 'Value'.
+evalValueExpr :: ValueExpr -> Value
+evalValueExpr vExpr =
+  case vExpr of
+    ValueExprAdd x y -> evalValueExpr x <> evalValueExpr y
+    ValueExprNegate x -> negateValue (evalValueExpr x)
+    ValueExprLovelace quant -> valueFromList [(AdaAssetId, quant)]
+    ValueExprMultiAsset polId aName quant ->
+      valueFromList [(AssetId polId aName , quant)]
+
+
+------------------------------------------------------------------------------
+-- Expression parser
+------------------------------------------------------------------------------
+
+-- | Intermediate representation of a parsed multi-asset value.
+data ValueExpr
+  = ValueExprAdd !ValueExpr !ValueExpr
+  | ValueExprNegate !ValueExpr
+  | ValueExprLovelace !Quantity
+  | ValueExprMultiAsset !PolicyId !AssetName !Quantity
+  deriving (Eq, Ord, Show)
+
+parseValueExpr :: Parser ValueExpr
+parseValueExpr =
+    buildExpressionParser operatorTable valueExprTerm
+      <?> "multi-asset value expression"
+  where
+    operatorTable =
+      [ [Prefix negateOp]
+      , [Infix  plusOp AssocLeft]
+      ]
+
+-- | Parse either a 'ValueExprLovelace' or 'ValueExprMultiAsset'.
+valueExprTerm :: Parser ValueExpr
+valueExprTerm = do
+    q <- try quantity <?> "quantity (word64)"
+    aId <- try assetIdUnspecified <|> assetIdSpecified <?> "asset id"
+    _ <- spaces
+    pure $ case aId of
+      AdaAssetId -> ValueExprLovelace q
+      AssetId polId aName -> ValueExprMultiAsset polId aName q
+  where
+    -- Parse an asset ID which must be lead by one or more whitespace
+    -- characters and may be trailed by whitespace characters.
+    assetIdSpecified :: Parser AssetId
+    assetIdSpecified = some space *> assetId
+
+    -- Default for if an asset ID is not specified.
+    assetIdUnspecified :: Parser AssetId
+    assetIdUnspecified =
+      spaces
+        *> notFollowedBy alphaNum
+        $> AdaAssetId
+
+------------------------------------------------------------------------------
+-- Primitive parsers
+------------------------------------------------------------------------------
+
+plusOp :: Parser (ValueExpr -> ValueExpr -> ValueExpr)
+plusOp = (char '+' *> spaces) $> ValueExprAdd
+
+negateOp :: Parser (ValueExpr -> ValueExpr)
+negateOp = (char '-' *> spaces) $> ValueExprNegate
+
+-- | Period (\".\") parser.
+period :: Parser ()
+period = void $ char '.'
+
+-- | Word64 parser.
+word64 :: Parser Integer
+word64 = do
+  i <- decimal
+  if i > fromIntegral (maxBound :: Word64)
+    then
+      fail $
+        "expecting word64, but the number exceeds the max bound: " <> show i
+    else return i
+
+decimal :: Parser Integer
+decimal = do
+    digits <- many1 digit
+    return $! foldl' (\x d -> 10*x + toInteger (Char.digitToInt d)) 0 digits
+
+-- | Asset name parser.
+assetName :: Parser AssetName
+assetName =
+    toAssetName <$> some alphaNum
+  where
+    toAssetName = AssetName . Text.encodeUtf8 . Text.pack
+
+-- | Policy ID parser.
+policyId :: Parser PolicyId
+policyId = do
+  hexText <- many1 hexDigit
+  case textToPolicyId hexText of
+    Just p -> pure p
+    Nothing ->
+      fail $ "expecting a 56 hex-encoded policy ID, but found only "
+          ++ show (length hexText) ++ " hex digits"
+  where
+    textToPolicyId =
+        fmap PolicyId
+      . deserialiseFromRawBytesHex AsScriptHash
+      . Text.encodeUtf8
+      . Text.pack
+
+-- | Asset ID parser.
+assetId :: Parser AssetId
+assetId =
+    try adaAssetId
+      <|> nonAdaAssetId
+      <?> "asset ID"
+  where
+    -- Parse the ADA asset ID.
+    adaAssetId :: Parser AssetId
+    adaAssetId = string "lovelace" $> AdaAssetId
+
+    -- Parse a multi-asset ID.
+    nonAdaAssetId :: Parser AssetId
+    nonAdaAssetId = do
+      polId <- policyId
+      fullAssetId polId <|> assetIdNoAssetName polId
+
+    -- Parse a fully specified multi-asset ID with both a policy ID and asset
+    -- name.
+    fullAssetId :: PolicyId -> Parser AssetId
+    fullAssetId polId = do
+      _ <- period
+      aName <- assetName <?> "alphanumeric asset name"
+      pure (AssetId polId aName)
+
+    -- Parse a multi-asset ID that specifies a policy ID, but no asset name.
+    assetIdNoAssetName :: PolicyId -> Parser AssetId
+    assetIdNoAssetName polId = pure (AssetId polId "")
+
+-- | Quantity (word64) parser.
+quantity :: Parser Quantity
+quantity = fmap Quantity word64

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -90,4 +90,3 @@ data SigningKeyOrScriptFile = ScriptFileForWitness FilePath
 --
 data TxOutAnyEra = TxOutAnyEra AddressAny Value
   deriving (Eq, Show)
-

--- a/cardano-cli/test/Test/Cli/Gen.hs
+++ b/cardano-cli/test/Test/Cli/Gen.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Cli.Gen where
+
+import           Cardano.Prelude
+
+import qualified Data.Sequence.Strict as Strict
+
+import           Cardano.Api.Typed hiding (MaryEra)
+import           Cardano.CLI.Helpers (textShow)
+import           Cardano.CLI.Mary.Parser (Token (..), tokenToValue)
+import           Cardano.Crypto.Hash (hashToTextAsHex)
+import           Cardano.Ledger.Mary (MaryEra)
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as Timelock
+
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
+import qualified Shelley.Spec.Ledger.Scripts as Shelley
+
+import           Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+-- Lexing Token Generators
+
+genVariableSpace :: Gen Text
+genVariableSpace = Gen.text (Range.constant 1 10) $ return ' '
+
+genLovelaceToken :: Gen (Text, Token)
+genLovelaceToken = do
+  let mBound = fromIntegral (maxBound :: Word64)
+  w64 <-  Gen.integral_ (Range.constant 1 mBound)
+  space1 <- genVariableSpace
+  space2 <- genVariableSpace
+  return (textShow w64 <> space1 <> "lovelace" <> space2, LovelaceT w64)
+
+genValueTokenFullySpecified :: Gen (Text, Token)
+genValueTokenFullySpecified = do
+  sHash <- genScriptHashMaryText
+  assetId <- Gen.text (Range.constant 1 15) Gen.alphaNum
+  (mintedText, minted) <- genMintedText
+  variableSpace <- genVariableSpace
+  return ( mintedText <> variableSpace <> sHash <> "." <> assetId <> variableSpace
+         , MultiAssetT sHash assetId minted
+         )
+
+genValueTokenPidAndAssetId :: Gen (Text, Token)
+genValueTokenPidAndAssetId = do
+  sHash <- genScriptHashMaryText
+  assetId <- Gen.text (Range.constant 1 15) Gen.alphaNum
+  return ( sHash <> "." <> assetId
+         , MultiAssetT sHash assetId 1
+         )
+
+genValueTokenPidOnly :: Gen (Text, Token)
+genValueTokenPidOnly = do
+  sHash <- genScriptHashMaryText
+  (mintedText, minted) <- genMintedText
+  variableSpace <- genVariableSpace
+  return ( mintedText <> variableSpace <> sHash
+         , MultiAssetT sHash "" minted
+         )
+
+genValueTokens :: Gen [(Text, Token)]
+genValueTokens = do
+ valsFulSpec <- Gen.list (Range.constant 1 10) genValueTokenFullySpecified
+ valsPidAssetId <- Gen.list (Range.constant 1 10) genValueTokenPidAndAssetId
+ valsPidOnly <- Gen.list (Range.constant 1 10) genValueTokenPidOnly
+ return  $ valsFulSpec ++ valsPidAssetId ++ valsPidOnly
+
+genAdditionToken :: Gen (Text, Token)
+genAdditionToken = do spaces1 <- genVariableSpace
+                      return ("+" <> spaces1, AdditionT)
+
+genSubtractionToken :: Gen (Text, Token)
+genSubtractionToken = do spaces1 <- genVariableSpace
+                         return ("-" <> spaces1, SubtractionT)
+
+genTokens :: Gen (Text, [Token])
+genTokens = do lovelaces <- Gen.list (Range.constant 1 10) genLovelaceToken
+               vals <- genValueTokens
+               let total = lovelaces ++ vals
+               addOrSubtractTk <- Gen.choice [genAdditionToken, genSubtractionToken]
+               return . sequence $ intersperse addOrSubtractTk total
+
+genMintedText :: Gen (Text, Integer)
+genMintedText = do
+  let mBound = fromIntegral (maxBound :: Word64)
+  minted <- Gen.integral_ (Range.constant 0 mBound)
+  return (textShow minted, minted)
+
+-- Parsing Token Generators
+
+genValues :: Gen (Text, Value)
+genValues = do lovelaces <- Gen.list (Range.constant 1 10) genLovelaceValue
+               vals <- Gen.list (Range.constant 1 10) genMultiAssetValue
+               add <- genAdditionValue
+               let total = lovelaces ++ vals
+               return . mconcat  $ intersperse add total
+
+genLovelaceValue :: Gen (Text, Value)
+genLovelaceValue = do (input, lovelaceToken) <- genLovelaceToken
+                      return (input, tokenToValue lovelaceToken)
+
+genMultiAssetValue :: Gen (Text, Value)
+genMultiAssetValue = do vTkns <- genValueTokens
+                        (input, maToken) <- Gen.element vTkns
+                        return ( input
+                               , tokenToValue maToken
+                               )
+
+genAdditionValue :: Gen (Text, Value)
+genAdditionValue = do (input, AdditionT) <- genAdditionToken
+                      return (input, valueFromList [])
+
+genSubtractionValue :: Gen (Text, Value)
+genSubtractionValue = do (input, SubtractionT) <- genSubtractionToken
+                         return (input, valueFromList [])
+
+genMaryScriptHash :: Gen (Shelley.ScriptHash (MaryEra StandardCrypto))
+genMaryScriptHash = return . Timelock.hashTimelockScript $ Timelock.RequireAllOf Strict.empty
+
+genScriptHashMaryText :: Gen Text
+genScriptHashMaryText = do Shelley.ScriptHash h <- genMaryScriptHash
+                           return $ hashToTextAsHex h

--- a/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cli.MultiAssetParsing where
+
+import           Cardano.Prelude
+
+import           Cardano.Api.Typed
+import           Cardano.CLI.Mary.Parser
+import qualified Data.Text as Text
+import           Test.Cli.Gen
+import           Text.Parsec (ParseError)
+import qualified Text.Parsec as Parsec (parse)
+import           Text.Parsec.String (Parser)
+
+import           Hedgehog (Gen, Property, checkSequential, discover, evalEither, forAll, property,
+                     (===))
+import           Hedgehog.Internal.Property (failWith)
+
+{- HLINT ignore "Reduce duplication" -}
+
+-- Lexer
+lex :: Parser a -> Text -> Either ParseError a
+lex p = Parsec.parse p "" . Text.unpack
+
+-- Parser
+parse :: TParser a -> Tokens -> Either ParseError a
+parse p = Parsec.parse p ""
+
+-- Lexing
+
+prop_lexLovelace :: Property
+prop_lexLovelace =
+  property $ do
+    (input, expectedOutput) <- forAll genLovelaceToken
+    case lex lexToken input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+prop_lexValue_fullySpecified :: Property
+prop_lexValue_fullySpecified =
+  property $ do
+    (input, expectedOutput) <- forAll genValueTokenFullySpecified
+    case lex valueTokenFullySpecified input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+
+prop_lexValue_pid_and_asset_id :: Property
+prop_lexValue_pid_and_asset_id =
+  property $ do
+    (input, expectedOutput) <- forAll genValueTokenPidAndAssetId
+    case lex valueTokenPolicyIdAndAssetId input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+prop_lexValue_pid_only :: Property
+prop_lexValue_pid_only =
+  property $ do
+    (input, expectedOutput) <- forAll genValueTokenPidOnly
+    case lex valueTokenPolicyIdOnly input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+prop_lexAddition :: Property
+prop_lexAddition =
+  property $ do
+    (input, expectedOutput) <- forAll genAdditionToken
+    case lex addition input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+prop_lexSubtraction :: Property
+prop_lexSubtraction =
+  property $ do
+    (input, expectedOutput) <- forAll genSubtractionToken
+    case lex subtraction input of
+      Left pe -> failWith Nothing $ show pe
+      Right token -> token === expectedOutput
+
+prop_lexTokens :: Property
+prop_lexTokens =
+  property $ do
+    (input, expectedOutput) <- forAll genTokens
+    case lex lexTokens input of
+      Left pe -> failWith Nothing $ show pe
+      Right tokens ->
+        sort (foldl' (\n (_,tk) ->  tk : n) [] tokens) === sort expectedOutput
+
+-- Parsing
+
+prop_parseLovelace :: Property
+prop_parseLovelace =
+  property $ do
+    (input, expectedOutput) <- forAll genLovelaceValue
+    tkn <- evalEither $ lex lexTokens input
+    case parse preValueLovelace tkn of
+      Left pe -> failWith Nothing $ show pe
+      Right preVal -> preValToValue preVal === expectedOutput
+
+prop_parseMultiAsset :: Property
+prop_parseMultiAsset =
+  property $ do
+      (input, expectedOutput) <- forAll genMultiAssetValue
+      tkn <- evalEither $ lex lexTokens input
+      case parse preValueMultiAsset tkn of
+        Left pe -> failWith Nothing $ show pe
+        Right preVal -> preValToValue preVal === expectedOutput
+
+prop_parseAddition :: Property
+prop_parseAddition =
+  property $ do
+    (input, expectedOutput) <- forAll genAdditionValue
+    tkn <- evalEither $ lex lexTokens input
+    case parse preValueAddition tkn of
+      Left pe -> failWith Nothing $ show pe
+      Right preVal -> preValToValue preVal === expectedOutput
+
+prop_parseSubtraction :: Property
+prop_parseSubtraction =
+  property $ do
+    (input, expectedOutput) <- forAll genSubtractionValue
+    tkn <- evalEither $ lex lexTokens input
+    case parse preValueSubtraction tkn of
+      Left pe -> failWith Nothing $ show pe
+      Right preVal -> preValToValue preVal === expectedOutput
+
+prop_parse :: Property
+prop_parse = property $ do
+  (input, expectedOutput) <- forAll genValues
+  tkns <- evalEither $ lex lexTokens input
+  case parse preValueParser tkns of
+    Left pe -> failWith Nothing $ show pe
+    Right preVals -> calculateValue preVals === expectedOutput
+
+prop_addition_ada :: Property
+prop_addition_ada =
+  testAdditionOperation genAdditionValue genLovelaceValue
+
+prop_addition_multi_asset :: Property
+prop_addition_multi_asset =
+  testAdditionOperation genAdditionValue genMultiAssetValue
+
+prop_subtraction_multi_asset :: Property
+prop_subtraction_multi_asset =
+  testSubtractionOperation genSubtractionValue genMultiAssetValue
+
+testAdditionOperation :: Gen (Text, Value) -> Gen (Text,Value) -> Property
+testAdditionOperation binaryOperation value = property $ do
+  (input1, out1) <- forAll value
+  (input2, binaryOp) <- forAll binaryOperation
+  (input3, out2) <- forAll value
+  tkns <- evalEither $ lex lexTokens (input1 <> input2 <> input3)
+  case parse preValueParser tkns of
+    Left pe -> failWith Nothing $ show pe
+    Right preVals -> calculateValue preVals === (out1 <> binaryOp <> out2)
+
+testSubtractionOperation :: Gen (Text, Value) -> Gen (Text,Value) -> Property
+testSubtractionOperation binaryOperation value = property $ do
+  (input1, out1) <- forAll value
+  (input2, binaryOp) <- forAll binaryOperation
+  (input3, out2) <- forAll value
+  tkns <- evalEither $ lex lexTokens (input1 <> input2 <> input3)
+  case parse preValueParser tkns of
+    Left pe -> failWith Nothing $ show pe
+    Right preVals -> calculateValue preVals === (out1 <> binaryOp <> negateValue out2)
+
+-- -----------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  checkSequential $$discover
+

--- a/cardano-cli/test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test.hs
@@ -4,6 +4,7 @@ import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Cli.FilePermissions
 import qualified Test.Cli.ITN
+-- import qualified Test.Cli.MultiAssetParsing
 import qualified Test.Cli.Pioneers.Exercise1
 import qualified Test.Cli.Pioneers.Exercise2
 import qualified Test.Cli.Pioneers.Exercise3
@@ -14,9 +15,9 @@ main =
   defaultMain
     [ Test.Cli.FilePermissions.tests
     , Test.Cli.ITN.tests
+    -- , Test.Cli.MultiAssetParsing.tests
     , Test.Cli.Pioneers.Exercise1.tests
     , Test.Cli.Pioneers.Exercise2.tests
     , Test.Cli.Pioneers.Exercise3.tests
     , Test.Cli.Pioneers.Exercise4.tests
     ]
-


### PR DESCRIPTION
Introduce CLI parsing of a new proposed syntax for multi-asset `Value`s and `TxOut`s. Note that this new syntax is backward-compatible with the old syntax. i.e. the old transaction output CLI syntax: `${address}+{lovelace}` is still supported.

The new syntax is defined as follows:

# Values

## Specifying individual values

- Lovelace values can be specified in the following ways:
  - `${quantity} lovelace` (where `quantity` is a signed integer)
  - `${quantity}` (where `quantity` is a signed integer)

- Values for other assets can be specified in the following ways:
  - `${quantity} ${policyId}.${assetName}` (where `quantity` is a signed integer, `policyId` is a hex-encoded policy ID [script hash], and `assetName` is an alphanumeric asset name)
  - `${quantity} ${policyId}` (where `quantity` is a signed integer and `policyId` is a hex-encoded policy ID [script hash])

## Negating individual values

Individual values can be negated by utilizing the `-` prefix operator. All individual values can be prefixed by this operator. Some examples:

- `-42 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74`
- `-72191 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74.foo`
- `-100`
- `-920 lovelace`

## Combining individual values

Values can be combined by using the `+` binary operator. Some examples:

- `42 lovelace + -1` (this would result in a `Value` of 41 lovelace)
- `20 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74 + 12 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74.foo + -2 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74.bar`
- `201 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74.foo + 12 + -1 + 9 lovelace + 10 46f192e30c5d8fcc5ccbcd9c91e430283166b3382cd25261a1601b74`

# Transaction outputs

Transaction outputs can be specified in the following ways:

- `${address} ${value}` (where `address` is a Cardano address and `value` is a [value](#values))
- `${address}+${value}` (where `address` is a Cardano address and `value` is a [value](#values)) (n.b. this is actually the old tx out CLI syntax that is additionally supported by the new parser)