### PR TITLE
Remove the HardForkNotBeforeEpoch parameter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c1f326cd2c8df00d455370f9ecef02b2b6a5028f
-  --sha256: 0izjzxmc43g2jsdiipagqappz4fpz6cigvq7jcw5caaai4bm6mb6
+  tag: da2130c6b19d38cb9ec519ed4fb2d644b35e55cb
+  --sha256: 1jkic85qzp7lh2lab3iw6g1h71qar1ahvx0kinmh8hwjdrmyg6fl
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -229,28 +229,22 @@ instance FromJSON PartialNodeConfiguration where
       parseHardForkProtocol v = do
         npcTestShelleyHardForkAtEpoch   <- v .:? "TestShelleyHardForkAtEpoch"
         npcTestShelleyHardForkAtVersion <- v .:? "TestShelleyHardForkAtVersion"
-        npcShelleyHardForkNotBeforeEpoch <- v .:? "ShelleyHardForkNotBeforeEpoch"
 
         npcTestAllegraHardForkAtEpoch   <- v .:? "TestAllegraHardForkAtEpoch"
         npcTestAllegraHardForkAtVersion <- v .:? "TestAllegraHardForkAtVersion"
-        npcAllegraHardForkNotBeforeEpoch <- v .:? "AllegraHardForkNotBeforeEpoch"
 
         npcTestMaryHardForkAtEpoch   <- v .:? "TestMaryHardForkAtEpoch"
         npcTestMaryHardForkAtVersion <- v .:? "TestMaryHardForkAtVersion"
-        npcMaryHardForkNotBeforeEpoch <- v .:? "MaryHardForkNotBeforeEpoch"
 
         pure NodeHardForkProtocolConfiguration {
                npcTestShelleyHardForkAtEpoch,
                npcTestShelleyHardForkAtVersion,
-               npcShelleyHardForkNotBeforeEpoch,
 
                npcTestAllegraHardForkAtEpoch,
                npcTestAllegraHardForkAtVersion,
-               npcAllegraHardForkNotBeforeEpoch,
 
                npcTestMaryHardForkAtEpoch,
-               npcTestMaryHardForkAtVersion,
-               npcMaryHardForkNotBeforeEpoch
+               npcTestMaryHardForkAtVersion
              }
 
 -- | Default configuration is mainnet

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -110,13 +110,10 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                            NodeHardForkProtocolConfiguration {
                              npcTestShelleyHardForkAtEpoch,
                              npcTestShelleyHardForkAtVersion,
-                             npcShelleyHardForkNotBeforeEpoch,
                              npcTestAllegraHardForkAtEpoch,
                              npcTestAllegraHardForkAtVersion,
-                             npcAllegraHardForkNotBeforeEpoch,
                              npcTestMaryHardForkAtEpoch,
-                             npcTestMaryHardForkAtVersion,
-                             npcMaryHardForkNotBeforeEpoch
+                             npcTestMaryHardForkAtVersion
                            }
                            files = do
     byronGenesis <-
@@ -187,7 +184,6 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         -- The comments below also apply for the Shelley -> Allegra and Allegra -> Mary hard forks.
         -- Byron to Shelley hard fork parameters
         Consensus.ProtocolParamsTransition {
-          transitionLowerBound = npcShelleyHardForkNotBeforeEpoch,
           transitionTrigger =
             -- What will trigger the Byron -> Shelley hard fork?
             case npcTestShelleyHardForkAtEpoch of
@@ -213,7 +209,6 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         }
         -- Shelley to Allegra hard fork parameters
         Consensus.ProtocolParamsTransition {
-          transitionLowerBound = npcAllegraHardForkNotBeforeEpoch,
           transitionTrigger =
             case npcTestAllegraHardForkAtEpoch of
                Nothing -> Consensus.TriggerHardForkAtVersion
@@ -222,7 +217,6 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         }
         -- Allegra to Mary hard fork parameters
         Consensus.ProtocolParamsTransition {
-          transitionLowerBound = npcMaryHardForkNotBeforeEpoch,
           transitionTrigger =
             case npcTestMaryHardForkAtEpoch of
                Nothing -> Consensus.TriggerHardForkAtVersion

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -310,18 +310,13 @@ data NodeByronProtocolConfiguration =
 data NodeHardForkProtocolConfiguration =
      NodeHardForkProtocolConfiguration {
 
-       -- | If we have knowledge about when the Shelley hard fork is then we
-       -- have an opportunity to optimise the bulk sync slightly.
-       --
-       npcShelleyHardForkNotBeforeEpoch :: Maybe EpochNo
-
        -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
        --
        -- Obviously if this is used, all the nodes in the test cluster must be
        -- configured the same, or they will disagree.
        --
-     , npcTestShelleyHardForkAtEpoch :: Maybe EpochNo
+       npcTestShelleyHardForkAtEpoch :: Maybe EpochNo
 
        -- | For testing purposes we support specifying that the hard fork
        -- happens at a given major protocol version. For example this can be
@@ -333,11 +328,6 @@ data NodeHardForkProtocolConfiguration =
        -- configured the same, or they will disagree.
        --
      , npcTestShelleyHardForkAtVersion :: Maybe Word
-
-       -- | If we have knowledge about when the Allegra hard fork is then we
-       -- have an opportunity to optimise the bulk sync slightly.
-       --
-     , npcAllegraHardForkNotBeforeEpoch :: Maybe EpochNo
 
        -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
@@ -371,10 +361,6 @@ data NodeHardForkProtocolConfiguration =
        --
      , npcTestMaryHardForkAtVersion :: Maybe Word
 
-       -- | If we have knowledge about when the Shelley hard fork is then we
-       -- have an opportunity to optimise the bulk sync slightly.
-       --
-     , npcMaryHardForkNotBeforeEpoch :: Maybe EpochNo
      }
   deriving (Eq, Show)
 

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -11,7 +11,6 @@
   "RequiresNetworkMagic": "RequiresNoMagic",
   "ShelleyGenesisFile": "mainnet-shelley-genesis.json",
   "ShelleyGenesisHash": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
-  "ShelleyHardForkNotBeforeEpoch": 208,
   "TraceBlockFetchClient": false,
   "TraceBlockFetchDecisions": false,
   "TraceBlockFetchProtocol": false,


### PR DESCRIPTION
This propagates https://github.com/input-output-hk/ouroboros-network/pull/2736

The parameter was introduced because we expected it would improve the
performance by not having to recalculate some things until the epoch of the
transition has been reached. However, disabling it had no noticeable impact in
recent microbenchmarks.

This field is also needed for each new era, adding to the boilerplate. Moreover,
setting it incorrectly can cause *real* problems that are not always easy to
debug.

So remove it altogether.