### PR TITLE
Move Shelley commands to the top-lvl and deprecate "shelley" subcommand

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -35,7 +35,7 @@ parseClientCommand :: Parser ClientCommand
 parseClientCommand =
   asum
     [ parseByron <|> backwardsCompatibilityCommands
-    , parseShelley
+    , parseShelley <|> parseDeprecatedShelleySubcommand
     , parseDisplayVersion
     ]
 
@@ -51,15 +51,25 @@ parseByron =
          parseByronCommands
     ]
 
+-- | Parse Shelley-related commands at the top level of the CLI.
 parseShelley :: Parser ClientCommand
-parseShelley =
+parseShelley = ShelleyCommand <$> parseShelleyCommands
+
+-- | Parse Shelley-related commands under the now-deprecated \"shelley\"
+-- subcommand.
+--
+-- Note that this subcommand is 'internal' and is therefore hidden from the
+-- help text.
+parseDeprecatedShelleySubcommand :: Parser ClientCommand
+parseDeprecatedShelleySubcommand =
   subparser $ mconcat
-    [ commandGroup "Shelley specific commands"
+    [ commandGroup "Shelley specific commands (deprecated)"
     , metavar "Shelley specific commands"
     , command'
         "shelley"
-        "Shelley specific commands"
-        (ShelleyCommand <$> parseShelleyCommands)
+        "Shelley specific commands (deprecated)"
+        (DeprecatedShelleySubcommand <$> parseShelleyCommands)
+    , internal
     ]
 
 -- Yes! A --version flag or version command. Either guess is right!


### PR DESCRIPTION
This PR moves Shelley-related commands from under the "shelley" subcommand to the top-level of the CLI.

We still maintain support for the "shelley" subcommand (i.e. all of the commands still work), but its help text is hidden. However, the help text can still be accessed by running `cardano-cli shelley` or `cardano-cli shelley --help`:

```
$ cardano-cli shelley
Usage: cardano-cli shelley COMMAND
  Shelley specific commands (deprecated)

Available options:
  -h,--help                Show this help text

Available commands:
  ...
```

Additionally, a warning message is written to `stderr` when one attempts to run a command under the "shelley" subcommand. Example:

```
$ cardano-cli shelley address key-gen --verification-key-file /dev/null --signing-key-file /dev/null
WARNING: The "shelley" subcommand is now deprecated and will be removed in the future. Please use the top-level commands instead.
```