### PR TITLE
Improve lovelace parser failure in the cli

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2192,7 +2192,11 @@ pProtocolVersion =
 --
 
 parseLovelace :: Atto.Parser Lovelace
-parseLovelace = Lovelace <$> Atto.decimal
+parseLovelace = do
+  i <- Atto.decimal
+  if i > toInteger (maxBound :: Word64)
+  then fail $ show i <> " lovelace exceeds the Word64 upper bound"
+  else return $ Lovelace i
 
 parseAddress :: Atto.Parser (Address Shelley)
 parseAddress = do


### PR DESCRIPTION
Closes #2063 

Improved failure:
```
cabal exec cardano-cli -- shelley transaction build-raw --tx-in 91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0 --tx-out addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+18446744073709551616 --fee 1000 --ttl 1234 --out-file test
option --tx-out: Failed reading: 18446744073709551616 lovelace exceeds the Word64 upper bound
```