### PR TITLE
Custom multiasset Show Value instance

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -51,6 +51,7 @@ library
                         Cardano.Api.SerialiseRaw
                         Cardano.Api.SerialiseTextEnvelope
                         Cardano.Api.Utils
+                        Cardano.Api.Value
 
 
 

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -520,6 +520,8 @@ import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.Utils
+import           Cardano.Api.Value
+
 
 {- HLINT ignore "Redundant flip" -}
 
@@ -859,10 +861,6 @@ deriving instance Eq (TxOut Byron)
 deriving instance Eq (TxOut Shelley)
 deriving instance Show (TxOut Byron)
 deriving instance Show (TxOut Shelley)
-
-newtype Lovelace = Lovelace Integer
-  deriving (Eq, Ord, Enum, Show)
-
 
 toByronTxIn  :: TxIn -> Byron.TxIn
 toByronTxIn (TxIn txid (TxIx txix)) =

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -13,7 +13,7 @@ module Cardano.Api.Value
   , PolicyId
   , AssetName
   , AssetId(..)
-  , Value(..)
+  , Value
   , selectAsset
   , valueFromList
   , valueToList
@@ -35,11 +35,11 @@ module Cardano.Api.Value
 
 import           Prelude
 
-import           Data.String (IsString)
 import           Data.ByteString (ByteString)
+import qualified Data.Map.Merge.Strict as Map
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.Map.Merge.Strict as Map
+import           Data.String (IsString)
 
 import           Cardano.Api.Eras
 import           Cardano.Api.Script
@@ -94,7 +94,11 @@ data AssetId = AssetId !PolicyId !AssetName
 
 
 newtype Value = Value (Map AssetId Quantity)
-  deriving (Eq, Show)
+  deriving Eq
+
+instance Show Value where
+  showsPrec d v = showParen (d > 10) $
+    showString "valueFromList " . shows (valueToList v)
 
 instance Semigroup Value where
   Value a <> Value b = Value (mergeAssetMaps a b)

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Currency values
+--
+module Cardano.Api.Value
+  ( Lovelace(..)
+
+    -- * Multi-asset values
+  , Quantity
+  , PolicyId
+  , AssetName
+  , AssetId(..)
+  , Value(..)
+  , selectAsset
+  , valueFromList
+  , valueToList
+  , filterValue
+  , negateValue
+
+    -- ** Ada \/ Lovelace specifically
+  , quantityToLovelace
+  , lovelaceToQuantity
+  , selectLovelace
+  , lovelaceToValue
+
+    -- * Era-dependent use of multi-assert values
+  , MintValue(..)
+  , TxOutValue(..)
+  , AdaOnlyInEra(..)
+  , MultiAssetInEra(..)
+  ) where
+
+import           Prelude
+
+import           Data.String (IsString)
+import           Data.ByteString (ByteString)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Map.Merge.Strict as Map
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Script
+
+
+-- ----------------------------------------------------------------------------
+-- Lovelace
+--
+
+newtype Lovelace = Lovelace Integer
+  deriving stock (Show)
+  deriving newtype (Eq, Ord, Enum, Num)
+
+instance Semigroup Lovelace where
+  Lovelace a <> Lovelace b = Lovelace (a + b)
+
+instance Monoid Lovelace where
+  mempty = Lovelace 0
+
+
+-- ----------------------------------------------------------------------------
+-- Multi asset Value
+--
+
+newtype Quantity = Quantity Integer
+  deriving newtype (Eq, Ord, Num, Show)
+
+instance Semigroup Quantity where
+  Quantity a <> Quantity b = Quantity (a + b)
+
+instance Monoid Quantity where
+  mempty = Quantity 0
+
+lovelaceToQuantity :: Lovelace -> Quantity
+lovelaceToQuantity (Lovelace x) = Quantity x
+
+quantityToLovelace :: Quantity -> Lovelace
+quantityToLovelace (Quantity x) = Lovelace x
+
+
+newtype PolicyId = PolicyId ScriptHash
+  deriving stock (Show)
+  deriving newtype (Eq, Ord, IsString)
+
+newtype AssetName = AssetName ByteString
+  deriving stock (Show)
+  deriving newtype (Eq, Ord, IsString)
+
+data AssetId = AssetId !PolicyId !AssetName
+             | AdaAssetId
+  deriving (Eq, Ord, Show)
+
+
+newtype Value = Value (Map AssetId Quantity)
+  deriving (Eq, Show)
+
+instance Semigroup Value where
+  Value a <> Value b = Value (mergeAssetMaps a b)
+
+instance Monoid Value where
+  mempty = Value Map.empty
+
+
+{-# NOINLINE mergeAssetMaps #-}
+mergeAssetMaps :: Map AssetId Quantity
+               -> Map AssetId Quantity
+               -> Map AssetId Quantity
+mergeAssetMaps =
+    Map.merge
+      Map.preserveMissing
+      Map.preserveMissing
+      (Map.zipWithMaybeMatched mergeQuantity)
+  where
+    mergeQuantity :: AssetId -> Quantity -> Quantity -> Maybe Quantity
+    mergeQuantity _k a b =
+      case a <> b of
+        Quantity 0 -> Nothing
+        c          -> Just c
+
+selectAsset :: Value -> (AssetId -> Quantity)
+selectAsset (Value m) a = Map.findWithDefault mempty a m
+
+valueFromList :: [(AssetId, Quantity)] -> Value
+valueFromList = Value
+              . Map.filter (/= 0)
+              . Map.fromListWith (<>)
+
+valueToList :: Value -> [(AssetId, Quantity)]
+valueToList (Value m) = Map.toList m
+
+-- | This lets you write @a - b@ as @a <> negateValue b@.
+--
+negateValue :: Value -> Value
+negateValue (Value m) = Value (Map.map negate m)
+
+filterValue :: (AssetId -> Bool) -> Value -> Value
+filterValue p (Value m) = Value (Map.filterWithKey (\k _v -> p k) m)
+
+selectLovelace :: Value -> Lovelace
+selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
+
+lovelaceToValue :: Lovelace -> Value
+lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
+
+
+-- ----------------------------------------------------------------------------
+-- Era-dependent use of multi-assert values
+--
+
+data MintValue era where
+
+     MintNothing :: MintValue era
+
+     MintValue   :: MultiAssetInEra era -> Value -> MintValue era
+
+deriving instance Eq   (MintValue era)
+deriving instance Show (MintValue era)
+
+
+data TxOutValue era where
+
+     TxOutLovelace :: AdaOnlyInEra era -> Lovelace -> TxOutValue era
+
+     TxOutValue    :: MultiAssetInEra era -> Value -> TxOutValue era
+
+deriving instance Eq   (TxOutValue era)
+deriving instance Show (TxOutValue era)
+
+
+-- | Representation of whether multi-asset transactions are supported in a
+-- particular era.
+--
+data AdaOnlyInEra era where
+
+     AdaOnlyInByronEra   :: AdaOnlyInEra Byron
+     AdaOnlyInShelleyEra :: AdaOnlyInEra Shelley
+     AdaOnlyInAllegraEra :: AdaOnlyInEra Allegra
+
+deriving instance Eq   (AdaOnlyInEra era)
+deriving instance Show (AdaOnlyInEra era)
+
+-- | Representation of whether multi-asset transactions are supported in a
+-- particular era.
+--
+data MultiAssetInEra era where
+
+     -- | Multi-asset transactions are supported in the 'Mary' era.
+     MultiAssetInMaryEra :: MultiAssetInEra Mary
+
+deriving instance Eq   (MultiAssetInEra era)
+deriving instance Show (MultiAssetInEra era)
+


### PR DESCRIPTION
Which would allow the Value constructor to not be exported, thereby making it impossible to construct invalid `Value` values.

This also ensures the following REPL behaviour:

```
λ> import Cardano.Api.Value
λ> valueFromList [(AdaAssetId,100)]
valueFromList [(AdaAssetId,100)]
λ> valueFromList [(AdaAssetId,100), (AdaAssetId, 100)]
valueFromList [(AdaAssetId,200)]
λ> valueFromList [(AdaAssetId,100), (AdaAssetId, -100)]
valueFromList []
```

This is contrast to the old REPL behaviour:

```
λ> import Cardano.Api.Value
λ> valueFromList [(AdaAssetId,100)]
Value (fromList [(AdaAssetId,100)])
λ> valueFromList [(AdaAssetId,100), (AdaAssetId, 100)]
Value (fromList [(AdaAssetId,200)])
λ> valueFromList [(AdaAssetId,100), (AdaAssetId, -100)]
Value (fromList [])
```