### PR TITLE
Slightly more lenient chairman blocks assertion.

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Byron.hs
@@ -23,4 +23,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
   conf <- H.mkConf tempAbsPath' Nothing
   allNodes <- H.testnet conf
 
-  chairmanOver 120 55 conf allNodes
+  chairmanOver 120 53 conf allNodes


### PR DESCRIPTION
Reducing from `55` to `53` blocks for Byron testnet.

This is to avoid this failure in CI: https://github.com/input-output-hk/cardano-node/runs/1393451411?check_suite_focus=true