### PR TITLE
Potential work around for flaky builds

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -88,10 +88,14 @@ jobs:
         restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
 
     - name: Install dependencies
-      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+      run: |
+        cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies &&
+        cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
 
     - name: Build
-      run: cabal build cardano-node cardano-cli cardano-node-chairman --builddir="$CABAL_BUILDDIR"
+      run: |
+        cabal build cardano-node cardano-cli cardano-node-chairman --builddir="$CABAL_BUILDDIR" &&
+        cabal build cardano-node cardano-cli cardano-node-chairman --builddir="$CABAL_BUILDDIR"
 
     - name: Git clone
       run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror


### PR DESCRIPTION
Windows builds fail intermittently for Windows on Github Actions.  For example:

* https://github.com/input-output-hk/cardano-node/pull/2086/checks?check_run_id=1393807980

Retries might help avoid the problem.