### PR TITLE
Replace panic with fail in JSON parsers

### DIFF
--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -6,7 +6,7 @@
 module Cardano.Node.Orphans () where
 
 import           Cardano.Prelude
-import qualified Prelude
+import           Prelude (fail)
 
 import           Data.Aeson (FromJSON (..), Value (..))
 import qualified Data.Text as Text
@@ -19,15 +19,15 @@ instance FromJSON TracingVerbosity where
     "MinimalVerbosity" -> pure MinimalVerbosity
     "MaximalVerbosity" -> pure MaximalVerbosity
     "NormalVerbosity" -> pure NormalVerbosity
-    err -> panic $ "Parsing of TracingVerbosity failed, "
-                 <> err <> " is not a valid TracingVerbosity"
-  parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
+    err -> fail $ "Parsing of TracingVerbosity failed, "
+                <> Text.unpack err <> " is not a valid TracingVerbosity"
+  parseJSON invalid  = fail $ "Parsing of TracingVerbosity failed due to type mismatch. "
+                           <> "Encountered: " <> show invalid
 
 deriving instance Show TracingVerbosity
 
 instance FromJSON Update.ApplicationName where
   parseJSON (String x) = pure $ Update.ApplicationName x
   parseJSON invalid  =
-    panic $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> Text.pack (Prelude.show invalid)
+    fail $ "Parsing of application name failed due to type mismatch. "
+    <> "Encountered: " <> show invalid

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Node.Types
   ( -- * Configuration
@@ -48,7 +49,7 @@ module Cardano.Node.Types
   ) where
 
 import           Cardano.Prelude
-import           Prelude (String)
+import           Prelude (String, fail)
 
 import           Data.Aeson
 import           Data.IP (IP (..), IPv4, IPv6)
@@ -91,8 +92,8 @@ newtype GenesisFile = GenesisFile
 
 instance FromJSON GenesisFile where
   parseJSON (String genFp) = pure . GenesisFile $ Text.unpack genFp
-  parseJSON invalid = panic $ "Parsing of GenesisFile failed due to type mismatch. "
-                           <> "Encountered: " <> Text.pack (show invalid)
+  parseJSON invalid = fail $ "Parsing of GenesisFile failed due to type mismatch. "
+                          <> "Encountered: " <> show invalid
 
 newtype MaxConcurrencyBulkSync = MaxConcurrencyBulkSync
   { unMaxConcurrencyBulkSync :: Word }
@@ -163,9 +164,9 @@ instance FromJSON NodeHostIPv4Address where
   parseJSON (String ipStr) =
     case readMaybe $ Text.unpack ipStr of
       Just ip -> pure $ NodeHostIPv4Address ip
-      Nothing -> panic $ "Parsing of IPv4 failed: " <> ipStr
-  parseJSON invalid = panic $ "Parsing of IPv4 failed due to type mismatch. "
-                            <> "Encountered: " <> Text.pack (show invalid) <> "\n"
+      Nothing -> fail $ "Parsing of IPv4 failed: " <> Text.unpack ipStr
+  parseJSON invalid = fail $ "Parsing of IPv4 failed due to type mismatch. "
+                           <> "Encountered: " <> show invalid <> "\n"
 
 instance ToJSON NodeHostIPv4Address where
   toJSON (NodeHostIPv4Address ip) = String (Text.pack $ show ip)
@@ -180,9 +181,9 @@ instance FromJSON NodeHostIPv6Address where
   parseJSON (String ipStr) =
     case readMaybe $ Text.unpack ipStr of
       Just ip -> pure $ NodeHostIPv6Address ip
-      Nothing -> panic $ "Parsing of IPv6 failed: " <> ipStr
-  parseJSON invalid = panic $ "Parsing of IPv6 failed due to type mismatch. "
-                            <> "Encountered: " <> Text.pack (show invalid) <> "\n"
+      Nothing -> fail $ "Parsing of IPv6 failed: " <> Text.unpack ipStr
+  parseJSON invalid = fail $ "Parsing of IPv6 failed due to type mismatch. "
+                          <> "Encountered: " <> show invalid <> "\n"
 instance ToJSON NodeHostIPv6Address where
   toJSON (NodeHostIPv6Address ip) = String (Text.pack $ show ip)
 
@@ -196,9 +197,9 @@ instance FromJSON NodeHostIPAddress where
   parseJSON (String ipStr) =
     case readMaybe $ Text.unpack ipStr of
       Just ip -> pure $ NodeHostIPAddress ip
-      Nothing -> panic $ "Parsing of IP failed: " <> ipStr
-  parseJSON invalid = panic $ "Parsing of IP failed due to type mismatch. "
-                            <> "Encountered: " <> Text.pack (show invalid) <> "\n"
+      Nothing -> fail $ "Parsing of IP failed: " <> Text.unpack ipStr
+  parseJSON invalid = fail $ "Parsing of IP failed due to type mismatch. "
+                          <> "Encountered: " <> show invalid <> "\n"
 
 instance ToJSON NodeHostIPAddress where
   toJSON (NodeHostIPAddress ip) = String (Text.pack $ show ip)
@@ -235,8 +236,8 @@ instance FromJSON NodeDiffusionMode where
           -> pure $ NodeDiffusionMode InitiatorOnlyDiffusionMode
         "InitiatorAndResponder"
           -> pure $ NodeDiffusionMode InitiatorAndResponderDiffusionMode
-        _ -> panic "Parsing NodeDiffusionMode failed: can be either 'InitiatorOnly' or 'InitiatorAndResponder'"
-    parseJSON _ = panic "Parsing NodeDiffusionMode failed"
+        _ -> fail "Parsing NodeDiffusionMode failed: can be either 'InitiatorOnly' or 'InitiatorAndResponder'"
+    parseJSON _ = fail "Parsing NodeDiffusionMode failed"
 
 class AdjustFilePaths a where
   adjustFilePaths :: (FilePath -> FilePath) -> a -> a

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -39,7 +39,7 @@ module Cardano.Tracing.OrphanInstances.Common
   ) where
 
 import           Cardano.Prelude
-import qualified Prelude
+import           Prelude (fail)
 
 import           Data.Aeson
 import qualified Data.ByteString.Base16 as B16
@@ -77,23 +77,23 @@ instance FromJSON TracingVerbosity where
     "MinimalVerbosity" -> pure MinimalVerbosity
     "MaximalVerbosity" -> pure MaximalVerbosity
     "NormalVerbosity" -> pure NormalVerbosity
-    err -> panic $ "Parsing of TracingVerbosity failed, "
-                 <> err <> " is not a valid TracingVerbosity"
-  parseJSON invalid  = panic $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
+    invalid -> fail $ "Parsing of TracingVerbosity failed, "
+                    <> Text.unpack invalid <> " is not a valid TracingVerbosity"
+  parseJSON invalid  = fail $ "Parsing of TracingVerbosity failed due to type mismatch. "
+                            <> "Encountered: " <> show invalid
 
 instance FromJSON PortNumber where
   parseJSON (Number portNum) = case readMaybe . show $ coefficient portNum of
     Just port -> pure port
-    Nothing -> panic $ show portNum <> " is not a valid port number."
-  parseJSON invalid  = panic $ "Parsing of port number failed due to type mismatch. "
-                             <> "Encountered: " <> Text.pack (Prelude.show invalid)
+    Nothing -> fail $ show portNum <> " is not a valid port number."
+  parseJSON invalid  = fail $ "Parsing of port number failed due to type mismatch. "
+                            <> "Encountered: " <> show invalid
 
 instance FromJSON Update.ApplicationName where
   parseJSON (String x) = pure $ Update.ApplicationName x
   parseJSON invalid  =
-    panic $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> Text.pack (Prelude.show invalid)
+    fail $ "Parsing of application name failed due to type mismatch. "
+    <> "Encountered: " <> show invalid
 
 instance ToJSON (HeaderHash blk) => ToJSON (Tip blk) where
   toJSON TipGenesis = object [ "genesis" .= True ]


### PR DESCRIPTION
Attempt to take https://github.com/input-output-hk/cardano-node/pull/1955 to fruition

Replace panic with fail in JSON parsers in:

* Cardano.Node.Types
* Cardano.Node.Orphans
* Cardano.Tracing.OrphanInstances.Common