### PR TITLE
Don't use the same Shelley credentials for Allegra and Mary

### DIFF
--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -170,7 +170,8 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
               npcShelleySupportedProtocolVersionMajor
               npcShelleySupportedProtocolVersionMinor,
           allegraLeaderCredentials =
-            shelleyLeaderCredentials
+            -- TODO: separate credentials for Allega
+            Nothing
         }
         Consensus.ProtocolParamsMary {
           maryProtVer =
@@ -178,7 +179,8 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
               npcShelleySupportedProtocolVersionMajor
               npcShelleySupportedProtocolVersionMinor,
           maryLeaderCredentials =
-            shelleyLeaderCredentials
+            -- TODO: separate credentials for Mary
+            Nothing
         }
         -- ProtocolParamsTransition specifies the parameters needed to transition between two eras
         -- The comments below also apply for the Shelley -> Allegra and Allegra -> Mary hard forks.


### PR DESCRIPTION
This avoids tracing the same forge-related messages 3x instead of once. But this
is just temporary, until the node has been extended with credentials for all
eras (and if all of them are actually passed).

Moreover, I have some concerns about reusing the same set of credentials for all
eras. For each era, we have a thread that will update the credentials when
needed, i.e., evolve the KES key and securely forget the old one. If three eras
and thus threads all start out with the same KES key, they will all try to
update and erase the same KES key...