### PR TITLE
Start to use multi-asset tx out value type

### DIFF
--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -59,17 +59,42 @@ module Cardano.API (
     StakeKey,
     StakeExtendedKey,
 
+    -- * Currency values
+    -- ** Ada \/ Lovelace
+    Lovelace,
+
+    -- ** Multi-asset values
+    Quantity,
+    PolicyId,
+    AssetName,
+    AssetId(..),
+    Value,
+    selectAsset,
+    valueFromList,
+    valueToList,
+    filterValue,
+    negateValue,
+
+    -- ** Ada \/ Lovelace within multi-asset values
+    quantityToLovelace,
+    lovelaceToQuantity,
+    selectLovelace,
+    lovelaceToValue,
+
     -- * Building transactions
     -- | Constructing and inspecting transactions
     TxBody,
     TxId,
     getTxId,
     TxIn(TxIn),
-    TxOut(TxOut),
     TxIx(TxIx),
+    TxOut(TxOut),
+    TxOutValue(..),
+    AdaOnlyInEra(..),
+    MultiAssetInEra(..),
     TTL,
     TxFee,
-    Lovelace(Lovelace),
+    MintValue(..),
     makeByronTransaction,
     makeShelleyTransaction,
     SlotNo,

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -9,9 +9,9 @@ module Cardano.Api.Value
   ( Lovelace(..)
 
     -- * Multi-asset values
-  , Quantity
-  , PolicyId
-  , AssetName
+  , Quantity(..)
+  , PolicyId(..)
+  , AssetName(..)
   , AssetId(..)
   , Value
   , selectAsset

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -261,11 +261,11 @@ genTxBodyShelley =
 
 genByronTxOut :: Gen (TxOut Byron)
 genByronTxOut =
-  TxOut <$> genAddressByron <*> genLovelace
+  TxOut <$> genAddressByron <*> (TxOutAdaOnly AdaOnlyInByronEra <$> genLovelace)
 
 genShelleyTxOut :: Gen (TxOut Shelley)
 genShelleyTxOut =
-  TxOut <$> genAddressShelley <*> genLovelace
+  TxOut <$> genAddressShelley <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
 
 genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 ())
 genShelleyHash = return $ Crypto.hashWith CBOR.serialize' ()

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1461,7 +1461,9 @@ pTxOut =
   where
     parseTxOut :: Atto.Parser (TxOut Shelley)
     parseTxOut =
-      TxOut <$> parseAddress <* Atto.char '+' <*> parseLovelace
+      TxOut <$> parseAddress
+            <*  Atto.char '+'
+            <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> parseLovelace)
 
 pMint :: Parser String
 pMint =


### PR DESCRIPTION
Following on from #2083, and adding the remaining parts from #2054: use
the TxOutValue type in TxOut, though only for the Shelley era for the moment.