### PR TITLE
Improved tracing option parsing

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -1,15 +1,22 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
 
 module Cardano.Tracing.Config
   ( TraceOptions (..)
   , TraceSelection (..)
   , traceConfigParser
+  , OnOff (..)
   ) where
 
 import           Cardano.Prelude
 
 import           Data.Aeson
 import           Data.Aeson.Types (Parser)
+import           Data.Text (pack)
 
 import           Cardano.BM.Tracing (TracingVerbosity (..))
 
@@ -21,78 +28,182 @@ data TraceOptions
   | TracingOn TraceSelection
   deriving (Eq, Show)
 
+type TraceAcceptPolicy = ("TraceAcceptPolicy" :: Symbol)
+type TraceBlockchainTime = ("TraceBlockchainTime" :: Symbol)
+type TraceBlockFetchClient = ("TraceBlockFetchClient" :: Symbol)
+type TraceBlockFetchDecisions = ("TraceBlockFetchDecisions" :: Symbol)
+type TraceBlockFetchProtocol = ("TraceBlockFetchProtocol" :: Symbol)
+type TraceBlockFetchProtocolSerialised = ("TraceBlockFetchProtocolSerialised" :: Symbol)
+type TraceBlockFetchServer = ("TraceBlockFetchServer" :: Symbol)
+type TraceChainDB = ("TraceChainDB" :: Symbol)
+type TraceChainSyncClient = ("TraceChainSyncClient" :: Symbol)
+type TraceChainSyncBlockServer = ("TraceChainSyncBlockServer" :: Symbol)
+type TraceChainSyncHeaderServer = ("TraceChainSyncHeaderServer" :: Symbol)
+type TraceChainSyncProtocol = ("TraceChainSyncProtocol" :: Symbol)
+type TraceDnsResolver = ("TraceDnsResolver" :: Symbol)
+type TraceDnsSubscription = ("TraceDnsSubscription" :: Symbol)
+type TraceErrorPolicy = ("TraceErrorPolicy" :: Symbol)
+type TraceForge = ("TraceForge" :: Symbol)
+type TraceForgeStateInfo = ("TraceForgeStateInfo" :: Symbol)
+type TraceHandshake = ("TraceHandshake" :: Symbol)
+type TraceIpSubscription = ("TraceIpSubscription" :: Symbol)
+type TraceKeepAliveClient = ("TraceKeepAliveClient" :: Symbol)
+type TraceLocalChainSyncProtocol = ("TraceLocalChainSyncProtocol" :: Symbol)
+type TraceLocalErrorPolicy = ("TraceLocalErrorPolicy" :: Symbol)
+type TraceLocalHandshake = ("TraceLocalHandshake" :: Symbol)
+type TraceLocalTxSubmissionProtocol = ("TraceLocalTxSubmissionProtocol" :: Symbol)
+type TraceLocalTxSubmissionServer = ("TraceLocalTxSubmissionServer" :: Symbol)
+type TraceLocalStateQueryProtocol = ("TraceLocalStateQueryProtocol" :: Symbol)
+type TraceMempool = ("TraceMempool" :: Symbol)
+type TraceMux = ("TraceMux" :: Symbol)
+type TraceTxInbound = ("TraceTxInbound" :: Symbol)
+type TraceTxOutbound = ("TraceTxOutbound" :: Symbol)
+type TraceTxSubmissionProtocol = ("TraceTxSubmissionProtocol" :: Symbol)
+
+newtype OnOff (name :: Symbol) = OnOff { isOn :: Bool } deriving (Eq, Show)
+
+instance FromJSON (OnOff a) where
+    parseJSON (Data.Aeson.Bool b)= return $ OnOff b
+    parseJSON _ = mzero
+
+getName :: forall name. KnownSymbol name => OnOff name -> Text
+getName _ = pack (symbolVal (Proxy @name))
+
 data TraceSelection
   = TraceSelection
   { traceVerbosity :: !TracingVerbosity
 
   -- Per-trace toggles, alpha-sorted.
-  , traceAcceptPolicy :: !Bool
-  , traceBlockchainTime :: !Bool
-  , traceBlockFetchClient :: !Bool
-  , traceBlockFetchDecisions :: !Bool
-  , traceBlockFetchProtocol :: !Bool
-  , traceBlockFetchProtocolSerialised :: !Bool
-  , traceBlockFetchServer :: !Bool
-  , traceChainDB :: !Bool
-  , traceChainSyncClient :: !Bool
-  , traceChainSyncBlockServer :: !Bool
-  , traceChainSyncHeaderServer :: !Bool
-  , traceChainSyncProtocol :: !Bool
-  , traceDnsResolver :: !Bool
-  , traceDnsSubscription :: !Bool
-  , traceErrorPolicy :: !Bool
-  , traceForge :: !Bool
-  , traceForgeStateInfo :: !Bool
-  , traceHandshake :: !Bool
-  , traceIpSubscription :: !Bool
-  , traceKeepAliveClient :: !Bool
-  , traceLocalChainSyncProtocol :: !Bool
-  , traceLocalErrorPolicy :: !Bool
-  , traceLocalHandshake :: !Bool
-  , traceLocalTxSubmissionProtocol :: !Bool
-  , traceLocalTxSubmissionServer :: !Bool
-  , traceLocalStateQueryProtocol :: !Bool
-  , traceMempool :: !Bool
-  , traceMux :: !Bool
-  , traceTxInbound :: !Bool
-  , traceTxOutbound :: !Bool
-  , traceTxSubmissionProtocol :: !Bool
+  , traceAcceptPolicy :: OnOff TraceAcceptPolicy
+  , traceBlockFetchClient :: OnOff TraceBlockFetchClient
+  , traceBlockFetchDecisions :: OnOff TraceBlockFetchDecisions
+  , traceBlockFetchProtocol :: OnOff TraceBlockFetchProtocol
+  , traceBlockFetchProtocolSerialised :: OnOff TraceBlockFetchProtocolSerialised
+  , traceBlockFetchServer :: OnOff TraceBlockFetchServer
+  , traceBlockchainTime :: OnOff TraceBlockchainTime
+  , traceChainDB :: OnOff TraceChainDB
+  , traceChainSyncBlockServer :: OnOff TraceChainSyncBlockServer
+  , traceChainSyncClient :: OnOff TraceChainSyncClient
+  , traceChainSyncHeaderServer :: OnOff TraceChainSyncHeaderServer
+  , traceChainSyncProtocol :: OnOff TraceChainSyncProtocol
+  , traceDnsResolver :: OnOff TraceDnsResolver
+  , traceDnsSubscription :: OnOff TraceDnsSubscription
+  , traceErrorPolicy :: OnOff TraceErrorPolicy
+  , traceForge :: OnOff TraceForge
+  , traceForgeStateInfo :: OnOff TraceForgeStateInfo
+  , traceHandshake :: OnOff TraceHandshake
+  , traceIpSubscription :: OnOff TraceIpSubscription
+  , traceKeepAliveClient :: OnOff TraceKeepAliveClient
+  , traceLocalChainSyncProtocol :: OnOff TraceLocalChainSyncProtocol
+  , traceLocalErrorPolicy :: OnOff TraceLocalErrorPolicy
+  , traceLocalHandshake :: OnOff TraceLocalHandshake
+  , traceLocalStateQueryProtocol :: OnOff TraceLocalStateQueryProtocol
+  , traceLocalTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
+  , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
+  , traceMempool :: OnOff TraceMempool
+  , traceMux :: OnOff TraceMux
+  , traceTxInbound :: OnOff TraceTxInbound
+  , traceTxOutbound :: OnOff TraceTxOutbound
+  , traceTxSubmissionProtocol :: OnOff TraceTxSubmissionProtocol
   } deriving (Eq, Show)
 
 
 traceConfigParser :: Object -> Parser TraceOptions
 traceConfigParser v =
+  let acceptPolicy :: OnOff TraceAcceptPolicy
+      acceptPolicy = OnOff False
+      blockFetchClient :: OnOff TraceBlockFetchClient
+      blockFetchClient = OnOff False
+      blockFetchDecisions :: OnOff TraceBlockFetchDecisions
+      blockFetchDecisions = OnOff True
+      blockFetchProtocol :: OnOff TraceBlockFetchProtocol
+      blockFetchProtocol = OnOff False
+      blockFetchProtocolSerialised :: OnOff TraceBlockFetchProtocolSerialised
+      blockFetchProtocolSerialised = OnOff False
+      blockFetchServer :: OnOff TraceBlockFetchServer
+      blockFetchServer = OnOff False
+      blockchainTime :: OnOff TraceBlockchainTime
+      blockchainTime = OnOff False
+      chainDB :: OnOff TraceChainDB
+      chainDB = OnOff True
+      chainSyncBlockServer :: OnOff TraceChainSyncBlockServer
+      chainSyncBlockServer = OnOff False
+      chainSyncClient :: OnOff TraceChainSyncClient
+      chainSyncClient = OnOff True
+      chainSyncHeaderServer :: OnOff TraceChainSyncHeaderServer
+      chainSyncHeaderServer = OnOff False
+      chainSyncProtocol :: OnOff TraceChainSyncProtocol
+      chainSyncProtocol = OnOff False
+      dnsResolver :: OnOff TraceDnsResolver
+      dnsResolver = OnOff False
+      dnsSubscription :: OnOff TraceDnsSubscription
+      dnsSubscription = OnOff True
+      errorPolicy :: OnOff TraceErrorPolicy
+      errorPolicy = OnOff True
+      forge :: OnOff TraceForge
+      forge = OnOff True
+      forgeStateInfo :: OnOff TraceForgeStateInfo
+      forgeStateInfo = OnOff True
+      handshake :: OnOff TraceHandshake
+      handshake = OnOff False
+      ipSubscription :: OnOff TraceIpSubscription
+      ipSubscription = OnOff True
+      keepAliveClient :: OnOff TraceKeepAliveClient
+      keepAliveClient = OnOff False
+      localChainSyncProtocol :: OnOff TraceLocalChainSyncProtocol
+      localChainSyncProtocol = OnOff False
+      localErrorPolicy :: OnOff TraceLocalErrorPolicy
+      localErrorPolicy = OnOff True
+      localHandshake :: OnOff TraceLocalHandshake
+      localHandshake = OnOff False
+      localStateQueryProtocol :: OnOff TraceLocalStateQueryProtocol
+      localStateQueryProtocol = OnOff False
+      localTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
+      localTxSubmissionProtocol = OnOff False
+      localTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
+      localTxSubmissionServer = OnOff False
+      mempool :: OnOff TraceMempool
+      mempool = OnOff True
+      mux :: OnOff TraceMux
+      mux = OnOff True
+      txInbound :: OnOff TraceTxInbound
+      txInbound = OnOff False
+      txOutbound :: OnOff TraceTxOutbound
+      txOutbound = OnOff False
+      txSubmissionProtocol :: OnOff TraceTxSubmissionProtocol
+      txSubmissionProtocol = OnOff False in
+
   TracingOn <$> (TraceSelection
     <$> v .:? "TracingVerbosity" .!= NormalVerbosity
     -- Per-trace toggles, alpha-sorted.
-    <*> v .:? "TraceAcceptPolicy" .!= False
-    <*> v .:? "TraceBlockchainTime" .!= False
-    <*> v .:? "TraceBlockFetchClient" .!= False
-    <*> v .:? "TraceBlockFetchDecisions" .!= True
-    <*> v .:? "TraceBlockFetchProtocol" .!= False
-    <*> v .:? "TraceBlockFetchProtocolSerialised" .!= False
-    <*> v .:? "TraceBlockFetchServer" .!= False
-    <*> v .:? "TraceChainDb" .!= True
-    <*> v .:? "TraceChainSyncClient" .!= True
-    <*> v .:? "TraceChainSyncBlockServer" .!= False
-    <*> v .:? "TraceChainSyncHeaderServer" .!= False
-    <*> v .:? "TraceChainSyncProtocol" .!= False
-    <*> v .:? "TraceDNSResolver" .!= False
-    <*> v .:? "TraceDNSSubscription" .!= True
-    <*> v .:? "TraceErrorPolicy" .!= True
-    <*> v .:? "TraceForge" .!= True
-    <*> v .:? "TraceForgeStateInfo" .!= True
-    <*> v .:? "TraceHandshake" .!= False
-    <*> v .:? "TraceIpSubscription" .!= True
-    <*> v .:? "TraceKeepAliveClient" .!= False
-    <*> v .:? "TraceLocalChainSyncProtocol" .!= False
-    <*> v .:? "TraceLocalErrorPolicy" .!= True
-    <*> v .:? "TraceLocalHandshake" .!= False
-    <*> v .:? "TraceLocalTxSubmissionProtocol" .!= False
-    <*> v .:? "TraceLocalTxSubmissionServer" .!= False
-    <*> v .:? "TraceLocalStateQueryProtocol" .!= False
-    <*> v .:? "TraceMempool" .!= True
-    <*> v .:? "TraceMux" .!= True
-    <*> v .:? "TraceTxInbound" .!= False
-    <*> v .:? "TraceTxOutbound" .!= False
-    <*> v .:? "TraceTxSubmissionProtocol" .!= False)
+    <*> v .:? getName acceptPolicy .!= acceptPolicy
+    <*> v .:? getName blockFetchClient .!=  blockFetchClient
+    <*> v .:? getName blockFetchDecisions .!= blockFetchDecisions
+    <*> v .:? getName blockFetchProtocol .!= blockFetchProtocol
+    <*> v .:? getName blockFetchProtocolSerialised .!= blockFetchProtocolSerialised
+    <*> v .:? getName blockFetchServer .!= blockFetchServer
+    <*> v .:? getName blockchainTime .!= blockchainTime
+    <*> v .:? getName chainDB .!=  chainDB
+    <*> v .:? getName chainSyncBlockServer .!= chainSyncBlockServer
+    <*> v .:? getName chainSyncClient .!= chainSyncClient
+    <*> v .:? getName chainSyncHeaderServer .!= chainSyncHeaderServer
+    <*> v .:? getName chainSyncProtocol .!= chainSyncProtocol
+    <*> v .:? getName dnsResolver .!= dnsResolver
+    <*> v .:? getName dnsSubscription .!= dnsSubscription
+    <*> v .:? getName errorPolicy .!=  errorPolicy
+    <*> v .:? getName forge .!= forge
+    <*> v .:? getName forgeStateInfo .!= forgeStateInfo
+    <*> v .:? getName handshake .!= handshake
+    <*> v .:? getName ipSubscription .!= ipSubscription
+    <*> v .:? getName keepAliveClient .!= keepAliveClient
+    <*> v .:? getName localChainSyncProtocol .!= localChainSyncProtocol
+    <*> v .:? getName localErrorPolicy .!= localErrorPolicy
+    <*> v .:? getName localHandshake .!= localHandshake
+    <*> v .:? getName localStateQueryProtocol .!= localStateQueryProtocol
+    <*> v .:? getName localTxSubmissionProtocol .!= localTxSubmissionProtocol
+    <*> v .:? getName localTxSubmissionServer .!= localTxSubmissionServer
+    <*> v .:? getName mempool .!= mempool
+    <*> v .:? getName mux .!= mux
+    <*> v .:? getName txInbound .!= txInbound
+    <*> v .:? getName txOutbound .!= txOutbound
+    <*> v .:? getName txSubmissionProtocol .!= txSubmissionProtocol)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -944,29 +944,32 @@ traceCounter logValueName aCounter tracer = do
   traceNamedObject (appendName "metrics" tracer)
                    (meta, LogValue logValueName (PureI $ fromIntegral aCounter))
 
-tracerOnOff
-  :: Transformable Text IO a
-  => Bool -> TracingVerbosity -> LoggerName -> Trace IO Text -> Tracer IO a
-tracerOnOff False _ _ _ = nullTracer
-tracerOnOff True verb name trcer = annotateSeverity
-                                $ toLogObject' verb
-                                $ appendName name trcer
+tracerOnOff :: Transformable Text IO a
+            => OnOff b
+            -> TracingVerbosity
+            -> LoggerName
+            -> Trace IO Text
+            -> Tracer IO a
+tracerOnOff (OnOff False) _ _ _ = nullTracer
+tracerOnOff (OnOff True) verb name trcer = annotateSeverity
+                                        $ toLogObject' verb
+                                        $ appendName name trcer
 
 tracerOnOff'
-  :: Bool -> Tracer IO a -> Tracer IO a
-tracerOnOff' False _ = nullTracer
-tracerOnOff' True tr = tr
+  :: OnOff b -> Tracer IO a -> Tracer IO a
+tracerOnOff' (OnOff False) _ = nullTracer
+tracerOnOff' (OnOff True) tr = tr
 
 instance Show a => Show (WithSeverity a) where
   show (WithSeverity _sev a) = show a
 
 showOnOff
   :: (Show a, HasSeverityAnnotation a)
-  => Bool -> LoggerName -> Trace IO Text -> Tracer IO a
-showOnOff False _ _ = nullTracer
-showOnOff True name trcer = annotateSeverity
-                                $ showTracing
-                                $ withName name trcer
+  => OnOff b -> LoggerName -> Trace IO Text -> Tracer IO a
+showOnOff (OnOff False) _ _ = nullTracer
+showOnOff (OnOff True) name trcer = annotateSeverity
+                                        $ showTracing
+                                        $ withName name trcer
 
 withName :: Text -> Trace IO Text -> Tracer IO String
 withName name tr = contramap Text.pack $ toLogObject $ appendName name tr


### PR DESCRIPTION
TraceSelection contains 30+ bools for enabling/disabling different
tracers. This turns a bug in the order of those fields in
traceConfigParser from a run time error into a compile time error.
Based on an idea from @coot .