### PR TITLE
API changes for the Allegra & Mary eras

### DIFF
--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -55,19 +55,32 @@ module Cardano.API (
     -- * Payment addresses
     -- | Constructing and inspecting normal payment addresses
     Address,
-    NetworkId
-      ( Mainnet
-      , Testnet
-      ),
-    -- * Byron addresses
+    ByronAddr,
+    ShelleyAddr,
+    NetworkId(..),
+    -- ** Byron addresses
     makeByronAddress,
     ByronKey,
-    -- * Shelley addresses
+
+    -- ** Shelley addresses
     makeShelleyAddress,
-    PaymentCredential,
-    StakeAddressReference,
+    PaymentCredential(..),
+    StakeAddressReference(..),
     PaymentKey,
     PaymentExtendedKey,
+
+    -- ** Addresses in any era
+    AddressAny(..),
+
+    -- ** Addresses in specific eras
+    AddressInEra(..),
+    AddressTypeInEra(..),
+    byronAddressInEra,
+    shelleyAddressInEra,
+    anyAddressInShelleyBasedEra,
+    anyAddressInEra,
+    makeByronAddressInEra,
+    makeShelleyAddressInEra,
 
     -- * Stake addresses
     -- | Constructing and inspecting stake addresses

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -16,6 +16,13 @@ module Cardano.API (
     ShelleyEra,
     AllegraEra,
     MaryEra,
+    CardanoEra(..),
+    CardanoEraStyle(..),
+    IsCardanoEra(..),
+    -- ** Shelley-based eras
+    ShelleyBasedEra(..),
+    IsShelleyBasedEra(..),
+    ShelleyLedgerEra,
     -- ** Deprecated
     Byron,
     Shelley,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -11,6 +11,17 @@
 --
 
 module Cardano.API (
+    -- * Eras
+    ByronEra,
+    ShelleyEra,
+    AllegraEra,
+    MaryEra,
+    -- ** Deprecated
+    Byron,
+    Shelley,
+    Allegra,
+    Mary,
+    -- * Type tags
     HasTypeProxy(..),
     AsType(..),
     -- * Cryptographic key interface

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -105,23 +105,23 @@ data Address era where
        :: Shelley.Network
        -> Shelley.PaymentCredential StandardShelley
        -> Shelley.StakeReference    StandardShelley
-       -> Address Shelley
+       -> Address ShelleyEra
 
 deriving instance Eq (Address era)
 deriving instance Ord (Address era)
 deriving instance Show (Address era)
 
 
-instance HasTypeProxy (Address Byron) where
-    data AsType (Address Byron) = AsByronAddress
+instance HasTypeProxy (Address ByronEra) where
+    data AsType (Address ByronEra) = AsByronAddress
     proxyToAsType _ = AsByronAddress
 
-instance HasTypeProxy (Address Shelley) where
-    data AsType (Address Shelley) = AsShelleyAddress
+instance HasTypeProxy (Address ShelleyEra) where
+    data AsType (Address ShelleyEra) = AsShelleyAddress
     proxyToAsType _ = AsShelleyAddress
 
 
-instance SerialiseAsRawBytes (Address Byron) where
+instance SerialiseAsRawBytes (Address ByronEra) where
     serialiseToRawBytes (ByronAddress addr) = CBOR.serialize' addr
 
     deserialiseFromRawBytes AsByronAddress bs =
@@ -130,7 +130,7 @@ instance SerialiseAsRawBytes (Address Byron) where
         Right addr -> Just (ByronAddress addr)
 
 
-instance SerialiseAsRawBytes (Address Shelley) where
+instance SerialiseAsRawBytes (Address ShelleyEra) where
     serialiseToRawBytes (ByronAddress addr) =
         Shelley.serialiseAddr
       . Shelley.AddrBootstrap
@@ -149,7 +149,7 @@ instance SerialiseAsRawBytes (Address Shelley) where
           Just (Shelley.AddrBootstrap (Shelley.BootstrapAddress addr)) ->
             Just (ByronAddress addr)
 
-instance SerialiseAsBech32 (Address Shelley) where
+instance SerialiseAsBech32 (Address ShelleyEra) where
     bech32PrefixFor (ShelleyAddress Shelley.Mainnet _ _) = "addr"
     bech32PrefixFor (ShelleyAddress Shelley.Testnet _ _) = "addr_test"
     bech32PrefixFor (ByronAddress _)                     = "addr"
@@ -157,7 +157,7 @@ instance SerialiseAsBech32 (Address Shelley) where
     bech32PrefixesPermitted AsShelleyAddress = ["addr", "addr_test"]
 
 
-instance SerialiseAddress (Address Byron) where
+instance SerialiseAddress (Address ByronEra) where
     serialiseAddress addr@ByronAddress{} =
          Text.decodeLatin1
        . Base58.encodeBase58 Base58.bitcoinAlphabet
@@ -168,9 +168,9 @@ instance SerialiseAddress (Address Byron) where
       bs <- Base58.decodeBase58 Base58.bitcoinAlphabet (Text.encodeUtf8 txt)
       deserialiseFromRawBytes AsByronAddress bs
 
-instance SerialiseAddress (Address Shelley) where
+instance SerialiseAddress (Address ShelleyEra) where
     serialiseAddress (ByronAddress addr) =
-      serialiseAddress (ByronAddress addr :: Address Byron)
+      serialiseAddress (ByronAddress addr :: Address ByronEra)
 
     serialiseAddress addr@ShelleyAddress{} =
       serialiseToBech32 addr
@@ -187,7 +187,7 @@ instance SerialiseAddress (Address Shelley) where
           castByronToShelleyAddress <$>
           deserialiseAddress AsByronAddress t
 
-        castByronToShelleyAddress :: Address Byron -> Address Shelley
+        castByronToShelleyAddress :: Address ByronEra -> Address ShelleyEra
         castByronToShelleyAddress (ByronAddress addr) = ByronAddress addr
 
 
@@ -204,7 +204,7 @@ makeByronAddress nw (ByronVerificationKey vk) =
 makeShelleyAddress :: NetworkId
                    -> PaymentCredential
                    -> StakeAddressReference
-                   -> Address Shelley
+                   -> Address ShelleyEra
 makeShelleyAddress nw pc scr =
     ShelleyAddress
       (toShelleyNetwork nw)

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Cardano addresses: payment and stake addresses.
@@ -9,15 +11,29 @@ module Cardano.Api.Address (
     -- * Payment addresses
     -- | Constructing and inspecting normal payment addresses
     Address(..),
-    -- * Byron addresses
+
+    -- ** Byron addresses
+    ByronAddr,
     makeByronAddress,
-    ByronKey,
-    -- * Shelley addresses
+
+    -- ** Shelley addresses
+    ShelleyAddr,
     makeShelleyAddress,
     PaymentCredential(..),
     StakeAddressReference(..),
-    PaymentKey,
-    PaymentExtendedKey,
+
+    -- ** Addresses in any era
+    AddressAny(..),
+
+    -- ** Addresses in specific eras
+    AddressInEra(..),
+    AddressTypeInEra(..),
+    byronAddressInEra,
+    shelleyAddressInEra,
+    anyAddressInShelleyBasedEra,
+    anyAddressInEra,
+    makeByronAddressInEra,
+    makeShelleyAddressInEra,
 
     -- * Stake addresses
     -- | Constructing and inspecting stake addresses
@@ -36,18 +52,18 @@ module Cardano.Api.Address (
     SerialiseAddress(..),
 
     -- * Data family instances
-    AsType(..)
+    AsType(AsByronAddr, AsShelleyAddr, AsByronAddress, AsShelleyAddress,
+           AsAddress, AsAddressAny, AsAddressInEra, AsStakeAddress)
   ) where
 
 import           Prelude
 
+import           Data.Coerce
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import qualified Data.ByteString.Base58 as Base58
 
 import           Control.Applicative
-
-import qualified Cardano.Binary as CBOR
 
 import qualified Cardano.Chain.Common as Byron
 
@@ -61,7 +77,6 @@ import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Key
 import           Cardano.Api.KeysByron
-import           Cardano.Api.KeysPraos
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.NetworkId
 import           Cardano.Api.Script
@@ -88,112 +103,137 @@ class HasTypeProxy addr => SerialiseAddress addr where
 
 
 -- ----------------------------------------------------------------------------
+-- Payment address types
+--
+
+-- | A type used as a tag to distinguish Byron addresses.
+data ByronAddr
+
+-- | A type used as a tag to distinguish Shelley addresses.
+data ShelleyAddr
+
+instance HasTypeProxy ByronAddr where
+    data AsType ByronAddr = AsByronAddr
+    proxyToAsType _ = AsByronAddr
+
+instance HasTypeProxy ShelleyAddr where
+    data AsType ShelleyAddr = AsShelleyAddr
+    proxyToAsType _ = AsShelleyAddr
+
+
+-- ----------------------------------------------------------------------------
 -- Payment addresses
 --
 
-data Address era where
+-- | Addresses are used as locations where assets live. The address determines
+-- the rights needed to spend assets at the address: in particular holding some
+-- signing key or being able to satisfy the conditions of a script.
+--
+-- There are currently two types of address:
+--
+-- * Byron addresses, which use the type tag 'ByronAddr'; and
+-- * Shelley addresses, which use the type tag 'ShelleyAddr'. Notably, Shelley
+--   addresses support scripts and stake delegation.
+--
+-- The /address type/ is subtly from the /ledger era/ in which each
+-- address type is valid: while Byron addresses are the only choice in the
+-- Byron era, the Shelley era and all subsequent eras support both Byron and
+-- Shelley addresses. The 'Address' type param only says the type of the address
+-- (either Byron or Shelley). The 'AddressInEra' type connects the address type
+-- with the era in which it is supported.
+--
+data Address addrtype where
 
-     -- | Byron addresses are valid in both the Byron and Shelley era.
+     -- | Byron addresses were the only supported address type in the original
+     -- Byron era.
      --
      ByronAddress
        :: Byron.Address
-       -> Address era
+       -> Address ByronAddr
 
-     -- | Shelley addresses are only valid in the Shelley era.
+     -- | Shelley addresses allow delegation. Shelley addresses were introduced
+     -- in Shelley era and are thus supported from the Shelley era onwards
      --
      ShelleyAddress
        :: Shelley.Network
        -> Shelley.PaymentCredential StandardShelley
        -> Shelley.StakeReference    StandardShelley
-       -> Address ShelleyEra
+       -> Address ShelleyAddr
+       -- Note that the two ledger credential types here are parametrised by
+       -- the era, but in fact this is a phantom type parameter and they are
+       -- the same for all eras. See 'toShelleyAddr' below.
 
-deriving instance Eq (Address era)
-deriving instance Ord (Address era)
-deriving instance Show (Address era)
-
-
-instance HasTypeProxy (Address ByronEra) where
-    data AsType (Address ByronEra) = AsByronAddress
-    proxyToAsType _ = AsByronAddress
-
-instance HasTypeProxy (Address ShelleyEra) where
-    data AsType (Address ShelleyEra) = AsShelleyAddress
-    proxyToAsType _ = AsShelleyAddress
+deriving instance Eq   (Address addrtype)
+deriving instance Ord  (Address addrtype)
+deriving instance Show (Address addrtype)
 
 
-instance SerialiseAsRawBytes (Address ByronEra) where
-    serialiseToRawBytes (ByronAddress addr) = CBOR.serialize' addr
+instance HasTypeProxy addrtype => HasTypeProxy (Address addrtype) where
+    data AsType (Address addrtype) = AsAddress (AsType addrtype)
+    proxyToAsType _ = AsAddress (proxyToAsType (Proxy :: Proxy addrtype))
 
-    deserialiseFromRawBytes AsByronAddress bs =
-      case CBOR.decodeFull' bs of
-        Left  _    -> Nothing
-        Right addr -> Just (ByronAddress addr)
+pattern AsByronAddress :: AsType (Address ByronAddr)
+pattern AsByronAddress   = AsAddress AsByronAddr
+{-# COMPLETE AsByronAddress #-}
 
+pattern AsShelleyAddress :: AsType (Address ShelleyAddr)
+pattern AsShelleyAddress = AsAddress AsShelleyAddr
+{-# COMPLETE AsShelleyAddress #-}
 
-instance SerialiseAsRawBytes (Address ShelleyEra) where
+instance SerialiseAsRawBytes (Address ByronAddr) where
     serialiseToRawBytes (ByronAddress addr) =
         Shelley.serialiseAddr
       . Shelley.AddrBootstrap
       . Shelley.BootstrapAddress
       $ addr
 
-    serialiseToRawBytes (ShelleyAddress nw pc scr) =
-        Shelley.serialiseAddr (Shelley.Addr nw pc scr)
-
-    deserialiseFromRawBytes AsShelleyAddress bs =
-        case Shelley.deserialiseAddr bs of
-          Nothing -> Nothing
-          Just (Shelley.Addr nw pc scr) ->
-            Just (ShelleyAddress nw pc scr)
-
+    deserialiseFromRawBytes (AsAddress AsByronAddr) bs =
+        case Shelley.deserialiseAddr bs :: Maybe (Shelley.Addr StandardShelley) of
+          Nothing             -> Nothing
+          Just Shelley.Addr{} -> Nothing
           Just (Shelley.AddrBootstrap (Shelley.BootstrapAddress addr)) ->
             Just (ByronAddress addr)
 
-instance SerialiseAsBech32 (Address ShelleyEra) where
+instance SerialiseAsRawBytes (Address ShelleyAddr) where
+    serialiseToRawBytes (ShelleyAddress nw pc scr) =
+        Shelley.serialiseAddr (Shelley.Addr nw pc scr)
+
+    deserialiseFromRawBytes (AsAddress AsShelleyAddr) bs =
+        case Shelley.deserialiseAddr bs of
+          Nothing                       -> Nothing
+          Just Shelley.AddrBootstrap{}  -> Nothing
+          Just (Shelley.Addr nw pc scr) -> Just (ShelleyAddress nw pc scr)
+
+instance SerialiseAsBech32 (Address ShelleyAddr) where
     bech32PrefixFor (ShelleyAddress Shelley.Mainnet _ _) = "addr"
     bech32PrefixFor (ShelleyAddress Shelley.Testnet _ _) = "addr_test"
-    bech32PrefixFor (ByronAddress _)                     = "addr"
 
-    bech32PrefixesPermitted AsShelleyAddress = ["addr", "addr_test"]
+    bech32PrefixesPermitted (AsAddress AsShelleyAddr) = ["addr", "addr_test"]
 
 
-instance SerialiseAddress (Address ByronEra) where
+instance SerialiseAddress (Address ByronAddr) where
     serialiseAddress addr@ByronAddress{} =
          Text.decodeLatin1
        . Base58.encodeBase58 Base58.bitcoinAlphabet
        . serialiseToRawBytes
        $ addr
 
-    deserialiseAddress AsByronAddress txt = do
+    deserialiseAddress (AsAddress AsByronAddr) txt = do
       bs <- Base58.decodeBase58 Base58.bitcoinAlphabet (Text.encodeUtf8 txt)
-      deserialiseFromRawBytes AsByronAddress bs
+      deserialiseFromRawBytes (AsAddress AsByronAddr) bs
 
-instance SerialiseAddress (Address ShelleyEra) where
-    serialiseAddress (ByronAddress addr) =
-      serialiseAddress (ByronAddress addr :: Address ByronEra)
-
+instance SerialiseAddress (Address ShelleyAddr) where
     serialiseAddress addr@ShelleyAddress{} =
       serialiseToBech32 addr
 
-    deserialiseAddress AsShelleyAddress t =
-          deserialiseAsShelleyAddress
-      <|> deserialiseAsByronAddress
-      where
-        deserialiseAsShelleyAddress =
-          either (const Nothing) Just $
-          deserialiseFromBech32 AsShelleyAddress t
-
-        deserialiseAsByronAddress =
-          castByronToShelleyAddress <$>
-          deserialiseAddress AsByronAddress t
-
-        castByronToShelleyAddress :: Address ByronEra -> Address ShelleyEra
-        castByronToShelleyAddress (ByronAddress addr) = ByronAddress addr
+    deserialiseAddress (AsAddress AsShelleyAddr) t =
+      either (const Nothing) Just $
+      deserialiseFromBech32 (AsAddress AsShelleyAddr) t
 
 
 makeByronAddress :: NetworkId
                  -> VerificationKey ByronKey
-                 -> Address era
+                 -> Address ByronAddr
 makeByronAddress nw (ByronVerificationKey vk) =
     ByronAddress $
       Byron.makeVerKeyAddress
@@ -204,12 +244,160 @@ makeByronAddress nw (ByronVerificationKey vk) =
 makeShelleyAddress :: NetworkId
                    -> PaymentCredential
                    -> StakeAddressReference
-                   -> Address ShelleyEra
+                   -> Address ShelleyAddr
 makeShelleyAddress nw pc scr =
     ShelleyAddress
       (toShelleyNetwork nw)
       (toShelleyPaymentCredential pc)
       (toShelleyStakeReference scr)
+
+
+-- ----------------------------------------------------------------------------
+-- Either type of address
+--
+
+-- | Either a Byron address or a Shelley address.
+--
+-- Sometimes we need to be able to work with either of the two types of
+-- address (Byron or Shelley addresses), but without reference to an era in
+-- which the address will be used. This type serves that purpose.
+--
+data AddressAny = AddressByron   !(Address ByronAddr)
+                | AddressShelley !(Address ShelleyAddr)
+  deriving (Eq, Ord, Show)
+
+instance HasTypeProxy AddressAny where
+    data AsType AddressAny = AsAddressAny
+    proxyToAsType _ = AsAddressAny
+
+instance SerialiseAsRawBytes AddressAny where
+    serialiseToRawBytes (AddressByron   addr) = serialiseToRawBytes addr
+    serialiseToRawBytes (AddressShelley addr) = serialiseToRawBytes addr
+
+    deserialiseFromRawBytes AsAddressAny bs =
+      case Shelley.deserialiseAddr bs of
+        Nothing -> Nothing
+        Just (Shelley.AddrBootstrap (Shelley.BootstrapAddress addr)) ->
+          Just (AddressByron (ByronAddress addr))
+
+        Just (Shelley.Addr nw pc scr) ->
+          Just (AddressShelley (ShelleyAddress nw pc scr))
+
+instance SerialiseAddress AddressAny where
+    serialiseAddress (AddressByron   addr) = serialiseAddress addr
+    serialiseAddress (AddressShelley addr) = serialiseAddress addr
+
+    deserialiseAddress AsAddressAny t =
+          (AddressByron   <$> deserialiseAddress (AsAddress AsByronAddr)   t)
+      <|> (AddressShelley <$> deserialiseAddress (AsAddress AsShelleyAddr) t)
+
+
+-- ----------------------------------------------------------------------------
+-- Addresses in the context of a ledger era
+--
+
+-- | An 'Address' that can be used in a particular ledger era.
+--
+-- All current ledger eras support Byron addresses. Shelley addresses are
+-- supported in the 'ShelleyEra' and later eras.
+--
+data AddressInEra era where
+     AddressInEra :: AddressTypeInEra addrtype era
+                  -> Address addrtype
+                  -> AddressInEra era
+
+instance Eq (AddressInEra era) where
+  (==) (AddressInEra ByronAddressInAnyEra addr1)
+       (AddressInEra ByronAddressInAnyEra addr2) = addr1 == addr2
+
+  (==) (AddressInEra ShelleyAddressInEra{} addr1)
+       (AddressInEra ShelleyAddressInEra{} addr2) = addr1 == addr2
+
+  (==) (AddressInEra ByronAddressInAnyEra _)
+       (AddressInEra ShelleyAddressInEra{} _) = False
+
+  (==) (AddressInEra ShelleyAddressInEra{} _)
+       (AddressInEra ByronAddressInAnyEra _) = False
+
+deriving instance Show (AddressInEra era)
+
+data AddressTypeInEra addrtype era where
+
+     ByronAddressInAnyEra :: AddressTypeInEra ByronAddr era
+
+     ShelleyAddressInEra  :: ShelleyBasedEra era
+                          -> AddressTypeInEra ShelleyAddr era
+
+deriving instance Show (AddressTypeInEra addrtype era)
+
+
+instance HasTypeProxy era => HasTypeProxy (AddressInEra era) where
+    data AsType (AddressInEra era) = AsAddressInEra (AsType era)
+    proxyToAsType _ = AsAddressInEra (proxyToAsType (Proxy :: Proxy era))
+
+instance IsCardanoEra era => SerialiseAsRawBytes (AddressInEra era) where
+
+    serialiseToRawBytes (AddressInEra ByronAddressInAnyEra addr) =
+      serialiseToRawBytes addr
+
+    serialiseToRawBytes (AddressInEra ShelleyAddressInEra{} addr) =
+      serialiseToRawBytes addr
+
+    deserialiseFromRawBytes _ bs = do
+      anyAddressInEra =<< deserialiseFromRawBytes AsAddressAny bs
+
+instance IsCardanoEra era => SerialiseAddress (AddressInEra era) where
+    serialiseAddress (AddressInEra ByronAddressInAnyEra addr) =
+      serialiseAddress addr
+
+    serialiseAddress (AddressInEra ShelleyAddressInEra{} addr) =
+      serialiseAddress addr
+
+    deserialiseAddress _ t =
+      anyAddressInEra =<< deserialiseAddress AsAddressAny t
+
+
+byronAddressInEra :: Address ByronAddr -> AddressInEra era
+byronAddressInEra = AddressInEra ByronAddressInAnyEra
+
+
+shelleyAddressInEra :: IsShelleyBasedEra era
+                    => Address ShelleyAddr -> AddressInEra era
+shelleyAddressInEra = AddressInEra (ShelleyAddressInEra shelleyBasedEra)
+
+
+anyAddressInShelleyBasedEra :: IsShelleyBasedEra era
+                            => AddressAny -> AddressInEra era
+anyAddressInShelleyBasedEra (AddressByron   addr) = byronAddressInEra addr
+anyAddressInShelleyBasedEra (AddressShelley addr) = shelleyAddressInEra addr
+
+
+anyAddressInEra :: IsCardanoEra era
+                => AddressAny
+                -> Maybe (AddressInEra era)
+anyAddressInEra (AddressByron addr) =
+    Just (AddressInEra ByronAddressInAnyEra addr)
+
+anyAddressInEra (AddressShelley addr) =
+    case cardanoEraStyle of
+      LegacyByronEra      -> Nothing
+      ShelleyBasedEra era -> Just (AddressInEra (ShelleyAddressInEra era) addr)
+
+
+makeByronAddressInEra :: NetworkId
+                      -> VerificationKey ByronKey
+                      -> AddressInEra era
+makeByronAddressInEra nw vk =
+    byronAddressInEra (makeByronAddress nw vk)
+
+
+makeShelleyAddressInEra :: IsShelleyBasedEra era
+                        => NetworkId
+                        -> PaymentCredential
+                        -> StakeAddressReference
+                        -> AddressInEra era
+makeShelleyAddressInEra nw pc scr =
+    shelleyAddressInEra (makeShelleyAddress nw pc scr)
 
 
 -- ----------------------------------------------------------------------------
@@ -288,10 +476,26 @@ makeStakeAddress nw sc =
 -- Internal conversion functions
 --
 
-toShelleyAddr :: Address era -> Shelley.Addr StandardShelley
-toShelleyAddr (ByronAddress addr)        = Shelley.AddrBootstrap
-                                             (Shelley.BootstrapAddress addr)
-toShelleyAddr (ShelleyAddress nw pc scr) = Shelley.Addr nw pc scr
+toShelleyAddr :: AddressInEra era -> Shelley.Addr (ShelleyLedgerEra era)
+toShelleyAddr (AddressInEra ByronAddressInAnyEra (ByronAddress addr)) =
+    Shelley.AddrBootstrap (Shelley.BootstrapAddress addr)
+toShelleyAddr (AddressInEra (ShelleyAddressInEra _)
+                            (ShelleyAddress nw pc scr)) =
+    Shelley.Addr nw
+      (coerceShelleyPaymentCredential pc)
+      (coerceShelleyStakeReference   scr)
+  where
+    -- The era parameter in these types is a phantom type so it is safe to cast.
+    -- We choose to cast because we need to use an era-independent address
+    -- representation, but have to produce an era-dependent format used by the
+    -- Shelley ledger lib.
+    coerceShelleyPaymentCredential :: Shelley.PaymentCredential eraA
+                                   -> Shelley.PaymentCredential eraB
+    coerceShelleyPaymentCredential = coerce
+
+    coerceShelleyStakeReference :: Shelley.StakeReference eraA
+                                -> Shelley.StakeReference eraB
+    coerceShelleyStakeReference = coerce
 
 toShelleyStakeAddr :: StakeAddress -> Shelley.RewardAcnt StandardShelley
 toShelleyStakeAddr (StakeAddress nw sc) =

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -5,16 +5,6 @@
 
 module Cardano.Api.Byron
   ( module Cardano.API,
-    -- * Era
-    Byron,
-    HasTypeProxy(..),
-    AsType
-      ( AsByronAddress
-      , AsByronKey
-      , AsByronTx
-      , AsByronTxBody
-      , AsByronWitness
-      ),
 
     -- * Cryptographic key interface
     -- $keys

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -1,47 +1,89 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 
 -- | Cardano eras, sometimes we have to distinguish them.
 --
 module Cardano.Api.Eras
   ( -- * Eras
-    Byron
+    ByronEra
+  , ShelleyEra
+  , AllegraEra
+  , MaryEra
+
+    -- * Deprecated aliases
+  , Byron
   , Shelley
   , Allegra
   , Mary
-  , AsType(..)
+
+    -- * Data family instances
+  , AsType(AsByronEra, AsShelleyEra, AsAllegraEra, AsMaryEra,
+           AsByron,    AsShelley,    AsAllegra,    AsMary)
   ) where
 
 import           Cardano.Api.HasTypeProxy
 
 
 -- | A type used as a tag to distinguish the Byron era.
-data Byron
+data ByronEra
 
 -- | A type used as a tag to distinguish the Shelley era.
-data Shelley
+data ShelleyEra
 
 -- | A type used as a tag to distinguish the Allegra era.
-data Allegra
+data AllegraEra
 
 -- | A type used as a tag to distinguish the Mary era.
-data Mary
+data MaryEra
 
 
-instance HasTypeProxy Byron where
-    data AsType Byron = AsByron
-    proxyToAsType _ = AsByron
+instance HasTypeProxy ByronEra where
+    data AsType ByronEra = AsByronEra
+    proxyToAsType _ = AsByronEra
 
-instance HasTypeProxy Shelley where
-    data AsType Shelley = AsShelley
-    proxyToAsType _ = AsShelley
+instance HasTypeProxy ShelleyEra where
+    data AsType ShelleyEra = AsShelleyEra
+    proxyToAsType _ = AsShelleyEra
 
-instance HasTypeProxy Allegra where
-    data AsType Allegra = AsAllegra
-    proxyToAsType _ = AsAllegra
+instance HasTypeProxy AllegraEra where
+    data AsType AllegraEra = AsAllegraEra
+    proxyToAsType _ = AsAllegraEra
 
-instance HasTypeProxy Mary where
-    data AsType Mary = AsMary
-    proxyToAsType _ = AsMary
+instance HasTypeProxy MaryEra where
+    data AsType MaryEra = AsMaryEra
+    proxyToAsType _ = AsMaryEra
+
+
+-- ----------------------------------------------------------------------------
+-- Deprecated aliases
+--
+
+type Byron   = ByronEra
+type Shelley = ShelleyEra
+type Allegra = AllegraEra
+type Mary    = MaryEra
+
+{-# DEPRECATED Byron   "Use 'ByronEra' or 'ByronAddr' as appropriate" #-}
+{-# DEPRECATED Shelley "Use 'ShelleyEra' or 'ShelleyAddr' as appropriate" #-}
+{-# DEPRECATED Allegra "Use 'AllegraEra' instead" #-}
+{-# DEPRECATED Mary    "Use 'MaryEra' instead" #-}
+
+pattern AsByron   :: AsType ByronEra
+pattern AsByron    = AsByronEra
+
+pattern AsShelley :: AsType ShelleyEra
+pattern AsShelley  = AsShelleyEra
+
+pattern AsAllegra :: AsType AllegraEra
+pattern AsAllegra  = AsAllegraEra
+
+pattern AsMary    :: AsType MaryEra
+pattern AsMary     = AsMaryEra
+
+{-# DEPRECATED AsByron   "Use 'AsByronEra' instead" #-}
+{-# DEPRECATED AsShelley "Use 'AsShelleyEra' instead" #-}
+{-# DEPRECATED AsAllegra "Use 'AsAllegraEra' instead" #-}
+{-# DEPRECATED AsMary    "Use 'AsMaryEra' instead" #-}
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -36,7 +36,7 @@ import           Cardano.Api.Value
 --
 transactionFee :: Natural -- ^ The fixed tx fee
                -> Natural -- ^ The tx fee per byte
-               -> Tx Shelley
+               -> Tx ShelleyEra
                -> Lovelace
 transactionFee txFeeFixed txFeePerByte (ShelleyTx tx) =
     Lovelace (a * x + b)
@@ -59,7 +59,7 @@ transactionFee txFeeFixed txFeePerByte (ShelleyTx tx) =
 estimateTransactionFee :: NetworkId
                        -> Natural -- ^ The fixed tx fee
                        -> Natural -- ^ The tx fee per byte
-                       -> Tx Shelley
+                       -> Tx ShelleyEra
                        -> Int -- ^ The number of extra UTxO transaction inputs
                        -> Int -- ^ The number of extra transaction outputs
                        -> Int -- ^ The number of extra Shelley key witnesses

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -13,6 +13,8 @@ module Cardano.Api.Shelley
     -- * Payment addresses
     -- | Constructing and inspecting Shelley payment addresses
     Address(ShelleyAddress),
+    toShelleyAddr,
+    toShelleyStakeAddr,
     NetworkId(Mainnet, Testnet),
 
     -- * Building transactions
@@ -23,6 +25,7 @@ module Cardano.Api.Shelley
     TxOut(TxOut),
     TxIx(TxIx),
     Lovelace(Lovelace),
+    toShelleyLovelace,
     SlotNo(SlotNo),
 
     -- * Signing transactions
@@ -155,6 +158,8 @@ module Cardano.Api.Shelley
 
 import           Cardano.API
 import           Cardano.Api.Typed
+import           Cardano.Api.Address
+import           Cardano.Api.Value
 
 
 -- For the deprecated functions below

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -5,13 +5,6 @@
 
 module Cardano.Api.Shelley
   ( module Cardano.API,
-    -- * Era
-    Shelley,
-    HasTypeProxy(..),
-    AsType(AsShelleyAddress,
-           AsShelleyTxBody,
-           AsShelleyTx,
-           AsShelleyWitness),
 
     -- * Cryptographic key interface
     -- $keys

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -118,35 +118,35 @@ data Tx era where
 
      ByronTx
        :: Byron.ATxAux ByteString
-       -> Tx Byron
+       -> Tx ByronEra
 
      ShelleyTx
        :: Shelley.Tx StandardShelley
-       -> Tx Shelley
+       -> Tx ShelleyEra
 
-deriving instance Eq (Tx Byron)
-deriving instance Show (Tx Byron)
+deriving instance Eq (Tx ByronEra)
+deriving instance Show (Tx ByronEra)
 
-deriving instance Eq (Tx Shelley)
-deriving instance Show (Tx Shelley)
+deriving instance Eq (Tx ShelleyEra)
+deriving instance Show (Tx ShelleyEra)
 
-instance HasTypeProxy (Tx Byron) where
-    data AsType (Tx Byron) = AsByronTx
+instance HasTypeProxy (Tx ByronEra) where
+    data AsType (Tx ByronEra) = AsByronTx
     proxyToAsType _ = AsByronTx
 
-instance HasTypeProxy (Tx Shelley) where
-    data AsType (Tx Shelley) = AsShelleyTx
+instance HasTypeProxy (Tx ShelleyEra) where
+    data AsType (Tx ShelleyEra) = AsShelleyTx
     proxyToAsType _ = AsShelleyTx
 
 
-instance SerialiseAsCBOR (Tx Byron) where
+instance SerialiseAsCBOR (Tx ByronEra) where
     serialiseToCBOR (ByronTx tx) = CBOR.recoverBytes tx
 
     deserialiseFromCBOR AsByronTx bs =
       ByronTx <$>
         CBOR.decodeFullAnnotatedBytes "Byron Tx" fromCBOR (LBS.fromStrict bs)
 
-instance SerialiseAsCBOR (Tx Shelley) where
+instance SerialiseAsCBOR (Tx ShelleyEra) where
     serialiseToCBOR (ShelleyTx tx) =
       CBOR.serialize' tx
 
@@ -154,10 +154,10 @@ instance SerialiseAsCBOR (Tx Shelley) where
       ShelleyTx <$>
         CBOR.decodeAnnotator "Shelley Tx" fromCBOR (LBS.fromStrict bs)
 
-instance HasTextEnvelope (Tx Byron) where
+instance HasTextEnvelope (Tx ByronEra) where
     textEnvelopeType _ = "TxSignedByron"
 
-instance HasTextEnvelope (Tx Shelley) where
+instance HasTextEnvelope (Tx ShelleyEra) where
     textEnvelopeType _ = "TxSignedShelley"
 
 
@@ -165,52 +165,52 @@ data Witness era where
 
      ByronKeyWitness
        :: Byron.TxInWitness
-       -> Witness Byron
+       -> Witness ByronEra
 
      ShelleyBootstrapWitness
        :: Shelley.BootstrapWitness StandardShelley
-       -> Witness Shelley
+       -> Witness ShelleyEra
 
      ShelleyKeyWitness
        :: Shelley.WitVKey Shelley.Witness StandardShelley
-       -> Witness Shelley
+       -> Witness ShelleyEra
 
      ShelleyScriptWitness
        :: Shelley.Script StandardShelley
-       -> Witness Shelley
+       -> Witness ShelleyEra
 
      AllegraScriptwitness
        :: Allegra.Timelock StandardAllegra
-       -> Witness Allegra
+       -> Witness AllegraEra
 
      MaryScriptWitness
        :: Allegra.Timelock StandardMary
-       -> Witness Mary
+       -> Witness MaryEra
 
-deriving instance Eq (Witness Byron)
-deriving instance Show (Witness Byron)
+deriving instance Eq (Witness ByronEra)
+deriving instance Show (Witness ByronEra)
 
-deriving instance Eq (Witness Shelley)
-deriving instance Show (Witness Shelley)
+deriving instance Eq (Witness ShelleyEra)
+deriving instance Show (Witness ShelleyEra)
 
-instance HasTypeProxy (Witness Byron) where
-    data AsType (Witness Byron) = AsByronWitness
+instance HasTypeProxy (Witness ByronEra) where
+    data AsType (Witness ByronEra) = AsByronWitness
     proxyToAsType _ = AsByronWitness
 
-instance HasTypeProxy (Witness Shelley) where
-    data AsType (Witness Shelley) = AsShelleyWitness
+instance HasTypeProxy (Witness ShelleyEra) where
+    data AsType (Witness ShelleyEra) = AsShelleyWitness
     proxyToAsType _ = AsShelleyWitness
 
-instance SerialiseAsCBOR (Witness Byron) where
+instance SerialiseAsCBOR (Witness ByronEra) where
     serialiseToCBOR (ByronKeyWitness wit) = CBOR.serialize' wit
 
     deserialiseFromCBOR AsByronWitness bs =
       ByronKeyWitness <$> CBOR.decodeFull' bs
 
-instance SerialiseAsCBOR (Witness Shelley) where
+instance SerialiseAsCBOR (Witness ShelleyEra) where
     serialiseToCBOR = CBOR.serializeEncoding' . encodeShelleyWitness
       where
-        encodeShelleyWitness :: Witness Shelley -> CBOR.Encoding
+        encodeShelleyWitness :: Witness ShelleyEra -> CBOR.Encoding
         encodeShelleyWitness (ShelleyKeyWitness    wit) =
             CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> toCBOR wit
         encodeShelleyWitness (ShelleyBootstrapWitness wit) =
@@ -230,7 +230,7 @@ instance SerialiseAsCBOR (Witness Shelley) where
         CBOR.decodeAnnotator "Shelley Witness"
                              decodeShelleyWitness (LBS.fromStrict bs)
       where
-        decodeShelleyWitness :: CBOR.Decoder s (CBOR.Annotator (Witness Shelley))
+        decodeShelleyWitness :: CBOR.Decoder s (CBOR.Annotator (Witness ShelleyEra))
         decodeShelleyWitness =  do
           CBOR.decodeListLenOf 2
           t <- CBOR.decodeWord
@@ -247,10 +247,10 @@ instance SerialiseAsCBOR (Witness Shelley) where
             _ -> CBOR.cborError $ CBOR.DecoderErrorUnknownTag
                                     "Shelley Witness" (fromIntegral t)
 
-instance HasTextEnvelope (Witness Byron) where
+instance HasTextEnvelope (Witness ByronEra) where
     textEnvelopeType _ = "TxWitnessByron"
 
-instance HasTextEnvelope (Witness Shelley) where
+instance HasTextEnvelope (Witness ShelleyEra) where
     textEnvelopeType _ = "TxWitnessShelley"
 
 
@@ -294,7 +294,7 @@ makeSignedTransaction witnesses (ByronTxBody txbody) =
       (unAnnotated txbody)
       (Vector.fromList (map selectByronWitness witnesses))
   where
-    selectByronWitness :: Witness Byron -> Byron.TxInWitness
+    selectByronWitness :: Witness ByronEra -> Byron.TxInWitness
     selectByronWitness (ByronKeyWitness w) = w
 
 makeSignedTransaction witnesses (ShelleyTxBody txbody txmetadata) =
@@ -309,9 +309,9 @@ makeSignedTransaction witnesses (ShelleyTxBody txbody txmetadata) =
         (maybeToStrictMaybe txmetadata)
 
 makeByronKeyWitness :: NetworkId
-                    -> TxBody Byron
+                    -> TxBody ByronEra
                     -> SigningKey ByronKey
-                    -> Witness Byron
+                    -> Witness ByronEra
 makeByronKeyWitness nw (ByronTxBody txbody) =
     let txhash :: Byron.Hash Byron.Tx
         txhash = Byron.hashDecoded txbody
@@ -336,7 +336,7 @@ data WitnessNetworkIdOrByronAddress
   -- If this value is used in the construction of a Shelley bootstrap witness,
   -- the result will not consist of a derivation path. If that is required,
   -- specify a 'WitnessByronAddress' value instead.
-  | WitnessByronAddress !(Address Byron)
+  | WitnessByronAddress !(Address ByronEra)
   -- ^ Byron address.
   --
   -- If this value is used in the construction of a Shelley bootstrap witness,
@@ -344,9 +344,9 @@ data WitnessNetworkIdOrByronAddress
   -- address and used in the construction of the witness.
 
 makeShelleyBootstrapWitness :: WitnessNetworkIdOrByronAddress
-                            -> TxBody Shelley
+                            -> TxBody ShelleyEra
                             -> SigningKey ByronKey
-                            -> Witness Shelley
+                            -> Witness ShelleyEra
 makeShelleyBootstrapWitness nwOrAddr (ShelleyTxBody txbody _) (ByronSigningKey sk) =
     ShelleyBootstrapWitness $
       -- Byron era witnesses were weird. This reveals all that weirdness.
@@ -391,16 +391,16 @@ makeShelleyBootstrapWitness nwOrAddr (ShelleyTxBody txbody _) (ByronSigningKey s
         }
 
     -- The 'WitnessNetworkIdOrByronAddress' value converted to an 'Either'.
-    eitherNwOrAddr :: Either NetworkId (Address Byron)
+    eitherNwOrAddr :: Either NetworkId (Address ByronEra)
     eitherNwOrAddr =
       case nwOrAddr of
         WitnessNetworkId nw -> Left nw
         WitnessByronAddress addr -> Right addr
 
-    unByronAddr :: Address Byron -> Byron.Address
+    unByronAddr :: Address ByronEra -> Byron.Address
     unByronAddr (ByronAddress addr) = addr
 
-    unAddrAttrs :: Address Byron -> Byron.AddrAttributes
+    unAddrAttrs :: Address ByronEra -> Byron.AddrAttributes
     unAddrAttrs = Byron.attrData . Byron.addrAttributes . unByronAddr
 
     derivationPath :: Maybe Byron.HDAddressPayload
@@ -431,9 +431,9 @@ data ShelleyWitnessSigningKey =
      | WitnessGenesisUTxOKey     (SigningKey GenesisUTxOKey)
 
 
-makeShelleyKeyWitness :: TxBody Shelley
+makeShelleyKeyWitness :: TxBody ShelleyEra
                       -> ShelleyWitnessSigningKey
-                      -> Witness Shelley
+                      -> Witness ShelleyEra
 makeShelleyKeyWitness (ShelleyTxBody txbody _) =
     let txhash :: Shelley.Hash StandardCrypto Shelley.EraIndependentTxBody
         txhash = Shelley.hashAnnotated txbody
@@ -538,18 +538,18 @@ makeScriptWitness (MaryScript    s) = MaryScriptWitness s
 
 -- order of signing keys must match txins
 signByronTransaction :: NetworkId
-                     -> TxBody Byron
+                     -> TxBody ByronEra
                      -> [SigningKey ByronKey]
-                     -> Tx Byron
+                     -> Tx ByronEra
 signByronTransaction nw txbody sks =
     makeSignedTransaction witnesses txbody
   where
     witnesses = map (makeByronKeyWitness nw txbody) sks
 
 -- signing keys is a set
-signShelleyTransaction :: TxBody Shelley
+signShelleyTransaction :: TxBody ShelleyEra
                        -> [ShelleyWitnessSigningKey]
-                       -> Tx Shelley
+                       -> Tx ShelleyEra
 signShelleyTransaction txbody sks =
     makeSignedTransaction witnesses txbody
   where

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -336,7 +336,7 @@ data WitnessNetworkIdOrByronAddress
   -- If this value is used in the construction of a Shelley bootstrap witness,
   -- the result will not consist of a derivation path. If that is required,
   -- specify a 'WitnessByronAddress' value instead.
-  | WitnessByronAddress !(Address ByronEra)
+  | WitnessByronAddress !(Address ByronAddr)
   -- ^ Byron address.
   --
   -- If this value is used in the construction of a Shelley bootstrap witness,
@@ -391,16 +391,16 @@ makeShelleyBootstrapWitness nwOrAddr (ShelleyTxBody txbody _) (ByronSigningKey s
         }
 
     -- The 'WitnessNetworkIdOrByronAddress' value converted to an 'Either'.
-    eitherNwOrAddr :: Either NetworkId (Address ByronEra)
+    eitherNwOrAddr :: Either NetworkId (Address ByronAddr)
     eitherNwOrAddr =
       case nwOrAddr of
         WitnessNetworkId nw -> Left nw
         WitnessByronAddress addr -> Right addr
 
-    unByronAddr :: Address ByronEra -> Byron.Address
+    unByronAddr :: Address ByronAddr -> Byron.Address
     unByronAddr (ByronAddress addr) = addr
 
-    unAddrAttrs :: Address ByronEra -> Byron.AddrAttributes
+    unAddrAttrs :: Address ByronAddr -> Byron.AddrAttributes
     unAddrAttrs = Byron.attrData . Byron.addrAttributes . unByronAddr
 
     derivationPath :: Maybe Byron.HDAddressPayload

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -148,22 +148,25 @@ newtype TxIx = TxIx Word
   deriving stock (Eq, Ord, Show)
   deriving newtype (Enum)
 
-data TxOut era = TxOut (Address era) (TxOutValue era)
+data TxOut era = TxOut (AddressInEra era) (TxOutValue era)
 
-deriving instance Eq (TxOut ByronEra)
-deriving instance Eq (TxOut ShelleyEra)
-deriving instance Show (TxOut ByronEra)
-deriving instance Show (TxOut ShelleyEra)
+deriving instance Eq   (TxOut era)
+deriving instance Show (TxOut era)
 
 toByronTxIn  :: TxIn -> Byron.TxIn
 toByronTxIn (TxIn txid (TxIx txix)) =
     Byron.TxInUtxo (toByronTxId txid) (fromIntegral txix)
 
 toByronTxOut :: TxOut ByronEra -> Maybe Byron.TxOut
-toByronTxOut (TxOut (ByronAddress addr) (TxOutAdaOnly AdaOnlyInByronEra value)) =
+toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
+                    (TxOutAdaOnly AdaOnlyInByronEra value)) =
     Byron.TxOut addr <$> toByronLovelace value
 
-toByronTxOut (TxOut (ByronAddress _) (TxOutValue era _)) = case era of {}
+toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _))
+                    (TxOutValue era _)) = case era of {}
+
+toByronTxOut (TxOut (AddressInEra (ShelleyAddressInEra era) ShelleyAddress{})
+                    _) = case era of {}
 
 toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
 toByronLovelace (Lovelace x) =

--- a/cardano-api/src/Cardano/Api/TxSubmit.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit.hs
@@ -35,15 +35,15 @@ import           Cardano.Api.Typed
 data TxForMode mode where
 
      TxForByronMode
-       :: Tx Byron
+       :: Tx ByronEra
        -> TxForMode ByronMode
 
      TxForShelleyMode
-       :: Tx Shelley
+       :: Tx ShelleyEra
        -> TxForMode ShelleyMode
 
      TxForCardanoMode
-       :: Either (Tx Byron) (Tx Shelley)
+       :: Either (Tx ByronEra) (Tx ShelleyEra)
        -> TxForMode CardanoMode
 
 

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -72,16 +72,31 @@ module Cardano.Api.Typed (
     -- * Payment addresses
     -- | Constructing and inspecting normal payment addresses
     Address(..),
+    ByronAddr,
+    ShelleyAddr,
     NetworkId(..),
-    -- * Byron addresses
+    -- ** Byron addresses
     makeByronAddress,
     ByronKey,
-    -- * Shelley addresses
+    -- ** Shelley addresses
     makeShelleyAddress,
     PaymentCredential(..),
     StakeAddressReference(..),
     PaymentKey,
     PaymentExtendedKey,
+
+    -- ** Addresses in any era
+    AddressAny(..),
+
+    -- ** Addresses in specific eras
+    AddressInEra(..),
+    AddressTypeInEra(..),
+    byronAddressInEra,
+    shelleyAddressInEra,
+    anyAddressInShelleyBasedEra,
+    anyAddressInEra,
+    makeByronAddressInEra,
+    makeShelleyAddressInEra,
 
     -- * Stake addresses
     -- | Constructing and inspecting stake addresses

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -30,6 +30,13 @@ module Cardano.Api.Typed (
     ShelleyEra,
     AllegraEra,
     MaryEra,
+    CardanoEra(..),
+    CardanoEraStyle(..),
+    IsCardanoEra(..),
+    -- ** Shelley-based eras
+    ShelleyBasedEra(..),
+    IsShelleyBasedEra(..),
+    ShelleyLedgerEra,
     -- ** Deprecated
     Byron,
     Shelley,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -26,10 +26,16 @@
 --
 module Cardano.Api.Typed (
     -- * Eras
+    ByronEra,
+    ShelleyEra,
+    AllegraEra,
+    MaryEra,
+    -- ** Deprecated
     Byron,
     Shelley,
     Allegra,
     Mary,
+    -- * Type tags
     HasTypeProxy(..),
     AsType(..),
     -- * Cryptographic key interface

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -187,9 +187,9 @@ deriving instance Show (TxOutValue era)
 --
 data AdaOnlyInEra era where
 
-     AdaOnlyInByronEra   :: AdaOnlyInEra Byron
-     AdaOnlyInShelleyEra :: AdaOnlyInEra Shelley
-     AdaOnlyInAllegraEra :: AdaOnlyInEra Allegra
+     AdaOnlyInByronEra   :: AdaOnlyInEra ByronEra
+     AdaOnlyInShelleyEra :: AdaOnlyInEra ShelleyEra
+     AdaOnlyInAllegraEra :: AdaOnlyInEra AllegraEra
 
 deriving instance Eq   (AdaOnlyInEra era)
 deriving instance Show (AdaOnlyInEra era)
@@ -200,7 +200,7 @@ deriving instance Show (AdaOnlyInEra era)
 data MultiAssetInEra era where
 
      -- | Multi-asset transactions are supported in the 'Mary' era.
-     MultiAssetInMaryEra :: MultiAssetInEra Mary
+     MultiAssetInMaryEra :: MultiAssetInEra MaryEra
 
 deriving instance Eq   (MultiAssetInEra era)
 deriving instance Show (MultiAssetInEra era)

--- a/cardano-api/test/Test/Cardano/Api/Examples.hs
+++ b/cardano-api/test/Test/Cardano/Api/Examples.hs
@@ -43,7 +43,7 @@ import           Shelley.Spec.Ledger.PParams (PParams' (..), emptyPParams)
 import           Cardano.Api.Shelley.Genesis
 
 
-exampleAllShelley :: SimpleScript Api.Shelley
+exampleAllShelley :: SimpleScript Api.ShelleyEra
 exampleAllShelley =
   RequireAllOf [ RequireSignature SignaturesInShelleyEra
                    $ convertToHash "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
@@ -64,7 +64,7 @@ exampleAllShelley =
                ]
 
 
-exampleAnyShelley :: SimpleScript Api.Shelley
+exampleAnyShelley :: SimpleScript Api.ShelleyEra
 exampleAnyShelley =
   RequireAnyOf [ RequireSignature SignaturesInShelleyEra
                    $ convertToHash "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
@@ -80,7 +80,7 @@ exampleAnyShelley =
                    $ convertToHash "622be5fab3b5c3f371a50a535e4d3349c942a98cecee93b24e2fd11d"
                ]
 
-exampleMofNShelley :: SimpleScript Api.Shelley
+exampleMofNShelley :: SimpleScript Api.ShelleyEra
 exampleMofNShelley =
   RequireMOf 2 [ RequireSignature SignaturesInShelleyEra
                    $ convertToHash "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
@@ -92,7 +92,7 @@ exampleMofNShelley =
                    $ convertToHash "686024aecb5884d73a11b9ae4e63931112ba737e878d74638b78513a"
                ]
 
-exampleAllAllegra :: SimpleScript Api.Allegra
+exampleAllAllegra :: SimpleScript Api.AllegraEra
 exampleAllAllegra =
   RequireAllOf [ RequireSignature SignaturesInAllegraEra
                    (convertToHash "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a")
@@ -100,14 +100,14 @@ exampleAllAllegra =
                ]
 
 
-exampleAnyAllegra :: SimpleScript Api.Allegra
+exampleAnyAllegra :: SimpleScript Api.AllegraEra
 exampleAnyAllegra =
   RequireAnyOf [ RequireSignature SignaturesInAllegraEra
                    (convertToHash "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09")
                , RequireTimeAfter TimeLocksInAllegraEra (SlotNo 42)
                ]
 
-exampleMofNAllegra :: SimpleScript Api.Allegra
+exampleMofNAllegra :: SimpleScript Api.AllegraEra
 exampleMofNAllegra =
   RequireMOf 1 [ RequireSignature SignaturesInAllegraEra
                    (convertToHash "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413")
@@ -117,7 +117,7 @@ exampleMofNAllegra =
                ]
 
 
-exampleAllMary :: SimpleScript Api.Mary
+exampleAllMary :: SimpleScript Api.MaryEra
 exampleAllMary =
   RequireAllOf [ RequireSignature SignaturesInMaryEra
                    (convertToHash "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a")
@@ -125,14 +125,14 @@ exampleAllMary =
                ]
 
 
-exampleAnyMary :: SimpleScript Api.Mary
+exampleAnyMary :: SimpleScript Api.MaryEra
 exampleAnyMary =
   RequireAnyOf [ RequireSignature SignaturesInMaryEra
                    (convertToHash "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09")
                , RequireTimeAfter TimeLocksInMaryEra (SlotNo 42)
                ]
 
-exampleMofNMary :: SimpleScript Api.Mary
+exampleMofNMary :: SimpleScript Api.MaryEra
 exampleMofNMary =
   RequireMOf 1 [ RequireSignature SignaturesInMaryEra
                    (convertToHash "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413")

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -118,7 +118,7 @@ prop_roundtrip_signing_key_kes_CBOR =
 
 prop_roundtrip_script_CBOR :: Property
 prop_roundtrip_script_CBOR =
-  roundtrip_CBOR (AsScript AsShelley) genScript
+  roundtrip_CBOR (AsScript AsShelleyEra) genScript
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -41,11 +41,11 @@ import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 
 {- HLINT ignore "Reduce duplication" -}
 
-genAddressByron :: Gen (Address Byron)
+genAddressByron :: Gen (Address ByronEra)
 genAddressByron = makeByronAddress <$> genNetworkId
                                    <*> genVerificationKey AsByronKey
 
-genAddressShelley :: Gen (Address Shelley)
+genAddressShelley :: Gen (Address ShelleyEra)
 genAddressShelley =
   Gen.choice
     [ makeShelleyAddress <$> genNetworkId
@@ -89,10 +89,10 @@ genMofN s = do
 
 -- Shelley
 
-genMultiSigScriptShelley :: Gen (MultiSigScript Shelley)
+genMultiSigScriptShelley :: Gen (MultiSigScript ShelleyEra)
 genMultiSigScriptShelley = genMultiSigScriptsShelley >>= Gen.element
 
-genMultiSigScriptsShelley :: Gen [MultiSigScript Shelley]
+genMultiSigScriptsShelley :: Gen [MultiSigScript ShelleyEra]
 genMultiSigScriptsShelley =
   Gen.recursive Gen.choice
     -- Non-recursive generators
@@ -107,10 +107,10 @@ genMultiSigScriptsShelley =
 
 -- Allegra
 
-genMultiSigScriptAllegra :: Gen (MultiSigScript Allegra)
+genMultiSigScriptAllegra :: Gen (MultiSigScript AllegraEra)
 genMultiSigScriptAllegra = genMultiSigScriptsAllegra >>= Gen.element
 
-genMultiSigScriptsAllegra :: Gen [MultiSigScript Allegra]
+genMultiSigScriptsAllegra :: Gen [MultiSigScript AllegraEra]
 genMultiSigScriptsAllegra =
   Gen.recursive Gen.choice
     -- Non-recursive generators
@@ -132,10 +132,10 @@ genMultiSigScriptsAllegra =
 
 -- Mary
 
-genMultiSigScriptMary :: Gen (MultiSigScript Mary)
+genMultiSigScriptMary :: Gen (MultiSigScript MaryEra)
 genMultiSigScriptMary = genMultiSigScriptsMary >>= Gen.element
 
-genMultiSigScriptsMary :: Gen [MultiSigScript Mary]
+genMultiSigScriptsMary :: Gen [MultiSigScript MaryEra]
 genMultiSigScriptsMary =
   Gen.recursive Gen.choice
     -- Non-recursive generators
@@ -155,25 +155,25 @@ genMultiSigScriptsMary =
 
     ]
 
-genAllRequiredSig :: Gen (MultiSigScript Shelley)
+genAllRequiredSig :: Gen (MultiSigScript ShelleyEra)
 genAllRequiredSig =
   RequireAllOf <$> Gen.list (Range.constant 1 10) (genRequiredSig SignaturesInShelleyEra)
 
-genAnyRequiredSig :: Gen (MultiSigScript Shelley)
+genAnyRequiredSig :: Gen (MultiSigScript ShelleyEra)
 genAnyRequiredSig =
   RequireAnyOf <$> Gen.list (Range.constant 1 10) (genRequiredSig SignaturesInShelleyEra)
 
-genMofNRequiredSig :: Gen (MultiSigScript Shelley)
+genMofNRequiredSig :: Gen (MultiSigScript ShelleyEra)
 genMofNRequiredSig = do
  required <- Gen.integral (Range.linear 2 15)
  total <- Gen.integral (Range.linear (required + 1) 15)
  RequireMOf required <$> Gen.list (Range.singleton total) (genRequiredSig SignaturesInShelleyEra)
 
-genMultiSigScript :: Gen (MultiSigScript Shelley)
+genMultiSigScript :: Gen (MultiSigScript ShelleyEra)
 genMultiSigScript =
   Gen.choice [genAllRequiredSig, genAnyRequiredSig, genMofNRequiredSig]
 
-genScript :: Gen (Script Shelley)
+genScript :: Gen (Script ShelleyEra)
 genScript = makeMultiSigScript <$> genMultiSigScript
 
 genScriptHash :: Gen ScriptHash
@@ -250,7 +250,7 @@ genStakeCredential = do
   vKey <- genVerificationKey AsStakeKey
   return . StakeCredentialByKey $ verificationKeyHash vKey
 
-genTxBodyShelley :: Gen (TxBody Shelley)
+genTxBodyShelley :: Gen (TxBody ShelleyEra)
 genTxBodyShelley =
    makeShelleyTransaction
      <$> genTxExtraContent
@@ -259,11 +259,11 @@ genTxBodyShelley =
      <*> Gen.list (Range.constant 1 10) genTxIn
      <*> Gen.list (Range.constant 1 10) genShelleyTxOut
 
-genByronTxOut :: Gen (TxOut Byron)
+genByronTxOut :: Gen (TxOut ByronEra)
 genByronTxOut =
   TxOut <$> genAddressByron <*> (TxOutAdaOnly AdaOnlyInByronEra <$> genLovelace)
 
-genShelleyTxOut :: Gen (TxOut Shelley)
+genShelleyTxOut :: Gen (TxOut ShelleyEra)
 genShelleyTxOut =
   TxOut <$> genAddressShelley <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
 
@@ -274,7 +274,7 @@ genSlotNo :: Gen SlotNo
 genSlotNo = SlotNo <$> Gen.word64 Range.constantBounded
 
 -- TODO: Should probably have a naive generator that generates no inputs, no outputs etc
-genTxBodyByron :: Gen (TxBody Byron)
+genTxBodyByron :: Gen (TxBody ByronEra)
 genTxBodyByron = do
   txIns <- Gen.list (Range.constant 1 10) genTxIn
   txOuts <- Gen.list (Range.constant 1 10) genByronTxOut
@@ -282,7 +282,7 @@ genTxBodyByron = do
     Left err -> panic $ show err
     Right txBody -> return txBody
 
-genTxByron :: Gen (Tx Byron)
+genTxByron :: Gen (Tx ByronEra)
 genTxByron =
   makeSignedTransaction
     <$> Gen.list (Range.constant 1 10) genByronKeyWitness
@@ -297,13 +297,13 @@ genTxId = TxId <$> genShelleyHash
 genTxIndex :: Gen TxIx
 genTxIndex = TxIx <$> Gen.word Range.constantBounded
 
-genTxShelley :: Gen (Tx Shelley)
+genTxShelley :: Gen (Tx ShelleyEra)
 genTxShelley =
   makeSignedTransaction
     <$> genWitnessList
     <*> genTxBodyShelley
  where
-   genWitnessList :: Gen [Witness Shelley]
+   genWitnessList :: Gen [Witness ShelleyEra]
    genWitnessList = do
      bsWits <- Gen.list (Range.constant 0 10) genShelleyBootstrapWitness
      keyWits <- Gen.list (Range.constant 0 10) genShelleyKeyWitness
@@ -321,7 +321,7 @@ genTxFee = genLovelace
 genVerificationKey :: Key keyrole => AsType keyrole -> Gen (VerificationKey keyrole)
 genVerificationKey roletoken = getVerificationKey <$> genSigningKey roletoken
 
-genByronKeyWitness :: Gen (Witness Byron)
+genByronKeyWitness :: Gen (Witness ByronEra)
 genByronKeyWitness = do
   pmId <- genProtocolMagicId
   txinWitness <- genVKWitness pmId
@@ -334,20 +334,20 @@ genWitnessNetworkIdOrByronAddress =
     , WitnessByronAddress <$> genAddressByron
     ]
 
-genShelleyBootstrapWitness :: Gen (Witness Shelley)
+genShelleyBootstrapWitness :: Gen (Witness ShelleyEra)
 genShelleyBootstrapWitness =
  makeShelleyBootstrapWitness
    <$> genWitnessNetworkIdOrByronAddress
    <*> genTxBodyShelley
    <*> genSigningKey AsByronKey
 
-genShelleyKeyWitness :: Gen (Witness Shelley)
+genShelleyKeyWitness :: Gen (Witness ShelleyEra)
 genShelleyKeyWitness =
   makeShelleyKeyWitness
     <$> genTxBodyShelley
     <*> genShelleyWitnessSigningKey
 
-genShelleyWitness :: Gen (Witness Shelley)
+genShelleyWitness :: Gen (Witness ShelleyEra)
 genShelleyWitness = Gen.choice [genShelleyKeyWitness, genShelleyBootstrapWitness]
 
 genShelleyWitnessSigningKey :: Gen ShelleyWitnessSigningKey

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -41,20 +41,14 @@ import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 
 {- HLINT ignore "Reduce duplication" -}
 
-genAddressByron :: Gen (Address ByronEra)
+genAddressByron :: Gen (Address ByronAddr)
 genAddressByron = makeByronAddress <$> genNetworkId
                                    <*> genVerificationKey AsByronKey
 
-genAddressShelley :: Gen (Address ShelleyEra)
-genAddressShelley =
-  Gen.choice
-    [ makeShelleyAddress <$> genNetworkId
-                         <*> genPaymentCredential
-                         <*> genStakeAddressReference
-
-    , makeByronAddress   <$> genNetworkId
-                         <*> genVerificationKey AsByronKey
-    ]
+genAddressShelley :: Gen (Address ShelleyAddr)
+genAddressShelley = makeShelleyAddress <$> genNetworkId
+                                       <*> genPaymentCredential
+                                       <*> genStakeAddressReference
 
 genKESPeriod :: Gen KESPeriod
 genKESPeriod = KESPeriod <$> Gen.word Range.constantBounded
@@ -261,11 +255,13 @@ genTxBodyShelley =
 
 genByronTxOut :: Gen (TxOut ByronEra)
 genByronTxOut =
-  TxOut <$> genAddressByron <*> (TxOutAdaOnly AdaOnlyInByronEra <$> genLovelace)
+  TxOut <$> (byronAddressInEra <$> genAddressByron)
+        <*> (TxOutAdaOnly AdaOnlyInByronEra <$> genLovelace)
 
 genShelleyTxOut :: Gen (TxOut ShelleyEra)
 genShelleyTxOut =
-  TxOut <$> genAddressShelley <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
+  TxOut <$> (shelleyAddressInEra <$> genAddressShelley)
+        <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
 
 genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 ())
 genShelleyHash = return $ Crypto.hashWith CBOR.serialize' ()

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -449,7 +449,7 @@ data WitnessSigningData
   = KeyWitnessSigningData
       !SigningKeyFile
       -- ^ Path to a file that should contain a signing key.
-      !(Maybe (Address ByronEra))
+      !(Maybe (Address ByronAddr))
       -- ^ An optionally specified Byron address.
       --
       -- If specified, both the network ID and derivation path are extracted

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -162,7 +162,7 @@ renderKeyCmd cmd =
 data TransactionCmd
   = TxBuildRaw
       [TxIn]
-      [TxOut Shelley]
+      [TxOut ShelleyEra]
       (Maybe String) -- Placeholder for multi asset Values
       SlotNo
       Lovelace
@@ -449,7 +449,7 @@ data WitnessSigningData
   = KeyWitnessSigningData
       !SigningKeyFile
       -- ^ Path to a file that should contain a signing key.
-      !(Maybe (Address Byron))
+      !(Maybe (Address ByronEra))
       -- ^ An optionally specified Byron address.
       --
       -- If specified, both the network ID and derivation path are extracted

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1461,7 +1461,7 @@ pTxOut =
   where
     parseTxOut :: Atto.Parser (TxOut ShelleyEra)
     parseTxOut =
-      TxOut <$> parseAddress
+      TxOut <$> parseAddressInEra
             <*  Atto.char '+'
             <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> parseLovelace)
 
@@ -1589,9 +1589,9 @@ pQueryFilter = pAddresses <|> pure NoFilter
     pAddresses = FilterByAddress . Set.fromList <$>
                    some pFilterByAddress
 
-pFilterByAddress :: Parser (Address ShelleyEra)
+pFilterByAddress :: Parser AddressAny
 pFilterByAddress =
-    Opt.option (readerFromAttoParser parseAddress)
+    Opt.option (readerFromAttoParser parseAddressAny)
       (  Opt.long "address"
       <> Opt.metavar "ADDRESS"
       <> Opt.help "Filter by Cardano address(es) (Bech32-encoded)."
@@ -1605,7 +1605,7 @@ pFilterByStakeAddress =
       <> Opt.help "Filter by Cardano stake address (Bech32-encoded)."
       )
 
-pByronAddress :: Parser (Address ByronEra)
+pByronAddress :: Parser (Address ByronAddr)
 pByronAddress =
     Opt.option
       (Opt.eitherReader deserialise)
@@ -1614,7 +1614,7 @@ pByronAddress =
         <> Opt.help "Byron address (Base58-encoded)."
         )
   where
-    deserialise :: String -> Either String (Address ByronEra)
+    deserialise :: String -> Either String (Address ByronAddr)
     deserialise =
       maybe (Left "Invalid Byron address.") Right
         . deserialiseAddress AsByronAddress
@@ -2211,12 +2211,19 @@ pProtocolVersion =
 parseLovelace :: Atto.Parser Lovelace
 parseLovelace = Lovelace <$> Atto.decimal
 
-parseAddress :: Atto.Parser (Address ShelleyEra)
-parseAddress = do
+parseAddressAny :: Atto.Parser AddressAny
+parseAddressAny = do
     str <- lexPlausibleAddressString
-    case deserialiseAddress AsShelleyAddress str of
+    case deserialiseAddress AsAddressAny str of
       Nothing   -> fail "invalid address"
       Just addr -> pure addr
+
+parseAddressInEra :: IsCardanoEra era => Atto.Parser (AddressInEra era)
+parseAddressInEra = do
+    addr <- parseAddressAny
+    case anyAddressInEra addr of
+      Nothing        -> fail "invalid address in the target era"
+      Just addrinera -> pure addrinera
 
 parseStakeAddress :: Atto.Parser StakeAddress
 parseStakeAddress = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1449,7 +1449,7 @@ parseTxIx :: Atto.Parser TxIx
 parseTxIx = toEnum <$> Atto.decimal
 
 
-pTxOut :: Parser (TxOut Shelley)
+pTxOut :: Parser (TxOut ShelleyEra)
 pTxOut =
   Opt.option (readerFromAttoParser parseTxOut)
     (  Opt.long "tx-out"
@@ -1459,7 +1459,7 @@ pTxOut =
                 \Lovelace."
     )
   where
-    parseTxOut :: Atto.Parser (TxOut Shelley)
+    parseTxOut :: Atto.Parser (TxOut ShelleyEra)
     parseTxOut =
       TxOut <$> parseAddress
             <*  Atto.char '+'
@@ -1589,7 +1589,7 @@ pQueryFilter = pAddresses <|> pure NoFilter
     pAddresses = FilterByAddress . Set.fromList <$>
                    some pFilterByAddress
 
-pFilterByAddress :: Parser (Address Shelley)
+pFilterByAddress :: Parser (Address ShelleyEra)
 pFilterByAddress =
     Opt.option (readerFromAttoParser parseAddress)
       (  Opt.long "address"
@@ -1605,7 +1605,7 @@ pFilterByStakeAddress =
       <> Opt.help "Filter by Cardano stake address (Bech32-encoded)."
       )
 
-pByronAddress :: Parser (Address Byron)
+pByronAddress :: Parser (Address ByronEra)
 pByronAddress =
     Opt.option
       (Opt.eitherReader deserialise)
@@ -1614,7 +1614,7 @@ pByronAddress =
         <> Opt.help "Byron address (Base58-encoded)."
         )
   where
-    deserialise :: String -> Either String (Address Byron)
+    deserialise :: String -> Either String (Address ByronEra)
     deserialise =
       maybe (Left "Invalid Byron address.") Right
         . deserialiseAddress AsByronAddress
@@ -2211,7 +2211,7 @@ pProtocolVersion =
 parseLovelace :: Atto.Parser Lovelace
 parseLovelace = Lovelace <$> Atto.decimal
 
-parseAddress :: Atto.Parser (Address Shelley)
+parseAddress :: Atto.Parser (Address ShelleyEra)
 parseAddress = do
     str <- lexPlausibleAddressString
     case deserialiseAddress AsShelleyAddress str of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -110,24 +110,26 @@ runAddressBuild payVkeyTextOrFile mbStkVkeyOrFile nw mOutFp = do
 
     addr <- case payVKey of
               AByronVerificationKey vk ->
-                return (makeByronAddress nw vk)
+                return (AddressByron (makeByronAddress nw vk))
 
               APaymentVerificationKey vk ->
-                buildShelleyAddress vk
+                AddressShelley <$> buildShelleyAddress vk
 
               APaymentExtendedVerificationKey vk ->
-                buildShelleyAddress (castVerificationKey vk)
+                AddressShelley <$> buildShelleyAddress (castVerificationKey vk)
 
               AGenesisUTxOVerificationKey vk ->
-                buildShelleyAddress (castVerificationKey vk)
+                AddressShelley <$> buildShelleyAddress (castVerificationKey vk)
 
-    let addrText = serialiseAddress addr
+    let addrText = serialiseAddress (addr :: AddressAny)
 
     case mOutFp of
       Just (OutputFile fpath) -> liftIO $ Text.writeFile fpath addrText
       Nothing                 -> liftIO $ Text.putStrLn        addrText
 
   where
+    buildShelleyAddress :: VerificationKey PaymentKey
+                        -> ExceptT ShelleyAddressCmdError IO (Address ShelleyAddr)
     buildShelleyAddress vkey = do
       mstakeVKey <-
         case mbStkVkeyOrFile of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -206,7 +206,7 @@ runAddressBuildScript
 runAddressBuildScript (ScriptFile fp) nId mOutFp = do
   scriptLB <- handleIOExceptT (ShelleyAddressCmdReadFileException . FileIOError fp)
                 $ LB.readFile fp
-  script <- case eitherDecode scriptLB :: Either String (MultiSigScript Shelley) of
+  script <- case eitherDecode scriptLB :: Either String (MultiSigScript ShelleyEra) of
                Right mss -> return $ makeMultiSigScript mss
                Left err -> left . ShelleyAddressCmdAesonDecodeError fp $ Text.pack err
   let payCred = PaymentCredentialByScript $ scriptHash script

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
@@ -41,15 +41,13 @@ instance ToJSON AddressInfo where
 
 runAddressInfo :: Text -> Maybe OutputFile -> ExceptT ShelleyAddressInfoError IO ()
 runAddressInfo addrTxt mOutputFp = do
-    addrInfo <- case (Left  <$> deserialiseAddress AsShelleyAddress addrTxt)
+    addrInfo <- case (Left  <$> deserialiseAddress AsAddressAny addrTxt)
                  <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
 
       Nothing ->
         left $ ShelleyAddressInvalid addrTxt
 
-      Just (Left payaddr) ->
-        case payaddr of
-          ByronAddress{} ->
+      Just (Left (AddressByron payaddr)) ->
             pure $ AddressInfo
               { aiType = "payment"
               , aiEra = "byron"
@@ -57,7 +55,8 @@ runAddressInfo addrTxt mOutputFp = do
               , aiAddress = addrTxt
               , aiBase16 = asBase16 payaddr
               }
-          ShelleyAddress{} ->
+
+      Just (Left (AddressShelley payaddr)) ->
             pure $ AddressInfo
               { aiType = "payment"
               , aiEra = "shelley"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -369,7 +369,7 @@ updateTemplate
     :: SystemStart
     -> Maybe Lovelace
     -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey)
-    -> [Address Shelley]
+    -> [Address ShelleyEra]
     -> ShelleyGenesis StandardShelley
     -> ShelleyGenesis StandardShelley
 updateTemplate (SystemStart start) mAmount delKeys utxoAddrs template =
@@ -397,12 +397,12 @@ updateTemplate (SystemStart start) mAmount delKeys utxoAddrs template =
     eachAddrCoin :: Integer
     eachAddrCoin = totalCoin `div` fromIntegral (length utxoAddrs)
 
-    utxoList :: [(Address Shelley, Lovelace)]
+    utxoList :: [(Address ShelleyEra, Lovelace)]
     utxoList = fst $ List.foldl' folder ([], totalCoin) utxoAddrs
 
-    folder :: ([(Address Shelley, Lovelace)], Integer)
-           -> Address Shelley
-           -> ([(Address Shelley, Lovelace)], Integer)
+    folder :: ([(Address ShelleyEra, Lovelace)], Integer)
+           -> Address ShelleyEra
+           -> ([(Address ShelleyEra, Lovelace)], Integer)
     folder (acc, rest) addr
       | rest > eachAddrCoin + fromIntegral (length utxoAddrs) =
                     ((addr, Lovelace eachAddrCoin) : acc, rest - eachAddrCoin)
@@ -412,7 +412,7 @@ writeShelleyGenesis :: FilePath -> ShelleyGenesis StandardShelley -> ExceptT She
 writeShelleyGenesis fpath sg =
   handleIOExceptT (ShelleyGenesisCmdGenesisFileError . FileIOError fpath) $ LBS.writeFile fpath (encodePretty sg)
 
-toShelleyAddr :: Address Shelley -> Ledger.Addr StandardShelley
+toShelleyAddr :: Address ShelleyEra -> Ledger.Addr StandardShelley
 toShelleyAddr (ByronAddress addr)        = Ledger.AddrBootstrap
                                              (Ledger.BootstrapAddress addr)
 toShelleyAddr (ShelleyAddress nw pc scr) = Ledger.Addr nw pc scr
@@ -539,7 +539,7 @@ extractFileNameIndexes files = do
     filesIxs = [ (file, extractFileNameIndex file) | file <- files ]
 
 readInitialFundAddresses :: FilePath -> NetworkId
-                         -> ExceptT ShelleyGenesisCmdError IO [Address Shelley]
+                         -> ExceptT ShelleyGenesisCmdError IO [Address ShelleyEra]
 readInitialFundAddresses utxodir nw = do
     files <- liftIO (listDirectory utxodir)
     vkeys <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError $

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -32,11 +32,10 @@ import qualified Cardano.Crypto.Hash as Crypto
 
 import           Cardano.Api.Shelley.Genesis
 import           Cardano.Api.Typed
+import           Cardano.Api.Shelley
 
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 
-import qualified Shelley.Spec.Ledger.Address as Ledger
-import qualified Shelley.Spec.Ledger.Coin as Ledger
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 
 import           Cardano.CLI.Helpers (textShow)
@@ -369,7 +368,7 @@ updateTemplate
     :: SystemStart
     -> Maybe Lovelace
     -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey)
-    -> [Address ShelleyEra]
+    -> [AddressInEra ShelleyEra]
     -> ShelleyGenesis StandardShelley
     -> ShelleyGenesis StandardShelley
 updateTemplate (SystemStart start) mAmount delKeys utxoAddrs template =
@@ -397,12 +396,12 @@ updateTemplate (SystemStart start) mAmount delKeys utxoAddrs template =
     eachAddrCoin :: Integer
     eachAddrCoin = totalCoin `div` fromIntegral (length utxoAddrs)
 
-    utxoList :: [(Address ShelleyEra, Lovelace)]
+    utxoList :: [(AddressInEra ShelleyEra, Lovelace)]
     utxoList = fst $ List.foldl' folder ([], totalCoin) utxoAddrs
 
-    folder :: ([(Address ShelleyEra, Lovelace)], Integer)
-           -> Address ShelleyEra
-           -> ([(Address ShelleyEra, Lovelace)], Integer)
+    folder :: ([(AddressInEra ShelleyEra, Lovelace)], Integer)
+           -> AddressInEra ShelleyEra
+           -> ([(AddressInEra ShelleyEra, Lovelace)], Integer)
     folder (acc, rest) addr
       | rest > eachAddrCoin + fromIntegral (length utxoAddrs) =
                     ((addr, Lovelace eachAddrCoin) : acc, rest - eachAddrCoin)
@@ -411,14 +410,6 @@ updateTemplate (SystemStart start) mAmount delKeys utxoAddrs template =
 writeShelleyGenesis :: FilePath -> ShelleyGenesis StandardShelley -> ExceptT ShelleyGenesisCmdError IO ()
 writeShelleyGenesis fpath sg =
   handleIOExceptT (ShelleyGenesisCmdGenesisFileError . FileIOError fpath) $ LBS.writeFile fpath (encodePretty sg)
-
-toShelleyAddr :: Address ShelleyEra -> Ledger.Addr StandardShelley
-toShelleyAddr (ByronAddress addr)        = Ledger.AddrBootstrap
-                                             (Ledger.BootstrapAddress addr)
-toShelleyAddr (ShelleyAddress nw pc scr) = Ledger.Addr nw pc scr
-
-toShelleyLovelace :: Lovelace -> Ledger.Coin
-toShelleyLovelace (Lovelace l) = Ledger.Coin l
 
 
 -- -------------------------------------------------------------------------------------------------
@@ -539,7 +530,7 @@ extractFileNameIndexes files = do
     filesIxs = [ (file, extractFileNameIndex file) | file <- files ]
 
 readInitialFundAddresses :: FilePath -> NetworkId
-                         -> ExceptT ShelleyGenesisCmdError IO [Address ShelleyEra]
+                         -> ExceptT ShelleyGenesisCmdError IO [AddressInEra ShelleyEra]
 readInitialFundAddresses utxodir nw = do
     files <- liftIO (listDirectory utxodir)
     vkeys <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError $
@@ -551,8 +542,8 @@ readInitialFundAddresses utxodir nw = do
                  , takeExtension file == ".vkey" ]
     return [ addr | vkey <- vkeys
            , let vkh  = verificationKeyHash (castVerificationKey vkey)
-                 addr = makeShelleyAddress nw (PaymentCredentialByKey vkh)
-                                           NoStakeAddress
+                 addr = makeShelleyAddressInEra nw (PaymentCredentialByKey vkh)
+                                                NoStakeAddress
            ]
 
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -33,7 +33,6 @@ import qualified Shelley.Spec.Ledger.Keys as Shelley
 import           Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
 import           Cardano.Api.Typed
 
-import           Cardano.CLI.Byron.Key (CardanoEra (..))
 import qualified Cardano.CLI.Byron.Key as Byron
 import           Cardano.CLI.Helpers (textShow)
 import           Cardano.CLI.Shelley.Commands
@@ -349,9 +348,9 @@ convertByronSigningKey mPwd byronFormat convert
 
   where
     -- TODO: merge these two types
-    toCarandoEra :: ByronKeyFormat -> CardanoEra
-    toCarandoEra NonLegacyByronKeyFormat = ByronEra
-    toCarandoEra LegacyByronKeyFormat    = ByronEraLegacy
+    toCarandoEra :: ByronKeyFormat -> Byron.CardanoEra
+    toCarandoEra NonLegacyByronKeyFormat = Byron.ByronEra
+    toCarandoEra LegacyByronKeyFormat    = Byron.ByronEraLegacy
 
 
 convertByronVerificationKey

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -34,6 +34,7 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
 import           Cardano.Api.LocalChainSync (getLocalTip)
 import           Cardano.Api.Protocol
 import           Cardano.Api.Typed
+import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
 import           Cardano.CLI.Helpers (HelpersError, pPrintCBOR, renderHelpersError)
@@ -372,18 +373,11 @@ queryUTxOFromLocalState qFilter connectInfo@LocalNodeConnectInfo{localNodeConsen
     applyUTxOFilter (FilterByAddress as) = GetFilteredUTxO (toShelleyAddrs as)
     applyUTxOFilter NoFilter             = GetUTxO
 
-    -- TODO: ultimately, these should be exported from Cardano.API.Shelley
-    -- for the Shelley-specific types and conversion for the API wrapper types.
-    -- But alternatively, the API can also be extended to cover the queries
-    -- properly using the API types.
-
-    toShelleyAddrs :: Set (Address ShelleyEra) -> Set (Ledger.Addr StandardShelley)
-    toShelleyAddrs = Set.map toShelleyAddr
-
-    toShelleyAddr :: Address era -> Ledger.Addr StandardShelley
-    toShelleyAddr (ByronAddress addr)        = Ledger.AddrBootstrap
-                                                 (Ledger.BootstrapAddress addr)
-    toShelleyAddr (ShelleyAddress nw pc scr) = Ledger.Addr nw pc scr
+    --TODO: generalise across eras
+    toShelleyAddrs :: Set AddressAny -> Set (Ledger.Addr StandardShelley)
+    toShelleyAddrs = Set.map (toShelleyAddr
+                           . (anyAddressInShelleyBasedEra
+                                :: AddressAny -> AddressInEra ShelleyEra))
 
 
 -- | A mapping of Shelley reward accounts to both the stake pool that they

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -377,7 +377,7 @@ queryUTxOFromLocalState qFilter connectInfo@LocalNodeConnectInfo{localNodeConsen
     -- But alternatively, the API can also be extended to cover the queries
     -- properly using the API types.
 
-    toShelleyAddrs :: Set (Address Shelley) -> Set (Ledger.Addr StandardShelley)
+    toShelleyAddrs :: Set (Address ShelleyEra) -> Set (Ledger.Addr StandardShelley)
     toShelleyAddrs = Set.map toShelleyAddr
 
     toShelleyAddr :: Address era -> Ledger.Addr StandardShelley

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -126,7 +126,7 @@ runTransactionCmd cmd =
 
 runTxBuildRaw
   :: [Api.TxIn]
-  -> [Api.TxOut Api.Shelley]
+  -> [Api.TxOut Api.ShelleyEra]
   -> SlotNo
   -> Api.Lovelace
   -> [CertificateFile]
@@ -305,7 +305,7 @@ readProtocolParameters (ProtocolParamsFile fpath) = do
     Aeson.eitherDecode' pparams
 
 data SomeWitness
-  = AByronSigningKey           (Api.SigningKey Api.ByronKey) (Maybe (Address Byron))
+  = AByronSigningKey           (Api.SigningKey Api.ByronKey) (Maybe (Address ByronEra))
   | APaymentSigningKey         (Api.SigningKey Api.PaymentKey)
   | APaymentExtendedSigningKey (Api.SigningKey Api.PaymentExtendedKey)
   | AStakeSigningKey           (Api.SigningKey Api.StakeKey)
@@ -317,7 +317,7 @@ data SomeWitness
   | AGenesisDelegateExtendedSigningKey
                                (Api.SigningKey Api.GenesisDelegateExtendedKey)
   | AGenesisUTxOSigningKey     (Api.SigningKey Api.GenesisUTxOKey)
-  | AShelleyMultiSigScript     (Api.MultiSigScript Shelley)
+  | AShelleyMultiSigScript     (Api.MultiSigScript ShelleyEra)
 
 -- | Error deserialising a JSON-encoded script.
 newtype ScriptJsonDecodeError = ScriptJsonDecodeError String
@@ -413,7 +413,7 @@ partitionSomeWitnesses
   :: [ByronOrShelleyWitness]
   -> ( [ShelleyBootstrapWitnessSigningKeyData]
      , [Api.ShelleyWitnessSigningKey]
-     , [Api.MultiSigScript Shelley]
+     , [Api.MultiSigScript ShelleyEra]
      )
 partitionSomeWitnesses = reversePartitionedWits . foldl' go mempty
   where
@@ -434,7 +434,7 @@ partitionSomeWitnesses = reversePartitionedWits . foldl' go mempty
 data ByronOrShelleyWitness
   = AByronWitness !ShelleyBootstrapWitnessSigningKeyData
   | AShelleyKeyWitness !Api.ShelleyWitnessSigningKey
-  | AShelleyScriptWitness !(Api.MultiSigScript Shelley)
+  | AShelleyScriptWitness !(Api.MultiSigScript ShelleyEra)
 
 categoriseSomeWitness :: SomeWitness -> ByronOrShelleyWitness
 categoriseSomeWitness swsk =
@@ -458,7 +458,7 @@ data ShelleyBootstrapWitnessSigningKeyData
   = ShelleyBootstrapWitnessSigningKeyData
       !(SigningKey ByronKey)
       -- ^ Byron signing key.
-      !(Maybe (Address Byron))
+      !(Maybe (Address ByronEra))
       -- ^ An optionally specified Byron address.
       --
       -- If specified, both the network ID and derivation path are extracted
@@ -484,9 +484,9 @@ renderShelleyBootstrapWitnessError MissingNetworkIdOrByronAddressError =
 -- Shelley era).
 mkShelleyBootstrapWitness
   :: Maybe NetworkId
-  -> TxBody Shelley
+  -> TxBody ShelleyEra
   -> ShelleyBootstrapWitnessSigningKeyData
-  -> Either ShelleyBootstrapWitnessError (Witness Shelley)
+  -> Either ShelleyBootstrapWitnessError (Witness ShelleyEra)
 mkShelleyBootstrapWitness Nothing _ (ShelleyBootstrapWitnessSigningKeyData _ Nothing) =
   Left MissingNetworkIdOrByronAddressError
 mkShelleyBootstrapWitness (Just nw) txBody (ShelleyBootstrapWitnessSigningKeyData skey Nothing) =
@@ -498,9 +498,9 @@ mkShelleyBootstrapWitness _ txBody (ShelleyBootstrapWitnessSigningKeyData skey (
 -- encountered.
 mkShelleyBootstrapWitnesses
   :: Maybe NetworkId
-  -> TxBody Shelley
+  -> TxBody ShelleyEra
   -> [ShelleyBootstrapWitnessSigningKeyData]
-  -> Either ShelleyBootstrapWitnessError [Witness Shelley]
+  -> Either ShelleyBootstrapWitnessError [Witness ShelleyEra]
 mkShelleyBootstrapWitnesses mnw txBody =
   mapM (mkShelleyBootstrapWitness mnw txBody)
 
@@ -556,7 +556,7 @@ runTxSignWitness (TxBodyFile txBodyFile) witnessFiles (OutputFile oFp) = do
       . newExceptT
       $ Api.writeFileTextEnvelope oFp Nothing tx
 
-readWitnessFile :: WitnessFile -> ExceptT ShelleyTxCmdError IO (Witness Shelley)
+readWitnessFile :: WitnessFile -> ExceptT ShelleyTxCmdError IO (Witness ShelleyEra)
 readWitnessFile (WitnessFile fp) =
   firstExceptT ShelleyTxCmdReadTextViewFileError $ newExceptT (Api.readFileTextEnvelope AsShelleyWitness fp)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -305,7 +305,7 @@ readProtocolParameters (ProtocolParamsFile fpath) = do
     Aeson.eitherDecode' pparams
 
 data SomeWitness
-  = AByronSigningKey           (Api.SigningKey Api.ByronKey) (Maybe (Address ByronEra))
+  = AByronSigningKey           (Api.SigningKey Api.ByronKey) (Maybe (Address ByronAddr))
   | APaymentSigningKey         (Api.SigningKey Api.PaymentKey)
   | APaymentExtendedSigningKey (Api.SigningKey Api.PaymentExtendedKey)
   | AStakeSigningKey           (Api.SigningKey Api.StakeKey)
@@ -458,7 +458,7 @@ data ShelleyBootstrapWitnessSigningKeyData
   = ShelleyBootstrapWitnessSigningKeyData
       !(SigningKey ByronKey)
       -- ^ Byron signing key.
-      !(Maybe (Address ByronEra))
+      !(Maybe (Address ByronAddr))
       -- ^ An optionally specified Byron address.
       --
       -- If specified, both the network ID and derivation path are extracted

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -56,7 +56,7 @@ data OutputFormat
 
 -- | UTxO query filtering options.
 data QueryFilter
-  = FilterByAddress !(Set (Address ShelleyEra))
+  = FilterByAddress !(Set AddressAny)
   | NoFilter
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -56,7 +56,7 @@ data OutputFormat
 
 -- | UTxO query filtering options.
 data QueryFilter
-  = FilterByAddress !(Set (Address Shelley))
+  = FilterByAddress !(Set (Address ShelleyEra))
   | NoFilter
   deriving (Eq, Show)
 


### PR DESCRIPTION
Various refactoring needed to support the addition of two new Shelley-based eras

Rename the Byron, Shelley etc types to be clearly eras
(i.e. rename ByronEra -> ByronEra, Shelley to ShelleyEra etc)

New functionality for generic handling of eras, and Shelley-based eras in particular.
This makes it easier to write code that treats eras mostly uniformly when possible
and non-uniformly when necessary. It also lets us distinguish Byron vs Shelley-based
eras without unnecessarily having to distinguish between the different Shelley-based
eras. This is useful as the biggest differences are between Byron and later eras. It is
very often possible to treat all the Shelley-based eras uniformly.

Change how we handle addresses to properly distinguish the address type from the
era in which the address is valid. This would have been useful already but it is really
needed once we have multiple Shelley-based eras.