### PR TITLE
CAD-2324 node:  trace "nodeStartTime" as a counter

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -23,6 +23,7 @@ import           Control.Tracer
 import           Data.Text (breakOn, pack, take)
 import qualified Data.Text as Text
 import           Data.Time.Clock (getCurrentTime)
+import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import           Data.Version (showVersion)
 import           Network.HostName (getHostName)
 import           Network.Socket (AddrInfo, Socket)
@@ -289,7 +290,9 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
     traceNamedObject (appendName "networkMagic" tr)
                      (meta, LogMessage ("NetworkMagic " <> show (unNetworkMagic . getNetworkMagic $ Consensus.configBlock cfg)))
 
-    traceNodeBasicInfo tr =<< nodeBasicInfo nc p =<< getCurrentTime
+    startTime <- getCurrentTime
+    traceNodeBasicInfo tr =<< nodeBasicInfo nc p startTime
+    traceCounter "nodeStartTime" (ceiling $ utcTimeToPOSIXSeconds startTime) tr
 
     when ncValidateDB $ traceWith tracer "Performing DB validation"
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -20,6 +20,7 @@ module Cardano.Tracing.Tracers
   , TraceOptions
   , mkTracers
   , nullTracers
+  , traceCounter
   ) where
 
 import           Cardano.Prelude hiding (show)

--- a/shell.nix
+++ b/shell.nix
@@ -51,6 +51,7 @@ let
     stdenv.mkDerivation {
     name = "devops-shell";
     buildInputs = [
+      cabal-install
       niv
       cardano-cli
       bech32


### PR DESCRIPTION
This adds the `nodeStartTime` metric to the Prometheus export:
```
$  curl -s http://localhost:12798/metrics/ | grep nodeStart
cardano_node_metrics_nodeStartTime_int 1606215710
```