### PR TITLE
Completing API support for Allegra and Mary eras

### DIFF
--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -114,24 +114,47 @@ module Cardano.API (
 
     -- * Building transactions
     -- | Constructing and inspecting transactions
+
+    -- ** Transaction bodies
     TxBody,
+    makeTransactionBody,
+    TxBodyContent(..),
+
+    -- ** Transaction Ids
     TxId,
     getTxId,
+
+    -- ** Transaction inputs
     TxIn(TxIn),
     TxIx(TxIx),
+
+    -- ** Transaction outputs
     TxOut(TxOut),
     TxOutValue(..),
-    AdaOnlyInEra(..),
-    MultiAssetInEra(..),
-    TTL,
-    TxFee,
-    MintValue(..),
-    makeByronTransaction,
-    makeShelleyTransaction,
-    SlotNo,
-    TxExtraContent,
-    txExtraContentEmpty,
-    Certificate,
+
+    -- ** Other transaction body types
+    TxFee(..),
+    TxValidityLowerBound(..),
+    TxValidityUpperBound(..),
+    SlotNo(..),
+    TxMetadataInEra(..),
+    TxAuxScripts(..),
+    TxWithdrawals(..),
+    TxCertificates(..),
+    TxUpdateProposal(..),
+    TxMintValue(..),
+
+    -- ** Era-dependent transaction body features
+    OnlyAdaSupportedInEra(..),
+    MultiAssetSupportedInEra(..),
+    ValidityUpperBoundSupportedInEra(..),
+    ValidityNoUpperBoundSupportedInEra(..),
+    ValidityLowerBoundSupportedInEra(..),
+    TxMetadataSupportedInEra(..),
+    AuxScriptsSupportedInEra(..),
+    WithdrawalsSupportedInEra(..),
+    CertificatesSupportedInEra(..),
+    UpdateProposalSupportedInEra(..),
 
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.
@@ -176,7 +199,10 @@ module Cardano.API (
     TxMetadataJsonError (..),
     TxMetadataJsonSchemaError (..),
 
-    -- * Registering stake address and delegating
+    -- * Certificates
+    Certificate,
+
+    -- ** Registering stake address and delegating
     -- | Certificates that are embedded in transactions for registering and
     -- unregistering stake address, and for setting the stake pool delegation
     -- choice for a stake address.
@@ -184,7 +210,7 @@ module Cardano.API (
     makeStakeAddressDeregistrationCertificate,
     makeStakeAddressDelegationCertificate,
 
-    -- * Registering stake pools
+    -- ** Registering stake pools
     -- | Certificates that are embedded in transactions for registering and
     -- retiring stake pools. This includes updating the stake pool parameters.
     makeStakePoolRegistrationCertificate,
@@ -193,7 +219,7 @@ module Cardano.API (
     StakePoolRelay,
     StakePoolMetadataReference,
 
-    -- ** Stake pool off-chain metadata
+    -- * Stake pool off-chain metadata
     StakePoolMetadata,
     validateAndHashStakePoolMetadata,
     StakePoolMetadataValidationError,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -147,6 +147,7 @@ module Cardano.API (
     -- ** Era-dependent transaction body features
     OnlyAdaSupportedInEra(..),
     MultiAssetSupportedInEra(..),
+    TxFeesExplicitInEra (..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
     ValidityLowerBoundSupportedInEra(..),

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -193,7 +193,7 @@ deriving instance Show (ShelleyBasedEra era)
 -- of Shelley-based eras, but also non-uniform by making case distinctions on
 -- the 'ShelleyBasedEra' constructors.
 --
-class HasTypeProxy era => IsShelleyBasedEra era where
+class IsCardanoEra era => IsShelleyBasedEra era where
    shelleyBasedEra :: ShelleyBasedEra era
 
 instance IsShelleyBasedEra ShelleyEra where

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -29,6 +29,7 @@ module Cardano.Api.Script (
   , ScriptFeatureInEra(..)
   , SignatureFeature
   , TimeLocksFeature
+  , HasScriptFeatures
 
     -- * Deprecated aliases
   , MultiSigScript

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -271,10 +271,60 @@ instance Eq (Witness era) where
 
     (==) _ _ = False
 
-{-
-deriving instance Show (Witness ByronEra)
-deriving instance Show (Witness ShelleyEra)
--}
+-- The GADT in the ShelleyTx case requires a custom instance
+--TODO: once we start providing custom patterns we should do the show in terms
+-- of those. It'll be less verbose too!
+instance Show (Witness era) where
+    showsPrec p (ByronKeyWitness tx) =
+      showParen (p >= 11) $
+        showString "ByronKeyWitness "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyBootstrapWitness ShelleyBasedEraShelley tx) =
+      showParen (p >= 11) $
+        showString "ShelleyBootstrapWitness ShelleyBasedEraShelley "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyBootstrapWitness ShelleyBasedEraAllegra tx) =
+      showParen (p >= 11) $
+        showString "ShelleyBootstrapWitness ShelleyBasedEraAllegra "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyBootstrapWitness ShelleyBasedEraMary tx) =
+      showParen (p >= 11) $
+        showString "ShelleyBootstrapWitness ShelleyBasedEraMary "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyKeyWitness ShelleyBasedEraShelley tx) =
+      showParen (p >= 11) $
+        showString "ShelleyKeyWitness ShelleyBasedEraShelley "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyKeyWitness ShelleyBasedEraAllegra tx) =
+      showParen (p >= 11) $
+        showString "ShelleyKeyWitness ShelleyBasedEraAllegra "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyKeyWitness ShelleyBasedEraMary tx) =
+      showParen (p >= 11) $
+        showString "ShelleyKeyWitness ShelleyBasedEraMary "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyScriptWitness ShelleyBasedEraShelley tx) =
+      showParen (p >= 11) $
+        showString "ShelleyScriptWitness ShelleyBasedEraShelley "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyScriptWitness ShelleyBasedEraAllegra tx) =
+      showParen (p >= 11) $
+        showString "ShelleyScriptWitness ShelleyBasedEraAllegra "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyScriptWitness ShelleyBasedEraMary tx) =
+      showParen (p >= 11) $
+        showString "ShelleyScriptWitness ShelleyBasedEraMary "
+      . showsPrec 11 tx
+
 
 instance HasTypeProxy (Witness ByronEra) where
     data AsType (Witness ByronEra) = AsByronWitness

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -40,7 +40,8 @@ module Cardano.Api.Tx (
     getShelleyKeyWitnessVerificationKey,
 
     -- * Data family instances
-    AsType(AsTx, AsByronTx, AsShelleyTx, AsByronWitness, AsShelleyWitness),
+    AsType(AsTx, AsByronTx, AsShelleyTx,
+           AsWitness, AsByronWitness, AsShelleyWitness),
   ) where
 
 import           Prelude
@@ -326,13 +327,18 @@ instance Show (Witness era) where
       . showsPrec 11 tx
 
 
-instance HasTypeProxy (Witness ByronEra) where
-    data AsType (Witness ByronEra) = AsByronWitness
-    proxyToAsType _ = AsByronWitness
+instance HasTypeProxy era => HasTypeProxy (Witness era) where
+    data AsType (Witness era) = AsWitness (AsType era)
+    proxyToAsType _ = AsWitness (proxyToAsType (Proxy :: Proxy era))
 
-instance HasTypeProxy (Witness ShelleyEra) where
-    data AsType (Witness ShelleyEra) = AsShelleyWitness
-    proxyToAsType _ = AsShelleyWitness
+pattern AsByronWitness :: AsType (Witness ByronEra)
+pattern AsByronWitness   = AsWitness AsByronEra
+{-# COMPLETE AsByronWitness #-}
+
+pattern AsShelleyWitness :: AsType (Witness ShelleyEra)
+pattern AsShelleyWitness = AsWitness AsShelleyEra
+{-# COMPLETE AsShelleyWitness #-}
+
 
 instance SerialiseAsCBOR (Witness ByronEra) where
     serialiseToCBOR (ShelleyBootstrapWitness era _) = case era of {}

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -141,6 +141,29 @@ instance Eq (Tx era) where
 
     (==) (ByronTx{}) (ShelleyTx era _) = case era of {}
 
+-- The GADT in the ShelleyTx case requires a custom instance
+instance Show (Tx era) where
+    showsPrec p (ByronTx tx) =
+      showParen (p >= 11) $
+        showString "ByronTx "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyTx ShelleyBasedEraShelley tx) =
+      showParen (p >= 11) $
+        showString "ShelleyTx ShelleyBasedEraShelley "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyTx ShelleyBasedEraAllegra tx) =
+      showParen (p >= 11) $
+        showString "ShelleyTx ShelleyBasedEraAllegra "
+      . showsPrec 11 tx
+
+    showsPrec p (ShelleyTx ShelleyBasedEraMary tx) =
+      showParen (p >= 11) $
+        showString "ShelleyTx ShelleyBasedEraMary "
+      . showsPrec 11 tx
+
+
 instance HasTypeProxy era => HasTypeProxy (Tx era) where
     data AsType (Tx era) = AsTx (AsType era)
     proxyToAsType _ = AsTx (proxyToAsType (Proxy :: Proxy era))

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -242,11 +242,37 @@ data Witness era where
        -> Ledger.Script (ShelleyLedgerEra era)
        -> Witness era
 
-{-
-deriving instance Eq (Witness ByronEra)
-deriving instance Show (Witness ByronEra)
 
-deriving instance Eq (Witness ShelleyEra)
+-- The GADT in the Shelley cases requires a custom instance
+instance Eq (Witness era) where
+    (==) (ByronKeyWitness wA)
+         (ByronKeyWitness wB) = wA == wB
+
+    (==) (ShelleyBootstrapWitness era wA)
+         (ShelleyBootstrapWitness _   wB) =
+      case era of
+        ShelleyBasedEraShelley -> wA == wB
+        ShelleyBasedEraAllegra -> wA == wB
+        ShelleyBasedEraMary    -> wA == wB
+
+    (==) (ShelleyKeyWitness era wA)
+         (ShelleyKeyWitness _   wB) =
+      case era of
+        ShelleyBasedEraShelley -> wA == wB
+        ShelleyBasedEraAllegra -> wA == wB
+        ShelleyBasedEraMary    -> wA == wB
+
+    (==) (ShelleyScriptWitness era wA)
+         (ShelleyScriptWitness _   wB) =
+      case era of
+        ShelleyBasedEraShelley -> wA == wB
+        ShelleyBasedEraAllegra -> wA == wB
+        ShelleyBasedEraMary    -> wA == wB
+
+    (==) _ _ = False
+
+{-
+deriving instance Show (Witness ByronEra)
 deriving instance Show (Witness ShelleyEra)
 -}
 

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
@@ -135,7 +134,7 @@ instance Eq (Tx era) where
         ShelleyBasedEraAllegra -> txA == txB
         ShelleyBasedEraMary    -> txA == txB
 
-    (==) (ByronTx{}) (ShelleyTx era _) = case era of {}
+    (==) ByronTx{} (ShelleyTx era _) = case era of {}
 
 -- The GADT in the ShelleyTx case requires a custom instance
 instance Show (Tx era) where

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -51,6 +51,7 @@ module Cardano.Api.TxBody (
     -- * Era-dependent transaction body features
     OnlyAdaSupportedInEra(..),
     MultiAssetSupportedInEra(..),
+    TxFeesExplicitInEra (..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
     ValidityLowerBoundSupportedInEra(..),

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -130,26 +130,54 @@ module Cardano.Api.Typed (
 
     -- * Building transactions
     -- | Constructing and inspecting transactions
+
+    -- ** Transaction bodies
     TxBody(..),
-    TxId(..),
-    getTxId,
-    TxIn(..),
-    TxIx(..),
-    TxOut(..),
-    TxOutValue(..),
-    AdaOnlyInEra(..),
-    MultiAssetInEra(..),
-    TTL,
-    TxFee,
-    MintValue(..),
+    makeTransactionBody,
+    TxBodyContent(..),
+
+    -- ** Transitional utils
     makeByronTransaction,
     makeShelleyTransaction,
+
+    -- ** Transaction Ids
+    TxId(..),
+    getTxId,
+
+    -- ** Transaction inputs
+    TxIn(..),
+    TxIx(..),
+
+    -- ** Transaction outputs
+    TxOut(..),
+    TxOutValue(..),
+
+    -- ** Other transaction body types
+    TxFee(..),
+    TxValidityLowerBound(..),
+    TxValidityUpperBound(..),
     SlotNo(..),
-    TxExtraContent(..),
-    txExtraContentEmpty,
+    TxMetadataInEra(..),
+    TxAuxScripts(..),
+    TxWithdrawals(..),
+    TxCertificates(..),
     Certificate(..),
     toShelleyCertificate,
     fromShelleyCertificate,
+    TxUpdateProposal(..),
+    TxMintValue(..),
+
+    -- ** Era-dependent transaction body features
+    OnlyAdaSupportedInEra(..),
+    MultiAssetSupportedInEra(..),
+    ValidityUpperBoundSupportedInEra(..),
+    ValidityNoUpperBoundSupportedInEra(..),
+    ValidityLowerBoundSupportedInEra(..),
+    TxMetadataSupportedInEra(..),
+    AuxScriptsSupportedInEra(..),
+    WithdrawalsSupportedInEra(..),
+    CertificatesSupportedInEra(..),
+    UpdateProposalSupportedInEra(..),
 
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -269,6 +269,7 @@ module Cardano.Api.Typed (
     ScriptFeatureInEra(..),
     SignatureFeature,
     TimeLocksFeature,
+    HasScriptFeatures,
     -- *** Deprecated aliases
     MultiSigScript,
     makeMultiSigScript,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -170,6 +170,7 @@ module Cardano.Api.Typed (
     -- ** Era-dependent transaction body features
     OnlyAdaSupportedInEra(..),
     MultiAssetSupportedInEra(..),
+    TxFeesExplicitInEra (..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
     ValidityLowerBoundSupportedInEra(..),
@@ -801,4 +802,3 @@ submitTxToNodeLocal connctInfo tx = do
         pure $ SendMsgSubmitTx tx $ \result -> do
         atomically $ putTMVar resultVar result
         pure (TxSubmission.SendMsgDone ())
-

--- a/cardano-api/test/Test/Cardano/Api/MetaData.hs
+++ b/cardano-api/test/Test/Cardano/Api/MetaData.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Cardano.Api.MetaData
   ( tests
+  , genTxMetadata
   ) where
 
 import           Cardano.Prelude hiding (MetaData)

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -22,27 +22,43 @@ import qualified Hedgehog as H
 
 prop_roundtrip_txbody_byron_CBOR :: Property
 prop_roundtrip_txbody_byron_CBOR =
-  roundtrip_CBOR AsByronTxBody genTxBodyByron
+  roundtrip_CBOR (AsTxBody AsByronEra) (genTxBody ByronEra)
 
 prop_roundtrip_txbody_shelley_CBOR :: Property
 prop_roundtrip_txbody_shelley_CBOR =
-  roundtrip_CBOR AsShelleyTxBody genTxBodyShelley
+  roundtrip_CBOR (AsTxBody AsShelleyEra) (genTxBody ShelleyEra)
+
+prop_roundtrip_txbody_allegra_CBOR :: Property
+prop_roundtrip_txbody_allegra_CBOR =
+  roundtrip_CBOR (AsTxBody AsAllegraEra) (genTxBody AllegraEra)
+
+prop_roundtrip_txbody_mary_CBOR :: Property
+prop_roundtrip_txbody_mary_CBOR =
+  roundtrip_CBOR (AsTxBody AsMaryEra) (genTxBody MaryEra)
 
 prop_roundtrip_tx_byron_CBOR :: Property
 prop_roundtrip_tx_byron_CBOR =
-  roundtrip_CBOR AsByronTx genTxByron
+  roundtrip_CBOR (AsTx AsByronEra) (genTx ByronEra)
 
 prop_roundtrip_tx_shelley_CBOR :: Property
 prop_roundtrip_tx_shelley_CBOR =
-  roundtrip_CBOR AsShelleyTx genTxShelley
-
-prop_roundtrip_witness_shelley_CBOR :: Property
-prop_roundtrip_witness_shelley_CBOR =
-  roundtrip_CBOR AsShelleyWitness genShelleyWitness
+  roundtrip_CBOR (AsTx AsShelleyEra) (genTx ShelleyEra)
 
 prop_roundtrip_witness_byron_CBOR :: Property
 prop_roundtrip_witness_byron_CBOR =
-  roundtrip_CBOR AsByronWitness genByronKeyWitness
+  roundtrip_CBOR (AsWitness AsByronEra) genByronKeyWitness
+
+prop_roundtrip_witness_shelley_CBOR :: Property
+prop_roundtrip_witness_shelley_CBOR =
+  roundtrip_CBOR (AsWitness AsShelleyEra) (genShelleyWitness ShelleyEra)
+
+prop_roundtrip_witness_allegra_CBOR :: Property
+prop_roundtrip_witness_allegra_CBOR =
+  roundtrip_CBOR (AsWitness AsAllegraEra) (genShelleyWitness AllegraEra)
+
+prop_roundtrip_witness_mary_CBOR :: Property
+prop_roundtrip_witness_mary_CBOR =
+  roundtrip_CBOR (AsWitness AsMaryEra) (genShelleyWitness MaryEra)
 
 prop_roundtrip_operational_certificate_CBOR :: Property
 prop_roundtrip_operational_certificate_CBOR =
@@ -116,9 +132,17 @@ prop_roundtrip_signing_key_kes_CBOR :: Property
 prop_roundtrip_signing_key_kes_CBOR =
   roundtrip_CBOR (AsSigningKey AsKesKey) (genSigningKey AsKesKey)
 
-prop_roundtrip_script_CBOR :: Property
-prop_roundtrip_script_CBOR =
-  roundtrip_CBOR (AsScript AsShelleyEra) genScript
+prop_roundtrip_script_shelley_CBOR :: Property
+prop_roundtrip_script_shelley_CBOR =
+  roundtrip_CBOR (AsScript AsShelleyEra) (genScript ShelleyBasedEraShelley)
+
+prop_roundtrip_script_allegra_CBOR :: Property
+prop_roundtrip_script_allegra_CBOR =
+  roundtrip_CBOR (AsScript AsAllegraEra) (genScript ShelleyBasedEraAllegra)
+
+prop_roundtrip_script_mary_CBOR :: Property
+prop_roundtrip_script_mary_CBOR =
+  roundtrip_CBOR (AsScript AsMaryEra) (genScript ShelleyBasedEraMary)
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Test.Cardano.Api.Typed.Gen
   ( genAddressByron
   , genAddressShelley
   , genByronKeyWitness
   , genRequiredSig
   , genMofNRequiredSig
+  , genSimpleScript
+  , genSimpleScripts
   , genMultiSigScript
   , genMultiSigScriptAllegra
   , genMultiSigScriptMary
@@ -15,10 +20,8 @@ module Test.Cardano.Api.Typed.Gen
   , genShelleyWitness
   , genSigningKey
   , genStakeAddress
-  , genTxByron
-  , genTxShelley
-  , genTxBodyByron
-  , genTxBodyShelley
+  , genTx
+  , genTxBody
   , genVerificationKey
   ) where
 
@@ -27,15 +30,17 @@ import           Cardano.Api.Typed
 import           Cardano.Prelude
 
 import           Control.Monad.Fail (fail)
+import qualified Data.Map as Map
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Seed as Crypto
 
-import           Hedgehog (Gen)
+import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import           Test.Cardano.Api.MetaData (genTxMetadata)
 import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 
@@ -80,6 +85,22 @@ genMofN s = do
  let numKeys = length s
  required <- Gen.integral (Range.linear 0 numKeys)
  pure $ RequireMOf required s
+
+-- Script generators for a provided Shelley-based era
+
+genSimpleScript :: ShelleyBasedEra era -> Gen (SimpleScript era)
+genSimpleScript era =
+  case era of
+    ShelleyBasedEraShelley -> genMultiSigScriptShelley
+    ShelleyBasedEraAllegra -> genMultiSigScriptAllegra
+    ShelleyBasedEraMary -> genMultiSigScriptMary
+
+genSimpleScripts :: ShelleyBasedEra era -> Gen [SimpleScript era]
+genSimpleScripts era =
+  case era of
+    ShelleyBasedEraShelley -> genMultiSigScriptsShelley
+    ShelleyBasedEraAllegra -> genMultiSigScriptsAllegra
+    ShelleyBasedEraMary -> genMultiSigScriptsMary
 
 -- Shelley
 
@@ -167,11 +188,11 @@ genMultiSigScript :: Gen (MultiSigScript ShelleyEra)
 genMultiSigScript =
   Gen.choice [genAllRequiredSig, genAnyRequiredSig, genMofNRequiredSig]
 
-genScript :: Gen (Script ShelleyEra)
-genScript = makeMultiSigScript <$> genMultiSigScript
+genScript :: HasScriptFeatures era => ShelleyBasedEra era -> Gen (Script era)
+genScript era = SimpleScript <$> genSimpleScript era
 
 genScriptHash :: Gen ScriptHash
-genScriptHash = scriptHash <$> genScript
+genScriptHash = scriptHash <$> genScript ShelleyBasedEraShelley
 
 genNetworkId :: Gen NetworkId
 genNetworkId =
@@ -245,13 +266,11 @@ genStakeCredential = do
   return . StakeCredentialByKey $ verificationKeyHash vKey
 
 genTxBodyShelley :: Gen (TxBody ShelleyEra)
-genTxBodyShelley =
-   makeShelleyTransaction
-     <$> genTxExtraContent
-     <*> genTTL
-     <*> genTxFee
-     <*> Gen.list (Range.constant 1 10) genTxIn
-     <*> Gen.list (Range.constant 1 10) genShelleyTxOut
+genTxBodyShelley = do
+  res <- makeTransactionBody <$> genTxBodyContent ShelleyEra
+  case res of
+    Left err -> fail (show err) -- TODO: Render function for TxBodyError
+    Right txBody -> pure txBody
 
 genByronTxOut :: Gen (TxOut ByronEra)
 genByronTxOut =
@@ -272,17 +291,10 @@ genSlotNo = SlotNo <$> Gen.word64 Range.constantBounded
 -- TODO: Should probably have a naive generator that generates no inputs, no outputs etc
 genTxBodyByron :: Gen (TxBody ByronEra)
 genTxBodyByron = do
-  txIns <- Gen.list (Range.constant 1 10) genTxIn
-  txOuts <- Gen.list (Range.constant 1 10) genByronTxOut
-  case makeByronTransaction txIns txOuts of
-    Left err -> panic $ show err
-    Right txBody -> return txBody
-
-genTxByron :: Gen (Tx ByronEra)
-genTxByron =
-  makeSignedTransaction
-    <$> Gen.list (Range.constant 1 10) genByronKeyWitness
-    <*> genTxBodyByron
+  res <- makeTransactionBody <$> genTxBodyContent ByronEra
+  case res of
+    Left err -> fail (show err)
+    Right txBody -> pure txBody
 
 genTxIn :: Gen TxIn
 genTxIn = TxIn <$> genTxId <*> genTxIndex
@@ -293,26 +305,259 @@ genTxId = TxId <$> genShelleyHash
 genTxIndex :: Gen TxIx
 genTxIndex = TxIx <$> Gen.word Range.constantBounded
 
-genTxShelley :: Gen (Tx ShelleyEra)
-genTxShelley =
+genQuantity :: Gen Quantity
+genQuantity = Quantity <$> Gen.integral (Range.linear 0 5000)
+
+-- TODO: UTF8 bytes or random bytes?
+genAssetName :: Gen AssetName
+genAssetName = AssetName <$> Gen.bytes (Range.singleton 32)
+
+genPolicyId :: Gen PolicyId
+genPolicyId = PolicyId <$> genScriptHash
+
+genAssetId :: Gen AssetId
+genAssetId =
+  Gen.frequency
+    [ (1, pure AdaAssetId)
+    , (9, AssetId <$> genPolicyId <*> genAssetName)
+    ]
+
+genValue :: Gen Value
+genValue = valueFromList <$> Gen.list range genKeyValuePair
+  where
+    range :: Range Int
+    range = Range.constant 1 10
+
+    genKeyValuePair :: Gen (AssetId, Quantity)
+    genKeyValuePair = (,) <$> genAssetId <*> genQuantity
+
+genTxOutValue :: CardanoEra era -> Gen (TxOutValue era)
+genTxOutValue era =
+  case era of
+    ByronEra -> TxOutAdaOnly AdaOnlyInByronEra <$> genLovelace
+    ShelleyEra -> TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace
+    AllegraEra -> TxOutAdaOnly AdaOnlyInAllegraEra <$> genLovelace
+    MaryEra -> TxOutValue MultiAssetInMaryEra <$> genValue
+
+genTxOut :: CardanoEra era -> Gen (TxOut era)
+genTxOut era =
+  case era of
+    ByronEra -> genByronTxOut
+    ShelleyEra -> genShelleyTxOut
+    AllegraEra ->
+      TxOut
+        <$> (shelleyAddressInEra <$> genAddressShelley)
+        <*> (TxOutAdaOnly AdaOnlyInAllegraEra <$> genLovelace)
+    MaryEra ->
+      TxOut
+        <$> (shelleyAddressInEra <$> genAddressShelley)
+        <*> genTxOutValue era
+
+genTtl :: Gen SlotNo
+genTtl = genSlotNo
+
+-- TODO: Accept a range for generating ttl.
+genTxValidityLowerBound :: CardanoEra era -> Gen (TxValidityLowerBound era)
+genTxValidityLowerBound era =
+  case era of
+    ByronEra -> pure TxValidityNoLowerBound
+    ShelleyEra -> pure TxValidityNoLowerBound
+    AllegraEra -> TxValidityLowerBound ValidityLowerBoundInAllegraEra <$> genTtl
+    MaryEra -> TxValidityLowerBound ValidityLowerBoundInMaryEra <$> genTtl
+
+-- TODO: Accept a range for generating ttl.
+genTxValidityUpperBound :: CardanoEra era -> Gen (TxValidityUpperBound era)
+genTxValidityUpperBound era =
+  case era of
+    ByronEra -> pure (TxValidityNoUpperBound ValidityNoUpperBoundInByronEra)
+    ShelleyEra -> TxValidityUpperBound ValidityUpperBoundInShelleyEra <$> genTtl
+    AllegraEra -> TxValidityUpperBound ValidityUpperBoundInAllegraEra <$> genTtl
+    MaryEra -> TxValidityUpperBound ValidityUpperBoundInMaryEra <$> genTtl
+
+genTxValidityRange
+  :: CardanoEra era
+  -> Gen (TxValidityLowerBound era, TxValidityUpperBound era)
+genTxValidityRange era =
+  (,)
+    <$> genTxValidityLowerBound era
+    <*> genTxValidityUpperBound era
+
+genTxMetadataInEra :: CardanoEra era -> Gen (TxMetadataInEra era)
+genTxMetadataInEra era =
+  case era of
+    ByronEra -> pure TxMetadataNone
+    ShelleyEra ->
+      Gen.choice
+        [ pure TxMetadataNone
+        , TxMetadataInEra TxMetadataInShelleyEra <$> genTxMetadata
+        ]
+    AllegraEra ->
+      Gen.choice
+        [ pure TxMetadataNone
+        , TxMetadataInEra TxMetadataInAllegraEra <$> genTxMetadata
+        ]
+    MaryEra ->
+      Gen.choice
+        [ pure TxMetadataNone
+        , TxMetadataInEra TxMetadataInMaryEra <$> genTxMetadata
+        ]
+
+genTxAuxScripts :: CardanoEra era -> Gen (TxAuxScripts era)
+genTxAuxScripts era =
+  case era of
+    ByronEra -> pure TxAuxScriptsNone
+    ShelleyEra -> pure TxAuxScriptsNone
+    AllegraEra ->
+      TxAuxScripts AuxScriptsInAllegraEra
+        <$> (map SimpleScript <$> genSimpleScripts ShelleyBasedEraAllegra)
+    MaryEra ->
+      TxAuxScripts AuxScriptsInMaryEra
+        <$> (map SimpleScript <$> genSimpleScripts ShelleyBasedEraMary)
+
+genTxWithdrawals :: CardanoEra era -> Gen (TxWithdrawals era)
+genTxWithdrawals era =
+  case era of
+    ByronEra -> pure TxWithdrawalsNone
+    ShelleyEra ->
+      Gen.choice
+        [ pure TxWithdrawalsNone
+        , pure (TxWithdrawals WithdrawalsInShelleyEra mempty) -- TODO: Generate withdrawals
+        ]
+    AllegraEra ->
+      Gen.choice
+        [ pure TxWithdrawalsNone
+        , pure (TxWithdrawals WithdrawalsInAllegraEra mempty) -- TODO: Generate withdrawals
+        ]
+    MaryEra ->
+      Gen.choice
+        [ pure TxWithdrawalsNone
+        , pure (TxWithdrawals WithdrawalsInMaryEra mempty) -- TODO: Generate withdrawals
+        ]
+
+genTxCertificates :: CardanoEra era -> Gen (TxCertificates era)
+genTxCertificates era =
+  case era of
+    ByronEra -> pure TxCertificatesNone
+    ShelleyEra ->
+      Gen.choice
+        [ pure TxCertificatesNone
+        , pure (TxCertificates CertificatesInShelleyEra mempty) -- TODO: Generate certificates
+        ]
+    AllegraEra ->
+      Gen.choice
+        [ pure TxCertificatesNone
+        , pure (TxCertificates CertificatesInAllegraEra mempty) -- TODO: Generate certificates
+        ]
+    MaryEra ->
+      Gen.choice
+        [ pure TxCertificatesNone
+        , pure (TxCertificates CertificatesInMaryEra mempty) -- TODO: Generate certificates
+        ]
+
+genTxUpdateProposal :: CardanoEra era -> Gen (TxUpdateProposal era)
+genTxUpdateProposal era =
+  case era of
+    ByronEra -> pure TxUpdateProposalNone
+    ShelleyEra ->
+      Gen.choice
+        [ pure TxUpdateProposalNone
+        , pure (TxUpdateProposal UpdateProposalInShelleyEra emptyUpdateProposal) -- TODO: Generate proposals
+        ]
+    AllegraEra ->
+      Gen.choice
+        [ pure TxUpdateProposalNone
+        , pure (TxUpdateProposal UpdateProposalInAllegraEra emptyUpdateProposal) -- TODO: Generate proposals
+        ]
+    MaryEra ->
+      Gen.choice
+        [ pure TxUpdateProposalNone
+        , pure (TxUpdateProposal UpdateProposalInMaryEra emptyUpdateProposal) -- TODO: Generate proposals
+        ]
+  where
+    emptyUpdateProposal :: UpdateProposal
+    emptyUpdateProposal = UpdateProposal Map.empty (EpochNo 0)
+
+genTxMintValue :: CardanoEra era -> Gen (TxMintValue era)
+genTxMintValue era =
+  case era of
+    ByronEra -> pure TxMintNone
+    ShelleyEra -> pure TxMintNone
+    AllegraEra -> pure TxMintNone
+    MaryEra ->
+      Gen.choice
+        [ pure TxMintNone
+        , TxMintValue MultiAssetInMaryEra <$> genValue
+        ]
+
+genTxBodyContent :: CardanoEra era -> Gen (TxBodyContent era)
+genTxBodyContent era = do
+  trxIns <- Gen.list (Range.constant 1 10) genTxIn
+  trxOuts <- Gen.list (Range.constant 1 10) (genTxOut era)
+  fee <- genTxFee era
+  validityRange <- genTxValidityRange era
+  txMd <- genTxMetadataInEra era
+  auxScripts <- genTxAuxScripts era
+  withdrawals <- genTxWithdrawals era
+  certs <- genTxCertificates era
+  updateProposal <- genTxUpdateProposal era
+  mintValue <- genTxMintValue era
+
+  pure $ TxBodyContent
+    { txIns = trxIns
+    , txOuts = trxOuts
+    , txFee = fee
+    , txValidityRange = validityRange
+    , txMetadata = txMd
+    , txAuxScripts = auxScripts
+    , txWithdrawals = withdrawals
+    , txCertificates = certs
+    , txUpdateProposal = updateProposal
+    , txMintValue = mintValue
+    }
+
+genTxFee :: CardanoEra era -> Gen (TxFee era)
+genTxFee era =
+  case era of
+    ByronEra -> pure TxFeeImplicit
+    ShelleyEra -> TxFeeExplicit TxFeesExplicitInShelleyEra <$> genLovelace
+    AllegraEra -> TxFeeExplicit TxFeesExplicitInAllegraEra <$> genLovelace
+    MaryEra -> TxFeeExplicit TxFeesExplicitInMaryEra <$> genLovelace
+
+genTxBody :: CardanoEra era -> Gen (TxBody era)
+genTxBody era =
+  case era of
+    ByronEra -> genTxBodyByron
+    ShelleyEra -> genTxBodyShelley
+    AllegraEra -> do
+      res <- makeTransactionBody <$> genTxBodyContent AllegraEra
+      case res of
+        Left err -> fail (show err) -- TODO: Render function for TxBodyError
+        Right txBody -> pure txBody
+    MaryEra -> do
+      res <- makeTransactionBody <$> genTxBodyContent MaryEra
+      case res of
+        Left err -> fail (show err) -- TODO: Render function for TxBodyError
+        Right txBody -> pure txBody
+
+genTx :: forall era. CardanoEra era -> Gen (Tx era)
+genTx era =
   makeSignedTransaction
     <$> genWitnessList
-    <*> genTxBodyShelley
- where
-   genWitnessList :: Gen [Witness ShelleyEra]
-   genWitnessList = do
-     bsWits <- Gen.list (Range.constant 0 10) genShelleyBootstrapWitness
-     keyWits <- Gen.list (Range.constant 0 10) genShelleyKeyWitness
-     return $ bsWits ++ keyWits
+    <*> genTxBody era
+  where
+    genWitnessList :: Gen [Witness era]
+    genWitnessList =
+      case era of
+        ByronEra -> Gen.list (Range.constant 1 10) genByronKeyWitness
+        ShelleyEra -> genShelleyBasedWitnessList
+        AllegraEra -> genShelleyBasedWitnessList
+        MaryEra -> genShelleyBasedWitnessList
 
-genTxExtraContent :: Gen TxExtraContent
-genTxExtraContent = return txExtraContentEmpty
-
-genTTL :: Gen TTL
-genTTL = genSlotNo
-
-genTxFee :: Gen TxFee
-genTxFee = genLovelace
+    genShelleyBasedWitnessList :: IsShelleyBasedEra era => Gen [Witness era]
+    genShelleyBasedWitnessList = do
+      bsWits <- Gen.list (Range.constant 0 10) (genShelleyBootstrapWitness era)
+      keyWits <- Gen.list (Range.constant 0 10) (genShelleyKeyWitness era)
+      return $ bsWits ++ keyWits
 
 genVerificationKey :: Key keyrole => AsType keyrole -> Gen (VerificationKey keyrole)
 genVerificationKey roletoken = getVerificationKey <$> genSigningKey roletoken
@@ -330,21 +575,34 @@ genWitnessNetworkIdOrByronAddress =
     , WitnessByronAddress <$> genAddressByron
     ]
 
-genShelleyBootstrapWitness :: Gen (Witness ShelleyEra)
-genShelleyBootstrapWitness =
+genShelleyBootstrapWitness
+  :: IsShelleyBasedEra era
+  => CardanoEra era
+  -> Gen (Witness era)
+genShelleyBootstrapWitness era =
  makeShelleyBootstrapWitness
    <$> genWitnessNetworkIdOrByronAddress
-   <*> genTxBodyShelley
+   <*> genTxBody era
    <*> genSigningKey AsByronKey
 
-genShelleyKeyWitness :: Gen (Witness ShelleyEra)
-genShelleyKeyWitness =
+genShelleyKeyWitness
+  :: IsShelleyBasedEra era
+  => CardanoEra era
+  -> Gen (Witness era)
+genShelleyKeyWitness era =
   makeShelleyKeyWitness
-    <$> genTxBodyShelley
+    <$> genTxBody era
     <*> genShelleyWitnessSigningKey
 
-genShelleyWitness :: Gen (Witness ShelleyEra)
-genShelleyWitness = Gen.choice [genShelleyKeyWitness, genShelleyBootstrapWitness]
+genShelleyWitness
+  :: IsShelleyBasedEra era
+  => CardanoEra era
+  -> Gen (Witness era)
+genShelleyWitness era =
+  Gen.choice
+   [ genShelleyKeyWitness era
+   , genShelleyBootstrapWitness era
+   ]
 
 genShelleyWitnessSigningKey :: Gen ShelleyWitnessSigningKey
 genShelleyWitnessSigningKey =
@@ -355,11 +613,6 @@ genShelleyWitnessSigningKey =
              , WitnessGenesisDelegateKey <$>  genSigningKey AsGenesisDelegateKey
              , WitnessGenesisUTxOKey <$>  genSigningKey AsGenesisUTxOKey
              ]
-{-
--- TODO: makeScriptWitness = undefined
-genShelleyScriptWitness :: Gen (Witness Shelley)
-genShelleyScriptWitness = makeScriptWitness
--}
 
 genSeed :: Int -> Gen Crypto.Seed
 genSeed n = Crypto.mkSeedFromBytes <$> Gen.bytes (Range.singleton n)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -59,6 +59,7 @@ import qualified Shelley.Spec.Ledger.Keys as Ledger
 import           Shelley.Spec.Ledger.LedgerState (NewEpochState)
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
 import           Shelley.Spec.Ledger.PParams (PParams)
+import           Shelley.Spec.Ledger.Scripts ()
 import qualified Shelley.Spec.Ledger.TxBody as Ledger (TxId (..), TxIn (..), TxOut (..))
 import qualified Shelley.Spec.Ledger.UTxO as Ledger (UTxO (..))
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -161,17 +161,17 @@ runTxBuildRaw txins txouts ttl fee
           fmap Just <$> firstExceptT ShelleyTxCmdReadTextViewFileError $ newExceptT $
             Api.readFileTextEnvelope Api.AsUpdateProposal file
 
-    let txBody = Api.makeShelleyTransaction
-                   Api.txExtraContentEmpty {
-                     Api.txCertificates   = certs,
-                     Api.txWithdrawals    = withdrawals,
-                     Api.txMetadata       = mMetaData,
-                     Api.txUpdateProposal = mUpdateProp
-                   }
-                   ttl
-                   fee
-                   txins
-                   txouts
+    --TODO: update to new API
+    let Right txBody =
+          Api.makeShelleyTransaction
+            txins
+            txouts
+            ttl
+            fee
+            certs
+            withdrawals
+            mMetaData
+            mUpdateProp
 
     firstExceptT ShelleyTxCmdWriteFileError
       . newExceptT


### PR DESCRIPTION
Following on from #2111 with what is hopefully the last remaining API
changes needed to support all the Shelley-based eras.

All the representations and functions should now work for all
appropriate eras.