### PR TITLE
Nixos service: remove "after" dependency on multi-user.target

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -370,7 +370,7 @@ in {
     ##   2. heartbeat & watchdog functionality
     systemd.services."${systemdServiceName}" = {
       description   = "cardano-node node service";
-      after         = [ "network-online.target" "multi-user.target" ]
+      after         = [ "network-online.target" ]
         ++ lib.optional cfg.systemdSocketActivation "${systemdServiceName}.socket";
       requires = lib.mkIf cfg.systemdSocketActivation [ "${systemdServiceName}.socket" ];
       wants = [ "network-online.target" ];


### PR DESCRIPTION
 it causes a dependency cycle for services depending on cardano-node