### PR TITLE
CAD-2337 API extensions for address and credentials

### DIFF
--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -79,6 +79,7 @@ module Cardano.API (
     shelleyAddressInEra,
     anyAddressInShelleyBasedEra,
     anyAddressInEra,
+    toAddressAny,
     makeByronAddressInEra,
     makeShelleyAddressInEra,
 

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -49,8 +49,10 @@ module Cardano.Api.Address (
     toShelleyStakeAddr,
     toShelleyStakeCredential,
     fromShelleyAddr,
+    fromShelleyPaymentCredential,
     fromShelleyStakeAddr,
     fromShelleyStakeCredential,
+    fromShelleyStakeReference,
 
     -- * Serialising addresses
     SerialiseAddress(..),
@@ -554,6 +556,21 @@ fromShelleyStakeCredential (Shelley.KeyHashObj kh) =
 fromShelleyStakeCredential (Shelley.ScriptHashObj sh) =
     StakeCredentialByScript (fromShelleyScriptHash sh)
 
+fromShelleyPaymentCredential :: Shelley.PaymentCredential StandardShelley
+                             -> PaymentCredential
+fromShelleyPaymentCredential (Shelley.KeyHashObj kh) =
+  PaymentCredentialByKey (PaymentKeyHash kh)
+fromShelleyPaymentCredential (Shelley.ScriptHashObj sh) =
+  PaymentCredentialByScript (ScriptHash sh)
+
+fromShelleyStakeReference :: Shelley.StakeReference StandardShelley
+                          -> StakeAddressReference
+fromShelleyStakeReference (Shelley.StakeRefBase stakecred) =
+  StakeAddressByValue (fromShelleyStakeCredential stakecred)
+fromShelleyStakeReference (Shelley.StakeRefPtr ptr) =
+  StakeAddressByPointer ptr
+fromShelleyStakeReference Shelley.StakeRefNull =
+  NoStakeAddress
 
 -- The era parameter in these types is a phantom type so it is safe to cast.
 -- We choose to cast because we need to use an era-independent address
@@ -570,4 +587,3 @@ coerceShelleyStakeCredential = coerce
 coerceShelleyStakeReference :: Shelley.StakeReference eraA
                             -> Shelley.StakeReference eraB
 coerceShelleyStakeReference = coerce
-

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -32,6 +32,7 @@ module Cardano.Api.Address (
     shelleyAddressInEra,
     anyAddressInShelleyBasedEra,
     anyAddressInEra,
+    toAddressAny,
     makeByronAddressInEra,
     makeShelleyAddressInEra,
 
@@ -389,6 +390,9 @@ anyAddressInEra (AddressShelley addr) =
       LegacyByronEra      -> Nothing
       ShelleyBasedEra era -> Just (AddressInEra (ShelleyAddressInEra era) addr)
 
+toAddressAny :: Address addr -> AddressAny
+toAddressAny a@ShelleyAddress{} = AddressShelley a
+toAddressAny a@ByronAddress{}   = AddressByron a
 
 makeByronAddressInEra :: NetworkId
                       -> VerificationKey ByronKey

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -78,6 +78,11 @@ module Cardano.Api.Shelley
     EpochNo(..),
     NetworkMagic(..),
 
+    -- * Credentials & stake references
+    fromShelleyPaymentCredential,
+    fromShelleyStakeCredential,
+    fromShelleyStakeReference,
+
     -- * Scripts
     -- | Both 'PaymentCredential's and 'StakeCredential's can use scripts.
     -- Shelley supports multi-signatures via scripts.

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -95,6 +95,7 @@ module Cardano.Api.Typed (
     shelleyAddressInEra,
     anyAddressInShelleyBasedEra,
     anyAddressInEra,
+    toAddressAny,
     makeByronAddressInEra,
     makeShelleyAddressInEra,
 


### PR DESCRIPTION
- `toAddressAny :: Address addr -> AddressAny`
- `fromShelleyPaymentCredential ::  Shelley.PaymentCredential StandardShelley -> PaymentCredential`
- `fromShelleyStakeReference ::  Shelley.StakeReference StandardShelley -> StakeAddressReference`
- export `fromShelleyStakeCredential`