### PR TITLE
Initial CLI update for Allegra and Mary eras

### DIFF
--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -150,9 +150,10 @@ module Cardano.API (
     TxMintValue(..),
 
     -- ** Era-dependent transaction body features
-    OnlyAdaSupportedInEra(..),
     MultiAssetSupportedInEra(..),
-    TxFeesExplicitInEra (..),
+    OnlyAdaSupportedInEra(..),
+    TxFeesExplicitInEra(..),
+    TxFeesImplicitInEra(..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
     ValidityLowerBoundSupportedInEra(..),
@@ -163,7 +164,6 @@ module Cardano.API (
     UpdateProposalSupportedInEra(..),
 
     -- ** Feature availability functions
-    onlyAdaSupportedInEra,
     multiAssetSupportedInEra,
     txFeesExplicitInEra,
     validityUpperBoundSupportedInEra,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -17,12 +17,12 @@ module Cardano.API (
     AllegraEra,
     MaryEra,
     CardanoEra(..),
-    CardanoEraStyle(..),
     IsCardanoEra(..),
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
-    ShelleyLedgerEra,
+    CardanoEraStyle(..),
+    cardanoEraStyle,
     -- ** Deprecated
     Byron,
     Shelley,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -116,6 +116,7 @@ module Cardano.API (
     lovelaceToQuantity,
     selectLovelace,
     lovelaceToValue,
+    valueToLovelace,
 
     -- * Building transactions
     -- | Constructing and inspecting transactions

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -162,6 +162,19 @@ module Cardano.API (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
 
+    -- ** Feature availability functions
+    onlyAdaSupportedInEra,
+    multiAssetSupportedInEra,
+    txFeesExplicitInEra,
+    validityUpperBoundSupportedInEra,
+    validityNoUpperBoundSupportedInEra,
+    validityLowerBoundSupportedInEra,
+    txMetadataSupportedInEra,
+    auxScriptsSupportedInEra,
+    withdrawalsSupportedInEra,
+    certificatesSupportedInEra,
+    updateProposalSupportedInEra,
+
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.
     Tx,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -124,6 +124,7 @@ module Cardano.API (
     TxBody,
     makeTransactionBody,
     TxBodyContent(..),
+    TxBodyError(..),
 
     -- ** Transaction Ids
     TxId,

--- a/cardano-api/src/Cardano/API.hs
+++ b/cardano-api/src/Cardano/API.hs
@@ -18,11 +18,15 @@ module Cardano.API (
     MaryEra,
     CardanoEra(..),
     IsCardanoEra(..),
+    InAnyCardanoEra(..),
+
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
+    InAnyShelleyBasedEra(..),
     CardanoEraStyle(..),
     cardanoEraStyle,
+
     -- ** Deprecated
     Byron,
     Shelley,

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -388,7 +388,7 @@ anyAddressInEra (AddressByron addr) =
     Just (AddressInEra ByronAddressInAnyEra addr)
 
 anyAddressInEra (AddressShelley addr) =
-    case cardanoEraStyle of
+    case cardanoEraStyle cardanoEra of
       LegacyByronEra      -> Nothing
       ShelleyBasedEra era -> Just (AddressInEra (ShelleyAddressInEra era) addr)
 

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -13,7 +13,6 @@ module Cardano.Api.Eras
   , AllegraEra
   , MaryEra
   , CardanoEra(..)
-  , CardanoEraStyle(..)
   , IsCardanoEra(..)
 
     -- * Deprecated aliases
@@ -26,6 +25,10 @@ module Cardano.Api.Eras
   , ShelleyBasedEra(..)
   , IsShelleyBasedEra(..)
   , ShelleyLedgerEra
+
+    -- * Cardano eras, as Byron vs Shelley-based
+  , CardanoEraStyle(..)
+  , cardanoEraStyle
 
     -- * Data family instances
   , AsType(AsByronEra, AsShelleyEra, AsAllegraEra, AsMaryEra,
@@ -126,46 +129,24 @@ deriving instance Ord  (CardanoEra era)
 deriving instance Show (CardanoEra era)
 
 
--- | This is the same essential information as 'CardanoEra' but instead of a
--- flat set of alternative eras, it is factored into the legcy Byron era and
--- the current Shelley-based eras.
---
--- This way of factoring the eras is useful because in many cases the
--- major differences are between the Byron and Shelley-based eras, and
--- the Shelley-based eras can often be treated uniformly.
---
-data CardanoEraStyle era where
-     LegacyByronEra  ::                        CardanoEraStyle ByronEra
-     ShelleyBasedEra :: ShelleyBasedEra era -> CardanoEraStyle era
-
-deriving instance Eq   (CardanoEraStyle era)
-deriving instance Ord  (CardanoEraStyle era)
-deriving instance Show (CardanoEraStyle era)
-
-
 -- | The class of Cardano eras. This allows uniform handling of all Cardano
 -- eras, but also non-uniform by making case distinctions on the 'CardanoEra'
--- or 'CardanoEraStyle' constructors.
+-- constructors, or the 'CardanoEraStyle' constructors via `cardanoEraStyle`.
 --
 class HasTypeProxy era => IsCardanoEra era where
    cardanoEra      :: CardanoEra era
-   cardanoEraStyle :: CardanoEraStyle era
 
 instance IsCardanoEra ByronEra where
    cardanoEra      = ByronEra
-   cardanoEraStyle = LegacyByronEra
 
 instance IsCardanoEra ShelleyEra where
    cardanoEra      = ShelleyEra
-   cardanoEraStyle = ShelleyBasedEra ShelleyBasedEraShelley
 
 instance IsCardanoEra AllegraEra where
    cardanoEra      = AllegraEra
-   cardanoEraStyle = ShelleyBasedEra ShelleyBasedEraAllegra
 
 instance IsCardanoEra MaryEra where
    cardanoEra      = MaryEra
-   cardanoEraStyle = ShelleyBasedEra ShelleyBasedEraMary
 
 
 -- ----------------------------------------------------------------------------
@@ -204,6 +185,35 @@ instance IsShelleyBasedEra AllegraEra where
 
 instance IsShelleyBasedEra MaryEra where
    shelleyBasedEra = ShelleyBasedEraMary
+
+
+-- ----------------------------------------------------------------------------
+-- Cardano eras factored as Byron vs Shelley-based
+--
+
+-- | This is the same essential information as 'CardanoEra' but instead of a
+-- flat set of alternative eras, it is factored into the legcy Byron era and
+-- the current Shelley-based eras.
+--
+-- This way of factoring the eras is useful because in many cases the
+-- major differences are between the Byron and Shelley-based eras, and
+-- the Shelley-based eras can often be treated uniformly.
+--
+data CardanoEraStyle era where
+     LegacyByronEra  ::                        CardanoEraStyle ByronEra
+     ShelleyBasedEra :: ShelleyBasedEra era -> CardanoEraStyle era
+
+deriving instance Eq   (CardanoEraStyle era)
+deriving instance Ord  (CardanoEraStyle era)
+deriving instance Show (CardanoEraStyle era)
+
+-- | The 'CardanoEraStyle' for a 'CardanoEra'.
+--
+cardanoEraStyle :: CardanoEra era -> CardanoEraStyle era
+cardanoEraStyle ByronEra   = LegacyByronEra
+cardanoEraStyle ShelleyEra = ShelleyBasedEra ShelleyBasedEraShelley
+cardanoEraStyle AllegraEra = ShelleyBasedEra ShelleyBasedEraAllegra
+cardanoEraStyle MaryEra    = ShelleyBasedEra ShelleyBasedEraMary
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -37,6 +37,8 @@ module Cardano.Api.Eras
 
 import           Prelude
 
+import           Data.Type.Equality (TestEquality(..), (:~:)(Refl))
+
 import           Ouroboros.Consensus.Shelley.Eras as Ledger
                    (StandardShelley, StandardAllegra, StandardMary)
 
@@ -127,6 +129,13 @@ data CardanoEra era where
 deriving instance Eq   (CardanoEra era)
 deriving instance Ord  (CardanoEra era)
 deriving instance Show (CardanoEra era)
+
+instance TestEquality CardanoEra where
+    testEquality ByronEra   ByronEra   = Just Refl
+    testEquality ShelleyEra ShelleyEra = Just Refl
+    testEquality AllegraEra AllegraEra = Just Refl
+    testEquality MaryEra    MaryEra    = Just Refl
+    testEquality _          _          = Nothing
 
 
 -- | The class of Cardano eras. This allows uniform handling of all Cardano

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -14,6 +14,7 @@ module Cardano.Api.Eras
   , MaryEra
   , CardanoEra(..)
   , IsCardanoEra(..)
+  , InAnyCardanoEra(..)
 
     -- * Deprecated aliases
   , Byron
@@ -24,6 +25,9 @@ module Cardano.Api.Eras
     -- * Shelley-based eras
   , ShelleyBasedEra(..)
   , IsShelleyBasedEra(..)
+  , InAnyShelleyBasedEra(..)
+
+    -- ** Mapping to era types from the Shelley ledger library
   , ShelleyLedgerEra
 
     -- * Cardano eras, as Byron vs Shelley-based
@@ -158,6 +162,16 @@ instance IsCardanoEra MaryEra where
    cardanoEra      = MaryEra
 
 
+-- | This pairs up some era-dependent type with a 'CardanoEra' value that tells
+-- us what era it is, but hides the era type. This is useful when the era is
+-- not statically known, for example when deserialising from a file.
+--
+data InAnyCardanoEra thing where
+     InAnyCardanoEra :: CardanoEra era
+                     -> thing era
+                     -> InAnyCardanoEra thing
+
+
 -- ----------------------------------------------------------------------------
 -- Shelley-based eras
 --
@@ -194,6 +208,16 @@ instance IsShelleyBasedEra AllegraEra where
 
 instance IsShelleyBasedEra MaryEra where
    shelleyBasedEra = ShelleyBasedEraMary
+
+
+-- | This pairs up some era-dependent type with a 'ShelleyBasedEra' value that
+-- tells us what era it is, but hides the era type. This is useful when the era
+-- is not statically known, for example when deserialising from a file.
+--
+data InAnyShelleyBasedEra thing where
+     InAnyShelleyBasedEra :: ShelleyBasedEra era
+                          -> thing era
+                          -> InAnyShelleyBasedEra thing
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -167,7 +167,8 @@ instance IsCardanoEra MaryEra where
 -- not statically known, for example when deserialising from a file.
 --
 data InAnyCardanoEra thing where
-     InAnyCardanoEra :: CardanoEra era
+     InAnyCardanoEra :: IsCardanoEra era  -- Provide class constraint
+                     => CardanoEra era    -- and explicit value.
                      -> thing era
                      -> InAnyCardanoEra thing
 
@@ -215,7 +216,8 @@ instance IsShelleyBasedEra MaryEra where
 -- is not statically known, for example when deserialising from a file.
 --
 data InAnyShelleyBasedEra thing where
-     InAnyShelleyBasedEra :: ShelleyBasedEra era
+     InAnyShelleyBasedEra :: IsShelleyBasedEra era -- Provide class constraint
+                          => ShelleyBasedEra era   -- and explicit value.
                           -> thing era
                           -> InAnyShelleyBasedEra thing
 
@@ -233,8 +235,10 @@ data InAnyShelleyBasedEra thing where
 -- the Shelley-based eras can often be treated uniformly.
 --
 data CardanoEraStyle era where
-     LegacyByronEra  ::                        CardanoEraStyle ByronEra
-     ShelleyBasedEra :: ShelleyBasedEra era -> CardanoEraStyle era
+     LegacyByronEra  :: CardanoEraStyle ByronEra
+     ShelleyBasedEra :: IsShelleyBasedEra era -- Also provide class constraint
+                     => ShelleyBasedEra era
+                     -> CardanoEraStyle era
 
 deriving instance Eq   (CardanoEraStyle era)
 deriving instance Ord  (CardanoEraStyle era)

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -61,6 +61,19 @@ module Cardano.Api.TxBody (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
 
+    -- ** Feature availability functions
+    onlyAdaSupportedInEra,
+    multiAssetSupportedInEra,
+    txFeesExplicitInEra,
+    validityUpperBoundSupportedInEra,
+    validityNoUpperBoundSupportedInEra,
+    validityLowerBoundSupportedInEra,
+    txMetadataSupportedInEra,
+    auxScriptsSupportedInEra,
+    withdrawalsSupportedInEra,
+    certificatesSupportedInEra,
+    updateProposalSupportedInEra,
+
     -- * Data family instances
     AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody),
   ) where
@@ -257,6 +270,13 @@ data OnlyAdaSupportedInEra era where
 deriving instance Eq   (OnlyAdaSupportedInEra era)
 deriving instance Show (OnlyAdaSupportedInEra era)
 
+onlyAdaSupportedInEra :: CardanoEra era -> Maybe (OnlyAdaSupportedInEra era)
+onlyAdaSupportedInEra ByronEra   = Just AdaOnlyInByronEra
+onlyAdaSupportedInEra ShelleyEra = Just AdaOnlyInShelleyEra
+onlyAdaSupportedInEra AllegraEra = Just AdaOnlyInAllegraEra
+onlyAdaSupportedInEra MaryEra    = Nothing
+
+
 -- | A representation of whether the era supports multi-asset transactions.
 --
 -- The Mary and subsequent eras support multi-asset transactions.
@@ -268,6 +288,13 @@ data MultiAssetSupportedInEra era where
 
 deriving instance Eq   (MultiAssetSupportedInEra era)
 deriving instance Show (MultiAssetSupportedInEra era)
+
+multiAssetSupportedInEra :: CardanoEra era
+                         -> Maybe (MultiAssetSupportedInEra era)
+multiAssetSupportedInEra ByronEra   = Nothing
+multiAssetSupportedInEra ShelleyEra = Nothing
+multiAssetSupportedInEra AllegraEra = Nothing
+multiAssetSupportedInEra MaryEra    = Just MultiAssetInMaryEra
 
 
 -- | A representation of whether the era requires explicitly specified fees in
@@ -286,6 +313,12 @@ data TxFeesExplicitInEra era where
 deriving instance Eq   (TxFeesExplicitInEra era)
 deriving instance Show (TxFeesExplicitInEra era)
 
+txFeesExplicitInEra :: CardanoEra era -> Maybe (TxFeesExplicitInEra era)
+txFeesExplicitInEra ByronEra   = Nothing
+txFeesExplicitInEra ShelleyEra = Just TxFeesExplicitInShelleyEra
+txFeesExplicitInEra AllegraEra = Just TxFeesExplicitInAllegraEra
+txFeesExplicitInEra MaryEra    = Just TxFeesExplicitInMaryEra
+
 
 -- | A representation of whether the era supports transactions with an upper
 -- bound on the range of slots in which they are valid.
@@ -302,6 +335,13 @@ data ValidityUpperBoundSupportedInEra era where
 
 deriving instance Eq   (ValidityUpperBoundSupportedInEra era)
 deriving instance Show (ValidityUpperBoundSupportedInEra era)
+
+validityUpperBoundSupportedInEra :: CardanoEra era
+                                 -> Maybe (ValidityUpperBoundSupportedInEra era)
+validityUpperBoundSupportedInEra ByronEra   = Nothing
+validityUpperBoundSupportedInEra ShelleyEra = Just ValidityUpperBoundInShelleyEra
+validityUpperBoundSupportedInEra AllegraEra = Just ValidityUpperBoundInAllegraEra
+validityUpperBoundSupportedInEra MaryEra    = Just ValidityUpperBoundInMaryEra
 
 
 -- | A representation of whether the era supports transactions having /no/
@@ -323,6 +363,13 @@ data ValidityNoUpperBoundSupportedInEra era where
 deriving instance Eq   (ValidityNoUpperBoundSupportedInEra era)
 deriving instance Show (ValidityNoUpperBoundSupportedInEra era)
 
+validityNoUpperBoundSupportedInEra :: CardanoEra era
+                                   -> Maybe (ValidityNoUpperBoundSupportedInEra era)
+validityNoUpperBoundSupportedInEra ByronEra   = Just ValidityNoUpperBoundInByronEra
+validityNoUpperBoundSupportedInEra ShelleyEra = Nothing
+validityNoUpperBoundSupportedInEra AllegraEra = Just ValidityNoUpperBoundInAllegraEra
+validityNoUpperBoundSupportedInEra MaryEra    = Just ValidityNoUpperBoundInMaryEra
+
 
 -- | A representation of whether the era supports transactions with a lower
 -- bound on the range of slots in which they are valid.
@@ -339,6 +386,13 @@ data ValidityLowerBoundSupportedInEra era where
 deriving instance Eq   (ValidityLowerBoundSupportedInEra era)
 deriving instance Show (ValidityLowerBoundSupportedInEra era)
 
+validityLowerBoundSupportedInEra :: CardanoEra era
+                                 -> Maybe (ValidityLowerBoundSupportedInEra era)
+validityLowerBoundSupportedInEra ByronEra   = Nothing
+validityLowerBoundSupportedInEra ShelleyEra = Nothing
+validityLowerBoundSupportedInEra AllegraEra = Just ValidityLowerBoundInAllegraEra
+validityLowerBoundSupportedInEra MaryEra    = Just ValidityLowerBoundInMaryEra
+
 
 -- | A representation of whether the era supports transaction metadata.
 --
@@ -353,6 +407,13 @@ data TxMetadataSupportedInEra era where
 deriving instance Eq   (TxMetadataSupportedInEra era)
 deriving instance Show (TxMetadataSupportedInEra era)
 
+txMetadataSupportedInEra :: CardanoEra era
+                         -> Maybe (TxMetadataSupportedInEra era)
+txMetadataSupportedInEra ByronEra   = Nothing
+txMetadataSupportedInEra ShelleyEra = Just TxMetadataInShelleyEra
+txMetadataSupportedInEra AllegraEra = Just TxMetadataInAllegraEra
+txMetadataSupportedInEra MaryEra    = Just TxMetadataInMaryEra
+
 
 -- | A representation of whether the era supports auxiliary scripts in
 -- transactions.
@@ -366,6 +427,13 @@ data AuxScriptsSupportedInEra era where
 
 deriving instance Eq   (AuxScriptsSupportedInEra era)
 deriving instance Show (AuxScriptsSupportedInEra era)
+
+auxScriptsSupportedInEra :: CardanoEra era
+                         -> Maybe (AuxScriptsSupportedInEra era)
+auxScriptsSupportedInEra ByronEra   = Nothing
+auxScriptsSupportedInEra ShelleyEra = Nothing
+auxScriptsSupportedInEra AllegraEra = Just AuxScriptsInAllegraEra
+auxScriptsSupportedInEra MaryEra    = Just AuxScriptsInMaryEra
 
 
 -- | A representation of whether the era supports withdrawals from reward
@@ -383,6 +451,13 @@ data WithdrawalsSupportedInEra era where
 deriving instance Eq   (WithdrawalsSupportedInEra era)
 deriving instance Show (WithdrawalsSupportedInEra era)
 
+withdrawalsSupportedInEra :: CardanoEra era
+                          -> Maybe (WithdrawalsSupportedInEra era)
+withdrawalsSupportedInEra ByronEra   = Nothing
+withdrawalsSupportedInEra ShelleyEra = Just WithdrawalsInShelleyEra
+withdrawalsSupportedInEra AllegraEra = Just WithdrawalsInAllegraEra
+withdrawalsSupportedInEra MaryEra    = Just WithdrawalsInMaryEra
+
 
 -- | A representation of whether the era supports 'Certificate's embedded in
 -- transactions.
@@ -397,6 +472,13 @@ data CertificatesSupportedInEra era where
 
 deriving instance Eq   (CertificatesSupportedInEra era)
 deriving instance Show (CertificatesSupportedInEra era)
+
+certificatesSupportedInEra :: CardanoEra era
+                           -> Maybe (CertificatesSupportedInEra era)
+certificatesSupportedInEra ByronEra   = Nothing
+certificatesSupportedInEra ShelleyEra = Just CertificatesInShelleyEra
+certificatesSupportedInEra AllegraEra = Just CertificatesInAllegraEra
+certificatesSupportedInEra MaryEra    = Just CertificatesInMaryEra
 
 
 -- | A representation of whether the era supports 'UpdateProposal's embedded in
@@ -414,6 +496,13 @@ data UpdateProposalSupportedInEra era where
 
 deriving instance Eq   (UpdateProposalSupportedInEra era)
 deriving instance Show (UpdateProposalSupportedInEra era)
+
+updateProposalSupportedInEra :: CardanoEra era
+                             -> Maybe (UpdateProposalSupportedInEra era)
+updateProposalSupportedInEra ByronEra   = Nothing
+updateProposalSupportedInEra ShelleyEra = Just UpdateProposalInShelleyEra
+updateProposalSupportedInEra AllegraEra = Just UpdateProposalInAllegraEra
+updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -19,6 +19,7 @@ module Cardano.Api.TxBody (
     TxBody(..),
     makeTransactionBody,
     TxBodyContent(..),
+    TxBodyError(..),
 
     -- ** Transitional utils
     makeByronTransaction,

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -759,7 +759,7 @@ makeTransactionBody :: forall era.
                     => TxBodyContent era
                     -> Either (TxBodyError era) (TxBody era)
 makeTransactionBody =
-    case cardanoEraStyle :: CardanoEraStyle era of
+    case cardanoEraStyle (cardanoEra :: CardanoEra era) of
       LegacyByronEra      -> makeByronTransactionBody
       ShelleyBasedEra era -> makeShelleyTransactionBody era
 

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -191,6 +191,19 @@ module Cardano.Api.Typed (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
 
+    -- ** Feature availability functions
+    onlyAdaSupportedInEra,
+    multiAssetSupportedInEra,
+    txFeesExplicitInEra,
+    validityUpperBoundSupportedInEra,
+    validityNoUpperBoundSupportedInEra,
+    validityLowerBoundSupportedInEra,
+    txMetadataSupportedInEra,
+    auxScriptsSupportedInEra,
+    withdrawalsSupportedInEra,
+    certificatesSupportedInEra,
+    updateProposalSupportedInEra,
+
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.
     Tx(..),

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -297,6 +297,8 @@ module Cardano.Api.Typed (
     SignatureFeature,
     TimeLocksFeature,
     HasScriptFeatures,
+    coerceSimpleScriptEra,
+
     -- *** Deprecated aliases
     MultiSigScript,
     makeMultiSigScript,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -179,9 +179,10 @@ module Cardano.Api.Typed (
     TxMintValue(..),
 
     -- ** Era-dependent transaction body features
-    OnlyAdaSupportedInEra(..),
     MultiAssetSupportedInEra(..),
-    TxFeesExplicitInEra (..),
+    OnlyAdaSupportedInEra(..),
+    TxFeesExplicitInEra(..),
+    TxFeesImplicitInEra(..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
     ValidityLowerBoundSupportedInEra(..),
@@ -192,7 +193,6 @@ module Cardano.Api.Typed (
     UpdateProposalSupportedInEra(..),
 
     -- ** Feature availability functions
-    onlyAdaSupportedInEra,
     multiAssetSupportedInEra,
     txFeesExplicitInEra,
     validityUpperBoundSupportedInEra,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -132,6 +132,7 @@ module Cardano.Api.Typed (
     lovelaceToQuantity,
     selectLovelace,
     lovelaceToValue,
+    valueToLovelace,
 
     -- ** Alternative nested representation
     ValueNestedRep(..),

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -31,12 +31,13 @@ module Cardano.Api.Typed (
     AllegraEra,
     MaryEra,
     CardanoEra(..),
-    CardanoEraStyle(..),
     IsCardanoEra(..),
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
     ShelleyLedgerEra,
+    CardanoEraStyle(..),
+    cardanoEraStyle,
     -- ** Deprecated
     Byron,
     Shelley,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -32,9 +32,12 @@ module Cardano.Api.Typed (
     MaryEra,
     CardanoEra(..),
     IsCardanoEra(..),
+    InAnyCardanoEra(..),
+
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
+    InAnyShelleyBasedEra(..),
     ShelleyLedgerEra,
     CardanoEraStyle(..),
     cardanoEraStyle,

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -146,6 +146,7 @@ module Cardano.Api.Typed (
     TxBody(..),
     makeTransactionBody,
     TxBodyContent(..),
+    TxBodyError(..),
 
     -- ** Transitional utils
     makeByronTransaction,

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -26,6 +26,7 @@ module Cardano.Api.Value
   , lovelaceToQuantity
   , selectLovelace
   , lovelaceToValue
+  , valueToLovelace
 
     -- ** Alternative nested representation
   , ValueNestedRep(..)
@@ -205,6 +206,17 @@ selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
 lovelaceToValue :: Lovelace -> Value
 lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 
+-- | Check if the 'Value' consists of /only/ 'Lovelace' and no other assets,
+-- and if so then return the Lovelace.
+--
+-- See also 'selectLovelace' to select the Lovelace quantity from the Value,
+-- ignoring other assets.
+--
+valueToLovelace :: Value -> Maybe Lovelace
+valueToLovelace v =
+    case valueToList v of
+      [(AdaAssetId, q)] -> Just (quantityToLovelace q)
+      _                 -> Nothing
 
 toMaryValue :: forall ledgerera.
                Ledger.Crypto ledgerera ~ StandardCrypto

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -546,7 +546,7 @@ genTxBodyContent era = do
 genTxFee :: CardanoEra era -> Gen (TxFee era)
 genTxFee era =
   case era of
-    ByronEra -> pure TxFeeImplicit
+    ByronEra -> pure (TxFeeImplicit TxFeesImplicitInByronEra)
     ShelleyEra -> TxFeeExplicit TxFeesExplicitInShelleyEra <$> genLovelace
     AllegraEra -> TxFeeExplicit TxFeesExplicitInAllegraEra <$> genLovelace
     MaryEra -> TxFeeExplicit TxFeesExplicitInMaryEra <$> genLovelace

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -163,13 +163,20 @@ data TransactionCmd
   = TxBuildRaw
       UseCardanoEra
       [TxIn]
-      [TxOut ShelleyEra]
-      (Maybe String) -- Placeholder for multi asset Values
-      SlotNo
-      Lovelace
+      [TxOutAnyEra]
+      (Maybe Value)
+      -- ^ Multi-Asset value
+      (Maybe SlotNo)
+      -- ^ Transaction lower bound
+      (Maybe SlotNo)
+      -- ^ Transaction upper bound
+      (Maybe Lovelace)
+      -- ^ Tx fee
       [CertificateFile]
       [(StakeAddress, Lovelace)]
       TxMetadataJsonSchema
+      [ScriptFile]
+      -- ^ Auxillary scripts
       [MetaDataFile]
       (Maybe UpdateProposalFile)
       TxBodyFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -161,6 +161,7 @@ renderKeyCmd cmd =
 
 data TransactionCmd
   = TxBuildRaw
+      UseCardanoEra
       [TxIn]
       [TxOut ShelleyEra]
       (Maybe String) -- Placeholder for multi asset Values

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1516,11 +1516,19 @@ pTxLowerBound =
 pTxUpperBound :: Parser SlotNo
 pTxUpperBound =
   SlotNo <$>
-    Opt.option Opt.auto
-      (  Opt.long "upper-bound"
-      <> Opt.metavar "SLOT"
-      <> Opt.help "Time that transaction is valid until (in slots)."
-      )
+    ( Opt.option Opt.auto
+        (  Opt.long "upper-bound"
+        <> Opt.metavar "SLOT"
+        <> Opt.help "Time that transaction is valid until (in slots)."
+        )
+    <|>
+      Opt.option Opt.auto
+        (  Opt.long "ttl"
+        <> Opt.metavar "SLOT"
+        <> Opt.help "Time to live (in slots) (deprecated; use --upper-bound instead)."
+        )
+    )
+
 pTxFee :: Parser Lovelace
 pTxFee =
   Lovelace . (fromIntegral :: Natural -> Integer) <$>

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1483,7 +1483,7 @@ pTxOut =
                 \Lovelace."
     )
   where
-    parseTxOut :: Atto.Parser (TxOutAnyEra)
+    parseTxOut :: Atto.Parser TxOutAnyEra
     parseTxOut =
       TxOutAnyEra <$> parseAddressAny
                   <*  Atto.char '+'

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -492,7 +492,8 @@ pTransaction =
       $ Opt.command "sign-witness" assembleInfo <> Opt.internal
 
   pTransactionBuild :: Parser TransactionCmd
-  pTransactionBuild = TxBuildRaw <$> some pTxIn
+  pTransactionBuild = TxBuildRaw <$> pUseCardanoEra
+                                 <*> some pTxIn
                                  <*> some pTxOut
                                  <*> optional pMint
                                  <*> pTxTTL
@@ -1416,6 +1417,29 @@ pTxSubmitFile =
     <> Opt.help "Filepath of the transaction you intend to submit."
     <> Opt.completer (Opt.bashCompleter "file")
     )
+
+pUseCardanoEra :: Parser UseCardanoEra
+pUseCardanoEra = asum
+  [ Opt.flag' UseByronEra
+      (  Opt.long "byron-era"
+      <> Opt.help "Specify the Byron era"
+      )
+  , Opt.flag' UseShelleyEra
+      (  Opt.long "shelley-era"
+      <> Opt.help "Specify the Shelley era (default)"
+      )
+  , Opt.flag' UseAllegraEra
+      (  Opt.long "allegra-era"
+      <> Opt.help "Specify the Allegra era"
+      )
+  , Opt.flag' UseMaryEra
+      (  Opt.long "mary-era"
+      <> Opt.help "Specify the Mary era"
+      )
+
+    -- Default for now:
+  , pure UseShelleyEra
+  ]
 
 pTxIn :: Parser TxIn
 pTxIn =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -742,10 +742,11 @@ renderShelleyBootstrapWitnessError MissingNetworkIdOrByronAddressError =
 -- | Construct a Shelley bootstrap witness (i.e. a Byron key witness in the
 -- Shelley era).
 mkShelleyBootstrapWitness
-  :: Maybe NetworkId
-  -> TxBody ShelleyEra
+  :: IsShelleyBasedEra era
+  => Maybe NetworkId
+  -> TxBody era
   -> ShelleyBootstrapWitnessSigningKeyData
-  -> Either ShelleyBootstrapWitnessError (Witness ShelleyEra)
+  -> Either ShelleyBootstrapWitnessError (Witness era)
 mkShelleyBootstrapWitness Nothing _ (ShelleyBootstrapWitnessSigningKeyData _ Nothing) =
   Left MissingNetworkIdOrByronAddressError
 mkShelleyBootstrapWitness (Just nw) txBody (ShelleyBootstrapWitnessSigningKeyData skey Nothing) =
@@ -756,10 +757,11 @@ mkShelleyBootstrapWitness _ txBody (ShelleyBootstrapWitnessSigningKeyData skey (
 -- | Attempt to construct Shelley bootstrap witnesses until an error is
 -- encountered.
 mkShelleyBootstrapWitnesses
-  :: Maybe NetworkId
-  -> TxBody ShelleyEra
+  :: IsShelleyBasedEra era
+  => Maybe NetworkId
+  -> TxBody era
   -> [ShelleyBootstrapWitnessSigningKeyData]
-  -> Either ShelleyBootstrapWitnessError [Witness ShelleyEra]
+  -> Either ShelleyBootstrapWitnessError [Witness era]
 mkShelleyBootstrapWitnesses mnw txBody =
   mapM (mkShelleyBootstrapWitness mnw txBody)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -286,7 +285,7 @@ untypedCardanoEra MaryEra    = UseMaryEra
 validateTxIns :: CardanoEra era
               -> [TxIn]
               -> ExceptT ShelleyTxCmdError IO [TxIn]
-validateTxIns _ txins = return txins -- no validation or era-checking needed
+validateTxIns _ = return -- no validation or era-checking needed
 
 validateTxOuts :: forall era.
                   CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -104,9 +104,9 @@ renderShelleyTxCmdError err =
 runTransactionCmd :: TransactionCmd -> ExceptT ShelleyTxCmdError IO ()
 runTransactionCmd cmd =
   case cmd of
-    TxBuildRaw txins txouts _Values ttl fee certs wdrls
+    TxBuildRaw era txins txouts _Values ttl fee certs wdrls
                metadataSchema metadataFiles mUpProp out ->
-      runTxBuildRaw txins txouts ttl fee certs wdrls
+      runTxBuildRaw era txins txouts ttl fee certs wdrls
                     metadataSchema metadataFiles mUpProp out
     TxSign txinfile skfiles network txoutfile ->
       runTxSign txinfile skfiles network txoutfile
@@ -125,7 +125,8 @@ runTransactionCmd cmd =
       runTxSignWitness txBodyFile witnessFile outFile
 
 runTxBuildRaw
-  :: [Api.TxIn]
+  :: UseCardanoEra
+  -> [Api.TxIn]
   -> [Api.TxOut Api.ShelleyEra]
   -> SlotNo
   -> Api.Lovelace
@@ -136,7 +137,7 @@ runTxBuildRaw
   -> Maybe UpdateProposalFile
   -> TxBodyFile
   -> ExceptT ShelleyTxCmdError IO ()
-runTxBuildRaw txins txouts ttl fee
+runTxBuildRaw _useEra txins txouts ttl fee
               certFiles withdrawals
               metadataSchema metadataFiles
               mUpdatePropFile

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.Types
   ( CBORObject (..)
@@ -13,6 +14,7 @@ module Cardano.CLI.Types
   , ScriptFile (..)
   , UpdateProposalFile (..)
   , UseCardanoEra (..)
+  , withCardanoEra
   , VerificationKeyFile (..)
   ) where
 
@@ -87,4 +89,12 @@ data UseCardanoEra = UseByronEra
                    | UseAllegraEra
                    | UseMaryEra
                    deriving (Eq, Show)
+
+withCardanoEra :: UseCardanoEra
+               -> (forall era. IsCardanoEra era => CardanoEra era -> a)
+               -> a
+withCardanoEra UseByronEra   f = f ByronEra
+withCardanoEra UseShelleyEra f = f ShelleyEra
+withCardanoEra UseAllegraEra f = f AllegraEra
+withCardanoEra UseMaryEra    f = f MaryEra
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Types
   , SocketPath (..)
   , ScriptFile (..)
   , UpdateProposalFile (..)
+  , UseCardanoEra (..)
   , VerificationKeyFile (..)
   ) where
 
@@ -80,3 +81,10 @@ newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
 data SigningKeyOrScriptFile = ScriptFileForWitness FilePath
                             | SigningKeyFileForWitness FilePath
                             deriving (Eq, Show)
+
+data UseCardanoEra = UseByronEra
+                   | UseShelleyEra
+                   | UseAllegraEra
+                   | UseMaryEra
+                   deriving (Eq, Show)
+

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types
   ( CBORObject (..)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types
   ( CBORObject (..)
@@ -12,6 +13,7 @@ module Cardano.CLI.Types
   , SigningKeyOrScriptFile (..)
   , SocketPath (..)
   , ScriptFile (..)
+  , TxOutAnyEra (..)
   , UpdateProposalFile (..)
   , UseCardanoEra (..)
   , withCardanoEra
@@ -20,7 +22,7 @@ module Cardano.CLI.Types
 
 import           Cardano.Prelude
 
-import           Data.Aeson
+import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 
 import qualified Cardano.Chain.Slotting as Byron
@@ -47,7 +49,7 @@ newtype GenesisFile = GenesisFile
   deriving newtype (IsString, Show)
 
 instance FromJSON GenesisFile where
-  parseJSON (String genFp) = pure . GenesisFile $ Text.unpack genFp
+  parseJSON (Aeson.String genFp) = pure . GenesisFile $ Text.unpack genFp
   parseJSON invalid = panic $ "Parsing of GenesisFile failed due to type mismatch. "
                            <> "Encountered: " <> Text.pack (show invalid)
 
@@ -97,4 +99,12 @@ withCardanoEra UseByronEra   f = f ByronEra
 withCardanoEra UseShelleyEra f = f ShelleyEra
 withCardanoEra UseAllegraEra f = f AllegraEra
 withCardanoEra UseMaryEra    f = f MaryEra
+
+-- | A TxOut value that is the superset of possibilities for any era: any
+-- address type and allowing multi-asset values. This is used as the type for
+-- values passed on the command line. It can be converted into the
+-- era-dependent 'TxOutValue' type.
+--
+data TxOutAnyEra = TxOutAnyEra AddressAny Value
+  deriving (Eq, Show)
 


### PR DESCRIPTION
Re-implement the tx build-raw command in terms of the new era-generic TxBodyContent API.

This should allow it to work for all eras, including Byron. It checks that each feature can be used in the selected era.

There are still a number of TODOs, but this establishes the pattern.