### PR TITLE
Prefer Shelley CLI commands over Byron ones where they clash

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -34,8 +34,13 @@ pref = Opt.prefs showHelpOnEmpty
 parseClientCommand :: Parser ClientCommand
 parseClientCommand =
   asum
-    [ parseByron <|> backwardsCompatibilityCommands
-    , parseShelley <|> parseDeprecatedShelleySubcommand
+    -- There are name clashes between Shelley commands and the Byron backwards
+    -- compat commands (e.g. "genesis"), and we need to prefer the Shelley ones
+    -- so we list it first.
+    [ parseShelley
+    , parseByron
+    , parseDeprecatedShelleySubcommand
+    , backwardsCompatibilityCommands
     , parseDisplayVersion
     ]
 

--- a/cardano-node-chairman/src/Testnet/Byron.hs
+++ b/cardano-node-chairman/src/Testnet/Byron.hs
@@ -74,7 +74,9 @@ testnet H.Conf {..} = do
 
   -- Generate keys
   void $ H.execCli
-    [ "genesis"
+    [ "byron"
+    , "genesis"
+    , "genesis"
     , "--genesis-output-dir", tempAbsPath </> "genesis"
     , "--start-time", showUTCTimeSeconds startTime
     , "--protocol-parameters-file", tempAbsPath </> "protocol-params.json"

--- a/cardano-node-chairman/src/Testnet/ByronShelley.hs
+++ b/cardano-node-chairman/src/Testnet/ByronShelley.hs
@@ -200,7 +200,9 @@ testnet testnetOptions H.Conf {..} = do
 
   -- stuff
   void . H.execCli $
-    [ "genesis"
+    [ "byron"
+    , "genesis"
+    , "genesis"
     , "--protocol-magic", show @Int testnetMagic
     , "--start-time", showUTCTimeSeconds startTime
     , "--k", show @Int securityParam


### PR DESCRIPTION
We have done a fair bit of shuffling of CLI commands over time, and have
kept the old commands for backwards compatibility.

There was a name clash over the "genesis" top level command: between the
Shelley command and the backwards compat Byron command.

Reorder the command lists so we prefer the new Shelley commands, and
generally the new ones over the old ones.