### PR TITLE
CAD-2069: Tracing changes supporting K=1000, batch 1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -143,8 +143,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: b5965e013fbcfb2a155582953d4a9a99eee22a8a
-  --sha256: 0c2xmf57rw2p1llm69x4b3cxzigxj0iyxa6cl0ivps92m9l2rv2n
+  tag: 563e79f28c6da5c547463391d4c58a81442e48db
+  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
   subdir:
     contra-tracer
     iohk-monitoring

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -53,6 +55,7 @@ import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), Privac
                      mkLOMeta)
 import           Cardano.BM.Data.Tracer (HasTextFormatter (..), emptyObject, mkObject, trStructured,
                      trStructuredText)
+import           Cardano.BM.Stats
 import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
                      Severity (..), ToObject (..), Tracer (..), TracingVerbosity (..),
                      Transformable (..))
@@ -110,3 +113,15 @@ instance ToJSON (OneEraHash xs) where
 
 deriving newtype instance ToJSON ByronHash
 deriving newtype instance ToJSON BlockNo
+
+instance HasPrivacyAnnotation  ResourceStats
+instance HasSeverityAnnotation ResourceStats where
+  getSeverityAnnotation _ = Info
+instance Transformable Text IO ResourceStats where
+  trTransformer = trStructured
+
+instance ToObject ResourceStats where
+  toObject _verb stats =
+    case toJSON stats of
+      Object x -> x
+      _ -> mempty

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -10,6 +10,8 @@
 , compiler
 # Enable profiling
 , profiling ? false
+# Link with -eventlog
+, eventlog ? false
 # Enable asserts for given packages
 , assertedPackages ? []
 # Version info, to be passed when not building from a git work tree
@@ -114,6 +116,10 @@ let
         packages = lib.genAttrs projectPackages
           (name: { configureFlags = [ "--ghc-option=-Werror" ]; });
       }
+      (lib.optionalAttrs eventlog {
+        packages = lib.genAttrs ["cardano-node"]
+          (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
+      })
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
         packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -6,7 +6,7 @@
 with lib; with builtins;
 let
   cfg = config.services.cardano-node;
-  inherit (cfg.cardanoNodePkgs) commonLib cardano-node cardano-node-profiled cardano-node-asserted;
+  inherit (cfg.cardanoNodePkgs) commonLib cardano-node cardano-node-profiled cardano-node-eventlogged cardano-node-asserted;
   envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: let
@@ -100,6 +100,11 @@ in {
         default = "none";
       };
 
+      eventlog = mkOption {
+        type = types.bool;
+        default = false;
+      };
+
       asserts = mkOption {
         type = types.bool;
         default = false;
@@ -123,6 +128,7 @@ in {
         type = types.package;
         default = if (cfg.profiling != "none")
           then cardano-node-profiled
+          else if cfg.eventlog then cardano-node-eventlogged
           else if cfg.asserts then cardano-node-asserted
           else cardano-node;
         defaultText = "cardano-node";

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -24,6 +24,17 @@ pkgs: _: with pkgs;
       ;
     profiling = true;
   };
+  cardanoNodeEventlogHaskellPackages = import ./haskell.nix {
+    inherit compiler
+      pkgs
+      lib
+      stdenv
+      haskell-nix
+      buildPackages
+      gitrev
+      ;
+    eventlog = true;
+  };
   cardanoNodeAssertedHaskellPackages = import ./haskell.nix {
     inherit config
       pkgs
@@ -48,6 +59,7 @@ pkgs: _: with pkgs;
   inherit (cardanoNodeHaskellPackages.cardano-cli.components.exes) cardano-cli;
   inherit (cardanoNodeHaskellPackages.bech32.components.exes) bech32;
   cardano-node-profiled = cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node;
+  cardano-node-eventlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node;
   cardano-node-asserted = cardanoNodeAssertedHaskellPackages.cardano-node.components.exes.cardano-node;
 
   # expose the db-converter from the ouroboros-network we depend on


### PR DESCRIPTION
1. update `iohk-monitoring` to `master`
1. compact & frequent reporting of process statistics
1. optional `.eventlog` collection, via specially-linked `cardano-node-eventlogged` Nix attribute & `eventlog` node NixOS service flag