### PR TITLE
Classify an empty Value as consisting of 0 Lovelace

### DIFF
--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -215,6 +215,7 @@ lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 valueToLovelace :: Value -> Maybe Lovelace
 valueToLovelace v =
     case valueToList v of
+      []                -> Just (Lovelace 0)
       [(AdaAssetId, q)] -> Just (quantityToLovelace q)
       _                 -> Nothing
 


### PR DESCRIPTION
The valueToLovelace check if the value consists of only Lovelace and no
other assets, and if so then return the Lovelace.

Previously this function classified an empty value as not consisting of
only Lovelace. It is more useful to classify it the other way around and
define the result to be Just 0.

In particular this valueToLovelace check is used to see if a tx out is
using the multi-asset syntax, and when parsed as a multi-asset value "0"
is classified (correctly) as empty, since we do not represent 0
quantities. It's more useful to define this case as not using
multi-asset and to say this does consist only of Lovelace, with quantity
zero.