### PR TITLE
CAD-2069: Tracing changes supporting K=1000

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -113,6 +113,7 @@ library
                      , safe-exceptions
                      , scientific
                      , shelley-spec-ledger
+                     , stm
                      , strict-concurrency
                      , text
                      , time

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -296,7 +296,7 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
 
     startTime <- getCurrentTime
     traceNodeBasicInfo tr =<< nodeBasicInfo nc p startTime
-    traceCounter "nodeStartTime" (ceiling $ utcTimeToPOSIXSeconds startTime) tr
+    traceCounter "nodeStartTime" tr (ceiling $ utcTimeToPOSIXSeconds startTime)
 
     when ncValidateDB $ traceWith tracer "Performing DB validation"
 

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE NamedFieldPuns #-}
 module Cardano.Tracing.Kernel
   ( NodeKernelData (..)
   , mkNodeKernelData
   , setNodeKernel
   , mapNodeKernelDataIO
+  , nkQueryLedger
+  , nkQueryChain
   -- * Re-exports
   , NodeKernel (..)
   , LocalConnectionId
@@ -11,14 +14,18 @@ module Cardano.Tracing.Kernel
   , fromSMaybe
   ) where
 
-import           Cardano.Prelude hiding (atomically)
+import           Cardano.Prelude
 
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), fromSMaybe)
 
+import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Orphans ()
 
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteConnectionId)
 
@@ -43,3 +50,17 @@ mapNodeKernelDataIO ::
   -> IO (StrictMaybe a)
 mapNodeKernelDataIO f (NodeKernelData ref) =
   readIORef ref >>= traverse f
+
+nkQueryLedger ::
+     (ExtLedgerState blk -> a)
+  -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
+  -> IO a
+nkQueryLedger f NodeKernel{getChainDB} =
+  f <$> atomically (ChainDB.getCurrentLedger getChainDB)
+
+nkQueryChain ::
+     (AF.AnchoredFragment (Header blk) -> a)
+  -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
+  -> IO a
+nkQueryChain f NodeKernel{getChainDB} =
+  f <$> atomically (ChainDB.getCurrentChain getChainDB)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                      (TraceLocalTxSubmissionServerEvent (..))
 import           Ouroboros.Consensus.Node.Run (RunNode, estimateBlockSize)
 import           Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Protocol.BFT as BFT
 import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
@@ -326,6 +327,19 @@ instance ( tx ~ GenTx blk
 instance Transformable Text IO (TraceLocalTxSubmissionServerEvent blk) where
   trTransformer = trStructured
 
+instance HasPrivacyAnnotation a => HasPrivacyAnnotation (Consensus.TraceLabelCreds a)
+instance HasSeverityAnnotation a => HasSeverityAnnotation (Consensus.TraceLabelCreds a) where
+  getSeverityAnnotation (Consensus.TraceLabelCreds _ a) = getSeverityAnnotation a
+
+instance ToObject a => ToObject (Consensus.TraceLabelCreds a) where
+  toObject verb (Consensus.TraceLabelCreds creds val) =
+    mkObject [ "credentials" .= toJSON creds
+             , "val"         .= toObject verb val
+             ]
+
+instance (HasPrivacyAnnotation a, HasSeverityAnnotation a, ToObject a)
+      => Transformable Text IO (Consensus.TraceLabelCreds a) where
+  trTransformer = trStructured
 
 instance ( ConvertRawHash blk
          , LedgerSupportsProtocol blk

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -394,7 +394,13 @@ instance ( ConvertTxId blk
          , HasTxs blk
          )
       => ToObject (AnyMessageAndAgency (BlockFetch blk (Point blk))) where
-  toObject MaximalVerbosity (AnyMessageAndAgency _ (MsgBlock blk)) =
+  toObject MinimalVerbosity (AnyMessageAndAgency _ (MsgBlock blk)) =
+    mkObject [ "kind" .= String "MsgBlock"
+             , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
+             , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
+             ]
+
+  toObject verb (AnyMessageAndAgency _ (MsgBlock blk)) =
     mkObject [ "kind" .= String "MsgBlock"
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
@@ -402,13 +408,8 @@ instance ( ConvertTxId blk
              ]
       where
         presentTx :: GenTx blk -> Value
-        presentTx =  String . renderTxIdForVerbosity MaximalVerbosity . txId
+        presentTx =  String . renderTxIdForVerbosity verb . txId
 
-  toObject _v (AnyMessageAndAgency _ (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
-             , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
-             , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
-             ]
   toObject _v (AnyMessageAndAgency _ MsgRequestRange{}) =
     mkObject [ "kind" .= String "MsgRequestRange" ]
   toObject _v (AnyMessageAndAgency _ MsgStartBatch{}) =

--- a/cardano-node/src/Cardano/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Tracing/Render.hs
@@ -156,5 +156,5 @@ trimHashTextForVerbosity :: TracingVerbosity -> Text -> Text
 trimHashTextForVerbosity verb =
   case verb of
     MinimalVerbosity -> Text.take 7
-    NormalVerbosity -> Text.take 7
+    NormalVerbosity -> id
     MaximalVerbosity -> id


### PR DESCRIPTION
1. make NormalVerbosity usable for benchmarking.
2. chain density tracing in TraceStartLeadershipCheck.
3. dense pool-aware forging statistics tracking.