### PR TITLE
CAD-2166:  delegation map size trace & export (with UTxO size) to prometheus

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -495,8 +495,10 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
       Consensus.TraceStartLeadershipCheck slot -> do
         !query <- mapNodeKernelDataIO
                     (\nk ->
-                       (,) <$> nkQueryLedger (ledgerUtxoSize . ledgerState) nk
-                           <*> nkQueryChain fragmentChainDensity nk)
+                       (,,)
+                         <$> nkQueryLedger (ledgerUtxoSize . ledgerState) nk
+                         <*> nkQueryLedger (ledgerDelegMapSize . ledgerState) nk
+                         <*> nkQueryChain fragmentChainDensity nk)
                     nodeKern
         meta <- mkLOMeta sev Public
         traceNamedObject tr
@@ -507,8 +509,9 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
             ,("slot", toJSON $ unSlotNo slot)]
             ++ fromSMaybe []
                (query <&>
-                 \(utxoSize, chainDensity) ->
+                 \(utxoSize, delegMapSize, chainDensity) ->
                    [ ("utxoSize",     toJSON utxoSize)
+                   , ("delegMapSize", toJSON delegMapSize)
                    , ("chainDensity", toJSON (fromRational chainDensity :: Float))
                    ])
           )

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -501,6 +501,11 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
                          <*> nkQueryChain fragmentChainDensity nk)
                     nodeKern
         meta <- mkLOMeta sev Public
+        fromSMaybe (pure ()) $
+          query <&>
+            \(utxoSize, delegMapSize, _) -> do
+               traceCounter "utxoSize"     tr utxoSize
+               traceCounter "delegMapSize" tr delegMapSize
         traceNamedObject tr
           ( meta
           , LogStructured $ Map.fromList $


### PR DESCRIPTION
1. extend `LedgerQueries` with `delegMapSize` -- to query the effective delegation map size
1. trace `delegMapSize` with `TraceStartLeadershipCheck`
1. export both `utxoSize` and `delegMapSize` as metrics 
1. move all metrics to the `cardano.node.metrics` namespace.  This affects:
   - `cardano.node.Forge.metrics`
   - `cardano.node.ChainDB.metrics`


WARNING: breaking change -- see point №4.  This also simplifies configuration, making the following unnecessary:

https://github.com/input-output-hk/cardano-node/blob/master/configuration/cardano/mainnet-config.json#L66-L71

cc @disassembler @denisshevchenko 