### PR TITLE
MetaData -> Metadata

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 581767d1329f3f702e332af08355e81a0f85333e
-  --sha256: 198p4v2bi36y6x512w35qycvjm7nds7jf8qh7r84pj1qsy43vf7w
+  tag: deeff4d4edc1dda02f89396ed0c9ea865d64dbda
+  --sha256: 0fy1dg0yz5j80c6zvxyfnmg7mgiijwammva14fwslz5lmslz5rcr
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c2bd6814e231bfd48059f306ef486b830e524aa8
-  --sha256: 0sjp5i4szp5nf1dkwang5w8pydjx5p22by8wisihs1410rxgwd7n
+  tag: cf44f45313b9a62f127cf35e34590422266690fa
+  --sha256: 0kwlm810ywbbxyq5183a5xbk2v0ji1p1xlyj06ac8a13cx45gw7v
   subdir:
     io-sim
     io-sim-classes

--- a/cabal.project
+++ b/cabal.project
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8ced9d8713a7ad82f75a90c6103259e61c412d33
-  --sha256: 19inypc7ixydjjs7082iysanqrv9r276irs07lba7h1m2jy6d5xq
+  tag: 0c5b0a6619fadf22f4d62a12154e181a6d035c1c
+  --sha256: 0qjn7xsw5py05zmq9935z91719v5i4apsizwhkwppi8dahbanrs4
   subdir:
     cardano-prelude
     cardano-prelude-test

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -171,7 +171,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Gen
                         Test.Cardano.Api.Genesis
                         Test.Cardano.Api.Ledger
-                        Test.Cardano.Api.MetaData
+                        Test.Cardano.Api.Metadata
                         Test.Cardano.Api.Typed.Bech32
                         Test.Cardano.Api.Typed.CBOR
                         Test.Cardano.Api.Typed.Envelope

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -312,7 +312,7 @@ toShelleyPoolParams StakePoolParameters {
                               [ kh | StakeKeyHash kh <- stakePoolOwners ]
     , Shelley._poolRelays = Seq.fromList
                               (map toShelleyStakePoolRelay stakePoolRelays)
-    , Shelley._poolMD     = toShelleyPoolMetaData <$>
+    , Shelley._poolMD     = toShelleyPoolMetadata <$>
                               maybeToStrictMaybe stakePoolMetadata
     }
   where
@@ -332,12 +332,12 @@ toShelleyPoolParams StakePoolParameters {
       Shelley.MultiHostName
         (toShelleyDnsName dnsname)
 
-    toShelleyPoolMetaData :: StakePoolMetadataReference -> Shelley.PoolMetaData
-    toShelleyPoolMetaData StakePoolMetadataReference {
+    toShelleyPoolMetadata :: StakePoolMetadataReference -> Shelley.PoolMetadata
+    toShelleyPoolMetadata StakePoolMetadataReference {
                             stakePoolMetadataURL
                           , stakePoolMetadataHash = StakePoolMetadataHash mdh
                           } =
-      Shelley.PoolMetaData {
+      Shelley.PoolMetadata {
         Shelley._poolMDUrl  = toShelleyUrl stakePoolMetadataURL
       , Shelley._poolMDHash = Crypto.hashToBytes mdh
       }
@@ -377,7 +377,7 @@ fromShelleyPoolParams
     , stakePoolOwners        = map StakeKeyHash (Set.toList _poolOwners)
     , stakePoolRelays        = map fromShelleyStakePoolRelay
                                    (Foldable.toList _poolRelays)
-    , stakePoolMetadata      = fromShelleyPoolMetaData <$>
+    , stakePoolMetadata      = fromShelleyPoolMetadata <$>
                                  strictMaybeToMaybe _poolMD
     }
   where
@@ -397,15 +397,15 @@ fromShelleyPoolParams
       StakePoolRelayDnsSrvRecord
         (fromShelleyDnsName dnsname)
 
-    fromShelleyPoolMetaData :: Shelley.PoolMetaData -> StakePoolMetadataReference
-    fromShelleyPoolMetaData Shelley.PoolMetaData {
+    fromShelleyPoolMetadata :: Shelley.PoolMetadata -> StakePoolMetadataReference
+    fromShelleyPoolMetadata Shelley.PoolMetadata {
                               Shelley._poolMDUrl
                             , Shelley._poolMDHash
                             } =
       StakePoolMetadataReference {
         stakePoolMetadataURL  = Shelley.urlToText _poolMDUrl
       , stakePoolMetadataHash = StakePoolMetadataHash
-                              . fromMaybe (error "fromShelleyPoolMetaData: invalid hash. TODO: proper validation")
+                              . fromMaybe (error "fromShelleyPoolMetadata: invalid hash. TODO: proper validation")
                               . Crypto.hashFromBytes
                               $ _poolMDHash
       }

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -75,8 +75,8 @@ module Cardano.Api.Shelley
 
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- * Protocol parameter updates
     EpochNo(..),

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -113,7 +113,7 @@ import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
 import qualified Cardano.Ledger.ShelleyMA.Metadata as Allegra
-import qualified Shelley.Spec.Ledger.MetaData as Ledger (MetaDataHash, hashMetadata)
+import qualified Shelley.Spec.Ledger.Metadata as Ledger (MetadataHash, hashMetadata)
 import           Ouroboros.Consensus.Shelley.Eras
                    (StandardShelley, StandardAllegra, StandardMary)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
@@ -123,7 +123,7 @@ import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe(..), maybeToStrictMa
 import qualified Shelley.Spec.Ledger.Credential as Shelley
 import qualified Shelley.Spec.Ledger.Genesis as Shelley
 import qualified Shelley.Spec.Ledger.Keys as Shelley
-import qualified Shelley.Spec.Ledger.MetaData as Shelley
+import qualified Shelley.Spec.Ledger.Metadata as Shelley
 import qualified Shelley.Spec.Ledger.Tx as Shelley
 import qualified Shelley.Spec.Ledger.TxBody as Shelley
 import qualified Shelley.Spec.Ledger.UTxO as Shelley
@@ -1125,8 +1125,8 @@ toShelleyWithdrawal withdrawals =
 toShelleyAuxiliaryData :: Map Word64 TxMetadataValue
                        -> Ledger.Metadata StandardShelley
 toShelleyAuxiliaryData m =
-    Shelley.MetaData
-      (toShelleyMetaData m)
+    Shelley.Metadata
+      (toShelleyMetadata m)
 
 -- | In the Allegra and Mary eras the auxiliary data consists of the tx metadata
 -- and the axiliary scripts.
@@ -1141,11 +1141,11 @@ toAllegraAuxiliaryData :: forall era ledgeera.
                        -> Ledger.Metadata ledgeera
 toAllegraAuxiliaryData m ss =
     Allegra.Metadata
-      (toShelleyMetaData m)
+      (toShelleyMetadata m)
       (Seq.fromList (map toShelleyScript ss))
 
 hashAuxiliaryData :: Shelley.ValidateMetadata ledgeera
-                  => Ledger.Metadata ledgeera -> Ledger.MetaDataHash ledgeera
+                  => Ledger.Metadata ledgeera -> Ledger.MetadataHash ledgeera
 hashAuxiliaryData = Ledger.hashMetadata
 
 
@@ -1187,7 +1187,7 @@ makeShelleyTransaction :: [TxIn]
                        -> Maybe UpdateProposal
                        -> Either (TxBodyError ShelleyEra) (TxBody ShelleyEra)
 makeShelleyTransaction txIns txOuts ttl fee
-                       certs withdrawals mMetaData mUpdateProp =
+                       certs withdrawals mMetadata mUpdateProp =
     makeTransactionBody $
       TxBodyContent {
         txIns,
@@ -1196,7 +1196,7 @@ makeShelleyTransaction txIns txOuts ttl fee
         txValidityRange  = (TxValidityNoLowerBound,
                             TxValidityUpperBound
                               ValidityUpperBoundInShelleyEra ttl),
-        txMetadata       = case mMetaData of
+        txMetadata       = case mMetadata of
                              Nothing -> TxMetadataNone
                              Just md -> TxMetadataInEra
                                           TxMetadataInShelleyEra md,

--- a/cardano-api/src/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/src/Cardano/Api/TxMetadata.hs
@@ -24,8 +24,8 @@ module Cardano.Api.TxMetadata (
     TxMetadataJsonSchemaError (..),
 
     -- * Internal conversion functions
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- * Data family instances
     AsType(..)
@@ -62,7 +62,7 @@ import           Control.Monad (guard, when)
 
 import qualified Cardano.Binary as CBOR
 
-import qualified Shelley.Spec.Ledger.MetaData as Shelley
+import qualified Shelley.Spec.Ledger.Metadata as Shelley
 
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
@@ -100,14 +100,14 @@ instance HasTypeProxy TxMetadata where
 instance SerialiseAsCBOR TxMetadata where
     serialiseToCBOR =
           CBOR.serialize'
-        . Shelley.MetaData
-        . toShelleyMetaData
+        . Shelley.Metadata
+        . toShelleyMetadata
         . (\(TxMetadata m) -> m)
 
     deserialiseFromCBOR AsTxMetadata bs =
           TxMetadata
-        . fromShelleyMetaData
-        . (\(Shelley.MetaData m) -> m)
+        . fromShelleyMetadata
+        . (\(Shelley.Metadata m) -> m)
       <$> CBOR.decodeAnnotator "TxMetadata" fromCBOR (LBS.fromStrict bs)
 
 makeTransactionMetadata :: Map Word64 TxMetadataValue -> TxMetadata
@@ -118,37 +118,37 @@ makeTransactionMetadata = TxMetadata
 -- Internal conversion functions
 --
 
-toShelleyMetaData :: Map Word64 TxMetadataValue -> Map Word64 Shelley.MetaDatum
-toShelleyMetaData = Map.map toShelleyMetaDatum
+toShelleyMetadata :: Map Word64 TxMetadataValue -> Map Word64 Shelley.Metadatum
+toShelleyMetadata = Map.map toShelleyMetadatum
   where
-    toShelleyMetaDatum :: TxMetadataValue -> Shelley.MetaDatum
-    toShelleyMetaDatum (TxMetaNumber x) = Shelley.I x
-    toShelleyMetaDatum (TxMetaBytes  x) = Shelley.B x
-    toShelleyMetaDatum (TxMetaText   x) = Shelley.S x
-    toShelleyMetaDatum (TxMetaList  xs) = Shelley.List
-                                            [ toShelleyMetaDatum x | x <- xs ]
-    toShelleyMetaDatum (TxMetaMap   xs) = Shelley.Map
-                                            [ (toShelleyMetaDatum k,
-                                               toShelleyMetaDatum v)
+    toShelleyMetadatum :: TxMetadataValue -> Shelley.Metadatum
+    toShelleyMetadatum (TxMetaNumber x) = Shelley.I x
+    toShelleyMetadatum (TxMetaBytes  x) = Shelley.B x
+    toShelleyMetadatum (TxMetaText   x) = Shelley.S x
+    toShelleyMetadatum (TxMetaList  xs) = Shelley.List
+                                            [ toShelleyMetadatum x | x <- xs ]
+    toShelleyMetadatum (TxMetaMap   xs) = Shelley.Map
+                                            [ (toShelleyMetadatum k,
+                                               toShelleyMetadatum v)
                                             | (k,v) <- xs ]
 
-fromShelleyMetaData :: Map Word64 Shelley.MetaDatum -> Map Word64 TxMetadataValue
-fromShelleyMetaData = Map.Lazy.map fromShelleyMetaDatum
+fromShelleyMetadata :: Map Word64 Shelley.Metadatum -> Map Word64 TxMetadataValue
+fromShelleyMetadata = Map.Lazy.map fromShelleyMetadatum
   where
-    fromShelleyMetaDatum :: Shelley.MetaDatum -> TxMetadataValue
-    fromShelleyMetaDatum (Shelley.I     x) = TxMetaNumber x
-    fromShelleyMetaDatum (Shelley.B     x) = TxMetaBytes  x
-    fromShelleyMetaDatum (Shelley.S     x) = TxMetaText   x
-    fromShelleyMetaDatum (Shelley.List xs) = TxMetaList
-                                               [ fromShelleyMetaDatum x | x <- xs ]
-    fromShelleyMetaDatum (Shelley.Map  xs) = TxMetaMap
-                                               [ (fromShelleyMetaDatum k,
-                                                  fromShelleyMetaDatum v)
+    fromShelleyMetadatum :: Shelley.Metadatum -> TxMetadataValue
+    fromShelleyMetadatum (Shelley.I     x) = TxMetaNumber x
+    fromShelleyMetadatum (Shelley.B     x) = TxMetaBytes  x
+    fromShelleyMetadatum (Shelley.S     x) = TxMetaText   x
+    fromShelleyMetadatum (Shelley.List xs) = TxMetaList
+                                               [ fromShelleyMetadatum x | x <- xs ]
+    fromShelleyMetadatum (Shelley.Map  xs) = TxMetaMap
+                                               [ (fromShelleyMetadatum k,
+                                                  fromShelleyMetadatum v)
                                                | (k,v) <- xs ]
 
 
 -- ----------------------------------------------------------------------------
--- Validate tx metaData
+-- Validate tx metadata
 --
 
 -- | Validate transaction metadata. This is for use with existing constructed

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -238,8 +238,8 @@ module Cardano.Api.Typed (
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.
     TxMetadata(..),
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- ** Constructing metadata
     TxMetadataValue(..),

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -4,39 +4,39 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Cardano.Api.Gen
-  ( genMetaData
+  ( genMetadata
   ) where
 
 
-import           Cardano.Prelude hiding (MetaData)
+import           Cardano.Prelude hiding (Metadata)
 
 import qualified Data.Map.Strict as Map
 
-import           Shelley.Spec.Ledger.MetaData (MetaData (..), MetaDatum (..))
+import           Shelley.Spec.Ledger.Metadata (Metadata (..), Metadatum (..))
 
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-genMetaData :: Gen MetaData
-genMetaData = do
+genMetadata :: Gen Metadata
+genMetadata = do
   numberOfIndicies <- Gen.integral (Range.linear 1 15)
   let indexes = map (\i -> fromIntegral i :: Word64) [1..numberOfIndicies]
-  mDatums <- Gen.list (Range.singleton numberOfIndicies) genMetaDatum
-  return . MetaData . Map.fromList $ zip indexes mDatums
+  mDatums <- Gen.list (Range.singleton numberOfIndicies) genMetadatum
+  return . Metadata . Map.fromList $ zip indexes mDatums
 
-genMetaDatum :: Gen MetaDatum
-genMetaDatum = do
+genMetadatum :: Gen Metadatum
+genMetadatum = do
     int <- Gen.list (Range.linear 1 5) (I <$> Gen.integral (Range.linear 1 100))
     bytes <- Gen.list (Range.linear 1 5) (B <$> Gen.bytes (Range.linear 1 20))
     str <- Gen.list (Range.linear 1 5) (S <$> Gen.text (Range.linear 1 20) Gen.alphaNum)
     let mDatumList = int ++ bytes ++ str
 
-    singleMetaDatum <- Gen.element mDatumList
+    singleMetadatum <- Gen.element mDatumList
 
     Gen.choice
       [ return $ List mDatumList
-      , return $ Map [(singleMetaDatum, singleMetaDatum)]
-      , return $ Map [(List mDatumList, singleMetaDatum)]
-      , return $ Map [(singleMetaDatum, List mDatumList)]
+      , return $ Map [(singleMetadatum, singleMetadatum)]
+      , return $ Map [(List mDatumList, singleMetadatum)]
+      , return $ Map [(singleMetadatum, List mDatumList)]
       ]

--- a/cardano-api/test/Test/Cardano/Api/MetaData.hs
+++ b/cardano-api/test/Test/Cardano/Api/MetaData.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Cardano.Api.MetaData
+module Test.Cardano.Api.Metadata
   ( tests
   , genTxMetadata
   ) where
 
-import           Cardano.Prelude hiding (MetaData)
+import           Cardano.Prelude hiding (Metadata)
 
 import           Cardano.Api
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -46,7 +46,7 @@ import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import           Test.Cardano.Api.MetaData (genTxMetadata)
+import           Test.Cardano.Api.Metadata (genTxMetadata)
 import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -6,7 +6,7 @@ import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Ledger
-import qualified Test.Cardano.Api.MetaData
+import qualified Test.Cardano.Api.Metadata
 import qualified Test.Cardano.Api.Typed.Bech32
 import qualified Test.Cardano.Api.Typed.CBOR
 import qualified Test.Cardano.Api.Typed.Envelope
@@ -27,7 +27,7 @@ tests =
     [ Test.Cardano.Api.Typed.Value.tests
     , Test.Cardano.Api.Crypto.tests
     , Test.Cardano.Api.Ledger.tests
-    , Test.Cardano.Api.MetaData.tests
+    , Test.Cardano.Api.Metadata.tests
     , Test.Cardano.Api.Typed.Bech32.tests
     , Test.Cardano.Api.Typed.CBOR.tests
     , Test.Cardano.Api.Typed.Envelope.tests

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -141,10 +141,10 @@ createUpdateProposal
 createUpdateProposal nw sKey pVer sVer sysTag inshash paramsToUpdate =
     signProposal (toByronProtocolMagicId nw) proposalBody noPassSigningKey
   where
-    proposalBody = ProposalBody pVer protocolParamsUpdate sVer metaData
+    proposalBody = ProposalBody pVer protocolParamsUpdate sVer metadata
 
-    metaData :: M.Map SystemTag InstallerHash
-    metaData = M.singleton sysTag inshash
+    metadata :: M.Map SystemTag InstallerHash
+    metadata = M.singleton sysTag inshash
     noPassSigningKey = noPassSafeSigner sKey
     protocolParamsUpdate = createProtocolParametersUpdate
                              emptyProtocolParametersUpdate paramsToUpdate

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -36,9 +36,9 @@ module Cardano.CLI.Shelley.Commands
   , TxFile (..)
   , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
-  , MetaDataFile (..)
+  , MetadataFile (..)
   , PoolId (..)
-  , PoolMetaDataFile (..)
+  , PoolMetadataFile (..)
   , PrivKeyFile (..)
   , BlockId (..)
   , WitnessSigningData (..)
@@ -178,7 +178,7 @@ data TransactionCmd
       TxMetadataJsonSchema
       [ScriptFile]
       -- ^ Auxillary scripts
-      [MetaDataFile]
+      [MetadataFile]
       (Maybe UpdateProposalFile)
       TxBodyFile
   | TxSign TxBodyFile [WitnessSigningData] (Maybe NetworkId) TxFile
@@ -259,7 +259,7 @@ data PoolCmd
       -- ^ Epoch in which to retire the stake pool.
       OutputFile
   | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
-  | PoolMetaDataHash PoolMetaDataFile (Maybe OutputFile)
+  | PoolMetadataHash PoolMetadataFile (Maybe OutputFile)
   deriving (Eq, Show)
 
 renderPoolCmd :: PoolCmd -> Text
@@ -268,7 +268,7 @@ renderPoolCmd cmd =
     PoolRegistrationCert {} -> "stake-pool registration-certificate"
     PoolRetirementCert {} -> "stake-pool deregistration-certificate"
     PoolGetId {} -> "stake-pool id"
-    PoolMetaDataHash {} -> "stake-pool metadata-hash"
+    PoolMetadataHash {} -> "stake-pool metadata-hash"
 
 data QueryCmd =
     QueryProtocolParameters AnyCardanoEra Protocol NetworkId (Maybe OutputFile)
@@ -377,8 +377,8 @@ newtype GenesisKeyFile
   = GenesisKeyFile FilePath
   deriving (Eq, Show)
 
-data MetaDataFile = MetaDataFileJSON FilePath
-                  | MetaDataFileCBOR FilePath
+data MetadataFile = MetadataFileJSON FilePath
+                  | MetadataFileCBOR FilePath
 
   deriving (Eq, Show)
 
@@ -390,8 +390,8 @@ newtype PoolId
   = PoolId String -- Probably not a String
   deriving (Eq, Show)
 
-newtype PoolMetaDataFile = PoolMetaDataFile
-  { unPoolMetaDataFile :: FilePath }
+newtype PoolMetadataFile = PoolMetadataFile
+  { unPoolMetadataFile :: FilePath }
   deriving (Eq, Show)
 
 newtype GenesisDir

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -44,7 +44,7 @@ import qualified Shelley.Spec.Ledger.Delegation.Certificates as Ledger
 import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
-import           Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
+import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import qualified Shelley.Spec.Ledger.PParams as Ledger
 import qualified Shelley.Spec.Ledger.Rewards as Ledger
 import qualified Shelley.Spec.Ledger.STS.Prtcl as Ledger
@@ -109,7 +109,7 @@ deriving newtype instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJS
 deriving newtype instance ToJSON (ShelleyHash era)
 deriving newtype instance ToJSON (HashHeader era)
 
-deriving newtype instance ToJSON (MetaDataHash era)
+deriving newtype instance ToJSON (MetadataHash era)
 deriving newtype instance ToJSON Ledger.LogWeight
 deriving newtype instance ToJSON Ledger.Likelihood
 deriving newtype instance ToJSON (Ledger.PoolDistr StandardCrypto)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -513,7 +513,7 @@ pTransaction =
                                  <*> many pWithdrawal
                                  <*> pTxMetadataJsonSchema
                                  <*> many pScript
-                                 <*> many pMetaDataFile
+                                 <*> many pMetadataFile
                                  <*> optional pUpdateProposalFile
                                  <*> pTxBodyFile Output
 
@@ -638,14 +638,14 @@ pPoolCmd =
           (Opt.info pId $
              Opt.progDesc "Build pool id from the offline key")
       , Opt.command "metadata-hash"
-          (Opt.info pPoolMetaDataHashSubCmd $ Opt.progDesc "Print the hash of pool metadata.")
+          (Opt.info pPoolMetadataHashSubCmd $ Opt.progDesc "Print the hash of pool metadata.")
       ]
   where
     pId :: Parser PoolCmd
     pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pOutputFormat
 
-    pPoolMetaDataHashSubCmd :: Parser PoolCmd
-    pPoolMetaDataHashSubCmd = PoolMetaDataHash <$> pPoolMetaDataFile <*> pMaybeOutputFile
+    pPoolMetadataHashSubCmd :: Parser PoolCmd
+    pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
 
 
 pQueryCmd :: Parser QueryCmd
@@ -1040,9 +1040,9 @@ pCertificateFile =
          )
     )
 
-pPoolMetaDataFile :: Parser PoolMetaDataFile
-pPoolMetaDataFile =
-  PoolMetaDataFile <$>
+pPoolMetadataFile :: Parser PoolMetadataFile
+pPoolMetadataFile =
+  PoolMetadataFile <$>
     Opt.strOption
       (  Opt.long "pool-metadata-file"
       <> Opt.metavar "FILE"
@@ -1069,9 +1069,9 @@ pTxMetadataJsonSchema =
     -- Default to the no-schema conversion.
     pure TxMetadataJsonNoSchema
 
-pMetaDataFile :: Parser MetaDataFile
-pMetaDataFile =
-      MetaDataFileJSON <$>
+pMetadataFile :: Parser MetadataFile
+pMetadataFile =
+      MetadataFileJSON <$>
         ( Opt.strOption
             (  Opt.long "metadata-json-file"
             <> Opt.metavar "FILE"
@@ -1085,7 +1085,7 @@ pMetaDataFile =
             )
         )
   <|>
-      MetaDataFileCBOR <$>
+      MetadataFileCBOR <$>
         Opt.strOption
           (  Opt.long "metadata-cbor-file"
           <> Opt.metavar "FILE"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -57,8 +57,8 @@ data ShelleyTxCmdError
   | ShelleyTxCmdReadTextViewFileError !(FileError TextEnvelopeError)
   | ShelleyTxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
   | ShelleyTxCmdWriteFileError !(FileError ())
-  | ShelleyTxCmdMetaDataJsonParseError !FilePath !String
-  | ShelleyTxCmdMetaDataConversionError !FilePath !TxMetadataJsonError
+  | ShelleyTxCmdMetadataJsonParseError !FilePath !String
+  | ShelleyTxCmdMetadataConversionError !FilePath !TxMetadataJsonError
   | ShelleyTxCmdMetaValidationError !FilePath ![(Word64, TxMetadataRangeError)]
   | ShelleyTxCmdMetaDecodeError !FilePath !CBOR.DecoderError
   | ShelleyTxCmdBootstrapWitnessError !ShelleyBootstrapWitnessError
@@ -90,15 +90,15 @@ renderShelleyTxCmdError err =
     ShelleyTxCmdReadWitnessSigningDataError witSignDataErr ->
       renderReadWitnessSigningDataError witSignDataErr
     ShelleyTxCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyTxCmdMetaDataJsonParseError fp jsonErr ->
+    ShelleyTxCmdMetadataJsonParseError fp jsonErr ->
        "Invalid JSON format in file: " <> show fp
                 <> "\nJSON parse error: " <> Text.pack jsonErr
-    ShelleyTxCmdMetaDataConversionError fp metaDataErr ->
+    ShelleyTxCmdMetadataConversionError fp metadataErr ->
        "Error reading metadata at: " <> show fp
-                             <> "\n" <> Text.pack (displayError metaDataErr)
-    ShelleyTxCmdMetaDecodeError fp metaDataErr ->
+                             <> "\n" <> Text.pack (displayError metadataErr)
+    ShelleyTxCmdMetaDecodeError fp metadataErr ->
        "Error decoding CBOR metadata at: " <> show fp
-                             <> " Error: " <> show metaDataErr
+                             <> " Error: " <> show metadataErr
     ShelleyTxCmdMetaValidationError fp errs ->
       "Error validating transaction metadata at: " <> show fp <> "\n" <>
       Text.intercalate "\n"
@@ -218,7 +218,7 @@ runTxBuildRaw
   -> [(StakeAddress, Lovelace)]
   -> TxMetadataJsonSchema
   -> [ScriptFile]
-  -> [MetaDataFile]
+  -> [MetadataFile]
   -> Maybe UpdateProposalFile
   -> TxBodyFile
   -> ExceptT ShelleyTxCmdError IO ()
@@ -356,14 +356,14 @@ validateTxValidityUpperBound era (Just slot) =
 
 validateTxMetadataInEra :: CardanoEra era
                         -> TxMetadataJsonSchema
-                        -> [MetaDataFile]
+                        -> [MetadataFile]
                         -> ExceptT ShelleyTxCmdError IO (TxMetadataInEra era)
 validateTxMetadataInEra _ _ [] = return TxMetadataNone
 validateTxMetadataInEra era schema files =
     case txMetadataSupportedInEra era of
       Nothing -> txFeatureMismatch era TxFeatureTxMetadata
       Just supported -> do
-        metadata <- mconcat <$> mapM (readFileTxMetaData schema) files
+        metadata <- mconcat <$> mapM (readFileTxMetadata schema) files
         return (TxMetadataInEra supported metadata)
 
 
@@ -924,17 +924,17 @@ validateScriptSupportedInEra era script@(ScriptInAnyLang lang _) =
 -- Transaction metadata
 --
 
-readFileTxMetaData :: TxMetadataJsonSchema -> MetaDataFile
+readFileTxMetaData :: TxMetadataJsonSchema -> MetadataFile
                    -> ExceptT ShelleyTxCmdError IO TxMetadata
-readFileTxMetaData mapping (MetaDataFileJSON fp) = do
+readFileTxMetaData mapping (MetadataFileJSON fp) = do
     bs <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fp) $
           LBS.readFile fp
-    v  <- firstExceptT (ShelleyTxCmdMetaDataJsonParseError fp) $
+    v  <- firstExceptT (ShelleyTxCmdMetadataJsonParseError fp) $
           hoistEither $
             Aeson.eitherDecode' bs
-    firstExceptT (ShelleyTxCmdMetaDataConversionError fp) $ hoistEither $
+    firstExceptT (ShelleyTxCmdMetadataConversionError fp) $ hoistEither $
       metadataFromJson mapping v
-readFileTxMetaData _ (MetaDataFileCBOR fp) = do
+readFileTxMetadata _ (MetadataFileCBOR fp) = do
     bs <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fp) $
           BS.readFile fp
     txMetadata <- firstExceptT (ShelleyTxCmdMetaDecodeError fp) $ hoistEither $

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley
   ( keyTests
   , certificateTests
   , keyConversionTests
-  , metaDatatests
+  , metadataTests
   , multiSigTests
   , txTests
   ) where
@@ -152,8 +152,8 @@ keyConversionTests =
         , ("golden_convertCardanoAddressShelleyStakeSigningKey", golden_convertCardanoAddressShelleyStakeSigningKey)
         ]
 
-metaDatatests :: IO Bool
-metaDatatests =
+metadataTests :: IO Bool
+metadataTests =
   H.checkSequential
     $ H.Group "Metadata Goldens"
         [ ("golden_stakePoolMetadataHash", golden_stakePoolMetadataHash)

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog.Extras.Test.File as H
 
 golden_stakePoolMetadataHash :: Property
 golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  referenceStakePoolMetaData <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"
+  referenceStakePoolMetadata <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"
 
   stakePoolMetadataFile <- noteTempFile tempDir "stake-pool-metadata.json"
   outputStakePoolMetadataHashFp <- noteTempFile tempDir "stake-pool-metadata-hash.txt"
@@ -31,7 +31,7 @@ golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
     ]
 
   -- Check that the stake pool metadata hash file content is correct.
-  expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetaData
+  expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetadata
   actualStakePoolMetadataHash <- H.readFile outputStakePoolMetadataHashFp
 
   equivalence expectedStakePoolMetadataHash actualStakePoolMetadataHash

--- a/cardano-cli/test/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden.hs
@@ -10,7 +10,7 @@ main =
     [ Test.Golden.Shelley.keyTests
     , Test.Golden.Shelley.certificateTests
     , Test.Golden.Shelley.keyConversionTests
-    , Test.Golden.Shelley.metaDatatests
+    , Test.Golden.Shelley.metadataTests
     , Test.Golden.Shelley.multiSigTests
     , Test.Golden.Shelley.txTests
     ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -60,7 +60,7 @@ import           Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
 import           Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 
-import           Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
+import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import           Shelley.Spec.Ledger.STS.Bbody
 import           Shelley.Spec.Ledger.STS.Chain
 import           Shelley.Spec.Ledger.STS.Deleg
@@ -322,21 +322,21 @@ instance (ShelleyBasedEra era, ToObject (PredicateFailure (UTXO era)))
     mkObject [ "kind" .= String "MIRInsufficientGenesisSigsUTXOW"
              , "genesisSigs" .= genesisSigs
              ]
-  toObject _verb (MissingTxBodyMetaDataHash metaDataHash) =
-    mkObject [ "kind" .= String "MissingTxBodyMetaDataHash"
-             , "metaDataHash" .= metaDataHash
+  toObject _verb (MissingTxBodyMetadataHash metadataHash) =
+    mkObject [ "kind" .= String "MissingTxBodyMetadataHash"
+             , "metadataHash" .= metadataHash
              ]
-  toObject _verb (MissingTxMetaData txBodyMetaDataHash) =
-    mkObject [ "kind" .= String "MissingTxMetaData"
-             , "txBodyMetaDataHash" .= txBodyMetaDataHash
+  toObject _verb (MissingTxMetadata txBodyMetadataHash) =
+    mkObject [ "kind" .= String "MissingTxMetadata"
+             , "txBodyMetadataHash" .= txBodyMetadataHash
              ]
-  toObject _verb (ConflictingMetaDataHash txBodyMetaDataHash fullMetaDataHash) =
-    mkObject [ "kind" .= String "ConflictingMetaDataHash"
-             , "txBodyMetaDataHash" .= txBodyMetaDataHash
-             , "fullMetaDataHash" .= fullMetaDataHash
+  toObject _verb (ConflictingMetadataHash txBodyMetadataHash fullMetadataHash) =
+    mkObject [ "kind" .= String "ConflictingMetadataHash"
+             , "txBodyMetadataHash" .= txBodyMetadataHash
+             , "fullMetadataHash" .= fullMetadataHash
              ]
-  toObject _verb InvalidMetaData =
-    mkObject [ "kind" .= String "InvalidMetaData"
+  toObject _verb InvalidMetadata =
+    mkObject [ "kind" .= String "InvalidMetadata"
              ]
 
 instance ( ShelleyBasedEra era
@@ -777,7 +777,7 @@ showLastAppBlockNo wOblk =  case withOriginToMaybe wOblk of
 
 -- Common to cardano-cli
 
-deriving newtype instance ShelleyBasedEra era => ToJSON (MetaDataHash era)
+deriving newtype instance ShelleyBasedEra era => ToJSON (MetadataHash era)
 
 deriving instance ShelleyBasedEra era => ToJSON (TxIn era)
 deriving newtype instance ToJSON (TxId era)


### PR DESCRIPTION
Makes the spelling consistent. See also: input-output-hk/cardano-ledger-specs#2036 and input-output-hk/ouroboros-network#2786.


```
git ls-files -z | xargs -0 sed -i -e 's/MetaData/Metadata/g' -e 's/MetaDatum/Metadatum/g'
```