### PR TITLE
cardano-api: Fix haddock build

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -717,9 +717,9 @@ data TxBody era where
 
           -- The 'Ledger.Metadata' is really the /auxiliary/ data, it consists
           -- of one or several things, depending on era:
-          -- * tranaction metadata   (in Shelley and later)
-          -- * auxiliary scripts     (in Allegra and later)
-          -- * auxiliary script data (in Allonzo and later)
+          -- • tranaction metadata   (in Shelley and later)
+          -- • auxiliary scripts     (in Allegra and later)
+          -- • auxiliary script data (in Allonzo and later)
        -> Maybe (Ledger.Metadata (ShelleyLedgerEra era))
 
        -> TxBody era

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -717,7 +717,7 @@ data TxBody era where
 
           -- The 'Ledger.Metadata' is really the /auxiliary/ data, it consists
           -- of one or several things, depending on era:
-          -- • transaction metadata   (in Shelley and later)
+          -- • transaction metadata  (in Shelley and later)
           -- • auxiliary scripts     (in Allegra and later)
           -- • auxiliary script data (in Allonzo and later)
        -> Maybe (Ledger.Metadata (ShelleyLedgerEra era))

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -717,7 +717,7 @@ data TxBody era where
 
           -- The 'Ledger.Metadata' is really the /auxiliary/ data, it consists
           -- of one or several things, depending on era:
-          -- • tranaction metadata   (in Shelley and later)
+          -- • transaction metadata   (in Shelley and later)
           -- • auxiliary scripts     (in Allegra and later)
           -- • auxiliary script data (in Allonzo and later)
        -> Maybe (Ledger.Metadata (ShelleyLedgerEra era))


### PR DESCRIPTION
It was saying:

    src/Cardano/Api/TxBody.hs:720:11: error:
        parse error on input ‘-- * tranaction metadata   (in Shelley and later)’
        |
    720 |           -- * tranaction metadata   (in Shelley and later)
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
