### PR TITLE
Edge node nixos test fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,7 +55,7 @@ let
     '' else p;
 
   packages = {
-    inherit haskellPackages cardano-node cardano-cli db-converter
+    inherit haskellPackages cardano-node cardano-cli db-converter cardano-ping
       scripts nixosTests environments dockerImage mkCluster bech32;
 
     inherit (haskellPackages.cardano-node.identifier) version;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -62,8 +62,9 @@ pkgs: _: with pkgs;
   cardano-node-eventlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node;
   cardano-node-asserted = cardanoNodeAssertedHaskellPackages.cardano-node.components.exes.cardano-node;
 
-  # expose the db-converter from the ouroboros-network we depend on
+  # expose the db-converter and cardano-ping from the ouroboros-network we depend on
   inherit (cardanoNodeHaskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
+  inherit (cardanoNodeHaskellPackages.network-mux.components.exes) cardano-ping;
 
   mkCluster = callPackage ./supervisord-cluster;
   hfcCluster = callPackage ./supervisord-cluster/hfc {};

--- a/release.nix
+++ b/release.nix
@@ -108,7 +108,7 @@ let
   ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [
-    ["shell"]
+    ["shell"] ["cardano-ping"]
   ] ++ onlyBuildOnDefaultSystem;
   noMusl64Build = [ ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ]
     ++ noCrossBuild;


### PR DESCRIPTION
this include using `cardano-ping` to improve the edgeNode nixos test.