### PR TITLE
Pass a metrics tracer to teeTraceChainTip

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -275,7 +275,7 @@ mkTracers tOpts@(TracingOn trSel) tr nodeKern = do
   pure Tracers
     { chainDBTracer = tracerOnOff' (traceChainDB trSel) $
         annotateSeverity $ teeTraceChainTip tOpts elidedChainDB
-                             (appendName "ChainDB" tr) tr
+                             (appendName "ChainDB" tr) (appendName "metrics" tr)
     , consensusTracers = consensusTracers
     , nodeToClientTracers = nodeToClientTracers' trSel verb tr
     , nodeToNodeTracers = nodeToNodeTracers' trSel verb tr


### PR DESCRIPTION
After https://github.com/input-output-hk/cardano-node/pull/2158, it seems that ChainDB metrics were mistakenly being logged to `cardano.node` instead of `cardano.node.metrics`. This PR fixes that.