### PR TITLE
Release 1.24.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e499195fbdf38bbece09c36c239bc562921ed68c
-  --sha256: 0w78hsiwl0bg0qm6nzyckk1cd6qv6qzqgj55n4rymnl522n00nan
+  tag: 581767d1329f3f702e332af08355e81a0f85333e
+  --sha256: 198p4v2bi36y6x512w35qycvjm7nds7jf8qh7r84pj1qsy43vf7w
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.24.1 -- December 2020
 
-None
+- Fix the getTxId implementation for Byron-era transactions (#2169)
 
 ## 1.24.0 -- December 2020
 

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## 1.24.1 -- December 2020
 
+- New command `transaction policyid` for making multi-asset policy ids (#2176)
+- New command `byron transaction txid` to help scripts with getting the
+  transaction id for Byron transactions made using the cli (#2169)
+- New `--tx-file` flag for the command `transaction txid` to accept complete
+  txs, not just tx bodies (#2169)
 - Add a regression test for the "0" case of multi-asset tx out values (#2155)
 
 ## 1.24.0 -- December 2020
@@ -10,6 +15,13 @@
   for the new eras, and support for the special new features in the new eras:
   script extensions, tx validity intervals, auxiliary scripts, multi-asset tx
   outputs and asset minting. (#2072, #2129, #2136)
+- New flags for the `build-raw` command:
+  + `--lower-bound` and `--upper-bound` for the new Allegra-era feature
+    of transaction validity intervals. The existing flag `--ttl` is equivalent to
+    the new `--upper-bound`, but it is now optional in the Allegra era.
+  + `--script-file` for the new Allegra-era feature of being able to include
+     auxiliary scripts in a transaction.
+  + `--mint` for the Mary-era token minting feature.
 - It is now necessary to specify the target era (e.g. `--allegra-era`) when
   creating a transaction (with `build-raw`) so that the right format and
   feature-set is used. The `--shelley-era` remains the default.

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -3,11 +3,14 @@
 ## 1.24.1 -- December 2020
 
 ### node changes
-- Tracing changes to support "K=1000" benchmarks (#2156)
+- Move all metrics under the `cardano.node.metrics` namespace (#2158)
+- New metrics for the size of the UTxO and delegation maps (#2158)
+- Tracing changes to support "K=1000" benchmarks (#2156, #2175)
 - Mention the required `xz` tool in the Cabal build instructions (#2132)
 
 ### ledger changes
 - Fix the use of Shelley multi-sig scripts in the Allegra and later eras (#2035)
+- Fix the serialisation format for multi-asset values to follow the CDDL (#2039)
 - Additional "golden" tests for encodings in the Allegra and Mary eras (#2031)
 - Additional binary encoding "round-trip" tests (#2032)
 - Benchmarks for the transaction generators (#2024)


### PR DESCRIPTION
Bump dependency on ledger lib to bring in a fix for the serialisation for
mutli-asset values: accept the full 64-bit range for quantities.

Update the change logs for recent fixes.

