### PR TITLE
CAD-2378 CAD-2377 Node logging  fixes

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Metrics.hs
+++ b/cardano-node/src/Cardano/Tracing/Metrics.hs
@@ -142,7 +142,7 @@ mapForgingStatsTxsProcessed ::
   -> IO Int
 mapForgingStatsTxsProcessed fs f =
   atomicModifyIORef' (fsTxsProcessedNum fs) $
-    \txCount -> (f txCount, txCount)
+    \txCount -> join (,) $ f txCount
 
 mapForgingCurrentThreadStats ::
      ForgingStats

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -274,8 +274,7 @@ mkTracers tOpts@(TracingOn trSel) tr nodeKern = do
 
   pure Tracers
     { chainDBTracer = tracerOnOff' (traceChainDB trSel) $
-        annotateSeverity $ teeTraceChainTip tOpts elidedChainDB
-                             (appendName "ChainDB" tr) (appendName "metrics" tr)
+        annotateSeverity . teeTraceChainTip tOpts elidedChainDB $ appendName "ChainDB" tr
     , consensusTracers = consensusTracers
     , nodeToClientTracers = nodeToClientTracers' trSel verb tr
     , nodeToNodeTracers = nodeToNodeTracers' trSel verb tr
@@ -351,13 +350,12 @@ teeTraceChainTip
   => TraceOptions
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
   -> Trace IO Text
-  -> Trace IO Text
   -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-teeTraceChainTip TracingOff _ _ _ = nullTracer
-teeTraceChainTip (TracingOn trSel) elided trTrc trMet =
+teeTraceChainTip TracingOff _ _ = nullTracer
+teeTraceChainTip (TracingOn trSel) elided tr =
   Tracer $ \ev -> do
-    traceWith (teeTraceChainTipElide (traceVerbosity trSel) elided trTrc) ev
-    traceWith (ignoringSeverity (traceChainMetrics trMet)) ev
+    traceWith (teeTraceChainTip' tr) ev
+    traceWith (teeTraceChainTipElide (traceVerbosity trSel) elided tr) ev
 
 teeTraceChainTipElide
   :: ( ConvertRawHash blk
@@ -371,43 +369,36 @@ teeTraceChainTipElide
   -> Trace IO Text
   -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
 teeTraceChainTipElide = elideToLogObject
-{-# INLINE teeTraceChainTipElide #-}
 
-ignoringSeverity :: Tracer IO a -> Tracer IO (WithSeverity a)
-ignoringSeverity tr = Tracer $ \(WithSeverity _ ev) -> traceWith tr ev
-{-# INLINE ignoringSeverity #-}
+traceChainInformation :: Trace IO Text -> ChainInformation -> IO ()
+traceChainInformation tr ChainInformation { slots, blocks, density, epoch, slotInEpoch } = do
+  -- TODO this is executed each time the chain changes. How cheap is it?
+  meta <- mkLOMeta Critical Confidential
+  let tr' = appendName "metrics" tr
+      traceD :: Text -> Double -> IO ()
+      traceD msg d = traceNamedObject tr' (meta, LogValue msg (PureD d))
+      traceI :: Integral a => Text -> a -> IO ()
+      traceI msg i = traceNamedObject tr' (meta, LogValue msg (PureI (fromIntegral i)))
 
-traceChainMetrics
-  :: forall blk. HasHeader (Header blk)
-  => Trace IO Text -> Tracer IO (ChainDB.TraceEvent blk)
-traceChainMetrics tr = Tracer $ \ev ->
-  fromMaybe (pure ()) $
-    doTrace <$> chainTipInformation ev
- where
-   chainTipInformation :: ChainDB.TraceEvent blk -> Maybe ChainInformation
-   chainTipInformation = \case
-     ChainDB.TraceAddBlockEvent ev -> case ev of
-       ChainDB.SwitchedToAFork _warnings newTipInfo _ newChain ->
-         Just $ chainInformation newTipInfo newChain
-       ChainDB.AddedToCurrentChain _warnings newTipInfo _ newChain ->
-         Just $ chainInformation newTipInfo newChain
-       _ -> Nothing
-     _ -> Nothing
+  traceD "density"     (fromRational density)
+  traceI "slotNum"     slots
+  traceI "blockNum"    blocks
+  traceI "slotInEpoch" slotInEpoch
+  traceI "epoch"       (unEpochNo epoch)
 
-   doTrace :: ChainInformation -> IO ()
-   doTrace ChainInformation { slots, blocks, density, epoch, slotInEpoch } = do
-     -- TODO this is executed each time the chain changes. How cheap is it?
-     meta <- mkLOMeta Critical Confidential
-     let traceD :: Text -> Double -> IO ()
-         traceD msg d = traceNamedObject tr (meta, LogValue msg (PureD d))
-         traceI :: Integral a => Text -> a -> IO ()
-         traceI msg i = traceNamedObject tr (meta, LogValue msg (PureI (fromIntegral i)))
-
-     traceD "density"     (fromRational density)
-     traceI "slotNum"     slots
-     traceI "blockNum"    blocks
-     traceI "slotInEpoch" slotInEpoch
-     traceI "epoch"       (unEpochNo epoch)
+teeTraceChainTip'
+  :: HasHeader (Header blk)
+  => Trace IO Text -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
+teeTraceChainTip' tr =
+    Tracer $ \(WithSeverity _ ev') ->
+      case ev' of
+          (ChainDB.TraceAddBlockEvent ev) -> case ev of
+            ChainDB.SwitchedToAFork _warnings newTipInfo _ newChain ->
+              traceChainInformation tr (chainInformation newTipInfo newChain)
+            ChainDB.AddedToCurrentChain _warnings newTipInfo _ newChain ->
+              traceChainInformation tr (chainInformation newTipInfo newChain)
+            _ -> pure ()
+          _ -> pure ()
 
 --------------------------------------------------------------------------------
 -- Consensus Tracers
@@ -457,7 +448,8 @@ mkConsensusTracers trSel verb tr nodeKern fStats = do
     , Consensus.forgeTracer = tracerOnOff' (traceForge trSel) $
         Tracer $ \tlcev@(Consensus.TraceLabelCreds _ ev) -> do
           traceWith (annotateSeverity
-                     $ traceLeadershipChecks forgeTracers nodeKern verb tr) tlcev
+                     $ traceLeadershipChecks forgeTracers nodeKern verb
+                     $ appendName "LeadershipCheck" tr) tlcev
           traceWith (forgeTracer verb tr forgeTracers fStats) tlcev
           -- Don't track credentials in ForgeTime.
           traceWith (blockForgeOutcomeExtractor
@@ -514,9 +506,9 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
         fromSMaybe (pure ()) $
           query <&>
             \(utxoSize, delegMapSize, _) -> do
-                traceCounter "utxoSize"     tr utxoSize
-                traceCounter "delegMapSize" tr delegMapSize
-        traceNamedObject (appendName "LeadershipCheck" tr)
+               traceCounter "utxoSize"     tr utxoSize
+               traceCounter "delegMapSize" tr delegMapSize
+        traceNamedObject tr
           ( meta
           , LogStructured $ Map.fromList $
             [("kind", String "TraceStartLeadershipCheck")
@@ -805,7 +797,7 @@ forgeStateInfoTracer
   -> Tracer IO (Consensus.TraceLabelCreds (ForgeStateInfo blk))
 forgeStateInfoTracer p _ts tracer = Tracer $ \ev -> do
     let tr = appendName "Forge" tracer
-    traceWith (forgeStateInfoMetricsTraceTransformer p tracer) ev
+    traceWith (forgeStateInfoMetricsTraceTransformer p tr) ev
     traceWith (fsTracer tr) ev
   where
     fsTracer :: Trace IO Text -> Tracer IO (Consensus.TraceLabelCreds (ForgeStateInfo blk))

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -42,7 +42,6 @@ import           Control.Tracer.Transformers
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 
 import           Cardano.BM.Data.Aggregated (Measurable (..))
-import           Cardano.BM.Data.LogItem (LOContent (..), LoggerName)
 import           Cardano.BM.Data.Tracer (WithSeverity (..), annotateSeverity)
 import           Cardano.BM.Data.Transformers
 import           Cardano.BM.Internal.ElidingTracer
@@ -87,6 +86,7 @@ import           Cardano.Tracing.Metrics
 import           Cardano.Tracing.MicroBenchmarking
 import           Cardano.Tracing.Queries
 
+import           Cardano.Node.Configuration.Logging
 -- For tracing instances
 import           Cardano.Node.Protocol.Byron ()
 import           Cardano.Node.Protocol.Shelley ()
@@ -951,16 +951,6 @@ readableTraceBlockchainTimeEvent ev = case ev of
       "The system wall clock time moved backwards, but within our tolerance "
       <> "threshold. Previous 'current' time: " <> (Text.pack . show) prevTime
       <> ". New 'current' time: " <> (Text.pack . show) newTime
-
-traceCounter
-  :: Text
-  -> Trace IO Text
-  -> Int
-  -> IO ()
-traceCounter logValueName tracer aCounter = do
-  meta <- mkLOMeta Notice Public
-  traceNamedObject (appendName "metrics" tracer)
-                   (meta, LogValue logValueName (PureI $ fromIntegral aCounter))
 
 tracerOnOff :: Transformable Text IO a
             => OnOff b

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -635,11 +635,13 @@ notifyBlockForging fStats tr = Tracer $ \case
       =<< mapForgingCurrentThreadStats fStats
             (\fts -> (fts { ftsNodeCannotForgeNum = ftsNodeCannotForgeNum fts + 1 },
                        ftsNodeCannotForgeNum fts + 1))
-  Consensus.TraceNodeIsLeader{} ->
+  (Consensus.TraceNodeIsLeader (SlotNo slot')) -> do
+    let slot = fromIntegral slot'
     traceCounter "nodeIsLeaderNum" tr
       =<< mapForgingCurrentThreadStats fStats
-            (\fts -> (fts { ftsNodeIsLeaderNum = ftsNodeIsLeaderNum fts + 1 },
-                       ftsNodeIsLeaderNum fts + 1))
+            (\fts -> (fts { ftsNodeIsLeaderNum = ftsNodeIsLeaderNum fts + 1
+                          , ftsLastSlot = slot },
+                      ftsNodeIsLeaderNum fts + 1))
   Consensus.TraceForgedBlock {} ->
     traceCounter "blocksForgedNum" tr
       =<< mapForgingCurrentThreadStats fStats


### PR DESCRIPTION
- Fix #2183, by returning updated state in `mapForgingStatsTxsProcessed` instead of previous state (https://github.com/input-output-hk/cardano-node/blob/master/cardano-node/src/Cardano/Tracing/Metrics.hs#L143-L145)
- Fix #2187, by repeating the moved `ChainDB` and `Forge` metrics at old namespace locations
- Re-export a subset of process stats metrics via Prometheus.
- Fix a miscalculated missing slot metric.