### PR TITLE
Eliminate use of the LastKnownBlockVersion-Major for Shelley based eras

### DIFF
--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -215,15 +215,9 @@ instance FromJSON PartialNodeConfiguration where
                                       ++ "or GenesisFile, but not both"
         npcShelleyGenesisFileHash <- v .:? "ShelleyGenesisHash"
 
-        --TODO: these are silly names, allow better aliases:
-        protVerMajor    <- v .:  "LastKnownBlockVersion-Major"
-        protVerMinor    <- v .:  "LastKnownBlockVersion-Minor"
-
         pure NodeShelleyProtocolConfiguration {
                npcShelleyGenesisFile
              , npcShelleyGenesisFileHash
-             , npcShelleySupportedProtocolVersionMajor = protVerMajor
-             , npcShelleySupportedProtocolVersionMinor = protVerMinor
              }
 
       parseHardForkProtocol v = do

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -104,9 +104,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                            }
                            NodeShelleyProtocolConfiguration {
                              npcShelleyGenesisFile,
-                             npcShelleyGenesisFileHash,
-                             npcShelleySupportedProtocolVersionMajor,
-                             npcShelleySupportedProtocolVersionMinor
+                             npcShelleyGenesisFileHash
                            }
                            NodeHardForkProtocolConfiguration {
                              npcTestShelleyHardForkAtEpoch,
@@ -136,12 +134,23 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
       firstExceptT CardanoProtocolInstantiationErrorShelley $
         Shelley.readLeaderCredentials files
 
+    --TODO: all these protocol versions below are confusing and unnecessary.
+    -- It could and should all be automated and these config entries eliminated.
     return $!
       Consensus.ProtocolCardano
         Consensus.ProtocolParamsByron {
           byronGenesis = byronGenesis,
           byronPbftSignatureThreshold =
             PBftSignatureThreshold <$> npcByronPbftSignatureThresh,
+
+          -- This is /not/ the Byron protocol version. It is the protocol
+          -- version that this node will use in blocks it creates. It is used
+          -- in the Byron update mechanism to signal that this block-producing
+          -- node is ready to move to the new protocol. For example, when the
+          -- protocol version (according to the ledger state) is 0, this setting
+          -- should be 1 when we are ready to move. Similarly when the current
+          -- protocol version is 1, this should be 2 to indicate we are ready
+          -- to move into the Shelley era.
           byronProtocolVersion =
             Byron.ProtocolVersion
               npcByronSupportedProtocolVersionMajor
@@ -162,22 +171,28 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
             headMay shelleyLeaderCredentials
         }
         Consensus.ProtocolParamsShelley {
+          -- This is /not/ the Shelley protocol version. It is the protocol
+          -- version that this node will declare that it understands, when it
+          -- is in the Shelley era. That is, it is the version of protocol
+          -- /after/ Shelley, i.e. Allegra.
           shelleyProtVer =
-            ProtVer
-              npcShelleySupportedProtocolVersionMajor
-              npcShelleySupportedProtocolVersionMinor
+            ProtVer 3 0
         }
         Consensus.ProtocolParamsAllegra {
+          -- This is /not/ the Allegra protocol version. It is the protocol
+          -- version that this node will declare that it understands, when it
+          -- is in the Allegra era. That is, it is the version of protocol
+          -- /after/ Allegra, i.e. Mary.
           allegraProtVer =
-            ProtVer
-              npcShelleySupportedProtocolVersionMajor
-              npcShelleySupportedProtocolVersionMinor
+            ProtVer 4 0
         }
         Consensus.ProtocolParamsMary {
+          -- This is /not/ the Mary protocol version. It is the protocol
+          -- version that this node will declare that it understands, when it
+          -- is in the Mary era. Since Mary is currently the last known
+          -- protocol version then this is also the Mary protocol version.
           maryProtVer =
-            ProtVer
-              npcShelleySupportedProtocolVersionMajor
-              npcShelleySupportedProtocolVersionMinor
+            ProtVer 4 0
         }
         -- ProtocolParamsTransition specifies the parameters needed to transition between two eras
         -- The comments below also apply for the Shelley -> Allegra and Allegra -> Mary hard forks.

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -91,9 +91,7 @@ mkConsensusProtocolShelley
                                  Consensus.ProtocolShelley)
 mkConsensusProtocolShelley NodeShelleyProtocolConfiguration {
                             npcShelleyGenesisFile,
-                            npcShelleyGenesisFileHash,
-                            npcShelleySupportedProtocolVersionMajor,
-                            npcShelleySupportedProtocolVersionMinor
+                            npcShelleyGenesisFileHash
                           }
                           files = do
     (genesis, genesisHash) <- readGenesis npcShelleyGenesisFile
@@ -110,9 +108,7 @@ mkConsensusProtocolShelley NodeShelleyProtocolConfiguration {
       }
       Consensus.ProtocolParamsShelley {
         shelleyProtVer =
-          ProtVer
-            npcShelleySupportedProtocolVersionMajor
-            npcShelleySupportedProtocolVersionMinor
+          ProtVer 2 0
       }
 
 genesisHashToPraosNonce :: GenesisHash -> Nonce

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -268,16 +268,6 @@ data NodeShelleyProtocolConfiguration =
      NodeShelleyProtocolConfiguration {
        npcShelleyGenesisFile     :: !GenesisFile
      , npcShelleyGenesisFileHash :: !(Maybe GenesisHash)
-
-       -- | These declare the version of the protocol that the node is prepared
-       -- to run. This is usually the version of the protocol in use on the
-       -- chain now, but during protocol updates this version will be the one
-       -- that we declare that we are ready to move to. This is the endorsement
-       -- mechanism for determining when enough block producers are ready to
-       -- move to the next version.
-       --
-     , npcShelleySupportedProtocolVersionMajor :: !Natural
-     , npcShelleySupportedProtocolVersionMinor :: !Natural
      }
   deriving (Eq, Show)
 
@@ -288,12 +278,14 @@ data NodeByronProtocolConfiguration =
      , npcByronReqNetworkMagic     :: !RequiresNetworkMagic
      , npcByronPbftSignatureThresh :: !(Maybe Double)
 
+       --TODO: eliminate these two: it can be hard-coded
        -- | Update application name.
      , npcByronApplicationName     :: !Byron.ApplicationName
 
        -- | Application (ie software) version.
      , npcByronApplicationVersion  :: !Byron.NumSoftwareVersion
 
+       --TODO: eliminate these: it can be done automatically in consensus
        -- | These declare the version of the protocol that the node is prepared
        -- to run. This is usually the version of the protocol in use on the
        -- chain now, but during protocol updates this version will be the one

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -39,9 +39,10 @@ prop_sanityCheck_POM =
 testPartialYamlConfig :: PartialNodeConfiguration
 testPartialYamlConfig =
   PartialNodeConfiguration
-    { pncProtocolConfig = Last . Just . NodeProtocolConfigurationShelley
-                                          $ NodeShelleyProtocolConfiguration
-                                          (GenesisFile "dummmy-genesis-file") Nothing 1 2
+    { pncProtocolConfig = Last . Just
+                        . NodeProtocolConfigurationShelley
+                        $ NodeShelleyProtocolConfiguration
+                            (GenesisFile "dummmy-genesis-file") Nothing
     , pncSocketPath = Last Nothing
     , pncDiffusionMode = Last Nothing
     , pncMaxConcurrencyBulkSync = Last Nothing
@@ -102,7 +103,7 @@ expectedConfig =
     , ncShutdownOnSlotSynced = MaxSlotNo $ SlotNo 42
     , ncProtocolConfig = NodeProtocolConfigurationShelley
                            $ NodeShelleyProtocolConfiguration
-                             (GenesisFile "dummmy-genesis-file") Nothing 1 2
+                             (GenesisFile "dummmy-genesis-file") Nothing
     , ncSocketPath = Nothing
     , ncDiffusionMode = InitiatorAndResponderDiffusionMode
     , ncMaxConcurrencyBulkSync = Nothing


### PR DESCRIPTION
The node config file entries LastKnownBlockVersion-Major and -Minor are
now only used for the Byron era.

For the Shelley-based eras (Shelley, Allegra, Mary) we now hard-code the
numbers. There is no reason for them to be configurable. We will change
the consensus later to automate it and eliminate the config record
entries entirely.