### PR TITLE
Bump version to 1.24.2 and update change logs

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-api
 
+## 1.24.2 -- December 2020
+
+None
+
 ## 1.24.1 -- December 2020
 
 - Fix the getTxId implementation for Byron-era transactions (#2169)

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-api
-version:                1.24.1
+version:                1.24.2
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for cardano-cli
 
+## 1.24.2 -- December 2020
+
+- Rename the flags `--lower-bound` and `--upper-bound` to be `--invalid-before`
+  and `--invalid-hereafter` respectively, for naming consistency (#2186, #2190)
+- Hide the deprecated `--ttl` flag in the `--help` output (#2189, #2190)
+
 ## 1.24.1 -- December 2020
 
 - New command `transaction policyid` for making multi-asset policy ids (#2176)
@@ -16,9 +22,9 @@
   script extensions, tx validity intervals, auxiliary scripts, multi-asset tx
   outputs and asset minting. (#2072, #2129, #2136)
 - New flags for the `build-raw` command:
-  + `--lower-bound` and `--upper-bound` for the new Allegra-era feature
+  + `--invalid-before` and `--invalid-hereafter` for the new Allegra-era feature
     of transaction validity intervals. The existing flag `--ttl` is equivalent to
-    the new `--upper-bound`, but it is now optional in the Allegra era.
+    the new `--invalid-hereafter`, but it is now optional in the Allegra era.
   + `--script-file` for the new Allegra-era feature of being able to include
      auxiliary scripts in a transaction.
   + `--mint` for the Mary-era token minting feature.

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                  cardano-cli
-version:               1.24.1
+version:               1.24.2
 description:           The Cardano command-line interface.
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                  cardano-node-chairman
-version:               1.24.1
+version:               1.24.2
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,24 @@
 # Changelog for cardano-node
 
+## 1.24.2 -- December 2020
+
+### node changes
+- Eliminate the need to update the `LastKnownBlockVersion-*` entries in the node
+  config files for the Shelley-based eras. This means the configuration does not
+  need to be updated for the Allegra or Mary eras. (#2193)
+- Fix an off-by-one error in the `txsProcessedNum` metric (#2183, #2192)
+- Revert the renaming of the metrics from 1.24.1 (#2158, #2187, #2192)
+- Export some more metrics for selected OS and RTS stats (#2192)
+
+### consensus changes
+None
+
+### ledger changes
+None
+
+### network changes
+None
+
 ## 1.24.1 -- December 2020
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                  cardano-node
-version:               1.24.1
+version:               1.24.2
 description:           The cardano full node
 author:                IOHK
 maintainer:            operations@iohk.io


### PR DESCRIPTION
A few small fixes and improvements in the node and cli since 1.24.1
for issues found during integration testing.