### PR TITLE
Require unordered-containers >= 0.2.11

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -112,7 +112,7 @@ library
                       , transformers-except
                       , typed-protocols
                       , typed-protocols-examples
-                      , unordered-containers
+                      , unordered-containers >= 0.2.11
                       , vector
 
   default-language:     Haskell2010


### PR DESCRIPTION
Since we use the !? operator that was added in that version.