### PR TITLE
CAD-2399 ghc:  enable DWARF debug info: build everything with -g3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -40,6 +40,8 @@ tests: False
 
 test-show-details: direct
 
+package *
+  ghc-options: -g3
 -- Then enable specific tests in this repo
 
 package cardano-api

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -133,7 +133,7 @@ let
           (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
       })
       {
-        ghcOptions = "-g3";
+        ghcOptions = ["-g3"];
       }
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -133,7 +133,7 @@ let
           (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
       })
       {
-        packages.ghcOptions = "-g3";
+        ghcOptions = "-g3";
       }
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -132,6 +132,9 @@ let
         packages = lib.genAttrs ["cardano-node"]
           (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
       })
+      {
+        packages.ghcOptions = "-g3";
+      }
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
         packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "40a26afa33b421d7ede240b5d6c2a9a22313cb2b",
-        "sha256": "1cd6i1rrxxqnrg659zcq0xhkind67q0kx1gddr9sni8cdhwdlvqb",
+        "rev": "42b10678ff45cd1bd668093c3a9bcb093d5c1760",
+        "sha256": "0bianzf3y17qikx3cbzcr587hnljg3fgnax7y93nn4s9q2b8w283",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/40a26afa33b421d7ede240b5d6c2a9a22313cb2b.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/42b10678ff45cd1bd668093c3a9bcb093d5c1760.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
This is supposed to enable building with maximum DWARF debug information, by passing all packages the `-g3` flag.