### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 474409e03b559bd6c0943739619c21f110773cef
-  --sha256: 1h0pwddcwz2cfk9ysvqziichra99pslcgbhjpgiwm0412lc8gmps
+  tag: 4fdc309f855792ed30271c30dcd9159232404787
+  --sha256: 1j03pzqw0n10m9af17q37b6l90x2qdajp30xjpv2247rwpgip31i
   subdir:
     io-sim
     io-sim-classes

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-11-15T00:00:00Z
+index-state: 2020-12-11T00:00:00Z
 
 packages:
     cardano-api
@@ -91,8 +91,8 @@ package io-sim-classes
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 1312b41c520433478fd4297cfbe9e40d4f3114d4
-  --sha256: 1sw11ifzmbz12p1gmvh8laprmd947kf91l0xr1i4kxc0xnzn9fmf
+  tag: 6a6ea9695ee898dd7d4fd7a5d2cc639d7d5764f7
+  --sha256: 1hkq5i9fjjr4picx3plq3s09isrmx6jifpqf57c7viqfdrwlhjnj
   subdir:
     binary
     binary/test
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 581767d1329f3f702e332af08355e81a0f85333e
-  --sha256: 198p4v2bi36y6x512w35qycvjm7nds7jf8qh7r84pj1qsy43vf7w
+  tag: a638b9fa854fced8b8165631885268e3814f2d90
+  --sha256: 0jfdiha2xjjvqqi3dy410whzjiyhs3vxyic423ddlpbi1pdr3xdd
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8ced9d8713a7ad82f75a90c6103259e61c412d33
-  --sha256: 19inypc7ixydjjs7082iysanqrv9r276irs07lba7h1m2jy6d5xq
+  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c2bd6814e231bfd48059f306ef486b830e524aa8
-  --sha256: 0sjp5i4szp5nf1dkwang5w8pydjx5p22by8wisihs1410rxgwd7n
+  tag: 474409e03b559bd6c0943739619c21f110773cef
+  --sha256: 1h0pwddcwz2cfk9ysvqziichra99pslcgbhjpgiwm0412lc8gmps
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -176,7 +176,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Gen
                         Test.Cardano.Api.Genesis
                         Test.Cardano.Api.Ledger
-                        Test.Cardano.Api.MetaData
+                        Test.Cardano.Api.Metadata
                         Test.Cardano.Api.Typed.Bech32
                         Test.Cardano.Api.Typed.CBOR
                         Test.Cardano.Api.Typed.Envelope

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Certificates embedded in transactions
@@ -52,8 +51,6 @@ import           Network.Socket (PortNumber)
 import           Cardano.Slotting.Slot (EpochNo (..))
 import qualified Cardano.Crypto.Hash.Class as Crypto
 
-import qualified Cardano.Ledger.Era as Ledger
-import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
 
 import           Shelley.Spec.Ledger.BaseTypes
@@ -103,10 +100,10 @@ instance HasTypeProxy Certificate where
     proxyToAsType _ = AsCertificate
 
 instance ToCBOR Certificate where
-    toCBOR = toCBOR . toShelleyCertificate @StandardShelley
+    toCBOR = toCBOR . toShelleyCertificate
 
 instance FromCBOR Certificate where
-    fromCBOR = fromShelleyCertificate @StandardShelley <$> fromCBOR
+    fromCBOR = fromShelleyCertificate <$> fromCBOR
 
 instance HasTextEnvelope Certificate where
     textEnvelopeType _ = "CertificateShelley"
@@ -197,8 +194,7 @@ makeMIRCertificate = MIRCertificate
 -- Internal conversion functions
 --
 
-toShelleyCertificate :: Ledger.Crypto ledgerera ~ StandardCrypto
-                     => Certificate -> Shelley.DCert ledgerera
+toShelleyCertificate :: Certificate -> Shelley.DCert StandardCrypto
 toShelleyCertificate (StakeAddressRegistrationCertificate stakecred) =
     Shelley.DCertDeleg $
       Shelley.RegKey
@@ -248,8 +244,7 @@ toShelleyCertificate (MIRCertificate mirpot amounts) =
            | (sc, v) <- amounts ])
 
 
-fromShelleyCertificate :: Ledger.Crypto ledgerera ~ StandardCrypto
-                       => Shelley.DCert ledgerera -> Certificate
+fromShelleyCertificate :: Shelley.DCert StandardCrypto -> Certificate
 fromShelleyCertificate (Shelley.DCertDeleg (Shelley.RegKey stakecred)) =
     StakeAddressRegistrationCertificate
       (fromShelleyStakeCredential stakecred)
@@ -287,8 +282,7 @@ fromShelleyCertificate (Shelley.DCertMir (Shelley.MIRCert mirpot amounts)) =
       | (sc, v) <- Map.toList amounts ]
 
 
-toShelleyPoolParams :: Ledger.Crypto ledgerera ~ StandardCrypto
-                    => StakePoolParameters -> Shelley.PoolParams ledgerera
+toShelleyPoolParams :: StakePoolParameters -> Shelley.PoolParams StandardCrypto
 toShelleyPoolParams StakePoolParameters {
                       stakePoolId            = StakePoolKeyHash poolkh
                     , stakePoolVRF           = VrfKeyHash vrfkh
@@ -352,8 +346,7 @@ toShelleyPoolParams StakePoolParameters {
                  . Shelley.textToUrl
 
 
-fromShelleyPoolParams :: Ledger.Crypto ledgerera ~ StandardCrypto
-                      => Shelley.PoolParams ledgerera
+fromShelleyPoolParams :: Shelley.PoolParams StandardCrypto
                       -> StakePoolParameters
 fromShelleyPoolParams
     Shelley.PoolParams {

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -312,7 +312,7 @@ toShelleyPoolParams StakePoolParameters {
                               [ kh | StakeKeyHash kh <- stakePoolOwners ]
     , Shelley._poolRelays = Seq.fromList
                               (map toShelleyStakePoolRelay stakePoolRelays)
-    , Shelley._poolMD     = toShelleyPoolMetaData <$>
+    , Shelley._poolMD     = toShelleyPoolMetadata <$>
                               maybeToStrictMaybe stakePoolMetadata
     }
   where
@@ -332,12 +332,12 @@ toShelleyPoolParams StakePoolParameters {
       Shelley.MultiHostName
         (toShelleyDnsName dnsname)
 
-    toShelleyPoolMetaData :: StakePoolMetadataReference -> Shelley.PoolMetaData
-    toShelleyPoolMetaData StakePoolMetadataReference {
+    toShelleyPoolMetadata :: StakePoolMetadataReference -> Shelley.PoolMetadata
+    toShelleyPoolMetadata StakePoolMetadataReference {
                             stakePoolMetadataURL
                           , stakePoolMetadataHash = StakePoolMetadataHash mdh
                           } =
-      Shelley.PoolMetaData {
+      Shelley.PoolMetadata {
         Shelley._poolMDUrl  = toShelleyUrl stakePoolMetadataURL
       , Shelley._poolMDHash = Crypto.hashToBytes mdh
       }
@@ -377,7 +377,7 @@ fromShelleyPoolParams
     , stakePoolOwners        = map StakeKeyHash (Set.toList _poolOwners)
     , stakePoolRelays        = map fromShelleyStakePoolRelay
                                    (Foldable.toList _poolRelays)
-    , stakePoolMetadata      = fromShelleyPoolMetaData <$>
+    , stakePoolMetadata      = fromShelleyPoolMetadata <$>
                                  strictMaybeToMaybe _poolMD
     }
   where
@@ -397,15 +397,15 @@ fromShelleyPoolParams
       StakePoolRelayDnsSrvRecord
         (fromShelleyDnsName dnsname)
 
-    fromShelleyPoolMetaData :: Shelley.PoolMetaData -> StakePoolMetadataReference
-    fromShelleyPoolMetaData Shelley.PoolMetaData {
+    fromShelleyPoolMetadata :: Shelley.PoolMetadata -> StakePoolMetadataReference
+    fromShelleyPoolMetadata Shelley.PoolMetadata {
                               Shelley._poolMDUrl
                             , Shelley._poolMDHash
                             } =
       StakePoolMetadataReference {
         stakePoolMetadataURL  = Shelley.urlToText _poolMDUrl
       , stakePoolMetadataHash = StakePoolMetadataHash
-                              . fromMaybe (error "fromShelleyPoolMetaData: invalid hash. TODO: proper validation")
+                              . fromMaybe (error "fromShelleyPoolMetadata: invalid hash. TODO: proper validation")
                               . Crypto.hashFromBytes
                               $ _poolMDHash
       }

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -45,8 +45,10 @@ import           Prelude
 
 import           Data.Type.Equality (TestEquality(..), (:~:)(Refl))
 
+import           Cardano.Ledger.Era as Ledger (Crypto)
+
 import           Ouroboros.Consensus.Shelley.Eras as Ledger
-                   (StandardShelley, StandardAllegra, StandardMary)
+                   (StandardShelley, StandardAllegra, StandardMary, StandardCrypto)
 
 import           Cardano.Api.HasTypeProxy
 
@@ -239,7 +241,8 @@ deriving instance Show (ShelleyBasedEra era)
 -- of Shelley-based eras, but also non-uniform by making case distinctions on
 -- the 'ShelleyBasedEra' constructors.
 --
-class IsCardanoEra era => IsShelleyBasedEra era where
+class (IsCardanoEra era, Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto)
+   => IsShelleyBasedEra era where
    shelleyBasedEra :: ShelleyBasedEra era
 
 instance IsShelleyBasedEra ShelleyEra where

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -75,8 +75,8 @@ module Cardano.Api.Shelley
 
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- * Protocol parameter updates
     EpochNo(..),

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -113,7 +113,7 @@ import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
 import qualified Cardano.Ledger.ShelleyMA.Metadata as Allegra
-import qualified Shelley.Spec.Ledger.MetaData as Ledger (MetaDataHash, hashMetadata)
+import qualified Shelley.Spec.Ledger.Metadata as Ledger (MetadataHash, hashMetadata)
 import           Ouroboros.Consensus.Shelley.Eras
                    (StandardShelley, StandardAllegra, StandardMary)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
@@ -123,7 +123,7 @@ import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe(..), maybeToStrictMa
 import qualified Shelley.Spec.Ledger.Credential as Shelley
 import qualified Shelley.Spec.Ledger.Genesis as Shelley
 import qualified Shelley.Spec.Ledger.Keys as Shelley
-import qualified Shelley.Spec.Ledger.MetaData as Shelley
+import qualified Shelley.Spec.Ledger.Metadata as Shelley
 import qualified Shelley.Spec.Ledger.Tx as Shelley
 import qualified Shelley.Spec.Ledger.TxBody as Shelley
 import qualified Shelley.Spec.Ledger.UTxO as Shelley
@@ -1157,8 +1157,8 @@ toShelleyWithdrawal withdrawals =
 toShelleyAuxiliaryData :: Map Word64 TxMetadataValue
                        -> Ledger.Metadata StandardShelley
 toShelleyAuxiliaryData m =
-    Shelley.MetaData
-      (toShelleyMetaData m)
+    Shelley.Metadata
+      (toShelleyMetadata m)
 
 -- | In the Allegra and Mary eras the auxiliary data consists of the tx metadata
 -- and the axiliary scripts.
@@ -1173,11 +1173,11 @@ toAllegraAuxiliaryData :: forall era ledgeera.
                        -> Ledger.Metadata ledgeera
 toAllegraAuxiliaryData m ss =
     Allegra.Metadata
-      (toShelleyMetaData m)
+      (toShelleyMetadata m)
       (Seq.fromList (map toShelleyScript ss))
 
 hashAuxiliaryData :: Shelley.ValidateMetadata ledgeera
-                  => Ledger.Metadata ledgeera -> Ledger.MetaDataHash ledgeera
+                  => Ledger.Metadata ledgeera -> Ledger.MetadataHash ledgeera
 hashAuxiliaryData = Ledger.hashMetadata
 
 
@@ -1219,7 +1219,7 @@ makeShelleyTransaction :: [TxIn]
                        -> Maybe UpdateProposal
                        -> Either (TxBodyError ShelleyEra) (TxBody ShelleyEra)
 makeShelleyTransaction txIns txOuts ttl fee
-                       certs withdrawals mMetaData mUpdateProp =
+                       certs withdrawals mMetadata mUpdateProp =
     makeTransactionBody $
       TxBodyContent {
         txIns,
@@ -1228,7 +1228,7 @@ makeShelleyTransaction txIns txOuts ttl fee
         txValidityRange  = (TxValidityNoLowerBound,
                             TxValidityUpperBound
                               ValidityUpperBoundInShelleyEra ttl),
-        txMetadata       = case mMetaData of
+        txMetadata       = case mMetadata of
                              Nothing -> TxMetadataNone
                              Just md -> TxMetadataInEra
                                           TxMetadataInShelleyEra md,

--- a/cardano-api/src/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/src/Cardano/Api/TxMetadata.hs
@@ -24,8 +24,8 @@ module Cardano.Api.TxMetadata (
     TxMetadataJsonSchemaError (..),
 
     -- * Internal conversion functions
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- * Data family instances
     AsType(..)
@@ -62,7 +62,7 @@ import           Control.Monad (guard, when)
 
 import qualified Cardano.Binary as CBOR
 
-import qualified Shelley.Spec.Ledger.MetaData as Shelley
+import qualified Shelley.Spec.Ledger.Metadata as Shelley
 
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
@@ -100,14 +100,14 @@ instance HasTypeProxy TxMetadata where
 instance SerialiseAsCBOR TxMetadata where
     serialiseToCBOR =
           CBOR.serialize'
-        . Shelley.MetaData
-        . toShelleyMetaData
+        . Shelley.Metadata
+        . toShelleyMetadata
         . (\(TxMetadata m) -> m)
 
     deserialiseFromCBOR AsTxMetadata bs =
           TxMetadata
-        . fromShelleyMetaData
-        . (\(Shelley.MetaData m) -> m)
+        . fromShelleyMetadata
+        . (\(Shelley.Metadata m) -> m)
       <$> CBOR.decodeAnnotator "TxMetadata" fromCBOR (LBS.fromStrict bs)
 
 makeTransactionMetadata :: Map Word64 TxMetadataValue -> TxMetadata
@@ -118,37 +118,37 @@ makeTransactionMetadata = TxMetadata
 -- Internal conversion functions
 --
 
-toShelleyMetaData :: Map Word64 TxMetadataValue -> Map Word64 Shelley.MetaDatum
-toShelleyMetaData = Map.map toShelleyMetaDatum
+toShelleyMetadata :: Map Word64 TxMetadataValue -> Map Word64 Shelley.Metadatum
+toShelleyMetadata = Map.map toShelleyMetadatum
   where
-    toShelleyMetaDatum :: TxMetadataValue -> Shelley.MetaDatum
-    toShelleyMetaDatum (TxMetaNumber x) = Shelley.I x
-    toShelleyMetaDatum (TxMetaBytes  x) = Shelley.B x
-    toShelleyMetaDatum (TxMetaText   x) = Shelley.S x
-    toShelleyMetaDatum (TxMetaList  xs) = Shelley.List
-                                            [ toShelleyMetaDatum x | x <- xs ]
-    toShelleyMetaDatum (TxMetaMap   xs) = Shelley.Map
-                                            [ (toShelleyMetaDatum k,
-                                               toShelleyMetaDatum v)
+    toShelleyMetadatum :: TxMetadataValue -> Shelley.Metadatum
+    toShelleyMetadatum (TxMetaNumber x) = Shelley.I x
+    toShelleyMetadatum (TxMetaBytes  x) = Shelley.B x
+    toShelleyMetadatum (TxMetaText   x) = Shelley.S x
+    toShelleyMetadatum (TxMetaList  xs) = Shelley.List
+                                            [ toShelleyMetadatum x | x <- xs ]
+    toShelleyMetadatum (TxMetaMap   xs) = Shelley.Map
+                                            [ (toShelleyMetadatum k,
+                                               toShelleyMetadatum v)
                                             | (k,v) <- xs ]
 
-fromShelleyMetaData :: Map Word64 Shelley.MetaDatum -> Map Word64 TxMetadataValue
-fromShelleyMetaData = Map.Lazy.map fromShelleyMetaDatum
+fromShelleyMetadata :: Map Word64 Shelley.Metadatum -> Map Word64 TxMetadataValue
+fromShelleyMetadata = Map.Lazy.map fromShelleyMetadatum
   where
-    fromShelleyMetaDatum :: Shelley.MetaDatum -> TxMetadataValue
-    fromShelleyMetaDatum (Shelley.I     x) = TxMetaNumber x
-    fromShelleyMetaDatum (Shelley.B     x) = TxMetaBytes  x
-    fromShelleyMetaDatum (Shelley.S     x) = TxMetaText   x
-    fromShelleyMetaDatum (Shelley.List xs) = TxMetaList
-                                               [ fromShelleyMetaDatum x | x <- xs ]
-    fromShelleyMetaDatum (Shelley.Map  xs) = TxMetaMap
-                                               [ (fromShelleyMetaDatum k,
-                                                  fromShelleyMetaDatum v)
+    fromShelleyMetadatum :: Shelley.Metadatum -> TxMetadataValue
+    fromShelleyMetadatum (Shelley.I     x) = TxMetaNumber x
+    fromShelleyMetadatum (Shelley.B     x) = TxMetaBytes  x
+    fromShelleyMetadatum (Shelley.S     x) = TxMetaText   x
+    fromShelleyMetadatum (Shelley.List xs) = TxMetaList
+                                               [ fromShelleyMetadatum x | x <- xs ]
+    fromShelleyMetadatum (Shelley.Map  xs) = TxMetaMap
+                                               [ (fromShelleyMetadatum k,
+                                                  fromShelleyMetadatum v)
                                                | (k,v) <- xs ]
 
 
 -- ----------------------------------------------------------------------------
--- Validate tx metaData
+-- Validate tx metadata
 --
 
 -- | Validate transaction metadata. This is for use with existing constructed

--- a/cardano-api/src/Cardano/Api/Typed.hs
+++ b/cardano-api/src/Cardano/Api/Typed.hs
@@ -238,8 +238,8 @@ module Cardano.Api.Typed (
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.
     TxMetadata(..),
-    toShelleyMetaData,
-    fromShelleyMetaData,
+    toShelleyMetadata,
+    fromShelleyMetadata,
 
     -- ** Constructing metadata
     TxMetadataValue(..),

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -59,7 +59,6 @@ import qualified Data.Text.Encoding as Text
 
 import qualified Cardano.Chain.Common as Byron
 
-import qualified Cardano.Ledger.Era as Ledger
 import qualified Shelley.Spec.Ledger.Coin as Shelley
 import qualified Cardano.Ledger.Mary.Value as Mary
 
@@ -219,9 +218,7 @@ valueToLovelace v =
       [(AdaAssetId, q)] -> Just (quantityToLovelace q)
       _                 -> Nothing
 
-toMaryValue :: forall ledgerera.
-               Ledger.Crypto ledgerera ~ StandardCrypto
-            => Value -> Mary.Value ledgerera
+toMaryValue :: Value -> Mary.Value StandardCrypto
 toMaryValue v =
     Mary.Value lovelace other
   where
@@ -231,16 +228,14 @@ toMaryValue v =
               [ (toMaryPolicyID pid, Map.singleton (toMaryAssetName name) q)
               | (AssetId pid name, Quantity q) <- valueToList v ]
 
-    toMaryPolicyID :: PolicyId -> Mary.PolicyID ledgerera
+    toMaryPolicyID :: PolicyId -> Mary.PolicyID StandardCrypto
     toMaryPolicyID (PolicyId sh) = Mary.PolicyID (toShelleyScriptHash sh)
 
     toMaryAssetName :: AssetName -> Mary.AssetName
     toMaryAssetName (AssetName n) = Mary.AssetName n
 
 
-fromMaryValue :: forall ledgerera.
-                 Ledger.Crypto ledgerera ~ StandardCrypto
-              => Mary.Value ledgerera -> Value
+fromMaryValue :: Mary.Value StandardCrypto -> Value
 fromMaryValue (Mary.Value lovelace other) =
     Value $
       --TODO: write QC tests to show it's ok to use Map.fromAscList here
@@ -250,7 +245,7 @@ fromMaryValue (Mary.Value lovelace other) =
         | (pid, as) <- Map.toList other
         , (name, q) <- Map.toList as ]
   where
-    fromMaryPolicyID :: Mary.PolicyID ledgerera -> PolicyId
+    fromMaryPolicyID :: Mary.PolicyID StandardCrypto -> PolicyId
     fromMaryPolicyID (Mary.PolicyID sh) = PolicyId (fromShelleyScriptHash sh)
 
     fromMaryAssetName :: Mary.AssetName -> AssetName

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -8,7 +8,7 @@ module Test.Cardano.Api.Gen
   ) where
 
 
-import           Cardano.Prelude hiding (Metadata)
+import           Cardano.Prelude
 
 import qualified Data.Map.Strict as Map
 

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -4,39 +4,39 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Cardano.Api.Gen
-  ( genMetaData
+  ( genMetadata
   ) where
 
 
-import           Cardano.Prelude hiding (MetaData)
+import           Cardano.Prelude hiding (Metadata)
 
 import qualified Data.Map.Strict as Map
 
-import           Shelley.Spec.Ledger.MetaData (MetaData (..), MetaDatum (..))
+import           Shelley.Spec.Ledger.Metadata (Metadata (..), Metadatum (..))
 
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-genMetaData :: Gen MetaData
-genMetaData = do
+genMetadata :: Gen Metadata
+genMetadata = do
   numberOfIndicies <- Gen.integral (Range.linear 1 15)
   let indexes = map (\i -> fromIntegral i :: Word64) [1..numberOfIndicies]
-  mDatums <- Gen.list (Range.singleton numberOfIndicies) genMetaDatum
-  return . MetaData . Map.fromList $ zip indexes mDatums
+  mDatums <- Gen.list (Range.singleton numberOfIndicies) genMetadatum
+  return . Metadata . Map.fromList $ zip indexes mDatums
 
-genMetaDatum :: Gen MetaDatum
-genMetaDatum = do
+genMetadatum :: Gen Metadatum
+genMetadatum = do
     int <- Gen.list (Range.linear 1 5) (I <$> Gen.integral (Range.linear 1 100))
     bytes <- Gen.list (Range.linear 1 5) (B <$> Gen.bytes (Range.linear 1 20))
     str <- Gen.list (Range.linear 1 5) (S <$> Gen.text (Range.linear 1 20) Gen.alphaNum)
     let mDatumList = int ++ bytes ++ str
 
-    singleMetaDatum <- Gen.element mDatumList
+    singleMetadatum <- Gen.element mDatumList
 
     Gen.choice
       [ return $ List mDatumList
-      , return $ Map [(singleMetaDatum, singleMetaDatum)]
-      , return $ Map [(List mDatumList, singleMetaDatum)]
-      , return $ Map [(singleMetaDatum, List mDatumList)]
+      , return $ Map [(singleMetadatum, singleMetadatum)]
+      , return $ Map [(List mDatumList, singleMetadatum)]
+      , return $ Map [(singleMetadatum, List mDatumList)]
       ]

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -64,15 +64,15 @@ exampleShelleyGenesis =
   delegVerKeyHash = KeyHash "839b047f56e50654bdb504832186dc1ee0c73c8de2daec7ae6273827"
   delegVrfKeyHash :: Hash StandardCrypto (VerKeyVRF StandardCrypto)
   delegVrfKeyHash = "231391e7ec1c450a8518134cf6fad1a8e0ed7ffd66d740f8e8271347a6de7bf2"
-  initialFundedAddress :: Addr StandardShelley
+  initialFundedAddress :: Addr StandardCrypto
   initialFundedAddress = Addr Testnet paymentCredential (StakeRefBase stakingCredential)
     where
-      paymentCredential :: PaymentCredential StandardShelley
+      paymentCredential :: PaymentCredential StandardCrypto
       paymentCredential =
         KeyHashObj $ KeyHash
           "1c14ee8e58fbcbd48dc7367c95a63fd1d937ba989820015db16ac7e5"
 
-      stakingCredential :: StakeCredential StandardShelley
+      stakingCredential :: StakeCredential StandardCrypto
       stakingCredential =
         KeyHashObj $ KeyHash
           "e37a65ea2f9bcefb645de4312cf13d8ac12ae61cf242a9aa2973c9ee"

--- a/cardano-api/test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/Test/Cardano/Api/Ledger.hs
@@ -14,7 +14,7 @@ import           Hedgehog (Property, discover)
 import qualified Hedgehog
 import           Test.Tasty (TestTree)
 
-import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 
 import           Test.Shelley.Spec.Ledger.Serialisation.Generators.Genesis (genAddress)
 
@@ -33,7 +33,7 @@ prop_roundtrip_Address_CBOR :: Property
 prop_roundtrip_Address_CBOR =
   -- If this fails, FundPair and ShelleyGenesis can also fail.
   Hedgehog.property $ do
-    addr <- Hedgehog.forAll (genAddress @StandardShelley)
+    addr <- Hedgehog.forAll (genAddress @StandardCrypto)
     Hedgehog.tripping addr serialiseAddr deserialiseAddr
 
 -- -----------------------------------------------------------------------------

--- a/cardano-api/test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/Test/Cardano/Api/Metadata.hs
@@ -5,7 +5,7 @@ module Test.Cardano.Api.Metadata
   , genTxMetadata
   ) where
 
-import           Cardano.Prelude hiding (Metadata)
+import           Cardano.Prelude
 
 import           Cardano.Api
 

--- a/cardano-api/test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/Test/Cardano/Api/Metadata.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Cardano.Api.MetaData
+module Test.Cardano.Api.Metadata
   ( tests
   , genTxMetadata
   ) where
 
-import           Cardano.Prelude hiding (MetaData)
+import           Cardano.Prelude hiding (Metadata)
 
 import           Cardano.Api
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -46,7 +46,7 @@ import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import           Test.Cardano.Api.MetaData (genTxMetadata)
+import           Test.Cardano.Api.Metadata (genTxMetadata)
 import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 

--- a/cardano-api/test/cardano-api-test.cabal
+++ b/cardano-api/test/cardano-api-test.cabal
@@ -14,7 +14,7 @@ build-type:             Simple
 library
   exposed-modules:      Test.Cardano.Api.Typed.Gen
 
-  other-modules:        Test.Cardano.Api.MetaData
+  other-modules:        Test.Cardano.Api.Metadata
                         Test.Tasty.Hedgehog.Group
 
   build-depends:

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -6,7 +6,7 @@ import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Ledger
-import qualified Test.Cardano.Api.MetaData
+import qualified Test.Cardano.Api.Metadata
 import qualified Test.Cardano.Api.Typed.Bech32
 import qualified Test.Cardano.Api.Typed.CBOR
 import qualified Test.Cardano.Api.Typed.Envelope
@@ -27,7 +27,7 @@ tests =
     [ Test.Cardano.Api.Typed.Value.tests
     , Test.Cardano.Api.Crypto.tests
     , Test.Cardano.Api.Ledger.tests
-    , Test.Cardano.Api.MetaData.tests
+    , Test.Cardano.Api.Metadata.tests
     , Test.Cardano.Api.Typed.Bech32.tests
     , Test.Cardano.Api.Typed.CBOR.tests
     , Test.Cardano.Api.Typed.Envelope.tests

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -141,10 +141,11 @@ createUpdateProposal
 createUpdateProposal nw sKey pVer sVer sysTag inshash paramsToUpdate =
     signProposal (toByronProtocolMagicId nw) proposalBody noPassSigningKey
   where
-    proposalBody = ProposalBody pVer protocolParamsUpdate sVer metadata
+    proposalBody = ProposalBody pVer protocolParamsUpdate sVer updateMetadata
 
-    metadata :: M.Map SystemTag InstallerHash
-    metadata = M.singleton sysTag inshash
+    updateMetadata :: M.Map SystemTag InstallerHash
+    updateMetadata = M.singleton sysTag inshash
+
     noPassSigningKey = noPassSafeSigner sKey
     protocolParamsUpdate = createProtocolParametersUpdate
                              emptyProtocolParametersUpdate paramsToUpdate

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -141,10 +141,10 @@ createUpdateProposal
 createUpdateProposal nw sKey pVer sVer sysTag inshash paramsToUpdate =
     signProposal (toByronProtocolMagicId nw) proposalBody noPassSigningKey
   where
-    proposalBody = ProposalBody pVer protocolParamsUpdate sVer metaData
+    proposalBody = ProposalBody pVer protocolParamsUpdate sVer metadata
 
-    metaData :: M.Map SystemTag InstallerHash
-    metaData = M.singleton sysTag inshash
+    metadata :: M.Map SystemTag InstallerHash
+    metadata = M.singleton sysTag inshash
     noPassSigningKey = noPassSafeSigner sKey
     protocolParamsUpdate = createProtocolParametersUpdate
                              emptyProtocolParametersUpdate paramsToUpdate

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -36,9 +36,9 @@ module Cardano.CLI.Shelley.Commands
   , TxFile (..)
   , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
-  , MetaDataFile (..)
+  , MetadataFile (..)
   , PoolId (..)
-  , PoolMetaDataFile (..)
+  , PoolMetadataFile (..)
   , PrivKeyFile (..)
   , BlockId (..)
   , WitnessSigningData (..)
@@ -178,7 +178,7 @@ data TransactionCmd
       TxMetadataJsonSchema
       [ScriptFile]
       -- ^ Auxillary scripts
-      [MetaDataFile]
+      [MetadataFile]
       (Maybe UpdateProposalFile)
       TxBodyFile
   | TxSign TxBodyFile [WitnessSigningData] (Maybe NetworkId) TxFile
@@ -259,7 +259,7 @@ data PoolCmd
       -- ^ Epoch in which to retire the stake pool.
       OutputFile
   | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
-  | PoolMetaDataHash PoolMetaDataFile (Maybe OutputFile)
+  | PoolMetadataHash PoolMetadataFile (Maybe OutputFile)
   deriving (Eq, Show)
 
 renderPoolCmd :: PoolCmd -> Text
@@ -268,7 +268,7 @@ renderPoolCmd cmd =
     PoolRegistrationCert {} -> "stake-pool registration-certificate"
     PoolRetirementCert {} -> "stake-pool deregistration-certificate"
     PoolGetId {} -> "stake-pool id"
-    PoolMetaDataHash {} -> "stake-pool metadata-hash"
+    PoolMetadataHash {} -> "stake-pool metadata-hash"
 
 data QueryCmd =
     QueryProtocolParameters AnyCardanoEra Protocol NetworkId (Maybe OutputFile)
@@ -377,8 +377,8 @@ newtype GenesisKeyFile
   = GenesisKeyFile FilePath
   deriving (Eq, Show)
 
-data MetaDataFile = MetaDataFileJSON FilePath
-                  | MetaDataFileCBOR FilePath
+data MetadataFile = MetadataFileJSON FilePath
+                  | MetadataFileCBOR FilePath
 
   deriving (Eq, Show)
 
@@ -390,8 +390,8 @@ newtype PoolId
   = PoolId String -- Probably not a String
   deriving (Eq, Show)
 
-newtype PoolMetaDataFile = PoolMetaDataFile
-  { unPoolMetaDataFile :: FilePath }
+newtype PoolMetadataFile = PoolMetadataFile
+  { unPoolMetadataFile :: FilePath }
   deriving (Eq, Show)
 
 newtype GenesisDir

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -44,7 +44,7 @@ import qualified Shelley.Spec.Ledger.Delegation.Certificates as Ledger
 import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
-import           Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
+import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import qualified Shelley.Spec.Ledger.PParams as Ledger
 import qualified Shelley.Spec.Ledger.Rewards as Ledger
 import qualified Shelley.Spec.Ledger.STS.Prtcl as Ledger
@@ -109,7 +109,7 @@ deriving newtype instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJS
 deriving newtype instance ToJSON (ShelleyHash era)
 deriving newtype instance ToJSON (HashHeader era)
 
-deriving newtype instance ToJSON (MetaDataHash era)
+deriving newtype instance ToJSON (MetadataHash era)
 deriving newtype instance ToJSON Ledger.LogWeight
 deriving newtype instance ToJSON Ledger.Likelihood
 deriving newtype instance ToJSON (Ledger.PoolDistr StandardCrypto)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -33,6 +34,8 @@ import           Ouroboros.Consensus.Shelley.Eras
                     StandardShelley, StandardAllegra, StandardMary)
 import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Tip (..))
 
+import           Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
+import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Core as Core
 
 import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
@@ -44,7 +47,6 @@ import qualified Shelley.Spec.Ledger.Delegation.Certificates as Ledger
 import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
 import qualified Shelley.Spec.Ledger.Keys as Ledger
 import qualified Shelley.Spec.Ledger.LedgerState as Ledger
-import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import qualified Shelley.Spec.Ledger.PParams as Ledger
 import qualified Shelley.Spec.Ledger.Rewards as Ledger
 import qualified Shelley.Spec.Ledger.STS.Prtcl as Ledger
@@ -54,10 +56,10 @@ import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 import qualified Cardano.Ledger.Mary.Value as Ledger.Mary
 
-instance ShelleyBasedEra era => ToJSONKey (TxIn era) where
+instance ToJSONKey (TxIn StandardCrypto) where
   toJSONKey = ToJSONKeyText txInToText (Aeson.text . txInToText)
 
-txInToText :: ShelleyBasedEra era => TxIn era -> Text
+txInToText :: TxIn StandardCrypto -> Text
 txInToText (TxIn (TxId txidHash) ix) =
   hashToText txidHash
     <> Text.pack "#"
@@ -66,7 +68,7 @@ txInToText (TxIn (TxId txidHash) ix) =
 hashToText :: Hash crypto a -> Text
 hashToText = Text.decodeLatin1 . Crypto.hashToBytesAsHex
 
-deriving instance ShelleyBasedEra era => ToJSON (TxIn era)
+deriving instance ToJSON (TxIn StandardCrypto)
 
 instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJSON (TxOut era) where
   toJSON (TxOut addr amount) =
@@ -104,82 +106,64 @@ deriving newtype instance ToJSON BlockNo
 
 deriving newtype instance ToJSON (TxId era)
 
-deriving newtype instance (ShelleyBasedEra era, ToJSON (Core.Value era)) => ToJSON (UTxO era)
+deriving newtype instance ( ShelleyBasedEra era
+                          , ToJSON (Core.Value era)
+                          , Ledger.Crypto era ~ StandardCrypto
+                          ) => ToJSON (UTxO era)
 
 deriving newtype instance ToJSON (ShelleyHash era)
 deriving newtype instance ToJSON (HashHeader era)
 
-deriving newtype instance ToJSON (MetadataHash era)
+deriving newtype instance ToJSON (AuxiliaryDataHash StandardCrypto)
 deriving newtype instance ToJSON Ledger.LogWeight
 deriving newtype instance ToJSON Ledger.Likelihood
 deriving newtype instance ToJSON (Ledger.PoolDistr StandardCrypto)
 deriving newtype instance ToJSON DeltaCoin
 
-deriving newtype instance ToJSON (Ledger.Stake StandardShelley)
-deriving newtype instance ToJSON (Ledger.Stake StandardAllegra)
-deriving newtype instance ToJSON (Ledger.Stake StandardMary)
+deriving newtype instance ToJSON (Ledger.Stake StandardCrypto)
 
 deriving anyclass instance ToJSON (Ledger.GenDelegs StandardCrypto)
 deriving anyclass instance ToJSON (Ledger.IndividualPoolStake StandardCrypto)
+deriving anyclass instance ToJSON (Ledger.BlocksMade StandardCrypto)
 
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates StandardShelley)
 deriving anyclass instance ToJSON (Ledger.PPUPState StandardShelley)
-deriving anyclass instance ToJSON (Ledger.BlocksMade StandardShelley)
 
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates StandardAllegra)
 deriving anyclass instance ToJSON (Ledger.PPUPState StandardAllegra)
-deriving anyclass instance ToJSON (Ledger.BlocksMade StandardAllegra)
 
 deriving anyclass instance ToJSON (Ledger.ProposedPPUpdates StandardMary)
 deriving anyclass instance ToJSON (Ledger.PPUPState StandardMary)
-deriving anyclass instance ToJSON (Ledger.BlocksMade StandardMary)
 
 deriving instance ToJSON Ledger.Ptr
 deriving instance ToJSON Ledger.AccountState
 
-deriving instance ToJSON (Ledger.DPState StandardShelley)
-deriving instance ToJSON (Ledger.DState StandardShelley)
-deriving instance ToJSON (Ledger.InstantaneousRewards StandardShelley)
-deriving instance ToJSON (Ledger.SnapShot StandardShelley)
-deriving instance ToJSON (Ledger.SnapShots StandardShelley)
-deriving instance ToJSON (Ledger.NonMyopic StandardShelley)
+deriving instance ToJSON (Ledger.DPState StandardCrypto)
+deriving instance ToJSON (Ledger.DState StandardCrypto)
+deriving instance ToJSON (Ledger.InstantaneousRewards StandardCrypto)
+deriving instance ToJSON (Ledger.NonMyopic StandardCrypto)
+deriving instance ToJSON (Ledger.PState StandardCrypto)
+deriving instance ToJSON (Ledger.RewardUpdate StandardCrypto)
+deriving instance ToJSON (Ledger.SnapShot StandardCrypto)
+deriving instance ToJSON (Ledger.SnapShots StandardCrypto)
+deriving instance ToJSON (Ledger.StakeReference StandardCrypto)
+
 deriving instance ToJSON (Ledger.LedgerState StandardShelley)
 deriving instance ToJSON (Ledger.EpochState StandardShelley)
-deriving instance ToJSON (Ledger.RewardUpdate StandardShelley)
 deriving instance ToJSON (Ledger.NewEpochState StandardShelley)
 deriving instance ToJSON (Ledger.PParams' StrictMaybe StandardShelley)
-deriving instance ToJSON (Ledger.PState StandardShelley)
-deriving instance ToJSON (Ledger.StakeReference StandardShelley)
 deriving instance ToJSON (Ledger.UTxOState StandardShelley)
 
-deriving instance ToJSON (Ledger.DPState StandardAllegra)
-deriving instance ToJSON (Ledger.DState StandardAllegra)
-deriving instance ToJSON (Ledger.InstantaneousRewards StandardAllegra)
-deriving instance ToJSON (Ledger.SnapShot StandardAllegra)
-deriving instance ToJSON (Ledger.SnapShots StandardAllegra)
-deriving instance ToJSON (Ledger.NonMyopic StandardAllegra)
 deriving instance ToJSON (Ledger.LedgerState StandardAllegra)
 deriving instance ToJSON (Ledger.EpochState StandardAllegra)
-deriving instance ToJSON (Ledger.RewardUpdate StandardAllegra)
 deriving instance ToJSON (Ledger.NewEpochState StandardAllegra)
 deriving instance ToJSON (Ledger.PParams' StrictMaybe StandardAllegra)
-deriving instance ToJSON (Ledger.PState StandardAllegra)
-deriving instance ToJSON (Ledger.StakeReference StandardAllegra)
 deriving instance ToJSON (Ledger.UTxOState StandardAllegra)
 
-deriving instance ToJSON (Ledger.DPState StandardMary)
-deriving instance ToJSON (Ledger.DState StandardMary)
-deriving instance ToJSON (Ledger.InstantaneousRewards StandardMary)
-deriving instance ToJSON (Ledger.SnapShot StandardMary)
-deriving instance ToJSON (Ledger.SnapShots StandardMary)
-deriving instance ToJSON (Ledger.NonMyopic StandardMary)
 deriving instance ToJSON (Ledger.LedgerState StandardMary)
 deriving instance ToJSON (Ledger.EpochState StandardMary)
-deriving instance ToJSON (Ledger.RewardUpdate StandardMary)
 deriving instance ToJSON (Ledger.NewEpochState StandardMary)
 deriving instance ToJSON (Ledger.PParams' StrictMaybe StandardMary)
-deriving instance ToJSON (Ledger.PState StandardMary)
-deriving instance ToJSON (Ledger.StakeReference StandardMary)
 deriving instance ToJSON (Ledger.UTxOState StandardMary)
 
 deriving instance ToJSON (Ledger.FutureGenDeleg StandardCrypto)
@@ -190,9 +174,9 @@ deriving instance ToJSON (Ledger.ChainDepState StandardCrypto)
 deriving instance ToJSONKey Ledger.Ptr
 deriving instance ToJSONKey (Ledger.FutureGenDeleg StandardCrypto)
 
-deriving anyclass instance ToJSON    (Ledger.Mary.Value StandardMary)
-deriving newtype  instance ToJSON    (Ledger.Mary.PolicyID StandardMary)
-deriving anyclass instance ToJSONKey (Ledger.Mary.PolicyID StandardMary)
+deriving anyclass instance ToJSON    (Ledger.Mary.Value StandardCrypto)
+deriving newtype  instance ToJSON    (Ledger.Mary.PolicyID StandardCrypto)
+deriving anyclass instance ToJSONKey (Ledger.Mary.PolicyID StandardCrypto)
 deriving anyclass instance ToJSONKey  Ledger.Mary.AssetName
 
 instance ToJSON Ledger.Mary.AssetName where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -503,7 +503,7 @@ pTransaction =
                                  <*> many pWithdrawal
                                  <*> pTxMetadataJsonSchema
                                  <*> many pScript
-                                 <*> many pMetaDataFile
+                                 <*> many pMetadataFile
                                  <*> optional pUpdateProposalFile
                                  <*> pTxBodyFile Output
 
@@ -626,14 +626,14 @@ pPoolCmd =
           (Opt.info pId $
              Opt.progDesc "Build pool id from the offline key")
       , subParser "metadata-hash"
-          (Opt.info pPoolMetaDataHashSubCmd $ Opt.progDesc "Print the hash of pool metadata.")
+          (Opt.info pPoolMetadataHashSubCmd $ Opt.progDesc "Print the hash of pool metadata.")
       ]
   where
     pId :: Parser PoolCmd
     pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pOutputFormat
 
-    pPoolMetaDataHashSubCmd :: Parser PoolCmd
-    pPoolMetaDataHashSubCmd = PoolMetaDataHash <$> pPoolMetaDataFile <*> pMaybeOutputFile
+    pPoolMetadataHashSubCmd :: Parser PoolCmd
+    pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
 
 
 pQueryCmd :: Parser QueryCmd
@@ -1023,9 +1023,9 @@ pCertificateFile =
          )
     )
 
-pPoolMetaDataFile :: Parser PoolMetaDataFile
-pPoolMetaDataFile =
-  PoolMetaDataFile <$>
+pPoolMetadataFile :: Parser PoolMetadataFile
+pPoolMetadataFile =
+  PoolMetadataFile <$>
     Opt.strOption
       (  Opt.long "pool-metadata-file"
       <> Opt.metavar "FILE"
@@ -1052,9 +1052,9 @@ pTxMetadataJsonSchema =
     -- Default to the no-schema conversion.
     pure TxMetadataJsonNoSchema
 
-pMetaDataFile :: Parser MetaDataFile
-pMetaDataFile =
-      MetaDataFileJSON <$>
+pMetadataFile :: Parser MetadataFile
+pMetadataFile =
+      MetadataFileJSON <$>
         ( Opt.strOption
             (  Opt.long "metadata-json-file"
             <> Opt.metavar "FILE"
@@ -1068,7 +1068,7 @@ pMetaDataFile =
             )
         )
   <|>
-      MetaDataFileCBOR <$>
+      MetadataFileCBOR <$>
         Opt.strOption
           (  Opt.long "metadata-cbor-file"
           <> Opt.metavar "FILE"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -427,7 +427,7 @@ runGenesisCreateStaked (GenesisDir rootdir)
   stuffedUtxoAddrs <- liftIO $ replicateM (fromIntegral numStuffedUtxo)
                       genStuffedAddress
 
-  let poolMap :: Map (Ledger.KeyHash Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardShelley)
+  let poolMap :: Map (Ledger.KeyHash Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardCrypto)
       poolMap = Map.fromList $ mkDelegationMapEntry <$> delegations
       delegAddrs = dInitialUtxoAddr <$> delegations
       finalGenesis = updateTemplate start genDlgs mNonDlgAmount nonDelegAddrs poolMap stDlgAmount delegAddrs stuffedUtxoAddrs template
@@ -456,7 +456,7 @@ runGenesisCreateStaked (GenesisDir rootdir)
   where
     (,) delegsPerPool delegsRemaining = divMod genNumStDelegs genNumPools
     adjustTemplate t = t { sgNetworkMagic = unNetworkMagic (toNetworkMagic network) }
-    mkDelegationMapEntry :: Delegation -> (Ledger.KeyHash Ledger.Staking StandardCrypto, Ledger.PoolParams StandardShelley)
+    mkDelegationMapEntry :: Delegation -> (Ledger.KeyHash Ledger.Staking StandardCrypto, Ledger.PoolParams StandardCrypto)
     mkDelegationMapEntry d = (dDelegStaking d, dPoolParams d)
 
     gendir   = rootdir </> "genesis-keys"
@@ -579,10 +579,10 @@ data Delegation
   = Delegation
     { dInitialUtxoAddr  :: AddressInEra ShelleyEra
     , dDelegStaking     :: Ledger.KeyHash Ledger.Staking StandardCrypto
-    , dPoolParams       :: Ledger.PoolParams StandardShelley
+    , dPoolParams       :: Ledger.PoolParams StandardCrypto
     }
 
-buildPool :: NetworkId -> FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO (Ledger.PoolParams StandardShelley)
+buildPool :: NetworkId -> FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO (Ledger.PoolParams StandardCrypto)
 buildPool nw dir index = do
     StakePoolVerificationKey poolColdVK <- firstExceptT (ShelleyGenesisCmdPoolCmdError
                                                          . ShelleyPoolCmdReadFileError)
@@ -639,7 +639,7 @@ writeBulkPoolCredentials dir bulkIx poolIxs = do
      firstExceptT (ShelleyGenesisCmdAesonDecodeError fp . Text.pack) . hoistEither $
        Aeson.eitherDecodeStrict' content
 
-computeDelegation :: NetworkId -> FilePath -> Ledger.PoolParams StandardShelley -> Word -> ExceptT ShelleyGenesisCmdError IO Delegation
+computeDelegation :: NetworkId -> FilePath -> Ledger.PoolParams StandardCrypto -> Word -> ExceptT ShelleyGenesisCmdError IO Delegation
 computeDelegation nw delegDir pool delegIx = do
     paySVK <- firstExceptT (ShelleyGenesisCmdAddressCmdError
                            . ShelleyAddressCmdVerificationKeyTextOrFileError) $
@@ -708,7 +708,7 @@ updateTemplate
     -> Maybe Lovelace
     -> [AddressInEra ShelleyEra]
     -- Genesis staking: pools/delegation map & delegated initial UTxO spec:
-    -> Map (Ledger.KeyHash 'Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardShelley)
+    -> Map (Ledger.KeyHash 'Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardCrypto)
     -> Lovelace
     -> [AddressInEra ShelleyEra]
     -> [AddressInEra ShelleyEra]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -288,9 +288,8 @@ renderLocalStateQueryError lsqErr =
      <> "i.e. with --shelley-mode use --shelly-era flag"
 
 writeStakeAddressInfo
-  :: Ledger.Crypto ledgerera ~ StandardCrypto
-  => Maybe OutputFile
-  -> DelegationsAndRewards ledgerera
+  :: Maybe OutputFile
+  -> DelegationsAndRewards
   -> ExceptT ShelleyQueryCmdError IO ()
 writeStakeAddressInfo mOutFile dr@(DelegationsAndRewards _ _delegsAndRwds) =
   case mOutFile of
@@ -323,6 +322,7 @@ writeProtocolState mOutFile pstate =
 writeFilteredUTxOs :: forall era ledgerera.
                       ( Consensus.ShelleyBasedEra ledgerera
                       , ShelleyLedgerEra era ~ ledgerera
+                      , Ledger.Crypto ledgerera ~ StandardCrypto
                       , ToJSON (Ledger.Value ledgerera)
                       )
                    => ShelleyBasedEra era
@@ -336,7 +336,10 @@ writeFilteredUTxOs era mOutFile utxo =
         handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $ LBS.writeFile fpath (encodePretty utxo)
 
 printFilteredUTxOs :: forall era ledgerera.
-                      (Ledger.ShelleyBased ledgerera, ShelleyLedgerEra era ~ ledgerera)
+                      ( Ledger.ShelleyBased ledgerera
+                      , ShelleyLedgerEra era ~ ledgerera
+                      , Ledger.Crypto ledgerera ~ StandardCrypto
+                      )
                    => ShelleyBasedEra era -> Ledger.UTxO ledgerera -> IO ()
 printFilteredUTxOs era (Ledger.UTxO utxo) = do
     Text.putStrLn title
@@ -347,7 +350,7 @@ printFilteredUTxOs era (Ledger.UTxO utxo) = do
     title =
       "                           TxHash                                 TxIx        Amount"
 
-    printUtxo :: (Ledger.TxIn ledgerera, Ledger.TxOut ledgerera) -> IO ()
+    printUtxo :: (Ledger.TxIn StandardCrypto, Ledger.TxOut ledgerera) -> IO ()
     printUtxo (Ledger.TxIn (Ledger.TxId txhash) txin , Ledger.TxOut _ value) =
       Text.putStrLn $
         mconcat
@@ -433,6 +436,7 @@ printStakeDistribution (PoolDistr stakeDist) = do
 queryUTxOFromLocalState
   :: forall era ledgerera mode block.
      ShelleyLedgerEra era ~ ledgerera
+  => Ledger.Crypto ledgerera ~ StandardCrypto
   => IsShelleyBasedEra era
   => ShelleyBasedEra era
   -> QueryFilter
@@ -474,27 +478,26 @@ queryUTxOFromLocalState era qFilter
     applyUTxOFilter (FilterByAddress as) = Consensus.GetFilteredUTxO (toShelleyAddrs as)
     applyUTxOFilter NoFilter             = Consensus.GetUTxO
 
-    toShelleyAddrs :: Set AddressAny -> Set (Ledger.Addr ledgerera)
+    toShelleyAddrs :: Set AddressAny -> Set (Ledger.Addr StandardCrypto)
     toShelleyAddrs = Set.map (toShelleyAddr
                            . (anyAddressInShelleyBasedEra
                                 :: AddressAny -> AddressInEra era))
 
 -- | A mapping of Shelley reward accounts to both the stake pool that they
 -- delegate to and their reward account balance.
-data DelegationsAndRewards ledgerera
+data DelegationsAndRewards
   = DelegationsAndRewards
       !NetworkId
-      !(Map (Ledger.Credential Ledger.Staking ledgerera)
+      !(Map (Ledger.Credential Ledger.Staking StandardCrypto)
             (Maybe (Hash StakePoolKey), Coin))
 
-instance Ledger.Crypto ledgerera ~ StandardCrypto
-      => ToJSON (DelegationsAndRewards ledgerera) where
+instance ToJSON DelegationsAndRewards where
   toJSON (DelegationsAndRewards nw delegsAndRwds) =
       Aeson.Array . Vector.fromList
         . map delegAndRwdToJson $ Map.toList delegsAndRwds
     where
       delegAndRwdToJson
-        :: (Ledger.Credential Ledger.Staking ledgerera, (Maybe (Hash StakePoolKey), Coin))
+        :: (Ledger.Credential Ledger.Staking StandardCrypto, (Maybe (Hash StakePoolKey), Coin))
         -> Aeson.Value
       delegAndRwdToJson (k, (d, r)) =
         Aeson.object
@@ -503,7 +506,7 @@ instance Ledger.Crypto ledgerera ~ StandardCrypto
           , "rewardAccountBalance" .= r
           ]
 
-      renderAddress :: Ledger.Credential Ledger.Staking ledgerera -> Text
+      renderAddress :: Ledger.Credential Ledger.Staking StandardCrypto -> Text
       renderAddress = serialiseAddress
                     . StakeAddress (toShelleyNetwork nw)
                     . toShelleyStakeCredential
@@ -701,7 +704,7 @@ queryDelegationsAndRewardsFromLocalState
   -> Set StakeAddress
   -> LocalNodeConnectInfo mode block
   -> ExceptT ShelleyQueryCmdLocalStateQueryError IO
-             (DelegationsAndRewards ledgerera)
+             DelegationsAndRewards
 queryDelegationsAndRewardsFromLocalState era stakeaddrs
                                          connectInfo@LocalNodeConnectInfo{
                                            localNodeNetworkId,
@@ -740,10 +743,10 @@ queryDelegationsAndRewardsFromLocalState era stakeaddrs
         QueryResultSuccess drs -> return $ uncurry toDelegsAndRwds drs
   where
     toDelegsAndRwds
-      :: Map (Ledger.Credential Ledger.Staking ledgerera)
+      :: Map (Ledger.Credential Ledger.Staking StandardCrypto)
              (Ledger.KeyHash Ledger.StakePool StandardCrypto)
-      -> Ledger.RewardAccounts ledgerera
-      -> DelegationsAndRewards ledgerera
+      -> Ledger.RewardAccounts StandardCrypto
+      -> DelegationsAndRewards
     toDelegsAndRwds delegs rwdAcnts =
       DelegationsAndRewards localNodeNetworkId $
         Map.mapWithKey
@@ -751,7 +754,7 @@ queryDelegationsAndRewardsFromLocalState era stakeaddrs
           rwdAcnts
 
     toShelleyStakeCredentials :: Set StakeAddress
-                              -> Set (Ledger.StakeCredential ledgerera)
+                              -> Set (Ledger.StakeCredential StandardCrypto)
     toShelleyStakeCredentials =
       Set.map (toShelleyStakeCredential
              . fromShelleyStakeCredential

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley
   ( keyTests
   , certificateTests
   , keyConversionTests
-  , metaDatatests
+  , metadataTests
   , multiSigTests
   , txTests
   ) where
@@ -152,8 +152,8 @@ keyConversionTests =
         , ("golden_convertCardanoAddressShelleyStakeSigningKey", golden_convertCardanoAddressShelleyStakeSigningKey)
         ]
 
-metaDatatests :: IO Bool
-metaDatatests =
+metadataTests :: IO Bool
+metadataTests =
   H.checkSequential
     $ H.Group "Metadata Goldens"
         [ ("golden_stakePoolMetadataHash", golden_stakePoolMetadataHash)

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog.Extras.Test.File as H
 
 golden_stakePoolMetadataHash :: Property
 golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  referenceStakePoolMetaData <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"
+  referenceStakePoolMetadata <- noteInputFile "test/data/golden/shelley/metadata/stake_pool_metadata_hash"
 
   stakePoolMetadataFile <- noteTempFile tempDir "stake-pool-metadata.json"
   outputStakePoolMetadataHashFp <- noteTempFile tempDir "stake-pool-metadata-hash.txt"
@@ -31,7 +31,7 @@ golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
     ]
 
   -- Check that the stake pool metadata hash file content is correct.
-  expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetaData
+  expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetadata
   actualStakePoolMetadataHash <- H.readFile outputStakePoolMetadataHashFp
 
   equivalence expectedStakePoolMetadataHash actualStakePoolMetadataHash

--- a/cardano-cli/test/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden.hs
@@ -10,7 +10,7 @@ main =
     [ Test.Golden.Shelley.keyTests
     , Test.Golden.Shelley.certificateTests
     , Test.Golden.Shelley.keyConversionTests
-    , Test.Golden.Shelley.metaDatatests
+    , Test.Golden.Shelley.metadataTests
     , Test.Golden.Shelley.multiSigTests
     , Test.Golden.Shelley.txTests
     ]

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -279,6 +279,7 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
     , dtHandshakeTracer = handshakeTracer nodeTracers'
     , dtHandshakeLocalTracer = localHandshakeTracer nodeTracers'
     , dtDiffusionInitializationTracer = diffusionInitializationTracer nodeTracers'
+    , dtLedgerPeersTracer = nullTracer -- TODO network team
     }
 
   createTracers

--- a/cardano-node/src/Cardano/Tracing/Kernel.hs
+++ b/cardano-node/src/Cardano/Tracing/Kernel.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 module Cardano.Tracing.Kernel
   ( NodeKernelData (..)
@@ -20,6 +21,7 @@ import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), fromSMaybe)
 
 import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Ledger.Abstract (IsLedger, LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -52,7 +54,8 @@ mapNodeKernelDataIO f (NodeKernelData ref) =
   readIORef ref >>= traverse f
 
 nkQueryLedger ::
-     (ExtLedgerState blk -> a)
+     IsLedger (LedgerState blk)
+  => (ExtLedgerState blk -> a)
   -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -295,6 +295,7 @@ instance HasSeverityAnnotation (WithMuxBearer peer MuxTrace) where
     MuxTraceStartEagerly _ _ -> Debug
     MuxTraceStartOnDemand _ _ -> Debug
     MuxTraceStartedOnDemand _ _ -> Debug
+    MuxTraceTerminating {} -> Debug
     MuxTraceShutdown -> Debug
 
 --

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -47,6 +47,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Inspect
 import           Ouroboros.Consensus.Shelley.Protocol (TPraosCannotForge (..))
 import qualified Ouroboros.Consensus.Shelley.Protocol.HotKey as HotKey
 
+import qualified Cardano.Ledger.AuxiliaryData as Core
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Core
 import qualified Cardano.Ledger.Mary.Value as MA
@@ -60,7 +61,6 @@ import           Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
 import           Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 
-import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import           Shelley.Spec.Ledger.STS.Bbody
 import           Shelley.Spec.Ledger.STS.Chain
 import           Shelley.Spec.Ledger.STS.Deleg
@@ -420,8 +420,8 @@ instance ToJSONKey MA.AssetName where
 instance ToJSON MA.ValidityInterval where
   toJSON vi =
     Aeson.object $
-        [ "validFrom" .= x | x <- mbfield (MA.validFrom vi) ]
-     ++ [ "validTo"   .= x | x <- mbfield (MA.validTo   vi) ]
+        [ "invalidBefore"    .= x | x <- mbfield (MA.invalidBefore    vi) ]
+     ++ [ "invalidHereafter" .= x | x <- mbfield (MA.invalidHereafter vi) ]
     where
       mbfield SNothing  = []
       mbfield (SJust x) = [x]
@@ -777,15 +777,15 @@ showLastAppBlockNo wOblk =  case withOriginToMaybe wOblk of
 
 -- Common to cardano-cli
 
-deriving newtype instance ShelleyBasedEra era => ToJSON (MetadataHash era)
+deriving newtype instance Core.Crypto crypto => ToJSON (Core.AuxiliaryDataHash crypto)
 
-deriving instance ShelleyBasedEra era => ToJSON (TxIn era)
-deriving newtype instance ToJSON (TxId era)
+deriving instance Core.Crypto crypto => ToJSON (TxIn crypto)
+deriving newtype instance ToJSON (TxId crypto)
 deriving newtype instance ToJSON DeltaCoin
-instance ShelleyBasedEra era => ToJSONKey (TxIn era) where
+instance Core.Crypto crypto => ToJSONKey (TxIn crypto) where
   toJSONKey = ToJSONKeyText txInToText (Aeson.text . txInToText)
 
-txInToText :: ShelleyBasedEra era => TxIn era -> Text
+txInToText :: Core.Crypto crypto => TxIn crypto -> Text
 txInToText (TxIn (TxId txidHash) ix) =
   hashToText txidHash
     <> Text.pack "#"

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -60,7 +60,7 @@ import           Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
 import           Shelley.Spec.Ledger.Coin (DeltaCoin (..))
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 
-import           Shelley.Spec.Ledger.MetaData (MetaDataHash (..))
+import           Shelley.Spec.Ledger.Metadata (MetadataHash (..))
 import           Shelley.Spec.Ledger.STS.Bbody
 import           Shelley.Spec.Ledger.STS.Chain
 import           Shelley.Spec.Ledger.STS.Deleg
@@ -322,21 +322,21 @@ instance (ShelleyBasedEra era, ToObject (PredicateFailure (UTXO era)))
     mkObject [ "kind" .= String "MIRInsufficientGenesisSigsUTXOW"
              , "genesisSigs" .= genesisSigs
              ]
-  toObject _verb (MissingTxBodyMetaDataHash metaDataHash) =
-    mkObject [ "kind" .= String "MissingTxBodyMetaDataHash"
-             , "metaDataHash" .= metaDataHash
+  toObject _verb (MissingTxBodyMetadataHash metadataHash) =
+    mkObject [ "kind" .= String "MissingTxBodyMetadataHash"
+             , "metadataHash" .= metadataHash
              ]
-  toObject _verb (MissingTxMetaData txBodyMetaDataHash) =
-    mkObject [ "kind" .= String "MissingTxMetaData"
-             , "txBodyMetaDataHash" .= txBodyMetaDataHash
+  toObject _verb (MissingTxMetadata txBodyMetadataHash) =
+    mkObject [ "kind" .= String "MissingTxMetadata"
+             , "txBodyMetadataHash" .= txBodyMetadataHash
              ]
-  toObject _verb (ConflictingMetaDataHash txBodyMetaDataHash fullMetaDataHash) =
-    mkObject [ "kind" .= String "ConflictingMetaDataHash"
-             , "txBodyMetaDataHash" .= txBodyMetaDataHash
-             , "fullMetaDataHash" .= fullMetaDataHash
+  toObject _verb (ConflictingMetadataHash txBodyMetadataHash fullMetadataHash) =
+    mkObject [ "kind" .= String "ConflictingMetadataHash"
+             , "txBodyMetadataHash" .= txBodyMetadataHash
+             , "fullMetadataHash" .= fullMetadataHash
              ]
-  toObject _verb InvalidMetaData =
-    mkObject [ "kind" .= String "InvalidMetaData"
+  toObject _verb InvalidMetadata =
+    mkObject [ "kind" .= String "InvalidMetadata"
              ]
 
 instance ( ShelleyBasedEra era
@@ -777,7 +777,7 @@ showLastAppBlockNo wOblk =  case withOriginToMaybe wOblk of
 
 -- Common to cardano-cli
 
-deriving newtype instance ShelleyBasedEra era => ToJSON (MetaDataHash era)
+deriving newtype instance ShelleyBasedEra era => ToJSON (MetadataHash era)
 
 deriving instance ShelleyBasedEra era => ToJSON (TxIn era)
 deriving newtype instance ToJSON (TxId era)

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "93f833b3390b22287d50dda70f06be5fc419f334",
-        "sha256": "0r1zj1bw67wnis2lp7fifqw5qjr260g4hg11jvyyn1kwc0bq3cs7",
+        "rev": "22de1b849a7c4137401acc81376fc722d97aafa8",
+        "sha256": "1qm7lki0xq5n5w4dcxxawzwkkww5lr9sv45kp2f1zh9rdc1jmf68",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/93f833b3390b22287d50dda70f06be5fc419f334.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/22de1b849a7c4137401acc81376fc722d97aafa8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
* `MetaData` -> `Metadata`

* rename auxiliary data
  https://github.com/input-output-hk/cardano-ledger-specs/pull/2052
  + Rename the type family `Core.Metadata` to `Core.AuxiliaryData`.
  + Rename the Allegra & Mary `Metadata` to `AuxiliaryData`.
  + Rename ValidityInterval accessors:
    `validFrom` -> `invalidBefore`
    `validTo` -> `invalidHereafter`

* Parameterise era-independent types over the crypto instead of era
  https://github.com/input-output-hk/cardano-ledger-specs/pull/2038

  A bunch of types were parameterised over the era, while they were really
  era-independent. It is confusing to parameterise something over the era while
  it really is era-independent. Moreover, it requires much more needless
  conversions/coercions.

  (Nearly?) all of them are now parameterised by the crypto instead of the era.
  The Cardano API has been updated to reflect this. In most places, the
  `ledgerera` parameter has been replaced by `StandardCrypto`.
