### PR TITLE
Remove byron delegation cli commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,26 +246,6 @@ and ``signing-key-address`` subcommands (the latter requires the network magic):
    2cWKMJemoBakxhXgZSsMteLP9TUvz7owHyEYbUDwKRLsw2UGDrG93gPqmpv1D9ohWNddx
    VerKey address with root e5a3807d99a1807c3f161a1558bcbc45de8392e049682df01809c488, attributes: AddrAttributes { derivation path: {} }
 
-Delegation
-==========
-
-The ``issue-delegation-certificate`` subcommand enables generation of Byron genesis
-delegation certificates, given the following inputs:
-
-   - network magic
-   - starting epoch of delegation
-   - genesis delegator's signing key
-   - delegatee's verification key
-
-To check the generated delegation certificate, you can use the ``check-delegation`` subcommand,
-which would verify:
-
-   - certificate signature validity
-   - correspondence of the expected issuer/delegate with those on the certificate.
-
-The expected issuer and delegate are supplied through the ``--issuer-key`` and ``--delegate-key``
-options.
-
 Transactions
 ============
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -11,7 +11,6 @@ module Cardano.CLI.Byron.Commands
 
 import           Cardano.Prelude
 
-import           Cardano.Chain.Slotting (EpochNumber (..))
 import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
                      SoftwareVersion (..), SystemTag (..))
 
@@ -69,25 +68,6 @@ data ByronCommand =
         ByronKeyFormat
         NetworkId
         SigningKeyFile
-
-    --- Delegation Related Commands ---
-
-  | IssueDelegationCertificate
-        NetworkId
-        ByronKeyFormat
-        EpochNumber
-        -- ^ The epoch from which the delegation is valid.
-        SigningKeyFile
-        -- ^ The issuer of the certificate, who delegates their right to sign blocks.
-        VerificationKeyFile
-        -- ^ The delegate, who gains the right to sign blocks on behalf of the issuer.
-        NewCertificateFile
-        -- ^ Filepath of the newly created delegation certificate.
-  | CheckDelegation
-        NetworkId
-        CertificateFile
-        VerificationKeyFile
-        VerificationKeyFile
 
   | GetLocalNodeTip
         NetworkId


### PR DESCRIPTION
We delegate solely from Byron genesis on mainnet so there is no need for Byron era delegation commands in the cli.