### PR TITLE
Work around haskell.nix #231 in cardano-node-chairman.cabal

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -116,6 +116,9 @@ test-suite chairman-tests
                       , random
                       , resourcet
                       , tasty
+                      -- Workaround for https://github.com/input-output-hk/haskell.nix/issues/231
+                      -- Should be in build-tool-depends instead
+                      , tasty-discover
                       , tasty-hedgehog
                       , temporary
                       , text
@@ -138,10 +141,12 @@ test-suite chairman-tests
                         -Wpartial-fields
                         -Wcompat
                         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
-  build-tool-depends:   tasty-discover:tasty-discover
-                      , cardano-node:cardano-node
+  build-tool-depends:   cardano-node:cardano-node
                       , cardano-cli:cardano-cli
                       , cardano-node-chairman:cardano-node-chairman
+                      -- Workaround for https://github.com/input-output-hk/haskell.nix/issues/231
+                      -- Included in build-depends instead
+                      -- , tasty-discover:tasty-discover
 
 executable cardano-testnet
   import:               common-modules


### PR DESCRIPTION
Dependencies provided by haskell.nix do not satisfy build-tool-depends
within a nix-shell. We work around that by making tasty-discover a
library dependency of chairman tests and rely on the explicit inclusion
of the tasty-discover executable as a dependency in nix/haskell.nix.

See https://github.com/input-output-hk/haskell.nix/issues/231

We include tasty-discover as a library dependency of
cardano-node-chairman because the explicit inclusion of tasty-discover
pulls it from buildPackages. If tasty-discover is not in
build-tools-depends or build-depends, it will not be there at all.
Ideally when #231 is resolved we go back to specifying it in
build-tool-depends, remove the explicit inclusion of the executable
and everything just works.

Resolves #2232 