### PR TITLE
Add support for the QueryUTxO via the new IPC API

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -17,6 +17,11 @@ library
 
   exposed-modules:      Cardano.Api
                         Cardano.Api.Byron
+                        Cardano.Api.Shelley
+
+                        --TODO: these should either be removed once the new IPC
+                        -- is fully integrated, or re-exported via the export
+                        -- modules above
                         Cardano.Api.Crypto.Ed25519Bip32
                         Cardano.Api.LocalChainSync
                         Cardano.Api.Protocol
@@ -24,10 +29,14 @@ library
                         Cardano.Api.Protocol.Cardano
                         Cardano.Api.Protocol.Shelley
                         Cardano.Api.Protocol.Types
-                        Cardano.Api.Shelley
                         Cardano.Api.Shelley.Genesis
                         Cardano.Api.TxSubmit
                         Cardano.Api.Typed
+
+                        --TODO: this is only exported for now, until the old
+                        -- IPC parts are removed and this modules can be
+                        -- exported via the normal export modules above
+                        Cardano.Api.IPC
 
 
   other-modules:        Cardano.Api.TxSubmit.ErrorRender
@@ -42,7 +51,7 @@ library
                         Cardano.Api.Fees
                         Cardano.Api.Hash
                         Cardano.Api.HasTypeProxy
-                        Cardano.Api.IPC
+-- TODO: move here      Cardano.Api.IPC
                         Cardano.Api.Key
                         Cardano.Api.KeysByron
                         Cardano.Api.KeysShelley

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Cardano addresses: payment and stake addresses.

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -12,6 +12,7 @@ module Cardano.Api.Query (
     QueryInMode(..),
     QueryInEra(..),
     QueryInShelleyBasedEra(..),
+    UTxO(..),
 
     -- * Internal conversion functions
     toConsensusQuery,
@@ -20,6 +21,11 @@ module Cardano.Api.Query (
 
 import           Prelude
 import           Data.Bifunctor (bimap)
+import           Data.Maybe (catMaybes)
+import qualified Data.Set as Set
+import           Data.Set (Set)
+import qualified Data.Map as Map
+import           Data.Map (Map)
 import           Data.SOP.Strict (SListI)
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some(..))
@@ -35,9 +41,16 @@ import qualified Ouroboros.Consensus.Cardano.Block      as Consensus
 
 import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
 
+import qualified Cardano.Ledger.Era as Ledger
+import qualified Cardano.Ledger.Shelley.Constraints as Ledger
+
+import qualified Shelley.Spec.Ledger.API        as Shelley
+
+import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Eras
 import           Cardano.Api.Modes
+import           Cardano.Api.TxBody
 
 
 -- ----------------------------------------------------------------------------
@@ -67,18 +80,18 @@ data QueryInEra era result where
      QueryByronUpdateState :: QueryInEra ByronEra ByronUpdateState
 
      QueryInShelleyBasedEra :: ShelleyBasedEra era
-                            -> QueryInShelleyBasedEra result
+                            -> QueryInShelleyBasedEra era result
                             -> QueryInEra era result
 
 deriving instance Show (QueryInEra era result)
 
 
-data QueryInShelleyBasedEra result where
+data QueryInShelleyBasedEra era result where
      QueryChainPoint
-       :: QueryInShelleyBasedEra ChainPoint
+       :: QueryInShelleyBasedEra era ChainPoint
 
      QueryEpoch
-       :: QueryInShelleyBasedEra EpochNo
+       :: QueryInShelleyBasedEra era EpochNo
 
 --TODO: add support for these
 --     QueryGenesisParameters
@@ -93,9 +106,9 @@ data QueryInShelleyBasedEra result where
 --     QueryStakeDistribution
 --       :: QueryInShelleyBasedEra StakeDistribution
 
---     QueryUTxO
---       :: Maybe (Set AddressAny)
---       -> QueryInShelleyBasedEra UTxO
+     QueryUTxO
+       :: Maybe (Set AddressAny)
+       -> QueryInShelleyBasedEra era (UTxO era)
 
 --     QueryStakeAddresses
 --       :: Set StakeAddress
@@ -112,7 +125,7 @@ data QueryInShelleyBasedEra result where
 --     QueryProtocolState
 --       :: QueryInShelleyBasedEra ProtocolState
 
-deriving instance Show (QueryInShelleyBasedEra result)
+deriving instance Show (QueryInShelleyBasedEra era result)
 
 
 -- ----------------------------------------------------------------------------
@@ -123,6 +136,35 @@ deriving instance Show (QueryInShelleyBasedEra result)
 
 newtype ByronUpdateState = ByronUpdateState Byron.Update.State
   deriving Show
+
+newtype UTxO era = UTxO (Map TxIn (TxOut era))
+
+toShelleyAddrSet :: CardanoEra era
+                 -> Set AddressAny
+                 -> Set (Shelley.Addr Consensus.StandardCrypto)
+toShelleyAddrSet era =
+    Set.fromList
+  . map toShelleyAddr
+    -- Ignore any addresses that are not appropriate for the era,
+    -- e.g. Shelley addresses in the Byron era, as these would not
+    -- appear in the UTxO anyway.
+  . catMaybes
+  . map (anyAddressInEra era)
+  . Set.toList
+
+fromShelleyUTxO :: ShelleyLedgerEra era ~ ledgerera
+                => IsShelleyBasedEra era
+                => Ledger.ShelleyBased ledgerera
+                => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
+                => Shelley.UTxO ledgerera -> UTxO era
+fromShelleyUTxO =
+    --TODO: write an appropriate property to show it is safe to use
+    -- Map.fromListAsc or to use Map.mapKeysMonotonic
+    UTxO
+  . Map.fromList
+  . map (bimap fromShelleyTxIn fromShelleyTxOut)
+  . Map.toList
+  . Shelley.unUTxO
 
 
 -- ----------------------------------------------------------------------------
@@ -153,18 +195,28 @@ toConsensusQuery (QueryInEra erainmode (QueryInShelleyBasedEra era q)) =
 
 
 toConsensusQueryShelleyBased
-  :: forall era mode ledgerera block xs result.
+  :: forall era ledgerera mode block xs result.
      ConsensusBlockForEra era ~ Consensus.ShelleyBlock ledgerera
+  => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
   => ConsensusBlockForMode mode ~ block
   => block ~ Consensus.HardForkBlock xs
   => EraInMode era mode
-  -> QueryInShelleyBasedEra result
+  -> QueryInShelleyBasedEra era result
   -> Some (Consensus.Query block)
 toConsensusQueryShelleyBased erainmode QueryChainPoint =
     Some (consensusQueryInEraInMode erainmode Consensus.GetLedgerTip)
 
 toConsensusQueryShelleyBased erainmode QueryEpoch =
     Some (consensusQueryInEraInMode erainmode Consensus.GetEpochNo)
+
+toConsensusQueryShelleyBased erainmode (QueryUTxO Nothing) =
+    Some (consensusQueryInEraInMode erainmode Consensus.GetUTxO)
+
+toConsensusQueryShelleyBased erainmode (QueryUTxO (Just addrs)) =
+    Some (consensusQueryInEraInMode erainmode (Consensus.GetFilteredUTxO addrs'))
+  where
+    addrs' :: Set (Shelley.Addr Consensus.StandardCrypto)
+    addrs' = toShelleyAddrSet (eraInModeToEra erainmode) addrs
 
 
 consensusQueryInEraInMode
@@ -257,9 +309,12 @@ fromConsensusQueryResult (QueryInEra MaryEraInCardanoMode
 
 
 fromConsensusQueryResultShelleyBased
-  :: forall ledgerera result result'.
-     Consensus.ShelleyBasedEra ledgerera
-  => QueryInShelleyBasedEra result
+  :: forall era ledgerera result result'.
+     ShelleyLedgerEra era ~ ledgerera
+  => IsShelleyBasedEra era
+  => Consensus.ShelleyBasedEra ledgerera
+  => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
+  => QueryInShelleyBasedEra era result
   -> Consensus.Query (Consensus.ShelleyBlock ledgerera) result'
   -> result'
   -> result
@@ -272,6 +327,16 @@ fromConsensusQueryResultShelleyBased QueryEpoch q' epoch =
     case q' of
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
+
+fromConsensusQueryResultShelleyBased (QueryUTxO Nothing) q' utxo' =
+    case q' of
+      Consensus.GetUTxO -> fromShelleyUTxO utxo'
+      _                 -> fromConsensusQueryResultMismatch
+
+fromConsensusQueryResultShelleyBased (QueryUTxO Just{}) q' utxo' =
+    case q' of
+      Consensus.GetFilteredUTxO{} -> fromShelleyUTxO utxo'
+      _                           -> fromConsensusQueryResultMismatch
 
 
 -- | This should /only/ happen if we messed up the mapping in 'toConsensusQuery'

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -21,7 +21,7 @@ module Cardano.Api.Query (
 
 import           Prelude
 import           Data.Bifunctor (bimap)
-import           Data.Maybe (catMaybes)
+import           Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Map as Map
@@ -148,8 +148,7 @@ toShelleyAddrSet era =
     -- Ignore any addresses that are not appropriate for the era,
     -- e.g. Shelley addresses in the Byron era, as these would not
     -- appear in the UTxO anyway.
-  . catMaybes
-  . map (anyAddressInEra era)
+  . mapMaybe (anyAddressInEra era)
   . Set.toList
 
 fromShelleyUTxO :: ShelleyLedgerEra era ~ ledgerera

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -34,8 +34,14 @@ module Cardano.Api.Shelley
     -- | Constructing and inspecting transactions
     TxBody(ShelleyTxBody),
     TxId(TxId),
+    toShelleyTxId,
+    fromShelleyTxId,
     TxIn(TxIn),
+    toShelleyTxIn,
+    fromShelleyTxIn,
     TxOut(TxOut),
+    toShelleyTxOut,
+    fromShelleyTxOut,
     TxIx(TxIx),
     Lovelace(Lovelace),
     toShelleyLovelace,
@@ -158,5 +164,6 @@ module Cardano.Api.Shelley
 
 import           Cardano.Api
 import           Cardano.Api.Address
+import           Cardano.Api.TxBody
 import           Cardano.Api.Typed
 import           Cardano.Api.Value

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -41,6 +41,8 @@ import           Data.String
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Seed as Crypto
+import qualified Shelley.Spec.Ledger.Hashing as Shelley
+
 
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
@@ -316,8 +318,8 @@ genShelleyTxOut =
   TxOut <$> (shelleyAddressInEra <$> genAddressShelley)
         <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
 
-genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 ())
-genShelleyHash = return $ Crypto.hashWith CBOR.serialize' ()
+genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 Shelley.EraIndependentTxBody)
+genShelleyHash = return . Crypto.castHash $ Crypto.hashWith CBOR.serialize' ()
 
 genSlotNo :: Gen SlotNo
 genSlotNo = SlotNo <$> Gen.word64 Range.constantBounded

--- a/cardano-api/test/cardano-api-test.cabal
+++ b/cardano-api/test/cardano-api-test.cabal
@@ -30,6 +30,7 @@ library
                       , cardano-prelude
                       , containers
                       , hedgehog
+                      , shelley-spec-ledger
                       , tasty
                       , tasty-hedgehog
                       , text


### PR DESCRIPTION
There are still quite a few queries to cover. This covers just the
QueryUTxO one. This requires exporting a UTxO type.

For now the UTxO type has no interesting instances but the newtype
wrapper is exposed which just uses the other API types in a simple way.
```
newtype UTxO era = UTxO (Map TxIn (TxOut era))
```