### PR TITLE
CAD-2477:  clean up metric name space

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -277,7 +277,8 @@ mkTracers tOpts@(TracingOn trSel) tr nodeKern = do
 
   pure Tracers
     { chainDBTracer = tracerOnOff' (traceChainDB trSel) $
-        annotateSeverity . teeTraceChainTip tOpts elidedChainDB $ appendName "ChainDB" tr
+        annotateSeverity $ teeTraceChainTip tOpts elidedChainDB
+                             (appendName "ChainDB" tr) (appendName "metrics" tr)
     , consensusTracers = consensusTracers
     , nodeToClientTracers = nodeToClientTracers' trSel verb tr
     , nodeToNodeTracers = nodeToNodeTracers' trSel verb tr
@@ -353,12 +354,13 @@ teeTraceChainTip
   => TraceOptions
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
   -> Trace IO Text
+  -> Trace IO Text
   -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-teeTraceChainTip TracingOff _ _ = nullTracer
-teeTraceChainTip (TracingOn trSel) elided tr =
+teeTraceChainTip TracingOff _ _ _ = nullTracer
+teeTraceChainTip (TracingOn trSel) elided trTrc trMet =
   Tracer $ \ev -> do
-    traceWith (teeTraceChainTip' tr) ev
-    traceWith (teeTraceChainTipElide (traceVerbosity trSel) elided tr) ev
+    traceWith (teeTraceChainTipElide (traceVerbosity trSel) elided trTrc) ev
+    traceWith (ignoringSeverity (traceChainMetrics trMet)) ev
 
 teeTraceChainTipElide
   :: ( ConvertRawHash blk
@@ -372,36 +374,43 @@ teeTraceChainTipElide
   -> Trace IO Text
   -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
 teeTraceChainTipElide = elideToLogObject
+{-# INLINE teeTraceChainTipElide #-}
 
-traceChainInformation :: Trace IO Text -> ChainInformation -> IO ()
-traceChainInformation tr ChainInformation { slots, blocks, density, epoch, slotInEpoch } = do
-  -- TODO this is executed each time the chain changes. How cheap is it?
-  meta <- mkLOMeta Critical Confidential
-  let tr' = appendName "metrics" tr
-      traceD :: Text -> Double -> IO ()
-      traceD msg d = traceNamedObject tr' (meta, LogValue msg (PureD d))
-      traceI :: Integral a => Text -> a -> IO ()
-      traceI msg i = traceNamedObject tr' (meta, LogValue msg (PureI (fromIntegral i)))
+ignoringSeverity :: Tracer IO a -> Tracer IO (WithSeverity a)
+ignoringSeverity tr = Tracer $ \(WithSeverity _ ev) -> traceWith tr ev
+{-# INLINE ignoringSeverity #-}
 
-  traceD "density"     (fromRational density)
-  traceI "slotNum"     slots
-  traceI "blockNum"    blocks
-  traceI "slotInEpoch" slotInEpoch
-  traceI "epoch"       (unEpochNo epoch)
+traceChainMetrics
+  :: forall blk. HasHeader (Header blk)
+  => Trace IO Text -> Tracer IO (ChainDB.TraceEvent blk)
+traceChainMetrics tr = Tracer $ \ev ->
+  fromMaybe (pure ()) $
+    doTrace <$> chainTipInformation ev
+ where
+   chainTipInformation :: ChainDB.TraceEvent blk -> Maybe ChainInformation
+   chainTipInformation = \case
+     ChainDB.TraceAddBlockEvent ev -> case ev of
+       ChainDB.SwitchedToAFork _warnings newTipInfo _ newChain ->
+         Just $ chainInformation newTipInfo newChain
+       ChainDB.AddedToCurrentChain _warnings newTipInfo _ newChain ->
+         Just $ chainInformation newTipInfo newChain
+       _ -> Nothing
+     _ -> Nothing
 
-teeTraceChainTip'
-  :: HasHeader (Header blk)
-  => Trace IO Text -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
-teeTraceChainTip' tr =
-    Tracer $ \(WithSeverity _ ev') ->
-      case ev' of
-          (ChainDB.TraceAddBlockEvent ev) -> case ev of
-            ChainDB.SwitchedToAFork _warnings newTipInfo _ newChain ->
-              traceChainInformation tr (chainInformation newTipInfo newChain)
-            ChainDB.AddedToCurrentChain _warnings newTipInfo _ newChain ->
-              traceChainInformation tr (chainInformation newTipInfo newChain)
-            _ -> pure ()
-          _ -> pure ()
+   doTrace :: ChainInformation -> IO ()
+   doTrace ChainInformation { slots, blocks, density, epoch, slotInEpoch } = do
+     -- TODO this is executed each time the chain changes. How cheap is it?
+     meta <- mkLOMeta Critical Confidential
+     let traceD :: Text -> Double -> IO ()
+         traceD msg d = traceNamedObject tr (meta, LogValue msg (PureD d))
+         traceI :: Integral a => Text -> a -> IO ()
+         traceI msg i = traceNamedObject tr (meta, LogValue msg (PureI (fromIntegral i)))
+
+     traceD "density"     (fromRational density)
+     traceI "slotNum"     slots
+     traceI "blockNum"    blocks
+     traceI "slotInEpoch" slotInEpoch
+     traceI "epoch"       (unEpochNo epoch)
 
 --------------------------------------------------------------------------------
 -- Consensus Tracers
@@ -452,8 +461,7 @@ mkConsensusTracers trSel verb tr nodeKern fStats = do
     , Consensus.forgeTracer = tracerOnOff' (traceForge trSel) $
         Tracer $ \tlcev@(Consensus.TraceLabelCreds _ ev) -> do
           traceWith (annotateSeverity
-                     $ traceLeadershipChecks forgeTracers nodeKern verb
-                     $ appendName "LeadershipCheck" tr) tlcev
+                     $ traceLeadershipChecks forgeTracers nodeKern verb tr) tlcev
           traceWith (forgeTracer verb tr forgeTracers fStats) tlcev
           -- Don't track credentials in ForgeTime.
           traceWith (blockForgeOutcomeExtractor
@@ -510,9 +518,9 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
         fromSMaybe (pure ()) $
           query <&>
             \(utxoSize, delegMapSize, _) -> do
-               traceCounter "utxoSize"     tr utxoSize
-               traceCounter "delegMapSize" tr delegMapSize
-        traceNamedObject tr
+                traceCounter "utxoSize"     tr utxoSize
+                traceCounter "delegMapSize" tr delegMapSize
+        traceNamedObject (appendName "LeadershipCheck" tr)
           ( meta
           , LogStructured $ Map.fromList $
             [("kind", String "TraceStartLeadershipCheck")
@@ -803,7 +811,7 @@ forgeStateInfoTracer
   -> Tracer IO (Consensus.TraceLabelCreds (ForgeStateInfo blk))
 forgeStateInfoTracer p _ts tracer = Tracer $ \ev -> do
     let tr = appendName "Forge" tracer
-    traceWith (forgeStateInfoMetricsTraceTransformer p tr) ev
+    traceWith (forgeStateInfoMetricsTraceTransformer p tracer) ev
     traceWith (fsTracer tr) ev
   where
     fsTracer :: Trace IO Text -> Tracer IO (Consensus.TraceLabelCreds (ForgeStateInfo blk))

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -57,77 +57,11 @@
   "minSeverity": "Info",
   "options": {
     "mapBackends": {
-      "cardano.node-metrics": [
-        "EKGViewBK"
-      ],
-      "cardano.node.BlockFetchDecision.peers": [
-        "EKGViewBK"
-      ],
-      "cardano.node.ChainDB.metrics": [
-        "EKGViewBK"
-      ],
-      "cardano.node.Forge.metrics": [
-        "EKGViewBK"
-      ],
       "cardano.node.metrics": [
         "EKGViewBK"
       ]
     },
     "mapSubtrace": {
-      "#ekgview": {
-        "contents": [
-          [
-            {
-              "contents": "cardano.epoch-validation.benchmark",
-              "tag": "Contains"
-            },
-            [
-              {
-                "contents": ".monoclock.basic.",
-                "tag": "Contains"
-              }
-            ]
-          ],
-          [
-            {
-              "contents": "cardano.epoch-validation.benchmark",
-              "tag": "Contains"
-            },
-            [
-              {
-                "contents": "diff.RTS.cpuNs.timed.",
-                "tag": "Contains"
-              }
-            ]
-          ],
-          [
-            {
-              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
-              "tag": "StartsWith"
-            },
-            [
-              {
-                "contents": "diff.RTS.gcNum.timed.",
-                "tag": "Contains"
-              }
-            ]
-          ]
-        ],
-        "subtrace": "FilterTrace"
-      },
-      "benchmark": {
-        "contents": [
-          "GhcRtsStats",
-          "MonotonicClock"
-        ],
-        "subtrace": "ObservableTrace"
-      },
-      "cardano.epoch-validation.utxo-stats": {
-        "subtrace": "NoTrace"
-      },
-      "cardano.node-metrics": {
-        "subtrace": "Neutral"
-      },
       "cardano.node.metrics": {
         "subtrace": "Neutral"
       }

--- a/configuration/cardano/shelley_qa-config.json
+++ b/configuration/cardano/shelley_qa-config.json
@@ -59,77 +59,11 @@
   "minSeverity": "Debug",
   "options": {
     "mapBackends": {
-      "cardano.node-metrics": [
-        "EKGViewBK"
-      ],
-      "cardano.node.BlockFetchDecision.peers": [
-        "EKGViewBK"
-      ],
-      "cardano.node.ChainDB.metrics": [
-        "EKGViewBK"
-      ],
-      "cardano.node.Forge.metrics": [
-        "EKGViewBK"
-      ],
       "cardano.node.metrics": [
         "EKGViewBK"
       ]
     },
     "mapSubtrace": {
-      "#ekgview": {
-        "contents": [
-          [
-            {
-              "contents": "cardano.epoch-validation.benchmark",
-              "tag": "Contains"
-            },
-            [
-              {
-                "contents": ".monoclock.basic.",
-                "tag": "Contains"
-              }
-            ]
-          ],
-          [
-            {
-              "contents": "cardano.epoch-validation.benchmark",
-              "tag": "Contains"
-            },
-            [
-              {
-                "contents": "diff.RTS.cpuNs.timed.",
-                "tag": "Contains"
-              }
-            ]
-          ],
-          [
-            {
-              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
-              "tag": "StartsWith"
-            },
-            [
-              {
-                "contents": "diff.RTS.gcNum.timed.",
-                "tag": "Contains"
-              }
-            ]
-          ]
-        ],
-        "subtrace": "FilterTrace"
-      },
-      "benchmark": {
-        "contents": [
-          "GhcRtsStats",
-          "MonotonicClock"
-        ],
-        "subtrace": "ObservableTrace"
-      },
-      "cardano.epoch-validation.utxo-stats": {
-        "subtrace": "NoTrace"
-      },
-      "cardano.node-metrics": {
-        "subtrace": "Neutral"
-      },
       "cardano.node.metrics": {
         "subtrace": "Neutral"
       }

--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -254,9 +254,6 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
       - EKGViewBK

--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -55,7 +55,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: True
 
@@ -278,7 +278,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.

--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -97,7 +97,7 @@ defaultBackends:
 # traceForwardTo:
 #   tag: RemotePipe
 #   contents: "logs/pipe"
-# 
+#
 # Example using Windows named pipes:
 # traceForwardTo:
 #   tag: RemotePipe
@@ -257,13 +257,8 @@ options:
     cardano.node.BlockFetchDecision.peers:
       - TraceForwarderBK
       - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK  
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -65,12 +65,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -60,10 +60,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -44,31 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -65,12 +65,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -60,10 +60,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -44,31 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -65,10 +65,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -70,12 +70,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -44,36 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -52,7 +52,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: True
 
@@ -269,7 +269,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -94,7 +94,7 @@ defaultBackends:
 # traceForwardTo:
 #   tag: RemotePipe
 #   contents: "logs/pipe"
-# 
+#
 # Example using Windows named pipes:
 # traceForwardTo:
 #   tag: RemotePipe
@@ -245,16 +245,8 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK  
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK
@@ -281,4 +273,3 @@ options:
     cardano.node.TraceIpSubscription: Info
     cardano.node.TraceMux: Info
     cardano.node.Handshake: Debug
-

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -52,7 +52,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: True
 
@@ -266,7 +266,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.
@@ -275,4 +275,3 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
-

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -94,7 +94,7 @@ defaultBackends:
 # traceForwardTo:
 #   tag: RemotePipe
 #   contents: "logs/pipe"
-# 
+#
 # Example using Windows named pipes:
 # traceForwardTo:
 #   tag: RemotePipe
@@ -242,16 +242,8 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK  
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -252,10 +252,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
 
 # If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -218,10 +218,8 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
     cardano.node.metrics:
-      - EKGViewBK  
+      - EKGViewBK
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
     # - TraceForwarderBK
     # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -230,29 +230,6 @@ options:
     # cardano.node.commit:
     #   - TraceForwarderBK
 
-  # This section is more expressive still, and needs to be properly documented.
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
-
 # If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.
 # traceForwardTo:

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -224,8 +224,6 @@ options:
       - EKGViewBK  
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
     # - TraceForwarderBK
-    cardano.node-metrics:
-      - EKGViewBK
     # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
     # cardano.node.release:
     #   - TraceForwarderBK

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -252,10 +252,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
 
 # If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -218,10 +218,8 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
     cardano.node.metrics:
-      - EKGViewBK  
+      - EKGViewBK
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
     # - TraceForwarderBK
     # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -230,29 +230,6 @@ options:
     # cardano.node.commit:
     #   - TraceForwarderBK
 
-  # This section is more expressive still, and needs to be properly documented.
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
-
 # If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.
 # traceForwardTo:

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -224,8 +224,6 @@ options:
       - EKGViewBK  
     # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
     # - TraceForwarderBK
-    cardano.node-metrics:
-      - EKGViewBK
     # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
     # cardano.node.release:
     #   - TraceForwarderBK

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -213,8 +213,6 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -238,7 +238,3 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -215,26 +215,3 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-
-  # This section is more expressive still, and needs to be properly documented.
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -217,8 +217,6 @@ options:
       - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
-    cardano.node-metrics:
-      - EKGViewBK
 
   # This section is more expressive still, and needs to be properly documented.
   mapSubtrace:

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -65,12 +65,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -60,10 +60,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -44,31 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -65,12 +65,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -60,10 +60,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -44,31 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -65,10 +65,6 @@ options:
         - - tag: Contains
             contents: diff.RTS.gcNum.timed.
       subtrace: FilterTrace
-    'cardano.epoch-validation.utxo-stats':
-      # Change the `subtrace` value to `Neutral` in order to log
-      # `UTxO`-related messages during epoch validation.
-      subtrace: NoTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -70,12 +70,6 @@ options:
       # `UTxO`-related messages during epoch validation.
       subtrace: NoTrace
   mapBackends:
-    cardano.node.ChainDB.metrics:
-      - EKGViewBK
-    cardano.node.metrics.Forge:
-      - EKGViewBK
-    cardano.node.metrics.Mempool:
-      - EKGViewBK
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -44,36 +44,11 @@ defaultScribes:
 
 # more options which can be passed as key-value pairs:
 options:
-  mapSubtrace:
-    benchmark:
-      contents:
-        - GhcRtsStats
-        - MonotonicClock
-      subtrace: ObservableTrace
-    '#ekgview':
-      contents:
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: .monoclock.basic.
-      - - tag: Contains
-          contents: 'cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.cpuNs.timed.
-      - - tag: StartsWith
-          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
-        - - tag: Contains
-            contents: diff.RTS.gcNum.timed.
-      subtrace: FilterTrace
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
 # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
 #     - TraceForwarderBK
-    cardano.node.peers:
-      - EKGViewBK
-    cardano.node.BlockFetchDecision.peers:
-      - EKGViewBK
 # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
 #    cardano.node.release:
 #      - TraceForwarderBK

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -265,61 +265,9 @@ It is also possible to have more fine grained control over filtering of trace ou
 	    "mapBackends": {
 	      "cardano.node.metrics": [
 	        "EKGViewBK"
-	      ],
-	      "cardano.node.BlockFetchDecision.peers": [
-	        "EKGViewBK"
 	      ]
 	    },
 	    "mapSubtrace": {
-	      "benchmark": {
-	        "contents": [
-	          "GhcRtsStats",
-	          "MonotonicClock"
-	        ],
-	        "subtrace": "ObservableTrace"
-	      },
-	      "#ekgview": {
-	        "contents": [
-	          [
-	            {
-	              "contents": "cardano.epoch-validation.benchmark",
-	              "tag": "Contains"
-	            },
-	            [
-	              {
-	                "contents": ".monoclock.basic.",
-	                "tag": "Contains"
-	              }
-	            ]
-	          ],
-	          [
-	            {
-	              "contents": "cardano.epoch-validation.benchmark",
-	              "tag": "Contains"
-	            },
-	            [
-	              {
-	                "contents": "diff.RTS.cpuNs.timed.",
-	                "tag": "Contains"
-	              }
-	            ]
-	          ],
-	          [
-	            {
-	              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
-	              "tag": "StartsWith"
-	            },
-	            [
-	              {
-	                "contents": "diff.RTS.gcNum.timed.",
-	                "tag": "Contains"
-	              }
-	            ]
-	          ]
-	        ],
-	        "subtrace": "FilterTrace"
-	      },
-
 	      "cardano.node.metrics": {
 	        "subtrace": "Neutral"
 	      }

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -263,7 +263,7 @@ It is also possible to have more fine grained control over filtering of trace ou
 ```json
 	  "options": {
 	    "mapBackends": {
-	      "cardano.node-metrics": [
+	      "cardano.node.metrics": [
 	        "EKGViewBK"
 	      ],
 	      "cardano.node.BlockFetchDecision.peers": [
@@ -328,9 +328,6 @@ It is also possible to have more fine grained control over filtering of trace ou
 
 	      "cardano.epoch-validation.utxo-stats": {
 	        "subtrace": "NoTrace"
-	      },
-	      "cardano.node-metrics": {
-	        "subtrace": "Neutral"
 	      },
 	      "cardano.node.metrics": {
 	        "subtrace": "Neutral"

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -320,9 +320,6 @@ It is also possible to have more fine grained control over filtering of trace ou
 	        "subtrace": "FilterTrace"
 	      },
 
-	      "cardano.epoch-validation.utxo-stats": {
-	        "subtrace": "NoTrace"
-	      },
 	      "cardano.node.metrics": {
 	        "subtrace": "Neutral"
 	      }

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -268,12 +268,6 @@ It is also possible to have more fine grained control over filtering of trace ou
 	      ],
 	      "cardano.node.BlockFetchDecision.peers": [
 	        "EKGViewBK"
-	      ],
-	      "cardano.node.ChainDB.metrics": [
-	        "EKGViewBK"
-	      ],
-	      "cardano.node.metrics": [
-	        "EKGViewBK"
 	      ]
 	    },
 	    "mapSubtrace": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5b86d63a0b59b7666d19901b654d8fbde27d9500",
-        "sha256": "1mfb93nnw0x4gyq93v6lh6h7imliw4j0wp5l9gpdafy3rw621xzb",
+        "rev": "62757227a2b3202ae30b807f2b2aa9a927d34e0e",
+        "sha256": "15pzi61whix3hzkbac924993dxzf2bx7jlrbg4mma3c1saaa7n1g",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/5b86d63a0b59b7666d19901b654d8fbde27d9500.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/62757227a2b3202ae30b807f2b2aa9a927d34e0e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/scripts/lite/configuration/shelley-1.yaml
+++ b/scripts/lite/configuration/shelley-1.yaml
@@ -243,13 +243,8 @@ options:
     cardano.node.BlockFetchDecision.peers:
       - TraceForwarderBK
       - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK

--- a/scripts/lite/configuration/shelley-1.yaml
+++ b/scripts/lite/configuration/shelley-1.yaml
@@ -50,7 +50,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: False
 
@@ -264,7 +264,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.

--- a/scripts/lite/configuration/shelley-1.yaml
+++ b/scripts/lite/configuration/shelley-1.yaml
@@ -240,9 +240,6 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
       - EKGViewBK
@@ -268,4 +265,3 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
-

--- a/scripts/lite/configuration/shelley-2.yaml
+++ b/scripts/lite/configuration/shelley-2.yaml
@@ -243,13 +243,8 @@ options:
     cardano.node.BlockFetchDecision.peers:
       - TraceForwarderBK
       - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK

--- a/scripts/lite/configuration/shelley-2.yaml
+++ b/scripts/lite/configuration/shelley-2.yaml
@@ -50,7 +50,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: False
 
@@ -264,7 +264,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.

--- a/scripts/lite/configuration/shelley-2.yaml
+++ b/scripts/lite/configuration/shelley-2.yaml
@@ -240,9 +240,6 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
       - EKGViewBK
@@ -268,4 +265,3 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
-

--- a/scripts/lite/configuration/shelley-3.yaml
+++ b/scripts/lite/configuration/shelley-3.yaml
@@ -243,13 +243,8 @@ options:
     cardano.node.BlockFetchDecision.peers:
       - TraceForwarderBK
       - EKGViewBK
-    cardano.node.ChainDB.metrics:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
-      - EKGViewBK
-    cardano.node.Forge.metrics:
       - EKGViewBK
     cardano.node.release:
       - TraceForwarderBK

--- a/scripts/lite/configuration/shelley-3.yaml
+++ b/scripts/lite/configuration/shelley-3.yaml
@@ -50,7 +50,7 @@ ApplicationVersion: 1
 TurnOnLogging: True
 
 # Enable the collection of various OS metrics such as memory and CPU use.
-# These metrics are traced in the context name: 'cardano.node-metrics' and can
+# These metrics are traced in the context name: 'cardano.node.metrics' and can
 # be directed to the logs or monitoring backends.
 TurnOnLogMetrics: False
 
@@ -264,7 +264,7 @@ options:
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":
   mapScribes:
-    cardano.node-metrics:
+    cardano.node.metrics:
       - "FileSK::logs/mainnet.log"
 
   # apply a filter on message severity on messages in a specific named context.

--- a/scripts/lite/configuration/shelley-3.yaml
+++ b/scripts/lite/configuration/shelley-3.yaml
@@ -240,9 +240,6 @@ options:
   # an override and not an extension so anything matched here will not
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
-    cardano.node.BlockFetchDecision.peers:
-      - TraceForwarderBK
-      - EKGViewBK
     cardano.node.metrics:
       - TraceForwarderBK
       - EKGViewBK
@@ -268,4 +265,3 @@ options:
   mapSeverity:
     cardano.node.ChainDB: Notice
     cardano.node.DnsSubscription: Debug
-


### PR DESCRIPTION
1. Consolidate all metrics under `cardano.node.metrics`.
2. Update configs.
3. Eliminate mentions of stale namespace references.

Now:
![Screenshot from 2021-01-15 19-27-04](https://user-images.githubusercontent.com/452652/104752479-c5fef300-5767-11eb-981f-c2b233f54205.png)

Before:
![Screenshot from 2021-01-15 01-25-50](https://user-images.githubusercontent.com/452652/104658321-92728900-56d3-11eb-9d68-d098f4d5db4a.png)
