### PR TITLE
Change the CLI's MIR cert command to take stake addresses

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -307,7 +307,7 @@ renderQueryCmd cmd =
     QueryProtocolState' {} -> "query protocol-state"
 
 data GovernanceCmd
-  = GovernanceMIRCertificate MIRPot [VerificationKeyFile] [Lovelace] OutputFile
+  = GovernanceMIRCertificate MIRPot [StakeAddress] [Lovelace] OutputFile
   | GovernanceGenesisKeyDelegationCertificate
       (VerificationKeyOrHashOrFile GenesisKey)
       (VerificationKeyOrHashOrFile GenesisDelegateKey)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -65,7 +65,7 @@ parseShelleyCommands =
       , Opt.command "address"
           (Opt.info (AddressCmd <$> pAddressCmd) $ Opt.progDesc "Payment address commands")
       , Opt.command "stake-address"
-          (Opt.info (StakeAddressCmd <$> pStakeAddress) $ Opt.progDesc "Stake address commands")
+          (Opt.info (StakeAddressCmd <$> pStakeAddressCmd) $ Opt.progDesc "Stake address commands")
       , Opt.command "key"
           (Opt.info (KeyCmd <$> pKeyCmd) $ Opt.progDesc "Key utility commands")
       , Opt.command "transaction"
@@ -199,8 +199,8 @@ pScript = ScriptFile <$> Opt.strOption
   <> Opt.completer (Opt.bashCompleter "file")
   )
 
-pStakeAddress :: Parser StakeAddressCmd
-pStakeAddress =
+pStakeAddressCmd :: Parser StakeAddressCmd
+pStakeAddressCmd =
     asum
       [ subParser "key-gen"
           (Opt.info pStakeAddressKeyGen $ Opt.progDesc "Create a stake address key pair")
@@ -737,7 +737,7 @@ pGovernanceCmd =
     pMIRCertificate :: Parser GovernanceCmd
     pMIRCertificate = GovernanceMIRCertificate
                         <$> pMIRPot
-                        <*> some pStakeVerificationKeyFile
+                        <*> some pStakeAddress
                         <*> some pRewardAmt
                         <*> pOutputFile
 
@@ -1777,6 +1777,14 @@ pAddress =
       (  Opt.long "address"
       <> Opt.metavar "ADDRESS"
       <> Opt.help "A Cardano address"
+      )
+
+pStakeAddress :: Parser StakeAddress
+pStakeAddress =
+    Opt.option (readerFromAttoParser parseStakeAddress)
+      (  Opt.long "stake-address"
+      <> Opt.metavar "ADDRESS"
+      <> Opt.help "Target stake address (bech32 format)."
       )
 
 pStakeVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
@@ -36,11 +36,12 @@ golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
 
   H.assertFilesExist [verKey, signKey]
 
+  let testAddr = "stake1u9j6axhcpd0exvrthn5dqzqt54g85akqvkn4uqmccm70qsc5hpv9w"
   -- Create MIR certificate
   void $ execCardanoCLI
     [ "governance","create-mir-certificate"
     , "--reserves" --TODO: Should also do "--reserves"
-    , "--stake-verification-key-file", verKey
+    , "--stake-address", testAddr
     , "--reward", "1000"
     , "--out-file", mirCertificate
     ]


### PR DESCRIPTION
Instead of taking stake verification key files. Stake addresses is the
more sensible choice since MIR certs really contain a stake credential
and a stake address is basically a wrapper for a stake credential.

There's no need to keep both options (key files and stake addrs) since
we can already convert from a stake vkey file to a stake address.

It's strictly more general, since this now support script-flavour stake
addresses. And sometimes we only have the stake address, not the vkey.