### PR TITLE
Bump to latest cardano-ledger-specs.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: cf3b01490a2cc7ebbb5ac6f7a4de79e8b1d5c70f
-  --sha256: 1v15xqy0qvb7ll4080pplrq2ygqgnf443kaq5i6mj0105941mcjc
+  tag: 3b27f2d472972f64fe2f59f9b7b2d0d2ccb1efaa
+  --sha256: 1yqx0nxi907q4a3rby31nxmryqv8in0y4fmvk3z4zjcqwn3rpi0v
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 8b176d11ccf5946fc3f715623cc779c3c449dc8d
-  --sha256: 0bn9zgx4vrxizxw79ay2dskh8l1lywz6jb4h8h2ikipi7bvkxq7m
+  tag: 7bfdf6ec5ab41e8ea690bfee994688db0d3cf3d0
+  --sha256: 11zgfwqqjvy9halv2iy2h1d5jmzdgw8pbp2a1w4zrav3mhckikpb
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -23,6 +23,7 @@ library
                         -- is fully integrated, or re-exported via the export
                         -- modules above
                         Cardano.Api.Crypto.Ed25519Bip32
+                        Cardano.Api.Eras
                         Cardano.Api.LocalChainSync
                         Cardano.Api.Protocol
                         Cardano.Api.Protocol.Byron
@@ -46,7 +47,6 @@ library
                         Cardano.Api.Address
                         Cardano.Api.Block
                         Cardano.Api.Certificate
-                        Cardano.Api.Eras
                         Cardano.Api.Error
                         Cardano.Api.Fees
                         Cardano.Api.Hash

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 
 -- | Cardano eras, sometimes we have to distinguish them.
@@ -43,12 +43,12 @@ module Cardano.Api.Eras
 
 import           Prelude
 
-import           Data.Type.Equality (TestEquality(..), (:~:)(Refl))
+import           Data.Type.Equality ((:~:) (Refl), TestEquality (..))
 
 import           Cardano.Ledger.Era as Ledger (Crypto)
 
-import           Ouroboros.Consensus.Shelley.Eras as Ledger
-                   (StandardShelley, StandardAllegra, StandardMary, StandardCrypto)
+import           Ouroboros.Consensus.Shelley.Eras as Ledger (StandardAllegra, StandardCrypto,
+                     StandardMary, StandardShelley)
 
 import           Cardano.Api.HasTypeProxy
 

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -54,7 +54,6 @@ import           Ouroboros.Network.Block (Serialised)
 import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
 
 import qualified Cardano.Ledger.Era as Ledger
-import qualified Cardano.Ledger.Shelley.Constraints as Ledger
 
 import qualified Shelley.Spec.Ledger.API as Shelley
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
@@ -173,20 +172,23 @@ toShelleyAddrSet era =
   . mapMaybe (anyAddressInEra era)
   . Set.toList
 
-fromShelleyUTxO :: ShelleyLedgerEra era ~ ledgerera
-                => IsShelleyBasedEra era
-                => Ledger.ShelleyBased ledgerera
-                => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
-                => Shelley.UTxO ledgerera -> UTxO era
-fromShelleyUTxO =
-    --TODO: write an appropriate property to show it is safe to use
-    -- Map.fromListAsc or to use Map.mapKeysMonotonic
-    UTxO
-  . Map.fromList
-  . map (bimap fromShelleyTxIn fromShelleyTxOut)
-  . Map.toList
-  . Shelley.unUTxO
 
+fromUTxO
+  :: ShelleyLedgerEra era ~ ledgerera
+  => ShelleyBasedEra era
+  -> Shelley.UTxO ledgerera
+  -> UTxO era
+fromUTxO eraConversion utxo =
+  case eraConversion of
+    ShelleyBasedEraShelley ->
+      let Shelley.UTxO sUtxo = utxo
+      in UTxO . Map.fromList . map (bimap fromShelleyTxIn fromShelleyTxOut) $ Map.toList sUtxo
+    ShelleyBasedEraAllegra ->
+      let Shelley.UTxO sUtxo = utxo
+      in UTxO . Map.fromList . map (bimap fromShelleyTxIn (fromTxOut ShelleyBasedEraAllegra)) $ Map.toList sUtxo
+    ShelleyBasedEraMary ->
+      let Shelley.UTxO sUtxo = utxo
+      in UTxO . Map.fromList . map (bimap fromShelleyTxIn (fromTxOut ShelleyBasedEraMary)) $ Map.toList sUtxo
 
 fromShelleyPoolDistr :: Shelley.PoolDistr StandardCrypto
                      -> Map (Hash StakePoolKey) Rational
@@ -351,7 +353,7 @@ fromConsensusQueryResult (QueryInEra ShelleyEraInShelleyMode
                                      (QueryInShelleyBasedEra _era q)) q' r' =
     case (q', r') of
       (Consensus.DegenQuery q'', Consensus.DegenQueryResult r'') ->
-        Right (fromConsensusQueryResultShelleyBased q q'' r'')
+        Right (fromConsensusQueryResultShelleyBased ShelleyBasedEraShelley q q'' r'')
 
 fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
                                      (QueryInShelleyBasedEra era _)) _ _ =
@@ -362,7 +364,7 @@ fromConsensusQueryResult (QueryInEra ShelleyEraInCardanoMode
     case q' of
       Consensus.QueryIfCurrentShelley q'' ->
         bimap fromConsensusEraMismatch
-              (fromConsensusQueryResultShelleyBased q q'')
+              (fromConsensusQueryResultShelleyBased ShelleyBasedEraShelley q q'')
               r'
       _ -> fromConsensusQueryResultMismatch
 
@@ -371,7 +373,7 @@ fromConsensusQueryResult (QueryInEra AllegraEraInCardanoMode
     case q' of
       Consensus.QueryIfCurrentAllegra q'' ->
         bimap fromConsensusEraMismatch
-              (fromConsensusQueryResultShelleyBased q q'')
+              (fromConsensusQueryResultShelleyBased ShelleyBasedEraAllegra q q'')
               r'
       _ -> fromConsensusQueryResultMismatch
 
@@ -380,7 +382,7 @@ fromConsensusQueryResult (QueryInEra MaryEraInCardanoMode
     case q' of
       Consensus.QueryIfCurrentMary q'' ->
         bimap fromConsensusEraMismatch
-              (fromConsensusQueryResultShelleyBased q q'')
+              (fromConsensusQueryResultShelleyBased ShelleyBasedEraMary q q'')
               r'
       _ -> fromConsensusQueryResultMismatch
 
@@ -388,55 +390,55 @@ fromConsensusQueryResult (QueryInEra MaryEraInCardanoMode
 fromConsensusQueryResultShelleyBased
   :: forall era ledgerera result result'.
      ShelleyLedgerEra era ~ ledgerera
-  => IsShelleyBasedEra era
   => Consensus.ShelleyBasedEra ledgerera
   => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
-  => QueryInShelleyBasedEra era result
+  => ShelleyBasedEra era
+  -> QueryInShelleyBasedEra era result
   -> Consensus.Query (Consensus.ShelleyBlock ledgerera) result'
   -> result'
   -> result
-fromConsensusQueryResultShelleyBased QueryChainPoint q' point =
+fromConsensusQueryResultShelleyBased _ QueryChainPoint q' point =
     case q' of
       Consensus.GetLedgerTip -> fromConsensusPoint point
       _                      -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryEpoch q' epoch =
+fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
     case q' of
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryGenesisParameters q' r' =
+fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =
     case q' of
       Consensus.GetGenesisConfig -> fromShelleyGenesis
                                       (Consensus.getCompactGenesis r')
       _                          -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryProtocolParameters q' r' =
+fromConsensusQueryResultShelleyBased _ QueryProtocolParameters q' r' =
     case q' of
       Consensus.GetCurrentPParams -> fromShelleyPParams r'
       _                           -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryProtocolParametersUpdate q' r' =
+fromConsensusQueryResultShelleyBased _ QueryProtocolParametersUpdate q' r' =
     case q' of
       Consensus.GetProposedPParamsUpdates -> fromShelleyProposedPPUpdates r'
       _                                   -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryStakeDistribution q' r' =
+fromConsensusQueryResultShelleyBased _ QueryStakeDistribution q' r' =
     case q' of
       Consensus.GetStakeDistribution -> fromShelleyPoolDistr r'
       _                              -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased (QueryUTxO Nothing) q' utxo' =
+fromConsensusQueryResultShelleyBased shelleyBasedEra' (QueryUTxO Nothing) q' utxo' =
     case q' of
-      Consensus.GetUTxO -> fromShelleyUTxO utxo'
+      Consensus.GetUTxO -> fromUTxO shelleyBasedEra' utxo'
       _                 -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased (QueryUTxO Just{}) q' utxo' =
+fromConsensusQueryResultShelleyBased shelleyBasedEra' (QueryUTxO Just{}) q' utxo' =
     case q' of
-      Consensus.GetFilteredUTxO{} -> fromShelleyUTxO utxo'
+      Consensus.GetFilteredUTxO{} -> fromUTxO shelleyBasedEra' utxo'
       _                           -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryStakeAddresses{} q' r' =
+fromConsensusQueryResultShelleyBased _ QueryStakeAddresses{} q' r' =
     case q' of
       Consensus.GetFilteredDelegationsAndRewardAccounts{}
         -> let (delegs, rwaccs) = r'
@@ -444,12 +446,12 @@ fromConsensusQueryResultShelleyBased QueryStakeAddresses{} q' r' =
                 fromShelleyDelegations delegs)
       _ -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryLedgerState{} q' r' =
+fromConsensusQueryResultShelleyBased _ QueryLedgerState{} q' r' =
     case q' of
       Consensus.GetCBOR Consensus.DebugNewEpochState -> LedgerState r'
       _                                              -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased QueryProtocolState q' r' =
+fromConsensusQueryResultShelleyBased _ QueryProtocolState q' r' =
     case q' of
       Consensus.GetCBOR Consensus.DebugChainDepState -> ProtocolState r'
       _                                              -> fromConsensusQueryResultMismatch
@@ -476,4 +478,3 @@ fromConsensusQueryResultMismatch =
 fromConsensusEraMismatch :: SListI xs
                          => Consensus.MismatchEraInfo xs -> EraMismatch
 fromConsensusEraMismatch = Consensus.mkEraMismatch
-

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -107,7 +107,7 @@ deriving newtype instance ToJSON BlockNo
 deriving newtype instance ToJSON (TxId era)
 
 deriving newtype instance ( ShelleyBasedEra era
-                          , ToJSON (Core.Value era)
+                          , ToJSON (Core.TxOut era)
                           , Ledger.Crypto era ~ StandardCrypto
                           ) => ToJSON (UTxO era)
 

--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -455,7 +455,7 @@ localInitiatorNetworkApplication
       versionedNodeToClientProtocols
         version
         versionData
-        (\_ _ -> protocols blockVersion))
+        (\_ _ -> protocols blockVersion version))
     (Map.toList (supportedNodeToClientVersions proxy))
   where
     proxy :: Proxy blk
@@ -465,8 +465,9 @@ localInitiatorNetworkApplication
 
     protocols
       :: BlockNodeToClientVersion blk
+      -> NodeToClientVersion
       -> NodeToClientProtocols InitiatorMode ByteString m () Void
-    protocols byronClientVersion  =
+    protocols byronClientVersion version =
       NodeToClientProtocols
       { localChainSyncProtocol =
           InitiatorProtocolOnly $
@@ -495,4 +496,4 @@ localInitiatorNetworkApplication
             , cTxSubmissionCodec
             , cStateQueryCodec
             } =
-          clientCodecs cfg byronClientVersion
+          clientCodecs cfg byronClientVersion version

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -41,7 +41,7 @@ import           Cardano.BM.Backend.TraceForwarder (plugin)
 import           Cardano.BM.Configuration (Configuration)
 import qualified Cardano.BM.Configuration as Config
 import qualified Cardano.BM.Configuration.Model as Config
-import           Cardano.BM.Data.Aggregated (Measurable(..))
+import           Cardano.BM.Data.Aggregated (Measurable (..))
 import           Cardano.BM.Data.Backend (Backend, BackendKind)
 import           Cardano.BM.Data.LogItem (LOContent (..), LOMeta (..), LoggerName)
 import qualified Cardano.BM.Observer.Monadic as Monadic
@@ -74,7 +74,7 @@ import qualified Shelley.Spec.Ledger.API as SL
 import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Types
-import           Cardano.Tracing.OrphanInstances.Common()
+import           Cardano.Tracing.OrphanInstances.Common ()
 import           Paths_cardano_node (version)
 
 --------------------------------

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -166,8 +166,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
           shelleyBasedGenesis = shelleyGenesis,
           shelleyBasedInitialNonce =
             Shelley.genesisHashToPraosNonce shelleyGenesisHash,
-          shelleyBasedLeaderCredentials =
-            shelleyLeaderCredentials
+          shelleyBasedLeaderCredentials = shelleyLeaderCredentials
         }
         Consensus.ProtocolParamsShelley {
           -- This is /not/ the Shelley protocol version. It is the protocol

--- a/cardano-node/src/Cardano/Node/Query.hs
+++ b/cardano-node/src/Cardano/Node/Query.hs
@@ -19,14 +19,14 @@ import           Data.Time.Clock (UTCTime)
 -- Consensus
 import           Ouroboros.Consensus.Block (BlockProtocol, SlotNo)
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
-import           Ouroboros.Consensus.Config (TopLevelConfig, configLedger, configBlock)
+import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock, configLedger)
 import           Ouroboros.Consensus.Config.SupportsNode (getSystemStart)
 import qualified Ouroboros.Consensus.HardFork.Combinator.Compat as HF
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
                      (HardForkLedgerConfig (DegenLedgerConfig))
 import qualified Ouroboros.Consensus.HardFork.History.Qry as HFI
-import qualified Ouroboros.Consensus.Ledger.Query as Consensus (answerQuery, Query)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerCfg (..), ExtLedgerState)
+import qualified Ouroboros.Consensus.Ledger.Query as Consensus (Query, answerQuery)
 import           Ouroboros.Consensus.Node (RunNode)
 import           Ouroboros.Consensus.Node.ProtocolInfo (pInfoConfig)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -42,8 +42,8 @@ import qualified Shelley.Spec.Ledger.API as SL
 -- Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
-import           Ouroboros.Consensus.Cardano.ShelleyHFC (ShelleyBlockHFC)
 import qualified Ouroboros.Consensus.Cardano.CanHardFork as CanHardFork
+import           Ouroboros.Consensus.Cardano.ShelleyHFC (ShelleyBlockHFC)
 
 import           Cardano.Tracing.Kernel
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
@@ -81,6 +82,7 @@ import           Shelley.Spec.Ledger.STS.Rupd
 import           Shelley.Spec.Ledger.STS.Snap
 import           Shelley.Spec.Ledger.STS.Tick
 import           Shelley.Spec.Ledger.STS.Updn
+import           Shelley.Spec.Ledger.STS.Upec
 import           Shelley.Spec.Ledger.STS.Utxo
 import           Shelley.Spec.Ledger.STS.Utxow
 
@@ -112,6 +114,7 @@ instance ShelleyBasedEra era => ToObject (Header (ShelleyBlock era)) where
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (UTXO era))
          , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => ToObject (ApplyTxError era) where
   toObject verb (ApplyTxError predicateFailures) =
     HMS.unions $ map (toObject verb) predicateFailures
@@ -158,6 +161,7 @@ instance ToObject HotKey.KESEvolutionError where
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (UTXO era))
          , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "BBODY" era))
          ) => ToObject (ShelleyLedgerError era) where
   toObject verb (BBodyError (BlockTransitionError fs)) =
     mkObject [ "kind" .= String "BBodyError"
@@ -221,8 +225,10 @@ instance Core.Crypto crypto => ToObject (ChainTransitionError crypto) where
              ]
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
+         , ToObject (PredicateFailure (Core.EraRule "BBODY" era))
+         , ToObject (PredicateFailure (Core.EraRule "TICK" era))
+         , ToObject (PredicateFailure (Core.EraRule "TICKN" era))
          ) => ToObject (ChainPredicateFailure era) where
   toObject _verb (HeaderSizeTooLargeCHAIN hdrSz maxHdrSz) =
     mkObject [ "kind" .= String "HeaderSizeTooLarge"
@@ -247,6 +253,7 @@ instance ( ShelleyBasedEra era
                       \protocol version."
   toObject verb (BbodyFailure f) = toObject verb f
   toObject verb (TickFailure  f) = toObject verb f
+  toObject verb (TicknFailure  f) = toObject verb f
   toObject verb (PrtclFailure f) = toObject verb f
   toObject verb (PrtclSeqFailure f) = toObject verb f
 
@@ -270,6 +277,7 @@ instance ToObject (PrtlSeqFailure crypto) where
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (UTXO era))
          , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => ToObject (BbodyPredicateFailure era) where
   toObject _verb (WrongBlockBodySizeBBODY actualBodySz claimedBodySz) =
     mkObject [ "kind" .= String "WrongBlockBodySizeBBODY"
@@ -287,6 +295,7 @@ instance ( ShelleyBasedEra era
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (UTXO era))
          , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => ToObject (LedgersPredicateFailure era) where
   toObject verb (LedgerFailure f) = toObject verb f
 
@@ -294,13 +303,17 @@ instance ( ShelleyBasedEra era
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (UTXO era))
          , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
+         , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
          ) => ToObject (LedgerPredicateFailure era) where
   toObject verb (UtxowFailure f) = toObject verb f
   toObject verb (DelegsFailure f) = toObject verb f
 
 
-instance (ShelleyBasedEra era, ToObject (PredicateFailure (UTXO era)))
-      => ToObject (UtxowPredicateFailure era) where
+instance ( ShelleyBasedEra era
+         , ToObject (PredicateFailure (UTXO era))
+         , ToObject (PredicateFailure (Core.EraRule "UTXO" era))
+         ) => ToObject (UtxowPredicateFailure era) where
   toObject _verb (InvalidWitnessesUTXOW wits) =
     mkObject [ "kind" .= String "InvalidWitnessesUTXOW"
              , "invalidWitnesses" .= map textShow wits
@@ -342,6 +355,8 @@ instance (ShelleyBasedEra era, ToObject (PredicateFailure (UTXO era)))
 instance ( ShelleyBasedEra era
          , ToJSON (Core.Value era)
          , ToJSON (Core.Delta (Core.Value era))
+         , ToJSON (Core.TxOut era)
+         , ToObject (PredicateFailure (Core.EraRule "PPUP" era))
          )
       => ToObject (UtxoPredicateFailure era) where
   toObject _verb (BadInputsUTxO badInputs) =
@@ -429,6 +444,8 @@ instance ToJSON MA.ValidityInterval where
 instance ( ShelleyBasedEra era
          , ToJSON (Core.Value era)
          , ToJSON (Core.Delta (Core.Value era))
+         , ToJSON (Core.TxOut era)
+         , ToObject (PredicateFailure (Core.EraRule "PPUP" era))
          ) => ToObject (MA.UtxoPredicateFailure era) where
   toObject _verb (MA.BadInputsUTxO badInputs) =
     mkObject [ "kind" .= String "BadInputsUTxO"
@@ -480,6 +497,11 @@ instance ( ShelleyBasedEra era
              ]
   toObject _verb MA.TriesToForgeADA =
     mkObject [ "kind" .= String "TriesToForgeADA" ]
+  toObject _verb (MA.OutputTooBigUTxO badOutputs) =
+    mkObject [ "kind" .= String "OutputTooBigUTxO"
+             , "outputs" .= badOutputs
+             , "error" .= String "Too many asset ids in the tx output"
+             ]
 
 renderBadInputsUTxOErr ::  Set (TxIn era) -> Value
 renderBadInputsUTxOErr txIns
@@ -506,7 +528,9 @@ instance ToObject (PpupPredicateFailure era) where
              ]
 
 
-instance ShelleyBasedEra era => ToObject (DelegsPredicateFailure era) where
+instance ( ShelleyBasedEra era
+         , ToObject (PredicateFailure (Core.EraRule "DELPL" era))
+         ) => ToObject (DelegsPredicateFailure era) where
   toObject _verb (DelegateeNotRegisteredDELEG targetPool) =
     mkObject [ "kind" .= String "DelegateeNotRegisteredDELEG"
              , "targetPool" .= targetPool
@@ -518,7 +542,9 @@ instance ShelleyBasedEra era => ToObject (DelegsPredicateFailure era) where
   toObject verb (DelplFailure f) = toObject verb f
 
 
-instance ToObject (DelplPredicateFailure era) where
+instance ( ToObject (PredicateFailure (Core.EraRule "POOL" era))
+         , ToObject (PredicateFailure (Core.EraRule "DELEG" era))
+         ) => ToObject (DelplPredicateFailure era) where
   toObject verb (PoolFailure f) = toObject verb f
   toObject verb (DelegFailure f) = toObject verb f
 
@@ -616,14 +642,18 @@ instance ToObject (PoolPredicateFailure era) where
                     ]
 
 
-instance ToObject (TickPredicateFailure era) where
+instance ( ToObject (PredicateFailure (Core.EraRule "NEWEPOCH" era))
+         , ToObject (PredicateFailure (Core.EraRule "RUPD" era))
+         ) => ToObject (TickPredicateFailure era) where
   toObject verb (NewEpochFailure f) = toObject verb f
   toObject verb (RupdFailure f) = toObject verb f
 
 instance ToObject TicknPredicateFailure where
   toObject _verb x = case x of {} -- no constructors
 
-instance ToObject (NewEpochPredicateFailure era) where
+instance ( ToObject (PredicateFailure (Core.EraRule "EPOCH" era))
+         , ToObject (PredicateFailure (Core.EraRule "MIR" era))
+         ) => ToObject (NewEpochPredicateFailure era) where
   toObject verb (EpochFailure f) = toObject verb f
   toObject verb (MirFailure f) = toObject verb f
   toObject _verb (CorruptRewardUpdate update) =
@@ -631,10 +661,13 @@ instance ToObject (NewEpochPredicateFailure era) where
              , "update" .= String (show update) ]
 
 
-instance ToObject (EpochPredicateFailure era) where
+instance ( ToObject (PredicateFailure (Core.EraRule "POOLREAP" era))
+         , ToObject (PredicateFailure (Core.EraRule "SNAP" era))
+         , ToObject (PredicateFailure (Core.EraRule "UPEC" era))
+         ) => ToObject (EpochPredicateFailure era) where
   toObject verb (PoolReapFailure f) = toObject verb f
   toObject verb (SnapFailure f) = toObject verb f
-  toObject verb (NewPpFailure f) = toObject verb f
+  toObject verb (UpecFailure f) = toObject verb f
 
 
 instance ToObject (PoolreapPredicateFailure era) where
@@ -762,6 +795,13 @@ instance ToObject (OcertPredicateFailure crypto) where
 
 instance ToObject (UpdnPredicateFailure crypto) where
   toObject _verb x = case x of {} -- no constructors
+
+instance ToObject (UpecPredicateFailure era) where
+  toObject _verb (NewPpFailure (UnexpectedDepositPot totalOutstanding depositPot)) =
+    mkObject [ "kind" .= String "UnexpectedDepositPot"
+             , "totalOutstanding" .=  String (textShow totalOutstanding)
+             , "depositPot" .= String (textShow depositPot)
+             ]
 
 --------------------------------------------------------------------------------
 -- Helper functions

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -75,8 +75,8 @@ import           Ouroboros.Network.BlockFetch.Decision (FetchDecision, FetchDecl
 import qualified Ouroboros.Network.NodeToClient as NtC
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.Point (fromWithOrigin, withOrigin)
-import           Ouroboros.Network.Subscription
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (ShowQuery)
+import           Ouroboros.Network.Subscription
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB


### PR DESCRIPTION
Since the ledger is now starting to generalise things for Alonzo, some
similar changes must be made here:

- Reference to the `EraRule` family, which is used to encode the set of
  rules used in a given era.
- Various things (particularly `TxOut`) are now era-dependent, and so we
  cannot assume a Shelley-era TxOut.