### PR TITLE
New served.header.count metric

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,8 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7bfdf6ec5ab41e8ea690bfee994688db0d3cf3d0
-  --sha256: 11zgfwqqjvy9halv2iy2h1d5jmzdgw8pbp2a1w4zrav3mhckikpb
+  tag: 86515cf4488d71838ba2b89b9d619ce0b9e8ad3c
+  --sha256: 04vr19ihg1c1c4g8rwa15yq7h01s6mq11dk1r0z214rl9scd8rjn
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1000,6 +1000,19 @@ instance ConvertRawHash blk
                , "rolledBackBlock" .= String (renderPointForVerbosity verb pt)
                ]
 
+    TraceChainSyncRollForward ->
+      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollForward"
+               ]
+    TraceChainSyncRollBackward ->
+      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollBackward"
+               ]
+    TraceChainSyncIntersectFound ->
+      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncIntersectFound"
+               ]
+    TraceChainSyncIntersectNotFound ->
+      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncIntersectNotFound"
+               ]
+
 
 instance ( Show (ApplyTxErr blk), ToObject (ApplyTxErr blk), ToObject (GenTx blk),
            ToJSON (GenTxId blk)

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -19,7 +19,7 @@ defaultBackends:
   - KatipBK
 
 # if wanted, the EKG interface is listening on this port:
-#hasEKG: 12781
+hasEKG: 12781
 
 #hasPrometheus:
 #  - "127.0.0.1"
@@ -120,10 +120,10 @@ TraceChainDb: True
 TraceChainSyncClient: False
 
 # Trace ChainSync server (blocks).
-TraceChainSyncBlockServer: False
+TraceChainSyncBlockServer: True
 
 # Trace ChainSync server (headers).
-TraceChainSyncHeaderServer: False
+TraceChainSyncHeaderServer: True
 
 # Trace ChainSync protocol messages.
 TraceChainSyncProtocol: True

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -119,10 +119,10 @@ TraceChainDb: True
 TraceChainSyncClient: False
 
 # Trace ChainSync server (blocks).
-TraceChainSyncBlockServer: False
+TraceChainSyncBlockServer: True
 
 # Trace ChainSync server (headers).
-TraceChainSyncHeaderServer: False
+TraceChainSyncHeaderServer: True
 
 # Trace ChainSync protocol messages.
 TraceChainSyncProtocol: True

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -120,10 +120,10 @@ TraceChainDb: True
 TraceChainSyncClient: False
 
 # Trace ChainSync server (blocks).
-TraceChainSyncBlockServer: False
+TraceChainSyncBlockServer: True
 
 # Trace ChainSync server (headers).
-TraceChainSyncHeaderServer: False
+TraceChainSyncHeaderServer: True
 
 # Trace ChainSync protocol messages.
 TraceChainSyncProtocol: True


### PR DESCRIPTION
This implements "Counter, monotonically increasing, number of block headers by chain sync served" from https://github.com/input-output-hk/cardano-node/issues/2261

Requires https://github.com/input-output-hk/ouroboros-network/pull/2886 upstream.

![image](https://user-images.githubusercontent.com/63014/105130017-5bb8ca80-5b3a-11eb-94dd-ab2ab0b6be60.png)
