### PR TITLE
Optimize Hydra Eval

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,8 @@ let
 
     inherit (haskellPackages.cardano-node.identifier) version;
 
+    inherit (haskellPackages.cardano-node.project) plan-nix;
+
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);
 
     # `tests` are the test suites which have been built.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,8 +14,7 @@ let
   nixpkgs = if (sources ? nixpkgs)
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
-    else (builtins.trace "Using IOHK default nixpkgs"
-      iohkNixMain.nixpkgs);
+    else iohkNixMain.nixpkgs;
 
   # for inclusion in pkgs:
   overlays =

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -25,20 +25,23 @@ let
       src = ../.;
   };
 
+  # It is important this matches in both calls to cabalProject or `cabal configure`
+  # will run twice.
+  cabalProjectLocal = ''
+    allow-newer: terminfo:base
+  '';
+
   projectPackages = lib.attrNames (haskell-nix.haskellLib.selectProjectPackages
     (haskell-nix.cabalProject {
-      inherit src;
+      inherit src cabalProjectLocal;
       compiler-nix-name = compiler;
     }));
 
   # This creates the Haskell package set.
   # https://input-output-hk.github.io/haskell.nix/user-guide/projects/
   pkgSet = haskell-nix.cabalProject ({
-    inherit src;
+    inherit src cabalProjectLocal;
     compiler-nix-name = compiler;
-    cabalProjectLocal = ''
-      allow-newer: terminfo:base
-    '';
     modules = [
       # Allow reinstallation of Win32
       ({ pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {


### PR DESCRIPTION
Three changes that the hydra eval faster.  In order of importance:

### 1) Split `native` jobs into `linux` and `darwin`

Reduces the number of times hydra restarts the eval process because
memory is running low.  When both linux and darwin versions are
in the same attribute the evaluation runs out of memory more often
as it alternates between evaluating linux and darwin jobs.

Grouping all the linux and darwin jobs together reduces the number
of times the memory limit is reached.  This is makes the
"no change" eval more than 4x faster (270s vs 1300s).

### 2) Avoid duplicate `cabal configure`

To get a list of package names in the project we call
`cabalProject`, before using those names to provide the
overrides for another call to `cabalProject`.
`cabalProjectLocal` is not the same for the two calls and
as a result `cabal configure` is run twice (and it is very
slow for this project.  Passing the same `cabalProjectLocal`
value to both calls should improve evaluation greatly
when changes are made to the `cabal.project` or `.cabal`
files.

### 3) Include jobs to pin plan-nix

Pinning the `plan-nix` output means it is copied to the
hydra cache.  This may not improve eval on the hydra
machine itself, it will make testing evaluation on
other machines faster (since they will have access to the
cached plans).


### Jobset link

https://hydra.iohk.io/jobset/Cardano/cardano-node-pr-2294#tabs-jobs