### PR TITLE
Fix the missing tx metadata validation checks when using JSON format

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -932,8 +932,12 @@ readFileTxMetadata mapping (MetadataFileJSON fp) = do
     v  <- firstExceptT (ShelleyTxCmdMetadataJsonParseError fp) $
           hoistEither $
             Aeson.eitherDecode' bs
-    firstExceptT (ShelleyTxCmdMetadataConversionError fp) $ hoistEither $
+    txMetadata <- firstExceptT (ShelleyTxCmdMetadataConversionError fp) $ hoistEither $
       metadataFromJson mapping v
+    firstExceptT (ShelleyTxCmdMetaValidationError fp) $ hoistEither $ do
+        validateTxMetadata txMetadata
+        return txMetadata
+
 readFileTxMetadata _ (MetadataFileCBOR fp) = do
     bs <- handleIOExceptT (ShelleyTxCmdReadFileError . FileIOError fp) $
           BS.readFile fp


### PR DESCRIPTION
For some reason we were doing the JSON-specific format checks but
omiting the general tx metadata validation checks. This is as part of
the tx raw construction.