### PR TITLE
Add the eval-time GC roots to release.nix so they're cached.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -58,6 +58,9 @@ let
     inherit haskellPackages cardano-node cardano-cli db-converter cardano-ping
       scripts nixosTests environments dockerImage mkCluster bech32;
 
+    # so that eval time gc roots are cached (nix-tools stuff)
+    inherit (cardanoNodeHaskellPackages) roots;
+
     inherit (haskellPackages.cardano-node.identifier) version;
 
     exes = mapAttrsRecursiveCond (as: !(isDerivation as)) rewrite-static (collectComponents' "exes" haskellPackages);

--- a/release.nix
+++ b/release.nix
@@ -108,7 +108,7 @@ let
   ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [
-    ["shell"] ["cardano-ping"]
+    ["shell"] ["cardano-ping"] ["roots"]
   ] ++ onlyBuildOnDefaultSystem;
   noMusl64Build = [ ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ]
     ++ noCrossBuild;


### PR DESCRIPTION
 Otherwise they'll get GCd very quickly, which means people will need to
 build a lot to even open the shell.

(Thanks to @michaelpj for pointing the solution).