### PR TITLE
CAD-2196: simplify node configuration for trace forwarder

### DIFF
--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -255,17 +255,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2997'.
 # traceForwardTo:

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2998'.
 # traceForwardTo:

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2999'.
 # traceForwardTo:

--- a/configuration/chairman/shelly-only/configuration.yaml
+++ b/configuration/chairman/shelly-only/configuration.yaml
@@ -246,17 +246,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -243,17 +243,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -60,12 +60,9 @@ TracingVerbosity: NormalVerbosity
 # This setting lists the backends that will be available to use in the
 # configuration below. The logging backend is called Katip. Also enable the EKG
 # backend if you want to use the EKG or Prometheus monitoring interfaces.
-# You can also enable trace forwarder backend if node should send the metrics
-# to an external process.
 setupBackends:
   - KatipBK
 # - EKGViewBK
-# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
@@ -220,17 +217,8 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-    # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-    # - TraceForwarderBK
-    # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-    # cardano.node.release:
-    #   - TraceForwarderBK
-    # cardano.node.version:
-    #   - TraceForwarderBK
-    # cardano.node.commit:
-    #   - TraceForwarderBK
 
-# If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
+# Uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.
 # traceForwardTo:
 #   tag: RemoteSocket

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -60,12 +60,9 @@ TracingVerbosity: NormalVerbosity
 # This setting lists the backends that will be available to use in the
 # configuration below. The logging backend is called Katip. Also enable the EKG
 # backend if you want to use the EKG or Prometheus monitoring interfaces.
-# You can also enable trace forwarder backend if node should send the metrics
-# to an external process.
 setupBackends:
   - KatipBK
 # - EKGViewBK
-# - TraceForwarderBK
 
 # This specifies the default backends that trace output is sent to if it
 # is not specifically configured to be sent to other backends.
@@ -220,17 +217,8 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-    # Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-    # - TraceForwarderBK
-    # Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-    # cardano.node.release:
-    #   - TraceForwarderBK
-    # cardano.node.version:
-    #   - TraceForwarderBK
-    # cardano.node.commit:
-    #   - TraceForwarderBK
 
-# If 'TraceForwarderBK' is enabled, uncomment it to forward node's metrics
+# Uncomment it to forward node's metrics
 # to remote socket '127.0.0.1:2997'.
 # traceForwardTo:
 #   tag: RemoteSocket

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2997'.
 # traceForwardTo:

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2998'.
 # traceForwardTo:

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -10,9 +10,6 @@ rotation:
 # these backends are initialized:
 setupBackends:
   - KatipBK
-# Uncomment it to enable trace forwarder backend, if the node should
-# forward metrics to an external process.
-# - TraceForwarderBK
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
@@ -47,15 +44,6 @@ options:
   mapBackends:
     cardano.node.metrics:
       - EKGViewBK
-# Uncomment it to send 'cardano.node.metrics' to 'TraceForwarderBK' as well.
-#     - TraceForwarderBK
-# Uncomment it to send node's release, version and commit to 'TraceForwarderBK'.
-#    cardano.node.release:
-#      - TraceForwarderBK
-#    cardano.node.version:
-#      - TraceForwarderBK
-#    cardano.node.commit:
-#      - TraceForwarderBK
 
 # Uncomment it to forward node's metrics to remote socket '127.0.0.1:2999'.
 # traceForwardTo:

--- a/scripts/lite/configuration/shelley-1.yaml
+++ b/scripts/lite/configuration/shelley-1.yaml
@@ -241,17 +241,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":

--- a/scripts/lite/configuration/shelley-2.yaml
+++ b/scripts/lite/configuration/shelley-2.yaml
@@ -241,17 +241,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":

--- a/scripts/lite/configuration/shelley-3.yaml
+++ b/scripts/lite/configuration/shelley-3.yaml
@@ -241,17 +241,7 @@ options:
   # go to the default backend, only to the explicitly listed backends.
   mapBackends:
     cardano.node.metrics:
-      - TraceForwarderBK
       - EKGViewBK
-    cardano.node.release:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.version:
-      - TraceForwarderBK
-      - KatipBK
-    cardano.node.commit:
-      - TraceForwarderBK
-      - KatipBK
 
   # redirects traced values to a specific scribe which is identified by its
   # type and its name, separated by "::":


### PR DESCRIPTION
Now, to configure the node for working with RTView, the user should make only one single change in the node's configuration file - add `traceForwardTo` section, for example:

```
  "traceForwardTo": {
    "tag": "RemoteSocket",
    "contents": [
      "0.0.0.0",
      "3000"
    ]
  }
```

In this case:

1. `TraceForwarder` plugin will be activated,
2. all metrics/peers/errors will be forwarded by adding to `mapBackends` section.

Please note that `TurnOnLogMetrics` flag should be enabled anyway (for tracing resources metrics), but in the default configuration this flag is already `true`.