### PR TITLE
CAD-2653 haskell.nix:  bump to latest master

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "505130bfdaa9ecff5f50c4c415d4cb7db7089716",
-        "sha256": "1j193vhc7gd22lsk6dd8lfkq64aj7xmas23sb3gkr1v6ihchpaj6",
+        "rev": "40a26afa33b421d7ede240b5d6c2a9a22313cb2b",
+        "sha256": "1cd6i1rrxxqnrg659zcq0xhkind67q0kx1gddr9sni8cdhwdlvqb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/505130bfdaa9ecff5f50c4c415d4cb7db7089716.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/40a26afa33b421d7ede240b5d6c2a9a22313cb2b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
Bump `haskell.nix` to latest master, as https://github.com/input-output-hk/haskell.nix/pull/1006 fixes the following error that pops up during evaluation sometimes:

```
Package ‘Crypto-lib-Crypto-4.2.5.1’ in /nix/store/dxjrqxbhrw005w4z8fd9iglcazlz1gdg-haskell.nix-src/builder/comp-builder.nix:297 has an unfree license (‘Other License’), refusing to evaluate.
```
