### PR TITLE
Fix install instruction

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -156,7 +156,7 @@ Build the node and CLI with `cabal`:
 
 Install the newly built node and CLI commands:
 
-    cabal install all --bindir ~/.local/bin
+    cabal install all --installdir ~/.local/bin
 
 If this doesn't work, you can manually copy the executable files to the `~/.local/bin` directory. Replace the place holder `<TAGGED VERSION>` with your targeted version:
 


### PR DESCRIPTION
The old command gives

```
cabal: installdir is not defined. Set it in your cabal config file or use
--installdir=<path>
```