### PR TITLE
CAD-2572 Direct submission of the ChainSync headers served metric to EKG

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -145,8 +145,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: a89c38ed5825ba17ca79fddb85651007753d699d
-  --sha256: 0i4p3jbr9pxhklgbky2g7rfqhccvkqzph0ak5x8bb6kwp7c7b8wf
+  tag: 60b13d80afa266f02f363672950e896ed735e807
+  --sha256: 0gci6r4c6ldrgracbr4fni4hbrl62lmm5p70cafkwk21a0kqs8cz
   subdir:
     contra-tracer
     iohk-monitoring

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -76,6 +76,7 @@ library
                      , byron-spec-ledger
                      , bytestring
                      , deepseq
+                     , ekg
                      , cardano-api
                      , cardano-config
                      , cardano-crypto-class

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -76,7 +76,6 @@ library
                      , byron-spec-ledger
                      , bytestring
                      , deepseq
-                     , ekg
                      , cardano-api
                      , cardano-config
                      , cardano-crypto-class
@@ -90,6 +89,8 @@ library
                      , containers
                      , directory
                      , dns
+                     , ekg
+                     , ekg-core
                      , filepath
                      , generic-data
                      , hedgehog-extras

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -181,8 +181,8 @@ createLoggingLayer ver nodeConfig' p = do
   mbEkgDirect <- case mEKGServer of
                   Nothing -> pure Nothing
                   Just sv -> do
-                    refGauge <- liftIO $ newIORef (Map.empty)
-                    refLabel <- liftIO $ newIORef (Map.empty)
+                    refGauge <- liftIO $ newIORef Map.empty
+                    refLabel <- liftIO $ newIORef Map.empty
                     pure $ Just EKGDirect {
                         ekgServer = sv
                       , ekgGauges = refGauge

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -113,7 +113,7 @@ runNode cmdPc = do
                      p
 
     loggingLayer <- case eLoggingLayer of
-                      Left err -> putTextLn (show err) >> exitFailure
+                      Left err  -> putTextLn (show err) >> exitFailure
                       Right res -> return res
 
     !trace <- setupTrace loggingLayer
@@ -125,7 +125,11 @@ runNode cmdPc = do
     -- Used for ledger queries and peer connection status.
     nodeKernelData :: NodeKernelData blk <- mkNodeKernelData
 
-    tracers <- mkTracers (ncTraceConfig nc) trace nodeKernelData
+    tracers <- mkTracers
+                 (ncTraceConfig nc)
+                 trace
+                 nodeKernelData
+                 (llEKGServer loggingLayer)
 
     Async.withAsync (handlePeersListSimple trace nodeKernelData)
         $ \_peerLogingThread ->

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -129,7 +129,7 @@ runNode cmdPc = do
                  (ncTraceConfig nc)
                  trace
                  nodeKernelData
-                 (llEKGServer loggingLayer)
+                 (llEKGDirect loggingLayer)
 
     Async.withAsync (handlePeersListSimple trace nodeKernelData)
         $ \_peerLogingThread ->

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -279,7 +279,7 @@ mkTracers
   => TraceOptions
   -> Trace IO Text
   -> NodeKernelData blk
-  -> EKGDirect
+  -> Maybe EKGDirect
   -> IO (Tracers peer localPeer blk)
 mkTracers tOpts@(TracingOn trSel) tr nodeKern ekgDirect = do
   fStats <- mkForgingStats
@@ -368,7 +368,7 @@ teeTraceChainTip
      )
   => TraceOptions
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)
-  -> EKGDirect
+  -> Maybe EKGDirect
   -> Trace IO Text
   -> Trace IO Text
   -> Tracer IO (WithSeverity (ChainDB.TraceEvent blk))
@@ -398,10 +398,10 @@ ignoringSeverity tr = Tracer $ \(WithSeverity _ ev) -> traceWith tr ev
 
 traceChainMetrics
   :: forall blk. HasHeader (Header blk)
-  => EKGDirect -> Trace IO Text -> Tracer IO (ChainDB.TraceEvent blk)
-traceChainMetrics ekgDirect _tr = Tracer $ \ev ->
-  fromMaybe (pure ()) $
-    doTrace <$> chainTipInformation ev
+  => Maybe EKGDirect -> Trace IO Text -> Tracer IO (ChainDB.TraceEvent blk)
+traceChainMetrics Nothing _ = nullTracer
+traceChainMetrics (Just ekgDirect) _tr = Tracer $ \ev ->
+  fromMaybe (pure ()) $ doTrace <$> chainTipInformation ev
  where
    chainTipInformation :: ChainDB.TraceEvent blk -> Maybe ChainInformation
    chainTipInformation = \case

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -573,7 +573,7 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
    traceServedCount (Just ekgDirect) tHeadersServed ev =
      when (isRollForward ev) $ do
        count <- STM.modifyReadTVarIO tHeadersServed (+1)
-       sendEKGDirectInt ekgDirect "cardano.node.metrics.served_header_count" count
+       sendEKGDirectInt ekgDirect "cardano.node.metrics.served.header.counter" count
 
 traceLeadershipChecks ::
   forall blk


### PR DESCRIPTION
1. Bump `iohk-monitoring-framework` to the latest `master`, that includes EKG server extraction.
2. Define `EKGDirect` -- a direct handle onto the EKG server/store used by the EKG backend of the logging framework.
3. Stop submitting `cardano.node.metrics.served.header.counter.int` to the switchboard.
4. Submit it via `EKGDirect`, instead.