### PR TITLE
Import cardano-submit-api from cardano-rest repo

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -136,6 +136,23 @@ jobs:
     - name: Run tests
       run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 retry 2 cabal test --builddir="$CABAL_BUILDDIR" cardano-node-chairman
 
+    - name: Build & Test
+      run: |
+        mkdir -p artifacts
+
+        for exe in $(cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(.style == "local" and (."component-name" | startswith("exe:"))) | ."bin-file"'); do
+          ( cd artifacts
+            tar -C "$(dirname $exe)" -czf "$(basename $exe).tar.gz" "$(basename $exe)"
+          )
+        done
+
+    - name: Save Artifact
+      if: matrix.ghc == '8.10.3'
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.os }}_cardano-rest
+        path: ./artifacts
+
     - name: Delete socket files in preparation for upload artifacts
       if: ${{ always() }}
       run: |
@@ -149,3 +166,56 @@ jobs:
       with:
         name: chairman-test-artifacts-${{ matrix.os }}-${{ matrix.ghc }}
         path: ${{ runner.temp }}/chairman/
+
+  release:
+    needs: [build]
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.3.4
+
+    - name: Create Release Tag
+      id: create_release_tag
+      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+        prerelease: false
+
+    - name: Download Artifact (linux)
+      uses: actions/download-artifact@v1
+      with:
+        name: ubuntu-latest_cardano-rest
+
+    - name: Download Artifact (macOS)
+      uses: actions/download-artifact@v1
+      with:
+        name: macOS-latest_cardano-rest
+
+    - name: Upload Release Asset (cardano-submit-api, linux)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./ubuntu-latest_cardano-rest/cardano-submit-api.tar.gz
+        asset_name: cardano-submit-api_${{ steps.create_release_tag.outputs.TAG }}-linux.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload Release Asset (cardano-submit-api, macOS)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./macOS-latest_cardano-rest/cardano-submit-api.tar.gz
+        asset_name: cardano-submit-api_${{ steps.create_release_tag.outputs.TAG }}-macOS.tar.gz
+        asset_content_type: application/gzip

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,7 @@ packages:
     cardano-config
     cardano-node
     cardano-node-chairman
+    cardano-submit-api
     hedgehog-extras
     nix/supervisord-cluster/topology
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -6,22 +6,44 @@ description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io
 license:                Apache-2.0
-license-files:
-  LICENSE
-  NOTICE
+license-files:          LICENSE
+                        NOTICE
 build-type:             Simple
 extra-source-files:     README.md, ChangeLog.md
 
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+  if impl(ghc < 8.10)
+    ghc-options:        -Wno-incomplete-patterns
+
+
 library
+  import:               base, project-config
+
   hs-source-dirs:       src
 
   exposed-modules:      Cardano.Api
                         Cardano.Api.Byron
+                        Cardano.Api.Crypto.Ed25519Bip32
                         Cardano.Api.Shelley
                         Cardano.Api.ChainSync.Client
                         Cardano.Api.ChainSync.ClientPipelined
 
-                        Cardano.Api.Crypto.Ed25519Bip32
                         -- TODO: Eliminate in the future when
                         -- we create wrapper types for the ledger types
                         -- in this modulde
@@ -33,10 +55,7 @@ library
                         Cardano.Api.Protocol.Shelley
                         Cardano.Api.Protocol.Types
 
-
-  other-modules:        Cardano.Api.TxSubmit.ErrorRender
-                        Cardano.Api.TxSubmit.Types
-
+  other-modules:        
                         -- Splitting up the big Typed module:
                         Cardano.Api.Address
                         Cardano.Api.Block
@@ -49,8 +68,8 @@ library
                         Cardano.Api.IPC
                         Cardano.Api.Key
                         Cardano.Api.KeysByron
-                        Cardano.Api.KeysShelley
                         Cardano.Api.KeysPraos
+                        Cardano.Api.KeysShelley
                         Cardano.Api.Modes
                         Cardano.Api.NetworkId
                         Cardano.Api.OperationalCertificate
@@ -69,14 +88,12 @@ library
                         Cardano.Api.TxBody
                         Cardano.Api.TxInMode
                         Cardano.Api.TxMetadata
+                        Cardano.Api.TxSubmit.ErrorRender
+                        Cardano.Api.TxSubmit.Types
                         Cardano.Api.Utils
                         Cardano.Api.Value
 
-
-
-
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0
                       , aeson-pretty      >= 0.8.5
                       , attoparsec
                       , base16-bytestring >= 1.0
@@ -120,27 +137,13 @@ library
                       , unordered-containers >= 0.2.11
                       , vector
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-                        OverloadedStrings
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-
-  if impl(ghc < 8.10)
-    ghc-options:        -Wno-incomplete-patterns
-
 test-suite cardano-api-test
+  import:               base, project-config
   hs-source-dirs:       test
   main-is:              cardano-api-test.hs
   type:                 exitcode-stdio-1.0
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
                       , cardano-api
@@ -186,13 +189,4 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Typed.Value
                         Test.Tasty.Hedgehog.Group
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -152,7 +152,7 @@ module Cardano.Api (
     TxBodyError(..),
 
     -- ** Transaction Ids
-    TxId,
+    TxId(..),
     getTxId,
 
     -- ** Transaction inputs

--- a/cardano-api/src/Cardano/Api/TxSubmit/Types.hs
+++ b/cardano-api/src/Cardano/Api/TxSubmit/Types.hs
@@ -3,13 +3,14 @@ module Cardano.Api.TxSubmit.Types
   ( NodeApiEnv (..)
   , SocketPath (..)
   , TxSubmitStatus (..)
+  , ApplyMempoolPayloadErr(..)
   , renderTxSubmitStatus
   , textShow
   ) where
 
 import           Cardano.Api.TxSubmit.ErrorRender
 import           Cardano.Binary (DecoderError)
-import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr)
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr(..))
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.UTxO as Utxo
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
@@ -18,6 +18,8 @@ import           Test.Cardano.Api.Typed.Gen
 import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog.Group (fromGroup)
 
+{- HLINT ignore "Use map once" -}
+
 prop_roundtrip_Value_JSON :: Property
 prop_roundtrip_Value_JSON =
   property $ do v <- forAll genValueDefault
@@ -68,9 +70,6 @@ canonicalise =
 
     isZeroOrEmpty (ValueNestedBundleAda q) = q == 0
     isZeroOrEmpty (ValueNestedBundle _ as) = Map.null as
-
-{-# ANN canonicalise "HLint: ignore Use map once" #-}
-
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-api/test/cardano-api-test.cabal
+++ b/cardano-api/test/cardano-api-test.cabal
@@ -6,12 +6,33 @@ description:            Library for utilities used in testing the Cardano API.
 author:                 IOHK
 maintainer:             operations@iohk.io
 license:                Apache-2.0
-license-files:
-  LICENSE
-  NOTICE
+license-files:          LICENSE
+                        NOTICE
 build-type:             Simple
 
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+  if impl(ghc < 8.10)
+    ghc-options:        -Wno-incomplete-patterns
+
 library
+  import:               base, project-config
+
   exposed-modules:      Test.Cardano.Api.Typed.Gen
 
   other-modules:        Test.Cardano.Api.Metadata
@@ -33,17 +54,3 @@ library
                       , tasty
                       , tasty-hedgehog
                       , text
-
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-                        OverloadedStrings
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-
-  if impl(ghc < 8.10)
-    ghc-options:        -Wno-incomplete-patterns

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,75 +1,102 @@
 cabal-version: 2.4
 
-name:                  cardano-cli
-version:               1.25.0
-description:           The Cardano command-line interface.
-author:                IOHK
-maintainer:            operations@iohk.io
-license:               Apache-2.0
-license-files:
-  LICENSE
-  NOTICE
-build-type:            Simple
-extra-source-files:    README.md
+name:                   cardano-cli
+version:                1.25.0
+description:            The Cardano command-line interface.
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     README.md
 
 Flag unexpected_thunks
   Description:   Turn on unexpected thunks checks
   Default:       False
 
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+common maybe-unix
+  if !os(windows)
+     build-depends:    unix
+
+common maybe-Win32
+  if os(windows)
+     build-depends:    Win32
+
 library
+  import:               base, project-config
+                      , maybe-unix
+                      , maybe-Win32
 
   if flag(unexpected_thunks)
     cpp-options: -DUNEXPECTED_THUNKS
 
-  hs-source-dirs:      src
+  hs-source-dirs:       src
 
-  exposed-modules:     Cardano.CLI.Helpers
-                       Cardano.CLI.Parsers
-                       Cardano.CLI.Run
-                       Cardano.CLI.Types
+  exposed-modules:      Cardano.CLI.Helpers
+                        Cardano.CLI.Parsers
+                        Cardano.CLI.Run
+                        Cardano.CLI.Types
 
-                       Cardano.CLI.Environment
+                        Cardano.CLI.Environment
 
-                       Cardano.CLI.Byron.Commands
-                       Cardano.CLI.Byron.Parsers
-                       Cardano.CLI.Byron.Run
-                       Cardano.CLI.Byron.Delegation
-                       Cardano.CLI.Byron.Genesis
-                       Cardano.CLI.Byron.Key
-                       Cardano.CLI.Byron.Legacy
-                       Cardano.CLI.Byron.Tx
-                       Cardano.CLI.Byron.Query
-                       Cardano.CLI.Byron.UpdateProposal
-                       Cardano.CLI.Byron.Vote
+                        Cardano.CLI.Byron.Commands
+                        Cardano.CLI.Byron.Parsers
+                        Cardano.CLI.Byron.Run
+                        Cardano.CLI.Byron.Delegation
+                        Cardano.CLI.Byron.Genesis
+                        Cardano.CLI.Byron.Key
+                        Cardano.CLI.Byron.Legacy
+                        Cardano.CLI.Byron.Tx
+                        Cardano.CLI.Byron.Query
+                        Cardano.CLI.Byron.UpdateProposal
+                        Cardano.CLI.Byron.Vote
 
-                       Cardano.CLI.Shelley.Commands
-                       Cardano.CLI.Shelley.Key
-                       Cardano.CLI.Shelley.Orphans
-                       Cardano.CLI.Shelley.Parsers
-                       Cardano.CLI.Shelley.Run
-                       Cardano.CLI.Shelley.Run.Address
-                       Cardano.CLI.Shelley.Run.Address.Info
-                       Cardano.CLI.Shelley.Run.Genesis
-                       Cardano.CLI.Shelley.Run.Governance
-                       Cardano.CLI.Shelley.Run.Key
-                       Cardano.CLI.Shelley.Run.Node
-                       Cardano.CLI.Shelley.Run.Pool
-                       Cardano.CLI.Shelley.Run.Pretty
-                       Cardano.CLI.Shelley.Run.Query
-                       Cardano.CLI.Shelley.Run.StakeAddress
-                       Cardano.CLI.Shelley.Run.TextView
-                       Cardano.CLI.Shelley.Run.Transaction
+                        Cardano.CLI.Shelley.Commands
+                        Cardano.CLI.Shelley.Key
+                        Cardano.CLI.Shelley.Orphans
+                        Cardano.CLI.Shelley.Parsers
+                        Cardano.CLI.Shelley.Run
+                        Cardano.CLI.Shelley.Run.Address
+                        Cardano.CLI.Shelley.Run.Address.Info
+                        Cardano.CLI.Shelley.Run.Genesis
+                        Cardano.CLI.Shelley.Run.Governance
+                        Cardano.CLI.Shelley.Run.Key
+                        Cardano.CLI.Shelley.Run.Node
+                        Cardano.CLI.Shelley.Run.Pool
+                        Cardano.CLI.Shelley.Run.Pretty
+                        Cardano.CLI.Shelley.Run.Query
+                        Cardano.CLI.Shelley.Run.StakeAddress
+                        Cardano.CLI.Shelley.Run.TextView
+                        Cardano.CLI.Shelley.Run.Transaction
 
-                       Cardano.CLI.Mary.RenderValue
-                       Cardano.CLI.Mary.TxOutParser
-                       Cardano.CLI.Mary.ValueParser
+                        Cardano.CLI.Mary.RenderValue
+                        Cardano.CLI.Mary.TxOutParser
+                        Cardano.CLI.Mary.ValueParser
 
-                       Cardano.CLI.TopHandler
+                        Cardano.CLI.TopHandler
 
-  other-modules:       Paths_cardano_cli
+  other-modules:        Paths_cardano_cli
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0
                       , aeson-pretty      >= 0.8.5
                       , attoparsec
                       , bech32            >= 1.1.0
@@ -111,48 +138,27 @@ library
                       , unordered-containers
                       , vector
 
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-                       OverloadedStrings
-
-  ghc-options:         -Wall
-                       -Wincomplete-record-updates
-                       -Wincomplete-uni-patterns
-                       -Wredundant-constraints
-                       -Wpartial-fields
-                       -Wcompat
-
-  if os(windows)
-     build-depends:    Win32
-  else
-     build-depends:    unix
-
 executable cardano-cli
-  hs-source-dirs:      app
-  main-is:             cardano-cli.hs
-  default-language:    Haskell2010
-  ghc-options:         -threaded
-                       -Wall
-                       -rtsopts
-                       "-with-rtsopts=-T"
-  if !os(windows)
-     build-depends:    unix
+  import:               base, project-config
+                      , maybe-unix
+  hs-source-dirs:       app
+  main-is:              cardano-cli.hs
+  ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , cardano-cli
+  build-depends:        cardano-cli
                       , cardano-crypto-class
                       , cardano-prelude
                       , optparse-applicative
                       , transformers-except
-  default-extensions:  NoImplicitPrelude
 
 test-suite cardano-cli-test
+  import:               base, project-config
+
   hs-source-dirs:       test
   main-is:              cardano-cli-test.hs
   type:                 exitcode-stdio-1.0
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , bech32 >= 1.1.0
+  build-depends:        bech32            >= 1.1.0
                       , bytestring
                       , base16-bytestring
                       , cardano-api
@@ -160,7 +166,6 @@ test-suite cardano-cli-test
                       , cardano-cli
                       , cardano-node
                       , cardano-prelude
-                      , directory
                       , exceptions
                       , hedgehog
                       , hedgehog-extras
@@ -178,24 +183,16 @@ test-suite cardano-cli-test
                         Test.Cli.Pioneers.Exercise6
                         Test.OptParse
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
 test-suite cardano-cli-golden
+  import:               base, project-config
+
   hs-source-dirs:       test
   main-is:              cardano-cli-golden.hs
   type:                 exitcode-stdio-1.0
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0
                       , bytestring
                       , cardano-api
                       , cardano-cli
@@ -265,13 +262,4 @@ test-suite cardano-cli-golden
                         Test.Golden.Version
                         Test.OptParse
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -43,20 +43,20 @@ import           Cardano.Binary (Annotated (..))
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Crypto.Hashing (hashRaw)
 import           Cardano.Crypto.ProtocolMagic (AProtocolMagic (..), ProtocolMagic,
-                     ProtocolMagicId (..))
+                   ProtocolMagicId (..))
 
 import           Cardano.Chain.Common (BlockCount (..), TxFeePolicy (..), TxSizeLinear (..),
-                     decodeAddressBase58, rationalToLovelacePortion)
+                   decodeAddressBase58, rationalToLovelacePortion)
 import qualified Cardano.Chain.Common as Byron
 import           Cardano.Chain.Genesis (FakeAvvmOptions (..), TestnetBalanceOptions (..))
 import           Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
 import           Cardano.Chain.Update (ApplicationName (..), InstallerHash (..), NumSoftwareVersion,
-                     ProtocolVersion (..), SoftforkRule (..), SoftwareVersion (..), SystemTag (..),
-                     checkApplicationName, checkSystemTag)
+                   ProtocolVersion (..), SoftforkRule (..), SoftwareVersion (..), SystemTag (..),
+                   checkApplicationName, checkSystemTag)
 
 import           Cardano.Api hiding (UpdateProposal)
 import           Cardano.Api.Byron (Address (..), ByronProtocolParametersUpdate (..), Lovelace (..),
-                     toByronLovelace)
+                   toByronLovelace)
 
 import           Cardano.CLI.Byron.Commands
 import           Cardano.CLI.Byron.Genesis

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -1,44 +1,46 @@
 cabal-version: 2.4
 
-name:                  cardano-config
-version:               0.1.0.0
-author:                IOHK
-maintainer:            operations@iohk.io
-license:               Apache-2.0
-license-files:
-  LICENSE
-  NOTICE
-build-type:            Simple
-extra-source-files:    README.md
+name:                   cardano-config
+version:                0.1.0.0
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     README.md
 
 flag systemd
   description: Enable systemd support
   default:     True
   manual:      False
 
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
 library
-  hs-source-dirs:      src
+  import:               base, project-config
 
-  if os(linux) && flag(systemd)
-    cpp-options:       -DSYSTEMD
-    build-depends:     lobemo-scribe-systemd
+  hs-source-dirs:       src
 
-  exposed-modules:     Cardano.Config.Git.Rev
-                       Cardano.Config.Git.RevFromGit
+  exposed-modules:      Cardano.Config.Git.Rev
+                        Cardano.Config.Git.RevFromGit
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , cardano-prelude
+  build-depends:        cardano-prelude
                       , file-embed
                       , process
                       , template-haskell
                       , text
-
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-
-  ghc-options:       -Wall
-                     -Wincomplete-record-updates
-                     -Wincomplete-uni-patterns
-                     -Wredundant-constraints
-                     -Wpartial-fields
-                     -Wcompat

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,14 +1,43 @@
 cabal-version: 2.4
 
-name:                  cardano-node-chairman
-version:               1.25.0
-description:           The cardano full node
-author:                IOHK
-maintainer:            operations@iohk.io
-license:               Apache-2.0
-license-files:         LICENSE
-                       NOTICE
-build-type:            Simple
+name:                   cardano-node-chairman
+version:                1.25.0
+description:            The cardano full node
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+common maybe-unix
+  if !os(windows)
+      build-depends:    unix
+
+common maybe-Win32
+  if os(windows)
+     build-depends:     Win32
+
+common maybe-Win32-network
+  if os(windows)
+     build-depends:     Win32-network
 
 common common-modules
   hs-source-dirs:       src
@@ -21,6 +50,10 @@ common common-modules
                         Testnet.Shelley
 
 executable cardano-node-chairman
+  import:               base, project-config
+                      , common-modules
+                      , maybe-unix
+
   hs-source-dirs:       app
   main-is:              cardano-node-chairman.hs
   other-modules:        Cardano.Chairman
@@ -28,22 +61,12 @@ executable cardano-node-chairman
                         Cardano.Chairman.Commands.Version
                         Cardano.Chairman.Commands.Run
                         Paths_cardano_node_chairman
-  default-language:     Haskell2010
   ghc-options:          -threaded
-                        -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
                         -rtsopts
                         "-with-rtsopts=-T"
-                        -Wno-unticked-promoted-constructors
   build-depends:        base              >= 4.12       &&  < 5
                       , aeson             >= 1.5.6.0
-                      , async
                       , bytestring
-                      , call-stack
                       , cardano-api
                       , cardano-config
                       , cardano-ledger-byron
@@ -56,12 +79,7 @@ executable cardano-node-chairman
                       , filepath
                       , hedgehog
                       , hedgehog-extras
-                      , hspec
-                      , HUnit
                       , io-sim-classes
-                      , mmorph
-                      , mtl
-                      , network
                       , network-mux
                       , optparse-applicative
                       , ouroboros-consensus
@@ -71,89 +89,64 @@ executable cardano-node-chairman
                       , process
                       , random
                       , resourcet
-                      , tasty
-                      , tasty-hedgehog
-                      , temporary
                       , text
                       , time
-                      , transformers
-                      , transformers-except
-                      , typed-protocols
-                      , unliftio
                       , unordered-containers
 
-  default-extensions:   NoImplicitPrelude
-
-  if os(windows)
-     build-depends:     Win32
-  else
-     build-depends:     unix
-
 test-suite chairman-tests
-  import:               common-modules
+  import:               base, project-config
+                      , common-modules
+                      , maybe-unix
+
   hs-source-dirs:       test
+
   main-is:              Main.hs
+
   type:                 exitcode-stdio-1.0
-  if !os(windows)
-      build-depends:    unix
 
   build-depends:        base              >= 4.12       &&  < 5
                       , aeson             >= 1.5.6.0
-                      , async
-                      , call-stack
                       , containers
                       , directory
                       , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras
-                      , hspec
-                      , HUnit
-                      , mmorph
-                      , mtl
                       , network
                       , process
                       , random
                       , resourcet
                       , tasty
                       , tasty-hedgehog
-                      , temporary
                       , text
                       , time
-                      , transformers
                       , unliftio
                       , unordered-containers
+
   other-modules:        Spec.Chairman.Chairman
                         Spec.Chairman.Byron
                         Spec.Chairman.ByronShelley
                         Spec.Chairman.Shelley
                         Spec.Network
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
   build-tool-depends:   cardano-node:cardano-node
                       , cardano-cli:cardano-cli
                       , cardano-node-chairman:cardano-node-chairman
 
 executable cardano-testnet
-  import:               common-modules
+  import:               base, project-config
+                      , maybe-unix
+                      , common-modules
+
   hs-source-dirs:       testnet
+
   main-is:              Main.hs
-  if !os(windows)
-      build-depends:    unix
 
   build-depends:        base              >= 4.12       &&  < 5
                       , aeson             >= 1.5.6.0
                       , ansi-terminal
-                      , async
-                      , call-stack
                       , cardano-config
                       , containers
                       , directory
@@ -161,22 +154,15 @@ executable cardano-testnet
                       , filepath
                       , hedgehog
                       , hedgehog-extras
-                      , hspec
-                      , HUnit
-                      , mmorph
-                      , network
                       , optparse-applicative
                       , process
                       , random
                       , resourcet
                       , stm
-                      , tasty
-                      , tasty-hedgehog
-                      , temporary
                       , text
                       , time
-                      , unliftio
                       , unordered-containers
+
   other-modules:        Paths_cardano_node_chairman
                         Testnet.Commands
                         Testnet.Commands.Byron
@@ -184,12 +170,5 @@ executable cardano-testnet
                         Testnet.Commands.Shelley
                         Testnet.Commands.Version
                         Testnet.Run
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,27 +1,62 @@
 cabal-version: 2.4
 
-name:                  cardano-node
-version:               1.25.0
-description:           The cardano full node
-author:                IOHK
-maintainer:            operations@iohk.io
-license:               Apache-2.0
-license-files:
-  LICENSE
-  NOTICE
-build-type:            Simple
-extra-source-files:    ChangeLog.md
+name:                   cardano-node
+version:                1.25.0
+description:            The cardano full node
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     ChangeLog.md
 
 Flag unexpected_thunks
-  Description:   Turn on unexpected thunks checks
-  Default:       False
+  Description:    Turn on unexpected thunks checks
+  Default:        False
 
 flag systemd
-  description: Enable systemd support
-  default:     True
-  manual:      False
+  description:    Enable systemd support
+  default:        True
+  manual:         False
+
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+  -- Pattern match checking has improved since 8.6.5. GHC now considers more
+  -- pattern matches as redundant than before, so disable this warning for older
+  -- versions of GHC that still consider them incomplete.
+  if impl(ghc < 8.10)
+    ghc-options:        -Wno-incomplete-patterns
+
+common maybe-Win32
+  if os(windows)
+    build-depends:      Win32
+
+common maybe-unix
+  if !os(windows)
+    build-depends:      unix
 
 library
+  import:               base, project-config
+                      , maybe-unix
+                      , maybe-Win32
   if flag(unexpected_thunks)
     cpp-options: -DUNEXPECTED_THUNKS
 
@@ -64,16 +99,13 @@ library
                        Cardano.Tracing.OrphanInstances.Network
                        Cardano.Tracing.OrphanInstances.Shelley
 
-
   other-modules:       Paths_cardano_node
                        Cardano.Node.Configuration.Socket
                        Cardano.Tracing.MicroBenchmarking
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0
                       , async
                       , base16-bytestring
-                      , byron-spec-ledger
                       , bytestring
                       , deepseq
                       , cardano-api
@@ -93,7 +125,6 @@ library
                       , ekg-core
                       , filepath
                       , generic-data
-                      , hedgehog-extras
                       , hostname
                       , iproute
                       , io-sim-classes
@@ -117,7 +148,6 @@ library
                       , scientific
                       , shelley-spec-ledger
                       , stm
-                      , strict-concurrency
                       , text
                       , time
                       , tracer-transformers
@@ -126,113 +156,46 @@ library
                       , unordered-containers
                       , yaml
 
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-                       OverloadedStrings
-
-  ghc-options:         -Wall
-                       -Wincomplete-record-updates
-                       -Wincomplete-uni-patterns
-                       -Wredundant-constraints
-                       -Wpartial-fields
-                       -Wcompat
-
-  -- Pattern match checking has improved since 8.6.5. GHC now considers more
-  -- pattern matches as redundant than before, so disable this warning for older
-  -- versions of GHC that still consider them incomplete.
-  if impl(ghc < 8.10)
-    ghc-options:       -Wno-incomplete-patterns
-
-  if os(windows)
-    build-depends:    Win32
-  else
-    build-depends:     unix
-
 executable cardano-node
-  hs-source-dirs:      app
-  main-is:             cardano-node.hs
-  default-language:    Haskell2010
-  ghc-options:         -threaded
-                       -Wall
-                       -Wincomplete-record-updates
-                       -Wincomplete-uni-patterns
-                       -Wredundant-constraints
-                       -Wpartial-fields
-                       -Wcompat
-                       -Wno-unticked-promoted-constructors
-                       -rtsopts
+  import:               base, project-config
+  hs-source-dirs:       app
+  main-is:              cardano-node.hs
+  ghc-options:          -threaded
+                        -rtsopts
   if arch(arm)
-    ghc-options:         "-with-rtsopts=-T -I0 -N1 -A16m"
+    ghc-options:        "-with-rtsopts=-T -I0 -N1 -A16m"
   else
-    ghc-options:         "-with-rtsopts=-T -I0 -N2 -A16m"
+    ghc-options:        "-with-rtsopts=-T -I0 -N2 -A16m"
 
-  other-modules:       Paths_cardano_node
+  other-modules:        Paths_cardano_node
 
-  build-depends:        base              >= 4.12       &&  < 5
-                      , cardano-config
+  build-depends:        cardano-config
                       , cardano-node
                       , cardano-prelude
                       , optparse-applicative
                       , text
 
-  if os(windows)
-     build-depends:    Win32
-  else
-     build-depends:    unix
-
 test-suite cardano-node-test
+  import:               base, project-config
+                      , maybe-unix
   hs-source-dirs:       test
   main-is:              cardano-node-test.hs
   type:                 exitcode-stdio-1.0
 
-  if !os(windows)
-      build-depends:     unix
-
-  build-depends:        base              >= 4.12       &&  < 5
-                      , aeson             >= 1.5.6.0
-                      , async
-                      , bytestring
+  build-depends:        aeson             >= 1.5.6.0
                       , cardano-api
-                      , cardano-config
-                      , cardano-crypto-class
-                      , cardano-crypto-test
-                      , cardano-crypto-wrapper
                       , cardano-node
                       , cardano-prelude
-                      , cardano-prelude-test
                       , cardano-slotting
-                      , containers
-                      , cryptonite
                       , directory
                       , hedgehog
                       , hedgehog-corpus
                       , iproute
-                      , mmorph
-                      , network
-                      , ouroboros-consensus
-                      , ouroboros-consensus-shelley
                       , ouroboros-network
-                      , process
-                      , random
-                      , resourcet
-                      , shelley-spec-ledger
-                      , shelley-spec-ledger-test
-                      , temporary
-                      , time
-                      , unliftio
 
   other-modules:        Test.Cardano.Node.FilePermissions
                         Test.Cardano.Node.Gen
                         Test.Cardano.Node.Json
                         Test.Cardano.Node.POM
 
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-submit-api/CHANGELOG.md
+++ b/cardano-submit-api/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/cardano-submit-api/LICENSE
+++ b/cardano-submit-api/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-submit-api/app/Main.hs
+++ b/cardano-submit-api/app/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
+
+import qualified Options.Applicative as Opt
+
+main :: IO ()
+main = runTxSubmitWebapi =<< Opt.execParser opts

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -1,0 +1,122 @@
+cabal-version: 2.4
+
+name:                   cardano-submit-api
+version:                3.1.2
+synopsis:               A web server that allows transactions to be POSTed to the cardano chain
+description:
+homepage:               https://github.com/input-output-hk/cardano-node
+bug-reports:            https://github.com/input-output-hk/cardano-node/issues
+license:                Apache-2.0
+license-file:           LICENSE
+author:                 IOHK Engineering Team
+maintainer:             operations@iohk.io
+copyright:              (c) 2019-2021 IOHK
+category:               Language
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common cardano-api                  { build-depends: cardano-api                                                  }
+common cardano-submit-api           { build-depends: cardano-submit-api                                           }
+
+common aeson                        { build-depends: aeson                            >= 1.5.5.1                  }
+common async                        { build-depends: async                            >= 2.2.2                    }
+common bytestring                   { build-depends: bytestring                       >= 0.10.8.2                 }
+common cardano-binary               { build-depends: cardano-binary                   >= 1.5.0                    }
+common cardano-crypto-class         { build-depends: cardano-crypto-class             >= 2.0.0                    }
+common cardano-ledger-byron         { build-depends: cardano-ledger-byron             >= 0.1.0.0                  }
+common formatting                   { build-depends: formatting                       >= 6.3.7                    }
+common http-media                   { build-depends: http-media                       >= 0.8.0.0                  }
+common iohk-monitoring              { build-depends: iohk-monitoring                  >= 0.1.10.1                 }
+common mtl                          { build-depends: mtl                              >= 2.2.2                    }
+common network                      { build-depends: network                          >= 3.1.2.1                  }
+common optparse-applicative         { build-depends: optparse-applicative             >= 0.16.1.0                 }
+common ouroboros-consensus-cardano  { build-depends: ouroboros-consensus-cardano      >= 0.1.0.0                  }
+common ouroboros-network            { build-depends: ouroboros-network                >= 0.1.0.0                  }
+common prometheus                   { build-depends: prometheus                       >= 2.2.2                    }
+common protolude                    { build-depends: protolude                        >= 0.3.0                    }
+common servant                      { build-depends: servant                          >= 0.18.2                   }
+common servant-server               { build-depends: servant-server                   >= 0.18.2                   }
+common streaming-commons            { build-depends: streaming-commons                >= 0.2.2.1                  }
+common text                         { build-depends: text                             >= 1.2.3.2                  }
+common transformers-except          { build-depends: transformers-except              >= 0.1.1                    }
+common warp                         { build-depends: warp                             >= 3.3.13                   }
+common yaml                         { build-depends: yaml                             >= 0.11.5.0                 }
+
+common project-config
+  default-language:     Haskell2010
+  
+  ghc-options:          -Wall
+                        -fwarn-incomplete-patterns
+                        -fwarn-redundant-constraints
+                        -Wcompat
+                        -Werror
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-all-missed-specialisations
+                        -Wno-implicit-prelude
+                        -Wno-missing-import-lists
+                        -Wno-safe
+                        -Wno-unsafe
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
+library
+  import:               base, project-config
+                      , aeson
+                      , async
+                      , bytestring
+                      , cardano-api
+                      , cardano-binary
+                      , cardano-crypto-class
+                      , cardano-ledger-byron
+                      , formatting
+                      , http-media
+                      , iohk-monitoring
+                      , mtl
+                      , network
+                      , optparse-applicative
+                      , ouroboros-consensus-cardano
+                      , ouroboros-network
+                      , prometheus
+                      , protolude
+                      , servant
+                      , servant-server
+                      , streaming-commons
+                      , text
+                      , transformers-except
+                      , warp
+                      , yaml
+
+  hs-source-dirs:       src
+
+  exposed-modules:      Cardano.TxSubmit
+
+  other-modules:        Cardano.TxSubmit.CLI.Parsers
+                      , Cardano.TxSubmit.CLI.Types
+                      , Cardano.TxSubmit.Config
+                      , Cardano.TxSubmit.ErrorRender
+                      , Cardano.TxSubmit.Metrics
+                      , Cardano.TxSubmit.Rest.Parsers
+                      , Cardano.TxSubmit.Rest.Types
+                      , Cardano.TxSubmit.Rest.Web
+                      , Cardano.TxSubmit.Tracing.ToObjectOrphans
+                      , Cardano.TxSubmit.Types
+                      , Cardano.TxSubmit.Util
+                      , Cardano.TxSubmit.Web
+
+executable cardano-submit-api
+  import:               base, project-config
+                      , cardano-submit-api
+                      , optparse-applicative
+  main-is:              Main.hs
+  hs-source-dirs:       app
+  ghc-options:          -threaded -rtsopts "-with-rtsopts=-T -I0"
+
+test-suite unit
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  main-is:              test.hs
+  hs-source-dirs:       test

--- a/cardano-submit-api/config/tx-submit-mainnet-config.yaml
+++ b/cardano-submit-api/config/tx-submit-mainnet-config.yaml
@@ -1,0 +1,100 @@
+# Tx Submission Server Configuration
+
+EnableLogMetrics: False
+EnableLogging: True
+
+# ------------------------------------------------------------------------------
+# Logging configuration follows.
+
+# global filter; messages must have at least this severity to pass:
+minSeverity: Info
+
+# global file rotation settings:
+rotation:
+  rpLogLimitBytes: 5000000
+  rpKeepFilesNum:  10
+  rpMaxAgeHours:   24
+
+# these backends are initialized:
+setupBackends:
+  - AggregationBK
+  - KatipBK
+  # - EditorBK
+  # - EKGViewBK
+
+# if not indicated otherwise, then messages are passed to these backends:
+defaultBackends:
+  - KatipBK
+
+# if wanted, the GUI is listening on this port:
+# hasGUI: 12787
+
+# if wanted, the EKG interface is listening on this port:
+# hasEKG: 12788
+
+# here we set up outputs of logging in 'katip':
+setupScribes:
+  - scKind: StdoutSK
+    scName: stdout
+    scFormat: ScText
+    scRotation: null
+
+# if not indicated otherwise, then log output is directed to this:
+defaultScribes:
+  - - StdoutSK
+    - stdout
+
+# more options which can be passed as key-value pairs:
+options:
+  cfokey:
+    value: "Release-1.0.0"
+  mapSubtrace:
+    benchmark:
+      contents:
+        - GhcRtsStats
+        - MonotonicClock
+      subtrace: ObservableTrace
+    '#ekgview':
+      contents:
+      - - tag: Contains
+          contents: 'cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: .monoclock.basic.
+      - - tag: Contains
+          contents: 'cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: diff.RTS.cpuNs.timed.
+      - - tag: StartsWith
+          contents: '#ekgview.#aggregation.cardano.epoch-validation.benchmark'
+        - - tag: Contains
+            contents: diff.RTS.gcNum.timed.
+      subtrace: FilterTrace
+    'cardano.epoch-validation.utxo-stats':
+      # Change the `subtrace` value to `Neutral` in order to log
+      # `UTxO`-related messages during epoch validation.
+      subtrace: NoTrace
+    '#messagecounters.aggregation':
+      subtrace: NoTrace
+    '#messagecounters.ekgview':
+      subtrace: NoTrace
+    '#messagecounters.switchboard':
+      subtrace: NoTrace
+    '#messagecounters.katip':
+      subtrace: NoTrace
+    '#messagecounters.monitoring':
+      subtrace: NoTrace
+    'cardano.#messagecounters.aggregation':
+      subtrace: NoTrace
+    'cardano.#messagecounters.ekgview':
+      subtrace: NoTrace
+    'cardano.#messagecounters.switchboard':
+      subtrace: NoTrace
+    'cardano.#messagecounters.katip':
+      subtrace: NoTrace
+    'cardano.#messagecounters.monitoring':
+      subtrace: NoTrace
+  mapBackends:
+    cardano.epoch-validation.benchmark:
+      - AggregationBK
+    '#aggregation.cardano.epoch-validation.benchmark':
+      - EKGViewBK

--- a/cardano-submit-api/src/Cardano/TxSubmit.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit
+  ( runTxSubmitWebapi
+  , opts
+  ) where
+
+import           Cardano.BM.Trace (Trace, logInfo)
+import           Cardano.TxSubmit.CLI.Parsers (opts)
+import           Cardano.TxSubmit.CLI.Types (ConfigFile (unConfigFile), TxSubmitNodeParams (..))
+import           Cardano.TxSubmit.Config (GenTxSubmitNodeConfig (..), ToggleLogging (..),
+                   TxSubmitNodeConfig, readTxSubmitNodeConfig)
+import           Cardano.TxSubmit.Metrics (registerMetricsServer)
+import           Cardano.TxSubmit.Web (runTxSubmitServer)
+import           Control.Applicative (Applicative (..))
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (liftIO))
+import           Data.Either (Either (..))
+import           Data.Function (($))
+import           Data.Text (Text)
+import           System.IO (IO)
+
+import qualified Cardano.BM.Setup as Logging
+import qualified Cardano.BM.Trace as Logging
+import qualified Control.Concurrent.Async as Async
+
+runTxSubmitWebapi :: TxSubmitNodeParams -> IO ()
+runTxSubmitWebapi tsnp = do
+    tsnc <- readTxSubmitNodeConfig (unConfigFile $ tspConfigFile tsnp)
+    trce <- mkTracer tsnc
+    (metrics, metricsServer) <- registerMetricsServer
+    txSubmitServer <- Async.async $
+      runTxSubmitServer trce metrics tspWebserverConfig tspProtocol tspNetworkId tspSocketPath
+    void $ Async.waitAnyCancel
+      [ txSubmitServer
+      , metricsServer
+      ]
+    logInfo trce "runTxSubmitWebapi: Async.waitAnyCancel returned"
+  where
+    TxSubmitNodeParams
+      { tspProtocol
+      , tspNetworkId
+      , tspSocketPath
+      , tspWebserverConfig
+      } = tsnp
+
+mkTracer :: TxSubmitNodeConfig -> IO (Trace IO Text)
+mkTracer enc = case tscToggleLogging enc of
+  LoggingOn -> liftIO $ Logging.setupTrace (Right $ tscLoggingConfig enc) "cardano-tx-submit"
+  LoggingOff -> pure Logging.nullTracer

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.CLI.Parsers
+  ( opts
+  , pTxSubmitNodeParams
+  , pConfigFile
+  , pNetworkId
+  , pProtocol
+  , pSocketPath
+  ) where
+
+import           Cardano.Api (AnyConsensusModeParams (..), ConsensusModeParams (..),
+                   EpochSlots (..), NetworkId (..), NetworkMagic (..))
+import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), SocketPath (..),
+                   TxSubmitNodeParams (..))
+import           Cardano.TxSubmit.Rest.Parsers (pWebserverConfig)
+import           Control.Applicative (Alternative (..), Applicative (..), (<**>))
+import           Data.Function ((.))
+import           Data.Functor (Functor (fmap), (<$>))
+import           Data.Semigroup (Semigroup ((<>)))
+import           Data.Word (Word64)
+import           Options.Applicative (Parser, ParserInfo)
+
+import qualified Options.Applicative as Opt
+
+opts :: ParserInfo TxSubmitNodeParams
+opts = Opt.info (pTxSubmitNodeParams <**> Opt.helper)
+  (   Opt.fullDesc
+  <>  Opt.progDesc "Cardano transaction submission web API."
+  )
+
+pTxSubmitNodeParams :: Parser TxSubmitNodeParams
+pTxSubmitNodeParams = TxSubmitNodeParams
+  <$> pConfigFile
+  <*> pProtocol
+  <*> pNetworkId
+  <*> pSocketPath
+  <*> pWebserverConfig 8090
+
+pConfigFile :: Parser ConfigFile
+pConfigFile = ConfigFile <$> Opt.strOption
+  (   Opt.long "config"
+  <>  Opt.help "Path to the tx-submit web API configuration file"
+  <>  Opt.completer (Opt.bashCompleter "file")
+  <>  Opt.metavar "FILEPATH"
+  )
+
+-- TODO: This was ripped from `cardano-cli` because, unfortunately, it's not
+-- exported. Once we export this parser from the appropriate module and update
+-- our `cardano-cli` dependency, we should remove this and import the parser
+-- from there.
+pNetworkId :: Parser NetworkId
+pNetworkId = pMainnet <|> fmap Testnet pTestnetMagic
+  where
+    pMainnet :: Parser NetworkId
+    pMainnet = Opt.flag' Mainnet
+      (   Opt.long "mainnet"
+      <>  Opt.help "Use the mainnet magic id."
+      )
+
+    pTestnetMagic :: Parser NetworkMagic
+    pTestnetMagic = NetworkMagic <$> Opt.option Opt.auto
+      (   Opt.long "testnet-magic"
+      <>  Opt.metavar "NATURAL"
+      <>  Opt.help "Specify a testnet magic id."
+      )
+
+
+-- TODO: This was ripped from `cardano-cli` because, unfortunately, it's not
+-- exported. Once we export this parser from the appropriate module and update
+-- our `cardano-cli` dependency, we should remove this and import the parser
+-- from there.
+pProtocol :: Parser AnyConsensusModeParams
+pProtocol =
+      ( Opt.flag' ()
+        (   Opt.long "shelley-mode"
+        <>  Opt.help "For talking to a node running in Shelley-only mode."
+        )
+        *> pShelley
+      )
+  <|> ( Opt.flag' ()
+        (   Opt.long "byron-mode"
+        <>  Opt.help "For talking to a node running in Byron-only mode."
+        )
+        *> pByron
+      )
+  <|> ( Opt.flag' ()
+        (   Opt.long "cardano-mode"
+        <>  Opt.help "For talking to a node running in full Cardano mode (default)."
+        )
+        *> pCardano
+      )
+  <|> -- Default to the Cardano protocol.
+      pure (AnyConsensusModeParams (CardanoModeParams (EpochSlots defaultByronEpochSlots)))
+  where
+    pByron :: Parser AnyConsensusModeParams
+    pByron = AnyConsensusModeParams . ByronModeParams <$> pEpochSlots
+
+    pShelley :: Parser AnyConsensusModeParams
+    pShelley = pure (AnyConsensusModeParams ShelleyModeParams)
+
+    pCardano :: Parser AnyConsensusModeParams
+    pCardano = AnyConsensusModeParams . CardanoModeParams <$> pEpochSlots
+
+    pEpochSlots :: Parser EpochSlots
+    pEpochSlots = EpochSlots <$> Opt.option Opt.auto
+      (   Opt.long "epoch-slots"
+      <>  Opt.metavar "NATURAL"
+      <>  Opt.help "The number of slots per epoch for the Byron era."
+      <>  Opt.value defaultByronEpochSlots -- Default to the mainnet value.
+      <>  Opt.showDefault
+      )
+
+    defaultByronEpochSlots :: Word64
+    defaultByronEpochSlots = 21600
+
+pSocketPath :: Parser SocketPath
+pSocketPath = SocketPath <$> Opt.strOption
+  (   Opt.long "socket-path"
+  <>  Opt.help "Path to a cardano-node socket"
+  <>  Opt.completer (Opt.bashCompleter "file")
+  <>  Opt.metavar "FILEPATH"
+  )

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
@@ -1,0 +1,30 @@
+module Cardano.TxSubmit.CLI.Types
+  ( ConfigFile (..)
+  , GenesisFile (..)
+  , SocketPath (..)
+  , TxSubmitNodeParams (..)
+  ) where
+
+import           Cardano.Api (AnyConsensusModeParams, NetworkId (..))
+import           Cardano.TxSubmit.Rest.Types (WebserverConfig)
+
+-- | The product type of all command line arguments
+data TxSubmitNodeParams = TxSubmitNodeParams
+  { tspConfigFile :: !ConfigFile
+  , tspProtocol :: !AnyConsensusModeParams
+  , tspNetworkId :: !NetworkId
+  , tspSocketPath :: !SocketPath
+  , tspWebserverConfig :: !WebserverConfig
+  }
+
+newtype ConfigFile = ConfigFile
+  { unConfigFile :: FilePath
+  }
+
+newtype GenesisFile = GenesisFile
+  { unGenesisFile :: FilePath
+  }
+
+newtype SocketPath = SocketPath
+  { unSocketPath :: FilePath
+  }

--- a/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.TxSubmit.Config
+  ( TxSubmitNodeConfig
+  , GenTxSubmitNodeConfig (..)
+  , readTxSubmitNodeConfig
+  , ToggleLogging(..)
+  , ToggleMetrics(..)
+  ) where
+
+
+import           Cardano.TxSubmit.Util (textShow)
+import           Control.Applicative (Applicative (pure, (<*>)))
+import           Control.Exception (IOException, catch)
+import           Data.Aeson (FromJSON (..), Object, Value (..), (.:))
+import           Data.Aeson.Types (Parser)
+import           Data.Bool (bool)
+import           Data.ByteString (ByteString)
+import           Data.Either (Either (Left, Right))
+import           Data.Eq (Eq)
+import           Data.Function (($))
+import           Data.Functor (Functor (..), (<$>))
+import           Data.Semigroup (Semigroup ((<>)))
+import           Protolude.Panic (panic)
+import           System.IO (FilePath, IO)
+import           Text.Show (Show)
+
+import qualified Cardano.BM.Configuration as Logging
+import qualified Cardano.BM.Configuration.Model as Logging
+import qualified Cardano.BM.Data.Configuration as Logging
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+
+type TxSubmitNodeConfig = GenTxSubmitNodeConfig Logging.Configuration
+
+data ToggleLogging = LoggingOn | LoggingOff deriving (Eq, Show)
+data ToggleMetrics = MetricsOn | MetricsOff deriving (Eq, Show)
+
+data GenTxSubmitNodeConfig a = GenTxSubmitNodeConfig
+  { tscLoggingConfig :: !a
+  , tscToggleLogging :: !ToggleLogging
+  , tscToggleMetrics :: !ToggleMetrics
+  }
+
+readTxSubmitNodeConfig :: FilePath -> IO TxSubmitNodeConfig
+readTxSubmitNodeConfig fp = do
+    res <- Yaml.decodeEither' <$> readLoggingConfig
+    case res of
+      Left err -> panic $ "readTxSubmitNodeConfig: Error parsing config: " <> textShow err
+      Right icr -> convertLogging icr
+  where
+    readLoggingConfig :: IO ByteString
+    readLoggingConfig =
+      catch (B8.readFile fp) $ \(_ :: IOException) ->
+        panic $ "Cannot find the logging configuration file at : " <> T.pack fp
+
+convertLogging :: GenTxSubmitNodeConfig Logging.Representation -> IO TxSubmitNodeConfig
+convertLogging tsc = do
+  lc <- Logging.setupFromRepresentation $ tscLoggingConfig tsc
+  pure $ tsc { tscLoggingConfig = lc }
+
+---------------------------------------------------------------------------------------------------
+
+instance FromJSON (GenTxSubmitNodeConfig Logging.Representation) where
+  parseJSON o = Aeson.withObject "top-level" parseGenTxSubmitNodeConfig o
+
+parseGenTxSubmitNodeConfig :: Object -> Parser (GenTxSubmitNodeConfig Logging.Representation)
+parseGenTxSubmitNodeConfig o = GenTxSubmitNodeConfig
+    <$> parseJSON (Object o)
+    <*> fmap (bool LoggingOff LoggingOn) (o .: "EnableLogging")
+    <*> fmap (bool MetricsOff MetricsOn) (o .: "EnableLogMetrics")

--- a/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.ErrorRender
+  ( renderApplyMempoolPayloadErr
+  , renderEraMismatch
+  ) where
+
+-- This file contains error renders. They should have been defined at a lower level, with the error
+-- type definitions, but for some reason have not been.
+-- They will be defined here for now and then moved where they are supposed to be once they
+-- are working.
+
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
+import           Cardano.Chain.UTxO.UTxO (UTxOError (..))
+import           Cardano.Chain.UTxO.Validation (TxValidationError (..), UTxOValidationError (..))
+import           Data.Text (Text)
+import           Formatting (build, sformat, stext, (%))
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+
+import qualified Data.Text as T
+
+renderApplyMempoolPayloadErr :: ApplyMempoolPayloadErr -> Text
+renderApplyMempoolPayloadErr err =
+    case err of
+      MempoolTxErr ve -> renderValidationError ve
+      MempoolDlgErr {} -> "Delegation error"
+      MempoolUpdateProposalErr {} -> "Update proposal error"
+      MempoolUpdateVoteErr {} -> "Update vote error"
+
+renderValidationError :: UTxOValidationError -> Text
+renderValidationError ve =
+  case ve of
+    UTxOValidationTxValidationError tve -> renderTxValidationError tve
+    UTxOValidationUTxOError ue -> renderUTxOError ue
+
+renderTxValidationError :: TxValidationError -> Text
+renderTxValidationError tve =
+  "Tx Validation: " <>
+    case tve of
+      TxValidationLovelaceError txt e ->
+        sformat ("Lovelace error "% stext %": "% build) txt e
+      TxValidationFeeTooSmall tx expected actual ->
+        sformat ("Tx "% build %" fee "% build %"too low, expected "% build) tx actual expected
+      TxValidationWitnessWrongSignature wit pmid sig ->
+        sformat ("Bad witness "% build %" for signature "% stext %" protocol magic id "% stext) wit (textShow sig) (textShow pmid)
+      TxValidationWitnessWrongKey wit addr ->
+        sformat ("Bad witness "% build %" for address "% build) wit addr
+      TxValidationMissingInput tx ->
+        sformat ("Validation cannot find input tx "% build) tx
+      -- Fields are <expected> <actual>
+      TxValidationNetworkMagicMismatch expected actual ->
+        mconcat [ "Bad network magic  ", textShow actual, ", expected ", textShow expected ]
+      TxValidationTxTooLarge expected actual ->
+        mconcat [ "Tx is ", textShow actual, " bytes, but expected < ", textShow expected, " bytes" ]
+      TxValidationUnknownAddressAttributes ->
+        "Unknown address attributes"
+      TxValidationUnknownAttributes ->
+        "Unknown attributes"
+
+renderUTxOError :: UTxOError -> Text
+renderUTxOError ue =
+  "UTxOError: " <>
+    case ue of
+      UTxOMissingInput tx -> sformat ("Lookup of tx "% build %" failed") tx
+      UTxOOverlappingUnion -> "Union or two overlapping UTxO sets"
+
+renderEraMismatch :: EraMismatch -> Text
+renderEraMismatch EraMismatch{ledgerEraName, otherEraName} =
+  "The era of the node and the tx do not match. " <>
+  "The node is running in the " <> ledgerEraName <>
+  " era, but the transaction is for the " <> otherEraName <> " era."
+
+textShow :: Show a => a -> Text
+textShow = T.pack . show

--- a/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.Metrics
+  ( TxSubmitMetrics(..)
+  , makeMetrics
+  , registerMetricsServer
+  ) where
+
+import           Control.Applicative (Applicative (pure), (<$>))
+import           Control.Concurrent.Async (Async, async)
+import           Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
+import           Data.Function (($), (.))
+import           Data.Monoid (Monoid (mempty))
+import           System.IO (IO)
+import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..), registerGauge,
+                   runRegistryT, unRegistryT)
+import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)
+import           System.Metrics.Prometheus.Metric.Gauge (Gauge)
+
+newtype TxSubmitMetrics = TxSubmitMetrics
+  { tsmCount :: Gauge
+  }
+
+registerMetricsServer :: IO (TxSubmitMetrics, Async ())
+registerMetricsServer =
+  runRegistryT $ do
+    metrics <- makeMetrics
+    registry <- RegistryT ask
+    server <- liftIO . async $ runReaderT (unRegistryT $ serveMetricsT 8081 []) registry
+    pure (metrics, server)
+
+makeMetrics :: RegistryT IO TxSubmitMetrics
+makeMetrics = TxSubmitMetrics <$> registerGauge "tx_submit_count" mempty

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.Rest.Parsers
+  ( pWebserverConfig
+  ) where
+
+import           Cardano.TxSubmit.Rest.Types (WebserverConfig (..))
+import           Data.String (fromString)
+import           Network.Wai.Handler.Warp (HostPreference, Port)
+import           Options.Applicative (Parser, auto, help, long, metavar, option, showDefault,
+                   strOption, value)
+
+pWebserverConfig :: Port -> Parser WebserverConfig
+pWebserverConfig defaultPort = do
+  wcHost <- pHostPreferenceOption
+  wcPort <- pPortOption defaultPort
+  pure WebserverConfig
+    { wcHost
+    , wcPort
+    }
+
+pHostPreferenceOption :: Parser HostPreference
+pHostPreferenceOption = fromString <$>
+  strOption
+    (  long "listen-address"
+    <> metavar "HOST"
+    <> help
+        (   "Specification of which host to the bind API server to. "
+        <>  "Can be an IPv[46] address, hostname, or '*'."
+        )
+    <> value "127.0.0.1" <> showDefault)
+
+pPortOption :: Port -> Parser Port
+pPortOption defaultPort = option auto $ long "port"
+  <> metavar "INT"
+  <> help "Port used for the API server."
+  <> value defaultPort
+  <> showDefault

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE StrictData #-}
+
+module Cardano.TxSubmit.Rest.Types
+  ( WebserverConfig(..)
+  , toWarpSettings
+  ) where
+
+import           Data.Function ((&))
+
+import qualified Network.Wai.Handler.Warp as Warp
+
+------------------------------------------------------------
+data WebserverConfig = WebserverConfig
+  { wcHost :: Warp.HostPreference
+  , wcPort :: Warp.Port
+  }
+
+instance Show WebserverConfig where
+  show WebserverConfig {wcHost, wcPort} = show wcHost <> ":" <> show wcPort
+
+toWarpSettings :: WebserverConfig -> Warp.Settings
+toWarpSettings WebserverConfig {wcHost, wcPort} =
+  Warp.defaultSettings & Warp.setHost wcHost & Warp.setPort wcPort

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.Rest.Web
+  ( runSettings
+  ) where
+
+import           Cardano.BM.Trace (Trace, logInfo)
+import           Control.Exception (bracket)
+import           Data.Streaming.Network (bindPortTCP)
+import           Data.Text (Text)
+import           Network.Socket (close, getSocketName, withSocketsDo)
+import           Network.Wai.Handler.Warp (Settings, getHost, getPort, runSettingsSocket)
+import           Servant (Application)
+
+import qualified Data.Text as T
+
+-- | Like 'Network.Wai.Handler.Warp.runSettings', except with better logging.
+runSettings :: Trace IO Text -> Settings -> Application -> IO ()
+runSettings trace settings app = withSocketsDo $ bracket
+  (bindPortTCP (getPort settings) (getHost settings))
+  close
+  (\socket -> do
+    addr <- getSocketName socket
+    logInfo trace $ "Running server on " <> T.pack (show addr)
+    runSettingsSocket settings socket app)

--- a/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+
+module Cardano.TxSubmit.Tracing.ToObjectOrphans () where
+
+import           Cardano.BM.Data.Severity (Severity (Debug, Error, Notice, Warning))
+import           Cardano.BM.Data.Tracer (HasPrivacyAnnotation, HasSeverityAnnotation (..),
+                   HasTextFormatter, ToObject (toObject), Transformable (..), mkObject,
+                   trStructured)
+import           Data.Aeson ((.=))
+import           Data.Text (Text)
+import           Ouroboros.Network.NodeToClient (ErrorPolicyTrace (..), WithAddr (..))
+
+import qualified Network.Socket as Socket
+
+instance HasPrivacyAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace)
+instance HasSeverityAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  getSeverityAnnotation (WithAddr _ ev) = case ev of
+    ErrorPolicySuspendPeer {} -> Warning -- peer misbehaved
+    ErrorPolicySuspendConsumer {} -> Notice -- peer temporarily not useful
+    ErrorPolicyLocalNodeError {} -> Error
+    ErrorPolicyResumePeer {} -> Debug
+    ErrorPolicyKeepSuspended {} -> Debug
+    ErrorPolicyResumeConsumer {} -> Debug
+    ErrorPolicyResumeProducer {} -> Debug
+    ErrorPolicyUnhandledApplicationException {} -> Error
+    ErrorPolicyUnhandledConnectionException {} -> Error
+    ErrorPolicyAcceptException {} -> Error
+
+instance HasTextFormatter (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+
+-- transform @ErrorPolicyTrace@
+instance Transformable Text IO (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  trTransformer verb tr = trStructured verb tr
+
+instance ToObject (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+  toObject _verb (WithAddr addr ev) =
+    mkObject [ "kind" .= ("ErrorPolicyTrace" :: String)
+             , "address" .= show addr
+             , "event" .= show ev ]

--- a/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+module Cardano.TxSubmit.Types
+  ( TxSubmitApi
+  , TxSubmitApiRecord (..)
+  , TxSubmitWebApiError (..)
+  , TxSubmitPort (..)
+  , EnvSocketError(..)
+  , TxCmdError(..)
+  , renderTxSubmitWebApiError
+  , renderTxCmdError
+  ) where
+
+import           Cardano.Api (AnyCardanoEra, AnyConsensusMode (..), TextEnvelopeError, TxId)
+import           Cardano.Binary (DecoderError)
+import           Cardano.TxSubmit.Util (textShow)
+import           Data.Aeson (ToJSON (..), Value (..))
+import           Data.ByteString.Char8 (ByteString)
+import           Data.Text (Text)
+import           Formatting (build, sformat)
+import           GHC.Generics (Generic)
+import           Network.HTTP.Media ((//))
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import           Servant (Accept (..), JSON, MimeRender (..), MimeUnrender (..), PostAccepted,
+                   ReqBody, (:>))
+import           Servant.API.Generic (ToServantApi, (:-))
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
+
+newtype TxSubmitPort = TxSubmitPort Int
+
+-- | An error that can occur in the transaction submission web API.
+data TxSubmitWebApiError
+  = TxSubmitDecodeHex
+  | TxSubmitEmpty
+  | TxSubmitDecodeFail !DecoderError
+  | TxSubmitBadTx !Text
+  | TxSubmitFail TxCmdError
+
+newtype EnvSocketError = CliEnvVarLookup Text deriving (Eq, Show)
+
+data TxCmdError
+  = TxCmdSocketEnvError EnvSocketError
+  | TxCmdEraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
+  | TxCmdTxReadError !TextEnvelopeError
+  | TxCmdTxSubmitError !Text
+  | TxCmdTxSubmitErrorEraMismatch !EraMismatch
+
+instance ToJSON TxSubmitWebApiError where
+  toJSON = convertJson
+
+convertJson :: TxSubmitWebApiError -> Value
+convertJson = String . renderTxSubmitWebApiError
+
+renderTxCmdError :: TxCmdError -> Text
+renderTxCmdError (TxCmdSocketEnvError socketError) = "socket env error " <> textShow socketError
+renderTxCmdError (TxCmdEraConsensusModeMismatch mode era) = "era consensus mode mismatch" <> textShow mode <> " " <> textShow era
+renderTxCmdError (TxCmdTxReadError envelopeError) = "transaction read error " <> textShow envelopeError
+renderTxCmdError (TxCmdTxSubmitError msg) = "transaction submit error " <> msg
+renderTxCmdError (TxCmdTxSubmitErrorEraMismatch eraMismatch) = "transaction submit era mismatch" <> textShow eraMismatch
+
+renderTxSubmitWebApiError :: TxSubmitWebApiError -> Text
+renderTxSubmitWebApiError st =
+  case st of
+    TxSubmitDecodeHex -> "Provided data was hex encoded and this webapi expects raw binary"
+    TxSubmitEmpty -> "Provided transaction has zero length"
+    TxSubmitDecodeFail err -> sformat build err
+    TxSubmitBadTx tt -> mconcat ["Transactions of type '", tt, "' not supported"]
+    TxSubmitFail err -> renderTxCmdError err
+
+-- | Servant API which provides access to tx submission webapi
+type TxSubmitApi = "api" :> ToServantApi TxSubmitApiRecord
+
+-- | A servant-generic record with all the methods of the API
+newtype TxSubmitApiRecord route = TxSubmitApiRecord
+  { _txSubmitPost :: route
+        :- "submit"
+        :> "tx"
+        :> ReqBody '[CBORStream] ByteString
+        :> PostAccepted '[JSON] TxId
+  } deriving (Generic)
+
+data CBORStream
+
+instance Accept CBORStream where
+  contentType _ = "application" // "cbor"
+
+instance MimeRender CBORStream ByteString where
+    mimeRender _ = LBS.fromStrict
+
+instance MimeRender CBORStream LBS.ByteString where
+    mimeRender _ = id
+
+instance MimeUnrender CBORStream ByteString where
+    mimeUnrender _ = Right . LBS.toStrict
+
+instance MimeUnrender CBORStream LBS.ByteString where
+    mimeUnrender _ = Right

--- a/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.TxSubmit.Util
+  ( logException
+  , textShow
+  ) where
+
+import           Cardano.BM.Trace (Trace, logError)
+import           Control.Exception (SomeException, catch, throwIO)
+import           Data.Function (($), (.))
+import           Data.Semigroup (Semigroup ((<>)))
+import           Data.Text (Text)
+import           System.IO (IO)
+import           Text.Show (Show (..))
+
+import qualified Data.Text as T
+
+-- | ouroboros-network catches 'SomeException' and if a 'nullTracer' is passed into that
+-- code, the caught exception will not be logged. Therefore wrap all tx submission code that
+-- is called from network with an exception logger so at least the exception will be
+-- logged (instead of silently swallowed) and then rethrown.
+logException :: Trace IO Text -> Text -> IO a -> IO a
+logException tracer txt action = action `catch` logger
+  where
+    logger :: SomeException -> IO a
+    logger e = do
+      logError tracer $ txt <> textShow e
+      throwIO e
+
+textShow :: Show a => a -> Text
+textShow = T.pack . show

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+
+module Cardano.TxSubmit.Web
+  ( runTxSubmitServer
+  ) where
+
+import           Cardano.Api (AllegraEra, AnyCardanoEra (AnyCardanoEra),
+                   AnyConsensusMode (AnyConsensusMode), AnyConsensusModeParams (..),
+                   AsType (AsAllegraEra, AsByronEra, AsMaryEra, AsShelleyEra, AsTx), ByronEra,
+                   CardanoEra (AllegraEra, ByronEra, MaryEra, ShelleyEra), FromSomeType (..),
+                   HasTextEnvelope, HasTypeProxy (AsType), InAnyCardanoEra (..),
+                   LocalNodeConnectInfo (LocalNodeConnectInfo, localConsensusModeParams, localNodeNetworkId, localNodeSocketPath),
+                   MaryEra, NetworkId, ShelleyEra, TextEnvelopeError (TextEnvelopeAesonDecodeError),
+                   ToJSON, Tx, TxId (..), TxInMode (TxInMode),
+                   TxValidationErrorInMode (TxValidationEraMismatch, TxValidationErrorInMode),
+                   consensusModeOnly, deserialiseFromTextEnvelopeAnyOf, getTxBody, getTxId,
+                   submitTxToNodeLocal, toEraInMode)
+import           Cardano.BM.Trace (Trace, logInfo)
+import           Cardano.Binary (DecoderError)
+import           Cardano.TxSubmit.CLI.Types (SocketPath (SocketPath))
+import           Cardano.TxSubmit.Metrics (TxSubmitMetrics (..))
+import           Cardano.TxSubmit.Rest.Types (WebserverConfig (..), toWarpSettings)
+import           Cardano.TxSubmit.Types (EnvSocketError (..),
+                   TxCmdError (TxCmdEraConsensusModeMismatch, TxCmdTxReadError, TxCmdTxSubmitError, TxCmdTxSubmitErrorEraMismatch),
+                   TxSubmitApi, TxSubmitApiRecord (..), TxSubmitWebApiError (TxSubmitFail),
+                   renderTxCmdError)
+import           Cardano.TxSubmit.Util (logException)
+import           Control.Monad.Except (ExceptT, MonadError (throwError), MonadIO (liftIO),
+                   runExceptT)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
+                   hoistMaybe, left, newExceptT)
+import           Data.Aeson (ToJSON (..))
+import           Data.Bifunctor (first)
+import           Data.ByteString.Char8 (ByteString)
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import           Servant (Application, Handler, ServerError (..), err400, throwError)
+import           Servant.API.Generic (toServant)
+import           Servant.Server.Generic (AsServerT)
+import           System.Environment (lookupEnv)
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.TxSubmit.Rest.Web as Web
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Char as Char
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as T
+import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
+import qualified Servant
+import qualified System.IO as IO
+import qualified System.Metrics.Prometheus.Metric.Gauge as Gauge
+
+runTxSubmitServer
+  :: Trace IO Text
+  -> TxSubmitMetrics
+  -> WebserverConfig
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> SocketPath
+  -> IO ()
+runTxSubmitServer trace metrics webserverConfig protocol networkId socketPath = do
+  logException trace "tx-submit-webapi." $
+    Web.runSettings trace (toWarpSettings webserverConfig) $ txSubmitApp trace metrics protocol networkId socketPath
+  logInfo trace "txSubmitApp: exiting"
+
+txSubmitApp
+  :: Trace IO Text
+  -> TxSubmitMetrics
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> SocketPath
+  -> Application
+txSubmitApp trace metrics connectInfo networkId socketPath =
+    Servant.serve (Proxy :: Proxy TxSubmitApi) (toServant handlers)
+  where
+    handlers :: TxSubmitApiRecord (AsServerT Handler)
+    handlers = TxSubmitApiRecord
+      { _txSubmitPost = txSubmitPost trace metrics connectInfo networkId socketPath
+      }
+
+-- | Read the node socket path from the environment.
+-- Fails if the environment variable is not set.
+readEnvSocketPath :: ExceptT EnvSocketError IO SocketPath
+readEnvSocketPath =
+    maybe (left $ CliEnvVarLookup (T.pack envName)) (pure . SocketPath)
+      =<< liftIO (lookupEnv envName)
+  where
+    envName :: String
+    envName = "CARDANO_NODE_SOCKET_PATH"
+
+readByteStringTextEnvelopeAnyOf2
+  :: [FromSomeType HasTextEnvelope b]
+  -> ByteString
+  -> ExceptT TextEnvelopeError IO b
+readByteStringTextEnvelopeAnyOf2 types content = hoistEither $ do
+  te <- first TextEnvelopeAesonDecodeError $ Aeson.eitherDecodeStrict' content
+  deserialiseFromTextEnvelopeAnyOf types te
+
+readByteStringInAnyCardanoEra
+  :: ( HasTextEnvelope (thing ByronEra)
+     , HasTextEnvelope (thing ShelleyEra)
+     , HasTextEnvelope (thing AllegraEra)
+     , HasTextEnvelope (thing MaryEra)
+     )
+  => (forall era. AsType era -> AsType (thing era))
+  -> ByteString
+  -> ExceptT TextEnvelopeError IO (InAnyCardanoEra thing)
+readByteStringInAnyCardanoEra asThing = readByteStringTextEnvelopeAnyOf2
+  [ FromSomeType (asThing AsByronEra)   (InAnyCardanoEra ByronEra)
+  , FromSomeType (asThing AsShelleyEra) (InAnyCardanoEra ShelleyEra)
+  , FromSomeType (asThing AsAllegraEra) (InAnyCardanoEra AllegraEra)
+  , FromSomeType (asThing AsMaryEra)    (InAnyCardanoEra MaryEra)
+  ]
+
+readByteStringTx :: ByteString -> ExceptT TxCmdError IO (InAnyCardanoEra Tx)
+readByteStringTx bs = firstExceptT TxCmdTxReadError $ readByteStringInAnyCardanoEra AsTx bs
+
+txSubmitPost
+  :: Trace IO Text
+  -> TxSubmitMetrics
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> SocketPath
+  -> ByteString
+  -> Handler TxId
+txSubmitPost trace metrics (AnyConsensusModeParams cModeParams) networkId (SocketPath socketPath) txBytes = handle $ do
+    InAnyCardanoEra era tx <- readByteStringTx txBytes
+    let cMode = AnyConsensusMode $ consensusModeOnly cModeParams
+    eraInMode <- hoistMaybe
+                   (TxCmdEraConsensusModeMismatch cMode (AnyCardanoEra era))
+                   (toEraInMode era $ consensusModeOnly cModeParams)
+    let txInMode = TxInMode tx eraInMode
+        localNodeConnInfo = LocalNodeConnectInfo
+                              { localConsensusModeParams = cModeParams
+                              , localNodeNetworkId = networkId
+                              , localNodeSocketPath = socketPath
+                              }
+
+    res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
+    case res of
+      Net.Tx.SubmitSuccess -> do
+        liftIO $ T.putStrLn "Transaction successfully submitted."
+        return $ getTxId (getTxBody tx)
+      Net.Tx.SubmitFail reason ->
+        case reason of
+          TxValidationErrorInMode err _eraInMode -> left . TxCmdTxSubmitError . T.pack $ show err
+          TxValidationEraMismatch mismatchErr -> left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
+    where
+      handle :: ExceptT TxCmdError IO TxId -> Handler TxId
+      handle f = do
+        result <- liftIO $ runExceptT f
+        handleSubmitResult result
+
+      errorResponse :: ToJSON e => e -> Handler a
+      errorResponse e = throwError $ err400 { errBody = Aeson.encode e }
+
+      -- Log relevant information, update the metrics, and return the result to
+      -- the client.
+      handleSubmitResult :: Either TxCmdError TxId -> Handler TxId
+      handleSubmitResult res =
+        case res of
+          Left err -> do
+            liftIO $ logInfo trace $
+              "txSubmitPost: failed to submit transaction: "
+                <> renderTxCmdError err
+            errorResponse (TxSubmitFail err)
+          Right txid -> do
+            liftIO $ logInfo trace $
+              "txSubmitPost: successfully submitted transaction "
+                <> renderMediumTxId txid
+            liftIO $ Gauge.inc (tsmCount metrics)
+            pure txid
+
+-- | Render the first 16 characters of a transaction ID.
+renderMediumTxId :: TxId -> Text
+renderMediumTxId (TxId hash) = renderMediumHash hash
+
+-- | Render the first 16 characters of a hex-encoded hash.
+renderMediumHash :: Crypto.Hash crypto a -> Text
+renderMediumHash = T.take 16 . T.decodeLatin1 . Crypto.hashToBytesAsHex

--- a/cardano-submit-api/swagger.yaml
+++ b/cardano-submit-api/swagger.yaml
@@ -1,0 +1,56 @@
+swagger: '2.0'
+schemes: ["http"]
+host: localhost
+basePath: /
+info:
+  title: cardano-submit-api
+  version: 3.1.0
+  license:
+    name: Apache-2.0
+    url: https://github.com/input-output-hk/cardano-rest/blob/master/submit-api/LICENSE
+  description: |
+    <p align="right"><img style="position: relative; top: -10em; margin-bottom: -12em;" width="20%" src="https://cardanodocs.com/img/cardano.png"></img></p>
+
+x-tagGroups: []
+
+definitions: {}
+
+paths:
+  /api/submit/tx:
+    post:
+      operationId: postTransaction
+      summary: Submit Tx
+      description: Submit an already serialized transaction to the network.
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          type: string
+          enum: ["application/cbor"]
+
+      x-code-samples:
+        - lang: "Shell"
+          label: "cURL"
+          source: |
+            # Assuming `data` is a serialized transaction on the file-system.
+            curl -X POST \
+                --header "Content-Type: application/cbor" \
+                --data-binary @data http://localhost:8101/api/submit/tx
+      produces:
+        - "application/json"
+      responses:
+        202:
+          description: Ok
+          schema:
+            description: The transaction id.
+            type: string
+            format: hex
+            minLength: 64
+            maxLength: 64
+            example: 92bcd06b25dfbd89b578d536b4d3b7dd269b7c2aa206ed518012cffe0444d67f
+
+        400:
+          description: Bad Request
+          schema:
+            type: string
+            description: An error message.

--- a/cardano-submit-api/test/run.sh
+++ b/cardano-submit-api/test/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+function assert () {
+  got=$1; want=$2
+
+  if [[ $got =~ "$want" ]]; then
+    echo "✓ $want"
+  else
+    echo -e "✗ $got\ndoes not match \"$want\""
+  fi
+}
+
+function fail_if_server_is_not_running () {
+  URL=$1
+  # Check if the server is running
+  TMP=$(mktemp)
+  curl -v --stderr $TMP $URL
+  if [[ $(cat $TMP) =~ "Failed to connect" ]]; then
+    echo "cardano-submit-api must be up-and-running on ${URL%%/api*} to execute the test bench."
+    exit 1
+  fi;
+}
+
+URL=http://localhost:8090/api/submit/tx
+DATA="83a40081825820c84dbd7b780ff9be2bcc6990f043030fe649342f9fa7ba1bfa6fb5c0079501a400018282582b82d818582183581cf810f5ffa3613a7edcc1e733d0d73c89645d02221648a031436fd840a0001a4f7ed7fd1a45bb41e082581d619fc8d50cd36af0e35f43db0e2f220e4ccb774925f2ef3542875b37701a000f4240021a00030d40031a00f9c7cca102818458205e3eb96f2cfd7844b5eed5498fe487fc5271178fb251ebf3d33c5d8f49036d9358403c9ef2ce22b8a3fce622472f84c932679f95e0f3e139378fe9d6ab5442c60a9b87de374a0bc37667b1bf8d5c6bffb436ffd84b0fa56a7c86342962b9c293390758208ed6ca9faabd8499f021c2e51745436c99f9eab6c92f4b09b255bdd9f39bae2a41a0f6"
+# 83                                      # array(3)
+#    A4                                   # map(4)
+#       00                                # unsigned(0)
+#       81                                # array(1)
+#          82                             # array(2)
+#             58 20                       # bytes(32)
+#                C84DBD7B780FF9BE2BCC6990F043030FE649342F9FA7BA1BFA6FB5C0079501A4 # "\xC8M\xBD{x\x0F\xF9\xBE+\xCCi\x90\xF0C\x03\x0F\xE6I4/\x9F\xA7\xBA\e\xFAo\xB5\xC0\a\x95\x01\xA4"
+#             00                          # unsigned(0)
+#       01                                # unsigned(1)
+#       82                                # array(2)
+#          82                             # array(2)
+#             58 2B                       # bytes(43)
+#                82D818582183581CF810F5FFA3613A7EDCC1E733D0D73C89645D02221648A031436FD840A0001A4F7ED7FD # "\x82\xD8\x18X!\x83X\x1C\xF8\x10\xF5\xFF\xA3a:~\xDC\xC1\xE73\xD0\xD7<\x89d]\x02\"\x16H\xA01Co\xD8@\xA0\x00\x1AO~\xD7\xFD"
+#             1A 45BB41E0                 # unsigned(1169900000)
+#          82                             # array(2)
+#             58 1D                       # bytes(29)
+#                619FC8D50CD36AF0E35F43DB0E2F220E4CCB774925F2EF3542875B3770 # "a\x9F\xC8\xD5\f\xD3j\xF0\xE3_C\xDB\x0E/\"\x0EL\xCBwI%\xF2\xEF5B\x87[7p"
+#             1A 000F4240                 # unsigned(1000000)
+#       02                                # unsigned(2)
+#       1A 00030D40                       # unsigned(200000)
+#       03                                # unsigned(3)
+#       1A 00F9C7CC                       # unsigned(16369612)
+#    A1                                   # map(1)
+#       02                                # unsigned(2)
+#       81                                # array(1)
+#          84                             # array(4)
+#             58 20                       # bytes(32)
+#                5E3EB96F2CFD7844B5EED5498FE487FC5271178FB251EBF3D33C5D8F49036D93 # "^>\xB9o,\xFDxD\xB5\xEE\xD5I\x8F\xE4\x87\xFCRq\x17\x8F\xB2Q\xEB\xF3\xD3<]\x8FI\x03m\x93"
+#             58 40                       # bytes(64)
+#                3C9EF2CE22B8A3FCE622472F84C932679F95E0F3E139378FE9D6AB5442C60A9B87DE374A0BC37667B1BF8D5C6BFFB436FFD84B0FA56A7C86342962B9C2933907 # "<\x9E\xF2\xCE\"\xB8\xA3\xFC\xE6\"G/\x84\xC92g\x9F\x95\xE0\xF3\xE197\x8F\xE9\xD6\xABTB\xC6\n\x9B\x87\xDE7J\v\xC3vg\xB1\xBF\x8D\\k\xFF\xB46\xFF\xD8K\x0F\xA5j|\x864)b\xB9\xC2\x939\a"
+#             58 20                       # bytes(32)
+#                8ED6CA9FAABD8499F021C2E51745436C99F9EAB6C92F4B09B255BDD9F39BAE2A # "\x8E\xD6\xCA\x9F\xAA\xBD\x84\x99\xF0!\xC2\xE5\x17ECl\x99\xF9\xEA\xB6\xC9/K\t\xB2U\xBD\xD9\xF3\x9B\xAE*"
+#             41                          # bytes(1)
+#                A0                       # "\xA0"
+#    F6                                   # primitive(22)
+
+fail_if_server_is_not_running $URL
+
+echo -e "=== Data is Base16 ==="
+RESULT=$(curl --silent -H "Content-Type: application/cbor" -X POST -d $DATA $URL)
+assert "$RESULT" "Provided data was hex encoded and this webapi expects raw binary"
+
+echo -e "=== Data is Base64 ==="
+BASE64=$(xxd -r -p <<< $DATA | base64 -w 0)
+RESULT=$(curl --silent -H "Content-Type: application/cbor" -X POST -d $BASE64 $URL)
+assert "$RESULT" "Deserialisation failure while decoding Shelley Tx.\nCBOR failed with error: DeserialiseFailure 0 \\\"expected list len or indef\\\""
+
+echo -e "=== Data is Empty ==="
+TMP=$(mktemp)
+RESULT=$(curl --silent -H "Content-Type: application/cbor" -X POST --data-binary @$TMP $URL)
+assert "$RESULT" "Provided transaction has zero length"
+
+echo -e "=== Content-Type is not 'application/cbor' ==="
+TMP=$(mktemp)
+RESULT=$(curl -v --stderr $TMP -H "Content-Type: application/json" -X POST --data-binary @$TMP $URL)
+assert "$(cat $TMP)" "415 Unsupported Media Type"
+
+echo -e "=== Data is well-formed but invalid ==="
+TMP=$(mktemp)
+xxd -r -p <<< $DATA > $TMP
+RESULT=$(curl --silent -H "Content-Type: application/cbor" -X POST --data-binary @$TMP $URL)
+assert "$RESULT" "ApplyTxError"

--- a/cardano-submit-api/test/test.hs
+++ b/cardano-submit-api/test/test.hs
@@ -1,0 +1,3 @@
+
+main :: IO ()
+main = putStrLn "cardano-tx-submit test"

--- a/cardano-submit-api/testing-tx-submit.md
+++ b/cardano-submit-api/testing-tx-submit.md
@@ -1,0 +1,122 @@
+# Testing cardano-submit-api
+
+Setting this up for testing and for actual use on a real network.
+
+
+### Pre-requisites
+
+You will need some a cardano network with payment address and keys.  This may be on `mainnet`, official `testnet`
+or a testnet that you've set up yourself.  We will assume these files are in a direction called `playground`:
+
+* `user-1-payment.addr` - User 1 payment address.  This address must have sufficient funds.
+* `user-1-payment.vkey` - User 1 verification key.
+* `user-2-payment.addr` - User 2 payment address.
+* `magic.flag` - The network magic flag.  This will be `--testnet-magic <magic>` or `--mainnet`
+  dependening on the network you are using.
+* `node.socket` - The socket file for your network, or a symlink to that socket file.  If you
+  have a node running (for example, `mainnet` or `testnet` Daedalus), you can the socket file
+  using `ps aux | grep cardano-node` and looking for the `--node-socket`.
+
+You will also need to have `yj` installed.  This can be done via `brew`, `apt-get` or `snap`.
+
+### Install and run the cardano-submit-api
+
+Install the `cardani-submit-api`:
+
+```bash
+cardano-node $ cabal install cardano-submit-api --overwrite-policy=always
+```
+
+Install the `cardani-cli`:
+
+```bash
+cardano-node $ cabal install cardano-cli --overwrite-policy=always
+```
+
+Copy the configuration yaml to your `playground` and tweak it:
+
+```bash
+playground $ cat <configuration-yaml-file> | yj -jy > submit-api-config.yaml
+playground $ cat >> submit-api-config.yaml <<EOF
+EnableLogMetrics: False
+EnableLogging: True
+EOF
+```
+
+Then run the `cardani-submit-api` against your network:
+
+```bash
+playground $ cardano-submit-api --config submit-api-config.yaml --socket-path node.socket --port 8090 $(cat magic.flag)
+```
+
+### Build and submit a transaction
+
+In another terminal, find out how much ADA is in your user 1 payment address:
+
+```bash
+playground $ CARDANO_NODE_SOCKET_PATH=node.socket cardano-cli query utxo --address $(cat user-1-payment.addr)  --testnet-magic 1097911063
+                           TxHash                                 TxIx        Amount
+--------------------------------------------------------------------------------------
+8a3d63d4d95f669ef62570f2936ad50d2cfad399e04808ca21474e70b11987ee     0        97640000 lovelace
+```
+
+Save that date into environment variables for future use.  For example:
+
+```bash
+playground $ txhash=8a3d63d4d95f669ef62570f2936ad50d2cfad399e04808ca21474e70b11987ee
+playground $ balance=97640000
+```
+
+Find out much much will remain after paying `1000000 lovelace` to the target account:
+
+```bash
+playground $ remaining=$(echo "$balance - 1000000 - 180000" | bc)
+```
+
+Build a raw transaction:
+
+```bash
+playground $ cardano-cli transaction build-raw \
+  --mary-era \
+  --tx-in "$txhash#0" \
+  --tx-out "$(cat testnet-user-1-payment.addr)+$remaining" \
+  --tx-out "$(cat testnet-user-2-payment.addr)+1000000" \
+  --invalid-hereafter "21168607" \
+  --fee 180000 \
+  --out-file tx.raw
+```
+
+Sign the transaction:
+
+```bash
+playground $ cardano-cli transaction sign \
+  --tx-body-file tx.raw \
+  --signing-key-file testnet-user-1-payment.skey \
+  $(cat magic.flag) \
+  --out-file tx.signed
+```
+
+Submit the signed transaction using curl:
+
+```bash
+playground $ curl --header "Content-Type: application/cbor" -X POST http://localhost:8090/api/submit/tx --data-binary @tx.signed
+"8a3d63d4d95f669ef62570f2936ad50d2cfad399e04808ca21474e70b11987ee"%
+```
+
+The string returned is the new transaction hash.
+
+You can check your user 2 payment address has received the funds by querying the following:
+
+```bash
+CARDANO_NODE_SOCKET_PATH=node.socket cardano-cli query utxo --address $(cat testnet-user-2-payment.addr)  --testnet-magic 1097911063
+                           TxHash                                 TxIx        Amount
+--------------------------------------------------------------------------------------
+24e12cf8937db7fc95a39ca7780a5a1cb425ee53321d730254d661cc96be572f     1        1000000 lovelace
+8a3d63d4d95f669ef62570f2936ad50d2cfad399e04808ca21474e70b11987ee     1        1000000 lovelace
+```
+
+Additionally, the `cardano-submit-api` will print out a record of the transaction in its `stdout`:
+
+```
+[cardano-tx-submit:Info:26] [2021-03-11 03:32:35.13 UTC] txSubmitPost: successfully submitted transaction 8a3d63d4d95f669e
+```

--- a/hedgehog-extras/hedgehog-extras.cabal
+++ b/hedgehog-extras/hedgehog-extras.cabal
@@ -10,7 +10,28 @@ license-files:          LICENSE
                         NOTICE
 build-type:             Simple
 
+common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+
+common maybe-Win32-network
+  if os(windows)
+     build-depends:     Win32-network
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+
+  if impl(ghc >= 8.10)
+    ghc-options:        -Wunused-packages
+
 library
+  import:               base, project-config
+                      , maybe-Win32-network
   hs-source-dirs:       src
   build-depends:        base              >= 4.12 && < 5
                       , aeson             >= 1.5.6.0
@@ -27,7 +48,6 @@ library
                       , network
                       , filepath
                       , process
-                      , random
                       , resourcet
                       , stm
                       , temporary
@@ -36,7 +56,6 @@ library
                       , transformers
                       , unliftio
                       , unordered-containers
-                      , Win32-network
   exposed-modules:      Hedgehog.Extras.Aeson
                         Hedgehog.Extras.Internal.Cli
                         Hedgehog.Extras.Internal.Plan
@@ -58,11 +77,3 @@ library
                         Hedgehog.Extras.Test.MonadAssertion
                         Hedgehog.Extras.Test.Network
                         Hedgehog.Extras.Test.Process
-  default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat

--- a/scripts/benchmarking/common.sh
+++ b/scripts/benchmarking/common.sh
@@ -3,8 +3,8 @@
 ## Don't ask, the story is too sad -- function env sharing & tmux involved.
 set -o allexport
 
-__COMMON_SRCROOT=${__COMMON_SRCROOT:-"$(realpath $(dirname "$0")/..)"}
-. "${__COMMON_SRCROOT}/scripts/lib.sh" "${__COMMON_SRCROOT}"
+__COMMON_SRCROOT=${__COMMON_SRCROOT:-"$(realpath $(dirname "$0")/../..)"}
+. "${__COMMON_SRCROOT}/scripts/benchmarking/lib.sh" "${__COMMON_SRCROOT}"
 
 usage() {
         cat <<EOF

--- a/scripts/benchmarking/lib-cli.sh
+++ b/scripts/benchmarking/lib-cli.sh
@@ -60,7 +60,7 @@ genesis() {
                 --real-pbft
                 --secret-seed                  "${not_so_secret}"
         )
-        run_quiet cardano-cli cardano-cli genesis "${ARGS[@]}"
+        run_quiet cardano-cli cardano-cli byron genesis genesis "${ARGS[@]}"
 
         # move new genesis to configuration
         local GENHASH=$(run_quiet cardano-cli cardano-cli print-genesis-hash --genesis-json "${tmpdir}/genesis.json" | tail -1)

--- a/scripts/benchmarking/lib.sh
+++ b/scripts/benchmarking/lib.sh
@@ -5,7 +5,7 @@
 ## TODO:  debug the spectacular failure this causes..
 # set -e
 
-. "${__COMMON_SRCROOT}/scripts/lib-nix.sh"
+. "${__COMMON_SRCROOT}/scripts/benchmarking/lib-nix.sh"
 
 ##
 ## This depends on the setup done by scripts/common.sh


### PR DESCRIPTION
Publishes binaries as Github Actions artefacts (as `cardano-rest` did)
Also removed more unused dependencies.