### PR TITLE
Downgrade termination event from warning to notice

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -156,7 +156,7 @@ instance HasSeverityAnnotation (TraceChainSyncClientEvent blk) where
   getSeverityAnnotation (TraceFoundIntersection _ _ _) = Info
   getSeverityAnnotation (TraceRolledBack _) = Notice
   getSeverityAnnotation (TraceException _) = Warning
-  getSeverityAnnotation (TraceTermination _) = Warning
+  getSeverityAnnotation (TraceTermination _) = Notice
 
 
 instance HasPrivacyAnnotation (TraceChainSyncServerEvent blk)


### PR DESCRIPTION
Other examples of similar events use either `Notice` or `Debug`. For example:

```
    MuxTraceTerminating {} -> Debug
    MuxTraceShutdown -> Debug
    SubscriptionTraceCloseSocket {} -> Debug
    SubscriptionTraceCloseSocket {} -> Info
    SubscriptionTraceCloseSocket {} -> Debug
    BlockFetch.ClientTerminating {} -> Notice
```
