### PR TITLE
CAD-2564: trace KES metrics even if there is error

### DIFF
--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -23,7 +23,7 @@ import qualified Ouroboros.Consensus.Cardano as Consensus (Protocol)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 import           Cardano.Tracing.Constraints (TraceConstraints)
-import           Cardano.Tracing.Metrics (HasKESMetricsData)
+import           Cardano.Tracing.Metrics (HasKESMetricsData, HasKESInfo)
 
 data Protocol = ByronProtocol
               | ShelleyProtocol
@@ -51,6 +51,7 @@ instance FromJSON Protocol where
 
 type SomeConsensusProtocolConstraints blk =
      ( HasKESMetricsData blk
+     , HasKESInfo blk
      , RunNode blk
      , TraceConstraints blk
      )

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -66,6 +66,7 @@ import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import qualified Ouroboros.Consensus.Node.Run as Consensus (RunNode)
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import qualified Ouroboros.Consensus.Shelley.Protocol.HotKey as HotKey
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (BlockNo (..), HasHeader (..), Point, StandardHash,
@@ -100,6 +101,8 @@ import           Ouroboros.Network.TxSubmission.Inbound
 import qualified Ouroboros.Network.Diffusion as ND
 import qualified Cardano.Node.STM as STM
 import qualified Control.Concurrent.STM as STM
+
+import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 
 {- HLINT ignore "Redundant bracket" -}
 {- HLINT ignore "Use record patterns" -}
@@ -267,6 +270,7 @@ mkTracers
   :: forall peer localPeer blk.
      ( Consensus.RunNode blk
      , HasKESMetricsData blk
+     , HasKESInfo blk
      , TraceConstraints blk
      , Show peer, Eq peer
      , Show localPeer
@@ -446,6 +450,7 @@ mkConsensusTracers
      , ToObject (ForgeStateUpdateError blk)
      , Consensus.RunNode blk
      , HasKESMetricsData blk
+     , HasKESInfo blk
      , Show (Header blk)
      )
   => TraceSelection
@@ -662,12 +667,14 @@ teeForge' tr =
           LogValue "adoptedSlotLast" $ PureI $ fromIntegral $ unSlotNo slot
 
 forgeTracer
-  :: ( Consensus.RunNode blk
+  :: forall blk.
+     ( Consensus.RunNode blk
      , ToObject (CannotForge blk)
      , ToObject (LedgerErr (LedgerState blk))
      , ToObject (OtherHeaderEnvelopeError blk)
      , ToObject (ValidationErr (BlockProtocol blk))
      , ToObject (ForgeStateUpdateError blk)
+     , HasKESInfo blk
      )
   => TracingVerbosity
   -> Trace IO Text
@@ -683,6 +690,29 @@ forgeTracer verb tr forgeTracers fStats =
     traceWith (annotateSeverity
                  $ teeForge forgeTracers verb
                  $ appendName "Forge" tr) tlcev
+    traceKESInfoIfKESExpired ev
+ where
+  traceKESInfoIfKESExpired ev =
+    case ev of
+      Consensus.TraceForgeStateUpdateError _ reason ->
+        -- KES-key cannot be evolved, but anyway trace KES-values.
+        case getKESInfo (Proxy @blk) reason of
+          Nothing -> pure ()
+          Just kesInfo -> do
+            let logValues :: [LOContent a]
+                logValues =
+                  [ LogValue "operationalCertificateStartKESPeriod"
+                      $ PureI . fromIntegral . unKESPeriod . HotKey.kesStartPeriod $ kesInfo
+                  , LogValue "operationalCertificateExpiryKESPeriod"
+                      $ PureI . fromIntegral . unKESPeriod . HotKey.kesEndPeriod $ kesInfo
+                  , LogValue "currentKESPeriod"
+                      $ PureI 0
+                  , LogValue "remainingKESPeriods"
+                      $ PureI 0
+                  ]
+            meta <- mkLOMeta Critical Confidential
+            mapM_ (traceNamedObject (appendName "metrics" tr) . (meta,)) logValues
+      _ -> pure ()
 
 notifyBlockForging
   :: ForgingStats


### PR DESCRIPTION
Previously, KES-related information wasn't traced if the node has expired KES-key. Now KES-related information will be traced anyway.

Now, even if KES-key is poisoned, KES-metrics is here:

```
$ curl 0.0.0.0:12798/metrics | grep KES
cardano_node_metrics_operationalCertificateExpiryKESPeriod_int 72
cardano_node_metrics_currentKESPeriod_int 0
cardano_node_metrics_remainingKESPeriods_int 0
cardano_node_metrics_operationalCertificateStartKESPeriod_int 10
```