### PR TITLE
Only use `reorder-goals` for windows builds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -179,10 +179,6 @@ source-repository-package
     typed-protocols-examples
     Win32-network
 
--- Needed for the Windows cabal constraint solver.
-max-backjumps: 10000
-reorder-goals: True
-
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -29,6 +29,11 @@ let
   # will run twice.
   cabalProjectLocal = ''
     allow-newer: terminfo:base
+  ''
+  # Needed for the Windows cabal constraint solver.
+  + lib.optionalString stdenv.hostPlatform.isWindows ''
+    max-backjumps: 10000
+    reorder-goals: True
   '';
 
   projectPackages = lib.attrNames (haskell-nix.haskellLib.selectProjectPackages


### PR DESCRIPTION
Using `reorder-goals` makes `cabal configure` work for windows, but makes it significantly slower for linux:

Without reorder goals
```
$ time nix-build -A plan-nix
...
Resolving dependencies...
...
real	1m48.648s
user	0m3.526s
sys	0m0.312s
```

With reorder goals:
```
$ time nix-build -A plan-nix
...
Resolving dependencies...
...
real	7m48.627s
user	0m4.095s
sys	0m0.369s
```
