### PR TITLE
CAD-2712 supervisord: provide a cabal-based supervisord cluster in default Nix shell + bugfixes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,8 @@ doc                                                           @olgahryniuk
 README.*                                                      @olgahryniuk
 cardano-cli/README.md                                         @olgahryniuk
 
+nix/supervisord-cluster                                       @deepfire @denisshevchenko @jutaro @MarcFontaine
+
 .buildkite                                                    @devops
 .github                                                       @devops
 ci                                                            @devops

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,14 @@ test-chairmans-cluster:
 profiles:
 	@jq . $$(nix-build -A profiles)
 
+cluster-shell:
+	nix-shell --max-jobs 8 --cores 0 -A 'devops' --arg 'autoStartCluster' 'true'
+
 setup:
 	sed -ni '1,/--- 8< ---/ p' cabal.project
+
+restore:
+	git checkout HEAD cabal.project
 
 cli node:
 	cabal --ghc-options="+RTS -qn8 -A32M -RTS" build cardano-$@

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ profiles:
 cluster-shell:
 	nix-shell --max-jobs 8 --cores 0 -A 'devops' --arg 'autoStartCluster' 'true'
 
-setup:
+cabal-setup setup:
 	sed -ni '1,/--- 8< ---/ p' cabal.project
 
-restore:
+cabal-restore restore:
 	git checkout HEAD cabal.project
 
 cli node:

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ cluster-shell:
 	nix-shell --max-jobs 8 --cores 0 -A 'devops' --arg 'autoStartCluster' 'true'
 
 cabal-setup setup:
-	sed -ni '1,/--- 8< ---/ p' cabal.project
+	./scripts/cabal-inside-nix-shell.sh
 
 cabal-restore restore:
-	git checkout HEAD cabal.project
+	./scripts/cabal-inside-nix-shell.sh --restore
 
 cli node:
 	cabal --ghc-options="+RTS -qn8 -A32M -RTS" build cardano-$@
@@ -71,4 +71,4 @@ full-clean: clean
 cls:
 	echo -en "\ec"
 
-.PHONY: stylish-haskell cabal-hashes ghcid ghcid-test run-test test-ghci test-ghcid help clean clean-profile proclean cls
+.PHONY: stylish-haskell cabal-hashes ghcid ghcid-test run-test test-ghci test-ghcid help clean clean-profile proclean cls cabal-setup setup cabal-restore restore

--- a/cabal.project
+++ b/cabal.project
@@ -87,9 +87,10 @@ package io-sim-classes
 
 -- ---------------------------------------------------------
 
--- The two following one-liners will restore / cut off the remainder of this file (for nix-shell users):
--- git checkout HEAD "$(git rev-parse --show-toplevel)"/cabal.project
--- sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project
+-- The two following one-liners will cut off / restore the remainder of this file (for nix-shell users):
+-- scripts/cabal-inside-nix-shell.sh
+-- scripts/cabal-inside-nix-shell.sh --restore
+-- --------------------------- 8< --------------------------
 -- Please do not put any `source-repository-package` clause above this line.
 
 source-repository-package

--- a/default.nix
+++ b/default.nix
@@ -81,7 +81,7 @@ let
       };
     };
 
-    profiles = (mkCluster {}).profilesJSON;
+    profiles = (mkCluster customConfig).profilesJSON;
 
     shell = import ./shell.nix {
       inherit pkgs;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -67,7 +67,6 @@ pkgs: _: with pkgs;
   inherit (cardanoNodeHaskellPackages.network-mux.components.exes) cardano-ping;
 
   mkCluster = callPackage ./supervisord-cluster;
-  hfcCluster = callPackage ./supervisord-cluster/hfc {};
   cardanolib-py = callPackage ./cardanolib-py {};
 
   clusterTests = import ./supervisord-cluster/tests { inherit pkgs; };

--- a/nix/supervisord-cluster/base-env.nix
+++ b/nix/supervisord-cluster/base-env.nix
@@ -1,5 +1,4 @@
-{
-  defaultLogConfig
+{ defaultLogConfig
 , stateDir
 , era
 }:

--- a/nix/supervisord-cluster/cardano-exes.nix
+++ b/nix/supervisord-cluster/cardano-exes.nix
@@ -1,0 +1,42 @@
+{ lib
+, stateDir
+, useCabalRun ? false
+, cabal-install
+, cardano-cli
+, cardano-node
+}@args:
+with lib;
+let
+  runner = exe:
+    if useCabalRun
+    then toString
+      [ "${cabal-install}/bin/cabal"
+        "-v0"
+        "run"
+        "exe:cardano-${exe}"
+        "--"
+      ]
+    else "${args."cardano-${exe}"}/bin/cardano-${exe}";
+in
+''
+function cli() {
+  ${runner "cli"} "$@"
+}
+
+function node() {
+  ${runner "node"} "$@"
+}
+
+${optionalString useCabalRun
+  ''
+  echo 'Prebuilding executables with Cabal..'
+  ${cabal-install}/bin/cabal build exe:cardano-cli
+  ${cabal-install}/bin/cabal build exe:cardano-node
+  ''}
+${optionalString (!useCabalRun)
+  ''
+  echo 'Nix-supplied executables are:'
+  echo '${cardano-node}/bin/cardano-node'
+  echo '${cardano-cli}/bin/cardano-cli'
+  ''}
+''

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -23,113 +23,34 @@ let
   profileDump = pkgs.writeText "profile-${profile.name}.json"
     (__toJSON profile);
 
-  ## This yields two attributes: 'params' and 'files'
-  genesis = pkgs.callPackage ./genesis.nix
-    { inherit
-      lib
-      path
-      stateDir
-      baseEnvConfig
-      basePort
-      profile
-      ;
-    };
-
   baseEnvConfig = pkgs.callPackage ./base-env.nix
     { inherit (pkgs.commonLib.cardanoLib) defaultLogConfig;
       inherit stateDir;
       inherit (profile) era;
     };
-  mkStartScript = envConfig: let
-    systemdCompat.options = {
-      systemd.services = lib.mkOption {};
-      systemd.sockets = lib.mkOption {};
-      users = lib.mkOption {};
-      assertions = lib.mkOption {};
-    };
-    eval = let
-      extra = {
-        services.cardano-node = {
-          enable = true;
-          inherit (envConfig) operationalCertificate kesKey vrfKey topology nodeConfig nodeConfigFile port dbPrefix socketPath;
-          inherit stateDir;
-        };
-      };
-    in lib.evalModules {
-      prefix = [];
-      modules = import ../nixos/module-list.nix ++ [ systemdCompat extra ];
-      args = { inherit pkgs; };
-    };
-  in pkgs.writeScript "cardano-node" ''
-    #!${pkgs.stdenv.shell}
-    ${eval.config.services.cardano-node.script}
-  '';
-  topologyFile = selfPort: {
-    Producers = map (p:
-      {
-        addr = "127.0.0.1";
-        port = p;
-        valency = 1;
-      }) (lib.filter (p: p != selfPort) (lib.genList (i: basePort + i + 1) (composition.n_bft_hosts + composition.n_pools)));
-  };
-  supervisorConfig = pkgs.writeText "supervisor.conf" (pkgs.commonLib.supervisord.writeSupervisorConfig ({
-    supervisord = {
-      logfile = "${stateDir}/supervisord.log";
-      pidfile = "${stateDir}/supervisord.pid";
-    };
-    supervisorctl = {};
-    inet_http_server = {
-      port = "127.0.0.1:9001";
-    };
-    "rpcinterface:supervisor" = {
-      "supervisor.rpcinterface_factory" = "supervisor.rpcinterface:make_main_rpcinterface";
-    };
-  } // lib.listToAttrs (map (i:
-    lib.nameValuePair "program:bft${toString i}" {
-      command = let
-        envConfig = baseEnvConfig // rec {
-          operationalCertificate = "${stateDir}/nodes/node-bft${toString i}/op.cert";
-          kesKey = "${stateDir}/nodes/node-bft${toString i}/kes.skey";
-          vrfKey = "${stateDir}/nodes/node-bft${toString i}/vrf.skey";
-          topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
-          socketPath = "${stateDir}/bft${toString i}.socket";
-          dbPrefix = "db-bft${toString i}";
-          port = basePort + i;
-          nodeConfigFile = "${stateDir}/config.json";
-        };
-        script = mkStartScript envConfig;
-      in "${script}";
-      stdout_logfile = "${stateDir}/bft${toString i}.stdout";
-      stderr_logfile = "${stateDir}/bft${toString i}.stderr";
-    }
-  ) (lib.genList (i: i + 1) composition.n_bft_hosts))
-  // lib.listToAttrs (map (i:
-    lib.nameValuePair "program:pool${toString i}" {
-      command = let
-        envConfig = baseEnvConfig // rec {
-          operationalCertificate = "${stateDir}/nodes/node-pool${toString i}/op.cert";
-          kesKey = "${stateDir}/nodes/node-pool${toString i}/kes.skey";
-          vrfKey = "${stateDir}/nodes/node-pool${toString i}/vrf.skey";
-          topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
-          socketPath = "${stateDir}/pool${toString i}.socket";
-          dbPrefix = "db-pool${toString i}";
-          port = basePort + composition.n_bft_hosts + i;
-          nodeConfigFile = "${stateDir}/config.json";
-        };
-        script = mkStartScript envConfig;
-      in "${script}";
-      stdout_logfile = "${stateDir}/pool${toString i}.stdout";
-      stderr_logfile = "${stateDir}/pool${toString i}.stderr";
-    }
-  ) (lib.genList (i: i + 1) composition.n_pools))
-  // {
-    "program:webserver" = {
-      command = "${pkgs.python3}/bin/python -m http.server ${toString basePort}";
-      directory = "${stateDir}/webserver";
+
+  ## This yields two attributes: 'params' and 'files'
+  genesis = pkgs.callPackage ./genesis.nix
+    { inherit
+      lib
+      stateDir
+      baseEnvConfig
+      basePort
+      profile;
+      path = lib.makeBinPath
+        [ cardano-cli bech32 pkgs.jq pkgs.gnused pkgs.coreutils pkgs.bash pkgs.moreutils ];
     };
 
-  } // extraSupervisorConfig));
-  path = lib.makeBinPath [ cardano-cli bech32 pkgs.jq pkgs.gnused pkgs.coreutils pkgs.bash pkgs.moreutils ];
+  supervisorConfig = pkgs.callPackage ./supervisor.nix
+    { inherit
+      pkgs
+      lib
+      stateDir
+      baseEnvConfig
+      basePort
+      profile
+      extraSupervisorConfig;
+    };
 
   start = pkgs.writeScriptBin "start-cluster" ''
     echo "Profile '${profile.name}' dump in: ${profileDump}"
@@ -139,7 +60,9 @@ let
       echo "Cluster already running. Please run `stop-cluster` first!"
     fi
     ${genesis.files}
-    ${pkgs.python3Packages.supervisor}/bin/supervisord --config ${supervisorConfig} $@
+    ${pkgs.python3Packages.supervisor}/bin/supervisord \
+        --config ${__trace "supervisorConfig: ${supervisorConfig} "
+                   supervisorConfig} $@
     while [ ! -S $CARDANO_NODE_SOCKET_PATH ]; do echo "Waiting 5 seconds for bft node to start"; sleep 5; done
     echo "Transfering genesis funds to pool owners, register pools and delegations"
     cardano-cli transaction submit \

--- a/nix/supervisord-cluster/profiles.nix
+++ b/nix/supervisord-cluster/profiles.nix
@@ -8,8 +8,8 @@
 , ...
 }:
 
-runCommand "cluster-profiles.json" { buildInputs = [ jq ]; } ''
-    jq --argjson eras '${__toJSON eras}' '
+runCommand "cluster-profiles.json" {} ''
+    ${jq}/bin/jq --argjson eras '${__toJSON eras}' '
       include "profiles" { search: "${./.}" };
 
       $eras

--- a/nix/supervisord-cluster/supervisor.nix
+++ b/nix/supervisord-cluster/supervisor.nix
@@ -1,0 +1,109 @@
+{ pkgs
+, lib
+, stateDir
+, baseEnvConfig
+, basePort
+, profile
+  ## Last-moment overrides:
+, extraSupervisorConfig
+}:
+
+with profile;
+
+let
+  mkStartScript = envConfig: let
+    systemdCompat.options = {
+      systemd.services = lib.mkOption {};
+      systemd.sockets = lib.mkOption {};
+      users = lib.mkOption {};
+      assertions = lib.mkOption {};
+    };
+    eval = let
+      extra = {
+        services.cardano-node = {
+          enable = true;
+          ## topology wtf?
+          inherit (envConfig) operationalCertificate kesKey vrfKey topology nodeConfig nodeConfigFile port dbPrefix socketPath;
+          inherit stateDir;
+        };
+      };
+    in lib.evalModules {
+      prefix = [];
+      modules = import ../nixos/module-list.nix ++ [ systemdCompat extra ];
+      args = { inherit pkgs; };
+    };
+  in pkgs.writeScript "cardano-node" ''
+    #!${pkgs.stdenv.shell}
+    ${eval.config.services.cardano-node.script}
+  '';
+
+  topologyFile = selfPort: {
+    Producers = map (p:
+      {
+        addr = "127.0.0.1";
+        port = p;
+        valency = 1;
+      }) (lib.filter (p: p != selfPort) (lib.genList (i: basePort + i + 1) (composition.n_bft_hosts + composition.n_pools)));
+  };
+
+  config =
+  (pkgs.commonLib.supervisord.writeSupervisorConfig ({
+    supervisord = {
+      logfile = "${stateDir}/supervisord.log";
+      pidfile = "${stateDir}/supervisord.pid";
+    };
+    supervisorctl = {};
+    inet_http_server = {
+      port = "127.0.0.1:9001";
+    };
+    "rpcinterface:supervisor" = {
+      "supervisor.rpcinterface_factory" = "supervisor.rpcinterface:make_main_rpcinterface";
+    };
+  } // lib.listToAttrs (map (i:
+    lib.nameValuePair "program:bft${toString i}" {
+      command = let
+        envConfig = baseEnvConfig // rec {
+          operationalCertificate = "${stateDir}/nodes/node-bft${toString i}/op.cert";
+          kesKey = "${stateDir}/nodes/node-bft${toString i}/kes.skey";
+          vrfKey = "${stateDir}/nodes/node-bft${toString i}/vrf.skey";
+          topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
+          socketPath = "${stateDir}/bft${toString i}.socket";
+          dbPrefix = "db-bft${toString i}";
+          port = basePort + i;
+          nodeConfigFile = "${stateDir}/config.json";
+        };
+        script = mkStartScript envConfig;
+      in "${script}";
+      stdout_logfile = "${stateDir}/bft${toString i}.stdout";
+      stderr_logfile = "${stateDir}/bft${toString i}.stderr";
+    }
+  ) (lib.genList (i: i + 1) composition.n_bft_hosts))
+  // lib.listToAttrs (map (i:
+    lib.nameValuePair "program:pool${toString i}" {
+      command = let
+        envConfig = baseEnvConfig // rec {
+          operationalCertificate = "${stateDir}/nodes/node-pool${toString i}/op.cert";
+          kesKey = "${stateDir}/nodes/node-pool${toString i}/kes.skey";
+          vrfKey = "${stateDir}/nodes/node-pool${toString i}/vrf.skey";
+          topology = __toFile "topology.yaml" (__toJSON (topologyFile port));
+          socketPath = "${stateDir}/pool${toString i}.socket";
+          dbPrefix = "db-pool${toString i}";
+          port = basePort + composition.n_bft_hosts + i;
+          nodeConfigFile = "${stateDir}/config.json";
+        };
+        script = mkStartScript envConfig;
+      in "${script}";
+      stdout_logfile = "${stateDir}/pool${toString i}.stdout";
+      stderr_logfile = "${stateDir}/pool${toString i}.stderr";
+    }
+  ) (lib.genList (i: i + 1) composition.n_pools))
+  // {
+    "program:webserver" = {
+      command = "${pkgs.python3}/bin/python -m http.server ${toString basePort}";
+      directory = "${stateDir}/webserver";
+    };
+
+  } // extraSupervisorConfig));
+
+in
+  pkgs.writeText "supervisor.conf" config

--- a/nix/supervisord-cluster/supervisor.nix
+++ b/nix/supervisord-cluster/supervisor.nix
@@ -51,6 +51,7 @@ let
     supervisord = {
       logfile = "${stateDir}/supervisord.log";
       pidfile = "${stateDir}/supervisord.pid";
+      strip_ansi = true;
     };
     supervisorctl = {};
     inet_http_server = {

--- a/nix/supervisord-cluster/supervisor.nix
+++ b/nix/supervisord-cluster/supervisor.nix
@@ -4,6 +4,7 @@
 , baseEnvConfig
 , basePort
 , profile
+, useCabalRun
   ## Last-moment overrides:
 , extraSupervisorConfig
 }:
@@ -25,7 +26,9 @@ let
           ## topology wtf?
           inherit (envConfig) operationalCertificate kesKey vrfKey topology nodeConfig nodeConfigFile port dbPrefix socketPath;
           inherit stateDir;
-        };
+        } // lib.optionalAttrs useCabalRun
+          { executable = "cabal run exe:cardano-node --";
+          };
       };
     in lib.evalModules {
       prefix = [];

--- a/nix/supervisord-cluster/tests/default.nix
+++ b/nix/supervisord-cluster/tests/default.nix
@@ -1,5 +1,5 @@
-{
-  pkgs
+{ pkgs
+, mkCluster
 }: let
   inherit (pkgs) mkCluster cardano-cli cardanolib-py cardano-node;
   stateDir = "./state-cluster-test";

--- a/scripts/cabal-inside-nix-shell.sh
+++ b/scripts/cabal-inside-nix-shell.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project
+case $1 in
+    --exit | --undo | --restore )
+        git checkout HEAD cabal.project;;
+    * )
+        sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project
+esac

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 # It just takes the shell attribute from default.nix.
 { config ? {}
 , customConfig ? {}
+, autoStartCluster ? false
 , sourcesOverride ? {}
 , withHoogle ? true
 , pkgs ? import ./nix {
@@ -91,6 +92,11 @@ let
         * stop-cluster - stop a local development cluster
 
       "
+
+      ${lib.optionalString autoStartCluster ''
+      echo "Starting cluster (because 'auto-start-cluster' is true):"
+      start-cluster
+      ''}
     '';
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -50,10 +50,10 @@ let
 
     shellHook = ''
       echo "Setting 'cabal.project' for local builds.."
-      make setup
+      make cabal-setup
       function atexit() {
           echo "Reverting 'cabal.project' to the index version.."
-          make restore
+          make cabal-restore
       }
       trap atexit EXIT
     '';

--- a/shell.nix
+++ b/shell.nix
@@ -50,10 +50,11 @@ let
 
     shellHook = ''
       echo "Setting 'cabal.project' for local builds.."
-      make cabal-setup
+      ./scripts/cabal-inside-nix-shell.sh
+
       function atexit() {
           echo "Reverting 'cabal.project' to the index version.."
-          make cabal-restore
+          ./scripts/cabal-inside-nix-shell.sh --restore
       }
       trap atexit EXIT
     '';


### PR DESCRIPTION
1. Call `make cabal-setup` / `make cabal-restore` at default `nix-shell` entry/exit, allowing cabal to accept the Nix-supplied dependencies.
2. Provide `start-cluster`/`stop-cluster` inside the default `nix-shell` -- using the `cabal run`-provided binaries, instead of Nix-provided ones.
3. Work around a `supervisord tail` bug:  https://github.com/Supervisor/supervisor/issues/531
4. Factor the `supervisord.nix` configuration module.
5. `start-cluster --trace` now verbosely dumps the shell trace (`set -x`).