### PR TITLE
Use Cabal 3.4.0.0 for Haddock build

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -36,7 +36,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.4.0.0-rc4
+        cabal-version: 3.4.0.0
 
     - name: Haskell versions
       run: |


### PR DESCRIPTION
Target to correct https://github.com/input-output-hk/cardano-node/pull/2406/checks?check_run_id=1973546388