### PR TITLE
Update to latest ouroboros-network

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -111,8 +111,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 99e2f2e32ebfca3291fa523ddcae14c8cbb48fa0
-  --sha256: 0fy8y7cp10ls8p3zs2fqzqpd41vri6z0imhyif5wa9bi2rp57i3z
+  tag: a4eaf8819515003e287c8960817d2599cfdda1c6
+  --sha256: 0ayq5xaxdf6c5y524c3gz3052dcclqf93kiwf1zhpmq6q960l45y
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -160,8 +160,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 96cf17bcc6ea4ef455a19430313ce17d476d62b5
-  --sha256: 00xp605lb8qp1jhp43mg7818x8yzn2rnsd18qcy5721yj4q675nz
+  tag: a8e3ad077e7a84727381a0a4d930450116209f95
+  --sha256: 04dp49hnk473fz1pa0n6chs1x69x01l7fjsxhrajqcijmksdi9f9
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -87,7 +87,7 @@ library
                       , cardano-crypto
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
-                      , cardano-ledger
+                      , cardano-ledger-byron
                       , cardano-ledger-shelley-ma
                       , cardano-prelude
                       , cardano-slotting
@@ -157,7 +157,7 @@ test-suite cardano-api-test
                       , cardano-crypto-test
                       , cardano-crypto-tests
                       , cardano-crypto-wrapper
-                      , cardano-ledger-test
+                      , cardano-ledger-byron-test
                       , cardano-prelude
                       , cardano-prelude-test
                       , cardano-slotting

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -66,6 +66,8 @@ import qualified Cardano.Ledger.Era as Ledger
 
 import qualified Shelley.Spec.Ledger.API as Shelley
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
+import qualified Shelley.Spec.Ledger.PParams as Shelley
+import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 
 import           Cardano.Api.Address
 import           Cardano.Api.Block
@@ -181,6 +183,8 @@ instance (Typeable era, Shelley.TransLedgerState FromCBOR (ShelleyLedgerEra era)
 instance ( IsShelleyBasedEra era
          , ShelleyLedgerEra era ~ ledgerera
          , Consensus.ShelleyBasedEra ledgerera
+         , ToJSON (Core.PParams ledgerera)
+         , ToJSON (Shelley.PParamsDelta ledgerera)
          , ToJSON (Core.TxOut ledgerera)) => ToJSON (LedgerState era) where
   toJSON (LedgerState newEpochS) = object [ "lastEpoch" .= Shelley.nesEL newEpochS
                                           , "blocksBefore" .= Shelley.nesBprev newEpochS
@@ -423,6 +427,8 @@ fromConsensusQueryResult (QueryInEra MaryEraInCardanoMode
 fromConsensusQueryResultShelleyBased
   :: forall era ledgerera result result'.
      ShelleyLedgerEra era ~ ledgerera
+  => Shelley.PParams ledgerera ~ Core.PParams ledgerera
+  => Shelley.PParamsDelta ledgerera ~ Shelley.PParamsUpdate ledgerera
   => Consensus.ShelleyBasedEra ledgerera
   => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
   => ShelleyBasedEra era

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -45,7 +45,7 @@ import           Data.String
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Seed as Crypto
-import qualified Shelley.Spec.Ledger.Hashing as Shelley
+import qualified Cardano.Ledger.SafeHash as Ledger
 
 
 import           Hedgehog (Gen, Range)
@@ -322,7 +322,7 @@ genShelleyTxOut =
   TxOut <$> (shelleyAddressInEra <$> genAddressShelley)
         <*> (TxOutAdaOnly AdaOnlyInShelleyEra <$> genLovelace)
 
-genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 Shelley.EraIndependentTxBody)
+genShelleyHash :: Gen (Crypto.Hash Crypto.Blake2b_256 Ledger.EraIndependentTxBody)
 genShelleyHash = return . Crypto.castHash $ Crypto.hashWith CBOR.serialize' ()
 
 genSlotNo :: Gen SlotNo

--- a/cardano-api/test/cardano-api-test.cabal
+++ b/cardano-api/test/cardano-api-test.cabal
@@ -26,7 +26,7 @@ library
                       , cardano-binary
                       , cardano-crypto-class
                       , cardano-crypto-test
-                      , cardano-ledger-test
+                      , cardano-ledger-byron-test
                       , cardano-prelude
                       , containers
                       , hedgehog

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -84,7 +84,7 @@ library
                      , cardano-crypto
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
-                     , cardano-ledger
+                     , cardano-ledger-byron
                      , cardano-ledger-shelley-ma
                      , cardano-node
                      , cardano-prelude
@@ -233,7 +233,7 @@ test-suite cardano-cli-golden
                       , cardano-api
                       , cardano-cli
                       , cardano-crypto-wrapper
-                      , cardano-ledger
+                      , cardano-ledger-byron
                       , cardano-prelude
                       , cborg
                       , containers

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -46,7 +46,7 @@ executable cardano-node-chairman
                       , call-stack
                       , cardano-api
                       , cardano-config
-                      , cardano-ledger
+                      , cardano-ledger-byron
                       , cardano-node
                       , cardano-prelude
                       , containers

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -80,7 +80,7 @@ library
                      , cardano-config
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
-                     , cardano-ledger
+                     , cardano-ledger-byron
                      , cardano-ledger-shelley-ma
                      , cardano-prelude
                      , cardano-slotting

--- a/cardano-node/src/Cardano/Tracing/ConvertTxId.hs
+++ b/cardano-node/src/Cardano/Tracing/ConvertTxId.hs
@@ -14,6 +14,7 @@ import           Data.SOP.Strict
 
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Byron.Crypto
+import qualified Cardano.Ledger.SafeHash as Ledger
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Byron.Ledger.Mempool (TxId (..))
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -36,7 +37,7 @@ instance ConvertTxId ByronBlock where
 
 instance ConvertTxId (ShelleyBlock c) where
   txIdToRawBytes (ShelleyTxId txId) =
-    Crypto.hashToBytes . Shelley._unTxId $ txId
+    Crypto.hashToBytes . Ledger.extractHash . Shelley._unTxId $ txId
 
 instance All ConvertTxId xs
       => ConvertTxId (HardForkBlock xs) where


### PR DESCRIPTION
One oddity here is that overlapping ToJSON instances for PParamsUpdate were revealed.

The instances are different.

This PR removed the instance in `Cardano.Tracing.OrphanInstances.Shelley`, but this might not be the right thing to do.
