### PR TITLE
added indication that latest GHC version may fail

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -90,7 +90,7 @@ Create a working directory for your builds:
     ./configure
     sudo make install
 
-This assumes GHC 8.10.2 on Linux (the most recent version at the time of writing).  If you are installing on MacOSX or Windows, download the compiler from `https://www.haskell.org/platform/mac.html` instead, and follow the installation instructions.
+This assumes GHC 8.10.2 on Linux (the most recent version at the time of writing).  If you are installing on MacOSX or Windows, download the compiler from `https://www.haskell.org/platform/mac.html` instead, and follow the installation instructions. Note that using a newer version than the one specified may produce compilation errors.
 
 #### Install Libsodium
 


### PR DESCRIPTION
when trying to build with GHC 8.10.4, the following error was produced when running "cabal build all":
cardano cabal: Failed to build ListLike-4.7.2

this was remedied by using GHC 8.10.2 instead