### PR TITLE
Modify tip cardano-cli query to also return the current epoch

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -420,7 +420,7 @@ module Cardano.Api (
     QueryInEra(..),
     queryNodeLocalState,
 
-    -- *** Query local node chain tip
+    -- *** Common queries
     getLocalChainTip,
 
     -- * Node operation

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -54,7 +54,7 @@ module Cardano.Api.IPC (
     QueryInShelleyBasedEra(..),
     queryNodeLocalState,
 
-    -- *** Tip query
+    -- *** Common queries
     getLocalChainTip,
 
     -- *** Helpers
@@ -544,3 +544,4 @@ chainSyncGetCurrentTip tipVar =
         void $ atomically $ tryPutTMVar tipVar tip
         pure $ Net.Sync.SendMsgDone ()
     }
+

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -108,6 +108,7 @@ library
                       , time
                       , transformers-except
                       , utf8-string
+                      , unordered-containers
                       , vector
 
   default-language:    Haskell2010

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -287,7 +287,7 @@ renderPoolCmd cmd =
 
 data QueryCmd =
     QueryProtocolParameters' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryTip AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryTip AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeDistribution' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeAddressInfo AnyCardanoEra AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
   | QueryUTxO' AnyCardanoEra AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -676,7 +676,8 @@ pQueryCmd =
 
     pQueryTip :: Parser QueryCmd
     pQueryTip = QueryTip
-                  <$> pConsensusModeParams
+                  <$> pCardanoEra
+                  <*> pConsensusModeParams
                   <*> pNetworkId
                   <*> pMaybeOutputFile
 

--- a/doc/stake-pool-operations/retire_stakepool.md
+++ b/doc/stake-pool-operations/retire_stakepool.md
@@ -7,26 +7,17 @@ To retire a pool we need to:
 
 The deregistration certificate contains the _epoch_ in which we want to retire the pool. This epoch must be _after_ the current epoch and _not later than_ `eMax` epochs in the future, where `eMax` is a protocol parameter.
 
-So we first need to figure out the current epoch. Provided we are in the shelley mode we can use the following calculation.
+So we first need to figure out the current epoch. The simplest way to get the current epoch is via the `tip` command:
 
-The number of _slots per epoch_ is recorded in the genesis file, and we can get it with
-
-    cat mainnet-shelley-genesis.json | grep epoch
-    > "epochLength": 21600,
-
-So one epoch lasts for 21600 slots. We get the current slot by querying the tip:
-
-    export CARDANO_NODE_SOCKET_PATH=relay-db/node-socket
-    cardano-cli query tip --mainnet
-
-    > Tip (SlotNo {unSlotNo = 856232}) ...
-
-This gives us
-
-    expr 856232 / 21600
-    > 39
-
-So we are currently in epoch 39.
+```bash
+> cardano-cli query tip --testnet-magic 42 --mary-era --cardano-mode
+{
+  "epoch": 51,
+  "hash": "19fdfc54e7a1e2fb7ff45254a6aa0aa88ea7a80de4b48297924c9abf353f9cb7",
+  "slot": 21592,
+  "block": 1123022
+}
+```
 
 You can also get the current epoch if you are monitoring a node with [EKG](../logging-monitoring/ekg.md):
 

--- a/doc/stake-pool-operations/retire_stakepool.md
+++ b/doc/stake-pool-operations/retire_stakepool.md
@@ -7,7 +7,7 @@ To retire a pool we need to:
 
 The deregistration certificate contains the _epoch_ in which we want to retire the pool. This epoch must be _after_ the current epoch and _not later than_ `eMax` epochs in the future, where `eMax` is a protocol parameter.
 
-So we first need to figure out the current epoch. The simplest way to get the current epoch is via the `tip` command:
+First, you need to figure out the current epoch. The simplest way to get the current epoch is to use the `tip` command:
 
 ```bash
 > cardano-cli query tip --testnet-magic 42 --mary-era --cardano-mode
@@ -40,7 +40,7 @@ We can look up `eMax` by querying the current protocol parameters:
 
 This means the earliest epoch for retirement is 52 (one in the future), and the latest is 69 (current epoch plus `eMax`).
 
-So for example, we can decide to retire in epoch 53.
+For example, we can decide to retire in epoch 53.
 
 #### Create deregistration certificate
 


### PR DESCRIPTION
Closes #1737 
```
> cabal exec cardano-cli -- query tip --shelley-era --shelley-mode --testnet-magic 42
{
    "epoch": 0,
    "hash": "19fdfc54e7a1e2fb7ff45254a6aa0aa88ea7a80de4b48297924c9abf353f9cb7",
    "slot": 42,
    "block": 3
}
```