### PR TITLE
CAD-2717: cardano node service extensions

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -399,7 +399,7 @@ in {
       };
 
       topology = mkOption {
-        type = types.nullOr types.path;
+        type = types.nullOr (types.either types.str types.path);
         default = null;
         description = ''
           Cluster topology. If not set `producers` array is used to generated topology file.

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -50,22 +50,21 @@ let
       ];
     };
     instanceDbPath = "${cfg.databasePath}${optionalString (i > 0) "-${toString i}"}";
-    exec = "cardano-node run";
-        cmd = builtins.filter (x: x != "") [
-          "${cfg.package}/bin/${exec}"
-          "--config ${realNodeConfigFile}"
-          "--database-path ${instanceDbPath}"
-          "--topology ${topology}"
-        ] ++ (lib.optionals (!cfg.systemdSocketActivation) ([
-          "--host-addr ${cfg.hostAddr}"
-          "--port ${toString (cfg.port + i)}"
-          "--socket-path ${cfg.socketPath}"
-        ] ++ lib.optional (cfg.ipv6HostAddr != null)
-          "--host-ipv6-addr ${cfg.ipv6HostAddr}"
-        )) ++ consensusParams.${cfg.nodeConfig.Protocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
+    cmd = builtins.filter (x: x != "") [
+      "${cfg.executable} run"
+      "--config ${realNodeConfigFile}"
+      "--database-path ${instanceDbPath}"
+      "--topology ${topology}"
+    ] ++ (lib.optionals (!cfg.systemdSocketActivation) ([
+      "--host-addr ${cfg.hostAddr}"
+      "--port ${toString (cfg.port + i)}"
+      "--socket-path ${cfg.socketPath}"
+    ] ++ lib.optional (cfg.ipv6HostAddr != null)
+      "--host-ipv6-addr ${cfg.ipv6HostAddr}"
+    )) ++ consensusParams.${cfg.nodeConfig.Protocol} ++ cfg.extraArgs ++ cfg.rtsArgs;
     in ''
         choice() { i=$1; shift; eval "echo \''${$((i + 1))}"; }
-        echo "Starting ${exec}: ${concatStringsSep "\"\n   echo \"" cmd}"
+        echo "Starting: ${concatStringsSep "\"\n   echo \"" cmd}"
         echo "..or, once again, in a single line:"
         echo "${toString cmd}"
         ${lib.optionalString (cfg.environment == "selfnode") ''
@@ -162,6 +161,15 @@ in {
         defaultText = "cardano-node";
         description = ''
           The cardano-node package that should be used
+        '';
+      };
+
+      executable = mkOption {
+        type = types.str;
+        default = "${cfg.package}/bin/cardano-node";
+        defaultText = "cardano-node";
+        description = ''
+          The cardano-node executable invocation to use
         '';
       };
 


### PR DESCRIPTION
1. Allow the `topology` path config option to also be a string.
2. Add the `executable` option, to allow customising the way the node is started -- so that we can, for example, use `cabal run -- cardano-node`.