### PR TITLE
Avoid reorder goals on platforms that don't need it 

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -60,6 +60,13 @@ jobs:
         cat ./cabal.project.local.github-pages >> ./cabal.project.local
         cat ./cabal.project.local
 
+    - name: Disable reorder goals on MacOS and Linux
+      # Avoid reorder goals for platforms that don't need it because re-order goals can take up to 10 minutes
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+      run: |
+        cat cabal.project | sed 's|reorder-goals: True|reorder-goals: False|g' > cabal.project.tmp
+        mv cabal.project.tmp cabal.project
+
     - name: Cabal Configure
       run: cabal configure --builddir="$CABAL_BUILDDIR" --write-ghc-environment-files=always
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -101,6 +101,13 @@ jobs:
     - name: Cabal update
       run: retry 2 cabal update
 
+    - name: Disable reorder goals on MacOS and Linux
+      # Avoid reorder goals for platforms that don't need it because re-order goals can take up to 10 minutes
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+      run: |
+        cat cabal.project | sed 's|reorder-goals: True|reorder-goals: False|g' > cabal.project.tmp
+        mv cabal.project.tmp cabal.project
+
     - name: Cabal Configure
       run: retry 2 cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 


### PR DESCRIPTION
The build optimisation that saves up to 10 minutes per configuration where it is disabled (ie. 4x per job).

This is useful not only to reduce feedback time but also because builds are a bit clogged today.