### PR TITLE
Make release manager a codeowner for cabal.project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,9 @@
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
 
+# Release manager added for notification on dependency updates
+cabal.project                                                 @LaurenceIO
+
 # /doc folder and README.* needs to be owned by @docs-access
 doc                                                           @docs-access
 README.*                                                      @docs-access


### PR DESCRIPTION
We do not envision that the release manager will actually review the PR
here, but adding as a codeowner will ensure he gets tagged on any
dependency bumps.