### PR TITLE
Updating cardano-ledger

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -114,8 +114,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a4eaf8819515003e287c8960817d2599cfdda1c6
-  --sha256: 0ayq5xaxdf6c5y524c3gz3052dcclqf93kiwf1zhpmq6q960l45y
+  tag: ba747792561bc6ba3e707aa1ffd70b2823aa8ac4
+  --sha256: 15xzjqw6h2rbg6rx5pc13394yi94zfgbpx36p3d7gp4li7mvvwfm
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -163,8 +163,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 8716d2f8f98a35ac07b0acf3b29fc125132f15df
-  --sha256: 107vdlhldqzmh7gprgxvhjkwm4irl8h73931f9llaina8s24ssy8
+  tag: 5a6fc581d33e0ccc8b1a8a0cc05d6bc215b5c290
+  --sha256: 0x6v27jsrm0p2jb7i3gz7v05gi5r9jky8x3vl8wl0mq2lj34bjyr
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -38,6 +38,7 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as ShelleyEpoch
 import qualified Shelley.Spec.Ledger.LedgerState as ShelleyLedger
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import qualified Shelley.Spec.Ledger.Rewards as Shelley
+import qualified Shelley.Spec.Ledger.RewardUpdate as Shelley
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
@@ -246,6 +247,10 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.RewardUpdate crypto) where
                           , "deltaF" .= Shelley.deltaF rUpdate
                           , "nonMyopic" .= Shelley.nonMyopic rUpdate
                           ]
+
+instance Crypto.Crypto crypto => ToJSON (Shelley.PulsingRewUpdate crypto) where
+  toJSON (Shelley.Pulsing _ _) = Aeson.Null
+  toJSON (Shelley.Complete ru) = toJSON ru
 
 instance ToJSON Shelley.DeltaCoin where
   toJSON (Shelley.DeltaCoin i) = toJSON i

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -33,17 +33,18 @@ module Cardano.Api.Query (
     ProtocolState(..),
 
     LedgerState(..),
+    decodeLedgerState,
   ) where
 
 import           Data.Aeson (ToJSON (..), object, (.=))
 import           Data.Bifunctor (bimap)
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (mapMaybe)
 import           Data.SOP.Strict (SListI)
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Typeable
 import           Prelude
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
@@ -64,10 +65,10 @@ import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Ledger
 
+import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Shelley.Spec.Ledger.API as Shelley
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import qualified Shelley.Spec.Ledger.PParams as Shelley
-import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 
 import           Cardano.Api.Address
 import           Cardano.Api.Block
@@ -176,8 +177,13 @@ newtype SerialisedLedgerState era
 data LedgerState era where
   LedgerState :: ShelleyLedgerEra era ~ ledgerera => Shelley.NewEpochState ledgerera -> LedgerState era
 
-instance (Typeable era, Shelley.TransLedgerState FromCBOR (ShelleyLedgerEra era)) => FromCBOR (LedgerState era) where
-  fromCBOR = LedgerState <$> (fromCBOR :: Decoder s (Shelley.NewEpochState (ShelleyLedgerEra era)))
+decodeLedgerState ::
+  forall s era ledgerera.
+  ( ShelleyLedgerEra era ~ ledgerera,
+    Consensus.ShelleyBasedEra ledgerera
+  ) =>
+  Decoder s (LBS.ByteString -> LedgerState era)
+decodeLedgerState = (LedgerState <$>) <$> ((. Full) . runAnnotator <$> fromCBOR)
 
 -- TODO: Shelley based era class!
 instance ( IsShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -170,6 +170,8 @@ module Cardano.Api.Shelley
     toShelleyNetwork,
     fromShelleyPParams,
 
+    decodeLedgerState,
+
   ) where
 
 import           Cardano.Api

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -34,7 +34,11 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
 
 import           Cardano.Api
 import           Cardano.Api.Byron
-import           Cardano.Api.Shelley
+import           Cardano.Api.Shelley (LedgerState, PoolId, ProtocolParameters, ProtocolState (..),
+                   QueryInShelleyBasedEra (QueryLedgerState, QueryProtocolParameters,
+                   QueryProtocolState, QueryStakeAddresses, QueryStakeDistribution, QueryUTxO),
+                   SerialisedLedgerState (..), ShelleyLedgerEra, StakeAddress (StakeAddress),
+                   UTxO (..), decodeLedgerState, fromShelleyStakeCredential)
 
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
 import           Cardano.CLI.Helpers (HelpersError (..), pPrintCBOR, renderHelpersError)
@@ -43,14 +47,16 @@ import           Cardano.CLI.Shelley.Orphans ()
 import           Cardano.CLI.Shelley.Parsers (OutputFile (..), QueryCmd (..))
 import           Cardano.CLI.Types
 
-import           Cardano.Binary (decodeFull)
+import           Cardano.Binary (decodeFull, decodeFullDecoder)
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
+
 import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
-import           Ouroboros.Network.Block (Serialised (..))
+import           Ouroboros.Network.Block (Serialised (..), unwrapCBORinCBOR)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
                    (AcquireFailure (..))
 import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
@@ -356,25 +362,25 @@ writeStakeAddressInfo mOutFile delegsAndRewards =
 
 writeLedgerState :: forall era ledgerera.
                     ShelleyLedgerEra era ~ ledgerera
+                 => Consensus.ShelleyBasedEra ledgerera
                  => ToJSON (LedgerState era)
-                 => FromCBOR (LedgerState era)
                  => Maybe OutputFile
                  -> SerialisedLedgerState era
                  -> ExceptT ShelleyQueryCmdError IO ()
 writeLedgerState mOutFile qState@(SerialisedLedgerState serLedgerState) =
   case mOutFile of
-    Nothing -> case decodeLedgerState qState of
+    Nothing -> case decodeLedgerState' qState of
                  Left bs -> firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
-                 Right ledgerState -> liftIO . LBS.putStrLn $ encodePretty ledgerState
+                 Right ledgerState -> liftIO . LBS.putStrLn . encodePretty $ ledgerState
     Just (OutputFile fpath) ->
       handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath $ unSerialised serLedgerState
  where
-   decodeLedgerState
+   decodeLedgerState'
      :: SerialisedLedgerState era
      -> Either LBS.ByteString (LedgerState era)
-   decodeLedgerState (SerialisedLedgerState (Serialised ls)) =
-     first (const ls) (decodeFull ls)
+   decodeLedgerState' (SerialisedLedgerState (Serialised ls)) =
+     first (const ls) (decodeFullDecoder "LedgerState" (unwrapCBORinCBOR decodeLedgerState) ls)
 
 
 writeProtocolState :: Crypto.Crypto StandardCrypto
@@ -577,7 +583,7 @@ obtainLedgerEraClassConstraints
   => ShelleyBasedEra era
   -> ((Ledger.ShelleyBased ledgerera
       , ToJSON (LedgerState era)
-      , FromCBOR (LedgerState era)
+      , Consensus.ShelleyBasedEra  ledgerera
       ) => a) -> a
 obtainLedgerEraClassConstraints ShelleyBasedEraShelley f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAllegra f = f

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -265,13 +265,14 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
            onKernel nodeKernel
        }
      StdRunNodeArgs
-       { srnBfcMaxConcurrencyBulkSync = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
-       , srnBfcMaxConcurrencyDeadline = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
-       , srcChainDbValidateOverride   = ncValidateDB nc
-       , srnDatabasePath              = dbPath
-       , srnDiffusionArguments        = diffusionArguments
-       , srnDiffusionTracers          = diffusionTracers
-       , srnTraceChainDB              = chainDBTracer nodeTracers
+       { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
+       , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
+       , srnChainDbValidateOverride     = ncValidateDB nc
+       , srnDatabasePath                = dbPath
+       , srnDiffusionArguments          = diffusionArguments
+       , srnDiffusionTracers            = diffusionTracers
+       , srnEnableInDevelopmentVersions = False -- TODO get this value from the node configuration?
+       , srnTraceChainDB                = chainDBTracer nodeTracers
        }
  where
   createDiffusionTracers :: Tracers RemoteConnectionId LocalConnectionId blk


### PR DESCRIPTION
I have updated the cardano ledger package to the current master, and ouroboros-network to my last commit in https://github.com/input-output-hk/ouroboros-network/pull/2971.

* The ledger state now stores an PulsingRewUpdate instead of a
  RewardUpdate. The PulsingRewUpdate allows us to compute the staking
  rewards incrementally instead of all at once. This involves a new
  serialization format for the reward updates.
* Annotated decoders are now used for PParams and PParamsDelta (the
  data structures now store their own serialization). Additionally, the
  LedgerState also now uses an annotated decoder. The serialization in
  consensus has been changed to use the cbor-in-cbor encoding for these
  types (including in the queries).
* A bug was fixed in the reward calculation which was introduced in
  commit 31083fc5cecbe17f3628393072094b130058edd9.
* The ledger repo now uses ghc-8.10.4 and cabal-3.4.0.0.

**Question** is it okay that I have removed the `FromCBOR` instances of the protocol parameter updates and the ledger state? I did add the necessary functions to serialize them.