### PR TITLE
Re-export chain sync client definitions

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -18,6 +18,8 @@ library
   exposed-modules:      Cardano.Api
                         Cardano.Api.Byron
                         Cardano.Api.Shelley
+                        Cardano.Api.ChainSync.Client
+                        Cardano.Api.ChainSync.ClientPipelined
 
                         Cardano.Api.Crypto.Ed25519Bip32
                         -- TODO: Eliminate in the future when
@@ -114,6 +116,7 @@ library
                       , time
                       , transformers
                       , transformers-except
+                      , typed-protocols
                       , unordered-containers >= 0.2.11
                       , vector
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -403,7 +403,10 @@ module Cardano.Api (
 --  connectToRemoteNode,
 
     -- *** Chain sync protocol
+    -- | To construct a @ChainSyncClient@ see @Cardano.Api.Client@ or
+    -- @Cardano.Api.ClientPipelined@.
     ChainSyncClient(..),
+    ChainSyncClientPipelined(..),
     BlockInMode(..),
     LocalNodeClientProtocolsInMode,
 

--- a/cardano-api/src/Cardano/Api/ChainSync/Client.hs
+++ b/cardano-api/src/Cardano/Api/ChainSync/Client.hs
@@ -1,0 +1,17 @@
+
+module Cardano.Api.ChainSync.Client (
+      -- * Protocol type for the client
+      -- | The protocol states from the point of view of the client.
+      ChainSyncClient(..)
+    , ClientStIdle(..)
+    , ClientStNext(..)
+    , ClientStIntersect(..)
+
+      -- * Null chain sync client
+    , chainSyncClientNull
+
+      -- * Utilities
+    , mapChainSyncClient
+    ) where
+
+import           Ouroboros.Network.Protocol.ChainSync.Client

--- a/cardano-api/src/Cardano/Api/ChainSync/ClientPipelined.hs
+++ b/cardano-api/src/Cardano/Api/ChainSync/ClientPipelined.hs
@@ -1,0 +1,34 @@
+
+module Cardano.Api.ChainSync.ClientPipelined (
+      -- * Pipelined protocol type for the client
+      -- | The protocol states from the point of view of the client.
+      ChainSyncClientPipelined (..)
+    , ClientPipelinedStIdle (..)
+    , ClientStNext (..)
+    , ClientPipelinedStIntersect (..)
+    , ChainSyncInstruction (..)
+
+      -- * Implementation Helpers
+      -- | It's generally idiomatic to use these functions to implement your
+      -- pipelined client. It aids in deciding when to make pipelined requests
+      -- vs process received responses.
+    , PipelineDecision(..)
+    , MkPipelineDecision(..)
+    , runPipelineDecision
+    , constantPipelineDecision
+    , pipelineDecisionMax
+    , pipelineDecisionMin
+    , pipelineDecisionLowHighMark
+
+      -- * Type level natural numbers
+    , N (..)
+    , Nat (..)
+    , natToInt
+
+      -- * Utilities
+    , mapChainSyncClientPipelined
+    ) where
+
+import           Network.TypedProtocol.Pipelined (N (..), Nat (..), natToInt)
+import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision

--- a/cardano-client-demo/ScanBlocks.hs
+++ b/cardano-client-demo/ScanBlocks.hs
@@ -1,9 +1,7 @@
 
 import           Cardano.Api
+import           Cardano.Api.ChainSync.Client
 import           Cardano.Api.Shelley
-
--- TODO: Export this via Cardano.Api
-import           Ouroboros.Network.Protocol.ChainSync.Client
 
 import           Control.Monad (when)
 import           Data.Time

--- a/cardano-client-demo/ScanBlocksPipelined.hs
+++ b/cardano-client-demo/ScanBlocksPipelined.hs
@@ -4,18 +4,9 @@
 {-# OPTIONS_GHC -freduction-depth=0 #-}
 
 import           Cardano.Api
+import           Cardano.Api.ChainSync.ClientPipelined
 import qualified Cardano.Chain.Slotting as Byron (EpochSlots (..))
-
--- TODO: Export this via cardano-api. Do we want to export the pipelined and
--- non-pipelined stuff from different modules, or instead resolve the name
--- clashes?
 import           Cardano.Slotting.Slot
-import           Network.TypedProtocol.Pipelined (N (..), Nat (..), natToInt, unsafeIntToNat)
-import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
-                   (ChainSyncClientPipelined (ChainSyncClientPipelined),
-                   ClientPipelinedStIdle (CollectResponse, SendMsgDone, SendMsgRequestNextPipelined),
-                   ClientStNext (..))
-import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 
 import           Control.Monad (when)
 import           Data.Kind

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -20,7 +20,6 @@ executable scan-blocks
   build-depends:        base              >= 4.12       &&  < 5
                       , cardano-api
                       , filepath
-                      , ouroboros-network
                       , time
   default-language:    Haskell2010
 
@@ -32,7 +31,5 @@ executable scan-blocks-pipelined
                        cardano-ledger-byron,
                        cardano-slotting,
                        filepath,
-                       ouroboros-network,
                        time,
-                       typed-protocols,
   default-language:    Haskell2010


### PR DESCRIPTION
This allows me to remove dependencies on ouroboros-network and protocols in the cardano-client-demo package.