### PR TITLE
Updating cardano-ledger

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -114,8 +114,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a4eaf8819515003e287c8960817d2599cfdda1c6
-  --sha256: 0ayq5xaxdf6c5y524c3gz3052dcclqf93kiwf1zhpmq6q960l45y
+  tag: 653dadcc70cd6456784f597866dd44a952cfbfb9
+  --sha256: 03dc6qf9w5xi8psz6sd14w7y1fa6dxf356c0nfp1q8qlg8ndix1r
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -163,8 +163,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 8716d2f8f98a35ac07b0acf3b29fc125132f15df
-  --sha256: 107vdlhldqzmh7gprgxvhjkwm4irl8h73931f9llaina8s24ssy8
+  tag: 80978a02ad43696538f731e399528d7597a3ffe6
+  --sha256: 1wv4mlvjfhsi243gzgjnlfr9s4c7c45yx3yp0f7drq0advzabsga
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -447,6 +447,7 @@ module Cardano.Api (
     -- transaction for special operations.
     makeMIRCertificate,
     makeGenesisKeyDelegationCertificate,
+    MIRTarget (..),
 
     -- * Protocol parameter updates
     UpdateProposal(..),

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -38,6 +38,7 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as ShelleyEpoch
 import qualified Shelley.Spec.Ledger.LedgerState as ShelleyLedger
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import qualified Shelley.Spec.Ledger.Rewards as Shelley
+import qualified Shelley.Spec.Ledger.RewardUpdate as Shelley
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
@@ -246,6 +247,10 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.RewardUpdate crypto) where
                           , "deltaF" .= Shelley.deltaF rUpdate
                           , "nonMyopic" .= Shelley.nonMyopic rUpdate
                           ]
+
+instance Crypto.Crypto crypto => ToJSON (Shelley.PulsingRewUpdate crypto) where
+  toJSON (Shelley.Pulsing _ _) = Aeson.Null
+  toJSON (Shelley.Complete ru) = toJSON ru
 
 instance ToJSON Shelley.DeltaCoin where
   toJSON (Shelley.DeltaCoin i) = toJSON i

--- a/cardano-api/src/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/src/Cardano/Api/TxMetadata.hs
@@ -100,7 +100,9 @@ instance HasTypeProxy TxMetadata where
 instance SerialiseAsCBOR TxMetadata where
     serialiseToCBOR =
           CBOR.serialize'
-        . Shelley.Metadata
+        . (Shelley.Metadata :: Map Word64 Shelley.Metadatum -> Shelley.Metadata ())
+        -- The Shelley (Metadata era) is always polymorphic in era,
+        -- so we pick the unit type.
         . toShelleyMetadata
         . (\(TxMetadata m) -> m)
 
@@ -108,7 +110,10 @@ instance SerialiseAsCBOR TxMetadata where
           TxMetadata
         . fromShelleyMetadata
         . (\(Shelley.Metadata m) -> m)
-      <$> CBOR.decodeAnnotator "TxMetadata" fromCBOR (LBS.fromStrict bs)
+      <$> (CBOR.decodeAnnotator "TxMetadata" fromCBOR (LBS.fromStrict bs)
+           :: Either CBOR.DecoderError (Shelley.Metadata ()))
+        -- The Shelley (Metadata era) is always polymorphic in era,
+        -- so we pick the unit type.
 
 makeTransactionMetadata :: Map Word64 TxMetadataValue -> TxMetadata
 makeTransactionMetadata = TxMetadata

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -40,6 +40,7 @@ module Cardano.Api.Value
   , toByronLovelace
   , toShelleyLovelace
   , fromShelleyLovelace
+  , fromShelleyDeltaLovelace
   , toMaryValue
   , fromMaryValue
 
@@ -104,6 +105,9 @@ toShelleyLovelace (Lovelace l) = Shelley.Coin l
 
 fromShelleyLovelace :: Shelley.Coin -> Lovelace
 fromShelleyLovelace (Shelley.Coin l) = Lovelace l
+
+fromShelleyDeltaLovelace :: Shelley.DeltaCoin -> Lovelace
+fromShelleyDeltaLovelace (Shelley.DeltaCoin d) = Lovelace d
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/test/Test/Cardano/Api/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Gen.hs
@@ -18,7 +18,7 @@ import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-genMetadata :: Gen Metadata
+genMetadata :: Gen (Metadata era)
 genMetadata = do
   numberOfIndicies <- Gen.integral (Range.linear 1 15)
   let indexes = map (\i -> fromIntegral i :: Word64) [1..numberOfIndicies]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -73,7 +73,7 @@ runGovernanceMIRCertificate mirPot sAddrs rwdAmts (OutputFile oFp) = do
                oFp (length sAddrs) (length rwdAmts)
 
     let sCreds  = map stakeAddrToStakeCredential sAddrs
-        mirCert = makeMIRCertificate mirPot (zip sCreds rwdAmts)
+        mirCert = makeMIRCertificate mirPot (StakeAddressesMIR $ zip sCreds rwdAmts)
 
     firstExceptT ShelleyGovernanceCmdTextEnvWriteError
       . newExceptT
@@ -86,6 +86,9 @@ runGovernanceMIRCertificate mirPot sAddrs rwdAmts (OutputFile oFp) = do
     stakeAddrToStakeCredential :: StakeAddress -> StakeCredential
     stakeAddrToStakeCredential (StakeAddress _ scred) =
       fromShelleyStakeCredential scred
+
+-- TODO runGovernanceMIRCertificate does not cover the case where a MIR certificate
+-- transfers lovelace from one pot to the opposite pot.
 
 runGovernanceGenesisKeyDelegationCertificate
   :: VerificationKeyOrHashOrFile GenesisKey

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -265,13 +265,14 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
            onKernel nodeKernel
        }
      StdRunNodeArgs
-       { srnBfcMaxConcurrencyBulkSync = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
-       , srnBfcMaxConcurrencyDeadline = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
-       , srcChainDbValidateOverride   = ncValidateDB nc
-       , srnDatabasePath              = dbPath
-       , srnDiffusionArguments        = diffusionArguments
-       , srnDiffusionTracers          = diffusionTracers
-       , srnTraceChainDB              = chainDBTracer nodeTracers
+       { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
+       , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
+       , srnChainDbValidateOverride     = ncValidateDB nc
+       , srnDatabasePath                = dbPath
+       , srnDiffusionArguments          = diffusionArguments
+       , srnDiffusionTracers            = diffusionTracers
+       , srnEnableInDevelopmentVersions = False -- TODO get this value from the node configuration
+       , srnTraceChainDB                = chainDBTracer nodeTracers
        }
  where
   createDiffusionTracers :: Tracers RemoteConnectionId LocalConnectionId blk
@@ -388,7 +389,8 @@ createDiffusionArguments publicIPv4SocketsOrAddrs
     -- merged into `ouroboros-networ`.
     { daIPv4Address = eitherSocketOrSocketInfo <$> publicIPv4SocketsOrAddrs
     , daIPv6Address = eitherSocketOrSocketInfo <$> publicIPv6SocketsOrAddrs
-    , daLocalAddress = fmap unSocketPath
+    , daLocalAddress = Just -- TODO allow expressing the Nothing case in the config
+                     .  fmap unSocketPath
                      . eitherSocketOrSocketInfo
                      $ localSocketOrPath
     , daIpProducers  = ipProducers

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -546,6 +546,23 @@ instance ToObject (DelegPredicateFailure era) where
     mkObject [ "kind" .= String "DuplicateGenesisVRFDELEG"
              , "keyHash" .= vrfKeyHash
              ]
+  toObject _verb MIRTransferNotCurrentlyAllowed =
+    mkObject [ "kind" .= String "MIRTransferNotCurrentlyAllowed"
+             ]
+  toObject _verb MIRNegativesNotCurrentlyAllowed =
+    mkObject [ "kind" .= String "MIRNegativesNotCurrentlyAllowed"
+             ]
+  toObject _verb (InsufficientForTransferDELEG mirpot attempted available) =
+    mkObject [ "kind" .= String "DuplicateGenesisVRFDELEG"
+             , "pot" .= String (case mirpot of
+                                  ReservesMIR -> "Reserves"
+                                  TreasuryMIR -> "Treasury")
+             , "attempted" .= attempted
+             , "available" .= available
+             ]
+  toObject _verb MIRProducesNegativeUpdate =
+    mkObject [ "kind" .= String "MIRProducesNegativeUpdate"
+             ]
 
 
 instance ToObject (PoolPredicateFailure era) where


### PR DESCRIPTION
I have updated the cardano ledger package to the current master, and ouroboros-network to my last commit in https://github.com/input-output-hk/ouroboros-network/pull/2984

This replaces #2455, since `jc/update-ledger-to-ba74779256` was an overly-ambitious (and now incorrect) branch name. :smile: 

* The ledger state now stores an PulsingRewUpdate instead of a
  RewardUpdate. The PulsingRewUpdate allows us to compute the staking
  rewards incrementally instead of all at once. This involves a new
  serialization format for the reward updates.
* A bug was fixed in the reward calculation which was introduced in
  commit 31083fc5cecbe17f3628393072094b130058edd9.
  (the bug was not a part of any release.)
* The MIR certificates now have additional functionality, but such
  functionality is prohibited until protocol major version 5. Binary
  compatibility is preserved for the original functionality. The new
  functionality is the ability to transfer lovelace between the reserves
  and the treasury.
* The ledger repo now uses ghc-8.10.4 and cabal-3.4.0.0.