### PR TITLE
Remove problematic apt-get repository

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -92,6 +92,9 @@ jobs:
     - name: Install build environment
       if: matrix.os == 'ubuntu-latest'
       run: |
+        # Remove problematic apt-get repository
+        sudo rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+
         sudo apt-get update
         sudo apt-get -y install libsodium23 libsodium-dev
         sudo apt-get -y install libsystemd0 libsystemd-dev


### PR DESCRIPTION
`apt-get` can sometimes fail due to a problematic apt-get repository.  See https://github.com/actions/virtual-environments/issues/2919

Remove this repository since we don't use it anyway to work around the problem.