### PR TITLE
Use RTS --disable-delayed-os-memory-return by default for the node

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -162,10 +162,14 @@ executable cardano-node
   main-is:              cardano-node.hs
   ghc-options:          -threaded
                         -rtsopts
+
+  ghc-options:          "-with-rtsopts=-T -I0 -N1 -A16m"
   if arch(arm)
-    ghc-options:        "-with-rtsopts=-T -I0 -N1 -A16m --disable-delayed-os-memory-return"
+    ghc-options:        "-with-rtsopts=-N1"
   else
-    ghc-options:        "-with-rtsopts=-T -I0 -N2 -A16m --disable-delayed-os-memory-return"
+    ghc-options:        "-with-rtsopts=-N2"
+  if impl(ghc >= 8.10)
+    ghc-options:        "-with-rtsopts=--disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -163,7 +163,7 @@ executable cardano-node
   ghc-options:          -threaded
                         -rtsopts
 
-  ghc-options:          "-with-rtsopts=-T -I0 -N1 -A16m"
+  ghc-options:          "-with-rtsopts=-T -I0 -A16m"
   if arch(arm)
     ghc-options:        "-with-rtsopts=-N1"
   else

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -163,9 +163,9 @@ executable cardano-node
   ghc-options:          -threaded
                         -rtsopts
   if arch(arm)
-    ghc-options:        "-with-rtsopts=-T -I0 -N1 -A16m"
+    ghc-options:        "-with-rtsopts=-T -I0 -N1 -A16m --disable-delayed-os-memory-return"
   else
-    ghc-options:        "-with-rtsopts=-T -I0 -N2 -A16m"
+    ghc-options:        "-with-rtsopts=-T -I0 -N2 -A16m --disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node
 


### PR DESCRIPTION
By default on Linux the RTS uses a fast method of returning memory to
the kernel. This fast method allows the kernel to free the memory
lazily when there is memory pressure. The downside of leting the kernel
do it lazily is that the RSS measure is also only updated lazily.

This has the effect of scaring system admins that the RSS is really
high, when in reality that does not reflect the actual amount of memory
being used.

So by using +RTS --disable-delayed-os-memory-return we ask the RTS to
not use the faster freeing method and use the normal method that updates
the RSS eagerly.