### PR TITLE
supervisord:  provide the cardano-topology attribute

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -85,7 +85,7 @@ let
       }
       {
         # Stamp executables with the git revision and add shell completion
-        packages = lib.genAttrs ["cardano-node" "cardano-cli"] (name: {
+        packages = lib.genAttrs ["cardano-node" "cardano-cli" "cardano-topology"] (name: {
           components.exes.${name}.postInstall = ''
             ${lib.optionalString stdenv.hostPlatform.isWindows setLibSodium}
             ${setGitRev}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -57,6 +57,7 @@ pkgs: _: with pkgs;
   #Grab the executable component of our package.
   inherit (cardanoNodeHaskellPackages.cardano-node.components.exes) cardano-node;
   inherit (cardanoNodeHaskellPackages.cardano-cli.components.exes) cardano-cli;
+  inherit (cardanoNodeHaskellPackages.cardano-topology.components.exes) cardano-topology;
   inherit (cardanoNodeHaskellPackages.bech32.components.exes) bech32;
   cardano-node-profiled = cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node;
   cardano-node-eventlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node;


### PR DESCRIPTION
This fixes `nix-shell -A devops`.