### PR TITLE
fix inline code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,8 +146,8 @@ The general synopsis is as follows:
 
    Usage: cardano-cli (Era based commands | Byron specific commands | Miscellaneous commands)
 
-> NOTE: the exact invocation command depends on the environment.  If you have only built ``cardano-cli``, without installing it, then you have to prepend :code:`cabal run -- `
-before :code:`cardano-cli`.  We henceforth assume that the necessary environment-specific adjustment has been made, so we only mention ``cardano-cli``.
+> NOTE: the exact invocation command depends on the environment.  If you have only built ``cardano-cli``, without installing it, then you have to prepend ``cabal run -- ``
+before ``cardano-cli``.  We henceforth assume that the necessary environment-specific adjustment has been made, so we only mention ``cardano-cli``.
 
 The subcommands are subdivided in groups, and their full list can be seen in the output of ``cardano-cli --help``.
 


### PR DESCRIPTION
Github seems to be confused by the ```:code:``` inline style.