### PR TITLE
Adapt packages to use Protocol type class

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -174,8 +174,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7f90c8c59ffc7d61a4e161e886d8962a9c26787a
-  --sha256: 0hnw6hvbyny3wniaqw8d37l4ysgp8xrq5d84fapxfm525a4hfs0x
+  tag: 66dd5eb0f4bf20272e30a8c5c0a0c9d3992de039
+  --sha256: 1z23l4l81afdzmsh0bgs4ivg0nv58l4mp7g25qa4nfsczl6j07cf
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -58,9 +58,9 @@ import qualified Ouroboros.Consensus.Block as Consensus
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.Cardano.ByronHFC as Consensus
-import qualified Ouroboros.Consensus.Cardano.ShelleyHFC as Consensus
 import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
 import qualified Ouroboros.Consensus.HardFork.Combinator.Degenerate as Consensus
+import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 
 import qualified Cardano.Chain.Block as Byron

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -185,22 +185,6 @@ instance Eq AnyCardanoEra where
         Nothing   -> False
         Just Refl -> True -- since no constructors share types
 
-instance Enum AnyCardanoEra where
-    toEnum 0 = AnyCardanoEra ByronEra
-    toEnum 1 = AnyCardanoEra ShelleyEra
-    toEnum 2 = AnyCardanoEra AllegraEra
-    toEnum 3 = AnyCardanoEra MaryEra
-    toEnum _ = error "AnyCardanoEra.toEnum: bad argument"
-
-    fromEnum (AnyCardanoEra ByronEra)   = 0
-    fromEnum (AnyCardanoEra ShelleyEra) = 1
-    fromEnum (AnyCardanoEra AllegraEra) = 2
-    fromEnum (AnyCardanoEra MaryEra)    = 3
-
-instance Bounded AnyCardanoEra where
-    minBound = AnyCardanoEra ByronEra
-    maxBound = AnyCardanoEra MaryEra
-
 instance ToJSON AnyCardanoEra where
    toJSON (AnyCardanoEra era) = toJSON era
 

--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -43,10 +43,10 @@ import           Data.SOP.Strict (K (K), NS (S, Z))
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.Cardano.ByronHFC as Consensus (ByronBlockHFC)
-import qualified Ouroboros.Consensus.Cardano.ShelleyHFC as Consensus (ShelleyBlockHFC)
 import           Ouroboros.Consensus.HardFork.Combinator as Consensus (EraIndex (..), eraIndexSucc,
                    eraIndexZero)
 import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardMary, StandardShelley)
+import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus (ShelleyBlockHFC)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
 

--- a/cardano-api/src/Cardano/Api/Protocol/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Byron.hs
@@ -6,14 +6,15 @@ module Cardano.Api.Protocol.Byron
   , mkSomeNodeClientProtocolByron
   ) where
 
-import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
+import           Cardano.Api.Protocol.Types (ProtocolClient(..),
+                     ProtocolClientInfoArgs(ProtocolClientInfoArgsByron),
+                     SomeNodeClientProtocol(..))
 import           Cardano.Chain.Slotting (EpochSlots)
-import           Ouroboros.Consensus.Cardano (ProtocolByron, ProtocolClient (ProtocolClientByron))
 import           Ouroboros.Consensus.Cardano.ByronHFC
 
 mkNodeClientProtocolByron :: EpochSlots
-                          -> ProtocolClient ByronBlockHFC ProtocolByron
-mkNodeClientProtocolByron = ProtocolClientByron
+                          -> ProtocolClientInfoArgs ByronBlockHFC
+mkNodeClientProtocolByron = ProtocolClientInfoArgsByron
 
 mkSomeNodeClientProtocolByron :: EpochSlots
                               -> SomeNodeClientProtocol

--- a/cardano-api/src/Cardano/Api/Protocol/Cardano.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Cardano.hs
@@ -6,17 +6,16 @@ module Cardano.Api.Protocol.Cardano
   , mkSomeNodeClientProtocolCardano
   ) where
 
-import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
+import           Cardano.Api.Protocol.Types (ProtocolClient(..),
+                     ProtocolClientInfoArgs(ProtocolClientInfoArgsCardano),
+                     SomeNodeClientProtocol (..))
 import           Cardano.Chain.Slotting (EpochSlots)
-import           Ouroboros.Consensus.Cardano (ProtocolCardano,
-                     ProtocolClient (ProtocolClientCardano))
 import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
 
 mkNodeClientProtocolCardano :: EpochSlots
-                            -> ProtocolClient (CardanoBlock StandardCrypto)
-                                              ProtocolCardano
-mkNodeClientProtocolCardano = ProtocolClientCardano
+                            -> ProtocolClientInfoArgs (CardanoBlock StandardCrypto)
+mkNodeClientProtocolCardano = ProtocolClientInfoArgsCardano
 
 mkSomeNodeClientProtocolCardano :: EpochSlots
                                 -> SomeNodeClientProtocol

--- a/cardano-api/src/Cardano/Api/Protocol/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Shelley.hs
@@ -7,19 +7,15 @@ module Cardano.Api.Protocol.Shelley
   ) where
 
 
-import           Ouroboros.Consensus.Cardano (ProtocolClient (ProtocolClientShelley),
-                     ProtocolShelley)
-import           Ouroboros.Consensus.Cardano.ShelleyHFC
+import           Ouroboros.Consensus.Shelley.ShelleyHFC
 
 import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
-import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
+import           Cardano.Api.Protocol.Types
 
 
-mkNodeClientProtocolShelley :: ProtocolClient
-                                 (ShelleyBlockHFC StandardShelley)
-                                 ProtocolShelley
-mkNodeClientProtocolShelley = ProtocolClientShelley
+mkNodeClientProtocolShelley :: ProtocolClientInfoArgs (ShelleyBlockHFC StandardShelley)
+mkNodeClientProtocolShelley = ProtocolClientInfoArgsShelley
 
 
 mkSomeNodeClientProtocolShelley :: SomeNodeClientProtocol

--- a/cardano-api/src/Cardano/Api/Protocol/Types.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Types.hs
@@ -1,17 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Api.Protocol.Types
-  ( SomeNodeClientProtocol(..)
+  ( BlockType(..)
+  , Protocol(..)
+  , ProtocolInfoArgs(..)
+  , ProtocolClient(..)
+  , ProtocolClientInfoArgs(..)
+  , SomeNodeClientProtocol(..)
   ) where
 
-import           Ouroboros.Consensus.Block (BlockProtocol)
+import           Cardano.Prelude
+
+import           Cardano.Chain.Slotting (EpochSlots)
+
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Cardano
+import           Ouroboros.Consensus.Cardano.Node
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo(..), ProtocolInfo(..))
 import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.ShelleyHFC (ShelleyBlockHFC)
+import           Ouroboros.Consensus.Util.IOLike (IOLike)
+
+class (RunNode blk, IOLike m) => Protocol m blk where
+  data ProtocolInfoArgs m blk
+  protocolInfo :: ProtocolInfoArgs m blk -> ProtocolInfo m blk
+
+-- | Node client support for each consensus protocol.
+--
+-- This is like 'Protocol' but for clients of the node, so with less onerous
+-- requirements than to run a node.
+--
+class (RunNode blk) => ProtocolClient blk where
+  data ProtocolClientInfoArgs blk
+  protocolClientInfo :: ProtocolClientInfoArgs blk -> ProtocolClientInfo blk
+
+
+-- | Run PBFT against the Byron ledger
+instance IOLike m => Protocol m ByronBlockHFC where
+  data ProtocolInfoArgs m ByronBlockHFC = ProtocolInfoArgsByron ProtocolParamsByron
+  protocolInfo (ProtocolInfoArgsByron params) = inject $ protocolInfoByron params
+
+instance IOLike m => Protocol m (CardanoBlock StandardCrypto) where
+  data ProtocolInfoArgs m (CardanoBlock StandardCrypto) = ProtocolInfoArgsCardano
+    ProtocolParamsByron
+    (ProtocolParamsShelleyBased StandardShelley)
+    ProtocolParamsShelley
+    ProtocolParamsAllegra
+    ProtocolParamsMary
+    (ProtocolParamsTransition ByronBlock (ShelleyBlock StandardShelley))
+    (ProtocolParamsTransition (ShelleyBlock StandardShelley) (ShelleyBlock StandardAllegra))
+    (ProtocolParamsTransition (ShelleyBlock StandardAllegra) (ShelleyBlock StandardMary))
+  protocolInfo (ProtocolInfoArgsCardano
+               paramsByron
+               paramsShelleyBased
+               paramsShelley
+               paramsAllegra
+               paramsMary
+               paramsByronShelley
+               paramsShelleyAllegra
+               paramsAllegraMary) =
+    protocolInfoCardano
+      paramsByron
+      paramsShelleyBased
+      paramsShelley
+      paramsAllegra
+      paramsMary
+      paramsByronShelley
+      paramsShelleyAllegra
+      paramsAllegraMary
+
+instance ProtocolClient ByronBlockHFC where
+  data ProtocolClientInfoArgs ByronBlockHFC =
+    ProtocolClientInfoArgsByron EpochSlots
+  protocolClientInfo (ProtocolClientInfoArgsByron epochSlots) =
+    inject $ protocolClientInfoByron epochSlots
+
+instance ProtocolClient (CardanoBlock StandardCrypto) where
+  data ProtocolClientInfoArgs (CardanoBlock StandardCrypto) =
+    ProtocolClientInfoArgsCardano EpochSlots
+  protocolClientInfo (ProtocolClientInfoArgsCardano epochSlots) =
+    protocolClientInfoCardano epochSlots
+
+instance IOLike m => Protocol m (ShelleyBlockHFC StandardShelley) where
+  data ProtocolInfoArgs m (ShelleyBlockHFC StandardShelley) = ProtocolInfoArgsShelley
+    (ProtocolParamsShelleyBased StandardShelley)
+    ProtocolParamsShelley
+  protocolInfo (ProtocolInfoArgsShelley paramsShelleyBased paramsShelley) =
+    inject $ protocolInfoShelley paramsShelleyBased paramsShelley
+
+instance ProtocolClient (ShelleyBlockHFC StandardShelley) where
+  data ProtocolClientInfoArgs (ShelleyBlockHFC StandardShelley) =
+    ProtocolClientInfoArgsShelley
+  protocolClientInfo ProtocolClientInfoArgsShelley =
+    inject protocolClientInfoShelley
+
+data BlockType blk where
+  ByronBlockType :: BlockType ByronBlockHFC
+  ShelleyBlockType :: BlockType (ShelleyBlockHFC StandardShelley)
+  CardanoBlockType :: BlockType (CardanoBlock StandardCrypto)
+
+deriving instance Eq (BlockType blk)
+deriving instance Show (BlockType blk)
 
 data SomeNodeClientProtocol where
 
      SomeNodeClientProtocol
-       :: RunNode blk
-       => ProtocolClient blk (BlockProtocol blk)
+       :: (RunNode blk, ProtocolClient blk)
+       => ProtocolClientInfoArgs blk
        -> SomeNodeClientProtocol

--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -12,7 +12,7 @@
 module Cardano.Chairman (chairmanTest) where
 
 
-import           Cardano.Api.Protocol.Types (SomeNodeClientProtocol (..))
+import           Cardano.Api.Protocol.Types
 import           Cardano.Node.Types (SocketPath (..))
 import           Cardano.Prelude hiding (ByteString, STM, atomically, catch, option, show, throwIO)
 import           Control.Monad.Class.MonadAsync
@@ -23,8 +23,8 @@ import           Control.Monad.Class.MonadTimer
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Coerce (coerce)
-import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig, GetHeader (..), Header)
-import           Ouroboros.Consensus.Cardano
+import           Ouroboros.Consensus.Block (CodecConfig, GetHeader (..), Header)
+import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx)
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (HasNetworkProtocolVersion (..),
@@ -72,7 +72,7 @@ chairmanTest tracer protocol nw securityParam runningTime progressThreshold sock
   traceWith tracer ("Will observe nodes for " ++ show runningTime)
   traceWith tracer ("Will require chain growth of " ++ show progressThreshold)
 
-  SomeNodeClientProtocol (ptcl :: ProtocolClient blk (BlockProtocol blk)) <- return protocol
+  SomeNodeClientProtocol (ptcl :: ProtocolClientInfoArgs blk) <- return protocol
 
   -- Run the chairman and get the final snapshot of the chain from each node.
   chainsSnapshot <- runChairman

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -19,7 +19,7 @@ import           Cardano.Prelude hiding (option)
 import           Control.Monad.Class.MonadTime (DiffTime)
 import           Control.Tracer (Tracer (..), stdoutTracer)
 import           Options.Applicative
-import           Ouroboros.Consensus.Cardano (SecurityParam (..))
+import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 
 import qualified Data.Time.Clock as DTC
 import qualified Options.Applicative as Opt

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -80,7 +80,6 @@ executable cardano-node-chairman
                       , network-mux
                       , optparse-applicative
                       , ouroboros-consensus
-                      , ouroboros-consensus-cardano
                       , ouroboros-network
                       , ouroboros-network-framework
                       , process

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -64,10 +64,8 @@ import           Cardano.BM.Tracing
 
 import qualified Cardano.Chain.Genesis as Gen
 import           Cardano.Slotting.Slot (EpochSize (..))
-import           Ouroboros.Consensus.Block (BlockProtocol)
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
-import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.CanHardFork
 import qualified Ouroboros.Consensus.Config as Consensus
@@ -77,9 +75,11 @@ import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
 import qualified Shelley.Spec.Ledger.API as SL
 
+import           Cardano.Api.Protocol.Types (BlockType (..), protocolInfo)
 import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Types
+import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 import           Cardano.Tracing.OrphanInstances.Common ()
 import           Paths_cardano_node (version)
 
@@ -150,7 +150,7 @@ loggingCLIConfiguration = maybe emptyConfig readConfig
 createLoggingLayer
   :: Text
   -> NodeConfiguration
-  -> Consensus.Protocol IO blk (BlockProtocol blk)
+  -> SomeConsensusProtocol
   -> ExceptT ConfigError IO LoggingLayer
 createLoggingLayer ver nodeConfig' p = do
 
@@ -306,21 +306,21 @@ shutdownLoggingLayer = shutdown . llSwitchboard
 -- It will be sent once TraceForwarderBK is connected to an external process
 -- (for example, RTView).
 nodeBasicInfo :: NodeConfiguration
-              -> Consensus.Protocol IO blk (BlockProtocol blk)
+              -> SomeConsensusProtocol
               -> UTCTime
               -> IO [LogObject Text]
-nodeBasicInfo nc p nodeStartTime' = do
+nodeBasicInfo nc (SomeConsensusProtocol whichP pForInfo) nodeStartTime' = do
   meta <- mkLOMeta Notice Public
-  let cfg = pInfoConfig $ Consensus.protocolInfo p
+  let cfg = pInfoConfig $ protocolInfo pForInfo
       protocolDependentItems =
-        case p of
-          Consensus.ProtocolByron {} ->
+        case whichP of
+          ByronBlockType ->
             let DegenLedgerConfig cfgByron = Consensus.configLedger cfg
             in getGenesisValuesByron cfg cfgByron
-          Consensus.ProtocolShelley {} ->
+          ShelleyBlockType ->
             let DegenLedgerConfig cfgShelley = Consensus.configLedger cfg
             in getGenesisValues "Shelley" cfgShelley
-          Consensus.ProtocolCardano {} ->
+          CardanoBlockType ->
             let CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary = Consensus.configLedger cfg
             in getGenesisValuesByron cfg cfgByron
                ++ getGenesisValues "Shelley" cfgShelley

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -1,14 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Node.Protocol.Byron
-  (
-    -- * Protocol exposing the specific type
-    -- | Use this when you need the specific instance
-    mkConsensusProtocolByron
-
-    -- * Protocols hiding the specific type
-    -- | Use this when you want to handle protocols generically
-  , mkSomeConsensusProtocolByron
+  ( mkSomeConsensusProtocolByron
     -- * Errors
   , ByronProtocolInstantiationError(..)
   , renderByronProtocolInstantiationError
@@ -26,6 +19,7 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as Text
 
 import           Cardano.Api.Byron
+import qualified Cardano.Api.Protocol.Types as Protocol
 
 import qualified Cardano.Crypto.Hash as Crypto
 
@@ -36,9 +30,8 @@ import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)
 
-import           Ouroboros.Consensus.Cardano hiding (Protocol)
+import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import           Ouroboros.Consensus.Cardano.ByronHFC
 
 import           Cardano.Node.Types
 
@@ -63,24 +56,7 @@ mkSomeConsensusProtocolByron
   :: NodeByronProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ByronProtocolInstantiationError IO SomeConsensusProtocol
-mkSomeConsensusProtocolByron nc files =
-
-    -- Applying the SomeConsensusProtocol here is a check that
-    -- the type of mkConsensusProtocolByron fits all the class
-    -- constraints we need to run the protocol.
-    SomeConsensusProtocol <$> mkConsensusProtocolByron nc files
-
-
--- | Instantiate 'Consensus.Protocol' for Byron specifically.
---
--- Use this when you need to run the consensus with this specific protocol.
---
-mkConsensusProtocolByron
-  :: NodeByronProtocolConfiguration
-  -> Maybe ProtocolFilepaths
-  -> ExceptT ByronProtocolInstantiationError IO
-             (Consensus.Protocol IO ByronBlockHFC ProtocolByron)
-mkConsensusProtocolByron NodeByronProtocolConfiguration {
+mkSomeConsensusProtocolByron NodeByronProtocolConfiguration {
                            npcByronGenesisFile,
                            npcByronGenesisFileHash,
                            npcByronReqNetworkMagic,
@@ -98,8 +74,7 @@ mkConsensusProtocolByron NodeByronProtocolConfiguration {
 
     optionalLeaderCredentials <- readLeaderCredentials genesisConfig files
 
-    return $
-      Consensus.ProtocolByron $ Consensus.ProtocolParamsByron {
+    return $ SomeConsensusProtocol Protocol.ByronBlockType $ Protocol.ProtocolInfoArgsByron $ Consensus.ProtocolParamsByron {
         byronGenesis = genesisConfig,
         byronPbftSignatureThreshold =
           PBftSignatureThreshold <$> npcByronPbftSignatureThresh,

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -404,16 +404,9 @@ instance AdjustFilePaths a => AdjustFilePaths (Maybe a) where
 
 instance AdjustFilePaths (Last NodeProtocolConfiguration) where
 
-  adjustFilePaths f (Last (Just (NodeProtocolConfigurationByron pc))) =
-    Last . Just $ NodeProtocolConfigurationByron (adjustFilePaths f pc)
+  adjustFilePaths f (Last (Just npc)) =
+    Last . Just $ adjustFilePaths f npc
 
-  adjustFilePaths f (Last (Just (NodeProtocolConfigurationShelley pc))) =
-    Last . Just $ NodeProtocolConfigurationShelley (adjustFilePaths f pc)
-
-  adjustFilePaths f (Last (Just (NodeProtocolConfigurationCardano pcb pcs pch))) =
-    Last . Just $ NodeProtocolConfigurationCardano (adjustFilePaths f pcb)
-                                                   (adjustFilePaths f pcs)
-                                                   pch
   adjustFilePaths _ (Last Nothing) = Last Nothing
 
 instance AdjustFilePaths (Last SocketPath) where

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -494,7 +494,7 @@ isRollForward (TraceChainSyncRollForward _) = True
 isRollForward _ = False
 
 isTraceBlockFetchServerBlockCount :: TraceBlockFetchServerEvent blk -> Bool
-isTraceBlockFetchServerBlockCount TraceBlockFetchServerSendBlock = True
+isTraceBlockFetchServerBlockCount (TraceBlockFetchServerSendBlock _) = True
 
 mkConsensusTracers
   :: forall blk peer localPeer.


### PR DESCRIPTION
This PR depends on https://github.com/input-output-hk/ouroboros-network/pull/2978

In that PR, the `Protocol` type that the cardano-node packages use is removed. This is so that ouroboros-network does not need to enumerate all the consensus modes it implements. The majority of changes in this PR are in reaction to that, creating a type class to replace it.

We found that it would take a significant increase in code complexity to remove the explicit enumeration of supported consensus modes in two places: 
- cardano-node/src/Cardano/Node/Configuration/Logging.hs:nodeBasicInfo
- cardano-node/src/Cardano/Node/Query.hs

For that purpose, we have written the GADT `BlockType` which provides the little bit of type discovery these places need. 

In addition, we have removed the `Enum` instance for `AnyCardanoEra`. The motivation is that we anticipate the inclusion of experimental eras and consensus modes in the code base which cannot reasonably be said to be enumerable among the mainnet eras. This instance does not appear to be used anywhere. If it needs to be preserved then we will need an answer on how to handle eras we don't expect to be part of mainnet (at least when they are first implemented).