### PR TITLE
Enable creation of MIR transfer certificates

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -307,7 +307,12 @@ renderQueryCmd cmd =
     QueryProtocolState' {} -> "query protocol-state"
 
 data GovernanceCmd
-  = GovernanceMIRCertificate MIRPot [StakeAddress] [Lovelace] OutputFile
+  = GovernanceMIRPayStakeAddressesCertificate
+      MIRPot
+      [StakeAddress]
+      [Lovelace]
+      OutputFile
+  | GovernanceMIRTransfer Lovelace OutputFile TransferDirection
   | GovernanceGenesisKeyDelegationCertificate
       (VerificationKeyOrHashOrFile GenesisKey)
       (VerificationKeyOrHashOrFile GenesisDelegateKey)
@@ -322,7 +327,9 @@ renderGovernanceCmd :: GovernanceCmd -> Text
 renderGovernanceCmd cmd =
   case cmd of
     GovernanceGenesisKeyDelegationCertificate {} -> "governance create-genesis-key-delegation-certificate"
-    GovernanceMIRCertificate {} -> "governance create-mir-certificate"
+    GovernanceMIRPayStakeAddressesCertificate {} -> "governance create-mir-certificate stake-addresses"
+    GovernanceMIRTransfer _ _ TransferToTreasury -> "governance create-mir-certificate transfer-to-treasury"
+    GovernanceMIRTransfer _ _ TransferToReserves -> "governance create-mir-certificate transfer-to-reserves"
     GovernanceUpdateProposal {} -> "governance create-update-proposal"
 
 data TextViewCmd

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Types
   , SigningKeyOrScriptFile (..)
   , SocketPath (..)
   , ScriptFile (..)
+  , TransferDirection(..)
   , TxOutAnyEra (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
@@ -82,6 +83,10 @@ newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
 data SigningKeyOrScriptFile = ScriptFileForWitness FilePath
                             | SigningKeyFileForWitness FilePath
                             deriving (Eq, Show)
+
+-- | Determines the direction in which the MIR certificate will transfer ADA.
+data TransferDirection = TransferToReserves | TransferToTreasury
+                         deriving Show
 
 -- | A TxOut value that is the superset of possibilities for any era: any
 -- address type and allowing multi-asset values. This is used as the type for

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -37,7 +37,7 @@ import           System.Win32.File
 #endif
 
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
-                     mkLOMeta)
+                   mkLOMeta)
 import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
@@ -46,10 +46,10 @@ import           Paths_cardano_node (version)
 import qualified Cardano.Crypto.Libsodium as Crypto
 
 import           Cardano.Node.Configuration.Logging (LoggingLayer (..), Severity (..),
-                     createLoggingLayer, nodeBasicInfo, shutdownLoggingLayer)
+                   createLoggingLayer, nodeBasicInfo, shutdownLoggingLayer)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
-                     PartialNodeConfiguration (..), defaultPartialNodeConfiguration,
-                     makeNodeConfiguration, parseNodeConfigurationFP)
+                   PartialNodeConfiguration (..), defaultPartialNodeConfiguration,
+                   makeNodeConfiguration, parseNodeConfigurationFP)
 import           Cardano.Node.Types
 import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 
@@ -58,8 +58,8 @@ import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
 import           Ouroboros.Consensus.Node (DiffusionArguments (..), DiffusionTracers (..),
-                     DnsSubscriptionTarget (..), IPSubscriptionTarget (..), RunNode,
-                     RunNodeArgs (..), StdRunNodeArgs (..))
+                   DnsSubscriptionTarget (..), IPSubscriptionTarget (..), RunNode, RunNodeArgs (..),
+                   StdRunNodeArgs (..))
 import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -67,7 +67,7 @@ import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode)
 
 import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
-                     gatherConfiguredSockets, getSocketOrSocketInfoAddr, renderSocketConfigError)
+                   gatherConfiguredSockets, getSocketOrSocketInfoAddr, renderSocketConfigError)
 import           Cardano.Node.Configuration.Topology
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Protocol (mkConsensusProtocol, renderProtocolInstantiationError)
@@ -374,7 +374,7 @@ createDiffusionArguments
   -> Maybe (SocketOrSocketInfo Socket AddrInfo)
    -- ^ Either a socket bound to IPv6 address provided by systemd or IPv6
    -- address to bind to for NodeToNode communication.
-  -> SocketOrSocketInfo Socket SocketPath
+  -> Maybe (SocketOrSocketInfo Socket SocketPath)
   -- ^ Either a SOCKET_UNIX socket provided by systemd or a path for
   -- NodeToClient communication.
   -> DiffusionMode
@@ -383,7 +383,7 @@ createDiffusionArguments
   -> DiffusionArguments
 createDiffusionArguments publicIPv4SocketsOrAddrs
                          publicIPv6SocketsOrAddrs
-                         localSocketOrPath
+                         mLocalSocketOrPath
                          diffusionMode
                          ipProducers dnsProducers
                          =
@@ -392,10 +392,8 @@ createDiffusionArguments publicIPv4SocketsOrAddrs
     -- merged into `ouroboros-networ`.
     { daIPv4Address = eitherSocketOrSocketInfo <$> publicIPv4SocketsOrAddrs
     , daIPv6Address = eitherSocketOrSocketInfo <$> publicIPv6SocketsOrAddrs
-    , daLocalAddress = Just -- TODO allow expressing the Nothing case in the config
-                     .  fmap unSocketPath
-                     . eitherSocketOrSocketInfo
-                     $ localSocketOrPath
+    , daLocalAddress = mLocalSocketOrPath >>= return . fmap unSocketPath
+                                                     . eitherSocketOrSocketInfo
     , daIpProducers  = ipProducers
     , daDnsProducers = dnsProducers
     -- TODO: these limits are arbitrary at the moment;


### PR DESCRIPTION
- Make adjustments to allow the node to be started without a socket file
- Amend `MIRTarget` with clearer names

Add the following commands to the cli:
```
governance create-mir-certificate stake-addresses
governance create-mir-certificate transfer-to-treasury
governance create-mir-certificate transfer-to-reserves
```
Relevant ticket: input-output-hk/cardano-ledger-specs#1484