### PR TITLE
nix-shell:  don't provide 'start-cluster' on Darwin, due to BigSur psmisc issue

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -43,6 +43,11 @@ let
       sqlite-interactive
       tmux
       pkgs.git
+    ]
+    ## Local cluster not available on Darwin,
+    ## because psmisc fails to build on Big Sur.
+    ++ lib.optionals (!stdenv.isDarwin)
+    [
       clusterCabal.start
       clusterCabal.stop
     ];


### PR DESCRIPTION
Work around the issue @polinavino reported on Big Sur:
```
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Makefile:571: src/killall] Error 1
make[2]: Leaving directory '/private/tmp/nix-build-psmisc-23.3.drv-0/source'
make[1]: *** [Makefile:641: all-recursive] Error 1
make[1]: Leaving directory '/private/tmp/nix-build-psmisc-23.3.drv-0/source'
make: *** [Makefile:457: all] Error 2
builder for '/nix/store/sj9kfnrpkza0vx3vxdhslznf7x900qvy-psmisc-23.3.drv' failed with exit code 2
building '/nix/store/zfzmdm0wvpds62nq8jh5mlf38r0bfppb-shelley-spec-non-integral-lib-shelley-spec-non-integral-0.1.0.0-haddock.drv'...
cannot build derivation '/nix/store/5jj5x7808kq740dzab12dk4kf8vg95ra-start-cluster.drv': 1 dependencies couldn't be built
error: build of '/nix/store/3krhih7d07fgshn24f4r7mvncbkqi939-ghc-shell-for-packages-ghc-8.10.4-env.drv', '/nix/store/5jj5x7808kq740dzab12dk4kf8vg95ra-start-cluster.drv' failed
```