### PR TITLE
stake-snapshot and pool-params query commands

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -55,11 +55,6 @@ jobs:
     - name: Cabal update
       run: cabal update
 
-    - name: Use cabal.project.local.github-pages
-      run: |
-        cat ./cabal.project.local.github-pages >> ./cabal.project.local
-        cat ./cabal.project.local
-
     - name: Disable reorder goals on MacOS and Linux
       # Avoid reorder goals for platforms that don't need it because re-order goals can take up to 10 minutes
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
@@ -69,6 +64,11 @@ jobs:
 
     - name: Cabal Configure
       run: cabal configure --builddir="$CABAL_BUILDDIR" --write-ghc-environment-files=always
+
+    - name: Use cabal.project.local.github-pages
+      run: |
+        cat ./cabal.project.local.github-pages >> ./cabal.project.local
+        cat ./cabal.project.local
 
     - name: Record dependencies
       run: |
@@ -103,8 +103,8 @@ jobs:
       if: github.ref == 'refs/heads/master'
       run: |
         git fetch origin gh-pages:gh-pages
-        git config --local user.email "$(git show --format="%aN" | head -n 1)"
-        git config --local user.name  "$(git show --format="%aE" | head -n 1)"
+        git config --local user.email "operations@iohk.io"
+        git config --local user.name  "Input Output HK"
         git add .
         git stash
         git checkout gh-pages

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,6 @@ packages:
     cardano-node
     cardano-node-chairman
     cardano-submit-api
-    hedgehog-extras
     nix/supervisord-cluster/topology
 
 package cardano-api
@@ -25,9 +24,6 @@ package cardano-node
   ghc-options: -Werror
 
 package cardano-node-chairman
-  ghc-options: -Werror
-
-package hedgehog-extras
   ghc-options: -Werror
 
 package cryptonite
@@ -94,6 +90,12 @@ package io-sim-classes
 -- scripts/cabal-inside-nix-shell.sh --restore
 -- --------------------------- 8< --------------------------
 -- Please do not put any `source-repository-package` clause above this line.
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/hedgehog-extras
+  tag: 8bcd3c9dc22cc44f9fcfe161f4638a384fc7a187
+  --sha256: 12viwpahjdfvlqpnzdgjp40nw31rvyznnab1hml9afpaxd6ixh70
 
 source-repository-package
   type: git
@@ -165,9 +167,15 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/Win32-network
+  tag: 94153b676617f8f33abe8d8182c37377d2784bd1
+  --sha256: 0pb7bg0936fldaa5r08nqbxvi2g8pcy4w3c7kdcg7pdgmimr30ss
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1ab4ded9eb5a6e7dec9bdd1869506f6a6eb73f42
-  --sha256: 1h1hwpww6b8c8hggr9x70417bs432glzhdfzdd7bvzhlc32lb30m
+  tag: 7f90c8c59ffc7d61a4e161e886d8962a9c26787a
+  --sha256: 0hnw6hvbyny3wniaqw8d37l4ysgp8xrq5d84fapxfm525a4hfs0x
   subdir:
     io-sim
     io-sim-classes
@@ -180,7 +188,6 @@ source-repository-package
     ouroboros-network-framework
     typed-protocols
     typed-protocols-examples
-    Win32-network
 
 constraints:
     hedgehog >= 1.0

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,16 @@
 # Changelog for cardano-api
 
+## 1.26.1 -- March 2021
+
+- The cardano-submit-api now takes transactions encoded as CBOR rather than
+  JSON. This reverts a change to existing behaviour for backwards compatibility.
+  (#2491, #2512)
+- Remove a backwards-compatibility workaround related to the optional query
+  point (#2241 below) when querying the NodeLocalState. This had resulted in
+  spurious notifications of disconnection in the logs. Note that as a
+  consequence of this, instances of the CLI and other tools using the 1.26.1 API
+  will fail to query node state from older versions of the node. (#2540)
+
 ## 1.26.0 -- March 2020
 - Added a demo for the use of cardano-client. This is an API to allow writing
   programs to interact with the cardano node. (#2295, #2303)

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-api
-version:                1.26.0
+version:                1.26.1
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -24,13 +24,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
-
-  if impl(ghc < 8.10)
-    ghc-options:        -Wno-incomplete-patterns
-
+                        -Wunused-packages
 
 library
   import:               base, project-config

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -43,6 +43,7 @@ module Cardano.Api.Eras
 
 import           Prelude
 
+import           Data.Aeson (ToJSON, toJSON)
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 
 import           Cardano.Ledger.Era as Ledger (Crypto)
@@ -136,6 +137,12 @@ data CardanoEra era where
 deriving instance Eq   (CardanoEra era)
 deriving instance Ord  (CardanoEra era)
 deriving instance Show (CardanoEra era)
+
+instance ToJSON (CardanoEra era) where
+   toJSON ByronEra   = "Byron"
+   toJSON ShelleyEra = "Shelley"
+   toJSON AllegraEra = "Allegra"
+   toJSON MaryEra    = "Mary"
 
 instance TestEquality CardanoEra where
     testEquality ByronEra   ByronEra   = Just Refl
@@ -312,4 +319,3 @@ type family ShelleyLedgerEra era where
   ShelleyLedgerEra ShelleyEra = Ledger.StandardShelley
   ShelleyLedgerEra AllegraEra = Ledger.StandardAllegra
   ShelleyLedgerEra MaryEra    = Ledger.StandardMary
-

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -159,6 +159,7 @@ import           Cardano.Api.KeysShelley
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Script
+import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
@@ -292,20 +293,20 @@ instance IsCardanoEra era => ToJSON (TxOut era) where
       ShelleyAddressInEra sbe ->
         case sbe of
           ShelleyBasedEraShelley ->
-            let hexAddr = serialiseToRawBytesHexText addr
-            in object [ "address" .= hexAddr
-                      , "value" .= toJSON val
-                      ]
+            object
+              [ "address" .= serialiseToBech32 addr
+              , "value" .= toJSON val
+              ]
           ShelleyBasedEraAllegra ->
-            let hexAddr = serialiseToRawBytesHexText addr
-            in object [ "address" .= hexAddr
-                      , "value" .= toJSON val
-                      ]
+            object
+              [ "address" .= serialiseToBech32 addr
+              , "value" .= toJSON val
+              ]
           ShelleyBasedEraMary ->
-            let hexAddr = serialiseToRawBytesHexText addr
-            in object [ "address" .= hexAddr
-                      , "value" .= toJSON val
-                      ]
+            object
+              [ "address" .= serialiseToBech32 addr
+              , "value" .= toJSON val
+              ]
 
 
 

--- a/cardano-api/test/cardano-api-test.cabal
+++ b/cardano-api/test/cardano-api-test.cabal
@@ -18,17 +18,12 @@ common project-config
                         OverloadedStrings
 
   ghc-options:          -Wall
+                        -Wcompat
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
-                        -Wredundant-constraints
                         -Wpartial-fields
-                        -Wcompat
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
-
-  if impl(ghc < 8.10)
-    ghc-options:        -Wno-incomplete-patterns
+                        -Wredundant-constraints
+                        -Wunused-packages
 
 library
   import:               base, project-config

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-cli
 
+## 1.26.1 -- March 2021
+- It's no longer necessary to specify the era when making a CLI query. When not
+  specified, the current era will be used as a default. (#2470)
+
 ## 1.26.0 -- March 2021
 - Add three new queries to the CLI, exposing functionality already present in
   the API:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-cli
-version:                1.26.0
+version:                1.26.1
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -29,9 +29,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
 common maybe-unix
   if !os(windows)
@@ -137,6 +135,7 @@ library
                       , utf8-string
                       , unordered-containers
                       , vector
+                      , yaml
 
 executable cardano-cli
   import:               base, project-config
@@ -208,6 +207,7 @@ test-suite cardano-cli-golden
                       , text
                       , time
                       , unordered-containers
+  build-tool-depends:   cardano-cli:cardano-cli
 
   other-modules:        Test.Golden.Shelley
                         Test.Golden.Byron.SigningKeys
@@ -259,6 +259,7 @@ test-suite cardano-cli-golden
                         Test.Golden.Shelley.Transaction.CalculateMinFee
                         Test.Golden.Shelley.Transaction.CreateWitness
                         Test.Golden.Shelley.Transaction.Sign
+                        Test.Golden.TxView
                         Test.Golden.Version
                         Test.OptParse
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -286,13 +286,15 @@ renderPoolCmd cmd =
     PoolMetadataHash {} -> "stake-pool metadata-hash"
 
 data QueryCmd =
-    QueryProtocolParameters' AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryTip AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeDistribution' AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeAddressInfo AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
-  | QueryUTxO' AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
-  | QueryLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+    QueryProtocolParameters' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryTip AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeDistribution' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeAddressInfo AnyCardanoEra AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
+  | QueryUTxO' AnyCardanoEra AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
+  | QueryLedgerState' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryProtocolState' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeSnapshot' AnyCardanoEra AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+  | QueryPoolParams' AnyCardanoEra AnyConsensusModeParams NetworkId (Hash StakePoolKey)
   deriving Show
 
 renderQueryCmd :: QueryCmd -> Text
@@ -305,6 +307,8 @@ renderQueryCmd cmd =
     QueryUTxO' {} -> "query utxo"
     QueryLedgerState' {} -> "query ledger-state"
     QueryProtocolState' {} -> "query protocol-state"
+    QueryStakeSnapshot' {} -> "query stake-snapshot"
+    QueryPoolParams' {} -> "query pool-params"
 
 data GovernanceCmd
   = GovernanceMIRCertificate MIRPot [StakeAddress] [Lovelace] OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -286,15 +286,15 @@ renderPoolCmd cmd =
     PoolMetadataHash {} -> "stake-pool metadata-hash"
 
 data QueryCmd =
-    QueryProtocolParameters' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryTip AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeDistribution' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeAddressInfo AnyCardanoEra AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
-  | QueryUTxO' AnyCardanoEra AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
-  | QueryLedgerState' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryProtocolState' AnyCardanoEra AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeSnapshot' AnyCardanoEra AnyConsensusModeParams NetworkId (Hash StakePoolKey)
-  | QueryPoolParams' AnyCardanoEra AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+    QueryProtocolParameters' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryTip AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeDistribution' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeAddressInfo AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
+  | QueryUTxO' AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
+  | QueryLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeSnapshot' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+  | QueryPoolParams' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
   deriving Show
 
 renderQueryCmd :: QueryCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -673,23 +673,20 @@ pQueryCmd =
     pQueryProtocolParameters :: Parser QueryCmd
     pQueryProtocolParameters =
       QueryProtocolParameters'
-        <$> pCardanoEra
-        <*> pConsensusModeParams
+        <$> pConsensusModeParams
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryTip :: Parser QueryCmd
     pQueryTip = QueryTip
-                  <$> pCardanoEra
-                  <*> pConsensusModeParams
+                  <$> pConsensusModeParams
                   <*> pNetworkId
                   <*> pMaybeOutputFile
 
     pQueryUTxO :: Parser QueryCmd
     pQueryUTxO =
       QueryUTxO'
-        <$> pCardanoEra
-        <*> pConsensusModeParams
+        <$> pConsensusModeParams
         <*> pQueryFilter
         <*> pNetworkId
         <*> pMaybeOutputFile
@@ -697,44 +694,38 @@ pQueryCmd =
     pQueryStakeDistribution :: Parser QueryCmd
     pQueryStakeDistribution =
       QueryStakeDistribution'
-        <$> pCardanoEra
-        <*> pConsensusModeParams
+        <$> pConsensusModeParams
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryStakeAddressInfo :: Parser QueryCmd
     pQueryStakeAddressInfo =
       QueryStakeAddressInfo
-        <$> pCardanoEra
-        <*> pConsensusModeParams
+        <$> pConsensusModeParams
         <*> pFilterByStakeAddress
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryLedgerState :: Parser QueryCmd
     pQueryLedgerState = QueryLedgerState'
-                          <$> pCardanoEra
-                          <*> pConsensusModeParams
+                          <$> pConsensusModeParams
                           <*> pNetworkId
                           <*> pMaybeOutputFile
 
     pQueryProtocolState :: Parser QueryCmd
     pQueryProtocolState = QueryProtocolState'
-                            <$> pCardanoEra
-                            <*> pConsensusModeParams
+                            <$> pConsensusModeParams
                             <*> pNetworkId
                             <*> pMaybeOutputFile
 
     pQueryStakeSnapshot :: Parser QueryCmd
     pQueryStakeSnapshot = QueryStakeSnapshot'
-                          <$> pCardanoEra
                           <*> pConsensusModeParams
                           <*> pNetworkId
                           <*> pStakePoolVerificationKeyHash
 
     pQueryPoolParams :: Parser QueryCmd
     pQueryPoolParams = QueryPoolParams'
-                          <$> pCardanoEra
                           <*> pConsensusModeParams
                           <*> pNetworkId
                           <*> pStakePoolVerificationKeyHash
@@ -1514,19 +1505,6 @@ pNetworkId =
       (  Opt.long "mainnet"
       <> Opt.help "Use the mainnet magic id."
       )
-
-{-
-pPoolId :: Parser PoolId
-pPoolId =
-  pMainnet <|> fmap Testnet pTestnetMagic
- where
-   pMainnet :: Parser NetworkId
-   pMainnet =
-    Opt.flag' Mainnet
-      (  Opt.long "mainnet"
-      <> Opt.help "Use the mainnet magic id."
-      )
--}
 
 pTestnetMagic :: Parser NetworkMagic
 pTestnetMagic =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -720,13 +720,13 @@ pQueryCmd =
 
     pQueryStakeSnapshot :: Parser QueryCmd
     pQueryStakeSnapshot = QueryStakeSnapshot'
-                          <*> pConsensusModeParams
+                          <$> pConsensusModeParams
                           <*> pNetworkId
                           <*> pStakePoolVerificationKeyHash
 
     pQueryPoolParams :: Parser QueryCmd
     pQueryPoolParams = QueryPoolParams'
-                          <*> pConsensusModeParams
+                          <$> pConsensusModeParams
                           <*> pNetworkId
                           <*> pStakePoolVerificationKeyHash
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -664,25 +664,32 @@ pQueryCmd =
         (Opt.info pQueryLedgerState $ Opt.progDesc "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)")
     , subParser "protocol-state"
         (Opt.info pQueryProtocolState $ Opt.progDesc "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)")
+    , subParser "stake-snapshot"
+        (Opt.info pQueryStakeSnapshot $ Opt.progDesc "Obtain the stake snapshot for a pool (mark,set,go,total -- advanced command)")
+    , subParser "pool-params"
+        (Opt.info pQueryPoolParams $ Opt.progDesc "Dump the pool parameters (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)")
     ]
   where
     pQueryProtocolParameters :: Parser QueryCmd
     pQueryProtocolParameters =
       QueryProtocolParameters'
-        <$> pConsensusModeParams
+        <$> pCardanoEra
+        <*> pConsensusModeParams
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryTip :: Parser QueryCmd
     pQueryTip = QueryTip
-                  <$> pConsensusModeParams
+                  <$> pCardanoEra
+                  <*> pConsensusModeParams
                   <*> pNetworkId
                   <*> pMaybeOutputFile
 
     pQueryUTxO :: Parser QueryCmd
     pQueryUTxO =
       QueryUTxO'
-        <$> pConsensusModeParams
+        <$> pCardanoEra
+        <*> pConsensusModeParams
         <*> pQueryFilter
         <*> pNetworkId
         <*> pMaybeOutputFile
@@ -690,29 +697,48 @@ pQueryCmd =
     pQueryStakeDistribution :: Parser QueryCmd
     pQueryStakeDistribution =
       QueryStakeDistribution'
-        <$> pConsensusModeParams
+        <$> pCardanoEra
+        <*> pConsensusModeParams
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryStakeAddressInfo :: Parser QueryCmd
     pQueryStakeAddressInfo =
       QueryStakeAddressInfo
-        <$> pConsensusModeParams
+        <$> pCardanoEra
+        <*> pConsensusModeParams
         <*> pFilterByStakeAddress
         <*> pNetworkId
         <*> pMaybeOutputFile
 
     pQueryLedgerState :: Parser QueryCmd
     pQueryLedgerState = QueryLedgerState'
-                          <$> pConsensusModeParams
+                          <$> pCardanoEra
+                          <*> pConsensusModeParams
                           <*> pNetworkId
                           <*> pMaybeOutputFile
 
     pQueryProtocolState :: Parser QueryCmd
     pQueryProtocolState = QueryProtocolState'
-                            <$> pConsensusModeParams
+                            <$> pCardanoEra
+                            <*> pConsensusModeParams
                             <*> pNetworkId
                             <*> pMaybeOutputFile
+
+    pQueryStakeSnapshot :: Parser QueryCmd
+    pQueryStakeSnapshot = QueryStakeSnapshot'
+                          <$> pCardanoEra
+                          <*> pConsensusModeParams
+                          <*> pNetworkId
+                          <*> pStakePoolVerificationKeyHash
+
+    pQueryPoolParams :: Parser QueryCmd
+    pQueryPoolParams = QueryPoolParams'
+                          <$> pCardanoEra
+                          <*> pConsensusModeParams
+                          <*> pNetworkId
+                          <*> pStakePoolVerificationKeyHash
+
 
 pGovernanceCmd :: Parser GovernanceCmd
 pGovernanceCmd =
@@ -1488,6 +1514,19 @@ pNetworkId =
       (  Opt.long "mainnet"
       <> Opt.help "Use the mainnet magic id."
       )
+
+{-
+pPoolId :: Parser PoolId
+pPoolId =
+  pMainnet <|> fmap Testnet pTestnetMagic
+ where
+   pMainnet :: Parser NetworkId
+   pMainnet =
+    Opt.flag' Mainnet
+      (  Opt.long "mainnet"
+      <> Opt.help "Use the mainnet magic id."
+      )
+-}
 
 pTestnetMagic :: Parser NetworkMagic
 pTestnetMagic =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -665,7 +665,7 @@ pQueryCmd =
     , subParser "protocol-state"
         (Opt.info pQueryProtocolState $ Opt.progDesc "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)")
     , subParser "stake-snapshot"
-        (Opt.info pQueryStakeSnapshot $ Opt.progDesc "Obtain the stake snapshot for a pool (mark,set,go,total -- advanced command)")
+        (Opt.info pQueryStakeSnapshot $ Opt.progDesc "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)")
     , subParser "pool-params"
         (Opt.info pQueryPoolParams $ Opt.progDesc "Dump the pool parameters (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)")
     ]
@@ -678,10 +678,11 @@ pQueryCmd =
         <*> pMaybeOutputFile
 
     pQueryTip :: Parser QueryCmd
-    pQueryTip = QueryTip
-                  <$> pConsensusModeParams
-                  <*> pNetworkId
-                  <*> pMaybeOutputFile
+    pQueryTip =
+      QueryTip
+        <$> pConsensusModeParams
+        <*> pNetworkId
+        <*> pMaybeOutputFile
 
     pQueryUTxO :: Parser QueryCmd
     pQueryUTxO =
@@ -707,28 +708,32 @@ pQueryCmd =
         <*> pMaybeOutputFile
 
     pQueryLedgerState :: Parser QueryCmd
-    pQueryLedgerState = QueryLedgerState'
-                          <$> pConsensusModeParams
-                          <*> pNetworkId
-                          <*> pMaybeOutputFile
+    pQueryLedgerState =
+      QueryLedgerState'
+        <$> pConsensusModeParams
+        <*> pNetworkId
+        <*> pMaybeOutputFile
 
     pQueryProtocolState :: Parser QueryCmd
-    pQueryProtocolState = QueryProtocolState'
-                            <$> pConsensusModeParams
-                            <*> pNetworkId
-                            <*> pMaybeOutputFile
+    pQueryProtocolState =
+      QueryProtocolState'
+        <$> pConsensusModeParams
+        <*> pNetworkId
+        <*> pMaybeOutputFile
 
     pQueryStakeSnapshot :: Parser QueryCmd
-    pQueryStakeSnapshot = QueryStakeSnapshot'
-                          <$> pConsensusModeParams
-                          <*> pNetworkId
-                          <*> pStakePoolVerificationKeyHash
+    pQueryStakeSnapshot =
+      QueryStakeSnapshot'
+        <$> pConsensusModeParams
+        <*> pNetworkId
+        <*> pStakePoolVerificationKeyHash
 
     pQueryPoolParams :: Parser QueryCmd
-    pQueryPoolParams = QueryPoolParams'
-                          <$> pConsensusModeParams
-                          <*> pNetworkId
-                          <*> pStakePoolVerificationKeyHash
+    pQueryPoolParams =
+      QueryPoolParams'
+        <$> pConsensusModeParams
+        <*> pNetworkId
+        <*> pStakePoolVerificationKeyHash
 
 
 pGovernanceCmd :: Parser GovernanceCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pretty.hs
@@ -1,107 +1,177 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
-module Cardano.CLI.Shelley.Run.Pretty (prettyTx) where
+-- | User-friendly pretty-printing for textual user interfaces (TUI)
+module Cardano.CLI.Shelley.Run.Pretty (friendlyTxBodyBS) where
 
-import           Cardano.Api
-                   (ShelleyBasedEra (ShelleyBasedEraAllegra, ShelleyBasedEraMary, ShelleyBasedEraShelley))
-import           Cardano.Api.Byron (TxBody (ByronTxBody))
-import           Cardano.Api.Shelley (TxBody (ShelleyTxBody))
-import           Cardano.CLI.Helpers (textShow)
-import qualified Cardano.Ledger.ShelleyMA.TxBody as ShelleyMA
 import           Cardano.Prelude
-import           Data.Aeson as JSON (Value, object, (.=))
-import           Data.Aeson.Encode.Pretty (Config (confCompare), defConfig, encodePretty')
+
+import           Data.Aeson (Object, Value (..), object, toJSON, (.=))
+import qualified Data.HashMap.Strict as HashMap
+import           Data.Yaml.Pretty (defConfig, encodePretty, setConfCompare)
+
+import           Cardano.Api as Api (AddressInEra (..),
+                   AddressTypeInEra (ByronAddressInAnyEra, ShelleyAddressInEra), CardanoEra,
+                   ShelleyBasedEra (ShelleyBasedEraAllegra, ShelleyBasedEraMary, ShelleyBasedEraShelley),
+                   ShelleyEra, TxBody, serialiseAddress)
+import           Cardano.Api.Byron (TxBody (ByronTxBody))
+import           Cardano.Api.Shelley (TxBody (ShelleyTxBody), fromShelleyAddr)
+import           Cardano.Binary (Annotated)
+import qualified Cardano.Chain.UTxO as Byron
+import           Cardano.Ledger.Shelley as Ledger (ShelleyEra)
+import           Cardano.Ledger.ShelleyMA (MaryOrAllegra (Allegra, Mary), ShelleyMAEra)
+import qualified Cardano.Ledger.ShelleyMA.TxBody as ShelleyMA
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
+import           Shelley.Spec.Ledger.API (Addr (..), TxOut (TxOut))
 import qualified Shelley.Spec.Ledger.API as Shelley
 
-prettyTx :: TxBody era -> LByteString
-prettyTx body0 =
-  encodePretty' defConfig{confCompare = compare} $
-  object $
-  case body0 of
-    ByronTxBody tx -> ["era" .= ("Byron" :: Text), "tx" .= tx]
-    ShelleyTxBody ShelleyBasedEraShelley body aux ->
-      [ "era" .= ("Shelley" :: Text)
-      , "inputs" .= _inputs
-      , "outputs" .= _outputs
-      , "certificates" .= fmap textShow _certs
-      , "withdrawals" .= withdrawals
-      , "fee" .= _txfee
-      , "timetolive" .= _ttl
-      , "update" .= fmap textShow _txUpdate
-      , "metadata_hash" .= fmap textShow _mdHash
-      , "auxiliary_data" .= fmap textShow aux
-      ]
-      where
-        Shelley.TxBody
-          { _inputs
-          , _outputs
-          , _certs
-          , _wdrls
-          , _txfee
-          , _ttl
-          , _txUpdate
-          , _mdHash
-          } =
-            body
-        Shelley.Wdrl withdrawals = _wdrls
-    ShelleyTxBody ShelleyBasedEraAllegra body aux ->
-      [ "era" .= ("Allegra" :: Text)
-      , "inputs" .= inputs
-      , "outputs" .= outputs
-      , "certificates" .= fmap textShow certificates
-      , "withdrawals" .= withdrawals
-      , "fee" .= txfee
-      , "validity_interval" .= prettyValidityInterval validity
-      , "update" .= fmap textShow update
-      , "auxiliary_data_hash" .= fmap textShow adHash
-      , "mint" .= mint
-      , "auxiliary_data" .= fmap textShow aux
-      ]
-      where
-        ShelleyMA.TxBody
-          inputs
-          outputs
-          certificates
-          (Shelley.Wdrl withdrawals)
-          txfee
-          validity
-          update
-          adHash
-          mint =
-            body
-    ShelleyTxBody ShelleyBasedEraMary body aux ->
-      [ "era" .= ("Mary" :: Text)
-      , "inputs" .= inputs
-      , "outputs" .= outputs
-      , "certificates" .= fmap textShow certificates
-      , "withdrawals" .= withdrawals
-      , "fee" .= txfee
-      , "validity_interval" .= prettyValidityInterval validity
-      , "update" .= fmap textShow update
-      , "auxiliary_data_hash" .= fmap textShow adHash
-      , "mint" .= mint
-      , "auxiliary_data" .= fmap textShow aux
-      ]
-      where
-        ShelleyMA.TxBody
-          inputs
-          outputs
-          certificates
-          (Shelley.Wdrl withdrawals)
-          txfee
-          validity
-          update
-          adHash
-          mint =
-            body
+import           Cardano.CLI.Helpers (textShow)
 
-prettyValidityInterval :: ShelleyMA.ValidityInterval -> JSON.Value
-prettyValidityInterval
+friendlyTxBodyBS :: CardanoEra era -> Api.TxBody era -> ByteString
+friendlyTxBodyBS era =
+  encodePretty (setConfCompare compare defConfig) . friendlyTxBody era
+
+friendlyTxBody :: CardanoEra era -> Api.TxBody era -> Value
+friendlyTxBody era txbody =
+  Object $
+    HashMap.fromList ["era" .= toJSON era]
+    <>
+    case txbody of
+      ByronTxBody body -> friendlyTxBodyByron body
+      ShelleyTxBody ShelleyBasedEraShelley body aux ->
+        addAuxData aux $ friendlyTxBodyShelley body
+      ShelleyTxBody ShelleyBasedEraAllegra body aux ->
+        addAuxData aux $ friendlyTxBodyAllegra body
+      ShelleyTxBody ShelleyBasedEraMary body aux ->
+        addAuxData aux $ friendlyTxBodyMary body
+
+addAuxData :: Show a => Maybe a -> Object -> Object
+addAuxData = HashMap.insert "auxiliary data" . maybe Null (toJSON . textShow)
+
+friendlyTxBodyByron :: Annotated Byron.Tx ByteString -> Object
+friendlyTxBodyByron = assertObject . toJSON
+
+friendlyTxBodyShelley
+  :: Shelley.TxBody (Ledger.ShelleyEra StandardCrypto) -> Object
+friendlyTxBodyShelley body =
+  HashMap.fromList
+    [ "inputs" .= Shelley._inputs body
+    , "outputs" .= fmap friendlyTxOutShelley (Shelley._outputs body)
+    , "certificates" .= fmap textShow (Shelley._certs body)
+    , "withdrawals" .= Shelley.unWdrl (Shelley._wdrls body)
+    , "fee" .= Shelley._txfee body
+    , "time to live" .= Shelley._ttl body
+    , "update" .= fmap textShow (Shelley._txUpdate body)
+    , "metadata hash" .= fmap textShow (Shelley._mdHash body)
+    ]
+
+friendlyTxBodyAllegra
+  :: ShelleyMA.TxBody (ShelleyMAEra 'Allegra StandardCrypto) -> Object
+friendlyTxBodyAllegra
+  (ShelleyMA.TxBody
+    inputs
+    outputs
+    certificates
+    (Shelley.Wdrl withdrawals)
+    txfee
+    validity
+    update
+    adHash
+    _mint -- mint is not used in Allegra, only in Mary+
+    ) =
+  HashMap.fromList
+    [ "inputs" .= inputs
+    , "outputs" .= fmap friendlyTxOutAllegra outputs
+    , "certificates" .= fmap textShow certificates
+    , "withdrawals" .= withdrawals
+    , "fee" .= txfee
+    , "validity interval" .= friendlyValidityInterval validity
+    , "update" .= fmap textShow update
+    , "auxiliary data hash" .= fmap textShow adHash
+    ]
+
+friendlyTxBodyMary
+  :: ShelleyMA.TxBody (ShelleyMAEra 'Mary StandardCrypto) -> Object
+friendlyTxBodyMary
+  (ShelleyMA.TxBody
+    inputs
+    outputs
+    certificates
+    (Shelley.Wdrl withdrawals)
+    txfee
+    validity
+    update
+    adHash
+    mint) =
+  HashMap.fromList
+    [ "inputs" .= inputs
+    , "outputs" .= fmap friendlyTxOutMary outputs
+    , "certificates" .= fmap textShow certificates
+    , "withdrawals" .= withdrawals
+    , "fee" .= txfee
+    , "validity interval" .= friendlyValidityInterval validity
+    , "update" .= fmap textShow update
+    , "auxiliary data hash" .= fmap textShow adHash
+    , "mint" .= mint
+    ]
+
+friendlyValidityInterval :: ShelleyMA.ValidityInterval -> Value
+friendlyValidityInterval
   ShelleyMA.ValidityInterval{invalidBefore, invalidHereafter} =
     object
-      [ "invalid_before" .= invalidBefore
-      , "invalid_hereafter" .= invalidHereafter
+      [ "invalid before" .= invalidBefore
+      , "invalid hereafter" .= invalidHereafter
       ]
+
+friendlyTxOutShelley :: TxOut (Ledger.ShelleyEra StandardCrypto) -> Value
+friendlyTxOutShelley (TxOut addr amount) =
+  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+
+friendlyTxOutAllegra :: TxOut (ShelleyMAEra 'Allegra StandardCrypto) -> Value
+friendlyTxOutAllegra (TxOut addr amount) =
+  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+
+friendlyTxOutMary :: TxOut (ShelleyMAEra 'Mary StandardCrypto) -> Value
+friendlyTxOutMary (TxOut addr amount) =
+  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+
+friendlyAddress :: Addr StandardCrypto -> Object
+friendlyAddress addr =
+  HashMap.fromList $
+    case addr of
+      Addr net cred ref ->
+        [ "address" .=
+            object
+              [ "network" .= net
+              , "credential" .= cred
+              , "stake reference" .= textShow ref
+              , "Bech32" .= addressBech32
+              ]
+        ]
+      AddrBootstrap _ ->
+        ["bootstrap address" .= object ["Bech32" .= String addressBech32]]
+  where
+    addressBech32 =
+      case fromShelleyAddr @Api.ShelleyEra addr of
+        AddressInEra (ShelleyAddressInEra _) a -> serialiseAddress a
+        AddressInEra ByronAddressInAnyEra a -> serialiseAddress a
+
+assertObject :: HasCallStack => Value -> Object
+assertObject = \case
+  Object obj -> obj
+  val -> panic $ "expected JSON Object, but got " <> typ
+    where
+      typ =
+        case val of
+          Array{}  -> "an Array"
+          Bool{}   -> "a Boolean"
+          Null     -> "Null"
+          Number{} -> "a Number"
+          Object{} -> "an Object"
+          String{} -> "a String"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -274,7 +274,7 @@ runQueryPoolParams (AnyConsensusModeParams cModeParams)
                   cModeParams
                   localNodeConnInfo
                   qInMode
-      obtainLedgerEraClassConstraints sbe (writePoolParams stakeDist poolid) result
+      obtainLedgerEraClassConstraints sbe (writePoolParams poolid) result
     Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 
@@ -302,7 +302,7 @@ runQueryStakeSnapshot (AnyConsensusModeParams cModeParams)
                   cModeParams
                   localNodeConnInfo
                   qInMode
-      obtainLedgerEraClassConstraints sbe (writeStakeSnapshot stakeDist poolid) result
+      obtainLedgerEraClassConstraints sbe (writeStakeSnapshot poolid) result
     Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 
@@ -474,11 +474,11 @@ writeStakeSnapshot :: forall era ledgerera.
                  => Era ledgerera
                  => FromCBOR (LedgerState era)
                  =>
-                    SerialisedLedgerState era
-                 -> Hash StakePoolKey
+                    Hash StakePoolKey
+                 -> SerialisedLedgerState era
                  -> ExceptT ShelleyQueryCmdError IO ()
 
-writeStakeSnapshot qState poolId =
+writeStakeSnapshot poolId qState =
        case decodeLedgerState qState of
            Left bs ->
                       firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
@@ -537,12 +537,12 @@ writePoolParams :: forall era ledgerera.
                  => FromCBOR (LedgerState era)
                  =>  Crypto.Crypto (Crypto ledgerera)
                  =>
-                    SerialisedLedgerState era
-                 -> Hash StakePoolKey
+                    Hash StakePoolKey
+                 -> SerialisedLedgerState era
                  -> ExceptT ShelleyQueryCmdError IO ()
 
 --    .nesEs.esLState._delegationState._pstate._pParams.<pool_id>
-writePoolParams qState poolId =
+writePoolParams poolId qState =
        case decodeLedgerState qState of
            Left bs ->
                       firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -103,93 +103,86 @@ renderShelleyQueryCmdError err =
 runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmd cmd =
   case cmd of
-    QueryProtocolParameters' era consensusModeParams network mOutFile ->
-      runQueryProtocolParameters era consensusModeParams network mOutFile
-    QueryTip era consensusModeParams network mOutFile ->
-      runQueryTip era consensusModeParams network mOutFile
-    QueryStakeDistribution' era consensusModeParams network mOutFile ->
-      runQueryStakeDistribution era consensusModeParams network mOutFile
-    QueryStakeAddressInfo era consensusModeParams addr network mOutFile ->
-      runQueryStakeAddressInfo era consensusModeParams addr network mOutFile
-    QueryLedgerState' era consensusModeParams network mOutFile ->
-      runQueryLedgerState era consensusModeParams network mOutFile
-    QueryStakeSnapshot' era consensusModeParams network poolid ->
-      runQueryStakeSnapshot era consensusModeParams network poolid
-    QueryPoolParams' era consensusModeParams network poolid ->
-      runQueryPoolParams era consensusModeParams network poolid
-    QueryProtocolState' era consensusModeParams network mOutFile ->
-      runQueryProtocolState era consensusModeParams network mOutFile
-    QueryUTxO' era consensusModeParams qFilter networkId mOutFile ->
-      runQueryUTxO era consensusModeParams qFilter networkId mOutFile
+    QueryProtocolParameters' consensusModeParams network mOutFile ->
+      runQueryProtocolParameters consensusModeParams network mOutFile
+    QueryTip consensusModeParams network mOutFile ->
+      runQueryTip consensusModeParams network mOutFile
+    QueryStakeDistribution' consensusModeParams network mOutFile ->
+      runQueryStakeDistribution consensusModeParams network mOutFile
+    QueryStakeAddressInfo consensusModeParams addr network mOutFile ->
+      runQueryStakeAddressInfo consensusModeParams addr network mOutFile
+    QueryLedgerState' consensusModeParams network mOutFile ->
+      runQueryLedgerState consensusModeParams network mOutFile
+    QueryStakeSnapshot' consensusModeParams network poolid ->
+      runQueryStakeSnapshot consensusModeParams network poolid
+    QueryPoolParams' consensusModeParams network poolid ->
+      runQueryPoolParams consensusModeParams network poolid
+    QueryProtocolState' consensusModeParams network mOutFile ->
+      runQueryProtocolState consensusModeParams network mOutFile
+    QueryUTxO' consensusModeParams qFilter networkId mOutFile ->
+      runQueryUTxO consensusModeParams qFilter networkId mOutFile
 
 runQueryProtocolParameters
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryProtocolParameters anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
-                           network mOutFile = do
+runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile = do
   SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr
                            readEnvSocketPath
-
-  let consensusMode = consensusModeOnly cModeParams
-  eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                 $ toEraInMode era consensusMode
-
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  qInMode <- case cardanoEraStyle era of
-               LegacyByronEra -> left ShelleyQueryCmdByronEra
-               ShelleyBasedEra sbe -> return . QueryInEra eraInMode
-                                        $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-  res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-  case res of
-    Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-    Right ePparams ->
-      case ePparams of
-        Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-        Right pparams -> writeProtocolParameters mOutFile pparams
-
-writeProtocolParameters
-  :: Maybe OutputFile
-  -> ProtocolParameters
-  -> ExceptT ShelleyQueryCmdError IO ()
-writeProtocolParameters mOutFile pparams =
-  case mOutFile of
-    Nothing -> liftIO $ LBS.putStrLn (encodePretty pparams)
-    Just (OutputFile fpath) ->
-      handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $
-        LBS.writeFile fpath (encodePretty pparams)
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let query = QueryInEra eInMode
+                    $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  query
+      writeProtocolParameters mOutFile result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
+ where
+  writeProtocolParameters
+    :: Maybe OutputFile
+    -> ProtocolParameters
+    -> ExceptT ShelleyQueryCmdError IO ()
+  writeProtocolParameters mOutFile' pparams =
+    case mOutFile' of
+      Nothing -> liftIO $ LBS.putStrLn (encodePretty pparams)
+      Just (OutputFile fpath) ->
+        handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $
+          LBS.writeFile fpath (encodePretty pparams)
 
 runQueryTip
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryTip (AnyCardanoEra era) (AnyConsensusModeParams cModeParams) network mOutFile = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
-    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-    tip <- liftIO $ getLocalChainTip localNodeConnInfo
+runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
+      consensusMode = consensusModeOnly cModeParams
 
-    let consensusMode = consensusModeOnly cModeParams
-
-    mEpoch <- mEpochQuery consensusMode tip localNodeConnInfo
-
-    let output = encodePretty . toObject mEpoch $ toJSON tip
-
-    case mOutFile of
-      Just (OutputFile fpath) -> liftIO $ LBS.writeFile fpath output
-      Nothing                 -> liftIO $ LBS.putStrLn        output
+  anyEra <- determineEra cModeParams localNodeConnInfo
+  mEpoch <- mEpochQuery anyEra consensusMode  localNodeConnInfo
+  tip <- liftIO $ getLocalChainTip localNodeConnInfo
+  let output = encodePretty . toObject mEpoch $ toJSON tip
+  case mOutFile of
+    Just (OutputFile fpath) -> liftIO $ LBS.writeFile fpath output
+    Nothing                 -> liftIO $ LBS.putStrLn        output
  where
    mEpochQuery
-     :: ConsensusMode mode
-     -> ChainTip
+     :: AnyCardanoEra
+     -> ConsensusMode mode
      -> LocalNodeConnectInfo mode
      -> ExceptT ShelleyQueryCmdError IO (Maybe EpochNo)
-   mEpochQuery cMode tip' lNodeConnInfo =
+   mEpochQuery (AnyCardanoEra era) cMode lNodeConnInfo =
      case toEraInMode era cMode of
        Nothing -> return Nothing
        Just eraInMode ->
@@ -197,8 +190,7 @@ runQueryTip (AnyCardanoEra era) (AnyConsensusModeParams cModeParams) network mOu
            LegacyByronEra -> return Nothing
            ShelleyBasedEra sbe -> do
              let epochQuery = QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryEpoch
-                 cPoint = chainTipToChainPoint tip'
-             eResult <- liftIO $ queryNodeLocalState lNodeConnInfo (Just cPoint) epochQuery
+             eResult <- liftIO $ queryNodeLocalState lNodeConnInfo Nothing epochQuery
              case eResult of
                Left _acqFail -> return Nothing
                Right eNum -> case eNum of
@@ -213,37 +205,35 @@ runQueryTip (AnyCardanoEra era) (AnyConsensusModeParams cModeParams) network mOu
    toObject _ _ = Aeson.Null
 
 
-
-
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
 --
 
 runQueryUTxO
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> QueryFilter
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryUTxO anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryUTxO (AnyConsensusModeParams cModeParams)
              qfilter network mOutFile = do
   SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
-  let consensusMode = consensusModeOnly cModeParams
-  eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                 $ toEraInMode era consensusMode
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
 
-  qInMode <- createQuery sbe eraInMode
-
-  eUtxo <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-  case eUtxo of
-    Left aF -> left $ ShelleyQueryCmdAcquireFailure aF
-    Right eU -> case eU of
-                  Left mismatch -> left $ ShelleyQueryCmdEraMismatch mismatch
-                  Right utxo -> writeFilteredUTxOs sbe mOutFile utxo
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      qInMode <- createQuery sbe eInMode
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  qInMode
+      writeFilteredUTxOs sbe mOutFile result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
  where
   createQuery
     :: ShelleyBasedEra era
@@ -260,175 +250,149 @@ runQueryUTxO anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
 
 
 runQueryPoolParams
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Hash StakePoolKey
   -> ExceptT ShelleyQueryCmdError IO ()
 
-runQueryPoolParams anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryPoolParams (AnyConsensusModeParams cModeParams)
                     network poolid = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-    let consensusMode = consensusModeOnly cModeParams
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-    eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                  $ toEraInMode era consensusMode
-
-    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-    sbe <- getSbe $ cardanoEraStyle era
-
-
-    let qInMode = QueryInEra eraInMode
-                    . QueryInShelleyBasedEra sbe
-                    $ QueryLedgerState
-
-    res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-    case res of
-      Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-      Right eStakeDist ->
-        case eStakeDist of
-          Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-          Right stakeDist -> obtainLedgerEraClassConstraints sbe
-                               $ writePoolParams stakeDist poolid
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let qInMode = QueryInEra eInMode
+                      . QueryInShelleyBasedEra sbe
+                      $ QueryLedgerState
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  qInMode
+      obtainLedgerEraClassConstraints sbe (writePoolParams stakeDist poolid) result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 
 runQueryStakeSnapshot
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Hash StakePoolKey
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeSnapshot anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryStakeSnapshot (AnyConsensusModeParams cModeParams)
                     network poolid = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-    let consensusMode = consensusModeOnly cModeParams
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-    eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                  $ toEraInMode era consensusMode
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let qInMode = QueryInEra eInMode
+                      . QueryInShelleyBasedEra sbe
+                      $ QueryLedgerState
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  qInMode
+      obtainLedgerEraClassConstraints sbe (writeStakeSnapshot stakeDist poolid) result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
-    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-    sbe <- getSbe $ cardanoEraStyle era
-
-
-    let qInMode = QueryInEra eraInMode
-                    . QueryInShelleyBasedEra sbe
-                    $ QueryLedgerState
-
-    res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-    case res of
-      Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-      Right eStakeDist ->
-        case eStakeDist of
-          Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-          Right stakeDist -> obtainLedgerEraClassConstraints sbe
-                               $ writeStakeSnapshot stakeDist poolid
 
 runQueryLedgerState
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryLedgerState anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryLedgerState (AnyConsensusModeParams cModeParams)
                     network mOutFile = do
-    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-    let consensusMode = consensusModeOnly cModeParams
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-    eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                  $ toEraInMode era consensusMode
-
-    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-    sbe <- getSbe $ cardanoEraStyle era
-
-
-    let qInMode = QueryInEra eraInMode
-                    . QueryInShelleyBasedEra sbe
-                    $ QueryLedgerState
-
-    res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-    case res of
-      Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-      Right eStakeDist ->
-        case eStakeDist of
-          Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-          Right stakeDist -> obtainLedgerEraClassConstraints sbe
-                               $ writeLedgerState mOutFile stakeDist
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let qInMode = QueryInEra eInMode
+                      . QueryInShelleyBasedEra sbe
+                      $ QueryLedgerState
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  qInMode
+      obtainLedgerEraClassConstraints sbe (writeLedgerState mOutFile) result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 
 runQueryProtocolState
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryProtocolState anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryProtocolState (AnyConsensusModeParams cModeParams)
                       network mOutFile = do
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-    SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
-    let consensusMode = consensusModeOnly cModeParams
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-    eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                  $ toEraInMode era consensusMode
-
-    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-
-    sbe <- getSbe $ cardanoEraStyle era
-
-
-    let qInMode = QueryInEra eraInMode
-                    . QueryInShelleyBasedEra sbe
-                    $ QueryProtocolState
-
-
-    res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-    case res of
-      Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-      Right eStakeDist ->
-        case eStakeDist of
-          Left mismatch -> left $ ShelleyQueryCmdEraMismatch mismatch
-          Right stakeDist -> writeProtocolState mOutFile stakeDist
-
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let qInMode = QueryInEra eInMode
+                      . QueryInShelleyBasedEra sbe
+                      $ QueryProtocolState
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  qInMode
+      writeProtocolState mOutFile result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
 
 runQueryStakeAddressInfo
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> StakeAddress
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeAddressInfo anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryStakeAddressInfo (AnyConsensusModeParams cModeParams)
                          (StakeAddress _ addr) network mOutFile = do
   SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
-
-  let consensusMode = consensusModeOnly cModeParams
-
-  eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                 $ toEraInMode era consensusMode
-
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
-  qInMode <- case cardanoEraStyle era of
-               LegacyByronEra -> left ShelleyQueryCmdByronEra
-               ShelleyBasedEra sbe ->
-                 let stakeAddr = Set.singleton $ fromShelleyStakeCredential addr
-                     query = QueryInShelleyBasedEra sbe
-                               $ QueryStakeAddresses stakeAddr network
 
-                 in return $ QueryInEra eraInMode query
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-  res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-  case res of
-    Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-    Right eDelegsAndRwds ->
-      case eDelegsAndRwds of
-        Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-        Right delegsAndRewards -> writeStakeAddressInfo mOutFile $ DelegationsAndRewards delegsAndRewards
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let stakeAddr = Set.singleton $ fromShelleyStakeCredential addr
+          query = QueryInEra eInMode
+                    . QueryInShelleyBasedEra sbe
+                    $ QueryStakeAddresses stakeAddr network
 
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  query
+      writeStakeAddressInfo mOutFile $ DelegationsAndRewards result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
 -- -------------------------------------------------------------------------------------------------
 
@@ -713,35 +677,32 @@ printUtxo shelleyBasedEra' txInOutTuple =
 
 
 runQueryStakeDistribution
-  :: AnyCardanoEra
-  -> AnyConsensusModeParams
+  :: AnyConsensusModeParams
   -> NetworkId
   -> Maybe OutputFile
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeDistribution anyEra@(AnyCardanoEra era) (AnyConsensusModeParams cModeParams)
+runQueryStakeDistribution (AnyConsensusModeParams cModeParams)
                           network mOutFile = do
   SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
-  let consensusMode = consensusModeOnly cModeParams
-  eraInMode <- hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch anyEra (AnyConsensusMode consensusMode))
-                 $ toEraInMode era (consensusModeOnly cModeParams)
-
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  qInMode <- case cardanoEraStyle era of
-               LegacyByronEra -> left ShelleyQueryCmdByronEra
-               ShelleyBasedEra sbe ->
-                 let query = QueryInShelleyBasedEra sbe
-                               QueryStakeDistribution
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
 
-                 in return $ QueryInEra eraInMode query
+  case toEraInMode era cMode of
+    Just eInMode -> do
+      let query = QueryInEra eInMode
+                    . QueryInShelleyBasedEra sbe
+                    $ QueryStakeDistribution
+      result <- executeQuery
+                  era
+                  cModeParams
+                  localNodeConnInfo
+                  query
+      writeStakeDistribution mOutFile result
+    Nothing -> left . ShelleyQueryCmdEraConsensusModeMismatch anyE $ AnyConsensusMode cMode
 
-  res <- liftIO $ queryNodeLocalState localNodeConnInfo Nothing qInMode
-  case res of
-    Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
-    Right eStakeDist ->
-      case eStakeDist of
-        Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
-        Right stakeDist ->  writeStakeDistribution mOutFile stakeDist
 
 writeStakeDistribution
   :: Maybe OutputFile
@@ -806,9 +767,58 @@ instance ToJSON DelegationsAndRewards where
 
 -- Helpers
 
+calcEraInMode
+  :: CardanoEra era
+  -> ConsensusMode mode
+  -> ExceptT ShelleyQueryCmdError IO (EraInMode era mode)
+calcEraInMode era mode=
+  hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (anyCardanoEra era) (AnyConsensusMode mode))
+                   $ toEraInMode era mode
+
+determineEra
+  :: ConsensusModeParams mode
+  -> LocalNodeConnectInfo mode
+  -> ExceptT ShelleyQueryCmdError IO AnyCardanoEra
+determineEra cModeParams localNodeConnInfo =
+  case consensusModeOnly cModeParams of
+    ByronMode -> return $ AnyCardanoEra ByronEra
+    ShelleyMode -> return $ AnyCardanoEra ShelleyEra
+    CardanoMode -> do
+      eraQ <- liftIO . queryNodeLocalState localNodeConnInfo Nothing
+                     $ QueryCurrentEra CardanoModeIsMultiEra
+      case eraQ of
+        Left acqFail -> left $ ShelleyQueryCmdAcquireFailure acqFail
+        Right anyCarEra -> return anyCarEra
+
+executeQuery
+  :: forall result era mode. CardanoEra era
+  -> ConsensusModeParams mode
+  -> LocalNodeConnectInfo mode
+  -> QueryInMode mode (Either EraMismatch result)
+  -> ExceptT ShelleyQueryCmdError IO result
+executeQuery era cModeP localNodeConnInfo q = do
+  eraInMode <- calcEraInMode era $ consensusModeOnly cModeP
+  case eraInMode of
+    ByronEraInByronMode -> left ShelleyQueryCmdByronEra
+    _ -> liftIO execQuery >>= queryResult
+ where
+   execQuery :: IO (Either AcquireFailure (Either EraMismatch result))
+   execQuery = queryNodeLocalState localNodeConnInfo Nothing q
+
 getSbe :: CardanoEraStyle era -> ExceptT ShelleyQueryCmdError IO (ShelleyBasedEra era)
 getSbe LegacyByronEra = left ShelleyQueryCmdByronEra
 getSbe (ShelleyBasedEra sbe) = return sbe
+
+queryResult
+  :: Either AcquireFailure (Either EraMismatch a)
+  -> ExceptT ShelleyQueryCmdError IO a
+queryResult eAcq =
+  case eAcq of
+    Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
+    Right eResult ->
+      case eResult of
+        Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err
+        Right result -> return result
 
 obtainLedgerEraClassConstraints
   :: ShelleyLedgerEra era ~ ledgerera
@@ -820,3 +830,4 @@ obtainLedgerEraClassConstraints
 obtainLedgerEraClassConstraints ShelleyBasedEraShelley f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAllegra f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraMary    f = f
+

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -47,7 +47,7 @@ import           Cardano.CLI.Shelley.Key (InputDecodeError, readSigningKeyFileAn
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Shelley.Run.Genesis (ShelleyGenesisCmdError (..), readShelleyGenesis,
                    renderShelleyGenesisCmdError)
-import           Cardano.CLI.Shelley.Run.Pretty (prettyTx)
+import           Cardano.CLI.Shelley.Run.Pretty (friendlyTxBodyBS)
 import           Cardano.CLI.Types
 
 data ShelleyTxCmdError
@@ -786,13 +786,13 @@ runTxGetTxId txfile = do
 
 runTxView :: InputTxFile -> ExceptT ShelleyTxCmdError IO ()
 runTxView txfile = do
-  InAnyCardanoEra _era txbody <-
+  InAnyCardanoEra era txbody <-
     case txfile of
       InputTxBodyFile (TxBodyFile txbodyFile) -> readFileTxBody txbodyFile
       InputTxFile (TxFile txFile) -> do
         InAnyCardanoEra era tx <- readFileTx txFile
         return . InAnyCardanoEra era $ getTxBody tx
-  liftIO $ LBS.putStrLn $ prettyTx txbody
+  liftIO $ BS.putStrLn $ friendlyTxBodyBS era txbody
 
 runTxCreateWitness
   :: TxBodyFile

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Golden.TxView (txViewTests) where
+
+import           Cardano.Prelude
+
+import           Hedgehog (Group (..), Property, checkSequential, (===))
+import           Hedgehog.Extras.Test.Base (moduleWorkspace, propertyOnce)
+
+import           Test.OptParse (execCardanoCLI, noteTempFile)
+
+{- HLINT ignore "Use camelCase" -}
+
+txViewTests :: IO Bool
+txViewTests =
+  checkSequential $
+    Group "`transaction view` Goldens"
+      [ ("golden_view_shelley", golden_view_shelley)
+      , ("golden_view_allegra", golden_view_allegra)
+      , ("golden_view_mary",    golden_view_mary)
+      ]
+
+golden_view_shelley :: Property
+golden_view_shelley =
+  propertyOnce $
+  moduleWorkspace "tmp" $ \tempDir -> do
+    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+
+    -- Create transaction body
+    void $
+      execCardanoCLI
+        [ "transaction", "build-raw"
+        , "--shelley-era"
+        , "--tx-in"
+        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
+            \#29"
+        , "--tx-out"
+        ,   "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+31"
+        , "--fee", "32"
+        , "--invalid-hereafter", "33"
+        , "--out-file", transactionBodyFile
+        ]
+
+    -- View transaction body
+    result <-
+      execCardanoCLI
+        ["transaction", "view", "--tx-body-file", transactionBodyFile]
+
+    lines (toS result) ===
+      [ "auxiliary data: null"
+      , "certificates: []"
+      , "era: Shelley"
+      , "fee: 32"
+      , "inputs:"
+      , "- fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29"
+      , "metadata hash: null"
+      , "outputs:"
+      , "- address:"
+      , "    Bech32: addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3"
+      , "    credential:"
+      , "      key hash: 5dbe1e2117641f8d618034b801a870ca731ce758c3bedd5c7e4429c1"
+      , "    network: Mainnet"
+      , "    stake reference: StakeRefNull"
+      , "  amount: 31"
+      , "time to live: 33"
+      , "update: null"
+      , "withdrawals: []"
+      , ""
+      ]
+
+golden_view_allegra :: Property
+golden_view_allegra =
+  propertyOnce $
+  moduleWorkspace "tmp" $ \tempDir -> do
+    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+
+    -- Create transaction body
+    void $
+      execCardanoCLI
+        [ "transaction", "build-raw"
+        , "--allegra-era"
+        , "--tx-in"
+        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
+            \#94"
+        , "--tx-out"
+        ,   "addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
+            \+99"
+        , "--fee", "100"
+        , "--invalid-hereafter", "101"
+        , "--out-file", transactionBodyFile
+        ]
+
+    -- View transaction body
+    result <-
+      execCardanoCLI
+        ["transaction", "view", "--tx-body-file", transactionBodyFile]
+
+    lines (toS result) ===
+      [ "auxiliary data: null"
+      , "auxiliary data hash: null"
+      , "certificates: []"
+      , "era: Allegra"
+      , "fee: 100"
+      , "inputs:"
+      , "- fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94"
+      , "outputs:"
+      , "- address:"
+      , "    Bech32: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
+      , "    credential:"
+      , "      key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313"
+      , "    network: Testnet"
+      , "    stake reference: \
+              \StakeRefBase (KeyHashObj (KeyHash \"c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0\"))"
+      , "  amount: 99"
+      , "update: null"
+      , "validity interval:"
+      , "  invalid before: null"
+      , "  invalid hereafter: 101"
+      , "withdrawals: []"
+      , ""
+      ]
+
+golden_view_mary :: Property
+golden_view_mary =
+  propertyOnce $
+  moduleWorkspace "tmp" $ \tempDir -> do
+    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+
+    -- Create transaction body
+    void $
+      execCardanoCLI
+        [ "transaction", "build-raw"
+        , "--mary-era"
+        , "--tx-in"
+        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
+            \#135"
+        , "--tx-out"
+        ,   "addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
+            \+138"
+        , "--fee", "139"
+        , "--invalid-before", "140"
+        -- , "--mint", "141" -- TODO(cblp, 2021-03-19, #2533) Transaction
+        -- cannot mint ada, only non-ada assets
+        , "--out-file", transactionBodyFile
+        ]
+
+    -- View transaction body
+    result <-
+      execCardanoCLI
+        ["transaction", "view", "--tx-body-file", transactionBodyFile]
+
+    lines (toS result) ===
+      [ "auxiliary data: null"
+      , "auxiliary data hash: null"
+      , "certificates: []"
+      , "era: Mary"
+      , "fee: 139"
+      , "inputs:"
+      , "- fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135"
+      , "mint:"
+      , "  lovelace: 0"
+      , "  policies: {}"
+      , "outputs:"
+      , "- address:"
+      , "    Bech32: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
+      , "    credential:"
+      , "      key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313"
+      , "    network: Testnet"
+      , "    stake reference: \
+              \StakeRefBase (KeyHashObj (KeyHash \"c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0\"))"
+      , "  amount:"
+      , "    lovelace: 138"
+      , "    policies: {}"
+      , "update: null"
+      , "validity interval:"
+      , "  invalid before: 140"
+      , "  invalid hereafter: null"
+      , "withdrawals: []"
+      , ""
+      ]

--- a/cardano-cli/test/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden.hs
@@ -7,6 +7,7 @@ import qualified Test.Golden.Byron.Tx
 import qualified Test.Golden.Byron.UpdateProposal
 import qualified Test.Golden.Byron.Vote
 import qualified Test.Golden.Shelley
+import qualified Test.Golden.TxView
 
 main :: IO ()
 main =
@@ -21,4 +22,5 @@ main =
     , Test.Golden.Shelley.metadataTests
     , Test.Golden.Shelley.multiSigTests
     , Test.Golden.Shelley.txTests
+    , Test.Golden.TxView.txViewTests
     ]

--- a/cardano-config/cardano-config.cabal
+++ b/cardano-config/cardano-config.cabal
@@ -22,14 +22,12 @@ common project-config
   default-extensions:   NoImplicitPrelude
 
   ghc-options:          -Wall
+                        -Wcompat
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
-                        -Wredundant-constraints
                         -Wpartial-fields
-                        -Wcompat
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wredundant-constraints
+                        -Wunused-packages
 
 library
   import:               base, project-config

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-node-chairman
-version:                1.25.0
+version:                1.26.1
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -23,9 +23,7 @@ common project-config
                         -Wno-unticked-promoted-constructors
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
 common maybe-unix
   if !os(windows)

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,27 @@
 # Changelog for cardano-node
 
+## 1.26.1 -- March 2021
+
+### node changes
+- Fix RTS options, which got accidentally corrupted in the previous release.
+  (#2511)
+- Support for GHC 8.6.5 has been dropped. (#2507)
+- Various internal improvements and refactorings. (#2505)
+- Disable the "uncoupled blocks" metric. This was shown in profiling to have an
+  unfortunately large overhead. This reverts the change introduced in #2321.
+  (#2510)
+- Update the iohk-monitoring framework to fix a file descriptor leak. (#2518)
+
+### ledger changes
+- Fix an unevalutated thunk error in reward computation. (#2183)
+- Additional properties added to the Mary/Allegra formal specification (#2178)
+- Updates to the Alonzo formal specification (#2189, #2194)
+- Work on implementing the upcoming Alonzo era. (#2176, #2185, #2190)
+
+### network changes
+- Add a tracer for the delay between when a block should have been forged and
+  when we're ready to adopt it. (#2995)
+
 ## 1.26.0 -- March 2021
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-node
-version:                1.26.0
+version:                1.26.1
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io
@@ -35,15 +35,7 @@ common project-config
                         -Wno-unticked-promoted-constructors
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
-
-  -- Pattern match checking has improved since 8.6.5. GHC now considers more
-  -- pattern matches as redundant than before, so disable this warning for older
-  -- versions of GHC that still consider them incomplete.
-  if impl(ghc < 8.10)
-    ghc-options:        -Wno-incomplete-patterns
+                        -Wunused-packages
 
 common maybe-Win32
   if os(windows)
@@ -163,15 +155,9 @@ executable cardano-node
                         -rtsopts
 
   if arch(arm)
-    if impl(ghc >= 8.10)
-      ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
-    else
-      ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1"
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
   else
-    if impl(ghc >= 8.10)
-      ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
-    else
-      ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2"
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node
 

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -59,9 +59,7 @@ common project-config
                         -Wno-missing-import-lists
                         -Wno-safe
                         -Wno-unsafe
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
 library
   import:               base, project-config

--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -18,11 +18,11 @@ docutils==0.16
 future==0.18.2
 idna==2.9
 imagesize==1.2.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 jsonpointer==2.0
 jsonref==0.2
 MarkupSafe==1.1.1
-Pygments==2.6.1
+Pygments==2.7.4
 pytz==2020.1
 requests==2.24.0
 six==1.15.0

--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -27,7 +27,7 @@ To download the source code and build it, you need the following packages and to
 * developer libraries for `ncurses`,
 * `ncurses` compatibility libraries,
 * the Haskell build tool `cabal`,
-* the GHC Haskell compiler.
+* the GHC Haskell compiler (version `8.10.2` or above).
 
 In Redhat, Fedora, and Centos:
 

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -7,7 +7,7 @@ with lib; with builtins;
 let
   cfg = config.services.cardano-node;
   inherit (cfg.cardanoNodePkgs) commonLib cardano-node cardano-node-profiled cardano-node-eventlogged cardano-node-asserted;
-  envConfig = cfg.environments.${cfg.environment}; systemdServiceName = "cardano-node${optionalString cfg.instanced "@"}";
+  envConfig = cfg.environments.${cfg.environment};
   runtimeDir = if cfg.runtimeDir == null then cfg.stateDir else "/run/${cfg.runtimeDir}";
   mkScript = cfg: i: let
     instanceConfig = cfg.nodeConfig // (optionalAttrs (cfg.nodeConfig ? hasEKG) {
@@ -85,10 +85,8 @@ let
         ''}
         # If exist copy state from existing instance instead of syncing from scratch:
         if [ ! -d ${instanceDbPath} ] && [ -d ${cfg.databasePath} ]; then
-          echo "Copying existing immutable db from ${instanceDbPath}"
-          mkdir -p ${instanceDbPath}
-          cp -a ${cfg.databasePath}/immutable ${instanceDbPath}/
-          cp -a ${cfg.databasePath}/protocolMagicId ${instanceDbPath}/
+          echo "Copying existing immutable db from ${cfg.databasePath}"
+          ${pkgs.rsync}/bin/rsync --archive --ignore-errors --exclude 'clean' ${cfg.databasePath}/ ${instanceDbPath}/ || true
         fi
         exec ${toString cmd}'';
 in {
@@ -100,14 +98,6 @@ in {
         description = ''
           Enable cardano-node, a node implementing ouroboros protocols
           (the blockchain protocols running cardano).
-        '';
-      };
-      instanced = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable systemd service instancing.
-          For details see https://fedoramagazine.org/systemd-template-unit-files/
         '';
       };
       instances = mkOption {
@@ -474,9 +464,9 @@ in {
   config = mkIf cfg.enable ( let
     stateDirBase = "/var/lib/";
     runDirBase = "/run/";
-    genInstanceConf = f: listToAttrs (if cfg.instances > 1 && !cfg.instanced
-      then genList (i: let n = "${systemdServiceName}-${toString i}"; in nameValuePair n (f n i)) cfg.instances
-      else [ (nameValuePair systemdServiceName (f systemdServiceName 0)) ]); in lib.mkMerge [
+    genInstanceConf = f: listToAttrs (if cfg.instances > 1
+      then genList (i: let n = "cardano-node-${toString i}"; in nameValuePair n (f n i)) cfg.instances
+      else [ (nameValuePair "cardano-node" (f "cardano-node" 0)) ]); in lib.mkMerge [
     {
       users.groups.cardano-node.gid = 10016;
       users.users.cardano-node = {
@@ -496,7 +486,7 @@ in {
         requires = optional cfg.systemdSocketActivation "${n}.socket"
           ++ (optional (cfg.instances > 1) "cardano-node.service");
         wants = [ "network-online.target" ];
-        wantedBy = mkIf (!cfg.instanced) [ "multi-user.target" ];
+        wantedBy = [ "multi-user.target" ];
         partOf = mkIf (cfg.instances > 1) ["cardano-node.service"];
         script = mkScript cfg i;
         serviceConfig = {

--- a/nix/supervisord-cluster/topology/cardano-topology.cabal
+++ b/nix/supervisord-cluster/topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                  cardano-topology
-version:               1.25.0
+version:               1.26.1
 description:           A cardano topology generator
 author:                IOHK
 maintainer:            operations@iohk.io
@@ -14,21 +14,22 @@ common base                         { build-depends: base                       
 
 common project-config
   default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
 
 executable cardano-topology
   import:               base, project-config
   hs-source-dirs:       .
   main-is:              cardano-topology.hs
   ghc-options:          -threaded
-                        -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
                         -rtsopts
                         "-with-rtsopts=-T"
-                        -Wno-unticked-promoted-constructors
   build-depends:        aeson
                       , bytestring
                       , containers
@@ -36,5 +37,3 @@ executable cardano-topology
                       , optparse-applicative
                       , split
                       , text
-
-  default-extensions:   NoImplicitPrelude


### PR DESCRIPTION
This PR provides two new query commands that should be useful to SPOs who are using the CNCLI set of tools, for example (as well as for internal IOG purposes):

`cardano-cli query stake-snapshot --stake-pool-id <poolid>`

`cardano-cli query pool-params --stake-pool-id <poolid>`

These commands allow users to access two pieces of information from the ledger state

1. stake snapshots
2. pool parameters, including retirements

The stake snapshot returns information about mark, set, go snapshots for a pool, plus the current total stake that can be used in a 'sigma' calculation:

```
cardano-cli query stake-snapshot --stake-pool-id a3e71398e80739522e907c35b8f652064e5268e62e9b78a9603f6b98 --mainnet
{
    "activeStakeGo": 200921353802160,
    "activeStakeMark": 209901353802160,
    "activeStakeTotal": 32334956959700987,
    "activeStakeSet": 201571353802160
}
```
The pool parameters return three pieces of information: current parameters, future parameters and retiring information.  They may be `null` if eg the parameters are not changing.

```
cardano-cli query pool-params --stake-pool-id a3e71398e80739522e907c35b8f652064e5268e62e9b78a9603f6b98 --mainnet
[
    {
        "publicKey": "a3e71398e80739522e907c35b8f652064e5268e62e9b78a9603f6b98",
        "cost": 340000000,
        "metadata": {
            "hash": "196eb1b2937af2c88647204920d19985501c99da3fc69e421a942b9b8f817e94",
            "url": "https://git.io/JTI4o"
        },
        "owners": [
            "6877dcb866858b2a4941351c98cd67202262bfd82a016cbbaa073927"
        ],
        "vrf": "11ad7c225b48721dbd9642de1ab05640fe53ab29af2df513f236cc7ac4617da6",
        "pledge": 0,
        "margin": 1,
        "rewardAccount": {
            "network": "Mainnet",
            "credential": {
                "key hash": "6877dcb866858b2a4941351c98cd67202262bfd82a016cbbaa073927"
            }
        },
        "relays": [
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3001,
                    "IPv4": "34.91.217.120"
                }
            },
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3001,
                    "IPv4": "34.91.176.78"
                }
            },
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3001,
                    "IPv4": "34.91.150.76"
                }
            }
        ]
    },
    null,
    null
]

```

The main advantage over using `query ledger-state` is that these commands avoid the need to dump the full ledger state (time consuming and memory intensive - meaning they reduce the total system demands for SPOs), and will make it easier to support CNCLI and other tools.  They also use existing internal operations (such as the ledger pool stake calculation), meaning that the information is guaranteed to be identical to that which the ledger is using (and without having to write scripts to extract/correlate the information).

I have decided to put these under 'query' rather than 'pool' since they are extracting info from the ledger state.