### PR TITLE
Prepare 1.26.1 release.

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,16 @@
 # Changelog for cardano-api
 
+## 1.26.1 -- March 2021
+
+- The cardano-submit-api now takes transactions encoded as CBOR rather than
+  JSON. This reverts a change to existing behaviour for backwards compatibility.
+  (#2491, #2512)
+- Remove a backwards-compatibility workaround related to the optional query
+  point (#2241 below) when querying the NodeLocalState. This had resulted in
+  spurious notifications of disconnection in the logs. Note that as a
+  consequence of this, instances of the CLI and other tools using the 1.26.1 API
+  will fail to query node state from older versions of the node. (#2540)
+
 ## 1.26.0 -- March 2020
 - Added a demo for the use of cardano-client. This is an API to allow writing
   programs to interact with the cardano node. (#2295, #2303)

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-api
-version:                1.26.0
+version:                1.26.1
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-cli
 
+## 1.26.1 -- March 2021
+- It's no longer necessary to specify the era when making a CLI query. When not
+  specified, the current era will be used as a default. (#2470)
+
 ## 1.26.0 -- March 2021
 - Add three new queries to the CLI, exposing functionality already present in
   the API:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-cli
-version:                1.26.0
+version:                1.26.1
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-node-chairman
-version:                1.26.0
+version:                1.26.1
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,27 @@
 # Changelog for cardano-node
 
+## 1.26.1 -- March 2021
+
+### node changes
+- Fix RTS options, which got accidentally corrupted in the previous release.
+  (#2511)
+- Support for GHC 8.6.5 has been dropped. (#2507)
+- Various internal improvements and refactorings. (#2505)
+- Disable the "uncoupled blocks" metric. This was shown in profiling to have an
+  unfortunately large overhead. This reverts the change introduced in #2321.
+  (#2510)
+- Update the iohk-monitoring framework to fix a file descriptor leak. (#2518)
+
+### ledger changes
+- Fix an unevalutated thunk error in reward computation. (#2183)
+- Additional properties added to the Mary/Allegra formal specification (#2178)
+- Updates to the Alonzo formal specification (#2189, #2194)
+- Work on implementing the upcoming Alonzo era. (#2176, #2185, #2190)
+
+### network changes
+- Add a tracer for the delay between when a block should have been forged and
+  when we're ready to adopt it. (#2995)
+
 ## 1.26.0 -- March 2021
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   cardano-node
-version:                1.26.0
+version:                1.26.1
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/nix/supervisord-cluster/topology/cardano-topology.cabal
+++ b/nix/supervisord-cluster/topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                  cardano-topology
-version:               1.26.0
+version:               1.26.1
 description:           A cardano topology generator
 author:                IOHK
 maintainer:            operations@iohk.io


### PR DESCRIPTION
This should not be merged until #2540 has been approved and merged.
Update changelogs and versions for 1.26.1 release.
