### PR TITLE
Updated stake-snapshot and pool-params CLI commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -299,6 +299,8 @@ data QueryCmd =
   | QueryUTxO' AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
   | QueryLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
+  | QueryStakeSnapshot' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+  | QueryPoolParams' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
   deriving Show
 
 renderQueryCmd :: QueryCmd -> Text
@@ -311,6 +313,8 @@ renderQueryCmd cmd =
     QueryUTxO' {} -> "query utxo"
     QueryLedgerState' {} -> "query ledger-state"
     QueryProtocolState' {} -> "query protocol-state"
+    QueryStakeSnapshot' {} -> "query stake-snapshot"
+    QueryPoolParams' {} -> "query pool-params"
 
 data GovernanceCmd
   = GovernanceMIRPayStakeAddressesCertificate

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -684,6 +684,10 @@ pQueryCmd =
         (Opt.info pQueryLedgerState $ Opt.progDesc "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)")
     , subParser "protocol-state"
         (Opt.info pQueryProtocolState $ Opt.progDesc "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)")
+    , subParser "stake-snapshot"
+        (Opt.info pQueryStakeSnapshot $ Opt.progDesc "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)")
+    , subParser "pool-params"
+        (Opt.info pQueryPoolParams $ Opt.progDesc "Dump the pool parameters (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)")
     ]
   where
     pQueryProtocolParameters :: Parser QueryCmd
@@ -733,6 +737,19 @@ pQueryCmd =
                             <$> pConsensusModeParams
                             <*> pNetworkId
                             <*> pMaybeOutputFile
+
+    pQueryStakeSnapshot :: Parser QueryCmd
+    pQueryStakeSnapshot = QueryStakeSnapshot'
+      <$> pConsensusModeParams
+      <*> pNetworkId
+      <*> pStakePoolVerificationKeyHash
+
+    pQueryPoolParams :: Parser QueryCmd
+    pQueryPoolParams = QueryPoolParams'
+      <$> pConsensusModeParams
+      <*> pNetworkId
+      <*> pStakePoolVerificationKeyHash
+
 
 pGovernanceCmd :: Parser GovernanceCmd
 pGovernanceCmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -48,6 +48,7 @@ import           Cardano.Binary (decodeFull)
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 
 import qualified Cardano.Ledger.Crypto as Crypto
+import qualified Cardano.Ledger.Era as Era
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
 import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
@@ -55,6 +56,10 @@ import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
                    (AcquireFailure (..))
 import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
+import           Shelley.Spec.Ledger.Coin
+import           Shelley.Spec.Ledger.EpochBoundary
+import           Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
+import           Shelley.Spec.Ledger.LedgerState hiding (LedgerState, _delegations)
 import           Shelley.Spec.Ledger.Scripts ()
 
 {- HLINT ignore "Reduce duplication" -}
@@ -68,6 +73,7 @@ data ShelleyQueryCmdError
   | ShelleyQueryCmdAcquireFailure !AcquireFailure
   | ShelleyQueryCmdEraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
   | ShelleyQueryCmdByronEra
+  | ShelleyQueryCmdPoolIdError (Hash StakePoolKey)
   | ShelleyQueryCmdEraMismatch !EraMismatch
   deriving Show
 
@@ -80,6 +86,7 @@ renderShelleyQueryCmdError err =
     ShelleyQueryCmdHelpersError helpersErr -> renderHelpersError helpersErr
     ShelleyQueryCmdAcquireFailure aqFail -> Text.pack $ show aqFail
     ShelleyQueryCmdByronEra -> "This query cannot be used for the Byron era"
+    ShelleyQueryCmdPoolIdError poolId -> "The pool id does not exist: " <> show poolId
     ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) (AnyCardanoEra era) ->
       "Consensus mode and era mismatch. Consensus mode: " <> show cMode <>
       " Era: " <> show era
@@ -100,6 +107,10 @@ runQueryCmd cmd =
       runQueryStakeAddressInfo consensusModeParams addr network mOutFile
     QueryLedgerState' consensusModeParams network mOutFile ->
       runQueryLedgerState consensusModeParams network mOutFile
+    QueryStakeSnapshot' consensusModeParams network poolid ->
+      runQueryStakeSnapshot consensusModeParams network poolid
+    QueryPoolParams' consensusModeParams network poolid ->
+      runQueryPoolParams consensusModeParams network poolid
     QueryProtocolState' consensusModeParams network mOutFile ->
       runQueryProtocolState consensusModeParams network mOutFile
     QueryUTxO' consensusModeParams qFilter networkId mOutFile ->
@@ -233,6 +244,55 @@ runQueryUTxO (AnyConsensusModeParams cModeParams)
   maybeFiltered :: QueryFilter -> Maybe (Set AddressAny)
   maybeFiltered (FilterByAddress as) = Just as
   maybeFiltered NoFilter = Nothing
+
+
+-- | Query the current and future parameters for a stake pool, including the retirement date.
+-- Any of these may be empty (in which case a null will be displayed).
+--
+
+runQueryPoolParams
+  :: AnyConsensusModeParams
+  -> NetworkId
+  -> Hash StakePoolKey
+  -> ExceptT ShelleyQueryCmdError IO ()
+runQueryPoolParams (AnyConsensusModeParams cModeParams) network poolid = do
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
+
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
+
+  eInMode <- toEraInMode era cMode
+    & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+  let qInMode = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryLedgerState
+  result <- executeQuery era cModeParams localNodeConnInfo qInMode
+  obtainLedgerEraClassConstraints sbe (writePoolParams poolid) result
+
+
+-- | Obtain stake snapshot information for a pool, plus information about the total active stake.
+-- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
+-- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
+runQueryStakeSnapshot
+  :: AnyConsensusModeParams
+  -> NetworkId
+  -> Hash StakePoolKey
+  -> ExceptT ShelleyQueryCmdError IO ()
+runQueryStakeSnapshot (AnyConsensusModeParams cModeParams) network poolid = do
+  SocketPath sockPath <- firstExceptT ShelleyQueryCmdEnvVarSocketErr readEnvSocketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
+
+  anyE@(AnyCardanoEra era) <- determineEra cModeParams localNodeConnInfo
+  let cMode = consensusModeOnly cModeParams
+  sbe <- getSbe $ cardanoEraStyle era
+
+  eInMode <- toEraInMode era cMode
+    & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+  let qInMode = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryLedgerState
+  result <- executeQuery era cModeParams localNodeConnInfo qInMode
+  obtainLedgerEraClassConstraints sbe (writeStakeSnapshot poolid) result
 
 
 runQueryLedgerState
@@ -375,13 +435,80 @@ writeLedgerState mOutFile qState@(SerialisedLedgerState serLedgerState) =
     Just (OutputFile fpath) ->
       handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath $ unSerialised serLedgerState
- where
-   decodeLedgerState
-     :: SerialisedLedgerState era
-     -> Either LBS.ByteString (LedgerState era)
-   decodeLedgerState (SerialisedLedgerState (Serialised ls)) =
-     first (const ls) (decodeFull ls)
 
+writeStakeSnapshot :: forall era ledgerera. ()
+  => ShelleyLedgerEra era ~ ledgerera
+  => Era.Crypto ledgerera ~ StandardCrypto
+  => FromCBOR (LedgerState era)
+  => PoolId
+  -> SerialisedLedgerState era
+  -> ExceptT ShelleyQueryCmdError IO ()
+writeStakeSnapshot (StakePoolKeyHash hk) qState =
+  case decodeLedgerState qState of
+    -- In the event of decode failure print the CBOR instead
+    Left bs -> firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
+
+    Right ledgerState -> do
+      -- Ledger State
+      let (LedgerState snapshot) = ledgerState
+
+      -- The three stake snapshots, obtained from the ledger state
+      let (SnapShots markS setS goS _) = esSnapshots $ nesEs snapshot
+
+      -- Calculate the three pool and active stake values for the given pool
+      liftIO . LBS.putStrLn $ encodePretty $ Stakes
+        { markPool = getPoolStake hk markS
+        , setPool = getPoolStake hk setS
+        , goPool = getPoolStake hk goS
+        , markTotal = getAllStake markS
+        , setTotal = getAllStake setS
+        , goTotal = getAllStake goS
+        }
+
+-- | Sum all the stake that is held by the pool
+getPoolStake :: KeyHash Shelley.Spec.Ledger.Keys.StakePool crypto -> SnapShot crypto -> Integer
+getPoolStake hash ss = pStake
+  where
+    Coin pStake = fold s
+    (Stake s) = poolStake hash (_delegations ss) (_stake ss)
+
+-- | Sum the active stake from a snapshot
+getAllStake :: SnapShot crypto -> Integer
+getAllStake (SnapShot stake _ _) = activeStake
+  where
+    Coin activeStake = fold . unStake $ stake
+
+-- | This function obtains the pool parameters, equivalent to the following jq query on the output of query ledger-state
+--   .nesEs.esLState._delegationState._pstate._pParams.<pool_id>
+writePoolParams :: forall era ledgerera. ()
+  => ShelleyLedgerEra era ~ ledgerera
+  => FromCBOR (LedgerState era)
+  => Crypto.Crypto (Era.Crypto ledgerera)
+  => Era.Crypto ledgerera ~ StandardCrypto
+  => PoolId
+  -> SerialisedLedgerState era
+  -> ExceptT ShelleyQueryCmdError IO ()
+writePoolParams (StakePoolKeyHash hk) qState =
+  case decodeLedgerState qState of
+    -- In the event of decode failure print the CBOR instead
+    Left bs -> firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
+
+    Right ledgerState -> do
+      let LedgerState snapshot = ledgerState
+      let poolState = _pstate $ _delegationState $ esLState $ nesEs snapshot
+
+      -- Pool parameters
+      let poolParams = Map.lookup hk $ _pParams poolState
+      let fPoolParams = Map.lookup hk $ _fPParams poolState
+      let retiring = Map.lookup hk $ _retiring poolState
+
+      liftIO . LBS.putStrLn $ encodePretty $ Params poolParams fPoolParams retiring
+
+decodeLedgerState :: forall era. ()
+  => FromCBOR (LedgerState era)
+  => SerialisedLedgerState era
+  -> Either LBS.ByteString (LedgerState era)
+decodeLedgerState (SerialisedLedgerState (Serialised ls)) = first (const ls) (decodeFull ls)
 
 writeProtocolState :: Crypto.Crypto StandardCrypto
                    => Maybe OutputFile
@@ -629,6 +756,7 @@ obtainLedgerEraClassConstraints
   -> ((Ledger.ShelleyBased ledgerera
       , ToJSON (LedgerState era)
       , FromCBOR (LedgerState era)
+      , Era.Crypto ledgerera ~ StandardCrypto
       ) => a) -> a
 obtainLedgerEraClassConstraints ShelleyBasedEraShelley f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAllegra f = f

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -15,16 +15,23 @@ module Cardano.CLI.Types
   , TxOutAnyEra (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
+  , Stakes (..)
+  , Params (..)
   ) where
 
 import           Cardano.Prelude
 
+import           Data.Aeson (ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 
 import qualified Cardano.Chain.Slotting as Byron
 
 import           Cardano.Api
+
+import qualified Cardano.Ledger.Crypto as Crypto
+
+import           Shelley.Spec.Ledger.TxBody (PoolParams (..))
 
 -- | Specify what the CBOR file is
 -- i.e a block, a tx, etc
@@ -61,6 +68,65 @@ data QueryFilter
   = FilterByAddress !(Set AddressAny)
   | NoFilter
   deriving (Eq, Show)
+
+-- | This data structure is used to allow nicely formatted output within the query stake-snapshot command.
+--
+-- "markPool", "setPool", "goPool" are the three ledger state stake snapshots (from most recent to least recent)
+-- go is the snapshot that is used for the current epoch, set will be used in the next epoch,
+-- mark for the epoch after that.  "markTotal", "setTotal", "goTotal" record the total active stake for each snapshot.
+--
+-- This information can be used by community tools to calculate upcoming leader schedules.
+data Stakes =  Stakes
+  { markPool :: Integer
+  , setPool :: Integer
+  , goPool :: Integer
+  , markTotal :: Integer
+  , setTotal :: Integer
+  , goTotal :: Integer
+  } deriving Show
+
+-- | Pretty printing for stake information
+instance ToJSON Stakes where
+  toJSON (Stakes m s g mt st gt) = object
+    [ "poolStakeMark" .= m
+    , "poolStakeSet" .= s
+    , "poolStakeGo" .= g
+    , "activeStakeMark" .= mt
+    , "activeStakeSet" .= st
+    , "activeStakeGo" .= gt
+    ]
+
+  toEncoding  (Stakes m s g mt st gt) = pairs $ mconcat
+    [ "poolStakeMark" .= m
+    , "poolStakeSet" .= s
+    , "poolStakeGo" .= g
+    , "activeStakeMark" .= mt
+    , "activeStakeSet" .= st
+    , "activeStakeGo" .= gt
+    ]
+
+-- | This data structure is used to allow nicely formatted output in the query pool-params command.
+-- params are the current pool parameter settings, futureparams are new parameters, retiringEpoch is the
+-- epoch that has been set for pool retirement.  Any of these may be Nothing.
+data Params crypto = Params
+  { poolParameters :: Maybe (PoolParams crypto)
+  , futurePoolParameters :: Maybe (PoolParams crypto)
+  , retiringEpoch :: Maybe EpochNo
+  } deriving Show
+
+-- | Pretty printing for pool parameters
+instance Crypto.Crypto crypto =>  ToJSON (Params crypto) where
+  toJSON (Params p fp r) = object
+    [ "poolParams" .= p
+    , "futurePoolParams" .= fp
+    , "retiring" .= r
+    ]
+
+  toEncoding (Params p fp r) = pairs $ mconcat
+    [ "poolParams" .= p
+    , "futurePoolParams" .= fp
+    , "retiring" .= r
+    ]
 
 newtype SigningKeyFile = SigningKeyFile
   { unSigningKeyFile :: FilePath }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,7 @@ cardano-node
    stake-pool-operations/KES_period
    stake-pool-operations/core_relay
    stake-pool-operations/register_stakepool
+   stake-pool-operations/query_stakepool
    stake-pool-operations/start_your_nodes
    stake-pool-operations/withdraw-rewards
    stake-pool-operations/retire_stakepool

--- a/doc/reference/cardano-node-cli-reference.md
+++ b/doc/reference/cardano-node-cli-reference.md
@@ -61,12 +61,14 @@ The `stake-pool` command contains the following sub commands:
 
 *cardano-cli query*
 The `query` command contains the following sub commands:
-* `protocol-parameters`(advanced): retrieves the node’s current pool parameters (a raw dump of `Ledger.ChainDepState`). This
+* `protocol-parameters` (advanced): retrieves the node’s current pool parameters (a raw dump of `Ledger.ChainDepState`). This
 * `tip`: gets the node’s current tip (slot number, hash, and block number)
 * `utxo`: retrieves the node’s current UTxO, filtered by address
 * `ledger-state` (advanced):  dumps the current state of the node (a raw dump of `Ledger.NewEpochState`)
 * `stake-address-info`: Get the current delegations and reward accounts filtered by stake address.
 * `stake-distribution`: Get the node's current aggregated stake distribution
+* `stake-snapshot` (advanced): Get the stake snapshot information for a stake pool
+* `pool-params` (advanced): Get the current and future parameters for a stake pool
 
 *cardano-cli governance*
 The `governance` command contains the following sub commands:

--- a/doc/stake-pool-operations/query_stakepool.md
+++ b/doc/stake-pool-operations/query_stakepool.md
@@ -1,0 +1,112 @@
+# Querying a Stake Pool
+
+Two queries are available for querying your stakepool:
+
+* `stake-snapshot` (advanced): Get the stake snapshot information for a stake pool
+* `pool-params` (advanced): Get the current and future parameters for a stake pool,
+  including retirement
+
+## Querying for stake snapshot
+
+The stake snapshot returns information about the mark, set, go ledger snapshots for a pool, plus
+the total active stake for each snapshot that can be used in a 'sigma' calculation:
+
+```bash
+$ cardano-cli query stake-snapshot \
+    --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 \
+    --mainnet
+{
+    "poolStakeGo": 40278547538358,
+    "activeStakeGo": 22753958467474959,
+    "poolStakeMark": 40424218559492,
+    "activeStakeMark": 22670949084364797,
+    "poolStakeSet": 39898761956772,
+    "activeStakeSet": 22488877070796904
+}
+```
+
+Each snapshot is taken at the end of a different era.  The `go` snapshot is the current one and
+was taken two epochs earlier, `set` was taken one epoch ago, and `mark` was taken immediately
+before the start of the current epoch.
+
+This command if for debugging purposes only and may fail when used in a memory constrained
+environment due to the size of the ledger state.
+
+# Querying for pool pparameters
+
+The pool parameters command returns three pieces of information: current parameters, future
+parameters and retiring information.
+
+They may be `null` if eg the parameters are not changing.
+
+```bash
+$ cardano-cli query pool-params \
+    --stake-pool-id d785ff6a030ae9d521770c00f264a2aa423e928c85fc620b13d46eda \
+    --mainnet
+{
+    "poolParams": {
+        "publicKey": "d785ff6a030ae9d521770c00f264a2aa423e928c85fc620b13d46eda",
+        "cost": 340000000,
+        "metadata": {
+            "hash": "b150b12a1301c4b1510ac8b9f53f7571cabb43455f6fd244cd8fd97504b1c869",
+            "url": "https://adalite.io/ADLT4-metadata.json"
+        },
+        "owners": [
+            "463a9695c9222183ee6e1523478722bebcb332fa3769f1d8ef40c7d0",
+            "5049c1dac0e597ee902f27a74a167cf135ae7c1717b0d3a417cd6c67"
+        ],
+        "vrf": "0a21e37b1917ce37a897eb2a8dc6715973a18d0586f7ab4962e3975561151348",
+        "pledge": 30000000000,
+        "margin": 3.0e-2,
+        "rewardAccount": {
+            "network": "Mainnet",
+            "credential": {
+                "key hash": "b1bc146a5fb0683c4e3836712d115b98619048bc307cc059b6adc76e"
+            }
+        },
+        "relays": [
+            {
+                "single host address": {
+                    "IPv6": null,
+                    "port": 3003,
+                    "IPv4": "54.228.75.154"
+                }
+            },
+            {
+                "single host address": {
+                    "IPv6": null,
+                    "port": 3001,
+                    "IPv4": "54.228.75.154"
+                }
+            },
+            {
+                "single host address": {
+                    "IPv6": null,
+                    "port": 3003,
+                    "IPv4": "34.249.11.89"
+                }
+            },
+            {
+                "single host address": {
+                    "IPv6": null,
+                    "port": 3001,
+                    "IPv4": "34.249.11.89"
+                }
+            }
+        ]
+    },
+    "futurePoolParams": null,
+    "retiring": null
+}
+```
+
+The main advantage of these commands over using `query ledger-state` is that they avoid the need
+to dump the full ledger state (which is both time consuming and memory intensive - meaning they
+reduce the total system demands for SPOs), and will make it easier to support CNCLI and other
+tools.
+
+They also use existing internal operations (such as the ledger pool stake and active stake
+calculations), meaning that the information is guaranteed to be identical to that which the
+ledger is using (and without having to write scripts to extract/correlate the information).
+
+This command if for debugging purposes only.


### PR DESCRIPTION
This PR provides two new query commands that should be useful to SPOs who are using the CNCLI set of tools, for example (as well as for internal IOG purposes):

`cardano-cli query stake-snapshot --stake-pool-id <poolid>`

`cardano-cli query pool-params --stake-pool-id <poolid>`

These commands allow users to access two pieces of information from the ledger state

1. stake snapshots
2. pool parameters, including retirements

The stake snapshot returns information about the mark, set, go ledger snapshots for a pool, plus the total active stake for each snapshot that can be used in a 'sigma' calculation:

```
cardano-cli query stake-snapshot --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --mainnet
{
    "poolStakeGo": 40278547538358,
    "activeStakeGo": 22753958467474959,
    "poolStakeMark": 40424218559492,
    "activeStakeMark": 22670949084364797,
    "poolStakeSet": 39898761956772,
    "activeStakeSet": 22488877070796904
}

```
Each snapshot is taken at the end of a different era.  The `go` snapshot is the current one and was taken two epochs earlier, `set` was taken one epoch ago, and `mark` was taken immediately before the start of the current epoch.

The pool parameters command returns three pieces of information: current parameters, future parameters and retiring information.  They may be `null` if eg the parameters are not changing.

```
cardano-cli query pool-params --stake-pool-id d785ff6a030ae9d521770c00f264a2aa423e928c85fc620b13d46eda --mainnet
{
    "poolParams": {
        "publicKey": "d785ff6a030ae9d521770c00f264a2aa423e928c85fc620b13d46eda",
        "cost": 340000000,
        "metadata": {
            "hash": "b150b12a1301c4b1510ac8b9f53f7571cabb43455f6fd244cd8fd97504b1c869",
            "url": "https://adalite.io/ADLT4-metadata.json"
        },
        "owners": [
            "463a9695c9222183ee6e1523478722bebcb332fa3769f1d8ef40c7d0",
            "5049c1dac0e597ee902f27a74a167cf135ae7c1717b0d3a417cd6c67"
        ],
        "vrf": "0a21e37b1917ce37a897eb2a8dc6715973a18d0586f7ab4962e3975561151348",
        "pledge": 30000000000,
        "margin": 3.0e-2,
        "rewardAccount": {
            "network": "Mainnet",
            "credential": {
                "key hash": "b1bc146a5fb0683c4e3836712d115b98619048bc307cc059b6adc76e"
            }
        },
        "relays": [
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3003,
                    "IPv4": "54.228.75.154"
                }
            },
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3001,
                    "IPv4": "54.228.75.154"
                }
            },
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3003,
                    "IPv4": "34.249.11.89"
                }
            },
            {
                "single host address": {
                    "IPv6": null,
                    "port": 3001,
                    "IPv4": "34.249.11.89"
                }
            }
        ]
    },
    "futurePoolParams": null,
    "retiring": null
}

```

The main advantage of these commands over using `query ledger-state` is that they avoid the need to dump the full ledger state (which is both time consuming and memory intensive - meaning they reduce the total system demands for SPOs), and will make it easier to support CNCLI and other tools.  They also use existing internal operations (such as the ledger pool stake and active stake calculations), meaning that the information is guaranteed to be identical to that which the ledger is using (and without having to write scripts to extract/correlate the information).

I have decided to put these under 'query' rather than 'pool' since they are extracting info from the ledger state.