### PR TITLE
CAD-2860: iohk monitoring for rHeap + a new metric

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: f6ab0631275d04dff1b990283bbf9671093e7505
-  --sha256: 0hknkpjmfgdlcag9p0z0xspxm7nxl696ajbnafi1b0vzxnkiyhdx
+  tag: bf3b4336dfd202fe0b5e765cdaa97788674e456c
+  --sha256: 1ilq7yq8a3mpy21fiqharx7vs2b555n78gf7m48kkd0pl58vq759
   subdir:
     contra-tracer
     iohk-monitoring

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -281,6 +281,7 @@ createLoggingLayer ver nodeConfig' p = do
      traceCounter "Stat.cputicks"    tr . fromIntegral $ rCentiCpu rs
      traceCounter "Mem.resident"     tr . fromIntegral $ rRSS rs
      traceCounter "RTS.gcLiveBytes"  tr . fromIntegral $ rLive rs
+     traceCounter "RTS.gcHeapBytes"  tr . fromIntegral $ rHeap rs
      traceCounter "RTS.gcMajorNum"   tr . fromIntegral $ rGcsMajor rs
      traceCounter "RTS.gcMinorNum"   tr . fromIntegral $ rGcsMinor rs
      traceCounter "RTS.gcticks"      tr . fromIntegral $ rCentiGC rs


### PR DESCRIPTION
This extends the per-second resource report with the GC heap metric, the `gcdetails_mem_in_use_bytes` from https://hackage.haskell.org/package/base/docs/GHC-Stats.html#t:RtsTime