### PR TITLE
Update keys_and_addresses.md

### DIFF
--- a/doc/stake-pool-operations/keys_and_addresses.md
+++ b/doc/stake-pool-operations/keys_and_addresses.md
@@ -66,6 +66,8 @@ This address __CAN'T__ receive payments but will receive the rewards from partic
 
 > NOTE: Ensure that your node has synced to the current block height which can be checked at [explorer.cardano.org](https://explorer.cardano.org). If it is not, you may see an error referring to the Byron Era.
 
+> NOTE2: Make sure that you query for the correct era. You can e.g. use `--mary-era` to query for the mary era.
+
 To query the balance of an address we need a running node and the environment variable `CARDANO_NODE_SOCKET_PATH` set to the path of the node.socket:
 
 ```


### PR DESCRIPTION
going through the tut, the `cardano-cli query utxo` yields an error: 

```
bash-4.4# cardano-cli query utxo --shelley-era --address $(cat payment.addr) --mainnet
Shelley command failed: query utxo  Error: A query from a certain era was applied to a ledger from a different era: EraMismatch {ledgerEraName = "Mary", otherEraName = "Shelley"}
```

This can be solved by explicitly mention the era (which has changed for weeks ago from shelley to mary)