### PR TITLE
Fix typo in Install pkg-config doc (for Windows)

### DIFF
--- a/doc/getting-started/building-the-node-on-windows.md
+++ b/doc/getting-started/building-the-node-on-windows.md
@@ -46,7 +46,7 @@ create `libsodium.pc` file, which contains:
 
 ```
 libdir=VCPKG_PATH/installed/x64-windows/bin
-includedir=VCPKG_PATH/intsalled/x64-windows/include
+includedir=VCPKG_PATH/installed/x64-windows/include
 
 Name: libsodium
 Description: libsodium library

--- a/doc/getting-started/building-the-node-on-windows.md
+++ b/doc/getting-started/building-the-node-on-windows.md
@@ -18,7 +18,7 @@ choco install --version 8.10.2 ghc
 ## Install pkg-config
 
 ```PowerShell
-choco install pgkconfiglite
+choco install pkgconfiglite
 ```
 
 ## Install vcpkg


### PR DESCRIPTION
Use correct package name `pkgconfiglite`
Otherwise it cannot be found on Chocolatey