### PR TITLE
Remove Byron Bech32 support

### DIFF
--- a/cardano-api/src/Cardano/Api/KeysByron.hs
+++ b/cardano-api/src/Cardano/Api/KeysByron.hs
@@ -52,11 +52,10 @@ import qualified Cardano.Crypto.Hashing as Byron
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Wallet
 
-import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Hash
 import           Cardano.Api.Key
 import           Cardano.Api.KeysShelley
-import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
@@ -151,14 +150,6 @@ instance SerialiseAsRawBytes (SigningKey ByronKey) where
     deserialiseFromRawBytes (AsSigningKey AsByronKey) bs =
       either (const Nothing) (Just . ByronSigningKey . Byron.SigningKey)
              (snd <$> CBOR.deserialiseFromBytes Byron.fromCBORXPrv (LB.fromStrict bs))
-
-instance SerialiseAsBech32 (VerificationKey ByronKey) where
-    bech32PrefixFor         _ =  "addr_xvk"
-    bech32PrefixesPermitted _ = ["addr_xvk"]
-
-instance SerialiseAsBech32 (SigningKey ByronKey) where
-    bech32PrefixFor         _ =  "addr_xsk"
-    bech32PrefixesPermitted _ = ["addr_xsk"]
 
 newtype instance Hash ByronKey = ByronKeyHash Byron.KeyHash
   deriving (Eq, Ord)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -211,9 +211,7 @@ readAddressVerificationKeyTextOrFile vkTextOrFile =
       readVerificationKeyTextOrFileAnyOf bech32Types textEnvTypes vkTextOrFile
   where
     bech32Types =
-      [ FromSomeType (AsVerificationKey AsByronKey)
-                     AByronVerificationKey
-      , FromSomeType (AsVerificationKey AsPaymentKey)
+      [ FromSomeType (AsVerificationKey AsPaymentKey)
                      APaymentVerificationKey
       , FromSomeType (AsVerificationKey AsPaymentExtendedKey)
                      APaymentExtendedVerificationKey

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -185,9 +185,7 @@ readSigningKeyFile skFile =
       ]
 
     bech32FileTypes =
-      [ FromSomeType (AsSigningKey AsByronKey)
-                      AByronSigningKey
-      , FromSomeType (AsSigningKey AsPaymentKey)
+      [ FromSomeType (AsSigningKey AsPaymentKey)
                       APaymentSigningKey
       , FromSomeType (AsSigningKey AsPaymentExtendedKey)
                       APaymentExtendedSigningKey

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -661,9 +661,7 @@ readWitnessSigningData (KeyWitnessSigningData skFile mbByronAddr) = do
       ]
 
     bech32FileTypes =
-      [ FromSomeType (AsSigningKey AsByronKey)
-                          (`AByronSigningKey` mbByronAddr)
-      , FromSomeType (AsSigningKey AsPaymentKey)
+      [ FromSomeType (AsSigningKey AsPaymentKey)
                           APaymentSigningKey
       , FromSomeType (AsSigningKey AsPaymentExtendedKey)
                           APaymentExtendedSigningKey


### PR DESCRIPTION
We use the prefix to distinguish keys, but according to the code, Byron and Shelley share the same prefix:

```bash
instance SerialiseAsBech32 (VerificationKey ByronKey) where
    bech32PrefixFor         _ =  "addr_xvk"
    bech32PrefixesPermitted _ = ["addr_xvk"]
```

```bash
instance SerialiseAsBech32 (VerificationKey PaymentExtendedKey) where
    bech32PrefixFor         _ =  "addr_xvk"
    bech32PrefixesPermitted _ = ["addr_xvk"]
```

We use the following list when deserialising:

```bash
    bech32Types =
      [ FromSomeType (AsVerificationKey AsByronKey)
                     AByronVerificationKey
      , FromSomeType (AsVerificationKey AsPaymentKey)
                     APaymentVerificationKey
      , FromSomeType (AsVerificationKey AsPaymentExtendedKey)
                     APaymentExtendedVerificationKey
      ]
```

So when deserialising a key like `addr_xvk18359zklg0x68ru6yhxyvsv3slt6wscs00mzsc45jrv9840dfutj5uxg6z6rp4w2pany4kjgg5tly8s5xv7fuyq5tf8kw9ehr7cy4lzcenyhck`, it thinks the keys are Byron because Byron appears first in the list and shares the same prefix as Shelley.

Having an instance for Byron declare that Byron keys have the `addr_xvk` prefix seems wrong.  This PR removes support for serialising and deserialising Byron keys with that prefix.