### PR TITLE
nix:  export cardano-node-profiled and cardano-node-eventlogged

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,7 +55,9 @@ let
     '' else p;
 
   packages = {
-    inherit haskellPackages cardano-node cardano-cli db-converter cardano-ping
+    inherit haskellPackages
+      cardano-node cardano-node-profiled cardano-node-eventlogged
+      cardano-cli db-converter cardano-ping
       scripts nixosTests environments dockerImage mkCluster bech32;
 
     # so that eval time gc roots are cached (nix-tools stuff)


### PR DESCRIPTION
Improve quality of life for the users of profiled/eventlogged builds of the node -- by enabling a simple:

- `nix-build -A cardano-node-profiled`
- `nix-build -A cardano-node-eventlogged`