### PR TITLE
release.nix:  attempt to get cardano-node-profiled into Hydra builds

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -121,7 +121,9 @@ let
   # Paths or prefixes of paths of derivations to build only on the default system (ie. linux on hydra):
   onlyBuildOnDefaultSystem = [
     ["checks" "hlint"] ["dockerImage"] ["clusterTests"] ["nixosTests"]
-    [ "haskellPackages" "cardano-node-chairman" "checks" ] [ "checks" "tests" "cardano-node-chairman" ]
+    [ "haskellPackages" "cardano-node-chairman" "checks" ]
+    [ "cardano-node-profiled" "components" "exes" ]
+    [ "checks" "tests" "cardano-node-chairman" ]
   ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [


### PR DESCRIPTION
An attempt to get `cardano-node-profiled` into Hydra builds.