### PR TITLE
cardano-cli transaction view: Add withdrawals

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -1548,8 +1548,6 @@ data TxBodyError =
      | TxBodyOutputOverflow Quantity TxOutInAnyEra
      | TxBodyMetadataError [(Word64, TxMetadataRangeError)]
      | TxBodyMintAdaError
-     | TxBodyAuxDataHashInvalidError
-     | TxBodyMintBeforeMaryError
      | TxBodyMissingProtocolParams
      deriving Show
 
@@ -1573,10 +1571,6 @@ instance Error TxBodyError where
         | (k, err) <- errs ]
     displayError TxBodyMintAdaError =
       "Transaction cannot mint ada, only non-ada assets"
-    displayError TxBodyMintBeforeMaryError =
-      "Transaction can mint in Mary era or later"
-    displayError TxBodyAuxDataHashInvalidError =
-      "Auxiliary data hash is invalid"
     displayError TxBodyMissingProtocolParams =
       "Transaction uses Plutus scripts but does not provide the protocol " ++
       "parameters to hash"

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -57,7 +57,7 @@
   - Auxiliary scripts (i.e. those included in the Tx auxiliary data, which are
     not required as transaction signers) must now be included with
     `--auxiliary-script-file` rather than with `--script-file`.
-  - Scripts witnessing txins, certificates, withdrawls and minting must now be
+  - Scripts witnessing txins, certificates, withdrawals and minting must now be
     paired with the thing they are witnessing. E.g.
     ```
     --certificate-file  $certfile --certificate-script-file $scriptfile

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -33,7 +33,8 @@ friendlyTxBody
   era
   (TxBody
     TxBodyContent
-      { txCertificates
+      { txAuxScripts
+      , txCertificates
       , txFee
       , txIns
       , txMetadata
@@ -44,7 +45,8 @@ friendlyTxBody
       , txWithdrawals
       }) =
   object
-    [ "certificates"      .= friendlyCertificates txCertificates
+    [ "auxiliary scripts" .= friendlyAuxScripts txAuxScripts
+    , "certificates"      .= friendlyCertificates txCertificates
     , "era"               .= era
     , "fee"               .= friendlyFee txFee
     , "inputs"            .= friendlyInputs txIns
@@ -185,6 +187,11 @@ friendlyMetadataValue = \case
     array
       [array [friendlyMetadataValue k, friendlyMetadataValue v] | (k, v) <- m]
   TxMetaText   text  -> toJSON text
+
+friendlyAuxScripts :: TxAuxScripts era -> Aeson.Value
+friendlyAuxScripts = \case
+  TxAuxScriptsNone       -> Null
+  TxAuxScripts _ scripts -> String $ textShow scripts
 
 friendlyInputs :: [(TxIn, build)] -> Aeson.Value
 friendlyInputs = toJSON . map fst

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -46,16 +46,16 @@ friendlyTxBody
       }) =
   object
     [ "auxiliary scripts" .= friendlyAuxScripts txAuxScripts
-    , "certificates"      .= friendlyCertificates txCertificates
-    , "era"               .= era
-    , "fee"               .= friendlyFee txFee
-    , "inputs"            .= friendlyInputs txIns
-    , "metadata"          .= friendlyMetadata txMetadata
-    , "mint"              .= friendlyMintValue txMintValue
-    , "outputs"           .= map friendlyTxOut txOuts
-    , "update proposal"   .= friendlyUpdateProposal txUpdateProposal
-    , "validity range"    .= friendlyValidityRange era txValidityRange
-    , "withdrawals"       .= friendlyWithdrawals txWithdrawals
+    , "certificates" .= friendlyCertificates txCertificates
+    , "era" .= era
+    , "fee" .= friendlyFee txFee
+    , "inputs" .= friendlyInputs txIns
+    , "metadata" .= friendlyMetadata txMetadata
+    , "mint" .= friendlyMintValue txMintValue
+    , "outputs" .= map friendlyTxOut txOuts
+    , "update proposal" .= friendlyUpdateProposal txUpdateProposal
+    , "validity range" .= friendlyValidityRange era txValidityRange
+    , "withdrawals" .= friendlyWithdrawals txWithdrawals
     ]
 
 -- | Special case of validity range:
@@ -78,7 +78,7 @@ friendlyValidityRange era = \case
         object
           [ "lower bound" .=
                 case lowerBound of
-                  TxValidityNoLowerBound   -> Null
+                  TxValidityNoLowerBound -> Null
                   TxValidityLowerBound _ s -> toJSON s
           , "upper bound" .=
               case upperBound of
@@ -95,10 +95,10 @@ friendlyWithdrawals TxWithdrawalsNone = Null
 friendlyWithdrawals (TxWithdrawals _ withdrawals) =
   array
     [ object
-        [ "address"     .= serialiseAddress addr
-        , "network"     .= net
-        , "credential"  .= cred
-        , "amount"      .= friendlyLovelace amount
+        [ "address" .= serialiseAddress addr
+        , "network" .= net
+        , "credential" .= cred
+        , "amount" .= friendlyLovelace amount
         ]
     | (addr@(StakeAddress net cred), amount, _) <- withdrawals
     ]
@@ -109,26 +109,26 @@ friendlyTxOut (TxOut addr amount mdatum) =
     AddressInEra ByronAddressInAnyEra _ ->
       object $ ("address era" .= String "Byron") : common
     AddressInEra (ShelleyAddressInEra _) (ShelleyAddress net cred stake) ->
-      object
-        $   [ "address era"         .= String "Shelley"
-            , "network"             .= net
-            , "payment credential"  .= cred
-            , "stake reference"     .= friendlyStakeReference stake
-            ]
-        ++  ["datum" .= datum | TxOutDatumHash _ datum <- [mdatum]]
-        ++  common
+      object $
+        [ "address era" .= String "Shelley"
+        , "network" .= net
+        , "payment credential" .= cred
+        , "stake reference" .= friendlyStakeReference stake
+        ]
+        ++ ["datum" .= datum | TxOutDatumHash _ datum <- [mdatum]]
+        ++ common
   where
     common :: [(Text, Aeson.Value)]
     common =
       [ "address" .= serialiseAddressForTxOut addr
-      , "amount"  .= friendlyTxOutValue amount
+      , "amount" .= friendlyTxOutValue amount
       ]
 
 friendlyStakeReference :: Shelley.StakeReference crypto -> Aeson.Value
 friendlyStakeReference = \case
   Shelley.StakeRefBase cred -> toJSON cred
-  Shelley.StakeRefNull      -> Null
-  Shelley.StakeRefPtr ptr   -> toJSON ptr
+  Shelley.StakeRefNull -> Null
+  Shelley.StakeRefPtr ptr -> toJSON ptr
 
 friendlyUpdateProposal :: TxUpdateProposal era -> Aeson.Value
 friendlyUpdateProposal = \case
@@ -137,12 +137,12 @@ friendlyUpdateProposal = \case
 
 friendlyCertificates :: TxCertificates ViewTx era -> Aeson.Value
 friendlyCertificates = \case
-  TxCertificatesNone    -> Null
+  TxCertificatesNone -> Null
   TxCertificates _ cs _ -> toJSON $ map textShow cs
 
 friendlyFee :: TxFee era -> Aeson.Value
 friendlyFee = \case
-  TxFeeImplicit _     -> "implicit"
+  TxFeeImplicit _ -> "implicit"
   TxFeeExplicit _ fee -> friendlyLovelace fee
 
 friendlyLovelace :: Lovelace -> Aeson.Value
@@ -166,7 +166,7 @@ friendlyAssetId = \case
       suffix =
         case assetName of
           "" -> ""
-          _  -> "." <> assetName
+          _ -> "." <> assetName
 
 friendlyTxOutValue :: TxOutValue era -> Aeson.Value
 friendlyTxOutValue = \case
@@ -175,22 +175,22 @@ friendlyTxOutValue = \case
 
 friendlyMetadata :: TxMetadataInEra era -> Aeson.Value
 friendlyMetadata = \case
-  TxMetadataNone                   -> Null
+  TxMetadataNone -> Null
   TxMetadataInEra _ (TxMetadata m) -> toJSON $ friendlyMetadataValue <$> m
 
 friendlyMetadataValue :: TxMetadataValue -> Aeson.Value
 friendlyMetadataValue = \case
-  TxMetaNumber int   -> toJSON int
-  TxMetaBytes  bytes -> String $ textShow bytes
-  TxMetaList   lst   -> array $ map friendlyMetadataValue lst
-  TxMetaMap    m     ->
+  TxMetaNumber int -> toJSON int
+  TxMetaBytes bytes -> String $ textShow bytes
+  TxMetaList lst -> array $ map friendlyMetadataValue lst
+  TxMetaMap m ->
     array
       [array [friendlyMetadataValue k, friendlyMetadataValue v] | (k, v) <- m]
-  TxMetaText   text  -> toJSON text
+  TxMetaText text -> toJSON text
 
 friendlyAuxScripts :: TxAuxScripts era -> Aeson.Value
 friendlyAuxScripts = \case
-  TxAuxScriptsNone       -> Null
+  TxAuxScriptsNone -> Null
   TxAuxScripts _ scripts -> String $ textShow scripts
 
 friendlyInputs :: [(TxIn, build)] -> Aeson.Value

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -4,29 +4,22 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
 module Cardano.CLI.Run.Friendly (friendlyTxBodyBS) where
 
 import           Cardano.Prelude
 
-import           Data.Aeson (Object, Value (..), object, toJSON, (.=))
+import           Data.Aeson
 import qualified Data.Aeson as Aeson
-import qualified Data.HashMap.Strict as HashMap
+import           Data.Yaml (array)
 import           Data.Yaml.Pretty (defConfig, encodePretty, setConfCompare)
 
 import           Cardano.Api as Api
-import           Cardano.Api.Byron (TxBody (ByronTxBody))
-import           Cardano.Api.Shelley (TxBody (ShelleyTxBody), fromShelleyAddr)
-import           Cardano.Binary (Annotated)
-import qualified Cardano.Chain.UTxO as Byron
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import           Cardano.Ledger.Shelley as Ledger (ShelleyEra)
-import           Cardano.Ledger.ShelleyMA (MaryOrAllegra (Allegra, Mary), ShelleyMAEra)
-import qualified Cardano.Ledger.ShelleyMA.TxBody as ShelleyMA
-import           Shelley.Spec.Ledger.API (Addr (..))
+import           Cardano.Api.Byron (Lovelace (..))
+import           Cardano.Api.Shelley (Address (ShelleyAddress), StakeAddress (..))
 import qualified Shelley.Spec.Ledger.API as Shelley
 
 import           Cardano.CLI.Helpers (textShow)
@@ -36,145 +29,145 @@ friendlyTxBodyBS era =
   encodePretty (setConfCompare compare defConfig) . friendlyTxBody era
 
 friendlyTxBody :: CardanoEra era -> TxBody era -> Aeson.Value
-friendlyTxBody era txbody =
-  Object $
-    HashMap.fromList ["era" .= toJSON era]
-    <>
-    case txbody of
-      ByronTxBody body -> friendlyTxBodyByron body
-      ShelleyTxBody ShelleyBasedEraShelley body _scripts _ aux _ ->
-        addAuxData aux $ friendlyTxBodyShelley body
-      ShelleyTxBody ShelleyBasedEraAllegra body _scripts _ aux _ ->
-        addAuxData aux $ friendlyTxBodyAllegra body
-      ShelleyTxBody ShelleyBasedEraMary body _scripts _ aux _ ->
-        addAuxData aux $ friendlyTxBodyMary body
-      ShelleyTxBody ShelleyBasedEraAlonzo _ _ _ _ _ ->
-        panic "friendlyTxBody: Alonzo not implemented yet" -- TODO alonzo
-
-addAuxData :: Show a => Maybe a -> Object -> Object
-addAuxData = HashMap.insert "auxiliary data" . maybe Null (toJSON . textShow)
-
-friendlyTxBodyByron :: Annotated Byron.Tx ByteString -> Object
-friendlyTxBodyByron = assertObject . toJSON
-
-friendlyTxBodyShelley
-  :: Shelley.TxBody (Ledger.ShelleyEra StandardCrypto) -> Object
-friendlyTxBodyShelley body =
-  HashMap.fromList
-    [ "inputs" .= Shelley._inputs body
-    , "outputs" .= fmap friendlyTxOutShelley (Shelley._outputs body)
-    , "certificates" .= fmap textShow (Shelley._certs body)
-    , "withdrawals" .= Shelley.unWdrl (Shelley._wdrls body)
-    , "fee" .= Shelley._txfee body
-    , "time to live" .= Shelley._ttl body
-    , "update" .= fmap textShow (Shelley._txUpdate body)
-    , "metadata hash" .= fmap textShow (Shelley._mdHash body)
+friendlyTxBody
+  era
+  (TxBody
+    TxBodyContent
+      { txCertificates
+      , txFee
+      , txIns
+      , txMintValue
+      , txOuts
+      , txUpdateProposal
+      , txValidityRange
+      , txWithdrawals
+      }) =
+  object
+    [ "certificates"      .= friendlyCertificates txCertificates
+    , "era"               .= era
+    , "fee"               .= friendlyFee txFee
+    , "inputs"            .= friendlyInputs txIns
+    , "mint"              .= friendlyMintValue txMintValue
+    , "outputs"           .= map friendlyTxOut txOuts
+    , "update proposal"   .= friendlyUpdateProposal txUpdateProposal
+    , "validity range"    .= friendlyValidityRange era txValidityRange
+    , "withdrawals"       .= friendlyWithdrawals txWithdrawals
     ]
 
-friendlyTxBodyAllegra
-  :: ShelleyMA.TxBody (ShelleyMAEra 'Allegra StandardCrypto) -> Object
-friendlyTxBodyAllegra
-  (ShelleyMA.TxBody
-    inputs
-    outputs
-    certificates
-    (Shelley.Wdrl withdrawals)
-    txfee
-    validity
-    update
-    adHash
-    _mint -- mint is not used in Allegra, only in Mary+
-    ) =
-  HashMap.fromList
-    [ "inputs" .= inputs
-    , "outputs" .= fmap friendlyTxOutAllegra outputs
-    , "certificates" .= fmap textShow certificates
-    , "withdrawals" .= withdrawals
-    , "fee" .= txfee
-    , "validity interval" .= friendlyValidityInterval validity
-    , "update" .= fmap textShow update
-    , "auxiliary data hash" .= fmap textShow adHash
+-- | Special case of validity range:
+-- in Shelley, upper bound is TTL, and no lower bound
+pattern ShelleyTtl
+  :: SlotNo -> (TxValidityLowerBound era, TxValidityUpperBound era)
+pattern ShelleyTtl ttl <-
+  ( TxValidityNoLowerBound
+  , TxValidityUpperBound ValidityUpperBoundInShelleyEra ttl
+  )
+
+friendlyValidityRange
+  :: CardanoEra era
+  -> (TxValidityLowerBound era, TxValidityUpperBound era)
+  -> Aeson.Value
+friendlyValidityRange era = \case
+  ShelleyTtl ttl -> object ["time to live" .= ttl]
+  (lowerBound, upperBound)
+    | isLowerBoundSupported || isUpperBoundSupported ->
+        object
+          [ "lower bound" .=
+                case lowerBound of
+                  TxValidityNoLowerBound   -> Null
+                  TxValidityLowerBound _ s -> toJSON s
+          , "upper bound" .=
+              case upperBound of
+                TxValidityNoUpperBound _ -> Null
+                TxValidityUpperBound _ s -> toJSON s
+          ]
+    | otherwise -> Null
+  where
+    isLowerBoundSupported = isJust $ validityLowerBoundSupportedInEra era
+    isUpperBoundSupported = isJust $ validityUpperBoundSupportedInEra era
+
+friendlyWithdrawals :: TxWithdrawals ViewTx era -> Aeson.Value
+friendlyWithdrawals TxWithdrawalsNone = Null
+friendlyWithdrawals (TxWithdrawals _ withdrawals) =
+  array
+    [ object
+        [ "address"     .= serialiseAddress addr
+        , "network"     .= net
+        , "credential"  .= cred
+        , "amount"      .= friendlyLovelace amount
+        ]
+    | (addr@(StakeAddress net cred), amount, _) <- withdrawals
     ]
 
-friendlyTxBodyMary
-  :: ShelleyMA.TxBody (ShelleyMAEra 'Mary StandardCrypto) -> Object
-friendlyTxBodyMary
-  (ShelleyMA.TxBody
-    inputs
-    outputs
-    certificates
-    (Shelley.Wdrl withdrawals)
-    txfee
-    validity
-    update
-    adHash
-    mint) =
-  HashMap.fromList
-    [ "inputs" .= inputs
-    , "outputs" .= fmap friendlyTxOutMary outputs
-    , "certificates" .= fmap textShow certificates
-    , "withdrawals" .= withdrawals
-    , "fee" .= txfee
-    , "validity interval" .= friendlyValidityInterval validity
-    , "update" .= fmap textShow update
-    , "auxiliary data hash" .= fmap textShow adHash
-    , "mint" .= mint
-    ]
-
-friendlyValidityInterval :: ShelleyMA.ValidityInterval -> Aeson.Value
-friendlyValidityInterval
-  ShelleyMA.ValidityInterval{invalidBefore, invalidHereafter} =
-    object
-      [ "invalid before" .= invalidBefore
-      , "invalid hereafter" .= invalidHereafter
+friendlyTxOut :: TxOut era -> Aeson.Value
+friendlyTxOut (TxOut addr amount mdatum) =
+  case addr of
+    AddressInEra ByronAddressInAnyEra _ ->
+      object $ ("address era" .= String "Byron") : common
+    AddressInEra (ShelleyAddressInEra _) (ShelleyAddress net cred stake) ->
+      object
+        $   [ "address era"         .= String "Shelley"
+            , "network"             .= net
+            , "payment credential"  .= cred
+            , "stake reference"     .= friendlyStakeReference stake
+            ]
+        ++  ["datum" .= datum | TxOutDatumHash _ datum <- [mdatum]]
+        ++  common
+  where
+    common :: [(Text, Aeson.Value)]
+    common =
+      [ "address" .= serialiseAddressForTxOut addr
+      , "amount"  .= friendlyTxOutValue amount
       ]
 
-friendlyTxOutShelley ::
-  Shelley.TxOut (Ledger.ShelleyEra StandardCrypto) -> Aeson.Value
-friendlyTxOutShelley (Shelley.TxOut addr amount) =
-  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+friendlyStakeReference :: Shelley.StakeReference crypto -> Aeson.Value
+friendlyStakeReference = \case
+  Shelley.StakeRefBase cred -> toJSON cred
+  Shelley.StakeRefNull      -> Null
+  Shelley.StakeRefPtr ptr   -> toJSON ptr
 
-friendlyTxOutAllegra ::
-  Shelley.TxOut (ShelleyMAEra 'Allegra StandardCrypto) -> Aeson.Value
-friendlyTxOutAllegra (Shelley.TxOut addr amount) =
-  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+friendlyUpdateProposal :: TxUpdateProposal era -> Aeson.Value
+friendlyUpdateProposal = \case
+  TxUpdateProposalNone -> Null
+  TxUpdateProposal _ p -> String $ textShow p
 
-friendlyTxOutMary ::
-  Shelley.TxOut (ShelleyMAEra 'Mary StandardCrypto) -> Aeson.Value
-friendlyTxOutMary (Shelley.TxOut addr amount) =
-  Object $ HashMap.insert "amount" (toJSON amount) $ friendlyAddress addr
+friendlyCertificates :: TxCertificates ViewTx era -> Aeson.Value
+friendlyCertificates = \case
+  TxCertificatesNone    -> Null
+  TxCertificates _ cs _ -> toJSON $ map textShow cs
 
-friendlyAddress :: Addr StandardCrypto -> Object
-friendlyAddress addr =
-  HashMap.fromList $
-    case addr of
-      Addr net cred ref ->
-        [ "address" .=
-            object
-              [ "network" .= net
-              , "credential" .= cred
-              , "stake reference" .= textShow ref
-              , "Bech32" .= addressBech32
-              ]
-        ]
-      AddrBootstrap _ ->
-        ["bootstrap address" .= object ["Bech32" .= String addressBech32]]
-  where
-    addressBech32 =
-      case fromShelleyAddr @Api.ShelleyEra addr of
-        AddressInEra (ShelleyAddressInEra _) a -> serialiseAddress a
-        AddressInEra ByronAddressInAnyEra a -> serialiseAddress a
+friendlyFee :: TxFee era -> Aeson.Value
+friendlyFee = \case
+  TxFeeImplicit _     -> "implicit"
+  TxFeeExplicit _ fee -> friendlyLovelace fee
 
-assertObject :: HasCallStack => Aeson.Value -> Object
-assertObject = \case
-  Object obj -> obj
-  val -> panic $ "expected JSON Object, but got " <> typ
+friendlyLovelace :: Lovelace -> Aeson.Value
+friendlyLovelace (Lovelace value) = String $ textShow value <> " Lovelace"
+
+friendlyMintValue :: TxMintValue ViewTx era -> Aeson.Value
+friendlyMintValue = \case
+  TxMintNone -> Null
+  TxMintValue _ v _ ->
+    object
+      [ friendlyAssetId assetId .= quantity
+      | (assetId, quantity) <- valueToList v
+      ]
+
+friendlyAssetId :: AssetId -> Text
+friendlyAssetId = \case
+  AdaAssetId -> "ADA"
+  AssetId policyId (AssetName assetName) ->
+    decodeUtf8 $ serialiseToRawBytesHex policyId <> suffix
     where
-      typ =
-        case val of
-          Array{}  -> "an Array"
-          Bool{}   -> "a Boolean"
-          Null     -> "Null"
-          Number{} -> "a Number"
-          Object{} -> "an Object"
-          String{} -> "a String"
+      suffix =
+        case assetName of
+          "" -> ""
+          _  -> "." <> assetName
+
+friendlyTxOutValue :: TxOutValue era -> Aeson.Value
+friendlyTxOutValue = \case
+  TxOutAdaOnly _ lovelace -> friendlyLovelace lovelace
+  TxOutValue _ multiasset -> toJSON multiasset
+
+friendlyInputs :: [(TxIn, build)] -> Aeson.Value
+friendlyInputs = toJSON . map fst

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -16,10 +16,38 @@ txViewTests :: IO Bool
 txViewTests =
   checkSequential $
     Group "`transaction view` Goldens"
-      [ ("golden_view_shelley", golden_view_shelley)
+      [ ("golden_view_byron",   golden_view_byron)
+      , ("golden_view_shelley", golden_view_shelley)
       , ("golden_view_allegra", golden_view_allegra)
       , ("golden_view_mary",    golden_view_mary)
+      -- , ("golden_view_alonzo",  golden_view_alonzo)
       ]
+
+golden_view_byron :: Property
+golden_view_byron =
+  propertyOnce $
+  moduleWorkspace "tmp" $ \tempDir -> do
+    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+
+    -- Create transaction body
+    void $
+      execCardanoCLI
+        [ "transaction", "build-raw"
+        , "--byron-era"
+        , "--tx-in"
+        ,   "F8EC302D19E3C8251C30B1434349BF2E949A1DBF14A4EBC3D512918D2D4D5C56\
+            \#88"
+        , "--tx-out"
+        ,   "5oP9ib6ym3XfwXuy3ksXZzgtBzXSArXAACQVXKqcPhiLnHVYjXJNu2T6Zomh8LAWLV\
+            \+68"
+        , "--out-file", transactionBodyFile
+        ]
+
+    -- View transaction body
+    result <-
+      execCardanoCLI
+        ["transaction", "view", "--tx-body-file", transactionBodyFile]
+    diffVsGoldenFile result "test/data/golden/byron/transaction-view.out"
 
 golden_view_shelley :: Property
 golden_view_shelley =

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -64,9 +64,12 @@ golden_view_shelley =
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
             \#29"
         , "--tx-out"
-        ,   "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+31"
+        ,   "addr_test1vz7w0r9epak6nmnh3mc8e2ypkjyu8zsc3xf7dpct6k577acxmcfyv+31"
         , "--fee", "32"
         , "--invalid-hereafter", "33"
+        , "--withdrawal"
+        ,   "stake_test1up00fz9lyqs5sjks82k22eqz7a9srym9vysjgp3h2ua2v2cm522kg\
+            \+42"
         , "--out-file", transactionBodyFile
         ]
 

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -127,8 +127,13 @@ golden_view_mary =
         , "--fee", "139"
         , "--invalid-before", "140"
         , "--mint"
-        ,   "142 69596718df8203759c0f9e86f3f79d1dd45bc9d34109a4fccc824e02"
-        , "--minting-script-file", "test/data/golden/shelley/multisig/scripts/any"
+        ,   "42 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
+            \ + \
+            \43 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.snow\
+            \ + \
+            \44 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.sky"
+        , "--minting-script-file", "test/data/golden/mary/scripts/mint.all"
+        , "--minting-script-file", "test/data/golden/mary/scripts/mint.any"
         , "--out-file", transactionBodyFile
         ]
 

--- a/cardano-cli/test/data/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/data/golden/allegra/transaction-view.out
@@ -1,20 +1,20 @@
-auxiliary data: null
-auxiliary data hash: null
-certificates: []
+certificates: null
 era: Allegra
-fee: 100
+fee: 100 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94
+mint: null
 outputs:
-- address:
-    Bech32: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
-    credential:
-      key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
-    network: Testnet
-    stake reference: StakeRefBase (KeyHashObj (KeyHash "c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0"))
-  amount: 99
-update: null
-validity interval:
-  invalid before: null
-  invalid hereafter: 101
-withdrawals: []
+- address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
+  address era: Shelley
+  amount: 99 Lovelace
+  network: Testnet
+  payment credential:
+    key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
+  stake reference:
+    key hash: c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0
+update proposal: null
+validity range:
+  lower bound: null
+  upper bound: 101
+withdrawals: null

--- a/cardano-cli/test/data/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/data/golden/allegra/transaction-view.out
@@ -3,6 +3,7 @@ era: Allegra
 fee: 100 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94
+metadata: null
 mint: null
 outputs:
 - address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4

--- a/cardano-cli/test/data/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/data/golden/allegra/transaction-view.out
@@ -1,3 +1,4 @@
+auxiliary scripts: null
 certificates: null
 era: Allegra
 fee: 100 Lovelace

--- a/cardano-cli/test/data/golden/byron/transaction-view.out
+++ b/cardano-cli/test/data/golden/byron/transaction-view.out
@@ -1,8 +1,15 @@
+auxiliary scripts: null
+certificates: null
 era: Byron
 fee: implicit
 inputs:
 - f8ec302d19e3c8251c30b1434349bf2e949a1dbf14a4ebc3d512918d2d4d5c56#88
+metadata: null
+mint: null
 outputs:
 - address: 82d818582683581ca862330fecc26edce11f2dce0b3713158d30d1f77141635adb7d2600a102431907e5001a11cea676
   address era: Byron
   amount: 68 Lovelace
+update proposal: null
+validity range: null
+withdrawals: null

--- a/cardano-cli/test/data/golden/byron/transaction-view.out
+++ b/cardano-cli/test/data/golden/byron/transaction-view.out
@@ -1,0 +1,8 @@
+era: Byron
+fee: implicit
+inputs:
+- f8ec302d19e3c8251c30b1434349bf2e949a1dbf14a4ebc3d512918d2d4d5c56#88
+outputs:
+- address: 82d818582683581ca862330fecc26edce11f2dce0b3713158d30d1f77141635adb7d2600a102431907e5001a11cea676
+  address era: Byron
+  amount: 68 Lovelace

--- a/cardano-cli/test/data/golden/mary/scripts/mint.all
+++ b/cardano-cli/test/data/golden/mary/scripts/mint.all
@@ -1,0 +1,3 @@
+{ "type": "all"
+, "scripts": []
+}

--- a/cardano-cli/test/data/golden/mary/scripts/mint.any
+++ b/cardano-cli/test/data/golden/mary/scripts/mint.any
@@ -1,0 +1,3 @@
+{ "type": "any"
+, "scripts": []
+}

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -1,3 +1,4 @@
+auxiliary scripts: null
 certificates: null
 era: Mary
 fee: 139 Lovelace

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -3,6 +3,7 @@ era: Mary
 fee: 139 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135
+metadata: null
 mint:
   69596718df8203759c0f9e86f3f79d1dd45bc9d34109a4fccc824e02: 142
 outputs:

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -6,7 +6,9 @@ inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135
 metadata: null
 mint:
-  69596718df8203759c0f9e86f3f79d1dd45bc9d34109a4fccc824e02: 142
+  52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.snow: 43
+  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf: 42
+  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.sky: 44
 outputs:
 - address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
   address era: Shelley

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -1,27 +1,22 @@
-auxiliary data: null
-auxiliary data hash: null
-certificates: []
+certificates: null
 era: Mary
-fee: 139
+fee: 139 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135
 mint:
-  lovelace: 0
-  policies:
-    69596718df8203759c0f9e86f3f79d1dd45bc9d34109a4fccc824e02:
-      '': 142
+  69596718df8203759c0f9e86f3f79d1dd45bc9d34109a4fccc824e02: 142
 outputs:
-- address:
-    Bech32: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
-    credential:
-      key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
-    network: Testnet
-    stake reference: StakeRefBase (KeyHashObj (KeyHash "c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0"))
+- address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
+  address era: Shelley
   amount:
     lovelace: 138
-    policies: {}
-update: null
-validity interval:
-  invalid before: 140
-  invalid hereafter: null
-withdrawals: []
+  network: Testnet
+  payment credential:
+    key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
+  stake reference:
+    key hash: c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0
+update proposal: null
+validity range:
+  lower bound: 140
+  upper bound: null
+withdrawals: null

--- a/cardano-cli/test/data/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/data/golden/shelley/transaction-view.out
@@ -7,14 +7,19 @@ inputs:
 metadata: null
 mint: null
 outputs:
-- address: addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3
+- address: addr_test1vz7w0r9epak6nmnh3mc8e2ypkjyu8zsc3xf7dpct6k577acxmcfyv
   address era: Shelley
   amount: 31 Lovelace
-  network: Mainnet
+  network: Testnet
   payment credential:
-    key hash: 5dbe1e2117641f8d618034b801a870ca731ce758c3bedd5c7e4429c1
+    key hash: bce78cb90f6da9ee778ef07ca881b489c38a188993e6870bd5a9ef77
   stake reference: null
 update proposal: null
 validity range:
   time to live: 33
-withdrawals: null
+withdrawals:
+- address: stake_test1up00fz9lyqs5sjks82k22eqz7a9srym9vysjgp3h2ua2v2cm522kg
+  amount: 42 Lovelace
+  credential:
+    key hash: 5ef488bf2021484ad03aaca56402f74b0193656121240637573aa62b
+  network: Testnet

--- a/cardano-cli/test/data/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/data/golden/shelley/transaction-view.out
@@ -3,6 +3,7 @@ era: Shelley
 fee: 32 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29
+metadata: null
 mint: null
 outputs:
 - address: addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3

--- a/cardano-cli/test/data/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/data/golden/shelley/transaction-view.out
@@ -1,18 +1,18 @@
-auxiliary data: null
-certificates: []
+certificates: null
 era: Shelley
-fee: 32
+fee: 32 Lovelace
 inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29
-metadata hash: null
+mint: null
 outputs:
-- address:
-    Bech32: addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3
-    credential:
-      key hash: 5dbe1e2117641f8d618034b801a870ca731ce758c3bedd5c7e4429c1
-    network: Mainnet
-    stake reference: StakeRefNull
-  amount: 31
-time to live: 33
-update: null
-withdrawals: []
+- address: addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3
+  address era: Shelley
+  amount: 31 Lovelace
+  network: Mainnet
+  payment credential:
+    key hash: 5dbe1e2117641f8d618034b801a870ca731ce758c3bedd5c7e4429c1
+  stake reference: null
+update proposal: null
+validity range:
+  time to live: 33
+withdrawals: null

--- a/cardano-cli/test/data/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/data/golden/shelley/transaction-view.out
@@ -1,3 +1,4 @@
+auxiliary scripts: null
 certificates: null
 era: Shelley
 fee: 32 Lovelace

--- a/doc/reference/multi-assets.md
+++ b/doc/reference/multi-assets.md
@@ -57,8 +57,8 @@ cardano-cli transaction build-raw \
             --mary-era \
             --fee 0 \
             --tx-in $TXIN \
-            --tx-out $ADDR + 5 $POLICYID.couttscoin\
-            --mint 5 $POLICYID.yourassetname \
+            --tx-out "$ADDR + 5 $POLICYID.couttscoin" \
+            --mint "5 $POLICYID.yourassetname" \
             --minting-script-file $SCRIPT \
             --out-file txbody
 ```


### PR DESCRIPTION
1. Restructure transaction friendly-printer to use generic getTransactionBodyContent
2. Add support of all other fields in transaction friendly-printer:
   - withdrawals
   - metadata
   - (aux?) scripts