### PR TITLE
leave a thunk in the Mark snapshot

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -117,8 +117,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 0730828363ad6d0669b7a5a12635e22944b32880
-  --sha256: 099j8xcmhlfqz5p8qpxsxixzlb06zmxxl7yqd06dkr96gbjd2npz
+  tag: 2e0e7b625492e5e0182464247f4c26d6949ab6f7
+  --sha256: 14affgsf0yl0y5mf9c5r9d9jvah2crrvcslq5cc2h4wii1agl07z
   subdir:
     byron/chain/executable-spec
     byron/crypto


### PR DESCRIPTION
Upgrade the `cardano-ledger-specs` package to https://github.com/input-output-hk/cardano-ledger-specs/tree/jc/dont-bang-the-mark

This is two commits above what is in 1.26.1, making the mark snapshot a thunk and forcing the evaluation in the `TICK` rule.