### PR TITLE
Minor improve on install guide for version 1.26.2

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -159,9 +159,10 @@ Install the newly built node and CLI commands:
 
 If this doesn't work, you can manually copy the executable files to the `~/.local/bin` directory. Replace the place holder `<TAGGED VERSION>` with your targeted version:
 
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<TAGGED VERSION>/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
+    # need to stop your current cardano node before cp-ing the bin file, and restart cardano node after then
+    cp $(find ~/cardano-node/dist-newstyle/build -type f -name "cardano-node" | grep "1.26.2") /usr/local/bin
 
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<TAGGED VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+    cp $(find ~/cardano-node/dist-newstyle/build -type f -name "cardano-cli" | grep "1.26.2") /usr/local/bin
 
 Check the version that has been installed:
 


### PR DESCRIPTION
The current build path not work for v1.26.2
```
    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<TAGGED VERSION>/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/

    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<TAGGED VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
```

Should be changed to
```
    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<TAGGED VERSION>/x/cardano-node/noopt/build/cardano-node/cardano-node ~/.local/bin/

    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<TAGGED VERSION>/x/cardano-cli/noopt/build/cardano-cli/cardano-cli ~/.local/bin/
```