### PR TITLE
Minor improvement for installation guide

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -159,9 +159,10 @@ Install the newly built node and CLI commands:
 
 If this doesn't work, you can manually copy the executable files to the `~/.local/bin` directory. Replace the place holder `<TAGGED VERSION>` with your targeted version:
 
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<TAGGED VERSION>/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
-
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<TAGGED VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+    # need to stop your current cardano node before cp-ing the bin file, and restart cardano node after then
+    export TAGGED_VERSION=$(git describe --tags)
+    cp $(find ~/cardano-node/dist-newstyle/build -type f -name "cardano-node" | grep "$TAGGED_VERSION") /usr/local/bin
+    cp $(find ~/cardano-node/dist-newstyle/build -type f -name "cardano-cli" | grep "$TAGGER_VERSION") /usr/local/bin
 
 Check the version that has been installed:
 


### PR DESCRIPTION
- Using find command to look for the correct binary path of `cardano-node` and `cardano-cli`
- Always get the latest tag