### PR TITLE
Improved installation instructions

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -153,15 +153,13 @@ Build the node and CLI with `cabal`:
 
     cabal build all
 
-Install the newly built node and CLI commands:
+Install the newly built node and CLI commands to the `~/.local/bin` directory:
 
-    cabal install --installdir ~/.local/bin cardano-cli cardano-node
+    cp -p "$(./scripts/bin-path.sh cardano-node)" ~/.local/bin/
+    cp -p "$(./scripts/bin-path.sh cardano-cli)" ~/.local/bin/
 
-If this doesn't work, you can manually copy the executable files to the `~/.local/bin` directory. Replace the place holder `<TAGGED VERSION>` with your targeted version:
-
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<TAGGED VERSION>/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
-
-    cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<TAGGED VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+Note, we avoid using `cabal install` because that method prevents the installed binaries from reporting
+the git revision with the `--version` switch.
 
 Check the version that has been installed:
 

--- a/scripts/bin-path.sh
+++ b/scripts/bin-path.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Find the path to the built executable in the cabal plan.
+
+exe="$1"
+
+if which jq > /dev/null; then
+  bin="$(jq -r '."install-plan"[] | select(."component-name" == "exe:'$exe'") | ."bin-file"' dist-newstyle/cache/plan.json | head -n 1)"
+
+  if [ -f "$bin" ]; then
+    echo "$bin"
+  else
+    echo "Error: $exe not built" 1>&2
+    exit 1
+  fi
+else
+  echo "Error: jq not installed" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
Installation instructions should work regardless of compiler version and preserve git revision in `exe --version`.