### PR TITLE
Update Cardano.Api.ProtocolParameters to ease integration with Alonzo

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -119,8 +119,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e8f19bcc9c8f405131cb95ca6ada26b2b4eac638
-  --sha256: 1v36d3lyhmadzj0abdfsppjna7n7llzqzp9ikx5yq28l2kda2f1p
+  tag: 46577026a5f3972258d675b193e0afc929d3905a
+  --sha256: 1daapjqkdmgmh0k61amim8k94vfca4z0pzbm1iv1y9ycyk0jbbxa
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -178,8 +178,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 8d44955afdebcf9cc521f60e3a9f31e853ace2c1
-  --sha256: 1vv40h3ljnyi67jy8mjj1bd97pjlb5lsc2praf92sdc132bqyzz7
+  tag: aad909cfba4e23c623121457f5ef84e5c41a9b62
+  --sha256: 0657a5wlszpkpql7yskw09gpwqwqvw3izx4an03l2yd608g169si
   subdir:
     io-sim
     io-sim-classes
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: ffc1768f5be7af66d8d745a31c9c6a77c5c55104
-  --sha256: 0qwj0xnvkrxsmfw883w3idfnhj073d5swcxl54zs7ay4fgwrm4c2
+  tag: 1578ab92f9ac389c68aa915370bf38ad7b4a75e9
+  --sha256: 1fnpv2l7zs1in1hgdpb85zv8l37kjcclz0zjzqmll391gbdsb99f
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cabal.project
+++ b/cabal.project
@@ -122,6 +122,7 @@ source-repository-package
   tag: e8f19bcc9c8f405131cb95ca6ada26b2b4eac638
   --sha256: 1v36d3lyhmadzj0abdfsppjna7n7llzqzp9ikx5yq28l2kda2f1p
   subdir:
+    alonzo/impl
     byron/chain/executable-spec
     byron/crypto
     byron/crypto/test
@@ -134,6 +135,7 @@ source-repository-package
     shelley/chain-and-ledger/dependencies/non-integer
     shelley/chain-and-ledger/executable-spec
     shelley/chain-and-ledger/shelley-spec-ledger-test
+    shelley-ma/shelley-ma-test
     shelley-ma/impl
     shelley-ma/shelley-ma-test
 
@@ -192,6 +194,17 @@ source-repository-package
     typed-protocols
     typed-protocols-examples
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus
+  tag: ffc1768f5be7af66d8d745a31c9c6a77c5c55104
+  --sha256: 0qwj0xnvkrxsmfw883w3idfnhj073d5swcxl54zs7ay4fgwrm4c2
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+    prettyprinter-configurable
+
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
@@ -203,3 +216,7 @@ constraints:
 
 package comonad
   flags: -test-doctests
+
+allow-newer:
+  monoidal-containers:aeson,
+  size-based:template-haskell

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -99,6 +99,7 @@ library
                       , cardano-crypto
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
+                      , cardano-ledger-alonzo
                       , cardano-ledger-byron
                       , cardano-ledger-core
                       , cardano-ledger-shelley-ma

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -69,6 +69,7 @@ library
                         Cardano.Api.NetworkId
                         Cardano.Api.OperationalCertificate
                         Cardano.Api.ProtocolParameters
+                        Cardano.Api.ProtocolParametersUpdate
                         Cardano.Api.Query
                         Cardano.Api.Script
                         Cardano.Api.SerialiseBech32

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -123,6 +123,7 @@ library
                       , ouroboros-consensus-shelley
                       , ouroboros-network
                       , ouroboros-network-framework
+                      , plutus-core
                       , scientific
                       , shelley-spec-ledger
                       , small-steps

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -24,6 +24,7 @@ module Cardano.Api (
 
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
+    anyCardanoEraShelleyBased,
     IsShelleyBasedEra(..),
     InAnyShelleyBasedEra(..),
     CardanoEraStyle(..),
@@ -285,7 +286,7 @@ module Cardano.Api (
     SimpleScriptV2,
     ScriptLanguage(..),
     SimpleScriptVersion(..),
-    PlutusScriptVersion,
+    PlutusScriptVersion(..),
     AnyScriptLanguage(..),
     IsScriptLanguage(..),
     IsSimpleScriptLanguage(..),
@@ -488,6 +489,8 @@ module Cardano.Api (
     -- * Protocol parameter updates
     UpdateProposal(..),
     ProtocolParametersUpdate(..),
+    ProtocolParametersError(..),
+    renderProtocolParamsErr,
     makeShelleyUpdateProposal,
     PraosNonce,
     makePraosNonce,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -526,7 +526,8 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
 import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.Query (SlotsInEpoch(..), SlotsToEpochEnd(..), slotToEpoch)
+import           Cardano.Api.ProtocolParametersUpdate
+import           Cardano.Api.Query (SlotsInEpoch (..), SlotsToEpochEnd (..), slotToEpoch)
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -197,7 +197,7 @@ fromConsensusBlock CardanoMode =
       Consensus.BlockMary b' ->
         BlockInMode (ShelleyBlock ShelleyBasedEraMary b')
                      MaryEraInCardanoMode
-
+      Consensus.BlockAlonzo _ -> error "fromConsensusBlock: Alonzo not implemented yet"
 
 -- ----------------------------------------------------------------------------
 -- Block headers

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -16,6 +16,7 @@ module Cardano.Api.Eras
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
   , anyCardanoEra
+  , anyCardanoEraShelleyBased
   , InAnyCardanoEra(..)
 
     -- * Deprecated aliases
@@ -197,6 +198,10 @@ anyCardanoEra ShelleyEra = AnyCardanoEra ShelleyEra
 anyCardanoEra AllegraEra = AnyCardanoEra AllegraEra
 anyCardanoEra MaryEra    = AnyCardanoEra MaryEra
 
+anyCardanoEraShelleyBased :: ShelleyBasedEra era -> AnyCardanoEra
+anyCardanoEraShelleyBased ShelleyBasedEraShelley = AnyCardanoEra ShelleyEra
+anyCardanoEraShelleyBased ShelleyBasedEraAllegra = AnyCardanoEra AllegraEra
+anyCardanoEraShelleyBased ShelleyBasedEraMary    = AnyCardanoEra MaryEra
 
 -- | This pairs up some era-dependent type with a 'CardanoEra' value that tells
 -- us what era it is, but hides the era type. This is useful when the era is

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -198,10 +198,10 @@ anyCardanoEra ShelleyEra = AnyCardanoEra ShelleyEra
 anyCardanoEra AllegraEra = AnyCardanoEra AllegraEra
 anyCardanoEra MaryEra    = AnyCardanoEra MaryEra
 
-anyCardanoEraShelleyBased :: ShelleyBasedEra era -> AnyCardanoEra
-anyCardanoEraShelleyBased ShelleyBasedEraShelley = AnyCardanoEra ShelleyEra
-anyCardanoEraShelleyBased ShelleyBasedEraAllegra = AnyCardanoEra AllegraEra
-anyCardanoEraShelleyBased ShelleyBasedEraMary    = AnyCardanoEra MaryEra
+anyCardanoEraShelleyBased :: ShelleyBasedEra era -> CardanoEra era
+anyCardanoEraShelleyBased ShelleyBasedEraShelley = ShelleyEra
+anyCardanoEraShelleyBased ShelleyBasedEraAllegra = AllegraEra
+anyCardanoEraShelleyBased ShelleyBasedEraMary    = MaryEra
 
 -- | This pairs up some era-dependent type with a 'CardanoEra' value that tells
 -- us what era it is, but hides the era type. This is useful when the era is

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -20,7 +20,6 @@ import           Numeric.Natural
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Byron
 
---import qualified Cardano.Ledger.Core as Core
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import qualified Shelley.Spec.Ledger.Tx as Shelley
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -20,8 +20,6 @@ import           Numeric.Natural
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Byron
 
-import qualified Shelley.Spec.Ledger.LedgerState as Shelley
-import qualified Shelley.Spec.Ledger.Tx as Shelley
 
 import           Cardano.Api.Eras
 import           Cardano.Api.NetworkId
@@ -50,19 +48,12 @@ transactionFee sbe txFeeFixed txFeePerByte tx =
     getFee :: Lovelace
     getFee =
       case tx of
-        ShelleyTx _ tx' -> let x = getTxSize sbe tx'
+        ShelleyTx _ tx' -> let x = getField @"txsize" tx'
                            in Lovelace (a * x + b)
         ByronTx _ -> case sbe :: ShelleyBasedEra ByronEra of {}
 
-    getTxSize :: ShelleyBasedEra era -> Shelley.Tx (ShelleyLedgerEra era) -> Integer
-    getTxSize ShelleyBasedEraShelley = Shelley.txsize
-    getTxSize ShelleyBasedEraAllegra = Shelley.txsize
-    getTxSize ShelleyBasedEraMary = Shelley.txsize
- -- TODO: Change Shelley.Tx to Tx type family
- -- getTxSize ShelleyBasedEraAlonzo = getField @"txsize"
 
     a = toInteger txFeePerByte
-    x = getField @"txsize" tx
     b = toInteger txFeeFixed
 
 --TODO: in the Byron case the per-byte is non-integral, would need different

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -50,6 +50,8 @@ transactionFee sbe txFeeFixed txFeePerByte tx =
       case tx of
         ShelleyTx _ tx' -> let x = getField @"txsize" tx'
                            in Lovelace (a * x + b)
+      --TODO: This can be made to work for Byron txs too. Do that: fill in this case
+        -- and remove the IsShelleyBasedEra constraint.
         ByronTx _ -> case sbe :: ShelleyBasedEra ByronEra of {}
 
 

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -619,9 +619,14 @@ mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis)
           Consensus.ProtocolParamsMary
             { Consensus.maryProtVer = shelleyProtVer dnc
             }
+          Consensus.ProtocolParamsAlonzo
+            { Consensus.alonzoGenesis = error "mkProtocolInfoCardano: Alonzo era not implemented yet"
+            , Consensus.alonzoProtVer = error "mkProtocolInfoCardano: Alonzo era not implemented yet"
+            }
           (ncByronToShelley dnc)
           (ncShelleyToAllegra dnc)
           (ncAllegraToMary dnc)
+          (error "mkProtocolInfoCardano: Alonzo era not implemented yet")
 
 shelleyPraosNonce :: ShelleyConfig -> Shelley.Spec.Nonce
 shelleyPraosNonce sCfg = Shelley.Spec.Nonce (Cardano.Crypto.Hash.Class.castHash . unGenesisHashShelley $ scGenesisHash sCfg)

--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -50,9 +50,9 @@ import qualified Ouroboros.Consensus.Cardano.ByronHFC as Consensus (ByronBlockHF
 import           Ouroboros.Consensus.HardFork.Combinator as Consensus (EraIndex (..), eraIndexSucc,
                    eraIndexZero)
 import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardMary, StandardShelley)
-import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus (ShelleyBlockHFC)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Ouroboros.Consensus.Shelley.Protocol (StandardCrypto)
+import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus (ShelleyBlockHFC)
 
 import qualified Cardano.Chain.Slotting as Byron (EpochSlots (..))
 
@@ -284,4 +284,7 @@ fromConsensusEraIndex CardanoMode = fromShelleyEraIndex
 
     fromShelleyEraIndex (Consensus.EraIndex (S (S (S (Z (K ())))))) =
       AnyEraInMode MaryEraInCardanoMode
+    fromShelleyEraIndex (Consensus.EraIndex (S (S (S (S (Z (K ()))))))) =
+      error "fromShelleyEraIndex: Alonzo not implemented yet"
+
 

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -12,7 +12,7 @@ module Cardano.Api.Orphans () where
 import           Prelude
 
 import           Control.Iterate.SetAlgebra (BiMap (..), Bimap)
-import           Data.Aeson (ToJSON (..), object, (.=))
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import qualified Data.ByteString.Base16 as B16
@@ -23,6 +23,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Coin as Shelley
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Crypto
@@ -37,8 +38,8 @@ import qualified Shelley.Spec.Ledger.Delegation.Certificates as Shelley
 import qualified Shelley.Spec.Ledger.EpochBoundary as ShelleyEpoch
 import qualified Shelley.Spec.Ledger.LedgerState as ShelleyLedger
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
-import qualified Shelley.Spec.Ledger.Rewards as Shelley
 import qualified Shelley.Spec.Ledger.RewardUpdate as Shelley
+import qualified Shelley.Spec.Ledger.Rewards as Shelley
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
@@ -278,3 +279,7 @@ instance ToJSON Shelley.RewardType where
 instance ToJSON (SafeHash.SafeHash c a) where
   toJSON = toJSON . SafeHash.extractHash
 
+instance FromJSON Alonzo.Prices where
+  parseJSON = withObject "Prices" $ \o -> do
+    obj <- o .: "executionUnitPrices"
+    Alonzo.Prices <$> obj .: "unitSpace" <*> obj .: "unitTime"

--- a/cardano-api/src/Cardano/Api/Protocol/Types.hs
+++ b/cardano-api/src/Cardano/Api/Protocol/Types.hs
@@ -22,11 +22,11 @@ import           Cardano.Chain.Slotting (EpochSlots)
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Cardano
-import           Ouroboros.Consensus.Cardano.Node
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
+import           Ouroboros.Consensus.Cardano.Node
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
-import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo(..), ProtocolInfo(..))
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo (..), ProtocolInfo (..))
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.ShelleyHFC (ShelleyBlockHFC)
@@ -58,27 +58,33 @@ instance IOLike m => Protocol m (CardanoBlock StandardCrypto) where
     ProtocolParamsShelley
     ProtocolParamsAllegra
     ProtocolParamsMary
+    ProtocolParamsAlonzo
     (ProtocolParamsTransition ByronBlock (ShelleyBlock StandardShelley))
     (ProtocolParamsTransition (ShelleyBlock StandardShelley) (ShelleyBlock StandardAllegra))
     (ProtocolParamsTransition (ShelleyBlock StandardAllegra) (ShelleyBlock StandardMary))
+    (ProtocolParamsTransition (ShelleyBlock StandardMary) (ShelleyBlock StandardAlonzo))
   protocolInfo (ProtocolInfoArgsCardano
                paramsByron
                paramsShelleyBased
                paramsShelley
                paramsAllegra
                paramsMary
+               paramsAlonzo
                paramsByronShelley
                paramsShelleyAllegra
-               paramsAllegraMary) =
+               paramsAllegraMary
+               paramsMaryAlonzo) =
     protocolInfoCardano
       paramsByron
       paramsShelleyBased
       paramsShelley
       paramsAllegra
       paramsMary
+      paramsAlonzo
       paramsByronShelley
       paramsShelleyAllegra
       paramsAllegraMary
+      paramsMaryAlonzo
 
 instance ProtocolClient ByronBlockHFC where
   data ProtocolClientInfoArgs ByronBlockHFC =

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,6 +16,8 @@
 module Cardano.Api.ProtocolParameters (
     -- * The updateable protocol paramaters
     ProtocolParameters(..),
+    ProtocolParametersError(..),
+    renderProtocolParamsErr,
     EpochNo,
 
     -- * Updates to the protocol paramaters
@@ -36,6 +39,7 @@ module Cardano.Api.ProtocolParameters (
     toShelleyPParamsUpdate,
     toShelleyProposedPPUpdates,
     toShelleyUpdate,
+    toUpdate,
     fromShelleyPParams,
     fromShelleyPParamsUpdate,
     fromShelleyProposedPPUpdates,
@@ -48,15 +52,19 @@ module Cardano.Api.ProtocolParameters (
 
 import           Prelude
 
-import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, withText, (.:), (.=))
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, withText, (.:), (.:?),
+                   (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Scientific (Scientific)
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time (NominalDiffTime, UTCTime)
+import           Data.Word (Word64)
 import           GHC.Generics
 import           Numeric.Natural
 
@@ -71,24 +79,30 @@ import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
 
-import           Shelley.Spec.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
-import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
-import qualified Shelley.Spec.Ledger.Genesis as Shelley
-import qualified Shelley.Spec.Ledger.Keys as Shelley
-import qualified Shelley.Spec.Ledger.PParams as Shelley
-
 import           Cardano.Api.Address
-import           Cardano.Api.Hash
+import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Hash
 import           Cardano.Api.KeysByron
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.NetworkId
+import           Cardano.Api.Script
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.TxMetadata
 import           Cardano.Api.Value
 import           Cardano.Binary
+
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Core as Core
+import           Shelley.Spec.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
+import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
+import qualified Shelley.Spec.Ledger.Genesis as Shelley
+import qualified Shelley.Spec.Ledger.Keys as Shelley
+import qualified Shelley.Spec.Ledger.PParams as Shelley
 
 
 -- | The values of the set of /updateable/ protocol paramaters. At any
@@ -102,7 +116,7 @@ import           Cardano.Binary
 --
 -- There are also paramaters fixed in the Genesis file. See 'GenesisParameters'.
 --
-data ProtocolParameters =
+data ProtocolParameters era =
      ProtocolParameters {
 
        -- | Protocol version, major and minor. Updating the major version is
@@ -170,7 +184,7 @@ data ProtocolParameters =
        -- | The minimum permitted value for new UTxO entries, ie for
        -- transaction outputs.
        --
-       protocolParamMinUTxOValue :: Lovelace,
+       protocolParamMinUTxOValue :: Maybe Lovelace,
 
        -- | The deposit required to register a stake address.
        --
@@ -213,14 +227,380 @@ data ProtocolParameters =
        --
        -- This is the \"tau\" incentives parameter from the design document.
        --
-       protocolParamTreasuryCut :: Rational
+       protocolParamTreasuryCut :: Rational,
+
+       -- Introduced in Alonzo
+
+       -- | Cost in ada per byte of UTxO storage (instead of
+       --protocolParamMinUTxOValue in the Alonzo era onwards).
+       protocolParamUTxOCostPerByte :: Maybe Lovelace,
+
+       -- | Cost models for non-native script languages.
+       protocolParamCostModels :: Maybe CostModel,
+
+       -- | Prices of execution units (for non-native script languages).
+       protocolParamPrices :: Maybe Prices,
+
+       -- | Max total script execution resources units allowed per tx
+       protocolParamMaxTxExUnits :: Maybe MaxTxExecutionUnits,
+
+       -- | Max total script execution resources units allowed per block
+       protocolParamMaxBlockExUnits :: Maybe MaxBlockExecutionUnits,
+
+       -- | Max size of a Value in a tx ouput.
+       protocolParamMaxValSize :: Maybe Natural
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON ProtocolParameters where
-  parseJSON = withObject "ProtocolParameters" $ \o -> do
-                v <- o .: "protocolVersion"
-                ProtocolParameters
+data ProtocolParametersError
+  = ProtocolParamsErrNoParamsInByron
+  | ProtocolParamsErrMustDefineMinUTxo AnyCardanoEra
+  -- Alonzo required protocol params
+  | ProtocolParamsErrMustDefineCostPerByte AnyCardanoEra
+  | ProtocolParamsErrMustDefineCostModel AnyCardanoEra
+  | ProtocolParamsErrMustDefineScriptExecPrices AnyCardanoEra
+  | ProtocolParamsErrMustDefineMaxTxExec AnyCardanoEra
+  | ProtocolParamsErrMustDefineMaxBlockExec AnyCardanoEra
+  | ProtocolParamsErrMustDefineMaxValueSize AnyCardanoEra
+  -- Error Checking
+  | ProtocolParametersErrorWrongVersion
+      (Natural,Natural)
+      (Natural,Natural)
+  deriving Show
+
+renderEra :: AnyCardanoEra -> Text
+renderEra (AnyCardanoEra ByronEra)   = "Byron"
+renderEra (AnyCardanoEra ShelleyEra) = "Shelley"
+renderEra (AnyCardanoEra AllegraEra) = "Allegra"
+renderEra (AnyCardanoEra MaryEra)    = "Mary"
+
+renderProtocolParamsErr :: ProtocolParametersError -> Text
+renderProtocolParamsErr ProtocolParamsErrNoParamsInByron =
+  "Protocol parameters are not supported in the Byron era."
+renderProtocolParamsErr (ProtocolParamsErrMustDefineMinUTxo era) =
+  "protocolParamMinUTxOValue must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineCostPerByte era) =
+  "protocolParamUTxOCostPerByte must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineCostModel era) =
+  "protocolParamCostModels must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineScriptExecPrices era) =
+  "protocolParamPrices must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineMaxTxExec era) =
+  "protocolParamMaxTxExUnits must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineMaxBlockExec era) =
+  "protocolParamMaxBlockExUnits must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParamsErrMustDefineMaxValueSize era) =
+  "protocolParamMaxValSize must be defined in " <> renderEra era
+renderProtocolParamsErr (ProtocolParametersErrorWrongVersion expected got) =
+     "Incorrect protocol version. Got: " <> Text.pack (show got)
+  <> " Expected: " <> Text.pack (show expected)
+
+createProtocolParameters
+  :: (Natural, Natural)           -- ^ Protocol version (major,minor)
+  -> Rational                     -- ^ Decentralization parameter
+  -> Maybe PraosNonce             -- ^ Extra entropy
+  -> Natural                      -- ^ Max block header size
+  -> Natural                      -- ^ Max block body size
+  -> Natural                      -- ^ Max tx size
+  -> Natural                      -- ^ Tx fee fixed (constant factor)
+  -> Natural                      -- ^ Tx fee per bytes (linear factor)
+  -> Maybe Lovelace               -- ^ Min UTxO value
+  -> Lovelace                     -- ^ Stake address deposit
+  -> Lovelace                     -- ^ Stake pool deposit
+  -> Lovelace                     -- ^ Min pool cost
+  -> EpochNo                      -- ^ Max pool retire epoch
+  -> Natural                      -- ^ Stake pool target number
+  -> Rational                     -- ^ Pool pledge influence
+  -> Rational                     -- ^ Monetary expansion
+  -> Rational                     -- ^ Treasury cut
+  -> Maybe Lovelace               -- ^ UTxO cost per byte
+  -> Maybe CostModel              -- ^ Cost model
+  -> Maybe Prices                 -- ^ Price of execution units
+  -> Maybe MaxTxExecutionUnits    -- ^ Script execution resources allowed per tx
+  -> Maybe MaxBlockExecutionUnits -- ^ Script execution resources allowed per block
+  -> Maybe Natural                -- ^ Max size of a Value in tx output
+  -> ProtocolParameters era
+createProtocolParameters ver decent exEntropy bHeadSize bBodySize maxTxSize
+                         txFeeFixed txFeePerByte minUtxo stakeAddrDep stakePoolDep
+                         minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+                         monExpansion treasuryCut utxoCostPerByte costModels
+                         prices maxTxExUnits maxBlockExUnits maxValueSize =
+  ProtocolParameters
+   { protocolParamProtocolVersion = ver
+   , protocolParamDecentralization = decent
+   , protocolParamExtraPraosEntropy = exEntropy
+   , protocolParamMaxBlockHeaderSize = bHeadSize
+   , protocolParamMaxBlockBodySize = bBodySize
+   , protocolParamMaxTxSize = maxTxSize
+   , protocolParamTxFeeFixed = txFeeFixed
+   , protocolParamTxFeePerByte = txFeePerByte
+   , protocolParamMinUTxOValue = minUtxo
+   , protocolParamStakeAddressDeposit = stakeAddrDep
+   , protocolParamStakePoolDeposit = stakePoolDep
+   , protocolParamMinPoolCost = minPoolCost
+   , protocolParamPoolRetireMaxEpoch = poolRetireEpochMax
+   , protocolParamStakePoolTargetNum = poolTargetNum
+   , protocolParamPoolPledgeInfluence = poolPledge
+   , protocolParamMonetaryExpansion = monExpansion
+   , protocolParamTreasuryCut = treasuryCut
+   -- Fields below Introduced in Alonzo
+   , protocolParamUTxOCostPerByte = utxoCostPerByte
+   , protocolParamCostModels = costModels
+   , protocolParamPrices = prices
+   , protocolParamMaxTxExUnits = maxTxExUnits
+   , protocolParamMaxBlockExUnits = maxBlockExUnits
+   , protocolParamMaxValSize = maxValueSize
+   }
+
+createProtocolParametersInEra
+  :: CardanoEra era
+  -> (Natural, Natural)           -- ^ Protocol version (major,minor)
+  -> Rational                     -- ^ Decentralization parameter
+  -> Maybe PraosNonce             -- ^ Extra entropy
+  -> Natural                      -- ^ Max block header size
+  -> Natural                      -- ^ Max block body size
+  -> Natural                      -- ^ Max tx size
+  -> Natural                      -- ^ Tx fee fixed (constant factor)
+  -> Natural                      -- ^ Tx fee per bytes (linear factor)
+  -> Maybe Lovelace               -- ^ Min UTxO value
+  -> Lovelace                     -- ^ Stake address deposit
+  -> Lovelace                     -- ^ Stake pool deposit
+  -> Lovelace                     -- ^ Min pool cost
+  -> EpochNo                      -- ^ Max pool retire epoch
+  -> Natural                      -- ^ Stake pool target number
+  -> Rational                     -- ^ Pool pledge influence
+  -> Rational                     -- ^ Monetary expansion
+  -> Rational                     -- ^ Treasury cut
+  -> Maybe Lovelace               -- ^ UTxO cost per byte
+  -> Maybe CostModel              -- ^ Cost model
+  -> Maybe Prices                 -- ^ Price of execution units
+  -> Maybe MaxTxExecutionUnits    -- ^ Script execution resources allowed per tx
+  -> Maybe MaxBlockExecutionUnits -- ^ Script execution resources allowed per block
+  -> Maybe Natural                -- ^ Max size of a Value in tx output
+  -> Either ProtocolParametersError (ProtocolParameters era)
+createProtocolParametersInEra
+   era ver decent exEntropy bHeadSize bBodySize maxTxSize
+   txFeeFixed txFeePerByte minUtxo stakeAddrDep stakePoolDep
+   minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+   monExpansion treasuryCut _utxoCostPerByte _costModels
+   _prices _maxTxExUnits _maxBlockExUnits _maxValueSize =
+  case cardanoEraStyle era of
+    LegacyByronEra -> Left ProtocolParamsErrNoParamsInByron
+    ShelleyBasedEra sbe -> do
+      checkNecessaryParamsSpecified sbe
+      case sbe of
+        ShelleyBasedEraShelley -> do
+          return $ createProtocolParameters
+                     ver decent exEntropy bHeadSize bBodySize maxTxSize
+                     txFeeFixed txFeePerByte minUtxo stakeAddrDep stakePoolDep
+                     minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+                     monExpansion treasuryCut Nothing Nothing Nothing Nothing
+                     Nothing Nothing
+        ShelleyBasedEraAllegra -> do
+          return $ createProtocolParameters
+                     ver decent exEntropy bHeadSize bBodySize maxTxSize
+                     txFeeFixed txFeePerByte minUtxo stakeAddrDep stakePoolDep
+                     minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+                     monExpansion treasuryCut Nothing Nothing Nothing Nothing
+                     Nothing Nothing
+        ShelleyBasedEraMary -> do
+          return $ createProtocolParameters
+                     ver decent exEntropy bHeadSize bBodySize maxTxSize
+                     txFeeFixed txFeePerByte minUtxo stakeAddrDep stakePoolDep
+                     minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+                     monExpansion treasuryCut Nothing Nothing Nothing Nothing
+                     Nothing Nothing
+     -- ShelleyBasedEraAlonzo ->
+     --   return $ createProtocolParameters
+     --              ver decent exEntropy bHeadSize bBodySize maxTxSize
+     --              txFeeFixed txFeePerByte Nothing stakeAddrDep stakePoolDep
+     --              minPoolCost poolRetireEpochMax poolTargetNum poolPledge
+     --              monExpansion treasuryCut utxoCostPerByte costModels
+     --              prices maxTxExUnits maxBlockExUnits maxValueSize
+ where
+  -- | Protocol parameters change in Alonzo. We check
+  --that the required protocol parameters are specified
+  --in the relevant era.
+  checkNecessaryParamsSpecified
+    :: ShelleyBasedEra era -> Either ProtocolParametersError ()
+  checkNecessaryParamsSpecified sbe' = do
+    let anyEra = anyCardanoEra era
+    case sbe' of
+      ShelleyBasedEraShelley ->
+         parameterExists minUtxo (ProtocolParamsErrMustDefineMinUTxo anyEra)
+      ShelleyBasedEraAllegra ->
+         parameterExists minUtxo (ProtocolParamsErrMustDefineMinUTxo anyEra)
+      ShelleyBasedEraMary ->
+         parameterExists minUtxo (ProtocolParamsErrMustDefineMinUTxo anyEra)
+  --  ShelleyBasedEraAlonzo -> do
+  --     parameterExists utxoCostPerByte (ProtocolParamsErrMustDefineCostPerByte anyEra)
+  --     parameterExists costModels (ProtocolParamsErrMustDefineCostModel anyEra)
+  --     parameterExists prices (ProtocolParamsErrMustDefineScriptExecPrices anyEra)
+  --     parameterExists maxTxExUnits (ProtocolParamsErrMustDefineMaxTxExec anyEra)
+  --     parameterExists maxBlockExUnits (ProtocolParamsErrMustDefineMaxBlockExec anyEra)
+  --     parameterExists maxValueSize (ProtocolParamsErrMustDefineMaxValueSize anyEra)
+
+  -- | Check if a protocol parameter was specified and fail if not.
+  parameterExists
+    :: Maybe a
+    -> ProtocolParametersError
+    -> Either ProtocolParametersError ()
+  parameterExists value err =
+    maybe (Left err) Right value >> Right ()
+
+
+newtype MaxTxExecutionUnits =
+    MaxTxExecutionUnits { unMaxTxExecutionUnits :: ExecutionUnits}
+    deriving (Eq, Show)
+
+_fromMaxTxExec :: Alonzo.ExUnits -> MaxTxExecutionUnits
+_fromMaxTxExec (Alonzo.ExUnits mMem mSteps) =
+  MaxTxExecutionUnits $ ExecutionUnits mMem mSteps
+
+_toTxExecUnits :: MaxTxExecutionUnits -> Alonzo.ExUnits
+_toTxExecUnits (MaxTxExecutionUnits (ExecutionUnits mMem mSteps)) =
+  Alonzo.ExUnits mMem mSteps
+
+instance ToJSON MaxTxExecutionUnits where
+  toJSON (MaxTxExecutionUnits (ExecutionUnits space time)) =
+    object [ "maxTxExecutionUnits" .=
+                object ["space" .= space, "time" .= time]
+           ]
+
+instance FromJSON MaxTxExecutionUnits where
+  parseJSON = withObject "MaxTxExecutionUnits" $ \o -> do
+    obj <- o .: "maxTxExecutionUnits"
+    MaxTxExecutionUnits
+      <$> (ExecutionUnits <$> obj .: "space" <*> obj .: "time")
+
+newtype MaxBlockExecutionUnits =
+    MaxBlockExecutionUnits { unMaxBlockExecutionUnits :: ExecutionUnits}
+    deriving (Eq, Show)
+
+_fromMaxBlockExec :: Alonzo.ExUnits -> MaxBlockExecutionUnits
+_fromMaxBlockExec (Alonzo.ExUnits mMem mSteps) =
+  MaxBlockExecutionUnits $ ExecutionUnits mMem mSteps
+
+_toExUnits :: MaxBlockExecutionUnits -> Alonzo.ExUnits
+_toExUnits (MaxBlockExecutionUnits (ExecutionUnits mMem mSteps)) =
+  Alonzo.ExUnits mMem mSteps
+
+instance ToJSON MaxBlockExecutionUnits where
+  toJSON (MaxBlockExecutionUnits (ExecutionUnits space time)) =
+    object [ "maxBlockExecutionUnits" .=
+                object ["space" .= space, "time" .= time]
+           ]
+
+instance FromJSON MaxBlockExecutionUnits where
+  parseJSON = withObject "MaxBlockExecutionUnits" $ \o -> do
+    obj <- o .: "maxBlockExecutionUnits"
+    MaxBlockExecutionUnits
+      <$> (ExecutionUnits <$> obj .: "space" <*> obj .: "time")
+
+data ExecutionUnits
+    = ExecutionUnits { space :: Word64
+                     , time :: Word64
+                     } deriving (Eq, Show)
+
+
+newtype CostModel = CostModel (Map AnyScriptLanguage Cost)
+                  deriving (Eq,Show)
+
+_fromLanguage :: Alonzo.Language -> AnyScriptLanguage
+_fromLanguage Alonzo.PlutusV1 = AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1)
+
+_fromCostModel :: Map Alonzo.Language Alonzo.CostModel -> CostModel
+_fromCostModel _ = CostModel mempty
+
+_toCostModel :: CostModel -> Map Alonzo.Language Alonzo.CostModel
+_toCostModel _ = Map.empty
+
+
+newtype Cost = Cost (Map.Map Operation Integer)
+             deriving (Eq, Show)
+
+data Operation = Add | Subtract | OtherOperation
+                 deriving (Eq, Ord, Show)
+
+instance ToJSON Operation where
+  toJSON Add = Aeson.String "Add"
+  toJSON Subtract = Aeson.String "Subtract"
+  toJSON OtherOperation = Aeson.String "OtherOperation"
+
+instance FromJSON Operation where
+  parseJSON = withText "Operation" $ \t ->
+                case t of
+                  "Add" -> return Add
+                  "Subtract" -> return Subtract
+                  "OtherOperation" -> return OtherOperation
+                  unOp -> fail $ "Unknown operation: " <> Text.unpack unOp
+
+instance ToJSON Cost where
+  toJSON (Cost c) = toJSON c
+
+instance Aeson.ToJSONKey Operation where
+  toJSONKey = Aeson.toJSONKeyText render
+    where
+      render = Text.pack . show
+
+instance FromJSON Cost where
+  parseJSON = withObject "Cost" $ \obj -> do
+   addCost <- obj .: "Add"
+   subtractCost <- obj .: "Subtract"
+   otherOperationCost <- obj .: "OtherOperation"
+   return . Cost $ Map.fromList [ (Add, addCost)
+                                , (Subtract, subtractCost)
+                                , (OtherOperation, otherOperationCost)
+                                ]
+
+instance ToJSON CostModel where
+  toJSON (CostModel map') =
+    object . concatMap toPair $ Map.toList map'
+      where
+        toPair :: (AnyScriptLanguage, Cost) -> [Aeson.Pair]
+     -- toPair (AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1), c) = ["PlutusScriptV1" .= toJSON c]
+        toPair (AnyScriptLanguage uLang, _) = error $ "Unsupported script language:" <> show uLang
+
+instance FromJSON CostModel where
+  parseJSON = withObject "CostModel" $ \o -> do
+    val <- o .: "PlutusScriptV1"
+    c <- (parseJSON val :: Aeson.Parser Cost)
+    return . CostModel . Map.fromList $ [(AnyScriptLanguage (error "PlutusScriptLanguage PlutusScriptV1"), c)]
+
+
+
+data Prices = Prices { perUnitSpace :: Lovelace
+                     , perUnitTime :: Lovelace
+                     }
+            deriving (Eq, Show)
+
+_fromPrices :: Alonzo.Prices -> Prices
+_fromPrices (Alonzo.Prices pMem pStep) =
+  Prices (fromShelleyLovelace pMem) (fromShelleyLovelace pStep)
+
+_toPrices :: Prices -> Alonzo.Prices
+_toPrices (Prices pMem pStep) =
+  Alonzo.Prices (toShelleyLovelace pMem) (toShelleyLovelace pStep)
+
+instance FromJSON Prices where
+  parseJSON = withObject "Prices" $ \o -> do
+    obj <- o .: "prices"
+    Prices <$> obj .: "unitSpace" <*> obj .: "unitTime"
+
+instance ToJSON Prices where
+  toJSON (Prices perSpace perTime) =
+    object [ "prices" .= object
+             [ "unitSpace" .= perSpace , "unitTime" .= perTime]
+           ]
+
+instance IsCardanoEra era => FromJSON (ProtocolParameters era) where
+  parseJSON = parseProtocolParameters cardanoEra
+
+parseProtocolParameters :: CardanoEra era -> Aeson.Value -> Aeson.Parser (ProtocolParameters era)
+parseProtocolParameters era =
+         withObject "ProtocolParameters" $ \o -> do
+           v <- o .: "protocolVersion"
+           eParams <- createProtocolParametersInEra era
                         <$> ((,) <$> v .: "major" <*> v .: "minor")
                         <*> o .: "decentralization"
                         <*> o .: "extraPraosEntropy"
@@ -229,7 +609,7 @@ instance FromJSON ProtocolParameters where
                         <*> o .: "maxTxSize"
                         <*> o .: "txFeeFixed"
                         <*> o .: "txFeePerByte"
-                        <*> o .: "minUTxOValue"
+                        <*> o .:? "minUTxOValue"
                         <*> o .: "stakeAddressDeposit"
                         <*> o .: "stakePoolDeposit"
                         <*> o .: "minPoolCost"
@@ -238,27 +618,65 @@ instance FromJSON ProtocolParameters where
                         <*> o .: "poolPledgeInfluence"
                         <*> o .: "monetaryExpansion"
                         <*> o .: "treasuryCut"
+                        <*> o .:? "utxoCostPerByte"
+                        <*> o .:? "costModel"
+                        <*> o .:? "prices"
+                        <*> o .:? "maxTxExecUnits"
+                        <*> o .:? "maxBlockExecUnits"
+                        <*> o .:? "maxValueSize"
+           case eParams of
+             Left err -> fail . Text.unpack $ renderProtocolParamsErr err
+             Right pparams -> return pparams
 
-instance ToJSON ProtocolParameters where
-  toJSON pp = object [ "extraPraosEntropy" .= protocolParamExtraPraosEntropy pp
-                     , "stakePoolTargetNum" .= protocolParamStakePoolTargetNum pp
-                     , "poolRetireMaxEpoch" .= protocolParamPoolRetireMaxEpoch pp
-                     , "decentralization" .= (fromRational $ protocolParamDecentralization pp :: Scientific)
-                     , "stakePoolDeposit" .= protocolParamStakePoolDeposit pp
-                     , "maxBlockHeaderSize" .= protocolParamMaxBlockHeaderSize pp
-                     , "maxBlockBodySize" .= protocolParamMaxBlockBodySize pp
-                     , "maxTxSize" .= protocolParamMaxTxSize pp
-                     , "treasuryCut" .= (fromRational $ protocolParamTreasuryCut pp :: Scientific)
-                     , "minPoolCost" .= protocolParamMinPoolCost pp
-                     , "monetaryExpansion" .= (fromRational $ protocolParamMonetaryExpansion pp :: Scientific)
-                     , "stakeAddressDeposit" .= protocolParamStakeAddressDeposit pp
-                     , "poolPledgeInfluence" .= (fromRational $ protocolParamPoolPledgeInfluence pp :: Scientific)
-                     , "protocolVersion" .= let (major, minor) = protocolParamProtocolVersion pp
-                                            in object ["major" .= major, "minor" .= minor]
-                     , "txFeeFixed" .= protocolParamTxFeeFixed pp
-                     , "txFeePerByte" .= protocolParamTxFeePerByte pp
-                     , "minUTxOValue"  .= protocolParamMinUTxOValue pp
-                     ]
+
+instance IsCardanoEra era => ToJSON (ProtocolParameters era) where
+  toJSON pp =
+    case cardanoEraStyle cardanoEra :: CardanoEraStyle era of
+      LegacyByronEra -> error "Protocol parameters are not supported in the Byron era."
+      ShelleyBasedEra sbe -> createProtocolParametersObject sbe pp
+
+createProtocolParametersObject
+  :: ShelleyBasedEra era  -> ProtocolParameters era -> Aeson.Value
+createProtocolParametersObject sbe pp =
+  object $ paramsCommonInAllEras <> eraDependentParams sbe
+ where
+  paramsCommonInAllEras :: [Aeson.Pair]
+  paramsCommonInAllEras =
+    [ "extraPraosEntropy" .= protocolParamExtraPraosEntropy pp
+    , "stakePoolTargetNum" .= protocolParamStakePoolTargetNum pp
+    , "poolRetireMaxEpoch" .= protocolParamPoolRetireMaxEpoch pp
+    , "decentralization" .= (fromRational $ protocolParamDecentralization pp :: Scientific)
+    , "stakePoolDeposit" .= protocolParamStakePoolDeposit pp
+    , "maxBlockHeaderSize" .= protocolParamMaxBlockHeaderSize pp
+    , "maxBlockBodySize" .= protocolParamMaxBlockBodySize pp
+    , "maxTxSize" .= protocolParamMaxTxSize pp
+    , "treasuryCut" .= (fromRational $ protocolParamTreasuryCut pp :: Scientific)
+    , "minPoolCost" .= protocolParamMinPoolCost pp
+    , "monetaryExpansion" .= (fromRational $ protocolParamMonetaryExpansion pp :: Scientific)
+    , "stakeAddressDeposit" .= protocolParamStakeAddressDeposit pp
+    , "poolPledgeInfluence" .= (fromRational $ protocolParamPoolPledgeInfluence pp :: Scientific)
+    , "protocolVersion" .= let (major, minor) = protocolParamProtocolVersion pp
+                           in object ["major" .= major, "minor" .= minor]
+    , "txFeeFixed" .= protocolParamTxFeeFixed pp
+    , "txFeePerByte" .= protocolParamTxFeePerByte pp
+    ]
+
+  eraDependentParams :: ShelleyBasedEra era -> [Aeson.Pair]
+  eraDependentParams sbe' =
+    case sbe' of
+      ShelleyBasedEraShelley ->
+        ["minUTxOValue" .= protocolParamMinUTxOValue pp]
+      ShelleyBasedEraAllegra ->
+        ["minUTxOValue" .= protocolParamMinUTxOValue pp]
+      ShelleyBasedEraMary ->
+        ["minUTxOValue" .= protocolParamMinUTxOValue pp]
+  --  ShelleyBasedEraAlonzo ->
+  --    [ "costModels"  .= protocolParamCostModels pp
+  --    , "execPrices" .= protocolParamPrices pp
+  --    , "maxTxExecutionUnits" .= protocolParamMaxTxExUnits pp
+  --    , "maxBlockExecutionUnits" .= protocolParamMaxBlockExUnits pp
+  --    , "maxValSize" .= protocolParamMaxValSize pp
+  --    ]
 
 -- ----------------------------------------------------------------------------
 -- Updates to the protocol paramaters
@@ -377,7 +795,27 @@ data ProtocolParametersUpdate =
        --
        -- This is the \"tau\" incentives parameter from the design document.
        --
-       protocolUpdateTreasuryCut :: Maybe Rational
+       protocolUpdateTreasuryCut :: Maybe Rational,
+       -- Introduced in Alonzo
+
+       -- | Cost in ada per byte of UTxO storage (instead of
+       --protocolParamMinUTxOValue in the Alonzo era onwards).
+       protocolUpdateUTxOCostPerByte :: Maybe Lovelace,
+
+       -- | Cost models for non-native script languages.
+       protocolUpdateCostModels :: Maybe CostModel,
+
+       -- | Prices of execution units (for non-native script languages).
+       protocolUpdatePrices :: Maybe Prices,
+
+       -- | Max total script execution resources units allowed per tx
+       protocolUpdateMaxTxExUnits :: Maybe MaxTxExecutionUnits,
+
+       -- | Max total script execution resources units allowed per block
+       protocolUpdateMaxBlockExUnits :: Maybe MaxBlockExecutionUnits,
+
+       -- | Max size of a Value in a tx output.
+       protocolUpdateParamMaxValSize :: Maybe Natural
     }
   deriving (Eq, Show)
 
@@ -398,9 +836,16 @@ instance Semigroup ProtocolParametersUpdate where
       , protocolUpdateMinPoolCost         = merge protocolUpdateMinPoolCost
       , protocolUpdatePoolRetireMaxEpoch  = merge protocolUpdatePoolRetireMaxEpoch
       , protocolUpdateStakePoolTargetNum  = merge protocolUpdateStakePoolTargetNum
-      , protocolUpdatePoolPledgeInfluence = merge protocolUpdatePoolPledgeInfluence
       , protocolUpdateMonetaryExpansion   = merge protocolUpdateMonetaryExpansion
+      , protocolUpdatePoolPledgeInfluence = merge protocolUpdatePoolPledgeInfluence
       , protocolUpdateTreasuryCut         = merge protocolUpdateTreasuryCut
+      -- Intoduced in Alonzo below.
+      , protocolUpdateUTxOCostPerByte     = merge protocolUpdateUTxOCostPerByte
+      , protocolUpdateCostModels          = merge protocolUpdateCostModels
+      , protocolUpdatePrices              = merge protocolUpdatePrices
+      , protocolUpdateMaxTxExUnits        = merge protocolUpdateMaxTxExUnits
+      , protocolUpdateMaxBlockExUnits     = merge protocolUpdateMaxBlockExUnits
+      , protocolUpdateParamMaxValSize     = merge protocolUpdateParamMaxValSize
       }
       where
         -- prefer the right hand side:
@@ -427,6 +872,12 @@ instance Monoid ProtocolParametersUpdate where
       , protocolUpdatePoolPledgeInfluence = Nothing
       , protocolUpdateMonetaryExpansion   = Nothing
       , protocolUpdateTreasuryCut         = Nothing
+      , protocolUpdateUTxOCostPerByte     = Nothing
+      , protocolUpdateCostModels          = Nothing
+      , protocolUpdatePrices              = Nothing
+      , protocolUpdateMaxTxExUnits        = Nothing
+      , protocolUpdateMaxBlockExUnits     = Nothing
+      , protocolUpdateParamMaxValSize     = Nothing
       }
 
 
@@ -476,6 +927,7 @@ instance HasTypeProxy UpdateProposal where
 instance HasTextEnvelope UpdateProposal where
     textEnvelopeType _ = "UpdateProposalShelley"
 
+--TODO: Jordan UpdateProposal needs to be parameterized by era or have access to the era
 instance SerialiseAsCBOR UpdateProposal where
     serialiseToCBOR = CBOR.serializeEncoding' . toCBOR . toShelleyUpdate @StandardShelley
     deserialiseFromCBOR _ bs =
@@ -495,7 +947,7 @@ makeShelleyUpdateProposal params genesisKeyHashes =
 -- Genesis paramaters
 --
 
-data GenesisParameters =
+data GenesisParameters era =
      GenesisParameters {
 
        -- | The reference time the system started. The time of slot zero.
@@ -554,7 +1006,7 @@ data GenesisParameters =
 
        -- | The initial values of the updateable 'ProtocolParameters'.
        --
-       protocolInitialUpdateableProtocolParameters :: ProtocolParameters
+       protocolInitialUpdateableProtocolParameters :: ProtocolParameters era
      }
 
 
@@ -583,6 +1035,90 @@ toShelleyProposedPPUpdates =
   . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
   . Map.map (toShelleyPParamsUpdate @ledgerera)
 
+toUpdate  :: ShelleyLedgerEra era ~ ledgerera
+          => Ledger.Crypto ledgerera ~ StandardCrypto
+          => ShelleyBasedEra era
+          -> UpdateProposal -> Shelley.Update ledgerera
+toUpdate sbe (UpdateProposal ppup epochno) =
+    Shelley.Update (toProposedPPUpdates sbe ppup) epochno
+
+toProposedPPUpdates :: ShelleyLedgerEra era ~ ledgerera
+                    => Ledger.Crypto ledgerera ~ StandardCrypto
+                    => ShelleyBasedEra era
+                    -> Map (Hash GenesisKey) ProtocolParametersUpdate
+                    -> Shelley.ProposedPPUpdates ledgerera
+toProposedPPUpdates sbe m =
+  let f = case sbe of
+            ShelleyBasedEraShelley -> toShelleyPParamsUpdate
+            ShelleyBasedEraAllegra -> toShelleyPParamsUpdate
+            ShelleyBasedEraMary -> toShelleyPParamsUpdate
+        --  ShelleyBasedEraAlonzo -> toAlonzoPParamsUpdate
+  in Shelley.ProposedPPUpdates
+       . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
+       $ Map.map f m
+
+{-
+toAlonzoPParamsUpdate :: ProtocolParametersUpdate
+                      -> Alonzo.PParamsUpdate ledgerera
+toAlonzoPParamsUpdate
+    ProtocolParametersUpdate {
+        protocolUpdateProtocolVersion
+      , protocolUpdateDecentralization
+      , protocolUpdateExtraPraosEntropy
+      , protocolUpdateMaxBlockHeaderSize
+      , protocolUpdateMaxBlockBodySize
+      , protocolUpdateMaxTxSize
+      , protocolUpdateTxFeeFixed
+      , protocolUpdateStakeAddressDeposit
+      , protocolUpdateStakePoolDeposit
+      , protocolUpdateMinPoolCost
+      , protocolUpdatePoolRetireMaxEpoch
+      , protocolUpdateStakePoolTargetNum
+      , protocolUpdatePoolPledgeInfluence
+      , protocolUpdateMonetaryExpansion
+      , protocolUpdateTreasuryCut
+
+      , protocolUpdateTxFeePerByte
+      , protocolUpdateMaxBlockExUnits
+      , protocolUpdateMaxTxExUnits
+      , protocolUpdatePrices
+      , protocolUpdateCostModels
+      , protocolUpdateUTxOCostPerByte
+     -- , protocolUpdateParamMaxValSize
+      } =
+      Alonzo.PParams
+           { Alonzo._minfeeA =    maybeToStrictMaybe protocolUpdateTxFeePerByte,
+             Alonzo._minfeeB    = maybeToStrictMaybe protocolUpdateTxFeeFixed,
+             Alonzo._maxBBSize  = maybeToStrictMaybe protocolUpdateMaxBlockBodySize,
+             Alonzo._maxTxSize  = maybeToStrictMaybe protocolUpdateMaxTxSize,
+             Alonzo._maxBHSize  = maybeToStrictMaybe protocolUpdateMaxBlockHeaderSize,
+             Alonzo._keyDeposit = toShelleyLovelace <$>
+                                    maybeToStrictMaybe protocolUpdateStakeAddressDeposit,
+             Alonzo._poolDeposit = toShelleyLovelace <$>
+                                     maybeToStrictMaybe protocolUpdateStakePoolDeposit,
+             Alonzo._eMax = maybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch,
+             Alonzo._nOpt = maybeToStrictMaybe protocolUpdateStakePoolTargetNum,
+             Alonzo._a0   = maybeToStrictMaybe protocolUpdatePoolPledgeInfluence,
+             Alonzo._rho  = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateMonetaryExpansion,
+             Alonzo._tau = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateTreasuryCut,
+             Alonzo._d = Shelley.unitIntervalFromRational <$>
+                                      maybeToStrictMaybe protocolUpdateDecentralization,
+             Alonzo._extraEntropy = toShelleyNonce <$>
+                                          maybeToStrictMaybe protocolUpdateExtraPraosEntropy,
+             Alonzo._protocolVersion = uncurry Shelley.ProtVer <$>
+                                          maybeToStrictMaybe protocolUpdateProtocolVersion,
+             Alonzo._minPoolCost = toShelleyLovelace <$>
+                                       maybeToStrictMaybe protocolUpdateMinPoolCost,
+
+             Alonzo._adaPerUTxOByte = toShelleyLovelace <$> maybeToStrictMaybe protocolUpdateUTxOCostPerByte,
+             Alonzo._costmdls = toCostModel <$> maybeToStrictMaybe protocolUpdateCostModels,
+             Alonzo._prices = toPrices <$> maybeToStrictMaybe protocolUpdatePrices,
+             Alonzo._maxTxExUnits = toTxExecUnits <$> maybeToStrictMaybe protocolUpdateMaxTxExUnits,
+             Alonzo._maxBlockExUnits = toExUnits <$> maybeToStrictMaybe protocolUpdateMaxBlockExUnits
+           }
+-}
 
 toShelleyPParamsUpdate :: ProtocolParametersUpdate
                        -> Shelley.PParamsUpdate ledgerera
@@ -705,55 +1241,111 @@ fromShelleyPParamsUpdate
                                             strictMaybeToMaybe _rho
     , protocolUpdateTreasuryCut         = Shelley.unitIntervalToRational <$>
                                             strictMaybeToMaybe _tau
+    , protocolUpdateUTxOCostPerByte     = Nothing
+    , protocolUpdateCostModels          = Nothing
+    , protocolUpdatePrices              = Nothing
+    , protocolUpdateMaxTxExUnits        = Nothing
+    , protocolUpdateMaxBlockExUnits     = Nothing
+    , protocolUpdateParamMaxValSize     = Nothing
     }
 
 
-fromShelleyPParams :: Shelley.PParams ledgerera
-                   -> ProtocolParameters
+toProtocolParamsShelley :: Shelley.PParams ledgerera -> ProtocolParameters era
+toProtocolParamsShelley pparams =
+   ProtocolParameters
+        { protocolParamProtocolVersion     = (\(Shelley.ProtVer a b) -> (a,b))
+                                               $ Shelley._protocolVersion pparams
+        , protocolParamDecentralization    = Shelley.unitIntervalToRational $ Shelley._d pparams
+        , protocolParamExtraPraosEntropy   = fromPraosNonce $ Shelley._extraEntropy pparams
+        , protocolParamMaxBlockHeaderSize  = Shelley._maxBHSize pparams
+        , protocolParamMaxBlockBodySize    = Shelley._maxBBSize pparams
+        , protocolParamMaxTxSize           = Shelley._maxTxSize pparams
+        , protocolParamTxFeeFixed          = Shelley._minfeeB pparams
+        , protocolParamTxFeePerByte        = Shelley._minfeeA pparams
+        , protocolParamMinUTxOValue        = Just . fromShelleyLovelace $ Shelley._minUTxOValue pparams
+        , protocolParamStakeAddressDeposit = fromShelleyLovelace $ Shelley._keyDeposit pparams
+        , protocolParamStakePoolDeposit    = fromShelleyLovelace $ Shelley._poolDeposit pparams
+        , protocolParamMinPoolCost         = fromShelleyLovelace $ Shelley._minPoolCost pparams
+        , protocolParamPoolRetireMaxEpoch  = Shelley._eMax pparams
+        , protocolParamStakePoolTargetNum  = Shelley._nOpt pparams
+        , protocolParamPoolPledgeInfluence = Shelley._a0 pparams
+        , protocolParamMonetaryExpansion   = Shelley.unitIntervalToRational $ Shelley._rho pparams
+        , protocolParamTreasuryCut         = Shelley.unitIntervalToRational $ Shelley._tau pparams
+        , protocolParamUTxOCostPerByte     = Nothing
+        , protocolParamCostModels          = Nothing
+        , protocolParamPrices              = Nothing
+        , protocolParamMaxTxExUnits        = Nothing
+        , protocolParamMaxBlockExUnits     = Nothing
+        , protocolParamMaxValSize          = Nothing
+        }
+
+
+_toProtocolParamsAlonzo :: Alonzo.PParams ledgerera -> ProtocolParameters era
+_toProtocolParamsAlonzo pparams =
+   ProtocolParameters
+        { protocolParamProtocolVersion     = (\(Shelley.ProtVer a b) -> (a,b))
+                                               $ Alonzo._protocolVersion pparams
+        , protocolParamDecentralization    = Shelley.unitIntervalToRational $ Alonzo._d pparams
+        , protocolParamExtraPraosEntropy   = fromPraosNonce $ Alonzo._extraEntropy pparams
+        , protocolParamMaxBlockHeaderSize  = Alonzo._maxBHSize pparams
+        , protocolParamMaxBlockBodySize    = Alonzo._maxBBSize pparams
+        , protocolParamMaxTxSize           = Alonzo._maxTxSize pparams
+        , protocolParamTxFeeFixed          = Alonzo._minfeeB pparams
+        , protocolParamTxFeePerByte        = Alonzo._minfeeA pparams
+        , protocolParamMinUTxOValue        = Nothing
+        , protocolParamStakeAddressDeposit = fromShelleyLovelace $ Alonzo._keyDeposit pparams
+        , protocolParamStakePoolDeposit    = fromShelleyLovelace $ Alonzo._poolDeposit pparams
+        , protocolParamMinPoolCost         = fromShelleyLovelace $ Alonzo._minPoolCost pparams
+        , protocolParamPoolRetireMaxEpoch  = Alonzo._eMax pparams
+        , protocolParamStakePoolTargetNum  = Alonzo._nOpt pparams
+        , protocolParamPoolPledgeInfluence = Alonzo._a0 pparams
+        , protocolParamMonetaryExpansion   = Shelley.unitIntervalToRational $ Alonzo._rho pparams
+        , protocolParamTreasuryCut         = Shelley.unitIntervalToRational $ Alonzo._tau pparams
+        , protocolParamUTxOCostPerByte     = Just . fromShelleyLovelace $ Alonzo._adaPerUTxOByte pparams
+        , protocolParamCostModels          = Just . _fromCostModel $ Alonzo._costmdls pparams
+        , protocolParamPrices              = Just . _fromPrices $ Alonzo._prices pparams
+        , protocolParamMaxTxExUnits        = Just . _fromMaxTxExec $ Alonzo._maxTxExUnits pparams
+        , protocolParamMaxBlockExUnits     = Just . _fromMaxBlockExec $ Alonzo._maxBlockExUnits pparams
+        , protocolParamMaxValSize          = Nothing --TODO: Waiting on consensus to update to latest ledger Just $ Alonzo._maxValSize pparams
+        }
+
 fromShelleyPParams
-    Shelley.PParams {
-      Shelley._minfeeA
-    , Shelley._minfeeB
-    , Shelley._maxBBSize
-    , Shelley._maxTxSize
-    , Shelley._maxBHSize
-    , Shelley._keyDeposit
-    , Shelley._poolDeposit
-    , Shelley._eMax
-    , Shelley._nOpt
-    , Shelley._a0
-    , Shelley._rho
-    , Shelley._tau
-    , Shelley._d
-    , Shelley._extraEntropy
-    , Shelley._protocolVersion
-    , Shelley._minUTxOValue
-    , Shelley._minPoolCost
-    } =
-    ProtocolParameters {
-      protocolParamProtocolVersion     = (\(Shelley.ProtVer a b) -> (a,b))
-                                           _protocolVersion
-    , protocolParamDecentralization    = Shelley.unitIntervalToRational _d
-    , protocolParamExtraPraosEntropy   = fromPraosNonce _extraEntropy
-    , protocolParamMaxBlockHeaderSize  = _maxBHSize
-    , protocolParamMaxBlockBodySize    = _maxBBSize
-    , protocolParamMaxTxSize           = _maxTxSize
-    , protocolParamTxFeeFixed          = _minfeeB
-    , protocolParamTxFeePerByte        = _minfeeA
-    , protocolParamMinUTxOValue        = fromShelleyLovelace _minUTxOValue
-    , protocolParamStakeAddressDeposit = fromShelleyLovelace _keyDeposit
-    , protocolParamStakePoolDeposit    = fromShelleyLovelace _poolDeposit
-    , protocolParamMinPoolCost         = fromShelleyLovelace _minPoolCost
-    , protocolParamPoolRetireMaxEpoch  = _eMax
-    , protocolParamStakePoolTargetNum  = _nOpt
-    , protocolParamPoolPledgeInfluence = _a0
-    , protocolParamMonetaryExpansion   = Shelley.unitIntervalToRational _rho
-    , protocolParamTreasuryCut         = Shelley.unitIntervalToRational _tau
-    }
+  :: ShelleyBasedEra era
+  -> Core.PParams (ShelleyLedgerEra era)
+  -> Either ProtocolParametersError (ProtocolParameters era)
+fromShelleyPParams sbe pparams =
+  let pp = case sbe of
+             ShelleyBasedEraShelley -> toProtocolParamsShelley pparams
+             ShelleyBasedEraAllegra -> toProtocolParamsShelley pparams
+             ShelleyBasedEraMary -> toProtocolParamsShelley pparams
+--           ShelleyBasedEraAlonzo -> toProtocolParamsAlonzo pparams
+  in do checkProtocolVersion sbe (protocolParamProtocolVersion pp)
+        return pp
 
 
-fromShelleyGenesis :: Shelley.ShelleyGenesis era -> GenesisParameters
+checkProtocolVersion
+  :: ShelleyBasedEra era
+  -> (Natural, Natural)
+  -> Either ProtocolParametersError ()
+checkProtocolVersion sbe protoVer  =
+  let expectedPVer = case sbe of
+                       ShelleyBasedEraShelley -> (2,0)
+                       ShelleyBasedEraAllegra -> (3,0)
+                       ShelleyBasedEraMary -> (4,0)
+              --      ShelleyBasedEraAlonzo -> (5,0)
+  in checkCondition (protoVer == expectedPVer)
+       $ ProtocolParametersErrorWrongVersion expectedPVer protoVer
+
+checkCondition :: Bool -> ProtocolParametersError -> Either ProtocolParametersError ()
+checkCondition True _ = Right ()
+checkCondition False ppe = Left ppe
+
 fromShelleyGenesis
+  :: ShelleyBasedEra era
+  -> Shelley.ShelleyGenesis (ShelleyLedgerEra era)
+  -> Either ProtocolParametersError (GenesisParameters era)
+fromShelleyGenesis
+    sbe
     Shelley.ShelleyGenesis {
       Shelley.sgSystemStart
     , Shelley.sgNetworkMagic
@@ -771,20 +1363,76 @@ fromShelleyGenesis
     , Shelley.sgInitialFunds = _  -- unused, not retained by the node
     , Shelley.sgStaking      = _  -- unused, not retained by the node
     } =
-    GenesisParameters {
-      protocolParamSystemStart            = sgSystemStart
-    , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
-                                              (NetworkMagic sgNetworkMagic)
-    , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
-    , protocolParamSecurity               = fromIntegral sgSecurityParam
-    , protocolParamEpochLength            = sgEpochLength
-    , protocolParamSlotLength             = sgSlotLength
-    , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
-    , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
-    , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
-    , protocolParamMaxLovelaceSupply      = Lovelace
-                                              (fromIntegral sgMaxLovelaceSupply)
-    , protocolInitialUpdateableProtocolParameters = fromShelleyPParams
-                                                      sgProtocolParams
-    }
-
+    case sbe of
+      ShelleyBasedEraShelley -> do
+       pparams <- fromShelleyPParams sbe sgProtocolParams
+       return $ GenesisParameters {
+         protocolParamSystemStart            = sgSystemStart
+       , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
+                                                 (NetworkMagic sgNetworkMagic)
+       , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
+       , protocolParamSecurity               = fromIntegral sgSecurityParam
+       , protocolParamEpochLength            = sgEpochLength
+       , protocolParamSlotLength             = sgSlotLength
+       , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
+       , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
+       , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
+       , protocolParamMaxLovelaceSupply      = Lovelace
+                                                 (fromIntegral sgMaxLovelaceSupply)
+       , protocolInitialUpdateableProtocolParameters = pparams
+       }
+      ShelleyBasedEraAllegra -> do
+         pparams <- fromShelleyPParams sbe sgProtocolParams
+         return $ GenesisParameters {
+           protocolParamSystemStart            = sgSystemStart
+         , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
+                                                   (NetworkMagic sgNetworkMagic)
+         , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
+         , protocolParamSecurity               = fromIntegral sgSecurityParam
+         , protocolParamEpochLength            = sgEpochLength
+         , protocolParamSlotLength             = sgSlotLength
+         , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
+         , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
+         , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
+         , protocolParamMaxLovelaceSupply      = Lovelace
+                                                   (fromIntegral sgMaxLovelaceSupply)
+         , protocolInitialUpdateableProtocolParameters = pparams
+         }
+      ShelleyBasedEraMary -> do
+         pparams <- fromShelleyPParams sbe sgProtocolParams
+         return $ GenesisParameters {
+           protocolParamSystemStart            = sgSystemStart
+         , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
+                                                   (NetworkMagic sgNetworkMagic)
+         , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
+         , protocolParamSecurity               = fromIntegral sgSecurityParam
+         , protocolParamEpochLength            = sgEpochLength
+         , protocolParamSlotLength             = sgSlotLength
+         , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
+         , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
+         , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
+         , protocolParamMaxLovelaceSupply      = Lovelace
+                                                   (fromIntegral sgMaxLovelaceSupply)
+         , protocolInitialUpdateableProtocolParameters = pparams
+         }
+{-
+      -- TODO: Ledger needs to update ShelleyGenesis with Core.PParams
+      -- type family.
+      ShelleyBasedEraAlonzo -> do
+         pparams <- fromShelleyPParams sbe (error "sgProtocolParams")
+         return $ GenesisParameters {
+           protocolParamSystemStart            = sgSystemStart
+         , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
+                                                   (NetworkMagic sgNetworkMagic)
+         , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
+         , protocolParamSecurity               = fromIntegral sgSecurityParam
+         , protocolParamEpochLength            = sgEpochLength
+         , protocolParamSlotLength             = sgSlotLength
+         , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
+         , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
+         , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
+         , protocolParamMaxLovelaceSupply      = Lovelace
+                                                   (fromIntegral sgMaxLovelaceSupply)
+         , protocolInitialUpdateableProtocolParameters = pparams
+         }
+-}

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -70,12 +70,11 @@ import           Cardano.Api.Script
 import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.TxMetadata
 import           Cardano.Api.Value
-import           Cardano.Binary
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Core as Core
-import qualified Language.PlutusCore.Evaluation.Machine.ExBudgeting as Plutus
+import qualified PlutusCore.Evaluation.Machine.ExBudgeting as Plutus
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.Genesis as Shelley
 import qualified Shelley.Spec.Ledger.Keys as Shelley
@@ -492,7 +491,6 @@ _fromCostModel aCostMap = Map.fromList . mapMaybe conv  $ Map.toList aCostMap
    conv :: (Alonzo.Language, Alonzo.CostModel) -> Maybe (AnyScriptLanguage, CostModel)
    conv (Alonzo.PlutusV1, Alonzo.CostModel _aCostModel) =
      Just (undefined, CostModel $ error "Need to bump ledger spec dependency")
-   conv (Alonzo.PlutusV1, _) = Nothing
 
 _toCostModel :: Map AnyScriptLanguage CostModel -> Map Alonzo.Language Alonzo.CostModel
 _toCostModel cMap = Map.fromList . mapMaybe conv $ Map.toList cMap

--- a/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
@@ -1,0 +1,675 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | The various Cardano protocol parameters, including:
+--
+-- * the current values of updateable protocol parameters: 'ProtocolParameters'
+-- * updates to protocol parameters: 'ProtocolParametersUpdate'
+-- * update proposals that can be embedded in transactions: 'UpdateProposal'
+-- * parameters fixed in the genesis file: 'GenesisParameters'
+--
+module Cardano.Api.ProtocolParametersUpdate (
+    -- * Updates to the protocol paramaters
+    ProtocolParametersUpdate(..),
+
+    -- * Update proposals to change the protocol paramaters
+    UpdateProposal(..),
+    makeShelleyUpdateProposal,
+
+    -- * Internal conversion functions
+    toShelleyPParamsUpdate,
+    toShelleyProposedPPUpdates,
+    toShelleyUpdate,
+    toUpdate,
+    fromShelleyPParamsUpdate,
+    fromShelleyProposedPPUpdates,
+    fromShelleyUpdate,
+
+    -- * Data family instances
+    AsType(..)
+  ) where
+
+import           Prelude
+
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.Text (Text)
+import           Data.Word (Word64)
+import           Numeric.Natural
+
+import           Control.Monad
+
+import qualified Cardano.Binary as CBOR
+
+import qualified Cardano.Ledger.Era as Ledger
+import qualified Cardano.Ledger.Shelley.Constraints as Shelley
+import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
+
+import           Cardano.Api.Address
+import           Cardano.Api.Eras
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Hash
+import           Cardano.Api.KeysByron
+import           Cardano.Api.KeysShelley
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.Value
+
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Language.PlutusCore.Evaluation.Machine.ExBudgeting as Plutus
+import           Shelley.Spec.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
+import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
+import qualified Shelley.Spec.Ledger.PParams as Shelley
+
+-- ----------------------------------------------------------------------------
+-- Updates to the protocol paramaters
+--
+
+-- | The representation of a change in the 'ProtocolParameters'.
+--
+data ProtocolParametersUpdate =
+     ProtocolParametersUpdate {
+
+       -- | Protocol version, major and minor. Updating the major version is
+       -- used to trigger hard forks.
+       --
+       protocolUpdateProtocolVersion :: Maybe (Natural, Natural),
+
+       -- | The decentralization parameter. This is fraction of slots that
+       -- belong to the BFT overlay schedule, rather than the Praos schedule.
+       -- So 1 means fully centralised, while 0 means fully decentralised.
+       --
+       -- This is the \"d\" parameter from the design document.
+       --
+       protocolUpdateDecentralization :: Maybe Rational,
+
+       -- | Extra entropy for the Praos per-epoch nonce.
+       --
+       -- This can be used to add extra entropy during the decentralisation
+       -- process. If the extra entropy can be demonstrated to be generated
+       -- randomly then this method can be used to show that the initial
+       -- federated operators did not subtly bias the initial schedule so that
+       -- they retain undue influence after decentralisation.
+       --
+       protocolUpdateExtraPraosEntropy :: Maybe (Maybe PraosNonce),
+
+       -- | The maximum permitted size of a block header.
+       --
+       -- This must be at least as big as the largest legitimate block headers
+       -- but should not be too much larger, to help prevent DoS attacks.
+       --
+       -- Caution: setting this to be smaller than legitimate block headers is
+       -- a sure way to brick the system!
+       --
+       protocolUpdateMaxBlockHeaderSize :: Maybe Natural,
+
+       -- | The maximum permitted size of the block body (that is, the block
+       -- payload, without the block header).
+       --
+       -- This should be picked with the Praos network delta security parameter
+       -- in mind. Making this too large can severely weaken the Praos
+       -- consensus properties.
+       --
+       -- Caution: setting this to be smaller than a transaction that can
+       -- change the protocol parameters is a sure way to brick the system!
+       --
+       protocolUpdateMaxBlockBodySize :: Maybe Natural,
+
+       -- | The maximum permitted size of a transaction.
+       --
+       -- Typically this should not be too high a fraction of the block size,
+       -- otherwise wastage from block fragmentation becomes a problem, and
+       -- the current implementation does not use any sophisticated box packing
+       -- algorithm.
+       --
+       protocolUpdateMaxTxSize :: Maybe Natural,
+
+       -- | The constant factor for the minimum fee calculation.
+       --
+       protocolUpdateTxFeeFixed :: Maybe Natural,
+
+       -- | The linear factor for the minimum fee calculation.
+       --
+       protocolUpdateTxFeePerByte :: Maybe Natural,
+
+       -- | The minimum permitted value for new UTxO entries, ie for
+       -- transaction outputs.
+       --
+       protocolUpdateMinUTxOValue :: Maybe Lovelace,
+
+       -- | The deposit required to register a stake address.
+       --
+       protocolUpdateStakeAddressDeposit :: Maybe Lovelace,
+
+       -- | The deposit required to register a stake pool.
+       --
+       protocolUpdateStakePoolDeposit :: Maybe Lovelace,
+
+       -- | The minimum value that stake pools are permitted to declare for
+       -- their cost parameter.
+       --
+       protocolUpdateMinPoolCost :: Maybe Lovelace,
+
+       -- | The maximum number of epochs into the future that stake pools
+       -- are permitted to schedule a retirement.
+       --
+       protocolUpdatePoolRetireMaxEpoch :: Maybe EpochNo,
+
+       -- | The equilibrium target number of stake pools.
+       --
+       -- This is the \"k\" incentives parameter from the design document.
+       --
+       protocolUpdateStakePoolTargetNum :: Maybe Natural,
+
+       -- | The influence of the pledge in stake pool rewards.
+       --
+       -- This is the \"a_0\" incentives parameter from the design document.
+       --
+       protocolUpdatePoolPledgeInfluence :: Maybe Rational,
+
+       -- | The monetary expansion rate. This determines the fraction of the
+       -- reserves that are added to the fee pot each epoch.
+       --
+       -- This is the \"rho\" incentives parameter from the design document.
+       --
+       protocolUpdateMonetaryExpansion :: Maybe Rational,
+
+       -- | The fraction of the fee pot each epoch that goes to the treasury.
+       --
+       -- This is the \"tau\" incentives parameter from the design document.
+       --
+       protocolUpdateTreasuryCut :: Maybe Rational,
+       -- Introduced in Alonzo
+
+       -- | Cost in ada per byte of UTxO storage (instead of
+       --protocolParamMinUTxOValue in the Alonzo era onwards).
+       protocolUpdateUTxOCostPerByte :: Maybe Lovelace,
+
+       -- | Cost models for non-native script languages.
+       protocolUpdateCostModels :: Map AnyScriptLanguage CostModel,
+
+       -- | Map AnyScriptLanguage ExecutionUnitPrices of execution units (for non-native script languages).
+       protocolUpdatePrices :: Map AnyScriptLanguage ExecutionUnitPrices,
+
+       -- | Max total script execution resources units allowed per tx
+       protocolUpdateMaxTxExUnits :: Maybe MaxTxExecutionUnits,
+
+       -- | Max total script execution resources units allowed per block
+       protocolUpdateMaxBlockExUnits :: Maybe MaxBlockExecutionUnits,
+
+       -- | Max size of a Value in a tx output.
+       protocolUpdateParamMaxValSize :: Maybe Natural
+    }
+  deriving (Eq, Show)
+
+instance Semigroup ProtocolParametersUpdate where
+    ppu1 <> ppu2 =
+      ProtocolParametersUpdate {
+        protocolUpdateProtocolVersion     = merge protocolUpdateProtocolVersion
+      , protocolUpdateDecentralization    = merge protocolUpdateDecentralization
+      , protocolUpdateExtraPraosEntropy   = merge protocolUpdateExtraPraosEntropy
+      , protocolUpdateMaxBlockHeaderSize  = merge protocolUpdateMaxBlockHeaderSize
+      , protocolUpdateMaxBlockBodySize    = merge protocolUpdateMaxBlockBodySize
+      , protocolUpdateMaxTxSize           = merge protocolUpdateMaxTxSize
+      , protocolUpdateTxFeeFixed          = merge protocolUpdateTxFeeFixed
+      , protocolUpdateTxFeePerByte        = merge protocolUpdateTxFeePerByte
+      , protocolUpdateMinUTxOValue        = merge protocolUpdateMinUTxOValue
+      , protocolUpdateStakeAddressDeposit = merge protocolUpdateStakeAddressDeposit
+      , protocolUpdateStakePoolDeposit    = merge protocolUpdateStakePoolDeposit
+      , protocolUpdateMinPoolCost         = merge protocolUpdateMinPoolCost
+      , protocolUpdatePoolRetireMaxEpoch  = merge protocolUpdatePoolRetireMaxEpoch
+      , protocolUpdateStakePoolTargetNum  = merge protocolUpdateStakePoolTargetNum
+      , protocolUpdateMonetaryExpansion   = merge protocolUpdateMonetaryExpansion
+      , protocolUpdatePoolPledgeInfluence = merge protocolUpdatePoolPledgeInfluence
+      , protocolUpdateTreasuryCut         = merge protocolUpdateTreasuryCut
+      -- Intoduced in Alonzo below.
+      , protocolUpdateUTxOCostPerByte     = merge protocolUpdateUTxOCostPerByte
+      , protocolUpdateCostModels          = mergeMap protocolUpdateCostModels
+      , protocolUpdatePrices              = mergeMap protocolUpdatePrices
+      , protocolUpdateMaxTxExUnits        = merge protocolUpdateMaxTxExUnits
+      , protocolUpdateMaxBlockExUnits     = merge protocolUpdateMaxBlockExUnits
+      , protocolUpdateParamMaxValSize     = merge protocolUpdateParamMaxValSize
+      }
+      where
+        -- prefer the right hand side:
+        merge :: (ProtocolParametersUpdate -> Maybe a) -> Maybe a
+        merge f = f ppu2 `mplus` f ppu1
+
+        -- need to use map merge where:
+        -- keys present in m1 and m2: remove/ignore m1 key
+        -- keys present in m1 and not m2 : remove/ignore m1 key
+        -- keys present in m2 and not m1: keep m2
+        -- I.e prefer m2 -- TODO: left off here. Remember plutus json jared sent you
+        mergeMap :: (ProtocolParametersUpdate -> Map AnyScriptLanguage a)
+                 -> Map AnyScriptLanguage a
+        mergeMap = undefined
+
+instance Monoid ProtocolParametersUpdate where
+    mempty =
+      ProtocolParametersUpdate {
+        protocolUpdateProtocolVersion     = Nothing
+      , protocolUpdateDecentralization    = Nothing
+      , protocolUpdateExtraPraosEntropy   = Nothing
+      , protocolUpdateMaxBlockHeaderSize  = Nothing
+      , protocolUpdateMaxBlockBodySize    = Nothing
+      , protocolUpdateMaxTxSize           = Nothing
+      , protocolUpdateTxFeeFixed          = Nothing
+      , protocolUpdateTxFeePerByte        = Nothing
+      , protocolUpdateMinUTxOValue        = Nothing
+      , protocolUpdateStakeAddressDeposit = Nothing
+      , protocolUpdateStakePoolDeposit    = Nothing
+      , protocolUpdateMinPoolCost         = Nothing
+      , protocolUpdatePoolRetireMaxEpoch  = Nothing
+      , protocolUpdateStakePoolTargetNum  = Nothing
+      , protocolUpdatePoolPledgeInfluence = Nothing
+      , protocolUpdateMonetaryExpansion   = Nothing
+      , protocolUpdateTreasuryCut         = Nothing
+      , protocolUpdateUTxOCostPerByte     = Nothing
+      , protocolUpdateCostModels          = mempty
+      , protocolUpdatePrices              = mempty
+      , protocolUpdateMaxTxExUnits        = Nothing
+      , protocolUpdateMaxBlockExUnits     = Nothing
+      , protocolUpdateParamMaxValSize     = Nothing
+      }
+
+-- ----------------------------------------------------------------------------
+-- Proposals embedded in transactions to update protocol parameters
+--
+
+data UpdateProposal =
+     UpdateProposal
+       !(Map (Hash GenesisKey) ProtocolParametersUpdate)
+       !EpochNo
+    deriving stock (Eq, Show)
+
+instance HasTypeProxy UpdateProposal where
+    data AsType UpdateProposal = AsUpdateProposal
+    proxyToAsType _ = AsUpdateProposal
+
+instance HasTextEnvelope UpdateProposal where
+    textEnvelopeType _ = "UpdateProposalShelley"
+
+--TODO: Jordan UpdateProposal needs to be parameterized by era or have access to the era
+instance SerialiseAsCBOR UpdateProposal where
+    serialiseToCBOR = CBOR.serializeEncoding' . toCBOR . toShelleyUpdate @StandardShelley
+    deserialiseFromCBOR _ bs =
+      fromShelleyUpdate @StandardShelley <$>
+        CBOR.decodeAnnotator "UpdateProposal" fromCBOR (LBS.fromStrict bs)
+
+
+makeShelleyUpdateProposal :: ProtocolParametersUpdate
+                          -> [Hash GenesisKey]
+                          -> EpochNo
+                          -> UpdateProposal
+makeShelleyUpdateProposal params genesisKeyHashes =
+    --TODO decide how to handle parameter validation
+    UpdateProposal (Map.fromList [ (kh, params) | kh <- genesisKeyHashes ])
+
+newtype CostModel = CostModel (Map.Map Text Integer)
+             deriving (Eq, Show)
+
+_fromLanguage :: Alonzo.Language -> AnyScriptLanguage
+_fromLanguage Alonzo.PlutusV1 = AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1)
+
+_fromCostModel :: Map Alonzo.Language Alonzo.CostModel -> Map AnyScriptLanguage CostModel
+_fromCostModel aCostMap = Map.fromList . mapMaybe conv  $ Map.toList aCostMap
+ where
+   conv :: (Alonzo.Language, Alonzo.CostModel) -> Maybe (AnyScriptLanguage, CostModel)
+   conv (Alonzo.PlutusV1, Alonzo.CostModel _aCostModel) =
+     Just (undefined, CostModel $ error "Need to bump ledger spec dependency")
+   conv (Alonzo.PlutusV1, _) = Nothing
+
+_toCostModel :: Map AnyScriptLanguage CostModel -> Map Alonzo.Language Alonzo.CostModel
+_toCostModel cMap = Map.fromList . mapMaybe conv $ Map.toList cMap
+ where
+   conv :: (AnyScriptLanguage, CostModel) -> Maybe (Alonzo.Language, Alonzo.CostModel)
+   conv (AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1), CostModel _costModel) =
+     Just (Alonzo.PlutusV1, Alonzo.CostModel $ error "Need to bump ledger spec dependency")
+   conv (AnyScriptLanguage (SimpleScriptLanguage _), _) = Nothing
+
+-- TODO: Need to bump the plutus dependency to get access to
+-- extractModelParams :: CostModel -> Maybe CostModelParams
+toCostModelParams :: Plutus.CostModel -> Maybe (Map Text Integer)
+toCostModelParams _ = Nothing
+
+instance FromJSON CostModel where
+  parseJSON v = do
+    pCostModel <- parseJSON v :: Aeson.Parser Plutus.CostModel
+    case toCostModelParams pCostModel of
+      Just cModelParams -> return $ CostModel cModelParams
+      Nothing ->
+        error $ "Error converting Plutus cost model to cost model params: " <> show pCostModel
+
+
+data ExecutionUnitPrices =
+  ExecutionUnitPrices { perUnitSpace :: Lovelace
+                      , perUnitTime :: Lovelace
+                      } deriving (Eq, Show)
+
+_fromPrices :: Alonzo.Prices -> ExecutionUnitPrices
+_fromPrices (Alonzo.Prices pMem pStep) =
+  ExecutionUnitPrices (fromShelleyLovelace pMem) (fromShelleyLovelace pStep)
+
+_toPrices :: ExecutionUnitPrices -> Alonzo.Prices
+_toPrices (ExecutionUnitPrices pMem pStep) =
+  Alonzo.Prices (toShelleyLovelace pMem) (toShelleyLovelace pStep)
+
+instance FromJSON ExecutionUnitPrices where
+  parseJSON = withObject "ExecutionUnitPrices" $ \o -> do
+    obj <- o .: "executionUnitPrices"
+    ExecutionUnitPrices <$> obj .: "unitSpace" <*> obj .: "unitTime"
+
+instance ToJSON ExecutionUnitPrices where
+  toJSON (ExecutionUnitPrices perSpace perTime) =
+    object [ "executionUnitPrices" .= object
+             [ "unitSpace" .= perSpace , "unitTime" .= perTime]
+           ]
+
+newtype MaxTxExecutionUnits =
+    MaxTxExecutionUnits { unMaxTxExecutionUnits :: ExecutionUnits}
+    deriving (Eq, Show)
+
+_fromMaxTxExec :: Alonzo.ExUnits -> MaxTxExecutionUnits
+_fromMaxTxExec (Alonzo.ExUnits mMem mSteps) =
+  MaxTxExecutionUnits $ ExecutionUnits mMem mSteps
+
+_toTxExecUnits :: MaxTxExecutionUnits -> Alonzo.ExUnits
+_toTxExecUnits (MaxTxExecutionUnits (ExecutionUnits mMem mSteps)) =
+  Alonzo.ExUnits mMem mSteps
+
+instance ToJSON MaxTxExecutionUnits where
+  toJSON (MaxTxExecutionUnits (ExecutionUnits space time)) =
+    object [ "maxTxExecutionUnits" .=
+                object ["space" .= space, "time" .= time]
+           ]
+
+instance FromJSON MaxTxExecutionUnits where
+  parseJSON = withObject "MaxTxExecutionUnits" $ \o -> do
+    obj <- o .: "maxTxExecutionUnits"
+    MaxTxExecutionUnits
+      <$> (ExecutionUnits <$> obj .: "space" <*> obj .: "time")
+
+newtype MaxBlockExecutionUnits =
+    MaxBlockExecutionUnits { unMaxBlockExecutionUnits :: ExecutionUnits}
+    deriving (Eq, Show)
+
+_fromMaxBlockExec :: Alonzo.ExUnits -> MaxBlockExecutionUnits
+_fromMaxBlockExec (Alonzo.ExUnits mMem mSteps) =
+  MaxBlockExecutionUnits $ ExecutionUnits mMem mSteps
+
+_toExUnits :: MaxBlockExecutionUnits -> Alonzo.ExUnits
+_toExUnits (MaxBlockExecutionUnits (ExecutionUnits mMem mSteps)) =
+  Alonzo.ExUnits mMem mSteps
+
+instance ToJSON MaxBlockExecutionUnits where
+  toJSON (MaxBlockExecutionUnits (ExecutionUnits space time)) =
+    object [ "maxBlockExecutionUnits" .=
+                object ["space" .= space, "time" .= time]
+           ]
+
+instance FromJSON MaxBlockExecutionUnits where
+  parseJSON = withObject "MaxBlockExecutionUnits" $ \o -> do
+    obj <- o .: "maxBlockExecutionUnits"
+    MaxBlockExecutionUnits
+      <$> (ExecutionUnits <$> obj .: "space" <*> obj .: "time")
+
+
+data ExecutionUnits
+    = ExecutionUnits { space :: Word64
+                     , time :: Word64
+                     } deriving (Eq, Show)
+
+
+
+-- ----------------------------------------------------------------------------
+-- Conversion functions
+--
+
+toShelleyUpdate :: ( Ledger.Crypto ledgerera ~ StandardCrypto
+                   , Shelley.PParamsDelta ledgerera
+                     ~ Shelley.PParamsUpdate ledgerera
+                   )
+                => UpdateProposal -> Shelley.Update ledgerera
+toShelleyUpdate (UpdateProposal ppup epochno) =
+    Shelley.Update (toShelleyProposedPPUpdates ppup) epochno
+
+
+toShelleyProposedPPUpdates :: forall ledgerera.
+                              ( Ledger.Crypto ledgerera ~ StandardCrypto
+                              , Shelley.PParamsDelta ledgerera
+                                ~ Shelley.PParamsUpdate ledgerera
+                              )
+                            => Map (Hash GenesisKey) ProtocolParametersUpdate
+                            -> Shelley.ProposedPPUpdates ledgerera
+toShelleyProposedPPUpdates =
+    Shelley.ProposedPPUpdates
+  . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
+  . Map.map (toShelleyPParamsUpdate @ledgerera)
+
+toUpdate  :: ShelleyLedgerEra era ~ ledgerera
+          => Ledger.Crypto ledgerera ~ StandardCrypto
+          => ShelleyBasedEra era
+          -> UpdateProposal -> Shelley.Update ledgerera
+toUpdate sbe (UpdateProposal ppup epochno) =
+    Shelley.Update (toProposedPPUpdates sbe ppup) epochno
+
+toProposedPPUpdates :: ShelleyLedgerEra era ~ ledgerera
+                    => Ledger.Crypto ledgerera ~ StandardCrypto
+                    => ShelleyBasedEra era
+                    -> Map (Hash GenesisKey) ProtocolParametersUpdate
+                    -> Shelley.ProposedPPUpdates ledgerera
+toProposedPPUpdates sbe m =
+  let f = case sbe of
+            ShelleyBasedEraShelley -> toShelleyPParamsUpdate
+            ShelleyBasedEraAllegra -> toShelleyPParamsUpdate
+            ShelleyBasedEraMary -> toShelleyPParamsUpdate
+        --  ShelleyBasedEraAlonzo -> toAlonzoPParamsUpdate
+  in Shelley.ProposedPPUpdates
+       . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
+       $ Map.map f m
+
+{-
+toAlonzoPParamsUpdate :: ProtocolParametersUpdate
+                      -> Alonzo.PParamsUpdate ledgerera
+toAlonzoPParamsUpdate
+    ProtocolParametersUpdate {
+        protocolUpdateProtocolVersion
+      , protocolUpdateDecentralization
+      , protocolUpdateExtraPraosEntropy
+      , protocolUpdateMaxBlockHeaderSize
+      , protocolUpdateMaxBlockBodySize
+      , protocolUpdateMaxTxSize
+      , protocolUpdateTxFeeFixed
+      , protocolUpdateStakeAddressDeposit
+      , protocolUpdateStakePoolDeposit
+      , protocolUpdateMinPoolCost
+      , protocolUpdatePoolRetireMaxEpoch
+      , protocolUpdateStakePoolTargetNum
+      , protocolUpdatePoolPledgeInfluence
+      , protocolUpdateMonetaryExpansion
+      , protocolUpdateTreasuryCut
+
+      , protocolUpdateTxFeePerByte
+      , protocolUpdateMaxBlockExUnits
+      , protocolUpdateMaxTxExUnits
+      , protocolUpdatePrices
+      , protocolUpdateCostModels
+      , protocolUpdateUTxOCostPerByte
+     -- , protocolUpdateParamMaxValSize
+      } =
+      Alonzo.PParams
+           { Alonzo._minfeeA =    maybeToStrictMaybe protocolUpdateTxFeePerByte,
+             Alonzo._minfeeB    = maybeToStrictMaybe protocolUpdateTxFeeFixed,
+             Alonzo._maxBBSize  = maybeToStrictMaybe protocolUpdateMaxBlockBodySize,
+             Alonzo._maxTxSize  = maybeToStrictMaybe protocolUpdateMaxTxSize,
+             Alonzo._maxBHSize  = maybeToStrictMaybe protocolUpdateMaxBlockHeaderSize,
+             Alonzo._keyDeposit = toShelleyLovelace <$>
+                                    maybeToStrictMaybe protocolUpdateStakeAddressDeposit,
+             Alonzo._poolDeposit = toShelleyLovelace <$>
+                                     maybeToStrictMaybe protocolUpdateStakePoolDeposit,
+             Alonzo._eMax = maybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch,
+             Alonzo._nOpt = maybeToStrictMaybe protocolUpdateStakePoolTargetNum,
+             Alonzo._a0   = maybeToStrictMaybe protocolUpdatePoolPledgeInfluence,
+             Alonzo._rho  = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateMonetaryExpansion,
+             Alonzo._tau = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateTreasuryCut,
+             Alonzo._d = Shelley.unitIntervalFromRational <$>
+                                      maybeToStrictMaybe protocolUpdateDecentralization,
+             Alonzo._extraEntropy = toShelleyNonce <$>
+                                          maybeToStrictMaybe protocolUpdateExtraPraosEntropy,
+             Alonzo._protocolVersion = uncurry Shelley.ProtVer <$>
+                                          maybeToStrictMaybe protocolUpdateProtocolVersion,
+             Alonzo._minPoolCost = toShelleyLovelace <$>
+                                       maybeToStrictMaybe protocolUpdateMinPoolCost,
+
+             Alonzo._adaPerUTxOByte = toShelleyLovelace <$> maybeToStrictMaybe protocolUpdateUTxOCostPerByte,
+             Alonzo._costmdls = toCostModel <$> maybeToStrictMaybe protocolUpdateCostModels,
+             Alonzo._prices = toPrices <$> maybeToStrictMaybe protocolUpdatePrices,
+             Alonzo._maxTxExUnits = toTxExecUnits <$> maybeToStrictMaybe protocolUpdateMaxTxExUnits,
+             Alonzo._maxBlockExUnits = toExUnits <$> maybeToStrictMaybe protocolUpdateMaxBlockExUnits
+           }
+-}
+
+toShelleyPParamsUpdate :: ProtocolParametersUpdate
+                       -> Shelley.PParamsUpdate ledgerera
+toShelleyPParamsUpdate
+    ProtocolParametersUpdate {
+      protocolUpdateProtocolVersion
+    , protocolUpdateDecentralization
+    , protocolUpdateExtraPraosEntropy
+    , protocolUpdateMaxBlockHeaderSize
+    , protocolUpdateMaxBlockBodySize
+    , protocolUpdateMaxTxSize
+    , protocolUpdateTxFeeFixed
+    , protocolUpdateTxFeePerByte
+    , protocolUpdateMinUTxOValue
+    , protocolUpdateStakeAddressDeposit
+    , protocolUpdateStakePoolDeposit
+    , protocolUpdateMinPoolCost
+    , protocolUpdatePoolRetireMaxEpoch
+    , protocolUpdateStakePoolTargetNum
+    , protocolUpdatePoolPledgeInfluence
+    , protocolUpdateMonetaryExpansion
+    , protocolUpdateTreasuryCut
+    } =
+    Shelley.PParams {
+      Shelley._minfeeA     = maybeToStrictMaybe protocolUpdateTxFeePerByte
+    , Shelley._minfeeB     = maybeToStrictMaybe protocolUpdateTxFeeFixed
+    , Shelley._maxBBSize   = maybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , Shelley._maxTxSize   = maybeToStrictMaybe protocolUpdateMaxTxSize
+    , Shelley._maxBHSize   = maybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , Shelley._keyDeposit  = toShelleyLovelace <$>
+                               maybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , Shelley._poolDeposit = toShelleyLovelace <$>
+                               maybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , Shelley._eMax        = maybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , Shelley._nOpt        = maybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , Shelley._a0          = maybeToStrictMaybe protocolUpdatePoolPledgeInfluence
+    , Shelley._rho         = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateMonetaryExpansion
+    , Shelley._tau         = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateTreasuryCut
+    , Shelley._d           = Shelley.unitIntervalFromRational <$>
+                               maybeToStrictMaybe protocolUpdateDecentralization
+    , Shelley._extraEntropy    = toShelleyNonce <$>
+                                   maybeToStrictMaybe protocolUpdateExtraPraosEntropy
+    , Shelley._protocolVersion = uncurry Shelley.ProtVer <$>
+                                   maybeToStrictMaybe protocolUpdateProtocolVersion
+    , Shelley._minUTxOValue    = toShelleyLovelace <$>
+                                   maybeToStrictMaybe protocolUpdateMinUTxOValue
+    , Shelley._minPoolCost     = toShelleyLovelace <$>
+                                   maybeToStrictMaybe protocolUpdateMinPoolCost
+    }
+
+fromShelleyUpdate :: ( Ledger.Crypto ledgerera ~ StandardCrypto
+                     , Shelley.PParamsDelta ledgerera
+                       ~ Shelley.PParamsUpdate ledgerera
+                     )
+                  => Shelley.Update ledgerera -> UpdateProposal
+fromShelleyUpdate (Shelley.Update ppup epochno) =
+    UpdateProposal (fromShelleyProposedPPUpdates ppup) epochno
+
+
+fromShelleyProposedPPUpdates :: ( Ledger.Crypto ledgerera ~ StandardCrypto
+                                , Shelley.PParamsDelta ledgerera
+                                  ~ Shelley.PParamsUpdate ledgerera
+                                )
+                             => Shelley.ProposedPPUpdates ledgerera
+                             -> Map (Hash GenesisKey) ProtocolParametersUpdate
+fromShelleyProposedPPUpdates =
+    Map.map fromShelleyPParamsUpdate
+  . Map.mapKeysMonotonic GenesisKeyHash
+  . (\(Shelley.ProposedPPUpdates ppup) -> ppup)
+
+
+fromShelleyPParamsUpdate :: Shelley.PParamsUpdate ledgerera
+                         -> ProtocolParametersUpdate
+fromShelleyPParamsUpdate
+    Shelley.PParams {
+      Shelley._minfeeA
+    , Shelley._minfeeB
+    , Shelley._maxBBSize
+    , Shelley._maxTxSize
+    , Shelley._maxBHSize
+    , Shelley._keyDeposit
+    , Shelley._poolDeposit
+    , Shelley._eMax
+    , Shelley._nOpt
+    , Shelley._a0
+    , Shelley._rho
+    , Shelley._tau
+    , Shelley._d
+    , Shelley._extraEntropy
+    , Shelley._protocolVersion
+    , Shelley._minUTxOValue
+    , Shelley._minPoolCost
+    } =
+    ProtocolParametersUpdate {
+      protocolUpdateProtocolVersion     = (\(Shelley.ProtVer a b) -> (a,b)) <$>
+                                          strictMaybeToMaybe _protocolVersion
+    , protocolUpdateDecentralization    = Shelley.unitIntervalToRational <$>
+                                            strictMaybeToMaybe _d
+    , protocolUpdateExtraPraosEntropy   = fromPraosNonce <$>
+                                            strictMaybeToMaybe _extraEntropy
+    , protocolUpdateMaxBlockHeaderSize  = strictMaybeToMaybe _maxBHSize
+    , protocolUpdateMaxBlockBodySize    = strictMaybeToMaybe _maxBBSize
+    , protocolUpdateMaxTxSize           = strictMaybeToMaybe _maxTxSize
+    , protocolUpdateTxFeeFixed          = strictMaybeToMaybe _minfeeB
+    , protocolUpdateTxFeePerByte        = strictMaybeToMaybe _minfeeA
+    , protocolUpdateMinUTxOValue        = fromShelleyLovelace <$>
+                                            strictMaybeToMaybe _minUTxOValue
+    , protocolUpdateStakeAddressDeposit = fromShelleyLovelace <$>
+                                            strictMaybeToMaybe _keyDeposit
+    , protocolUpdateStakePoolDeposit    = fromShelleyLovelace <$>
+                                            strictMaybeToMaybe _poolDeposit
+    , protocolUpdateMinPoolCost         = fromShelleyLovelace <$>
+                                            strictMaybeToMaybe _minPoolCost
+    , protocolUpdatePoolRetireMaxEpoch  = strictMaybeToMaybe _eMax
+    , protocolUpdateStakePoolTargetNum  = strictMaybeToMaybe _nOpt
+    , protocolUpdatePoolPledgeInfluence = strictMaybeToMaybe _a0
+    , protocolUpdateMonetaryExpansion   = Shelley.unitIntervalToRational <$>
+                                            strictMaybeToMaybe _rho
+    , protocolUpdateTreasuryCut         = Shelley.unitIntervalToRational <$>
+                                            strictMaybeToMaybe _tau
+    , protocolUpdateUTxOCostPerByte     = Nothing
+    , protocolUpdateCostModels          = mempty
+    , protocolUpdatePrices              = mempty
+    , protocolUpdateMaxTxExUnits        = Nothing
+    , protocolUpdateMaxBlockExUnits     = Nothing
+    , protocolUpdateParamMaxValSize     = Nothing
+    }
+

--- a/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
@@ -69,7 +69,7 @@ import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Language.PlutusCore.Evaluation.Machine.ExBudgeting as Plutus
+import qualified PlutusCore.Evaluation.Machine.ExBudgeting as Plutus
 import           Shelley.Spec.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.PParams as Shelley
@@ -307,7 +307,7 @@ instance SerialiseAsCBOR UpdateProposal where
     serialiseToCBOR = CBOR.serializeEncoding' . toCBOR . toShelleyUpdate @StandardShelley
     deserialiseFromCBOR _ bs =
       fromShelleyUpdate @StandardShelley <$>
-        CBOR.decodeAnnotator "UpdateProposal" fromCBOR (LBS.fromStrict bs)
+        CBOR.decodeFull (LBS.fromStrict bs)
 
 
 makeShelleyUpdateProposal :: ProtocolParametersUpdate
@@ -330,7 +330,6 @@ _fromCostModel aCostMap = Map.fromList . mapMaybe conv  $ Map.toList aCostMap
    conv :: (Alonzo.Language, Alonzo.CostModel) -> Maybe (AnyScriptLanguage, CostModel)
    conv (Alonzo.PlutusV1, Alonzo.CostModel _aCostModel) =
      Just (undefined, CostModel $ error "Need to bump ledger spec dependency")
-   conv (Alonzo.PlutusV1, _) = Nothing
 
 _toCostModel :: Map AnyScriptLanguage CostModel -> Map Alonzo.Language Alonzo.CostModel
 _toCostModel cMap = Map.fromList . mapMaybe conv $ Map.toList cMap

--- a/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParametersUpdate.hs
@@ -198,11 +198,11 @@ data ProtocolParametersUpdate =
        --protocolParamMinUTxOValue in the Alonzo era onwards).
        protocolUpdateUTxOCostPerByte :: Maybe Lovelace,
 
-       -- | Cost models for non-native script languages.
+       -- | Cost models for script languages that use them.
        protocolUpdateCostModels :: Map AnyScriptLanguage CostModel,
 
-       -- | Map AnyScriptLanguage ExecutionUnitPrices of execution units (for non-native script languages).
-       protocolUpdatePrices :: Map AnyScriptLanguage ExecutionUnitPrices,
+       -- | Map of script language execution unit prices.
+       protocolUpdatePrices :: Map AnyScriptLanguage Alonzo.Prices,
 
        -- | Max total script execution resources units allowed per tx
        protocolUpdateMaxTxExUnits :: Maybe MaxTxExecutionUnits,

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -88,6 +88,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.Orphans ()
 import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.ProtocolParametersUpdate
 import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -156,7 +156,7 @@ data QueryInShelleyBasedEra era result where
        :: QueryInShelleyBasedEra era (GenesisParameters era)
 
      QueryProtocolParameters
-       :: QueryInShelleyBasedEra era (ProtocolParameters era)
+       :: QueryInShelleyBasedEra era ProtocolParameters
 
      QueryProtocolParametersUpdate
        :: QueryInShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -44,6 +44,7 @@ module Cardano.Api.Query (
 
 import           Data.Aeson (ToJSON (..), object, (.=))
 import           Data.Bifunctor (bimap)
+import           Data.Either (fromRight)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (mapMaybe)
@@ -151,10 +152,10 @@ data QueryInShelleyBasedEra era result where
        :: QueryInShelleyBasedEra era EpochNo
 
      QueryGenesisParameters
-       :: QueryInShelleyBasedEra era GenesisParameters
+       :: QueryInShelleyBasedEra era (GenesisParameters era)
 
      QueryProtocolParameters
-       :: QueryInShelleyBasedEra era ProtocolParameters
+       :: QueryInShelleyBasedEra era (ProtocolParameters era)
 
      QueryProtocolParametersUpdate
        :: QueryInShelleyBasedEra era
@@ -483,15 +484,17 @@ fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =
+fromConsensusQueryResultShelleyBased shelleyBasedEra' QueryGenesisParameters q' r' =
     case q' of
-      Consensus.GetGenesisConfig -> fromShelleyGenesis
-                                      (Consensus.getCompactGenesis r')
+      Consensus.GetGenesisConfig -> fromRight (error "Handle")
+                                      $ fromShelleyGenesis shelleyBasedEra'
+                                          (Consensus.getCompactGenesis r')
       _                          -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryProtocolParameters q' r' =
+fromConsensusQueryResultShelleyBased shelleyBasedEra' QueryProtocolParameters q' r' =
     case q' of
-      Consensus.GetCurrentPParams -> fromShelleyPParams r'
+      Consensus.GetCurrentPParams -> fromRight (error "Handle")
+                                       $ fromShelleyPParams shelleyBasedEra' r'
       _                           -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased _ QueryProtocolParametersUpdate q' r' =

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -12,7 +11,7 @@ module Cardano.Api.Script (
     SimpleScriptV2,
     ScriptLanguage(..),
     SimpleScriptVersion(..),
-    PlutusScriptVersion,
+    PlutusScriptVersion(..),
     AnyScriptLanguage(..),
     IsScriptLanguage(..),
     IsSimpleScriptLanguage(..),
@@ -193,15 +192,14 @@ instance TestEquality SimpleScriptVersion where
     testEquality _              _              = Nothing
 
 
-data PlutusScriptVersion lang
-  -- For now, there are no such versions, but it'd be like this:
-  -- PlutusScriptV1 :: PlutusScriptVersion PlutusScriptV1
+data PlutusScriptVersion lang where
+    PlutusScriptV1 :: PlutusScriptVersion PlutusScriptV1
 
 deriving instance (Eq   (PlutusScriptVersion lang))
 deriving instance (Show (PlutusScriptVersion lang))
 
 instance TestEquality PlutusScriptVersion where
-    testEquality lang = case lang of {}
+    testEquality PlutusScriptV1 PlutusScriptV1 = Just Refl
 
 
 data AnyScriptLanguage where
@@ -215,6 +213,39 @@ instance Eq AnyScriptLanguage where
         Nothing   -> False
         Just Refl -> True -- since no constructors share types
 
+instance Ord AnyScriptLanguage where
+
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) <= AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) = True
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = False
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = False
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) <= AnyScriptLanguage (PlutusScriptLanguage _) = True
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) <= AnyScriptLanguage (PlutusScriptLanguage _) = True
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = True
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = True
+
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = False
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) <= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = True
+
+
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) >= AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) = False
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = True
+  AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = True
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) >= AnyScriptLanguage (PlutusScriptLanguage _) = False
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) >= AnyScriptLanguage (PlutusScriptLanguage _) = False
+
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = False
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = False
+
+
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1) = True
+  AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) >= AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2) = False
+
+
 instance Enum AnyScriptLanguage where
     toEnum 0 = AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1)
     toEnum 1 = AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2)
@@ -222,7 +253,7 @@ instance Enum AnyScriptLanguage where
 
     fromEnum (AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1)) = 0
     fromEnum (AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2)) = 1
-    fromEnum (AnyScriptLanguage (PlutusScriptLanguage lang)) = case lang of {}
+    fromEnum (AnyScriptLanguage (PlutusScriptLanguage PlutusScriptV1)) = 2
 
 instance Bounded AnyScriptLanguage where
     minBound = AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV1)
@@ -293,6 +324,9 @@ instance IsScriptLanguage lang => SerialiseAsCBOR (Script lang) where
     serialiseToCBOR (SimpleScript SimpleScriptV2 s) =
       CBOR.serialize' (toAllegraTimelock s :: Timelock.Timelock StandardCrypto)
 
+    serialiseToCBOR (PlutusScript PlutusScriptV1 _s) =
+          error "serialiseToCBOR: Plutus script CBOR serialisation not implemented yet."
+
     deserialiseFromCBOR _ bs =
       case scriptLanguage :: ScriptLanguage lang of
         SimpleScriptLanguage SimpleScriptV1 ->
@@ -307,7 +341,9 @@ instance IsScriptLanguage lang => SerialiseAsCBOR (Script lang) where
                                 -> SimpleScript SimpleScriptV2)
           <$> CBOR.decodeAnnotator "Script" fromCBOR (LBS.fromStrict bs)
 
-        PlutusScriptLanguage v -> case v of {}
+        PlutusScriptLanguage PlutusScriptV1 ->
+                  error "deserialiseFromCBOR: Plutus script CBOR \
+                        \decoding not implemented yet."
 
 
 instance IsScriptLanguage lang => HasTextEnvelope (Script lang) where
@@ -315,8 +351,7 @@ instance IsScriptLanguage lang => HasTextEnvelope (Script lang) where
       case scriptLanguage :: ScriptLanguage lang of
         SimpleScriptLanguage SimpleScriptV1 -> "SimpleScriptV1"
         SimpleScriptLanguage SimpleScriptV2 -> "SimpleScriptV2"
-        PlutusScriptLanguage v -> case v of {}
-
+        PlutusScriptLanguage PlutusScriptV1 -> "PlutusScriptV1"
 
 -- ----------------------------------------------------------------------------
 -- Scripts in any language
@@ -353,6 +388,8 @@ instance Eq ScriptInAnyLang where
 toScriptInAnyLang :: Script lang -> ScriptInAnyLang
 toScriptInAnyLang s@(SimpleScript v _) =
     ScriptInAnyLang (SimpleScriptLanguage v) s
+toScriptInAnyLang s@(PlutusScript v _) =
+    ScriptInAnyLang (PlutusScriptLanguage v) s
 
 instance HasTypeProxy ScriptInAnyLang where
     data AsType ScriptInAnyLang = AsScriptInAnyLang
@@ -377,7 +414,8 @@ instance SerialiseAsCBOR ScriptInAnyLang where
        <> CBOR.encodeWord 1
        <> toCBOR (toAllegraTimelock s :: Timelock.Timelock StandardCrypto)
 
-    serialiseToCBOR (ScriptInAnyLang (PlutusScriptLanguage v) _) = case v of {}
+    serialiseToCBOR (ScriptInAnyLang (PlutusScriptLanguage _) _) =
+      error "serialiseToCBOR: PlutusScript CBOR serialisation not implemented yet"
 
     deserialiseFromCBOR AsScriptInAnyLang bs =
         CBOR.decodeAnnotator "Script" decodeScript (LBS.fromStrict bs)
@@ -660,6 +698,8 @@ hashScript (SimpleScript SimpleScriptV2 s) =
                        -> Timelock.Timelock StandardCrypto)
   $ s
 
+hashScript (PlutusScript PlutusScriptV1 _s) =
+  error "hashScript: PlutusScript hash not implemented yet."
 
 toShelleyScriptHash :: ScriptHash -> Shelley.ScriptHash StandardCrypto
 toShelleyScriptHash (ScriptHash h) =  h
@@ -835,6 +875,7 @@ fromAllegraTimelock timelocks = go
 
 instance ToJSON (Script lang) where
   toJSON (SimpleScript _ script) = toJSON script
+  toJSON (PlutusScript _ _) = Aeson.Null
 
 instance ToJSON ScriptInAnyLang where
   toJSON (ScriptInAnyLang _ script) = toJSON script
@@ -871,7 +912,8 @@ instance IsScriptLanguage lang => FromJSON (Script lang) where
     case scriptLanguage :: ScriptLanguage lang of
       SimpleScriptLanguage lang -> SimpleScript lang <$>
                                      parseSimpleScript lang v
-      PlutusScriptLanguage lang -> case lang of {}
+      PlutusScriptLanguage _ ->
+        fail "Plutus scripts are not representable in JSON."
 
 
 instance FromJSON ScriptInAnyLang where

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -169,7 +169,7 @@ import           Cardano.Api.Hash
 import           Cardano.Api.KeysByron
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.ProtocolParametersUpdate
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR

--- a/cardano-api/src/Cardano/Api/TxInMode.hs
+++ b/cardano-api/src/Cardano/Api/TxInMode.hs
@@ -198,6 +198,9 @@ fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrMary err) =
       (ShelleyTxValidationError ShelleyBasedEraMary err)
       MaryEraInCardanoMode
 
+fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrAlonzo _) =
+    error "fromConsensusApplyTxErr: Alonzo era not implemented yet"
+
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrWrongEra err) =
     TxValidationEraMismatch err
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -82,8 +81,8 @@ genLovelace = Lovelace <$> Gen.integral (Range.linear 0 5000)
 genScript :: ScriptLanguage lang -> Gen (Script lang)
 genScript (SimpleScriptLanguage lang) =
     SimpleScript lang <$> genSimpleScript lang
-
-genScript (PlutusScriptLanguage lang) = case lang of {}
+genScript (PlutusScriptLanguage PlutusScriptV1) = Gen.discard
+-- TODO: Unsure how to generate this currently
 
 genSimpleScript :: SimpleScriptVersion lang -> Gen (SimpleScript lang)
 genSimpleScript lang =
@@ -645,24 +644,36 @@ genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce =
   Gen.maybe (makePraosNonce <$> Gen.bytes (Range.linear 0 32))
 
-genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> genRational
-    <*> genMaybePraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRational
-    <*> genRational
-    <*> genRational
+genProtocolParameters :: ShelleyBasedEra era -> Gen (ProtocolParameters era)
+genProtocolParameters sbe =
+  case sbe of
+    ShelleyBasedEraShelley -> genPreAlonzo
+    ShelleyBasedEraAllegra -> genPreAlonzo
+    ShelleyBasedEraMary -> genPreAlonzo
+ where
+   genPreAlonzo =
+    ProtocolParameters
+      <$> ((,) <$> genNat <*> genNat)
+      <*> genRational
+      <*> genMaybePraosNonce
+      <*> genNat
+      <*> genNat
+      <*> genNat
+      <*> genNat
+      <*> genNat
+      <*> (Just <$> genLovelace)
+      <*> genLovelace
+      <*> genLovelace
+      <*> genLovelace
+      <*> genEpochNo
+      <*> genNat
+      <*> genRational
+      <*> genRational
+      <*> genRational
+      <*> return Nothing
+      <*> return Nothing
+      <*> return Nothing
+      <*> return Nothing
+      <*> return Nothing
+      <*> return Nothing
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -670,8 +670,10 @@ genProtocolParameters sbe =
       <*> genRational
       <*> genRational
       <*> genRational
+      -- TODO: When Alonzo is implemented replace
+      -- below with generators.
       <*> return Nothing
-      <*> return Nothing
+      <*> return mempty
       <*> return Nothing
       <*> return Nothing
       <*> return Nothing

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -644,7 +644,7 @@ genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce =
   Gen.maybe (makePraosNonce <$> Gen.bytes (Range.linear 0 32))
 
-genProtocolParameters :: ShelleyBasedEra era -> Gen (ProtocolParameters era)
+genProtocolParameters :: ShelleyBasedEra era -> Gen ProtocolParameters
 genProtocolParameters sbe =
   case sbe of
     ShelleyBasedEraShelley -> genPreAlonzo

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -26,11 +26,17 @@ prop_roundtrip_praos_nonce_JSON = H.property $ do
   pNonce <- forAll $ Gen.just genMaybePraosNonce
   tripping pNonce encode eitherDecode
 
-prop_roundtrip_protocol_parameters_JSON :: Property
-prop_roundtrip_protocol_parameters_JSON = H.property $ do
-  pp <- forAll genProtocolParameters
-  tripping pp encode eitherDecode
+prop_roundtrip_protocol_parameters_JSON_Shelley :: Property
+prop_roundtrip_protocol_parameters_JSON_Shelley =
+  rountrip_JSON_Era genProtocolParameters ShelleyBasedEraShelley
 
+prop_roundtrip_protocol_parameters_JSON_Allegra :: Property
+prop_roundtrip_protocol_parameters_JSON_Allegra =
+  rountrip_JSON_Era genProtocolParameters ShelleyBasedEraAllegra
+
+prop_roundtrip_protocol_parameters_JSON_Mary :: Property
+prop_roundtrip_protocol_parameters_JSON_Mary =
+  rountrip_JSON_Era genProtocolParameters ShelleyBasedEraMary
 
 -- -----------------------------------------------------------------------------
 
@@ -42,7 +48,12 @@ roundtrip_CBOR typeProxy gen =
     val <- H.forAll gen
     H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
 
-
+rountrip_JSON_Era
+  :: (FromJSON a, ToJSON a, Eq a, Show a)
+  => (ShelleyBasedEra era -> Gen a) -> ShelleyBasedEra era -> Property
+rountrip_JSON_Era gen sbe = H.property $ do
+  pp <- H.forAll $ gen sbe
+  tripping pp encode eitherDecode
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -197,7 +197,7 @@ data TransactionCmd
       TxByronWitnessCount
   | TxCalculateMinValue
       ProtocolParamsSourceSpec
-      Value
+      TxBodyFile
   | TxGetTxId InputTxFile
   | TxView InputTxFile
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -561,8 +561,8 @@ pTransaction =
 
   pTransactionCalculateMinValue :: Parser TransactionCmd
   pTransactionCalculateMinValue = TxCalculateMinValue
-    <$> pProtocolParamsSourceSpec
-    <*> pMultiAsset
+    <$> (ParamsFromFile <$> pProtocolParamsFile)
+    <*> pTxBodyFile Input
 
   pProtocolParamsSourceSpec :: Parser ProtocolParamsSourceSpec
   pProtocolParamsSourceSpec =
@@ -1645,15 +1645,6 @@ pTxOut =
                   \Lovelace."
       )
 
-pMultiAsset :: Parser Value
-pMultiAsset =
-  Opt.option
-    (readerFromParsecParser parseValue)
-      (  Opt.long "multi-asset"
-      <> Opt.metavar "VALUE"
-      <> Opt.help "Multi-asset value(s) with the multi-asset cli syntax"
-      )
-
 pMintMultiAsset :: Parser (Value, [ScriptFile])
 pMintMultiAsset =
   (,) <$> Opt.option
@@ -2236,6 +2227,15 @@ pShelleyProtocolParametersUpdate =
     <*> optional pPoolInfluence
     <*> optional pMonetaryExpansion
     <*> optional pTreasuryExpansion
+    -- TODO: Update when Alonzo is incorporated
+    <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
+
+
 
 pMinFeeLinearFactor :: Parser Natural
 pMinFeeLinearFactor =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2229,8 +2229,8 @@ pShelleyProtocolParametersUpdate =
     <*> optional pTreasuryExpansion
     -- TODO: Update when Alonzo is incorporated
     <*> pure Nothing
-    <*> pure Nothing
-    <*> pure Nothing
+    <*> pure mempty
+    <*> pure mempty
     <*> pure Nothing
     <*> pure Nothing
     <*> pure Nothing

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -151,8 +151,9 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
     Nothing -> left $ ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE
  where
   writeProtocolParameters
-    :: Maybe OutputFile
-    -> ProtocolParameters
+    :: IsCardanoEra era
+    => Maybe OutputFile
+    -> ProtocolParameters era
     -> ExceptT ShelleyQueryCmdError IO ()
   writeProtocolParameters mOutFile' pparams =
     case mOutFile' of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -47,6 +47,7 @@ import           Cardano.CLI.Types
 import           Cardano.Binary (decodeFull)
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 
+import           Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Cardano.Ledger.Era as Era
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
@@ -56,14 +57,13 @@ import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
                    (AcquireFailure (..))
 import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
-import           Cardano.Ledger.Coin
 import           Shelley.Spec.Ledger.EpochBoundary
 import           Shelley.Spec.Ledger.Keys (KeyHash (..), KeyRole (..))
 import           Shelley.Spec.Ledger.LedgerState hiding (_delegations)
 import           Shelley.Spec.Ledger.Scripts ()
 
-import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified Data.Text.IO as T
+import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified System.IO as IO
 
 {- HLINT ignore "Reduce duplication" -}
@@ -151,9 +151,8 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
     Nothing -> left $ ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE
  where
   writeProtocolParameters
-    :: IsCardanoEra era
-    => Maybe OutputFile
-    -> ProtocolParameters era
+    :: Maybe OutputFile
+    -> ProtocolParameters
     -> ExceptT ShelleyQueryCmdError IO ()
   writeProtocolParameters mOutFile' pparams =
     case mOutFile' of
@@ -199,7 +198,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
   case mOutFile of
     Just (OutputFile fpath) -> liftIO $ LBS.writeFile fpath output
     Nothing                 -> liftIO $ LBS.putStrLn        output
-    
+
   where
     tuple3Fst :: (a, b, c) -> a
     tuple3Fst (a, _, _) = a

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -18,7 +18,7 @@ import           System.Info (arch, compilerName, compilerVersion, os)
 import           Cardano.Node.Configuration.POM (PartialNodeConfiguration)
 import           Cardano.Node.Handlers.TopLevel
 import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
-                     renderHelpDoc)
+                   renderHelpDoc)
 import           Cardano.Node.Run (runNode)
 
 main :: IO ()

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -103,6 +103,7 @@ library
                       , cardano-config
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
+                      , cardano-ledger-alonzo
                       , cardano-ledger-byron
                       , cardano-ledger-core
                       , cardano-ledger-shelley-ma

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -33,10 +33,10 @@ import qualified Data.Map as Map
 import           Data.Text (pack)
 import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Version (showVersion)
-import qualified System.Remote.Monitoring as EKG
+import           System.Metrics.Counter (Counter)
 import           System.Metrics.Gauge (Gauge)
 import           System.Metrics.Label (Label)
-import           System.Metrics.Counter (Counter)
+import qualified System.Remote.Monitoring as EKG
 
 import           Cardano.BM.Backend.Aggregation (plugin)
 import           Cardano.BM.Backend.EKGView (plugin)
@@ -78,8 +78,8 @@ import qualified Shelley.Spec.Ledger.API as SL
 import           Cardano.Api.Protocol.Types (BlockType (..), protocolInfo)
 import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
-import           Cardano.Node.Types
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import           Cardano.Node.Types
 import           Cardano.Tracing.OrphanInstances.Common ()
 import           Paths_cardano_node (version)
 
@@ -321,11 +321,12 @@ nodeBasicInfo nc (SomeConsensusProtocol whichP pForInfo) nodeStartTime' = do
             let DegenLedgerConfig cfgShelley = Consensus.configLedger cfg
             in getGenesisValues "Shelley" cfgShelley
           CardanoBlockType ->
-            let CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary = Consensus.configLedger cfg
+            let CardanoLedgerConfig cfgByron cfgShelley cfgAllegra cfgMary cfgAlonzo = Consensus.configLedger cfg
             in getGenesisValuesByron cfg cfgByron
                ++ getGenesisValues "Shelley" cfgShelley
                ++ getGenesisValues "Allegra" cfgAllegra
                ++ getGenesisValues "Mary"    cfgMary
+               ++ getGenesisValues "Alonzo"  cfgAlonzo
       items = nub $
         [ ("protocol",      pack . protocolName $ ncProtocol nc)
         , ("version",       pack . showVersion $ version)

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -150,6 +150,7 @@ instance FromJSON PartialNodeConfiguration where
           CardanoProtocol ->
             Last . Just  <$> (NodeProtocolConfigurationCardano <$> parseByronProtocol v
                                                                <*> parseShelleyProtocol v
+                                                               <*> parseAlonzoProtocol v
                                                                <*> parseHardForkProtocol v)
       pure PartialNodeConfiguration {
              pncProtocolConfig = pncProtocolConfig'
@@ -224,6 +225,24 @@ instance FromJSON PartialNodeConfiguration where
         pure NodeShelleyProtocolConfiguration {
                npcShelleyGenesisFile
              , npcShelleyGenesisFileHash
+             }
+
+      parseAlonzoProtocol v = do
+        primary   <- v .:? "AlonzoGenesisFile"
+        secondary <- v .:? "GenesisFile"
+        npcAlonzoGenesisFile <-
+          case (primary, secondary) of
+            (Just g, Nothing)  -> return g
+            (Nothing, Just g)  -> return g
+            (Nothing, Nothing) -> fail $ "Missing required field, either "
+                                      ++ "AlonzoGenesisFile or GenesisFile"
+            (Just _, Just _)   -> fail $ "Specify either AlonzoGenesisFile"
+                                      ++ "or GenesisFile, but not both"
+        npcAlonzoGenesisFileHash <- v .:? "AlonzoGenesisHash"
+
+        pure NodeAlonzoProtocolConfiguration {
+               npcAlonzoGenesisFile
+             , npcAlonzoGenesisFileHash
              }
 
       parseHardForkProtocol v = do

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -255,6 +255,9 @@ instance FromJSON PartialNodeConfiguration where
         npcTestMaryHardForkAtEpoch   <- v .:? "TestMaryHardForkAtEpoch"
         npcTestMaryHardForkAtVersion <- v .:? "TestMaryHardForkAtVersion"
 
+        npcTestAlonzoHardForkAtEpoch   <- v .:? "TestAlonzoHardForkAtEpoch"
+        npcTestAlonzoHardForkAtVersion <- v .:? "TestAlonzoHardForkAtVersion"
+
         pure NodeHardForkProtocolConfiguration {
                npcTestShelleyHardForkAtEpoch,
                npcTestShelleyHardForkAtVersion,
@@ -263,7 +266,10 @@ instance FromJSON PartialNodeConfiguration where
                npcTestAllegraHardForkAtVersion,
 
                npcTestMaryHardForkAtEpoch,
-               npcTestMaryHardForkAtVersion
+               npcTestMaryHardForkAtVersion,
+
+               npcTestAlonzoHardForkAtEpoch,
+               npcTestAlonzoHardForkAtVersion
              }
 
 -- | Default configuration is mainnet

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -39,11 +39,13 @@ mkConsensusProtocol NodeConfiguration{ncProtocolConfig, ncProtocolFiles} =
 
       NodeProtocolConfigurationCardano byronConfig
                                        shelleyConfig
+                                       alonzoConfig
                                        hardForkConfig ->
         firstExceptT CardanoProtocolInstantiationError $
           mkSomeConsensusProtocolCardano
             byronConfig
             shelleyConfig
+            alonzoConfig
             hardForkConfig
             (Just ncProtocolFiles)
 

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -14,7 +14,7 @@ module Cardano.Node.Protocol.Byron
 
 import           Cardano.Prelude
 import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither,
-                     hoistMaybe, left)
+                   hoistMaybe, left)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as Text
 
@@ -26,8 +26,8 @@ import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Byron.Crypto
 
 import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
+import qualified Cardano.Chain.Update as Update
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)
 
 import           Ouroboros.Consensus.Cardano
@@ -35,10 +35,10 @@ import qualified Ouroboros.Consensus.Cardano as Consensus
 
 import           Cardano.Node.Types
 
+import           Cardano.Node.Protocol.Types
 import           Cardano.Tracing.OrphanInstances.Byron ()
 import           Cardano.Tracing.OrphanInstances.HardFork ()
-
-import           Cardano.Node.Protocol.Types
+import           Cardano.Tracing.OrphanInstances.Shelley ()
 
 
 ------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -59,6 +59,7 @@ import           Cardano.Node.Protocol.Types
 mkSomeConsensusProtocolCardano
   :: NodeByronProtocolConfiguration
   -> NodeShelleyProtocolConfiguration
+  -> NodeAlonzoProtocolConfiguration
   -> NodeHardForkProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT CardanoProtocolInstantiationError IO SomeConsensusProtocol
@@ -77,6 +78,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcShelleyGenesisFile,
                              npcShelleyGenesisFileHash
                            }
+                           _AlonzoProtocolConfig
                            NodeHardForkProtocolConfiguration {
                              npcTestShelleyHardForkAtEpoch,
                              npcTestShelleyHardForkAtVersion,

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -140,7 +140,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           shelleyBasedGenesis = shelleyGenesis,
           shelleyBasedInitialNonce =
             Shelley.genesisHashToPraosNonce shelleyGenesisHash,
-          shelleyBasedLeaderCredentials = shelleyLeaderCredentials
+            shelleyBasedLeaderCredentials = shelleyLeaderCredentials
         }
         Consensus.ProtocolParamsShelley {
           -- This is /not/ the Shelley protocol version. It is the protocol
@@ -166,6 +166,15 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           maryProtVer =
             ProtVer 4 0
         }
+        Consensus.ProtocolParamsAlonzo {
+          -- This is /not/ the Alonzo protocol version. It is the protocol
+          -- version that this node will declare that it understands, when it
+          -- is in the Alonzo era. Since Alonzo is currently the last known
+          -- protocol version then this is a        Consensus.ProtocolParamsTransition {
+          alonzoGenesis = error "mkSomeConsensusProtocolCardano: Alonzo not implemented yet",
+          alonzoProtVer = error "mkSomeConsensusProtocolCardano: Alonzo not implemented yet"
+        }
+
         -- ProtocolParamsTransition specifies the parameters needed to transition between two eras
         -- The comments below also apply for the Shelley -> Allegra and Allegra -> Mary hard forks.
         -- Byron to Shelley hard fork parameters
@@ -208,6 +217,9 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                Nothing -> Consensus.TriggerHardForkAtVersion
                             (maybe 4 fromIntegral npcTestMaryHardForkAtVersion)
                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+        }
+        Consensus.ProtocolParamsTransition {
+          transitionTrigger = error "mkSomeConsensusProtocolCardano: Alonzo era not implemented yet"
         }
 
 ------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -54,7 +54,7 @@ import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
 import           Cardano.Node.Types
 import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 import           Cardano.Tracing.Constraints (TraceConstraints)
-import           Cardano.Tracing.Metrics (HasKESMetricsData (..), HasKESInfo (..))
+import           Cardano.Tracing.Metrics (HasKESInfo (..), HasKESMetricsData (..))
 
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)

--- a/cardano-node/src/Cardano/Tracing/Constraints.hs
+++ b/cardano-node/src/Cardano/Tracing/Constraints.hs
@@ -13,16 +13,21 @@ import           Cardano.BM.Tracing (ToObject)
 import           Cardano.Tracing.ConvertTxId (ConvertTxId)
 import           Cardano.Tracing.Queries (LedgerQueries)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge,
-                     ForgeStateUpdateError, Header)
+import           Cardano.Ledger.Alonzo (AlonzoEra)
+import           Cardano.Ledger.Alonzo.PParams (PParamsUpdate)
+import           Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail)
+import           Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
+import           Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
+import           Cardano.Ledger.Alonzo.TxBody (TxOut)
+import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateUpdateError,
+                   Header)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,  HasTxId,
-                     HasTxs (..))
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, HasTxId, HasTxs (..))
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
-
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
 
 -- | Tracing-related constraints for monitoring purposes.
 type TraceConstraints blk =
@@ -31,6 +36,8 @@ type TraceConstraints blk =
     , HasTxId (GenTx blk)
     , LedgerQueries blk
     , ToJSON   (TxId (GenTx blk))
+    , ToJSON   (TxOut (AlonzoEra StandardCrypto))
+    , ToJSON   (PParamsUpdate (AlonzoEra StandardCrypto))
     , ToObject (ApplyTxErr blk)
     , ToObject (GenTx blk)
     , ToObject (Header blk)
@@ -40,6 +47,9 @@ type TraceConstraints blk =
     , ToObject (ValidationErr (BlockProtocol blk))
     , ToObject (CannotForge blk)
     , ToObject (ForgeStateUpdateError blk)
+    , ToObject (UtxoPredicateFailure (AlonzoEra StandardCrypto))
+    , ToObject (AlonzoBbodyPredFail (AlonzoEra StandardCrypto))
+    , ToObject (AlonzoPredFail (AlonzoEra StandardCrypto))
     , Show blk
     , Show (Header blk)
     )

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -12,6 +12,7 @@ module Cardano.Tracing.OrphanInstances.Byron () where
 
 import           Cardano.Prelude
 
+import           Data.Aeson (Value (..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
@@ -22,14 +23,14 @@ import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..),
-                     ByronOtherHeaderEnvelopeError (..), TxId (..), byronHeaderRaw)
+                   ByronOtherHeaderEnvelopeError (..), TxId (..), byronHeaderRaw)
 import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..),
-                     ProtocolUpdate (..), UpdateState (..))
+                   ProtocolUpdate (..), UpdateState (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
-                     ChainValidationError (..), delegationCertificate)
+                   ChainValidationError (..), delegationCertificate)
 import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
 import           Cardano.Chain.Delegation (delegateVK)
 import           Cardano.Crypto.Signing (VerificationKey)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -16,6 +16,7 @@ module Cardano.Tracing.OrphanInstances.Consensus () where
 import           Cardano.Prelude hiding (show)
 import           Prelude (show)
 
+import           Data.Aeson (Value (..))
 import           Data.Text (pack)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -263,6 +264,7 @@ instance ( tx ~ GenTx blk
          , HasTxId tx
          , LedgerSupportsMempool blk
          , LedgerSupportsProtocol blk
+         , LedgerSupportsMempool blk
          , Show (TxId tx)
          , Show (ForgeStateUpdateError blk)
          , Show (CannotForge blk))

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -16,6 +16,7 @@ import           Cardano.Prelude hiding (show)
 import           Prelude (String, show)
 
 import           Control.Monad.Class.MonadTime (DiffTime, Time (..))
+import           Data.Aeson (Value (..))
 import qualified Data.IP as IP
 import           Data.Text (pack)
 

--- a/cardano-node/src/Cardano/Tracing/Queries.hs
+++ b/cardano-node/src/Cardano/Tracing/Queries.hs
@@ -62,8 +62,10 @@ instance LedgerQueries (Cardano.CardanoBlock c) where
     Cardano.LedgerStateShelley ledgerShelley -> ledgerUtxoSize ledgerShelley
     Cardano.LedgerStateAllegra ledgerAllegra -> ledgerUtxoSize ledgerAllegra
     Cardano.LedgerStateMary    ledgerMary    -> ledgerUtxoSize ledgerMary
+    Cardano.LedgerStateAlonzo  ledgerAlonzo  -> ledgerUtxoSize ledgerAlonzo
   ledgerDelegMapSize = \case
     Cardano.LedgerStateByron   ledgerByron   -> ledgerDelegMapSize ledgerByron
     Cardano.LedgerStateShelley ledgerShelley -> ledgerDelegMapSize ledgerShelley
     Cardano.LedgerStateAllegra ledgerAllegra -> ledgerDelegMapSize ledgerAllegra
     Cardano.LedgerStateMary    ledgerMary    -> ledgerDelegMapSize ledgerMary
+    Cardano.LedgerStateAlonzo  ledgerAlonzo  -> ledgerDelegMapSize ledgerAlonzo


### PR DESCRIPTION
Prepare Cardano.Api.ProtocolParameters for Alonzo era.

In the Alonzo era we introduce 6 new protocol parameters and remove 1
protocol parameter. In anticipation of the Alonzo era, we make some
modifications to the ProtocolParameters type.

minUTxOValue becomes a Maybe (This parameter gets deprecated in Alonzo)

We introduce the following but note that they are currently ignored:
- adaPerUTxoByte - Cost in ada per byte of UTxO storage (replaces
minUTxOValue)
- costmdls - The cost models for plutus scripts
- prices - The prices of execution units for plutus scripts
- maxTxExUnits - Max total script execution resource  units allowed per tx
- maxBlockExUnits - Max total script execution resource units allowed per block
- maxValSize - Max size of a Value in a tx output

We introduce an era parameter in the ProtocolParameters type in order to
reduce boilerplate. We have avoided the typical GADT pattern in
cardano-api to prevent an explosion of types.