### PR TITLE
Updated NetworkTopology configuration file format

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -166,8 +166,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 9d16672d2ada9a19106b1d720cf8d56948cfb022
-  --sha256: 08pld6jh1srshr19irlvy1p44j8q7kzwz6jczbavmxcc7k74z5km
+  tag: 163567274612fbb3bc6bec1868498a723540534a
+  --sha256: 0370ala822ww7k7bgpgsq2f5sf4ialrn0n3v56azc2s8xham25cs
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-node-chairman/src/Testnet/Byron.hs
+++ b/cardano-node-chairman/src/Testnet/Byron.hs
@@ -13,6 +13,7 @@ module Testnet.Byron
 
 import           Control.Monad
 import           Data.Aeson (Value, (.=))
+import           Data.Bool (Bool(..))
 import           Data.Eq
 import           Data.Function
 import           Data.Functor
@@ -148,13 +149,22 @@ testnet testnetOptions H.Conf {..} = do
 
     H.lbsWriteFile (tempAbsPath </> "topology-node-" <> si <> ".json") $ J.encode $
       J.object
-      [ ( "Producers"
-        , J.toJSON $ flip fmap [0 .. numBftNodes testnetOptions - 2] $ \j -> J.object
-          [ ("addr", "127.0.0.1")
-          , ("valency", J.toJSON @Int 1)
-          , ("port", J.toJSON (otherPorts L.!! j))
+      [ "LocalRoots" .= J.object
+        [ "groups" .= J.toJSON
+          [ J.object
+            [ "localRoots" .= J.object
+              [ "addrs" .= J.toJSON
+                (flip fmap [0 .. numBftNodes testnetOptions - 2] (\j ->
+                  J.object
+                    [ ("addr", "127.0.0.1")
+                    , ("port",  J.toJSON (otherPorts L.!! j))
+                    ]))
+              , "advertise" .= J.toJSON @Bool False
+              ]
+            , "valency" .= J.toJSON @Int 1
+            ]
           ]
-        )
+        ]
       ]
 
     H.writeFile (tempAbsPath </> "config-" <> si <> ".yaml") . L.unlines . fmap (rewriteConfiguration i) . L.lines =<<

--- a/cardano-node-chairman/src/Testnet/ByronShelley.hs
+++ b/cardano-node-chairman/src/Testnet/ByronShelley.hs
@@ -18,7 +18,7 @@ module Testnet.ByronShelley
   ) where
 
 #ifdef UNIX
-import           Prelude (map)
+import           Prelude (map, Bool(..))
 #endif
 
 import           Control.Monad
@@ -177,15 +177,25 @@ testnet testnetOptions H.Conf {..} = do
     let port = fromJust $ M.lookup node nodeToPort
     H.lbsWriteFile (tempAbsPath </> node </> "topology.json") $ J.encode $
       J.object
-      [ "Producers" .= J.toJSON
-        [ J.object
-          [ "addr" .= J.toJSON @String ifaceAddress
-          , "port" .= J.toJSON @Int peerPort
-          , "valency" .= J.toJSON @Int 1
+      [ "LocalRoots" .= J.object
+        [ "groups" .= J.toJSON
+          [ J.object
+            [ "localRoots" .= J.object
+              [ "addrs" .= J.toJSON
+                [ J.object
+                  [ "addr" .= J.toJSON @String ifaceAddress
+                  , "port" .= J.toJSON @Int peerPort
+                  ]
+                | peerPort <- allPorts \\ [port]
+                ]
+              , "advertise" .= J.toJSON @Bool False
+              ]
+            , "valency" .= J.toJSON @Int 1
+            ]
           ]
-        | peerPort <- allPorts \\ [port]
         ]
       ]
+
     H.writeFile (tempAbsPath </> node </> "port") (show port)
 
   H.lbsWriteFile (tempAbsPath </> "byron.genesis.spec.json") . J.encode $ J.object

--- a/cardano-node-chairman/src/Testnet/Shelley.hs
+++ b/cardano-node-chairman/src/Testnet/Shelley.hs
@@ -17,7 +17,7 @@ module Testnet.Shelley
   ) where
 
 #ifdef UNIX
-import           Prelude (Integer, map)
+import           Prelude (Integer, map, Bool(..))
 #else
 import           Prelude (Integer)
 #endif
@@ -219,15 +219,25 @@ testnet testnetOptions H.Conf {..} = do
     let port = fromJust $ M.lookup node nodeToPort
     H.lbsWriteFile (tempAbsPath </> node </> "topology.json") $ J.encode $
       J.object
-      [ "Producers" .= J.toJSON
-        [ J.object
-          [ "addr" .= J.toJSON @String ifaceAddress
-          , "port" .= J.toJSON @Int peerPort
-          , "valency" .= J.toJSON @Int 1
+      [ "LocalRoots" .= J.object
+        [ "groups" .= J.toJSON
+          [ J.object
+            [ "localRoots" .= J.object
+              [ "addrs" .= J.toJSON
+                [ J.object
+                  [ "addr" .= J.toJSON @String ifaceAddress
+                  , "port" .= J.toJSON @Int peerPort
+                  ]
+                | peerPort <- allPorts \\ [port]
+                ]
+              , "advertise" .= J.toJSON @Bool False
+              ]
+            , "valency" .= J.toJSON @Int 1
+            ]
           ]
-        | peerPort <- allPorts \\ [port]
         ]
       ]
+
     H.writeFile (tempAbsPath </> node </> "port") (show port)
 
   -- Generated node operator keys (cold, hot) and operational certs

--- a/cardano-node-chairman/test/Spec/Chairman/Byron.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Byron.hs
@@ -23,4 +23,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
   conf <- H.mkConf tempAbsPath' Nothing
   allNodes <- H.testnet H.defaultTestnetOptions conf
 
-  chairmanOver 120 52 conf allNodes
+  chairmanOver 240 52 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/ByronShelley.hs
@@ -24,4 +24,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
 
   allNodes <- H.testnet H.defaultTestnetOptions conf
 
-  chairmanOver 120 50 conf allNodes
+  chairmanOver 240 50 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
@@ -24,4 +24,4 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
 
   allNodes <- H.testnet H.defaultTestnetOptions conf
 
-  chairmanOver 120 21 conf allNodes
+  chairmanOver 240 21 conf allNodes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -62,6 +62,7 @@ library
   exposed-modules:     Cardano.Node.Configuration.Logging
                        Cardano.Node.Configuration.POM
                        Cardano.Node.Configuration.Topology
+                       Cardano.Node.Configuration.TopologyP2P
                        Cardano.Node.Handlers.Shutdown
                        Cardano.Node.Handlers.TopLevel
                        Cardano.Node.Orphans

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -72,8 +72,8 @@ data RootAddress = RootAddress
 instance FromJSON RootAddress where
   parseJSON = withObject "RootAddress" $ \o ->
                 RootAddress
-                  <$> o .: "addrs"
-                  <*> o .: "advertise"
+                  <$> o .:  "addrs"
+                  <*> o .:? "advertise" .!= DoNotAdvertisePeer
 
 instance ToJSON RootAddress where
   toJSON ra =

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -144,9 +144,9 @@ data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers]
 
 instance FromJSON NetworkTopology where
   parseJSON = withObject "NetworkTopology" $ \o ->
-                RealNodeTopology <$> o .: "LocalRoots"
-                                 <*> o .: "PublicRoots"
-                                 <*> (o .:? "useLedgerAfterSlot" .!= (UseLedger DontUseLedger))
+                RealNodeTopology <$> (o .:? "LocalRoots"     .!= LocalRootPeersGroups [])
+                                 <*> (o .:? "PublicRoots"    .!= [])
+                                 <*> (o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger)
 
 instance ToJSON NetworkTopology where
   toJSON top =

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Node.Configuration.TopologyP2P
+  ( TopologyError(..)
+  , NetworkTopology(..)
+  , PublicRootPeers(..)
+  , LocalRootPeersGroups(..)
+  , LocalRootPeers(..)
+  , RootAddress(..)
+  , NodeHostIPAddress(..)
+  , NodeHostIPv4Address(..)
+  , NodeHostIPv6Address(..)
+  , NodeSetup(..)
+  , PeerAdvertise(..)
+  , UseLedger(..)
+  , nodeAddressToSockAddr
+  , readTopologyFile
+  , rootAddressToRelayAddress
+  )
+where
+
+import           Cardano.Prelude
+import           Prelude (String)
+
+import qualified Control.Exception as Exception
+import           Data.Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as Text
+
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+
+import           Cardano.Node.Types
+import           Cardano.Node.Configuration.Topology (TopologyError (..), UseLedger (..))
+
+import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..), RelayAddress (..))
+
+data NodeSetup = NodeSetup
+  { nodeId :: !Word64
+  , nodeIPv4Address :: !(Maybe NodeIPv4Address)
+  , nodeIPv6Address :: !(Maybe NodeIPv6Address)
+  , producers :: ![RootAddress]
+  , useLedger :: !UseLedger
+  } deriving (Eq, Show)
+
+instance FromJSON NodeSetup where
+  parseJSON = withObject "NodeSetup" $ \o ->
+                NodeSetup
+                  <$> o .: "nodeId"
+                  <*> o .: "nodeIPv4Address"
+                  <*> o .: "nodeIPv6Address"
+                  <*> o .: "producers"
+                  <*> (o .:? "useLedgerAfterSlot" .!= (UseLedger DontUseLedger))
+
+instance ToJSON NodeSetup where
+  toJSON ns =
+    object
+      [ "nodeId" .= nodeId ns
+      , "nodeIPv4Address" .= nodeIPv4Address ns
+      , "nodeIPv6Address" .= nodeIPv6Address ns
+      , "producers" .= producers ns
+      , "useLedgerAfterSlot" .= useLedger ns
+      ]
+
+data RootAddress = RootAddress
+  { addrs :: [RelayAddress]
+  , advertise :: PeerAdvertise
+  } deriving (Eq, Show)
+
+instance FromJSON RootAddress where
+  parseJSON = withObject "RootAddress" $ \o ->
+                RootAddress
+                  <$> o .: "addrs"
+                  <*> o .: "advertise"
+
+instance ToJSON RootAddress where
+  toJSON ra =
+    object
+      [ "addrs" .= addrs ra
+      , "advertise" .= advertise ra
+      ]
+
+-- | Transforms a 'RootAddress' into a pair of 'RelayAddress' and its
+-- corresponding 'PeerAdvertise' value.
+--
+rootAddressToRelayAddress
+  :: RootAddress
+  -> [(RelayAddress, PeerAdvertise)]
+rootAddressToRelayAddress RootAddress { addrs, advertise } =
+    [ (ra, advertise) | ra <- addrs ]
+
+data LocalRootPeers = LocalRootPeers
+  { localRoots :: RootAddress
+  , valency :: Int
+  } deriving (Eq, Show)
+
+instance FromJSON LocalRootPeers where
+  parseJSON = withObject "LocalRootPeers" $ \o ->
+                LocalRootPeers
+                  <$> o .: "localRoots"
+                  <*> o .: "valency"
+
+instance ToJSON LocalRootPeers where
+  toJSON lrpg =
+    object
+      [ "localRoots" .= localRoots lrpg
+      , "valency" .= valency lrpg
+      ]
+
+newtype LocalRootPeersGroups = LocalRootPeersGroups
+  { groups :: [LocalRootPeers]
+  } deriving (Eq, Show)
+
+instance FromJSON LocalRootPeersGroups where
+  parseJSON = withObject "LocalRootPeersGroups" $ \o ->
+                LocalRootPeersGroups
+                  <$> o .: "groups"
+
+instance ToJSON LocalRootPeersGroups where
+  toJSON lrpg =
+    object
+      [ "groups" .= groups lrpg
+      ]
+
+newtype PublicRootPeers = PublicRootPeers
+  { publicRoots :: RootAddress
+  } deriving (Eq, Show)
+
+instance FromJSON PublicRootPeers where
+  parseJSON = withObject "PublicRootPeers" $ \o ->
+                PublicRootPeers
+                  <$> o .: "publicRoots"
+
+instance ToJSON PublicRootPeers where
+  toJSON prp =
+    object
+      [ "publicRoots" .= publicRoots prp
+      ]
+
+data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers] !UseLedger
+  deriving (Eq, Show)
+
+instance FromJSON NetworkTopology where
+  parseJSON = withObject "NetworkTopology" $ \o ->
+                RealNodeTopology <$> o .: "LocalRoots"
+                                 <*> o .: "PublicRoots"
+                                 <*> (o .:? "useLedgerAfterSlot" .!= (UseLedger DontUseLedger))
+
+instance ToJSON NetworkTopology where
+  toJSON top =
+    case top of
+      RealNodeTopology lrpg prp ul -> object [ "LocalRoots" .= lrpg
+                                            , "PublicRoots" .= prp
+                                            , "useLedgerAfterSlot" .= ul
+                                            ]
+
+-- | Read the `NetworkTopology` configuration from the specified file.
+-- While running a real protocol, this gives your node its own address and
+-- other remote peers it will attempt to connect to.
+readTopologyFile :: NodeConfiguration -> IO (Either Text NetworkTopology)
+readTopologyFile nc = do
+  eBs <- Exception.try $ BS.readFile (unTopology $ ncTopologyFile nc)
+
+  case eBs of
+    Left e -> return . Left $ handler e
+    Right bs -> return . first handlerJSON . eitherDecode $ LBS.fromStrict bs
+
+ where
+  handler :: IOException -> Text
+  handler e = Text.pack $ "Cardano.Node.Configuration.Topology.readTopologyFile: "
+                        ++ displayException e
+  handlerJSON :: String -> Text
+  handlerJSON err = "Is your topology file formatted correctly? \
+                    \The port and valency fields should be numerical. " <> Text.pack err

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -68,11 +68,11 @@ import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DomainAddress, PeerSelectionTargets (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..), RelayAddress (..), DomainAddress (..))
 
 import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                      gatherConfiguredSockets, getSocketOrSocketInfoAddr, renderSocketConfigError)
-import           Cardano.Node.Configuration.Topology
+import           Cardano.Node.Configuration.TopologyP2P
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Protocol (mkConsensusProtocol, renderProtocolInstantiationError)
 import           Cardano.Node.Protocol.Types
@@ -222,9 +222,15 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   eitherTopology <- readTopologyFile nc
   nt <- either (\err -> panic $ "Cardano.Node.Run.handleSimpleNode.readTopologyFile: " <> err) pure eitherTopology
 
-  let dnsLocalRoots :: [(NodeDnsAddress, PeerAdvertise)]
+  let relayAddresses = producerAddresses nt
+      dnsLocalRoots :: [(NodeDnsAddress, PeerAdvertise)]
+      dnsLocalRoots = [ (NodeAddress (NodeHostDnsAddress (decodeUtf8 $ domain))
+                                                         port
+                         , pa)
+                      | (RelayDomain (DomainAddress domain port), pa) <- relayAddresses ]
       ipLocalRoots  :: [(NodeIPAddress,  PeerAdvertise)]
-      (ipLocalRoots, dnsLocalRoots) = producerAddresses nt
+      ipLocalRoots = [ (NodeAddress (NodeHostIPAddress ip) port, pa)
+                     | (RelayAddress ip port, pa) <- relayAddresses ]
 
       diffusionArguments :: DiffusionArguments
       diffusionArguments =
@@ -431,24 +437,18 @@ createDiffusionArguments NodeConfiguration {
     , daTimeWaitTimeout       = ncTimeWaitTimeout
     }
 
-
 producerAddresses
   :: NetworkTopology
-  -> ( [(NodeIPAddress,  PeerAdvertise)]
-     , [(NodeDnsAddress, PeerAdvertise)])
+  -> [(RelayAddress,  PeerAdvertise)]
 producerAddresses nt =
   case nt of
-    RealNodeTopology producers' _ -> partitionEithers $ map remoteAddressToNodeAddress producers'
-    MockNodeTopology nodeSetup ->
-      partitionEithers . map remoteAddressToNodeAddress $ concatMap producers nodeSetup
+    RealNodeTopology lrpg prp _ ->
+      concatMap (rootAddressToRelayAddress . localRoots) (groups lrpg)
+      ++ concatMap rootAddressToRelayAddress (map publicRoots prp)
 
 useLedgerAfterSlot
   :: NetworkTopology
   -> UseLedgerAfter
 useLedgerAfterSlot nt =
   case nt of
-       RealNodeTopology _ (UseLedger ul) -> ul
-       MockNodeTopology (nodeSetup:_)    ->
-           let (UseLedger ul) = useLedger nodeSetup in
-           ul
-       MockNodeTopology [] -> DontUseLedger
+       RealNodeTopology _ _ (UseLedger ul) -> ul

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -36,12 +36,13 @@ import           System.Environment (lookupEnv)
 #ifdef UNIX
 import           System.Posix.Files
 import           System.Posix.Types (FileMode)
+import qualified System.Posix.Signals as Signals
 #else
 import           System.Win32.File
 #endif
 
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
-                     mkLOMeta)
+                     mkLOMeta, LOMeta)
 import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
@@ -230,6 +231,14 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   publicRootsVar <- newTVarIO publicRoots
   useLedgerVar <- newTVarIO (useLedgerAfterSlot nt)
 
+  _ <- Signals.installHandler
+        Signals.sigHUP
+        (updateVars meta localRootsVar publicRootsVar useLedgerVar)
+        Nothing
+  traceNamedObject
+          (appendName "signal-handler" trace)
+          (meta, LogMessage (Text.pack "Installed signal handler"))
+
   let
       diffusionArguments :: DiffusionArguments IO
       diffusionArguments =
@@ -257,6 +266,9 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   traceNamedObject
     (appendName "public-roots" trace)
     (meta, LogMessage . Text.pack . show $ publicRoots)
+  traceNamedObject
+    (appendName "use-ledger-after-slot" trace)
+    (meta, LogMessage . Text.pack . show $ useLedgerAfterSlot nt)
   traceNamedObject
     (appendName "local-socket" trace)
     (meta, LogMessage . Text.pack . show $ localSocketOrPath)
@@ -314,6 +326,37 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   traceNodeBasicInfo tr basicInfoItems =
     forM_ basicInfoItems $ \(LogObject nm mt content) ->
       traceNamedObject (appendName nm tr) (mt, content)
+
+  updateVars :: LOMeta
+             -> StrictTVar IO [(Int, Map RelayAddress PeerAdvertise)]
+             -> StrictTVar IO [RelayAddress]
+             -> StrictTVar IO UseLedgerAfter
+             -> Signals.Handler
+  updateVars meta localRootsVar publicRootsVar useLedgerVar =
+    Signals.Catch $ do
+      traceNamedObject
+          (appendName "signal-handler" trace)
+          (meta, LogMessage (Text.pack "SIGHUP signal received - Performing topology configuration update"))
+
+      eitherTopology <- readTopologyFile nc
+      nt <- either (\err -> panic $ "Cardano.Node.Run.handleSimpleNode.readTopologyFile: " <> err) pure eitherTopology
+
+      let (localRoots, publicRoots) = producerAddresses nt
+
+      atomically $ do
+        writeTVar localRootsVar localRoots
+        writeTVar publicRootsVar publicRoots
+        writeTVar useLedgerVar (useLedgerAfterSlot nt)
+
+      traceNamedObject
+        (appendName "local-roots" trace)
+        (meta, LogMessage . Text.pack . show $ localRoots)
+      traceNamedObject
+        (appendName "public-roots" trace)
+        (meta, LogMessage . Text.pack . show $ publicRoots)
+      traceNamedObject
+        (appendName "use-ledger-after-slot" trace)
+        (meta, LogMessage . Text.pack . show $ useLedgerAfterSlot nt)
 
 --------------------------------------------------------------------------------
 -- Helper functions

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -16,11 +16,13 @@ module Cardano.Node.Run
   , checkVRFFilePermissions
   ) where
 
-import           Cardano.Prelude hiding (ByteString, atomically, take, trace)
+import           Cardano.Prelude hiding (ByteString, atomically, take, trace, STM)
 import           Prelude (String)
+import qualified Data.Map as Map
 
 import qualified Control.Concurrent.Async as Async
 import           Control.Monad.Trans.Except.Extra (left)
+import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Tracer
 import           Data.Text (breakOn, pack, take)
 import qualified Data.Text as Text
@@ -28,7 +30,7 @@ import           Data.Time.Clock (getCurrentTime)
 import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import           Data.Version (showVersion)
 import           Network.HostName (getHostName)
-import           Network.Socket (AddrInfo, SockAddr, Socket)
+import           Network.Socket (AddrInfo, Socket)
 import           System.Directory (canonicalizePath, createDirectoryIfMissing, makeAbsolute)
 import           System.Environment (lookupEnv)
 #ifdef UNIX
@@ -67,8 +69,8 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
-                   DomainAddress, PeerSelectionTargets (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..), RelayAddress (..), DomainAddress (..))
+                   PeerSelectionTargets (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..), RelayAddress (..))
 
 import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                      gatherConfiguredSockets, getSocketOrSocketInfoAddr, renderSocketConfigError)
@@ -222,29 +224,23 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   eitherTopology <- readTopologyFile nc
   nt <- either (\err -> panic $ "Cardano.Node.Run.handleSimpleNode.readTopologyFile: " <> err) pure eitherTopology
 
-  let relayAddresses = producerAddresses nt
-      dnsLocalRoots :: [(NodeDnsAddress, PeerAdvertise)]
-      dnsLocalRoots = [ (NodeAddress (NodeHostDnsAddress (decodeUtf8 domain))
-                                                         port
-                         , pa)
-                      | (RelayDomain (DomainAddress domain port), pa) <- relayAddresses ]
-      ipLocalRoots  :: [(NodeIPAddress,  PeerAdvertise)]
-      ipLocalRoots = [ (NodeAddress (NodeHostIPAddress ip) port, pa)
-                     | (RelayAddress ip port, pa) <- relayAddresses ]
+  let (localRoots, publicRoots) = producerAddresses nt
 
-      diffusionArguments :: DiffusionArguments
+  localRootsVar <- newTVarIO localRoots
+  publicRootsVar <- newTVarIO publicRoots
+  useLedgerVar <- newTVarIO (useLedgerAfterSlot nt)
+
+  let
+      diffusionArguments :: DiffusionArguments IO
       diffusionArguments =
         createDiffusionArguments
           nc
           publicIPv4SocketOrAddr
           publicIPv6SocketOrAddr
           localSocketOrPath
-          ((\(a, b) -> (nodeHostIPAddressToSockAddr a, b))
-            `map` ipLocalRoots)
-          ((\(a,b) -> (nodeDnsAddressToDomainAddress a, b))
-            `map` dnsLocalRoots)
-          []
-          (useLedgerAfterSlot nt)
+          (readTVar localRootsVar)
+          (readTVar publicRootsVar)
+          (readTVar useLedgerVar)
 
   ipv4 <- traverse getSocketOrSocketInfoAddr publicIPv4SocketOrAddr
   ipv6 <- traverse getSocketOrSocketInfoAddr publicIPv6SocketOrAddr
@@ -257,10 +253,10 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
     (meta, LogMessage . Text.pack . show . ncDiffusionMode $ nc)
   traceNamedObject
     (appendName "local-roots" trace)
-    (meta, LogMessage . Text.pack . show $ dnsLocalRoots)
+    (meta, LogMessage . Text.pack . show $ localRoots)
   traceNamedObject
-    (appendName "local-roots" trace)
-    (meta, LogMessage . Text.pack . show $ ipLocalRoots)
+    (appendName "public-roots" trace)
+    (meta, LogMessage . Text.pack . show $ publicRoots)
   traceNamedObject
     (appendName "local-socket" trace)
     (meta, LogMessage . Text.pack . show $ localSocketOrPath)
@@ -378,11 +374,10 @@ createDiffusionArguments
   -> SocketOrSocketInfo Socket SocketPath
   -- ^ Either a SOCKET_UNIX socket provided by systemd or a path for
   -- NodeToClient communication.
-  -> [(SockAddr, PeerAdvertise)]
-  -> [(DomainAddress, PeerAdvertise)]
-  -> [DomainAddress]
-  -> UseLedgerAfter
-  -> DiffusionArguments
+  -> STM m [(Int, Map RelayAddress PeerAdvertise)]
+  -> STM m [RelayAddress]
+  -> STM m UseLedgerAfter
+  -> DiffusionArguments m
 createDiffusionArguments NodeConfiguration {
                            ncTargetNumberOfRootPeers,
                            ncTargetNumberOfKnownPeers,
@@ -395,10 +390,9 @@ createDiffusionArguments NodeConfiguration {
                          publicIPv4SocketsOrAddrs
                          publicIPv6SocketsOrAddrs
                          localSocketOrPath
-                         daStaticLocalRootPeers
-                         daLocalRootPeers
-                         daPublicRootPeers
-                         daUseLedgerAfter
+                         daReadLocalRootPeers
+                         daReadPublicRootPeers
+                         daReadUseLedgerAfter
                          =
   DiffusionArguments
     { daIPv4Address = case publicIPv4SocketsOrAddrs of
@@ -412,10 +406,9 @@ createDiffusionArguments NodeConfiguration {
     , daLocalAddress = case localSocketOrPath of  -- TODO allow expressing the Nothing case in the config
                         ActualSocket socket          -> Just $ Left socket
                         SocketInfo (SocketPath path) -> Just $ Right path
-    , daStaticLocalRootPeers
-    , daLocalRootPeers
-    , daPublicRootPeers
-    , daUseLedgerAfter
+    , daReadLocalRootPeers
+    , daReadPublicRootPeers
+    , daReadUseLedgerAfter
     -- TODO: these limits are arbitrary at the moment;
     -- issue: https://github.com/input-output-hk/ouroboros-network/issues/1836
     , daAcceptedConnectionsLimit = AcceptedConnectionsLimit {
@@ -439,12 +432,16 @@ createDiffusionArguments NodeConfiguration {
 
 producerAddresses
   :: NetworkTopology
-  -> [(RelayAddress,  PeerAdvertise)]
+  -> ([(Int, Map RelayAddress PeerAdvertise)], [RelayAddress])
 producerAddresses nt =
   case nt of
     RealNodeTopology lrpg prp _ ->
-      concatMap (rootAddressToRelayAddress . localRoots) (groups lrpg)
-      ++ concatMap rootAddressToRelayAddress (map publicRoots prp)
+      ( map (\lrp -> (valency lrp
+                           , Map.fromList $ rootAddressToRelayAddress
+                                          $ localRoots lrp))
+                  (groups lrpg)
+      , concatMap (map fst . rootAddressToRelayAddress)
+                  (map publicRoots prp))
 
 useLedgerAfterSlot
   :: NetworkTopology

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -224,7 +224,7 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
 
   let relayAddresses = producerAddresses nt
       dnsLocalRoots :: [(NodeDnsAddress, PeerAdvertise)]
-      dnsLocalRoots = [ (NodeAddress (NodeHostDnsAddress (decodeUtf8 $ domain))
+      dnsLocalRoots = [ (NodeAddress (NodeHostDnsAddress (decodeUtf8 domain))
                                                          port
                          , pa)
                       | (RelayDomain (DomainAddress domain port), pa) <- relayAddresses ]
@@ -449,6 +449,4 @@ producerAddresses nt =
 useLedgerAfterSlot
   :: NetworkTopology
   -> UseLedgerAfter
-useLedgerAfterSlot nt =
-  case nt of
-       RealNodeTopology _ _ (UseLedger ul) -> ul
+useLedgerAfterSlot (RealNodeTopology _ _ (UseLedger ul)) = ul

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -436,12 +436,15 @@ producerAddresses
 producerAddresses nt =
   case nt of
     RealNodeTopology lrpg prp _ ->
-      ( map (\lrp -> (valency lrp
-                           , Map.fromList $ rootAddressToRelayAddress
-                                          $ localRoots lrp))
-                  (groups lrpg)
-      , concatMap (map fst . rootAddressToRelayAddress)
-                  (map publicRoots prp))
+       ( map (\lrp -> ( valency lrp
+                     , Map.fromList $ rootAddressToRelayAddress
+                                    $ localRoots lrp
+                     )
+             )
+             (groups lrpg)
+       , concatMap (map fst . rootAddressToRelayAddress)
+                   (map publicRoots prp)
+       )
 
 useLedgerAfterSlot
   :: NetworkTopology

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -32,6 +32,7 @@ import qualified Network.Socket as Socket (SockAddr)
 import           Cardano.Tracing.ConvertTxId (ConvertTxId)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.Render
+import           Cardano.Node.Configuration.Topology (UseLedger (..))
 
 import           Ouroboros.Consensus.Block (ConvertRawHash (..), getHeader)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, HasTxs (..), txId)
@@ -181,6 +182,7 @@ instance HasSeverityAnnotation TraceLedgerPeers where
       PickedPeers {}                 -> Info
       FetchingNewLedgerState {}      -> Info
       DisabledLedgerPeers {}         -> Info
+      TraceUseLedgerAfter {}         -> Info
       WaitingOnRequest {}            -> Debug
       RequestForPeers {}             -> Debug
       ReusingLedgerState {}          -> Debug
@@ -1098,6 +1100,11 @@ instance ToObject TraceLedgerPeers where
   toObject _verb DisabledLedgerPeers =
     mkObject
       [ "kind" .= String "DisabledLedgerPeers"
+      ]
+  toObject _verb (TraceUseLedgerAfter ula) =
+    mkObject
+      [ "kind" .= String "TraceUseLedgerAfter"
+      , "useLedgerAfter" .= UseLedger ula
       ]
   toObject _verb WaitingOnRequest =
     mkObject

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -373,6 +373,7 @@ instance HasSeverityAnnotation (TracePeerSelection addr) where
       TracePromoteWarmFailed     {} -> Error
       TracePromoteWarmDone       {} -> Info
       TraceDemoteWarmPeers       {} -> Info
+      TracePromoteWarmLocalPeers {} -> Info
       TraceDemoteWarmFailed      {} -> Error
       TraceDemoteWarmDone        {} -> Info
       TraceDemoteHotPeers        {} -> Info

--- a/configuration/cardano/mainnet-topology.json
+++ b/configuration/cardano/mainnet-topology.json
@@ -1,9 +1,18 @@
 {
-  "Producers": [
-    {
-      "addr": "relays-new.cardano-mainnet.iohk.io",
-      "port": 3001,
-      "valency": 2
-    }
-  ]
+  "LocalRoots": {
+    "groups": [
+      {
+        "localRoots": {
+          "addrs": [
+            {
+              "addr": "relays-new.cardano-mainnet.iohk.io",
+              "port": 3001
+            }
+          ],
+          "advertise": false
+        },
+        "valency": 1
+      }
+    ]
+  }
 }

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -54,7 +54,7 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
 
 * `valency` tells the node how many connections your node should try to pick from the given group. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection.
 
-Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network. Go to our telegram channel to find out IP addresses and ports of peers.
+Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network.
 
 #### The genesis.json file
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -6,21 +6,55 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
 
 ```json
 {
-  "Producers": [
+  "LocalRoots": {
+    "groups": [
+      {
+        "localRoots": {
+          "addrs": [
+            {
+              "addr": "x.x.x.x",
+              "port": 3001
+            }
+          ],
+          "advertise": false
+        },
+        "valency": 1
+      }
+    ]
+  },
+  "PublicRoots": [
     {
-      "addr": "x.x.x.x",
-      "port": 3001,
-      "valency": 1
+      "publicRoots" : {
+        "addrs": [
+          {
+            "addr": "y.y.y.y",
+            "port": 3002
+          }
+        ],
+        "advertise": false
+      }
     }
-  ]
+  ],
+  "useLedgerAfterSlot": 0
 }
 ```
-* This means that your node will contact node at ip `x.x.x.x` on `port 3001`.
 
-* `valency` tells the node how many connections your node should have. It only has an effect for dns addresses. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection; for ip addresses, valency is used as a Boolean value, where `0` means to ignore the address.
+* The main difference between `LocalRoots` and `PublicRoots` is that with the former
+    you can specify different groups with different valencies. That can be useful to
+    inform your node of different targets withing a group to achieve. `LocalRoots`
+    is for peers which the node always should have as hot, such as their own block producer.
+    `PublicRoots` represent a source of fallback peers, a source of peers to be used if peers
+    from the ledger (`useLedgerAfterSlot`) is disabled or unavailable.
+
+* This means that your node will contact node at ip `x.x.x.x` on `port 3001`, and resolve
+    dns domain `y.y.y.y` (assuming they are), and try to maintain a connection with at least `1` of the
+    resolved ips.
+
+* `isDomain` tells if a given address is a dns address or not. If true and object `domain: { domain, port }` should be specified instead.
+
+* `valency` tells the node how many connections your node should try to pick from the given group. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection.
 
 Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network. Go to our telegram channel to find out IP addresses and ports of peers.
-
 
 #### The genesis.json file
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -50,11 +50,13 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
     dns domain `y.y.y.y` (assuming they are), and try to maintain a connection with at least `1` of the
     resolved ips.
 
-* `isDomain` tells if a given address is a dns address or not. If true and object `domain: { domain, port }` should be specified instead.
-
 * `valency` tells the node how many connections your node should try to pick from the given group. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection.
 
 Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network.
+
+You __can__ tell the node that the topology configuration file changed by sending a SIGHUP
+signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
+signal, `cardano-node` will re-read the file and restart all dns resolution.
 
 #### The genesis.json file
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -56,7 +56,8 @@ Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and th
 
 You __can__ tell the node that the topology configuration file changed by sending a SIGHUP
 signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
-signal, `cardano-node` will re-read the file and restart all dns resolution.
+signal, `cardano-node` will re-read the file and restart all dns resolution. Please
+**note** that this only applies to the topology configuration file!
 
 #### The genesis.json file
 


### PR DESCRIPTION
new file format follows the following structure:

```haskell
data RootAddress = RootAddress
  { addrs :: [RelayAddress]
  , advertise :: PeerAdvertise
  } deriving (Eq, Show)

data LocalRootPeers = LocalRootPeers
  { localRoots :: RootAddress
  , valency :: Int
  } deriving (Eq, Show)

newtype LocalRootPeersGroups = LocalRootPeersGroups
  { groups :: [LocalRootPeers]
  } deriving (Eq, Show)

newtype PublicRootPeers = PublicRootPeers
  { publicRoots :: RootAddress
  } deriving (Eq, Show)

data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers] !UseLedger
  deriving (Eq, Show)
```