### PR TITLE
Modify byron-to-mary/mkfiles.sh to allow starting nodes in specific era

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 The `scripts` directory consists of the following directories:
 - [benchmarking](#benchmarking)
 - [buildkite](#buildkite)
-- [byron-shelley](#byron-shelley)
+- [byron-shelley-allegra-mary](#byron-shelley-allegra-mary)
 - [lite](#lite)
 - [shelley-from-scratch](#shelley-from-scratch)
 
@@ -12,11 +12,16 @@ Contains all the scripts relevant to benchmarking `cardano-node`. See the benchm
 #### buildkite
 Contains scripts relevant to IOHK's CI.
 
-#### byron-shelley
-Contains a script that sets up a cluster beginning in the Byron era and can transition to the Shelley era.
-
+#### byron-shelley-allegra-mary
+Contains a script that sets up a cluster beginning in the Byron era and can transition to the Shelley era. You can also start a cluster in the Shelley, Allegra or Mary era by supplying an argument to `mk-files.sh`.
+E.g
+```bash
+./scripts/byron-to-mary/mk-files.sh shelley # Starts nodes in Shelley era
+./scripts/byron-to-mary/mk-files.sh allegra # Starts nodes in Allegra era
+./scripts/byron-to-mary/mk-files.sh mary    # Starts nodes in Mary era
+```
 #### lite
-Contains scripts that can start various clusters and intended to be as simple as possible.
+Contains scripts that can start various clusters and intended to be as simple as possible. Note that using the shelley only era testnet clusters breaks compatibility with some cli commands.
 
 #### shelley-from-scratch
 Contains a script that creates all the necessary keys etc to create a shelley cluster from scratch.

--- a/scripts/byron-to-mary/mkfiles.sh
+++ b/scripts/byron-to-mary/mkfiles.sh
@@ -32,8 +32,9 @@ set -e
 #    below. It's good for a quick test, and does not rely on posting update
 #    proposals to the chain.
 #    This is quite convenient, but it does not test that we can do the
-#    transition by posting update proposals to the network.
-#
+#    transition by posting update proposals to the network. For even more convenience
+#    if you want to start a node in Shelley, Allegra or Mary from epoch 0, supply the script
+#    with a shelley, allegra or mary string argument. E.g mkfiles.sh mary.
 
 ROOT=example
 
@@ -540,3 +541,31 @@ echo "  --cardano-mode --allegra-era --testnet-magic 42"
 echo
 echo "Similarly, use --mary-era in the Mary era."
 popd
+
+# For an automatic transition at epoch 0, specifying mary, allegra or shelley
+# will start the node in the appropriate era.
+echo ""
+if [ "$1" = "mary" ]; then
+  echo "TestShelleyHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  echo "TestAllegraHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  echo "TestMaryHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  sed -i ${ROOT}/configuration.yaml \
+      -e 's/LastKnownBlockVersion-Major: 1/LastKnownBlockVersion-Major: 4/'
+  echo "Nodes will start in Mary era from epoch 0"
+
+elif [ "$1" = "allegra" ]; then
+  echo "TestShelleyHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  echo "TestAllegraHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  sed -i ${ROOT}/configuration.yaml \
+      -e 's/LastKnownBlockVersion-Major: 1/LastKnownBlockVersion-Major: 3/'
+  echo "Nodes will start in Allegra era from epoch 0"
+
+elif [ "$1" = "shelley" ]; then
+  echo "TestShelleyHardForkAtEpoch: 0"  >> ${ROOT}/configuration.yaml
+  sed -i ${ROOT}/configuration.yaml \
+      -e 's/LastKnownBlockVersion-Major: 1/LastKnownBlockVersion-Major: 2/'
+  echo "Nodes will start in Shelley era from epoch 0"
+
+else
+  echo "Default yaml configuration applied."
+fi


### PR DESCRIPTION
You can also start a cluster in the Shelley, Allegra or Mary era by supplying an argument to `mk-files.sh`.

```bash
./scripts/byron-to-mary/mk-files.sh shelley # Start nodes in Shelley era
./scripts/byron-to-mary/mk-files.sh allegra # Start nodes in Allegra era
./scripts/byron-to-mary/mk-files.sh mary    # Start nodes in Mary era
```