### PR TITLE
CAD-2839 Workbench fixes

### DIFF
--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -190,6 +190,8 @@ let
 
     ln -s ${profile.topology.files} "${stateDir}"/topology
 
+    prebuild-executables
+
     genesis_args+=(
         ## Positionals:
         ${profile.JSON}

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -1,15 +1,21 @@
+let
+  basePortDefault    = 30000;
+  cacheDirDefault    = "${__getEnv "HOME"}/.cache";
+  stateDirDefault    = "state-cluster";
+  profileNameDefault = "default-mary";
+in
 { pkgs
 , lib
 , bech32
-, basePort ? 30000
-, stateDir ? "state-cluster"
-, cacheDir ? "${__getEnv "HOME"}/.cache"
+, basePort              ? basePortDefault
+, stateDir              ? stateDirDefault
+, cacheDir              ? cacheDirDefault
 , extraSupervisorConfig ? {}
-, useCabalRun ? false
-, workbenchDevMode ? false
-, enableEKG ? true
+, useCabalRun           ? false
+, workbenchDevMode      ? false
+, enableEKG             ? true
 ##
-, profileName ? "default-mary"
+, profileName           ? profileNameDefault
 , ...
 }:
 with lib;
@@ -170,13 +176,17 @@ let
 
     wb profile describe ${profileName}
 
-    if test -e "${stateDir}" && test ! -f "${stateDir}"/genesis/byron-protocol-params.json
-    then echo "workbench ERROR:  state directory exists, but looks suspicious -- refusing to remove it: '${stateDir}'" >&2
-         exit 1
-    fi
+    ${optionalString (stateDir != stateDirDefault)
+      ''
+      if test -e "${stateDir}" && test ! -f "${stateDir}"/supervisor/workbench-token
+      then echo "workbench ERROR:  state directory exists, but looks suspicious -- decide on removing it manually to continue:  rm -rf ${stateDir}" >&2
+           exit 1
+      fi
+      ''}
 
     rm -rf   "${stateDir}"
     mkdir -p "${stateDir}"/supervisor "${cacheDir}"
+    touch    "${stateDir}"/supervisor/workbench-token
 
     ln -s ${profile.topology.files} "${stateDir}"/topology
 

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -15,22 +15,31 @@ case "${op}" in
         ;;
 
     mkname )
-        local batch=$1
-        local profjson=$2
-        echo "$(date +'%Y'-'%m'-'%d'-'%H.%M').$batch.$prof"
+        local usage="USAGE: wb run mkname BATCH-NAME PROFILE-NAME"
+        local batch=${1:?$usage}
+        local prof=${2:?$usage}
+        echo -n "$(date +'%Y'-'%m'-'%d'-'%H.%M').$batch.$prof"
         ;;
 
     create )
+        local usage="USAGE: wb run create ??? BATCH-NAME PROFILE-NAME"
         ## Assumptions:
         ##   - genesis has been created
         ##   - the cluster is operating
-        local name=$1
-        local batch=$2
-        local prof=$3
+        local name=${1:?$usage}
+        local batch=${2:?$usage}
+        local prof=${3:?$usage}
 
         local dir=$runsdir/$name
         if test "$(realpath "$dir")" = test "$(realpath "$global_runsdir")" -o "$name" = '.'
         then fatal "bad, bad tag '$name'"; fi
+        ;;
+
+    ### Undocumented
+    describe | d )
+        cat <<EOF
+global_runsdir=$global_runsdir
+EOF
         ;;
 
     * ) usage_run;; esac

--- a/shell.nix
+++ b/shell.nix
@@ -80,12 +80,8 @@ let
     exactDeps = true;
 
     shellHook = ''
-      set -euo pipefail
-
       echo "workbench:  setting 'cabal.project' for local builds.."
       ./scripts/cabal-inside-nix-shell.sh
-
-      ${pkgs.workbench.shellHook}
 
       function atexit() {
           echo "workbench:  reverting 'cabal.project' to the index version.."
@@ -98,6 +94,8 @@ let
           fi''}
       }
       trap atexit EXIT
+
+      ${pkgs.workbench.shellHook}
 
       ${lib.optionalString autoStartCluster ''
       echo "workbench:  starting cluster (because 'autoStartCluster' is true):"

--- a/shell.nix
+++ b/shell.nix
@@ -95,6 +95,10 @@ let
       }
       trap atexit EXIT
 
+      ${lib.optionalString (autoStartCluster && useCabalRun) ''
+      unset NIX_ENFORCE_PURITY
+      ''}
+
       ${pkgs.workbench.shellHook}
 
       ${lib.optionalString autoStartCluster ''


### PR DESCRIPTION
- prebuild executables explicitly
- work around a Nix linker purity issue due to `NIX_ENFORCE_PURITY` in `shellHook`
- automatically deal with `state-cluster` being partially built, while it's safely default