### PR TITLE
Added hot configuration update via unix signal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -166,8 +166,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 880bdcc62ae3d1af560be07b247b380425e2a54e
-  --sha256: 08pld6jh1srshr19irlvy1p44j8q7kzwz6jczbavmxcc7k74z5km
+  tag: 163567274612fbb3bc6bec1868498a723540534a
+  --sha256: 0370ala822ww7k7bgpgsq2f5sf4ialrn0n3v56azc2s8xham25cs
   subdir:
     io-sim
     io-sim-classes

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -144,9 +144,9 @@ data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers]
 
 instance FromJSON NetworkTopology where
   parseJSON = withObject "NetworkTopology" $ \o ->
-                RealNodeTopology <$> o .: "LocalRoots"
-                                 <*> o .: "PublicRoots"
-                                 <*> (o .:? "useLedgerAfterSlot" .!= (UseLedger DontUseLedger))
+                RealNodeTopology <$> (o .:? "LocalRoots"     .!= LocalRootPeersGroups [])
+                                 <*> (o .:? "PublicRoots"    .!= [])
+                                 <*> (o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger)
 
 instance ToJSON NetworkTopology where
   toJSON top =

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -36,12 +36,13 @@ import           System.Environment (lookupEnv)
 #ifdef UNIX
 import           System.Posix.Files
 import           System.Posix.Types (FileMode)
+import qualified System.Posix.Signals as Signals
 #else
 import           System.Win32.File
 #endif
 
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
-                     mkLOMeta)
+                     mkLOMeta, LOMeta)
 import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
 import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
@@ -230,6 +231,14 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   publicRootsVar <- newTVarIO publicRoots
   useLedgerVar <- newTVarIO (useLedgerAfterSlot nt)
 
+  _ <- Signals.installHandler
+        Signals.sigHUP
+        (updateVars meta localRootsVar publicRootsVar useLedgerVar)
+        Nothing
+  traceNamedObject
+          (appendName "signal-handler" trace)
+          (meta, LogMessage (Text.pack "Installed signal handler"))
+
   let
       diffusionArguments :: DiffusionArguments IO
       diffusionArguments =
@@ -257,6 +266,9 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   traceNamedObject
     (appendName "public-roots" trace)
     (meta, LogMessage . Text.pack . show $ publicRoots)
+  traceNamedObject
+    (appendName "use-ledger-after-slot" trace)
+    (meta, LogMessage . Text.pack . show $ useLedgerAfterSlot nt)
   traceNamedObject
     (appendName "local-socket" trace)
     (meta, LogMessage . Text.pack . show $ localSocketOrPath)
@@ -314,6 +326,37 @@ handleSimpleNode p trace nodeTracers nc onKernel = do
   traceNodeBasicInfo tr basicInfoItems =
     forM_ basicInfoItems $ \(LogObject nm mt content) ->
       traceNamedObject (appendName nm tr) (mt, content)
+
+  updateVars :: LOMeta
+             -> StrictTVar IO [(Int, Map RelayAddress PeerAdvertise)]
+             -> StrictTVar IO [RelayAddress]
+             -> StrictTVar IO UseLedgerAfter
+             -> Signals.Handler
+  updateVars meta localRootsVar publicRootsVar useLedgerVar =
+    Signals.Catch $ do
+      traceNamedObject
+          (appendName "signal-handler" trace)
+          (meta, LogMessage (Text.pack "SIGHUP signal received - Performing topology configuration update"))
+
+      eitherTopology <- readTopologyFile nc
+      nt <- either (\err -> panic $ "Cardano.Node.Run.handleSimpleNode.readTopologyFile: " <> err) pure eitherTopology
+
+      let (localRoots, publicRoots) = producerAddresses nt
+
+      atomically $ do
+        writeTVar localRootsVar localRoots
+        writeTVar publicRootsVar publicRoots
+        writeTVar useLedgerVar (useLedgerAfterSlot nt)
+
+      traceNamedObject
+        (appendName "local-roots" trace)
+        (meta, LogMessage . Text.pack . show $ localRoots)
+      traceNamedObject
+        (appendName "public-roots" trace)
+        (meta, LogMessage . Text.pack . show $ publicRoots)
+      traceNamedObject
+        (appendName "use-ledger-after-slot" trace)
+        (meta, LogMessage . Text.pack . show $ useLedgerAfterSlot nt)
 
 --------------------------------------------------------------------------------
 -- Helper functions

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -50,11 +50,13 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
     dns domain `y.y.y.y` (assuming they are), and try to maintain a connection with at least `1` of the
     resolved ips.
 
-* `isDomain` tells if a given address is a dns address or not. If true and object `domain: { domain, port }` should be specified instead.
-
 * `valency` tells the node how many connections your node should try to pick from the given group. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection.
 
 Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network.
+
+You __can__ tell the node that the topology configuration file changed by sending a SIGHUP
+signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
+signal, `cardano-node` will re-read the file and restart all dns resolution.
 
 #### The genesis.json file
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -56,7 +56,8 @@ Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and th
 
 You __can__ tell the node that the topology configuration file changed by sending a SIGHUP
 signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
-signal, `cardano-node` will re-read the file and restart all dns resolution.
+signal, `cardano-node` will re-read the file and restart all dns resolution. Please
+**note** that this only applies to the topology configuration file!
 
 #### The genesis.json file
 


### PR DESCRIPTION
Example tracing log:

```
[bolt-nix:cardano.node.signal-handler:Notice:7] [2021-04-23 12:45:53.56 UTC] SIGHUP signal received - Performing topology configuration update
[bolt-nix:cardano.node.local-roots:Notice:7] [2021-04-23 12:45:53.56 UTC] [(1,fromList [(RelayDomain (DomainAddress {daDomain = "relays-new.cardano-mainnet.iohk.io", daPortNumber = 3001}),DoNotAdvertisePeer)])]
[bolt-nix:cardano.node.public-roots:Notice:7] [2021-04-23 12:45:53.56 UTC] [RelayAddress 35.72.162.10 7776]
[bolt-nix:cardano.node.use-ledger-after-slot:Notice:7] [2021-04-23 12:45:53.56 UTC] DontUseLedger
```

Still need to check if everything is working as intended over at `ouroboros-network`