### PR TITLE
CAD-2839 workbench:  fix executable prebuild in non-Cabal mode

### DIFF
--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -190,7 +190,7 @@ let
 
     ln -s ${profile.topology.files} "${stateDir}"/topology
 
-    prebuild-executables
+    workbench-prebuild-executables
 
     genesis_args+=(
         ## Positionals:

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -111,18 +111,23 @@ let
       ${exeCabalOp "run" "cardano-topology"} "$@"
     }
 
-    function prebuild-executables() {
+    export -f cardano-cli cardano-node cardano-topology
+
+    ''}
+
+    function workbench-prebuild-executables() {
+      ${optionalString useCabalRun
+        ''
       echo -n "workbench:  prebuilding executables:"
       for exe in cardano-cli cardano-node cardano-topology
       do echo -n " $exe"
          $exe --help >/dev/null || true
       done
+        ''}
       echo
     }
+    export -f workbench-prebuild-executables
 
-    export -f cardano-cli cardano-node cardano-topology prebuild-executables
-
-    ''}
     '';
 
   generateProfiles =


### PR DESCRIPTION
This fixes a small but annoying bug in the non-Cabal mode of `start-cluster` inside `nix-shell`.