### PR TITLE
riscv64 fix ld bug #2500, riscv64 GHC RTS not ready yet for -Nx

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -157,7 +157,11 @@ executable cardano-node
 
   if arch(arm)
     ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
-  else
+
+  if arch(riscv64)
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m --disable-delayed-os-memory-return"
+
+  if !arch(arm) && !arch(riscv64)
     ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -161,7 +161,7 @@ executable cardano-node
   if arch(riscv64)
     ghc-options:        "-with-rtsopts=-T -I0 -A16m --disable-delayed-os-memory-return"
 
-  if !arch(arm) && !arch(riscv64)
+  if arch(x86_64)
     ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node


### PR DESCRIPTION
RISCV64 Debian experimental GHC 8.10.2-1~exp3 seems not ready for some RTS options like -Nx 
Fix https://github.com/input-output-hk/cardano-node/issues/2500 issue

Now riscv64 1.26.2 can be used
```
root@2e9532ec0f86:/cardano# cardano-node --version
cardano-node 1.26.2 - linux-riscv64 - ghc-8.10
git rev 3531289c9f79eab7ac5d3272ce6e6821504fec4c
root@2e9532ec0f86:/cardano# cardano-cli --version
cardano-cli 1.26.2 - linux-riscv64 - ghc-8.10
git rev 3531289c9f79eab7ac5d3272ce6e6821504fec4c
```