### PR TITLE
Extend Cardano.Api.ProtocolParameters with Alonzo params

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -123,6 +123,7 @@ library
                       , ouroboros-consensus-shelley
                       , ouroboros-network
                       , ouroboros-network-framework
+                      , plutus-ledger-api
                       , scientific
                       , shelley-spec-ledger
                       , small-steps

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -14,6 +14,7 @@ module Cardano.Api.Script (
     SimpleScriptVersion(..),
     PlutusScriptVersion(..),
     AnyScriptLanguage(..),
+    AnyPlutusScriptVersion(..),
     IsScriptLanguage(..),
     IsSimpleScriptLanguage(..),
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -662,4 +662,11 @@ genProtocolParameters =
     <*> genRational
     <*> genRational
     <*> genRational
+    -- TODO: Add proper support for these generators.
+    <*> return Nothing
+    <*> return mempty
+    <*> return mempty
+    <*> return Nothing
+    <*> return Nothing
+    <*> return Nothing
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2236,6 +2236,13 @@ pShelleyProtocolParametersUpdate =
     <*> optional pPoolInfluence
     <*> optional pMonetaryExpansion
     <*> optional pTreasuryExpansion
+    -- TODO: Add proper support for these params
+    <*> pure Nothing
+    <*> pure mempty
+    <*> pure mempty
+    <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
 
 pMinFeeLinearFactor :: Parser Natural
 pMinFeeLinearFactor =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Script.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Script.hs
@@ -30,7 +30,7 @@ instance Error ScriptDecodeError where
   displayError (ScriptDecodeTextEnvelopeError err) =
     "Error decoding script: " ++ displayError err
   displayError (ScriptDecodeSimpleScriptError err) =
-    "Syncax error in script: " ++ displayError err
+    "Syntax error in script: " ++ displayError err
 
 
 -- | Read a script file. The file can either be in the text envelope format


### PR DESCRIPTION
* Add PlutusScriptV1 constructor in the existing `PlutusScriptVersion` type which previously had no constructors at all.
* Add API types for execution units, prices and cost models
* Extend the ProtocolParameters with Alonzo era ones, both `ProtocolParameters` and `ProtocolParametersUpdate`.

