### PR TITLE
CAD-2907 Tracing: more details

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -712,13 +712,18 @@ instance ToObject SlotNo where
              , "slot" .= toJSON (unSlotNo slot) ]
 
 
-instance ToObject (TraceFetchClientState header) where
+instance ConvertRawHash header => ToObject (TraceFetchClientState header) where
   toObject _verb BlockFetch.AddedFetchRequest {} =
     mkObject [ "kind" .= String "AddedFetchRequest" ]
   toObject _verb BlockFetch.AcknowledgedFetchRequest {} =
     mkObject [ "kind" .= String "AcknowledgedFetchRequest" ]
-  toObject _verb BlockFetch.CompletedBlockFetch {} =
-    mkObject [ "kind" .= String "CompletedBlockFetch" ]
+  toObject _verb (BlockFetch.CompletedBlockFetch pt _ _ _ _) =
+    mkObject [ "kind"  .= String "CompletedBlockFetch"
+             , "block" .= String
+               (case pt of
+                  GenesisPoint -> "Genesis"
+                  BlockPoint _ h -> renderHeaderHash (Proxy @header) h)
+             ]
   toObject _verb BlockFetch.CompletedFetchBatch {} =
     mkObject [ "kind" .= String "CompletedFetchBatch" ]
   toObject _verb BlockFetch.StartedFetchBatch {} =

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -537,7 +537,10 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
 
   pure Consensus.Tracers
     { Consensus.chainSyncClientTracer = tracerOnOff (traceChainSyncClient trSel) verb "ChainSyncClient" tr
-    , Consensus.chainSyncServerHeaderTracer = Tracer $ \ev -> traceServedCount mbEKGDirect ev
+    , Consensus.chainSyncServerHeaderTracer =
+      Tracer $ \ev -> do
+        traceWith (annotateSeverity . toLogObject' verb $ appendName "ChainSyncHeaderServer" tr) ev
+        traceServedCount mbEKGDirect ev
     , Consensus.chainSyncServerBlockTracer = tracerOnOff (traceChainSyncBlockServer trSel) verb "ChainSyncBlockServer" tr
     , Consensus.blockFetchDecisionTracer = tracerOnOff' (traceBlockFetchDecisions trSel) $
         annotateSeverity $ teeTraceBlockFetchDecision verb elidedFetchDecision tr


### PR DESCRIPTION
This adds more details to some of the traces:

1. `TraceBlockFetchServerSendBlock` is now a specific message (instead of the non-descript `TraceBlockFetchServerEvent`), and begets the hash of the block sent
2. `TraceForgedBlock` begets hashes of the new/previous blocks, as well as the block no
3. `CompletedBlockFetch` in the blockfetch client begets the hash of the received block
4. The chainsync server begets a trace of its events