### PR TITLE
Set LANG and LOCALE_ARCHIVE for nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,13 +28,19 @@ let
     ''
       echo "
         Commands:
-          * nix flake update --update-input <iohkNix|haskellNix> - update imput
+          * nix flake update --update-input <iohkNix|haskellNix> - update input
           * cardano-cli - used for key generation and other operations tasks
           * wb - cluster workbench
           * start-cluster - start a local development cluster
           * stop-cluster - stop a local development cluster
 
       "
+    '';
+  # Set locale
+  setLocale =
+    ''
+      export LANG="en_US.UTF-8";
+      export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
     '';
 
   # This provides a development environment that can be used with nix-shell or
@@ -81,6 +87,7 @@ let
       tmux
       pkgs.git
       pkgs.hlint
+      pkgs.glibcLocales
     ]
     ## Workbench's main script is called directly in dev mode.
     ++ lib.optionals (!workbenchDevMode)
@@ -112,6 +119,8 @@ let
       trap atexit EXIT
       ''}
       unset NIX_ENFORCE_PURITY
+
+      ${setLocale}
 
       ${lib.optionalString autoStartCluster ''
       echo "workbench:  starting cluster (because 'autoStartCluster' is true):"
@@ -151,6 +160,8 @@ let
 
       # Socket path default to first node launched by "start-cluster":
       export CARDANO_NODE_SOCKET_PATH=$(wb backend get-node-socket-path ${cluster.stateDir})
+
+      ${setLocale}
 
       # Unless using specific network:
       ${lib.optionalString (__hasAttr "network" customConfig) ''

--- a/shell.nix
+++ b/shell.nix
@@ -36,12 +36,16 @@ let
 
       "
     '';
-  # Set locale
+  # Test cases will assume a UTF-8 locale and provide text in this character encoding.
+  # So force the character encoding to UTF-8 and provide locale data.
   setLocale =
     ''
-      export LANG="en_US.UTF-8";
-      export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
+      export LANG="en_US.UTF-8"
+    '' + lib.optionalString haveGlibcLocales ''
+      export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
     '';
+
+  haveGlibcLocales = pkgs.glibcLocales != null && stdenv.hostPlatform.libc == "glibc";        
 
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
@@ -87,8 +91,7 @@ let
       tmux
       pkgs.git
       pkgs.hlint
-      pkgs.glibcLocales
-    ]
+    ] ++ lib.optional haveGlibcLocales pkgs.glibcLocales
     ## Workbench's main script is called directly in dev mode.
     ++ lib.optionals (!workbenchDevMode)
     [


### PR DESCRIPTION
Set correct locale env variables in nix so cardano-cli ran from nix-shell works as expected.

Without proper locale settings, e.g. multi-assets with unicode chars in asset name don't work:
```
$ cardano-cli transaction build-raw --fee 0 --out-file test_minting_unicode_asset_name_mint_estimate_tx.body --tx-in 2eaa1408eb5a4388ffa82d2c3f378dc2edb7c471a44ccfdf6bfeea4b54d0e858#0 --tx-out "addr_test1vzazmulffx974jaxjn3kv76kdew4kxr99tw4v5kad50xq7sfjytzv+900000000+5 7c7861c4b99224819818b335eb61c97e3bbec777aece7f1563d920bf.ěůřščžďťňkszw" --mint "5 7c7861c4b99224819818b335eb61c97e3bbec777aece7f1563d920bf.ěůřščžďťňkszw" --minting-script-file test_minting_unicode_asset_name.script
option --tx-out: 
           unexpected "\56516"
           expecting alphanumeric asset name
...
```
With correct locale there's no issue:
```
$ cardano-cli transaction build-raw --fee 191769 --out-file test_minting_unicode_asset_name_mint_tx.body --tx-in ff6a1d797d27e4408a293e5b2985556095afc8a28686e0d6ae403af962093098#0 --tx-out "addr_test1vrktl4mg8w83dl8untnmn99maz4yz4sjkk8m5jqay0xzgfq9jwrw6+899808231+5 e48c26399203edda32b52d52fd7c4d3566f350a037efbff00aedf883.ěůřščžďťňdxjk" --mint "5 e48c26399203edda32b52d52fd7c4d3566f350a037efbff00aedf883.ěůřščžďťňdxjk" --minting-script-file test_minting_unicode_asset_name.script

$ cardano-cli query utxo --address addr_test1vrktl4mg8w83dl8untnmn99maz4yz4sjkk8m5jqay0xzgfq9jwrw6 --out-file /dev/stdout --testnet-magic 42 --cardano-mode
{
    "96003f81df15b6d26f62a88d83b31ca9670bcfec4ea82ce739777ff20409e1fd#0": {
        "address": "addr_test1vrktl4mg8w83dl8untnmn99maz4yz4sjkk8m5jqay0xzgfq9jwrw6",
        "value": {
            "e48c26399203edda32b52d52fd7c4d3566f350a037efbff00aedf883": {
                "ěůřščžďťňdxjk": 5
            },
            "lovelace": 899808231
        }
    }
}
```