### PR TITLE
More API coverage for Alonzo tx body features

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library
                         Cardano.Api.Eras
                         Cardano.Api.Error
                         Cardano.Api.Fees
+                        Cardano.Api.GenesisParameters
                         Cardano.Api.Hash
                         Cardano.Api.HasTypeProxy
                         Cardano.Api.IPC

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -181,6 +181,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Typed.Envelope
                         Test.Cardano.Api.Typed.Gen
                         Test.Cardano.Api.Typed.JSON
+                        Test.Cardano.Api.Typed.Ord
                         Test.Cardano.Api.Typed.Orphans
                         Test.Cardano.Api.Typed.RawBytes
                         Test.Cardano.Api.Typed.Script

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -166,6 +166,7 @@ module Cardano.Api (
     TxOutDatumHash(..),
 
     -- ** Other transaction body types
+    TxInsCollateral(..),
     TxFee(..),
     TxValidityLowerBound(..),
     TxValidityUpperBound(..),
@@ -186,6 +187,7 @@ module Cardano.Api (
     ViewTx,
 
     -- ** Era-dependent transaction body features
+    CollateralSupportedInEra(..),
     MultiAssetSupportedInEra(..),
     OnlyAdaSupportedInEra(..),
     TxFeesExplicitInEra(..),
@@ -201,6 +203,7 @@ module Cardano.Api (
     UpdateProposalSupportedInEra(..),
 
     -- ** Feature availability functions
+    collateralSupportedInEra,
     multiAssetSupportedInEra,
     txFeesExplicitInEra,
     validityUpperBoundSupportedInEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -470,6 +470,7 @@ module Cardano.Api (
     LocalStateQueryClient(..),
     QueryInMode(..),
     QueryInEra(..),
+    QueryInShelleyBasedEra(..),
     queryNodeLocalState,
 
     -- *** Common queries

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -493,6 +493,9 @@ module Cardano.Api (
     GenesisUTxOKey,
     genesisUTxOPseudoTxIn,
 
+    -- ** Genesis paramaters
+    GenesisParameters(..),
+
     -- * Special transactions
     -- | There are various additional things that can be embedded in a
     -- transaction for special operations.
@@ -526,6 +529,7 @@ import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Fees
+import           Cardano.Api.GenesisParameters
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
 import           Cardano.Api.IPC

--- a/cardano-api/src/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/src/Cardano/Api/GenesisParameters.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Parameters fixed in the genesis file: 'GenesisParameters'
+--
+module Cardano.Api.GenesisParameters (
+
+    -- * Protocol paramaters fixed in the genesis file
+    GenesisParameters(..),
+    EpochSize(..),
+
+    -- * Internal conversion functions
+    fromShelleyGenesis,
+
+  ) where
+
+import           Prelude
+
+import           Data.Time (NominalDiffTime, UTCTime)
+
+import           Cardano.Slotting.Slot (EpochSize (..))
+
+import qualified Shelley.Spec.Ledger.Genesis as Shelley
+
+import           Cardano.Api.NetworkId
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Value
+
+
+-- ----------------------------------------------------------------------------
+-- Genesis parameters
+--
+
+data GenesisParameters =
+     GenesisParameters {
+
+       -- | The reference time the system started. The time of slot zero.
+       -- The time epoch against which all Ouroboros time slots are measured.
+       --
+       protocolParamSystemStart :: UTCTime,
+
+       -- | The network identifier for this blockchain instance. This
+       -- distinguishes the mainnet from testnets, and different testnets from
+       -- each other.
+       --
+       protocolParamNetworkId :: NetworkId,
+
+       -- | The Ouroboros Praos active slot coefficient, aka @f@.
+       --
+       protocolParamActiveSlotsCoefficient :: Rational,
+
+       -- | The Ouroboros security paramaters, aka @k@. This is the maximum
+       -- number of blocks the node would ever be prepared to roll back by.
+       --
+       -- Clients of the node following the chain should be prepared to handle
+       -- the node switching forks up to this long.
+       --
+       protocolParamSecurity :: Int,
+
+       -- | The number of Ouroboros time slots in an Ouroboros epoch.
+       --
+       protocolParamEpochLength :: EpochSize,
+
+       -- | The time duration of a slot.
+       --
+       protocolParamSlotLength :: NominalDiffTime,
+
+       -- | For Ouroboros Praos, the length of a KES period as a number of time
+       -- slots. The KES keys get evolved once per KES period.
+       --
+       protocolParamSlotsPerKESPeriod :: Int,
+
+       -- | The maximum number of times a KES key can be evolved before it is
+       -- no longer considered valid. This can be less than the maximum number
+       -- of times given the KES key size. For example the mainnet KES key size
+       -- would allow 64 evolutions, but the max KES evolutions param is 62.
+       --
+       protocolParamMaxKESEvolutions ::  Int,
+
+       -- | In the Shelley era, prior to decentralised governance, this is the
+       -- number of genesis key delegates that need to agree for an update
+       -- proposal to be enacted.
+       --
+       protocolParamUpdateQuorum ::  Int,
+
+       -- | The maximum supply for Lovelace. This determines the initial value
+       -- of the reserves.
+       --
+       protocolParamMaxLovelaceSupply :: Lovelace,
+
+       -- | The initial values of the updateable 'ProtocolParameters'.
+       --
+       protocolInitialUpdateableProtocolParameters :: ProtocolParameters
+     }
+
+
+-- ----------------------------------------------------------------------------
+-- Conversion functions
+--
+
+fromShelleyGenesis :: Shelley.ShelleyGenesis era -> GenesisParameters
+fromShelleyGenesis
+    Shelley.ShelleyGenesis {
+      Shelley.sgSystemStart
+    , Shelley.sgNetworkMagic
+    , Shelley.sgNetworkId
+    , Shelley.sgActiveSlotsCoeff
+    , Shelley.sgSecurityParam
+    , Shelley.sgEpochLength
+    , Shelley.sgSlotsPerKESPeriod
+    , Shelley.sgMaxKESEvolutions
+    , Shelley.sgSlotLength
+    , Shelley.sgUpdateQuorum
+    , Shelley.sgMaxLovelaceSupply
+    , Shelley.sgProtocolParams
+    , Shelley.sgGenDelegs    = _  -- unused, might be of interest
+    , Shelley.sgInitialFunds = _  -- unused, not retained by the node
+    , Shelley.sgStaking      = _  -- unused, not retained by the node
+    } =
+    GenesisParameters {
+      protocolParamSystemStart            = sgSystemStart
+    , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
+                                              (NetworkMagic sgNetworkMagic)
+    , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
+    , protocolParamSecurity               = fromIntegral sgSecurityParam
+    , protocolParamEpochLength            = sgEpochLength
+    , protocolParamSlotLength             = sgSlotLength
+    , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
+    , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
+    , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
+    , protocolParamMaxLovelaceSupply      = Lovelace
+                                              (fromIntegral sgMaxLovelaceSupply)
+    , protocolInitialUpdateableProtocolParameters = fromShelleyPParams
+                                                      sgProtocolParams
+    }
+

--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -50,7 +50,11 @@ import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.Cardano.ByronHFC as Consensus (ByronBlockHFC)
 import           Ouroboros.Consensus.HardFork.Combinator as Consensus (EraIndex (..), eraIndexSucc,
                    eraIndexZero)
-import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardMary, StandardShelley)
+import           Ouroboros.Consensus.Shelley.Eras
+                   (StandardShelley,
+                    StandardAllegra,
+                    StandardMary,
+                    StandardAlonzo)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus (ShelleyBlockHFC)
 
@@ -130,6 +134,7 @@ toEraInMode ByronEra   CardanoMode = Just ByronEraInCardanoMode
 toEraInMode ShelleyEra CardanoMode = Just ShelleyEraInCardanoMode
 toEraInMode AllegraEra CardanoMode = Just AllegraEraInCardanoMode
 toEraInMode MaryEra    CardanoMode = Just MaryEraInCardanoMode
+toEraInMode AlonzoEra  CardanoMode = Just AlonzoEraInCardanoMode
 toEraInMode _ _                    = Nothing
 
 
@@ -222,6 +227,7 @@ type family ConsensusBlockForEra era where
   ConsensusBlockForEra ShelleyEra = Consensus.ShelleyBlock StandardShelley
   ConsensusBlockForEra AllegraEra = Consensus.ShelleyBlock StandardAllegra
   ConsensusBlockForEra MaryEra    = Consensus.ShelleyBlock StandardMary
+  ConsensusBlockForEra AlonzoEra  = Consensus.ShelleyBlock StandardAlonzo
 
 
 

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -490,7 +490,7 @@ data ProtocolParametersUpdate =
        -- | Max size of a 'Value' in a tx output.
        --
        -- /Introduced in Alonzo/
-       protocolUpdateParamMaxValueSize :: Maybe Natural,
+       protocolUpdateMaxValueSize :: Maybe Natural,
 
        -- | The percentage of the script contribution to the txfee that must be
        -- provided as collateral inputs when including Plutus scripts.
@@ -531,7 +531,7 @@ instance Semigroup ProtocolParametersUpdate where
       , protocolUpdatePrices              = merge protocolUpdatePrices
       , protocolUpdateMaxTxExUnits        = merge protocolUpdateMaxTxExUnits
       , protocolUpdateMaxBlockExUnits     = merge protocolUpdateMaxBlockExUnits
-      , protocolUpdateParamMaxValueSize   = merge protocolUpdateParamMaxValueSize
+      , protocolUpdateMaxValueSize        = merge protocolUpdateMaxValueSize
       , protocolUpdateCollateralPercent   = merge protocolUpdateCollateralPercent
       , protocolUpdateMaxCollateralInputs = merge protocolUpdateMaxCollateralInputs
       }
@@ -569,7 +569,7 @@ instance Monoid ProtocolParametersUpdate where
       , protocolUpdatePrices              = Nothing
       , protocolUpdateMaxTxExUnits        = Nothing
       , protocolUpdateMaxBlockExUnits     = Nothing
-      , protocolUpdateParamMaxValueSize   = Nothing
+      , protocolUpdateMaxValueSize        = Nothing
       , protocolUpdateCollateralPercent   = Nothing
       , protocolUpdateMaxCollateralInputs = Nothing
       }
@@ -904,7 +904,7 @@ fromShelleyPParamsUpdate
     , protocolUpdatePrices              = Nothing
     , protocolUpdateMaxTxExUnits        = Nothing
     , protocolUpdateMaxBlockExUnits     = Nothing
-    , protocolUpdateParamMaxValueSize   = Nothing
+    , protocolUpdateMaxValueSize        = Nothing
     , protocolUpdateCollateralPercent   = Nothing
     , protocolUpdateMaxCollateralInputs = Nothing
     }

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -36,10 +36,6 @@ module Cardano.Api.ProtocolParameters (
     UpdateProposal(..),
     makeShelleyUpdateProposal,
 
-    -- * Protocol paramaters fixed in the genesis file
-    GenesisParameters(..),
-    EpochSize(..),
-
     -- * Internal conversion functions
     toShelleyPParamsUpdate,
     toShelleyProposedPPUpdates,
@@ -49,7 +45,6 @@ module Cardano.Api.ProtocolParameters (
     fromShelleyPParamsUpdate,
     fromShelleyProposedPPUpdates,
     fromShelleyUpdate,
-    fromShelleyGenesis,
     toAlonzoPrices,
     fromAlonzoPrices,
 
@@ -66,7 +61,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Scientific (Scientific)
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Time (NominalDiffTime, UTCTime)
 import           GHC.Generics
 import           Numeric.Natural
 
@@ -79,7 +73,7 @@ import           Data.Bifunctor (bimap)
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash.Class as Crypto
-import           Cardano.Slotting.Slot (EpochNo, EpochSize (..))
+import           Cardano.Slotting.Slot (EpochNo)
 
 import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
@@ -96,7 +90,6 @@ import qualified Shelley.Spec.Ledger.PParams as Ledger
 -- So we import in twice under different names.
 import qualified Shelley.Spec.Ledger.PParams as Shelley
                    (PParams, PParams'(..), PParamsUpdate)
-import qualified Shelley.Spec.Ledger.Genesis as Shelley
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
@@ -111,7 +104,6 @@ import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
 import           Cardano.Api.KeysByron
 import           Cardano.Api.KeysShelley
-import           Cardano.Api.NetworkId
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
@@ -719,73 +711,6 @@ makeShelleyUpdateProposal params genesisKeyHashes =
 
 
 -- ----------------------------------------------------------------------------
--- Genesis parameters
---
-
-data GenesisParameters =
-     GenesisParameters {
-
-       -- | The reference time the system started. The time of slot zero.
-       -- The time epoch against which all Ouroboros time slots are measured.
-       --
-       protocolParamSystemStart :: UTCTime,
-
-       -- | The network identifier for this blockchain instance. This
-       -- distinguishes the mainnet from testnets, and different testnets from
-       -- each other.
-       --
-       protocolParamNetworkId :: NetworkId,
-
-       -- | The Ouroboros Praos active slot coefficient, aka @f@.
-       --
-       protocolParamActiveSlotsCoefficient :: Rational,
-
-       -- | The Ouroboros security paramaters, aka @k@. This is the maximum
-       -- number of blocks the node would ever be prepared to roll back by.
-       --
-       -- Clients of the node following the chain should be prepared to handle
-       -- the node switching forks up to this long.
-       --
-       protocolParamSecurity :: Int,
-
-       -- | The number of Ouroboros time slots in an Ouroboros epoch.
-       --
-       protocolParamEpochLength :: EpochSize,
-
-       -- | The time duration of a slot.
-       --
-       protocolParamSlotLength :: NominalDiffTime,
-
-       -- | For Ouroboros Praos, the length of a KES period as a number of time
-       -- slots. The KES keys get evolved once per KES period.
-       --
-       protocolParamSlotsPerKESPeriod :: Int,
-
-       -- | The maximum number of times a KES key can be evolved before it is
-       -- no longer considered valid. This can be less than the maximum number
-       -- of times given the KES key size. For example the mainnet KES key size
-       -- would allow 64 evolutions, but the max KES evolutions param is 62.
-       --
-       protocolParamMaxKESEvolutions ::  Int,
-
-       -- | In the Shelley era, prior to decentralised governance, this is the
-       -- number of genesis key delegates that need to agree for an update
-       -- proposal to be enacted.
-       --
-       protocolParamUpdateQuorum ::  Int,
-
-       -- | The maximum supply for Lovelace. This determines the initial value
-       -- of the reserves.
-       --
-       protocolParamMaxLovelaceSupply :: Lovelace,
-
-       -- | The initial values of the updateable 'ProtocolParameters'.
-       --
-       protocolInitialUpdateableProtocolParameters :: ProtocolParameters
-     }
-
-
--- ----------------------------------------------------------------------------
 -- Conversion functions
 --
 
@@ -1142,42 +1067,5 @@ fromShelleyPParams
     , protocolParamMaxValueSize        = Nothing
     , protocolParamCollateralPercent   = Nothing
     , protocolParamMaxCollateralInputs = Nothing
-    }
-
-
-fromShelleyGenesis :: Shelley.ShelleyGenesis era -> GenesisParameters
-fromShelleyGenesis
-    Shelley.ShelleyGenesis {
-      Shelley.sgSystemStart
-    , Shelley.sgNetworkMagic
-    , Shelley.sgNetworkId
-    , Shelley.sgActiveSlotsCoeff
-    , Shelley.sgSecurityParam
-    , Shelley.sgEpochLength
-    , Shelley.sgSlotsPerKESPeriod
-    , Shelley.sgMaxKESEvolutions
-    , Shelley.sgSlotLength
-    , Shelley.sgUpdateQuorum
-    , Shelley.sgMaxLovelaceSupply
-    , Shelley.sgProtocolParams
-    , Shelley.sgGenDelegs    = _  -- unused, might be of interest
-    , Shelley.sgInitialFunds = _  -- unused, not retained by the node
-    , Shelley.sgStaking      = _  -- unused, not retained by the node
-    } =
-    GenesisParameters {
-      protocolParamSystemStart            = sgSystemStart
-    , protocolParamNetworkId              = fromShelleyNetwork sgNetworkId
-                                              (NetworkMagic sgNetworkMagic)
-    , protocolParamActiveSlotsCoefficient = sgActiveSlotsCoeff
-    , protocolParamSecurity               = fromIntegral sgSecurityParam
-    , protocolParamEpochLength            = sgEpochLength
-    , protocolParamSlotLength             = sgSlotLength
-    , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
-    , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
-    , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
-    , protocolParamMaxLovelaceSupply      = Lovelace
-                                              (fromIntegral sgMaxLovelaceSupply)
-    , protocolInitialUpdateableProtocolParameters = fromShelleyPParams
-                                                      sgProtocolParams
     }
 

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -270,59 +271,66 @@ data ProtocolParameters =
   deriving (Eq, Generic, Show)
 
 instance FromJSON ProtocolParameters where
-  parseJSON = withObject "ProtocolParameters" $ \o -> do
-                v <- o .: "protocolVersion"
-                ProtocolParameters
-                        <$> ((,) <$> v .: "major" <*> v .: "minor")
-                        <*> o .: "decentralization"
-                        <*> o .: "extraPraosEntropy"
-                        <*> o .: "maxBlockHeaderSize"
-                        <*> o .: "maxBlockBodySize"
-                        <*> o .: "maxTxSize"
-                        <*> o .: "txFeeFixed"
-                        <*> o .: "txFeePerByte"
-                        <*> o .: "minUTxOValue"
-                        <*> o .: "stakeAddressDeposit"
-                        <*> o .: "stakePoolDeposit"
-                        <*> o .: "minPoolCost"
-                        <*> o .: "poolRetireMaxEpoch"
-                        <*> o .: "stakePoolTargetNum"
-                        <*> o .: "poolPledgeInfluence"
-                        <*> o .: "monetaryExpansion"
-                        <*> o .: "treasuryCut"
-                        <*> o .:? "utxoCostPerWord"
-                        <*> o .:? "costModel"           .!= Map.empty
-                        <*> o .:? "executionUnitPrices"
-                        <*> o .:? "maxTxExecUnits"
-                        <*> o .:? "maxBlockExecUnits"
-                        <*> o .:? "maxValueSize"
+  parseJSON =
+    withObject "ProtocolParameters" $ \o -> do
+      v <- o .: "protocolVersion"
+      ProtocolParameters
+        <$> ((,) <$> v .: "major" <*> v .: "minor")
+        <*> o .: "decentralization"
+        <*> o .: "extraPraosEntropy"
+        <*> o .: "maxBlockHeaderSize"
+        <*> o .: "maxBlockBodySize"
+        <*> o .: "maxTxSize"
+        <*> o .: "txFeeFixed"
+        <*> o .: "txFeePerByte"
+        <*> o .: "minUTxOValue"
+        <*> o .: "stakeAddressDeposit"
+        <*> o .: "stakePoolDeposit"
+        <*> o .: "minPoolCost"
+        <*> o .: "poolRetireMaxEpoch"
+        <*> o .: "stakePoolTargetNum"
+        <*> o .: "poolPledgeInfluence"
+        <*> o .: "monetaryExpansion"
+        <*> o .: "treasuryCut"
+        <*> o .:? "utxoCostPerWord"
+        <*> o .:? "costModel" .!= Map.empty
+        <*> o .:? "executionUnitPrices"
+        <*> o .:? "maxTxExecUnits"
+        <*> o .:? "maxBlockExecUnits"
+        <*> o .:? "maxValueSize"
 
 instance ToJSON ProtocolParameters where
-  toJSON pp = object [ "extraPraosEntropy" .= protocolParamExtraPraosEntropy pp
-                     , "stakePoolTargetNum" .= protocolParamStakePoolTargetNum pp
-                     , "minUTxOValue" .= protocolParamMinUTxOValue pp
-                     , "poolRetireMaxEpoch" .= protocolParamPoolRetireMaxEpoch pp
-                     , "decentralization" .= (fromRational $ protocolParamDecentralization pp :: Scientific)
-                     , "stakePoolDeposit" .= protocolParamStakePoolDeposit pp
-                     , "maxBlockHeaderSize" .= protocolParamMaxBlockHeaderSize pp
-                     , "maxBlockBodySize" .= protocolParamMaxBlockBodySize pp
-                     , "maxTxSize" .= protocolParamMaxTxSize pp
-                     , "treasuryCut" .= (fromRational $ protocolParamTreasuryCut pp :: Scientific)
-                     , "minPoolCost" .= protocolParamMinPoolCost pp
-                     , "monetaryExpansion" .= (fromRational $ protocolParamMonetaryExpansion pp :: Scientific)
-                     , "stakeAddressDeposit" .= protocolParamStakeAddressDeposit pp
-                     , "poolPledgeInfluence" .= (fromRational $ protocolParamPoolPledgeInfluence pp :: Scientific)
-                     , "protocolVersion" .= let (major, minor) = protocolParamProtocolVersion pp
-                                            in object ["major" .= major, "minor" .= minor]
-                     , "txFeeFixed" .= protocolParamTxFeeFixed pp
-                     , "txFeePerByte" .= protocolParamTxFeePerByte pp
-                     -- Alonzo era:
-                     , "costModels"  .= protocolParamCostModels pp
-                     , "executionUnitPrices" .= protocolParamPrices pp
-                     , "maxTxExecutionUnits" .= protocolParamMaxTxExUnits pp
-                     , "maxBlockExecutionUnits" .= protocolParamMaxBlockExUnits pp
-                     , "maxValSize" .= protocolParamMaxValueSize pp
-                     ]
+  toJSON ProtocolParameters{..} =
+    object
+      [ "extraPraosEntropy"   .= protocolParamExtraPraosEntropy
+      , "stakePoolTargetNum"  .= protocolParamStakePoolTargetNum
+      , "minUTxOValue"        .= protocolParamMinUTxOValue
+      , "poolRetireMaxEpoch"  .= protocolParamPoolRetireMaxEpoch
+      , "decentralization"    .= (fromRational protocolParamDecentralization
+                                            :: Scientific)
+      , "stakePoolDeposit"    .= protocolParamStakePoolDeposit
+      , "maxBlockHeaderSize"  .= protocolParamMaxBlockHeaderSize
+      , "maxBlockBodySize"    .= protocolParamMaxBlockBodySize
+      , "maxTxSize"           .= protocolParamMaxTxSize
+      , "treasuryCut"         .= (fromRational protocolParamTreasuryCut
+                                            :: Scientific)
+      , "minPoolCost"         .= protocolParamMinPoolCost
+      , "monetaryExpansion"   .= (fromRational protocolParamMonetaryExpansion
+                                            :: Scientific)
+      , "stakeAddressDeposit" .= protocolParamStakeAddressDeposit
+      , "poolPledgeInfluence" .= (fromRational protocolParamPoolPledgeInfluence
+                                            :: Scientific)
+      , "protocolVersion"     .= let (major, minor) = protocolParamProtocolVersion
+                                  in object ["major" .= major, "minor" .= minor]
+      , "txFeeFixed"          .= protocolParamTxFeeFixed
+      , "txFeePerByte"        .= protocolParamTxFeePerByte
+      -- Alonzo era:
+      , "costModels"             .= protocolParamCostModels
+      , "executionUnitPrices"    .= protocolParamPrices
+      , "maxTxExecutionUnits"    .= protocolParamMaxTxExUnits
+      , "maxBlockExecutionUnits" .= protocolParamMaxBlockExUnits
+      , "maxValSize"             .= protocolParamMaxValueSize
+      ]
 
 -- ----------------------------------------------------------------------------
 -- Updates to the protocol paramaters

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -329,7 +329,7 @@ instance ToJSON ProtocolParameters where
       , "executionUnitPrices"    .= protocolParamPrices
       , "maxTxExecutionUnits"    .= protocolParamMaxTxExUnits
       , "maxBlockExecutionUnits" .= protocolParamMaxBlockExUnits
-      , "maxValSize"             .= protocolParamMaxValueSize
+      , "maxValueSize"           .= protocolParamMaxValueSize
       ]
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -266,7 +266,18 @@ data ProtocolParameters =
        -- | Max size of a Value in a tx ouput.
        --
        -- /Introduced in Alonzo/
-       protocolParamMaxValueSize :: Maybe Natural
+       protocolParamMaxValueSize :: Maybe Natural,
+
+       -- | The percentage of the script contribution to the txfee that must be
+       -- provided as collateral inputs when including Plutus scripts.
+       --
+       -- /Introduced in Alonzo/
+       protocolParamCollateralPercent :: Maybe Natural,
+
+       -- | The maximum number of collateral inputs allowed in a transaction.
+       --
+       -- /Introduced in Alonzo/
+       protocolParamMaxCollateralInputs :: Maybe Natural
     }
   deriving (Eq, Generic, Show)
 
@@ -298,6 +309,8 @@ instance FromJSON ProtocolParameters where
         <*> o .:? "maxTxExecUnits"
         <*> o .:? "maxBlockExecUnits"
         <*> o .:? "maxValueSize"
+        <*> o .:? "collateralPercentage"
+        <*> o .:? "maxCollateralInputs"
 
 instance ToJSON ProtocolParameters where
   toJSON ProtocolParameters{..} =
@@ -330,6 +343,8 @@ instance ToJSON ProtocolParameters where
       , "maxTxExecutionUnits"    .= protocolParamMaxTxExUnits
       , "maxBlockExecutionUnits" .= protocolParamMaxBlockExUnits
       , "maxValueSize"           .= protocolParamMaxValueSize
+      , "collateralPercentage"   .= protocolParamCollateralPercent
+      , "maxCollateralInputs"    .= protocolParamMaxCollateralInputs
       ]
 
 -- ----------------------------------------------------------------------------
@@ -480,7 +495,18 @@ data ProtocolParametersUpdate =
        -- | Max size of a 'Value' in a tx output.
        --
        -- /Introduced in Alonzo/
-       protocolUpdateParamMaxValueSize :: Maybe Natural
+       protocolUpdateParamMaxValueSize :: Maybe Natural,
+
+       -- | The percentage of the script contribution to the txfee that must be
+       -- provided as collateral inputs when including Plutus scripts.
+       --
+       -- /Introduced in Alonzo/
+       protocolUpdateCollateralPercent :: Maybe Natural,
+
+       -- | The maximum number of collateral inputs allowed in a transaction.
+       --
+       -- /Introduced in Alonzo/
+       protocolUpdateMaxCollateralInputs :: Maybe Natural
     }
   deriving (Eq, Show)
 
@@ -511,6 +537,8 @@ instance Semigroup ProtocolParametersUpdate where
       , protocolUpdateMaxTxExUnits        = merge protocolUpdateMaxTxExUnits
       , protocolUpdateMaxBlockExUnits     = merge protocolUpdateMaxBlockExUnits
       , protocolUpdateParamMaxValueSize   = merge protocolUpdateParamMaxValueSize
+      , protocolUpdateCollateralPercent   = merge protocolUpdateCollateralPercent
+      , protocolUpdateMaxCollateralInputs = merge protocolUpdateMaxCollateralInputs
       }
       where
         -- prefer the right hand side:
@@ -547,6 +575,8 @@ instance Monoid ProtocolParametersUpdate where
       , protocolUpdateMaxTxExUnits        = Nothing
       , protocolUpdateMaxBlockExUnits     = Nothing
       , protocolUpdateParamMaxValueSize   = Nothing
+      , protocolUpdateCollateralPercent   = Nothing
+      , protocolUpdateMaxCollateralInputs = Nothing
       }
 
 
@@ -902,6 +932,8 @@ fromShelleyPParamsUpdate
     , protocolUpdateMaxTxExUnits        = Nothing
     , protocolUpdateMaxBlockExUnits     = Nothing
     , protocolUpdateParamMaxValueSize   = Nothing
+    , protocolUpdateCollateralPercent   = Nothing
+    , protocolUpdateMaxCollateralInputs = Nothing
     }
 
 
@@ -986,7 +1018,9 @@ toAlonzoPParams ProtocolParameters {
                    protocolParamPrices          = Just prices,
                    protocolParamMaxTxExUnits    = Just maxTxExUnits,
                    protocolParamMaxBlockExUnits = Just maxBlockExUnits,
-                   protocolParamMaxValueSize    = Just maxValueSize
+                   protocolParamMaxValueSize    = Just maxValueSize,
+                   protocolParamCollateralPercent   = Just collateralPercentage,
+                   protocolParamMaxCollateralInputs = Just maxCollateralInputs
                  } =
     Alonzo.PParams {
       Alonzo._protocolVersion
@@ -1018,8 +1052,8 @@ toAlonzoPParams ProtocolParameters {
     , Alonzo._maxTxExUnits    = toAlonzoExUnits maxTxExUnits
     , Alonzo._maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
     , Alonzo._maxValSize      = maxValueSize
-    , Alonzo._collateralPercentage = error "TODO alonzo: toAlonzoPParams collateralPercentage"
-    , Alonzo._maxCollateralInputs  = error "TODO alonzo: toAlonzoPParams maxCollateralInputs"
+    , Alonzo._collateralPercentage = collateralPercentage
+    , Alonzo._maxCollateralInputs  = maxCollateralInputs
     }
 toAlonzoPParams ProtocolParameters { protocolParamUTxOCostPerWord = Nothing } =
   error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord"
@@ -1031,6 +1065,10 @@ toAlonzoPParams ProtocolParameters { protocolParamMaxBlockExUnits = Nothing } =
   error "toAlonzoPParams: must specify protocolParamMaxBlockExUnits"
 toAlonzoPParams ProtocolParameters { protocolParamMaxValueSize    = Nothing } =
     error "toAlonzoPParams: must specify protocolParamMaxValueSize"
+toAlonzoPParams ProtocolParameters { protocolParamCollateralPercent = Nothing } =
+    error "toAlonzoPParams: must specify protocolParamCollateralPercent"
+toAlonzoPParams ProtocolParameters { protocolParamMaxCollateralInputs = Nothing } =
+    error "toAlonzoPParams: must specify protocolParamMaxCollateralInputs"
 
 
 toAlonzoCostModels
@@ -1094,6 +1132,8 @@ fromShelleyPParams
     , protocolParamMaxTxExUnits        = Nothing
     , protocolParamMaxBlockExUnits     = Nothing
     , protocolParamMaxValueSize        = Nothing
+    , protocolParamCollateralPercent   = Nothing
+    , protocolParamMaxCollateralInputs = Nothing
     }
 
 

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -193,7 +193,7 @@ data ProtocolParameters =
        -- | The minimum permitted value for new UTxO entries, ie for
        -- transaction outputs.
        --
-       protocolParamMinUTxOValue :: Lovelace,
+       protocolParamMinUTxOValue :: Maybe Lovelace,
 
        -- | The deposit required to register a stake address.
        --
@@ -926,7 +926,7 @@ toShelleyPParams ProtocolParameters {
                    protocolParamMaxTxSize,
                    protocolParamTxFeeFixed,
                    protocolParamTxFeePerByte,
-                   protocolParamMinUTxOValue,
+                   protocolParamMinUTxOValue = Just minUTxOValue,
                    protocolParamStakeAddressDeposit,
                    protocolParamStakePoolDeposit,
                    protocolParamMinPoolCost,
@@ -948,7 +948,7 @@ toShelleyPParams ProtocolParameters {
      , Shelley._maxTxSize    = protocolParamMaxTxSize
      , Shelley._minfeeB      = protocolParamTxFeeFixed
      , Shelley._minfeeA      = protocolParamTxFeePerByte
-     , Shelley._minUTxOValue = toShelleyLovelace protocolParamMinUTxOValue
+     , Shelley._minUTxOValue = toShelleyLovelace minUTxOValue
      , Shelley._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
      , Shelley._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
      , Shelley._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
@@ -960,6 +960,8 @@ toShelleyPParams ProtocolParameters {
      , Shelley._tau          = Shelley.unitIntervalFromRational
                                  protocolParamTreasuryCut
      }
+toShelleyPParams ProtocolParameters { protocolParamMinUTxOValue = Nothing } =
+  error "toShelleyPParams: must specify protocolParamMinUTxOValue"
 
 toAlonzoPParams :: ProtocolParameters -> Alonzo.PParams ledgerera
 toAlonzoPParams ProtocolParameters {
@@ -1020,15 +1022,15 @@ toAlonzoPParams ProtocolParameters {
     , Alonzo._maxCollateralInputs  = error "TODO alonzo: toAlonzoPParams maxCollateralInputs"
     }
 toAlonzoPParams ProtocolParameters { protocolParamUTxOCostPerWord = Nothing } =
-  error "fromProtocolParamsAlonzo: must specify protocolParamUTxOCostPerWord"
+  error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord"
 toAlonzoPParams ProtocolParameters { protocolParamPrices          = Nothing } =
-  error "fromProtocolParamsAlonzo: must specify protocolParamPrices"
+  error "toAlonzoPParams: must specify protocolParamPrices"
 toAlonzoPParams ProtocolParameters { protocolParamMaxTxExUnits    = Nothing } =
-  error "fromProtocolParamsAlonzo: must specify protocolParamMaxTxExUnits"
+  error "toAlonzoPParams: must specify protocolParamMaxTxExUnits"
 toAlonzoPParams ProtocolParameters { protocolParamMaxBlockExUnits = Nothing } =
-  error "fromProtocolParamsAlonzo: must specify protocolParamMaxBlockExUnits"
+  error "toAlonzoPParams: must specify protocolParamMaxBlockExUnits"
 toAlonzoPParams ProtocolParameters { protocolParamMaxValueSize    = Nothing } =
-    error "fromProtocolParamsAlonzo: must specify protocolParamMaxValueSize"
+    error "toAlonzoPParams: must specify protocolParamMaxValueSize"
 
 
 toAlonzoCostModels
@@ -1077,7 +1079,7 @@ fromShelleyPParams
     , protocolParamMaxTxSize           = _maxTxSize
     , protocolParamTxFeeFixed          = _minfeeB
     , protocolParamTxFeePerByte        = _minfeeA
-    , protocolParamMinUTxOValue        = fromShelleyLovelace _minUTxOValue
+    , protocolParamMinUTxOValue        = Just (fromShelleyLovelace _minUTxOValue)
     , protocolParamStakeAddressDeposit = fromShelleyLovelace _keyDeposit
     , protocolParamStakePoolDeposit    = fromShelleyLovelace _poolDeposit
     , protocolParamMinPoolCost         = fromShelleyLovelace _minPoolCost

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -82,6 +82,7 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
+import           Cardano.Api.GenesisParameters
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -239,25 +239,17 @@ toShelleyAddrSet era =
   . Set.toList
 
 
-fromUTxO
-  :: ShelleyLedgerEra era ~ ledgerera
-  => ShelleyBasedEra era
-  -> Shelley.UTxO ledgerera
-  -> UTxO era
-fromUTxO eraConversion utxo =
-  case eraConversion of
-    ShelleyBasedEraShelley ->
-      let Shelley.UTxO sUtxo = utxo
-      in UTxO . Map.fromList . map (bimap fromShelleyTxIn fromShelleyTxOut) $ Map.toList sUtxo
-    ShelleyBasedEraAllegra ->
-      let Shelley.UTxO sUtxo = utxo
-      in UTxO . Map.fromList . map (bimap fromShelleyTxIn (fromTxOut ShelleyBasedEraAllegra)) $ Map.toList sUtxo
-    ShelleyBasedEraMary ->
-      let Shelley.UTxO sUtxo = utxo
-      in UTxO . Map.fromList . map (bimap fromShelleyTxIn (fromTxOut ShelleyBasedEraMary)) $ Map.toList sUtxo
-    ShelleyBasedEraAlonzo ->
-      let Shelley.UTxO sUtxo = utxo
-      in UTxO . Map.fromList . map (bimap fromShelleyTxIn (fromTxOut ShelleyBasedEraAlonzo)) $ Map.toList sUtxo
+fromUTxO :: ShelleyLedgerEra era ~ ledgerera
+         => Ledger.Crypto ledgerera ~ StandardCrypto
+         => ShelleyBasedEra era
+         -> Shelley.UTxO ledgerera
+         -> UTxO era
+fromUTxO era (Shelley.UTxO utxo) =
+    UTxO
+  . Map.fromList
+  . map (bimap fromShelleyTxIn (fromTxOut era))
+  . Map.toList
+  $ utxo
 
 fromShelleyPoolDistr :: Shelley.PoolDistr StandardCrypto
                      -> Map (Hash StakePoolKey) Rational

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -76,7 +76,6 @@ import qualified Cardano.Ledger.Era as Ledger
 
 import qualified Shelley.Spec.Ledger.API as Shelley
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
-import qualified Shelley.Spec.Ledger.PParams as Shelley
 
 import           Cardano.Api.Address
 import           Cardano.Api.Block
@@ -492,8 +491,6 @@ fromConsensusQueryResult (QueryInEra AlonzoEraInCardanoMode
 fromConsensusQueryResultShelleyBased
   :: forall era ledgerera result result'.
      ShelleyLedgerEra era ~ ledgerera
-  => Core.PParams ledgerera ~ Shelley.PParams ledgerera
-  => Core.PParamsDelta ledgerera ~ Shelley.PParamsUpdate ledgerera
   => Consensus.ShelleyBasedEra ledgerera
   => Ledger.Crypto ledgerera ~ Consensus.StandardCrypto
   => ShelleyBasedEra era
@@ -517,14 +514,14 @@ fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =
                                       (Consensus.getCompactGenesis r')
       _                          -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryProtocolParameters q' r' =
+fromConsensusQueryResultShelleyBased era QueryProtocolParameters q' r' =
     case q' of
-      Consensus.GetCurrentPParams -> fromShelleyPParams r'
+      Consensus.GetCurrentPParams -> fromLedgerPParams era r'
       _                           -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryProtocolParametersUpdate q' r' =
+fromConsensusQueryResultShelleyBased era QueryProtocolParametersUpdate q' r' =
     case q' of
-      Consensus.GetProposedPParamsUpdates -> fromShelleyProposedPPUpdates r'
+      Consensus.GetProposedPParamsUpdates -> fromLedgerProposedPPUpdates era r'
       _                                   -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased _ QueryStakeDistribution q' r' =

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -327,7 +327,7 @@ toConsensusQuery (QueryInEra erainmode (QueryInShelleyBasedEra era q)) =
       ShelleyEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
       AllegraEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
       MaryEraInCardanoMode    -> toConsensusQueryShelleyBased erainmode q
-      AlonzoEraInCardanoMode  -> error "toConsensusQuery: Alonzo not implemented yet"
+      AlonzoEraInCardanoMode  -> toConsensusQueryShelleyBased erainmode q
 
 
 toConsensusQueryShelleyBased
@@ -397,8 +397,7 @@ consensusQueryInEraInMode erainmode =
       ShelleyEraInCardanoMode -> Consensus.QueryIfCurrentShelley
       AllegraEraInCardanoMode -> Consensus.QueryIfCurrentAllegra
       MaryEraInCardanoMode    -> Consensus.QueryIfCurrentMary
-      AlonzoEraInCardanoMode  ->
-        error "consensusQueryInEraInMode: Alonzo not implemented yet"
+      AlonzoEraInCardanoMode  -> Consensus.QueryIfCurrentAlonzo
 
 
 -- ----------------------------------------------------------------------------
@@ -485,8 +484,14 @@ fromConsensusQueryResult (QueryInEra MaryEraInCardanoMode
       _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResult (QueryInEra AlonzoEraInCardanoMode
-                                     (QueryInShelleyBasedEra _ _)) _ _ =
-    error "fromConsensusQueryResult: Alonzo not implemented yet"
+                                     (QueryInShelleyBasedEra _era q)) q' r' =
+    case q' of
+      Consensus.BlockQuery (Consensus.QueryIfCurrentAlonzo q'')
+        -> bimap fromConsensusEraMismatch
+                 (fromConsensusQueryResultShelleyBased
+                    ShelleyBasedEraAlonzo q q'')
+                 r'
+      _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased
   :: forall era ledgerera result result'.

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -39,6 +39,7 @@ module Cardano.Api.Script (
     ScriptWitnessInCtx(..),
     ScriptDatum(..),
     ScriptRedeemer,
+    scriptWitnessScript,
 
     -- ** Languages supported in each era
     ScriptLanguageInEra(..),
@@ -654,6 +655,14 @@ data ScriptDatum witctx where
 
 deriving instance Eq   (ScriptDatum witctx)
 deriving instance Show (ScriptDatum witctx)
+
+
+scriptWitnessScript :: ScriptWitness witctx era -> ScriptInEra era
+scriptWitnessScript (SimpleScriptWitness langInEra version script) =
+    ScriptInEra langInEra (SimpleScript version script)
+
+scriptWitnessScript (PlutusScriptWitness langInEra version script _ _ _) =
+    ScriptInEra langInEra (PlutusScript version script)
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -716,6 +716,9 @@ data ScriptData = ScriptDataConstructor Integer [ScriptData]
                 | ScriptDataNumber      Integer
                 | ScriptDataBytes       BS.ByteString
   deriving (Eq, Ord, Show)
+  -- Note the order of constructors is the same as the Plutus definitions
+  -- so that the Ord instance is consistent with the Plutus one.
+  -- This is checked by prop_ord_distributive_ScriptData
 
 instance HasTypeProxy ScriptData where
     data AsType ScriptData = AsScriptData

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -77,8 +77,10 @@ module Cardano.Api.Script (
     fromAlonzoExUnits,
     toShelleyScriptHash,
     fromShelleyScriptHash,
-    toAlonzoScriptData,
-    fromAlonzoScriptData,
+    toPlutusData,
+    fromPlutusData,
+    toAlonzoData,
+    fromAlonzoData,
     toAlonzoLanguage,
     fromAlonzoLanguage,
 
@@ -90,6 +92,7 @@ module Cardano.Api.Script (
 import           Prelude
 
 import           Data.Word (Word64)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as SBS
@@ -131,6 +134,8 @@ import qualified Shelley.Spec.Ledger.Scripts as Shelley
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+
+import qualified Plutus.V1.Ledger.Api as Plutus
 
 import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy
@@ -705,19 +710,47 @@ deriving instance Show (ScriptWitnessInCtx witctx)
 
 type ScriptRedeemer = ScriptData
 
--- TODO alonzo: Placeholder type to re-present the Alonzo.Data type
-data ScriptData = ScriptData
-  deriving (Eq, Show)
+data ScriptData = ScriptDataConstructor Integer [ScriptData]
+                | ScriptDataMap         [(ScriptData, ScriptData)]
+                | ScriptDataList        [ScriptData]
+                | ScriptDataNumber      Integer
+                | ScriptDataBytes       BS.ByteString
+  deriving (Eq, Ord, Show)
 
 instance HasTypeProxy ScriptData where
     data AsType ScriptData = AsScriptData
     proxyToAsType _ = AsScriptData
 
-toAlonzoScriptData :: ScriptData -> Alonzo.Data ledgerera
-toAlonzoScriptData = error "TODO alonzo: toShelleyScriptData"
+toAlonzoData :: ScriptData -> Alonzo.Data ledgerera
+toAlonzoData = Alonzo.Data . toPlutusData
 
-fromAlonzoScriptData :: Alonzo.Data ledgerera -> ScriptData
-fromAlonzoScriptData = error "TODO alonzo: fromShelleyScriptData"
+fromAlonzoData :: Alonzo.Data ledgerera -> ScriptData
+fromAlonzoData = fromPlutusData . Alonzo.getPlutusData
+
+
+toPlutusData :: ScriptData -> Plutus.Data
+toPlutusData (ScriptDataConstructor int xs)
+                                  = Plutus.Constr int
+                                      [ toPlutusData x | x <- xs ]
+toPlutusData (ScriptDataMap  kvs) = Plutus.Map
+                                      [ (toPlutusData k, toPlutusData v)
+                                      | (k,v) <- kvs ]
+toPlutusData (ScriptDataList  xs) = Plutus.List
+                                      [ toPlutusData x | x <- xs ]
+toPlutusData (ScriptDataNumber n) = Plutus.I n
+toPlutusData (ScriptDataBytes bs) = Plutus.B bs
+
+fromPlutusData :: Plutus.Data -> ScriptData
+fromPlutusData (Plutus.Constr int xs)
+                                = ScriptDataConstructor int
+                                    [ fromPlutusData x | x <- xs ]
+fromPlutusData (Plutus.Map kvs) = ScriptDataMap
+                                    [ (fromPlutusData k, fromPlutusData v)
+                                    | (k,v) <- kvs ]
+fromPlutusData (Plutus.List xs) = ScriptDataList
+                                    [ fromPlutusData x | x <- xs ]
+fromPlutusData (Plutus.I     n) = ScriptDataNumber n
+fromPlutusData (Plutus.B    bs) = ScriptDataBytes bs
 
 
 newtype instance Hash ScriptData =

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -164,7 +164,6 @@ module Cardano.Api.Shelley
 
 
     -- ** Local State Query
-    QueryInShelleyBasedEra(..),
     DebugLedgerState(..),
     ProtocolState(..),
     SerialisedDebugLedgerState(..),

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -99,6 +99,10 @@ module Cardano.Api.Shelley
     toShelleyScriptHash,
     fromShelleyScriptHash,
     PlutusScript(..),
+    toPlutusData,
+    fromPlutusData,
+    toAlonzoData,
+    fromAlonzoData,
 
     -- * Certificates
     Certificate (..),

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -2134,7 +2134,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
 
     datums :: [Alonzo.Data StandardAlonzo]
     datums =
-      [ toAlonzoScriptData d
+      [ toAlonzoData d
       | (_, AnyScriptWitness
               (PlutusScriptWitness
                  _ _ _ (ScriptDatumForTxIn d) _ _)) <- witnesses
@@ -2144,7 +2144,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
     redeemers =
       Alonzo.Redeemers $
         Map.fromList
-          [ (ptr, (toAlonzoScriptData d, toAlonzoExUnits e))
+          [ (ptr, (toAlonzoData d, toAlonzoExUnits e))
           | (ptr, AnyScriptWitness
                     (PlutusScriptWitness _ _ _ _ d e)) <- witnesses
           ]
@@ -2321,7 +2321,7 @@ toAlonzoAuxiliaryData m ss ds =
     Alonzo.AuxiliaryData
       (toShelleyMetadata m)
       (Seq.fromList (map toShelleyScript ss))
-      (Set.fromList (map toAlonzoScriptData ds))
+      (Set.fromList (map toAlonzoData ds))
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -2210,7 +2210,7 @@ collectTxBodyScriptWitnesses TxBodyContent {
 
     -- This relies on the TxId Ord instance being consistent with the
     -- Shelley.TxId Ord instance via the toShelleyTxId conversion
-    -- TODO: add a QC property to ensure this
+    -- This is checked by prop_ord_distributive_TxId
     orderTxIns :: Ord k => [(k, v)] -> [v]
     orderTxIns = Map.elems . Map.fromList
 
@@ -2227,7 +2227,7 @@ collectTxBodyScriptWitnesses TxBodyContent {
 
     -- This relies on the StakeAddress Ord instance being consistent with the
     -- Shelley.RewardAcnt Ord instance via the toShelleyStakeAddr conversion
-    -- TODO: add a QC property to ensure this
+    -- This is checked by prop_ord_distributive_StakeAddress
     orderStakeAddrs :: Ord k => [(k, x, v)] -> [v]
     orderStakeAddrs = Map.elems . Map.fromList . map (\(k, _, v) -> (k, v))
 

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -43,6 +43,7 @@ module Cardano.Api.TxBody (
     TxOutDatumHash(..),
 
     -- * Other transaction body types
+    TxInsCollateral(..),
     TxFee(..),
     TxValidityLowerBound(..),
     TxValidityUpperBound(..),
@@ -61,6 +62,7 @@ module Cardano.Api.TxBody (
     ViewTx,
 
     -- * Era-dependent transaction body features
+    CollateralSupportedInEra(..),
     MultiAssetSupportedInEra(..),
     OnlyAdaSupportedInEra(..),
     TxFeesExplicitInEra(..),
@@ -77,6 +79,7 @@ module Cardano.Api.TxBody (
     UpdateProposalSupportedInEra(..),
 
     -- ** Feature availability functions
+    collateralSupportedInEra,
     multiAssetSupportedInEra,
     txFeesExplicitInEra,
     validityUpperBoundSupportedInEra,
@@ -437,6 +440,27 @@ fromAlonzoTxOutDataHash era (SJust dh) = TxOutDatumHash era (ScriptDataHash dh)
 -- Era-dependent transaction body features
 --
 
+-- | A representation of whether the era supports transactions with inputs used
+-- only for collateral for script fees.
+--
+-- The Alonzo and subsequent eras support collateral inputs.
+--
+data CollateralSupportedInEra era where
+
+     CollateralInAlonzoEra :: CollateralSupportedInEra AlonzoEra
+
+deriving instance Eq   (CollateralSupportedInEra era)
+deriving instance Show (CollateralSupportedInEra era)
+
+collateralSupportedInEra :: CardanoEra era
+                         -> Maybe (CollateralSupportedInEra era)
+collateralSupportedInEra ByronEra   = Nothing
+collateralSupportedInEra ShelleyEra = Nothing
+collateralSupportedInEra AllegraEra = Nothing
+collateralSupportedInEra MaryEra    = Nothing
+collateralSupportedInEra AlonzoEra  = Just CollateralInAlonzoEra
+
+
 -- | A representation of whether the era supports multi-asset transactions.
 --
 -- The Mary and subsequent eras support multi-asset transactions.
@@ -786,6 +810,24 @@ deriving instance Show a => Show (BuildTxWith build a)
 
 
 -- ----------------------------------------------------------------------------
+-- Transaction input values (era-dependent)
+--
+
+type TxIns build era = [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))]
+
+data TxInsCollateral era where
+
+     TxInsCollateralNone :: TxInsCollateral era
+
+     TxInsCollateral     :: CollateralSupportedInEra era
+                         -> [TxIn] -- Only key witnesses, no scripts.
+                         -> TxInsCollateral era
+
+deriving instance Eq   (TxInsCollateral era)
+deriving instance Show (TxInsCollateral era)
+
+
+-- ----------------------------------------------------------------------------
 -- Transaction output values (era-dependent)
 --
 
@@ -1002,7 +1044,8 @@ deriving instance Show (TxMintValue build era)
 
 data TxBodyContent build era =
      TxBodyContent {
-       txIns            :: [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))],
+       txIns            :: TxIns build era,
+       txInsCollateral  :: TxInsCollateral era,
        txOuts           :: [TxOut era],
        txFee            :: TxFee era,
        txValidityRange  :: (TxValidityLowerBound era,
@@ -1359,6 +1402,7 @@ fromLedgerTxBody
 fromLedgerTxBody era body mAux =
     TxBodyContent
       { txIns            = fromLedgerTxIns            era body
+      , txInsCollateral  = fromLedgerTxInsCollateral  era body
       , txOuts           = fromLedgerTxOuts           era body
       , txFee            = fromLedgerTxFee            era body
       , txValidityRange  = fromLedgerTxValidityRange  era body
@@ -1377,18 +1421,42 @@ fromLedgerTxBody era body mAux =
 
 
 fromLedgerTxIns
-  :: ShelleyBasedEra era
+  :: forall era.
+     ShelleyBasedEra era
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> [(TxIn,BuildTxWith ViewTx (Witness WitCtxTxIn era))]
 fromLedgerTxIns era body =
-  [ (fromShelleyTxIn input, ViewTx)
-  | input <-
-      case era of
-        ShelleyBasedEraShelley -> toList $ Shelley._inputs body
-        ShelleyBasedEraAllegra -> toList $ Allegra.inputs' body
-        ShelleyBasedEraMary    -> toList $ Mary.inputs'    body
-        ShelleyBasedEraAlonzo  -> toList $ Alonzo.inputs'  body
-  ]
+    [ (fromShelleyTxIn input, ViewTx)
+    | input <- Set.toList (inputs era body) ]
+  where
+    inputs :: ShelleyBasedEra era
+           -> Ledger.TxBody (ShelleyLedgerEra era)
+           -> Set (Shelley.TxIn StandardCrypto)
+    inputs ShelleyBasedEraShelley = Shelley._inputs
+    inputs ShelleyBasedEraAllegra = Allegra.inputs'
+    inputs ShelleyBasedEraMary    = Mary.inputs'
+    inputs ShelleyBasedEraAlonzo  = Alonzo.inputs'
+
+
+fromLedgerTxInsCollateral
+  :: forall era.
+     ShelleyBasedEra era
+  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> TxInsCollateral era
+fromLedgerTxInsCollateral era body =
+    case collateralSupportedInEra (shelleyBasedToCardanoEra era) of
+      Nothing        -> TxInsCollateralNone
+      Just supported -> TxInsCollateral supported
+                          [ fromShelleyTxIn input
+                          | input <- Set.toList (collateral era body) ]
+  where
+    collateral :: ShelleyBasedEra era
+               -> Ledger.TxBody (ShelleyLedgerEra era)
+               -> Set (Shelley.TxIn StandardCrypto)
+    collateral ShelleyBasedEraShelley = const Set.empty
+    collateral ShelleyBasedEraAllegra = const Set.empty
+    collateral ShelleyBasedEraMary    = const Set.empty
+    collateral ShelleyBasedEraAlonzo  = Alonzo.collateral'
 
 
 fromLedgerTxOuts
@@ -1721,6 +1789,7 @@ getByronTxBodyContent (Annotated Byron.UnsafeTx{txInputs, txOutputs} _) =
     TxBodyContent {
       txIns            = [ (fromByronTxIn input, ViewTx)
                          | input <- toList txInputs],
+      txInsCollateral  = TxInsCollateralNone,
       txOuts           = fromByronTxOut <$> toList txOutputs,
       txFee            = TxFeeImplicit TxFeesImplicitInByronEra,
       txValidityRange  = (TxValidityNoLowerBound,
@@ -1949,6 +2018,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraMary
 makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
                            txbodycontent@TxBodyContent {
                              txIns,
+                             txInsCollateral,
                              txOuts,
                              txFee,
                              txValidityRange = (lowerBound, upperBound),
@@ -1990,7 +2060,9 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
       ShelleyTxBody era
         (Alonzo.TxBody
           (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (error "TODO alonzo: add support for collateral")
+          (case txInsCollateral of
+             TxInsCollateralNone     -> Set.empty
+             TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins))
           (Seq.fromList (map toShelleyTxOut txOuts))
           (case txCertificates of
              TxCertificatesNone    -> Seq.empty

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -708,7 +708,7 @@ genProtocolParameters =
     <*> genNat
     <*> genNat
     <*> genNat
-    <*> genLovelace
+    <*> Gen.maybe genLovelace
     <*> genLovelace
     <*> genLovelace
     <*> genLovelace

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -12,6 +12,10 @@ module Test.Cardano.Api.Typed.Gen
   , genValueNestedBundle
   , genByronKeyWitness
 
+  , genTxId
+  , genTxIn
+  , genTxOut
+
     -- * Scripts
   , genScript
   , genSimpleScript

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -570,6 +570,7 @@ genTxBodyContent era = do
     , txValidityRange = validityRange
     , txMetadata = txMd
     , txAuxScripts = auxScripts
+    , txAuxScriptData = TxAuxScriptDataNone    --TODO: Alonzo era: Generate extra script data
     , txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
     , txProtocolParams = BuildTxWith mpparams
     , txWithdrawals = withdrawals

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -724,4 +724,6 @@ genProtocolParameters =
     <*> return Nothing
     <*> return Nothing
     <*> return Nothing
+    <*> return Nothing
+    <*> return Nothing
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -522,6 +522,7 @@ genTxBodyContent era = do
 
   pure $ TxBodyContent
     { txIns = map (, BuildTxWith (KeyWitness KeyWitnessForSpending)) trxIns
+    , txInsCollateral = TxInsCollateralNone --TODO: Alonzo era: Generate collateral inputs.
     , txOuts = trxOuts
     , txFee = fee
     , txValidityRange = validityRange

--- a/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Api.Typed.Ord
+  ( tests
+  ) where
+
+import           Prelude
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Hedgehog (Property, discover, (===))
+import qualified Hedgehog as H
+import           Test.Tasty (TestTree)
+import           Test.Tasty.Hedgehog.Group (fromGroup)
+
+import           Test.Cardano.Api.Typed.Gen
+
+{- HLINT ignore "Use camelCase" -}
+
+
+ord_distributive :: (Show a, Ord a, Ord b)
+                      => H.Gen a -> (a -> b) -> Property
+ord_distributive gen to =
+    H.property $ do
+      x <- H.forAll gen
+      y <- H.forAll gen
+      compare x y === compare (to x) (to y)
+
+
+prop_ord_distributive_TxId :: Property
+prop_ord_distributive_TxId =
+    ord_distributive genTxId toShelleyTxId
+
+prop_ord_distributive_TxIn :: Property
+prop_ord_distributive_TxIn =
+    ord_distributive genTxIn toShelleyTxIn
+
+prop_ord_distributive_Address :: Property
+prop_ord_distributive_Address =
+    ord_distributive genAddressShelley (toShelleyAddr . toAddressInAnyEra)
+  where
+    toAddressInAnyEra :: Address ShelleyAddr -> AddressInEra ShelleyEra
+    toAddressInAnyEra = anyAddressInShelleyBasedEra . toAddressAny
+
+prop_ord_distributive_StakeAddress :: Property
+prop_ord_distributive_StakeAddress =
+    ord_distributive genStakeAddress toShelleyStakeAddr
+
+prop_ord_distributive_ScriptData :: Property
+prop_ord_distributive_ScriptData =
+    ord_distributive genScriptData toPlutusData
+
+-- -----------------------------------------------------------------------------
+
+tests :: TestTree
+tests = fromGroup $$discover
+

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -9,8 +9,9 @@ import           Cardano.Prelude
 import           Data.Aeson
 
 import           Cardano.Api
+import           Cardano.Api.Shelley
 
-import           Hedgehog (Property, discover)
+import           Hedgehog (Property, discover, (===))
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Aeson
 import           Test.Tasty (TestTree)
@@ -121,6 +122,12 @@ prop_roundtrip_SimpleScriptV2_JSON =
   H.property $ do
     mss <- H.forAll $ genSimpleScript SimpleScriptV2
     H.tripping mss encode eitherDecode
+
+prop_roundtrip_ScriptData :: Property
+prop_roundtrip_ScriptData =
+  H.property $ do
+    sData <- H.forAll genScriptData
+    sData === fromAlonzoData (toAlonzoData sData)
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -11,6 +11,7 @@ import qualified Test.Cardano.Api.Typed.Bech32
 import qualified Test.Cardano.Api.Typed.CBOR
 import qualified Test.Cardano.Api.Typed.Envelope
 import qualified Test.Cardano.Api.Typed.JSON
+import qualified Test.Cardano.Api.Typed.Ord
 import qualified Test.Cardano.Api.Typed.Script
 import qualified Test.Cardano.Api.Typed.RawBytes
 import qualified Test.Cardano.Api.Typed.Value
@@ -32,6 +33,7 @@ tests =
     , Test.Cardano.Api.Typed.CBOR.tests
     , Test.Cardano.Api.Typed.Envelope.tests
     , Test.Cardano.Api.Typed.JSON.tests
+    , Test.Cardano.Api.Typed.Ord.tests
     , Test.Cardano.Api.Typed.Script.tests
     , Test.Cardano.Api.Typed.RawBytes.tests
     ]

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -54,7 +54,7 @@ import           Cardano.Chain.Update (ApplicationName (..), InstallerHash (..),
                    ProtocolVersion (..), SoftforkRule (..), SoftwareVersion (..), SystemTag (..),
                    checkApplicationName, checkSystemTag)
 
-import           Cardano.Api hiding (UpdateProposal)
+import           Cardano.Api hiding (UpdateProposal, GenesisParameters)
 import           Cardano.Api.Byron (Address (..), ByronProtocolParametersUpdate (..), Lovelace (..),
                    toByronLovelace)
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -20,7 +20,7 @@ import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
 
-import           Cardano.Api hiding (UpdateProposal)
+import           Cardano.Api hiding (UpdateProposal, GenesisParameters)
 import           Cardano.Api.Byron (SomeByronSigningKey (..), Tx (..), VerificationKey (..))
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -160,6 +160,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             )
             TxMetadataNone
             TxAuxScriptsNone
+            TxAuxScriptDataNone
             TxExtraKeyWitnessesNone
             (BuildTxWith Nothing)
             TxWithdrawalsNone
@@ -198,6 +199,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                      )
                      TxMetadataNone
                      TxAuxScriptsNone
+                     TxAuxScriptDataNone
                      TxExtraKeyWitnessesNone
                      (BuildTxWith Nothing)
                      TxWithdrawalsNone

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -152,6 +152,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             [ (fromByronTxIn txIn
               , BuildTxWith (KeyWitness KeyWitnessForSpending))
             ]
+            TxInsCollateralNone
             outs
             (TxFeeImplicit TxFeesImplicitInByronEra)
             ( TxValidityNoLowerBound
@@ -189,6 +190,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                        , BuildTxWith (KeyWitness KeyWitnessForSpending)
                        ) | txIn <- txIns
                      ]
+                     TxInsCollateralNone
                      outs
                      (TxFeeImplicit TxFeesImplicitInByronEra)
                      ( TxValidityNoLowerBound

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2242,6 +2242,8 @@ pShelleyProtocolParametersUpdate =
     <*> pure Nothing
     <*> pure Nothing
     <*> pure Nothing
+    <*> pure Nothing
+    <*> pure Nothing
 
 pMinFeeLinearFactor :: Parser Natural
 pMinFeeLinearFactor =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -721,7 +721,12 @@ runTxCalculateMinValue protocolParamsSourceSpec value = do
         firstExceptT ShelleyTxCmdGenesisCmdError (readShelleyGenesis f identity)
     ParamsFromFile f -> readProtocolParameters f
 
-  let minValues = calcMinimumDeposit value (protocolParamMinUTxOValue pp)
+  let minValues =
+        case protocolParamMinUTxOValue pp of
+          Nothing -> panic "TODO alonzo: runTxCalculateMinValue using new protocol params"
+          --TODO alonzo: there is a new formula for the min amount of ada in
+          -- a tx output, which uses a new param protocolParamUTxOCostPerWord
+          Just minUTxOValue -> calcMinimumDeposit value minUTxOValue
 
   liftIO $ IO.print minValues
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -192,6 +192,7 @@ renderFeature TxFeatureMintValue            = "Asset minting"
 renderFeature TxFeatureMultiAssetOutputs    = "Multi-Asset outputs"
 renderFeature TxFeatureScriptWitnesses      = "Script witnesses"
 renderFeature TxFeatureShelleyKeys          = "Shelley keys"
+renderFeature TxFeatureCollateral           = "Collateral inputs"
 
 runTransactionCmd :: TransactionCmd -> ExceptT ShelleyTxCmdError IO ()
 runTransactionCmd cmd =
@@ -254,6 +255,7 @@ runTxBuildRaw (AnyCardanoEra era) inputsAndScripts txouts mLowerBound
     txBodyContent <-
       TxBodyContent
         <$> validateTxIns  era inputsAndScripts
+        <*> pure TxInsCollateralNone --TODO alonzo: support this
         <*> validateTxOuts era txouts
         <*> validateTxFee  era mFee
         <*> ((,) <$> validateTxValidityLowerBound era mLowerBound
@@ -295,6 +297,7 @@ data TxFeature = TxFeatureShelleyAddresses
                | TxFeatureMultiAssetOutputs
                | TxFeatureScriptWitnesses
                | TxFeatureShelleyKeys
+               | TxFeatureCollateral
   deriving Show
 
 txFeatureMismatch :: CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -262,6 +262,7 @@ runTxBuildRaw (AnyCardanoEra era) inputsAndScripts txouts mLowerBound
                  <*> validateTxValidityUpperBound era mUpperBound)
         <*> validateTxMetadataInEra  era metadataSchema metadataFiles
         <*> validateTxAuxScripts     era scriptFiles
+        <*> pure TxAuxScriptDataNone     --TODO alonzo: support this
         <*> pure TxExtraKeyWitnessesNone --TODO alonzo: support this
         <*> pure (BuildTxWith Nothing) --TODO alonzo: support this
         <*> validateTxWithdrawals    era withdrawals


### PR DESCRIPTION
Cover more of the Alonzo cases in the API: the Tx, TxBody, ProtocolParams and Query modules.

This PR does not extend the CLI is to use the features, that's for follow-up PRs.

The main remaining Alonzo TODO in the API are:
1. The optional network id. This is low priority and can be added once the rest is done.
2. The supplementary script data, but this is waiting on ledger changes to move the extra script data from the auxiliary section to the witness section.
