### PR TITLE
Bring back Windows and macOS builds on Hydra

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,7 @@
   "nodes": {
     "customConfig": {
       "locked": {
-        "narHash": "sha256-t+2eKBUm6IZfWfgPUBcTEP64FJorFcY30NgmqAjLrjI=",
+        "narHash": "sha256-NdBgwn6xJOM5j+T4ViTq+7FToInEbzvKcdOBpjQvILw=",
         "path": "./custom-config",
         "type": "path"
       },
@@ -14,16 +14,16 @@
     "haskellNix": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2009": "nixpkgs-2009",
+        "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1619745466,
-        "narHash": "sha256-C3WTy9vrViORxyFUOjCxZDkD10XpFiqxxnqTqpIdQk8=",
+        "lastModified": 1624855579,
+        "narHash": "sha256-B/UNX/U1JCGubX/upCRB5Y870CwH7FYxsGhPiLWyyWg=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "648e46ba3a235520f8be2f23bd6dda22525c61a1",
+        "rev": "3856d2d24dca0ecc71fcfc314253a2a2d07a3c4f",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1622462876,
-        "narHash": "sha256-ClUx0o46Gmmt6thY+Ti72LxbZGqQe3uQKYpYDdqK7DY=",
+        "lastModified": 1624583467,
+        "narHash": "sha256-lhdK/YbANfBWNqrWPX9nS6Oj1TX/zQgfbXgC13O2wN0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "7f57f750e27c84def8e0ed2492eea01ea957cbf2",
+        "rev": "baf39a5a5e782c934eab58337284d4c59c2c57c8",
         "type": "github"
       },
       "original": {
@@ -54,65 +54,65 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1624291665,
+        "narHash": "sha256-kNkaoa3dai9WOi7fsPklCCWZ8hRAkXx0ZUhpYKShyUk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1607708579,
-        "narHash": "sha256-QyADEDydJJPa8n3xawnA82IJAcZHNNm6Pp5DU7exMr4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       }
     },
     "nixpkgs-2009": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1624271064,
+        "narHash": "sha256-qns/uRW7MR2EfVf6VEeLgCsCp7pIOjDeR44JzTF09MA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1624291665,
+        "narHash": "sha256-kNkaoa3dai9WOi7fsPklCCWZ8hRAkXx0ZUhpYKShyUk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1612284693,
-        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "lastModified": 1623862044,
+        "narHash": "sha256-mY7nldu9Wl/Yb0qMPihZrWw0bRWXNsk6iyYztw/6F6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       }
     },
@@ -123,18 +123,18 @@
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-unstable"
+          "nixpkgs-2105"
         ],
         "utils": "utils"
       }
     },
     "utils": {
       "locked": {
-        "lastModified": 1619345332,
-        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    nixpkgs.follows = "haskellNix/nixpkgs-2105";
     utils.url = "github:numtide/flake-utils";
     iohkNix = {
       url = "github:input-output-hk/iohk-nix";

--- a/nix/binary-release.nix
+++ b/nix/binary-release.nix
@@ -19,7 +19,6 @@ let
 in pkgs.runCommand name {
     buildInputs = with pkgs.buildPackages; [
       zip
-      haskellBuildUtils.package
     ];
   } ''
   mkdir -p $out release

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -130,7 +130,7 @@ let
           export CARDANO_NODE_CHAIRMAN=${config.hsPkgs.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman${pkgs.stdenv.hostPlatform.extensions.executable}
           export CARDANO_NODE_SRC=${src}
         ";
-      }
+      })
       ({ pkgs, ... }: lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin) {
         # Needed for profiled builds to fix an issue loading recursion-schemes part of makeBaseFunctor
         # that is missing from the `_p` output.  See https://gitlab.haskell.org/ghc/ghc/-/issues/18320

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -130,9 +130,12 @@ let
           export CARDANO_NODE_CHAIRMAN=${config.hsPkgs.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman${pkgs.stdenv.hostPlatform.extensions.executable}
           export CARDANO_NODE_SRC=${src}
         ";
-
+      }
+      ({ pkgs, ... }: lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin) {
         # Needed for profiled builds to fix an issue loading recursion-schemes part of makeBaseFunctor
         # that is missing from the `_p` output.  See https://gitlab.haskell.org/ghc/ghc/-/issues/18320
+        # This work around currently breaks regular builds on macOS with:
+        # <no location info>: error: ghc: ghc-iserv terminated (-11)
         packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
       })
       {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -130,6 +130,10 @@ let
           export CARDANO_NODE_CHAIRMAN=${config.hsPkgs.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman${pkgs.stdenv.hostPlatform.extensions.executable}
           export CARDANO_NODE_SRC=${src}
         ";
+
+        # Needed for profiled builds to fix an issue loading recursion-schemes part of makeBaseFunctor
+        # that is missing from the `_p` output.  See https://gitlab.haskell.org/ghc/ghc/-/issues/18320
+        packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
       })
       {
         packages = lib.genAttrs projectPackages

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -7,7 +7,7 @@
 , haskell-nix
 , buildPackages
 # GHC attribute name
-, compiler
+, compiler-nix-name
 # Enable profiling
 , profiling ? false
 # Link with -eventlog
@@ -35,8 +35,7 @@
 
 , projectPackages ? lib.attrNames (haskell-nix.haskellLib.selectProjectPackages
     (haskell-nix.cabalProject' {
-      inherit src cabalProjectLocal;
-      compiler-nix-name = compiler;
+      inherit src cabalProjectLocal compiler-nix-name;
     }).hsPkgs)
 }:
 let
@@ -44,8 +43,7 @@ let
   # This creates the Haskell package set.
   # https://input-output-hk.github.io/haskell.nix/user-guide/projects/
   pkgSet = haskell-nix.cabalProject' ({
-    inherit src cabalProjectLocal;
-    compiler-nix-name = compiler;
+    inherit src cabalProjectLocal compiler-nix-name;
     modules = [
       # Allow reinstallation of Win32
       ({ pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -130,7 +130,7 @@ final: prev: with final;
   python38 = prev.python38.override {
     packageOverrides = pythonFinal: pythonPrev: {
       uvloop = pythonPrev.uvloop.overrideAttrs (attrs: {
-        disabledTestPaths = [ "tests/test_tcp.py" "tests/test_sourcecode.py" ];
+        disabledTestPaths = [ "tests/test_tcp.py" "tests/test_sourcecode.py" "tests/test_dns.py" ];
       });
     };
   };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,10 +1,10 @@
 # our packages overlay
 final: prev: with final;
   let
-    compiler = config.haskellNix.compiler or "ghc8105";
+    compiler-nix-name = config.haskellNix.compiler or "ghc8105";
   in {
   cardanoNodeProject = import ./haskell.nix {
-    inherit compiler
+    inherit compiler-nix-name
       pkgs
       lib
       stdenv
@@ -15,7 +15,7 @@ final: prev: with final;
   };
   cardanoNodeHaskellPackages = cardanoNodeProject.hsPkgs;
   cardanoNodeProfiledHaskellPackages = (import ./haskell.nix {
-    inherit compiler
+    inherit compiler-nix-name
       pkgs
       lib
       stdenv
@@ -28,7 +28,7 @@ final: prev: with final;
     profiling = true;
   }).hsPkgs;
   cardanoNodeEventlogHaskellPackages = (import ./haskell.nix {
-    inherit compiler
+    inherit compiler-nix-name
       pkgs
       lib
       stdenv
@@ -41,7 +41,7 @@ final: prev: with final;
     eventlog = true;
   }).hsPkgs;
   cardanoNodeAssertedHaskellPackages = (import ./haskell.nix {
-    inherit compiler
+    inherit compiler-nix-name
       pkgs
       lib
       stdenv
@@ -76,13 +76,18 @@ final: prev: with final;
   inherit (cardanoNodeHaskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
   inherit (cardanoNodeHaskellPackages.network-mux.components.exes) cardano-ping;
 
-  cabal = haskell-nix.tool compiler "cabal" {
+  cabal = haskell-nix.tool compiler-nix-name "cabal" {
     version = "latest";
     inherit (cardanoNodeProject) index-state;
   };
 
-  hlint = haskell-nix.tool compiler "hlint" {
+  hlint = haskell-nix.tool compiler-nix-name "hlint" {
     version = "3.2.7";
+    inherit (cardanoNodeProject) index-state;
+  };
+
+  haskellBuildUtils = prev.haskellBuildUtils.override {
+    inherit compiler-nix-name;
     inherit (cardanoNodeProject) index-state;
   };
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -125,4 +125,13 @@ final: prev: with final;
   };
 
   clusterTests = import ./supervisord-cluster/tests { inherit pkgs; };
+
+  # Disable failing python uvloop tests
+  python38 = prev.python38.override {
+    packageOverrides = pythonFinal: pythonPrev: {
+      uvloop = pythonPrev.uvloop.overrideAttrs (attrs: {
+        disabledTestPaths = [ "tests/test_tcp.py" "tests/test_sourcecode.py" ];
+      });
+    };
+  };
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,7 @@
 # our packages overlay
 final: prev: with final;
   let
-    compiler = config.haskellNix.compiler or "ghc8104";
+    compiler = config.haskellNix.compiler or "ghc8105";
   in {
   cardanoNodeProject = import ./haskell.nix {
     inherit compiler

--- a/release.nix
+++ b/release.nix
@@ -131,6 +131,9 @@ let
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [
     ["shell"] ["cardano-ping"] ["roots"]
+    [ "haskellPackages" "cardano-testnet" ]
+    [ "checks" "tests" "cardano-testnet" ]
+    [ "tests" "cardano-testnet" ]
   ] ++ onlyBuildOnDefaultSystem;
   noMusl64Build = [ ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ["plan-nix"]]
     ++ noCrossBuild;

--- a/release.nix
+++ b/release.nix
@@ -27,11 +27,11 @@
 # Build for linux
 , linuxBuild ? builtins.elem "x86_64-linux" supportedSystems
 
-# PR #2657 Temporarily disable macos build
-, macosBuild ? false
+# Build for macos
+, macosBuild ? builtins.elem "x86_64-darwin" supportedSystems
 
-# PR #2657 Temporarily disable mingw32 cross build
-, windowsBuild ? false
+# Cross compilation to Windows is currently only supported on linux.
+, windowsBuild ? builtins.elem "x86_64-linux" supportedCrossSystems
 
 # A Hydra option
 , scrubJobs ? true
@@ -195,7 +195,6 @@ let
       [ jobs.cardano-node-linux ]
     ]))
     # macOS builds:
-    # NB. you can replace macosBuild with false to remove these jobs from "required"
     (optionals macosBuild (concatLists [
       (collectJobs jobs.macos.checks)
       (collectJobs jobs.macos.nixosTests)
@@ -204,7 +203,6 @@ let
       [ jobs.cardano-node-macos ]
     ]))
     # Windows builds:
-    # NB. you can replace windowsBuild with false to remove these jobs from "required"
     (optional windowsBuild jobs.cardano-node-win64)
     (optionals windowsBuild (collectJobs jobs.windows.checks))
     # Default system builds (linux on hydra):

--- a/shell.nix
+++ b/shell.nix
@@ -72,7 +72,8 @@ let
     tools = {
       haskell-language-server = {
         version = "latest";
-        inherit (cardanoNodeProject) index-state;
+        index-state = "2021-06-22T00:00:00Z";
+        # inherit (cardanoNodeProject) index-state;
       };
     };
 


### PR DESCRIPTION
The Windows and macOS builds were disabled in #2657 so that at least something could be merged.

- [x] Revert commit 8c0e2e9a152c3e240ce5957618e2ca88ae8aab0b.
- [ ] Fix failed build of `plutus-core:library:plutus-core` when cross-compiling to windows.

See [Hydra jobset for PR #2768](https://hydra.iohk.io/jobset/Cardano/cardano-node-pr-2768#tabs-jobs)

cc: @Jimbo4350 @disassembler @jbgi 
