### PR TITLE
If only one of IPv4 / IPv6 is configured, try the other protocol silently

### DIFF
--- a/cardano-node/src/Cardano/Node/Configuration/Socket.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Socket.hs
@@ -169,6 +169,21 @@ gatherConfiguredSockets NodeConfiguration { ncNodeIPv4Addr,
 
               pure (ipv4', ipv6')
 
+            -- When IPv4 host is specified, try IPv6, but do not fail if missing.
+            -- Very relevant if operator is using RFC4941 on their block producing-node.
+            (_, Nothing) -> do
+              info <- nodeAddressInfo Nothing ncNodePortNumber
+              let ipv6' = SocketInfo <$> find ((== AF_INET6) . addrFamily) info
+              
+              pure (ipv4, ipv6')
+
+            -- When IPv6 host is specified, try IPv4, but do not fail if missing.
+            (Nothing, _) -> do
+              info <- nodeAddressInfo Nothing ncNodePortNumber
+              let ipv4' = SocketInfo <$> find ((== AF_INET)  . addrFamily) info
+              
+              pure (ipv4', ipv6)
+
             _ -> pure (ipv4, ipv6)
 
 


### PR DESCRIPTION
Do not fail if it is missing, unlike when both IPv4 and IPv6 are missing.

should fix #2732

I am not sure if this is the best way to fix it, but currently the problem is that even if a host is IPv6-enabled but only has an IPv4 host address specified when starting the node, it cannot connect to IPv6 addresses. When the P2P protcol is going live, making sure both IPv4 and IPv6 work is even more important I reckon.

In the current situation IOHK relay DNS names do not return AAAA records. Even if AAAA records would be added now, not a single relay that has **only** an IPv4 host address specified will be able to connect to any of the IPv6 addresses, even though they might be fully IPv6 capable. Unless DNS entries are handled differently that is.

If neither IPv4 or IPv6 is specified, node can connect to IPv6 just fine.