### PR TITLE
Alonzo support for protocol parameter updates

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,3 +65,7 @@
 - ignore:
     name: Use camelCase
     within: Test.Cardano.Api.KeysByron
+- ignore:
+    name: Use camelCase
+    within: Test.Cardano.Api.Typed.JSON
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -61,3 +61,7 @@
 
 # To generate a suitable file for HLint do:
 # $ hlint --default > .hlint.yaml
+
+- ignore:
+    name: Use camelCase
+    within: Test.Cardano.Api.KeysByron

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -78,6 +78,7 @@ library
                         Cardano.Api.SerialiseJSON
                         Cardano.Api.SerialiseRaw
                         Cardano.Api.SerialiseTextEnvelope
+                        Cardano.Api.SerialiseUsing
                         Cardano.Api.Shelley.Genesis
                         Cardano.Api.SpecialByron
                         Cardano.Api.StakePoolMetadata

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -179,6 +179,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Gen
                         Test.Cardano.Api.Genesis
                         Test.Cardano.Api.Json
+                        Test.Cardano.Api.KeysByron
                         Test.Cardano.Api.Ledger
                         Test.Cardano.Api.Metadata
                         Test.Cardano.Api.Typed.Bech32
@@ -191,6 +192,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Typed.RawBytes
                         Test.Cardano.Api.Typed.Script
                         Test.Cardano.Api.Typed.Value
+                        Test.Cardano.Crypto.Seed.Gen
                         Test.Tasty.Hedgehog.Group
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -297,6 +297,7 @@ module Cardano.Api (
     SimpleScriptVersion(..),
     PlutusScriptVersion(..),
     AnyScriptLanguage(..),
+    AnyPlutusScriptVersion(..),
     IsScriptLanguage(..),
     IsSimpleScriptLanguage(..),
 
@@ -357,6 +358,9 @@ module Cardano.Api (
 
     -- * Script execution units
     ExecutionUnits(..),
+    ExecutionUnitPrices(..),
+    CostModel(..),
+    validateCostModel,
 
     -- ** Script addresses
     -- | Making addresses from scripts.

--- a/cardano-api/src/Cardano/Api/KeysByron.hs
+++ b/cardano-api/src/Cardano/Api/KeysByron.hs
@@ -155,6 +155,8 @@ instance SerialiseAsRawBytes (SigningKey ByronKey) where
 newtype instance Hash ByronKey = ByronKeyHash Byron.KeyHash
   deriving (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash ByronKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash ByronKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash ByronKey) where
     serialiseToRawBytes (ByronKeyHash (Byron.KeyHash vkh)) =
@@ -224,6 +226,8 @@ instance HasTextEnvelope (SigningKey ByronKeyLegacy) where
 newtype instance Hash ByronKeyLegacy = ByronKeyHashLegacy Byron.KeyHash
   deriving (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash ByronKeyLegacy)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash ByronKeyLegacy)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash ByronKeyLegacy) where
     serialiseToRawBytes (ByronKeyHashLegacy (Byron.KeyHash vkh)) =

--- a/cardano-api/src/Cardano/Api/KeysByron.hs
+++ b/cardano-api/src/Cardano/Api/KeysByron.hs
@@ -59,6 +59,7 @@ import           Cardano.Api.KeysShelley
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 
 
 -- | Byron-era payment keys. Used for Byron addresses and witnessing

--- a/cardano-api/src/Cardano/Api/KeysPraos.hs
+++ b/cardano-api/src/Cardano/Api/KeysPraos.hs
@@ -118,7 +118,9 @@ newtype instance Hash KesKey =
     KesKeyHash (Shelley.Hash StandardCrypto
                              (Shelley.VerKeyKES StandardCrypto))
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash VrfKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash KesKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash KesKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash KesKey) where
     serialiseToRawBytes (KesKeyHash vkh) =
@@ -213,6 +215,8 @@ newtype instance Hash VrfKey =
                              (Shelley.VerKeyVRF StandardCrypto))
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash VrfKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash VrfKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash VrfKey) where
     serialiseToRawBytes (VrfKeyHash vkh) =

--- a/cardano-api/src/Cardano/Api/KeysPraos.hs
+++ b/cardano-api/src/Cardano/Api/KeysPraos.hs
@@ -41,6 +41,7 @@ import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 
 
 --

--- a/cardano-api/src/Cardano/Api/KeysShelley.hs
+++ b/cardano-api/src/Cardano/Api/KeysShelley.hs
@@ -60,6 +60,7 @@ import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 
 
 --

--- a/cardano-api/src/Cardano/Api/KeysShelley.hs
+++ b/cardano-api/src/Cardano/Api/KeysShelley.hs
@@ -139,6 +139,8 @@ newtype instance Hash PaymentKey =
     PaymentKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash PaymentKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash PaymentKey) where
     serialiseToRawBytes (PaymentKeyHash (Shelley.KeyHash vkh)) =
@@ -278,7 +280,9 @@ instance SerialiseAsBech32 (SigningKey PaymentExtendedKey) where
 newtype instance Hash PaymentExtendedKey =
     PaymentExtendedKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentExtendedKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash PaymentExtendedKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash PaymentExtendedKey) where
     serialiseToRawBytes (PaymentExtendedKeyHash (Shelley.KeyHash vkh)) =
@@ -378,7 +382,9 @@ instance SerialiseAsBech32 (SigningKey StakeKey) where
 newtype instance Hash StakeKey =
     StakeKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash StakeKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakeKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash StakeKey) where
     serialiseToRawBytes (StakeKeyHash (Shelley.KeyHash vkh)) =
@@ -518,7 +524,9 @@ instance SerialiseAsBech32 (SigningKey StakeExtendedKey) where
 newtype instance Hash StakeExtendedKey =
     StakeExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash StakeExtendedKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakeExtendedKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash StakeExtendedKey) where
     serialiseToRawBytes (StakeExtendedKeyHash (Shelley.KeyHash vkh)) =
@@ -610,7 +618,9 @@ instance SerialiseAsRawBytes (SigningKey GenesisKey) where
 newtype instance Hash GenesisKey =
     GenesisKeyHash (Shelley.KeyHash Shelley.Genesis StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash GenesisKey) where
     serialiseToRawBytes (GenesisKeyHash (Shelley.KeyHash vkh)) =
@@ -739,7 +749,9 @@ instance SerialiseAsRawBytes (SigningKey GenesisExtendedKey) where
 newtype instance Hash GenesisExtendedKey =
     GenesisExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisExtendedKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisExtendedKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash GenesisExtendedKey) where
     serialiseToRawBytes (GenesisExtendedKeyHash (Shelley.KeyHash vkh)) =
@@ -832,7 +844,9 @@ instance SerialiseAsRawBytes (SigningKey GenesisDelegateKey) where
 newtype instance Hash GenesisDelegateKey =
     GenesisDelegateKeyHash (Shelley.KeyHash Shelley.GenesisDelegate StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisDelegateKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisDelegateKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash GenesisDelegateKey) where
     serialiseToRawBytes (GenesisDelegateKeyHash (Shelley.KeyHash vkh)) =
@@ -969,7 +983,9 @@ instance SerialiseAsRawBytes (SigningKey GenesisDelegateExtendedKey) where
 newtype instance Hash GenesisDelegateExtendedKey =
     GenesisDelegateExtendedKeyHash (Shelley.KeyHash Shelley.Staking StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisDelegateExtendedKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisDelegateExtendedKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash GenesisDelegateExtendedKey) where
     serialiseToRawBytes (GenesisDelegateExtendedKeyHash (Shelley.KeyHash vkh)) =
@@ -1062,7 +1078,9 @@ instance SerialiseAsRawBytes (SigningKey GenesisUTxOKey) where
 newtype instance Hash GenesisUTxOKey =
     GenesisUTxOKeyHash (Shelley.KeyHash Shelley.Payment StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisUTxOKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisUTxOKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash GenesisUTxOKey) where
     serialiseToRawBytes (GenesisUTxOKeyHash (Shelley.KeyHash vkh)) =
@@ -1166,7 +1184,9 @@ instance SerialiseAsBech32 (SigningKey StakePoolKey) where
 newtype instance Hash StakePoolKey =
     StakePoolKeyHash (Shelley.KeyHash Shelley.StakePool StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, IsString) via UsingRawBytesHex (Hash StakePoolKey)
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakePoolKey)
+  deriving anyclass SerialiseAsCBOR
 
 instance SerialiseAsRawBytes (Hash StakePoolKey) where
     serialiseToRawBytes (StakePoolKeyHash (Shelley.KeyHash vkh)) =

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -147,6 +147,7 @@ import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 
 {- HLINT ignore "Use section" -}
 

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -51,7 +51,6 @@ import qualified Data.Vector as Vector
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Text as Aeson.Text
-import qualified Data.Aeson.Types as Aeson
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 
 import           Control.Applicative (Alternative (..))
@@ -99,7 +98,9 @@ instance HasTypeProxy ScriptData where
 newtype instance Hash ScriptData =
     ScriptDataHash (Alonzo.DataHash StandardCrypto)
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash ScriptData)
+  deriving (Show, IsString)         via UsingRawBytesHex (Hash ScriptData)
+  deriving (ToJSON, FromJSON)       via UsingRawBytesHex (Hash ScriptData)
+  deriving (ToJSONKey, FromJSONKey) via UsingRawBytesHex (Hash ScriptData)
 
 instance SerialiseAsRawBytes (Hash ScriptData) where
     serialiseToRawBytes (ScriptDataHash dh) =
@@ -107,12 +108,6 @@ instance SerialiseAsRawBytes (Hash ScriptData) where
 
     deserialiseFromRawBytes (AsHash AsScriptData) bs =
       ScriptDataHash . Ledger.unsafeMakeSafeHash <$> Crypto.hashFromBytes bs
-
-instance ToJSON (Hash ScriptData) where
-    toJSON = toJSON . serialiseToRawBytesHexText
-
-instance Aeson.ToJSONKey (Hash ScriptData) where
-    toJSONKey = Aeson.toJSONKeyText serialiseToRawBytesHexText
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -69,6 +69,7 @@ import           Cardano.Api.Hash
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
 import           Cardano.Api.TxMetadata (parseAll, pSigned, pBytes)
 
 

--- a/cardano-api/src/Cardano/Api/SerialiseJSON.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseJSON.hs
@@ -4,9 +4,11 @@
 module Cardano.Api.SerialiseJSON
   ( serialiseToJSON
   , ToJSON(..)
+  , ToJSONKey
   , deserialiseFromJSON
   , prettyPrintJSON
   , FromJSON(..)
+  , FromJSONKey
   , JsonDecodeError(..)
   , readFileJSON
   , writeFileJSON
@@ -16,7 +18,7 @@ import           Prelude
 
 import           Control.Monad.Trans.Except (runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
-import           Data.Aeson (FromJSON (..), ToJSON (..))
+import           Data.Aeson (FromJSON (..), ToJSON (..), ToJSONKey, FromJSONKey)
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.ByteString (ByteString)

--- a/cardano-api/src/Cardano/Api/SerialiseRaw.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseRaw.hs
@@ -7,15 +7,12 @@ module Cardano.Api.SerialiseRaw
   , serialiseToRawBytesHex
   , deserialiseFromRawBytesHex
   , serialiseToRawBytesHexText
-  , UsingRawBytesHex(..)
   ) where
 
 import           Prelude
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Char8 as BSC
-import           Data.String (IsString (..))
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 
@@ -40,26 +37,3 @@ deserialiseFromRawBytesHex proxy hex =
     case Base16.decode hex of
       Right raw -> deserialiseFromRawBytes proxy raw
       Left _msg -> Nothing
-
-
--- | For use with @deriving via@, to provide 'Show' and\/or 'IsString' instances
--- using a hex encoding, based on the 'SerialiseAsRawBytes' instance.
---
--- > deriving (Show, IsString) via (UsingRawBytesHex Blah)
---
-newtype UsingRawBytesHex a = UsingRawBytesHex a
-
-instance SerialiseAsRawBytes a => Show (UsingRawBytesHex a) where
-    show (UsingRawBytesHex x) = show (serialiseToRawBytesHex x)
-
-instance SerialiseAsRawBytes a => IsString (UsingRawBytesHex a) where
-    fromString str =
-      case Base16.decode (BSC.pack str) of
-        Right raw -> case deserialiseFromRawBytes ttoken raw of
-          Just x  -> UsingRawBytesHex x
-          Nothing -> error ("fromString: cannot deserialise " ++ show str)
-        Left msg -> error ("fromString: invalid hex " ++ show str ++ ", " ++ msg)
-      where
-        ttoken :: AsType a
-        ttoken = proxyToAsType Proxy
-

--- a/cardano-api/src/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseUsing.hs
@@ -5,6 +5,7 @@
 module Cardano.Api.SerialiseUsing
   ( UsingRawBytes(..)
   , UsingRawBytesHex(..)
+  , UsingBech32(..)
   ) where
 
 import           Prelude
@@ -12,13 +13,16 @@ import           Prelude
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BSC
 import           Data.String (IsString (..))
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable
 
 import           Data.Aeson (ToJSONKey(..), FromJSONKey(..))
 import qualified Data.Aeson.Types as Aeson
 
+import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
@@ -88,3 +92,41 @@ instance (SerialiseAsRawBytes a, Typeable a) => FromJSON (UsingRawBytesHex a) wh
 instance SerialiseAsRawBytes a => ToJSONKey (UsingRawBytesHex a)
 instance (SerialiseAsRawBytes a, Typeable a) => FromJSONKey (UsingRawBytesHex a)
 
+
+-- | For use with @deriving via@, to provide instances for any\/all of 'Show',
+-- 'IsString', 'ToJSON', 'FromJSON', 'ToJSONKey', FromJSONKey' using a bech32
+-- encoding, based on the 'SerialiseAsBech32' instance.
+--
+-- > deriving (Show, IsString) via (UsingBech32 Blah)
+-- > deriving (ToJSON, FromJSON) via (UsingBech32 Blah)
+-- > deriving (ToJSONKey, FromJSONKey) via (UsingBech32 Blah)
+--
+newtype UsingBech32 a = UsingBech32 a
+
+instance SerialiseAsBech32 a => Show (UsingBech32 a) where
+    show (UsingBech32 x) = show (serialiseToBech32 x)
+
+instance SerialiseAsBech32 a => IsString (UsingBech32 a) where
+    fromString str =
+      case deserialiseFromBech32 ttoken (Text.pack str) of
+        Right x  -> UsingBech32 x
+        Left  e -> error ("fromString: " ++ show str ++ ": " ++ displayError e)
+      where
+        ttoken :: AsType a
+        ttoken = proxyToAsType Proxy
+
+instance SerialiseAsBech32 a => ToJSON (UsingBech32 a) where
+    toJSON (UsingBech32 x) = toJSON (serialiseToBech32 x)
+
+instance (SerialiseAsBech32 a, Typeable a) => FromJSON (UsingBech32 a) where
+    parseJSON =
+      Aeson.withText tname $ \str ->
+        case deserialiseFromBech32 ttoken str of
+          Right x -> return (UsingBech32 x)
+          Left  e -> fail (show str ++ ": " ++ displayError e)
+      where
+        ttoken = proxyToAsType (Proxy :: Proxy a)
+        tname  = (tyConName . typeRepTyCon . typeRep) (Proxy :: Proxy a)
+
+instance SerialiseAsBech32 a => ToJSONKey (UsingBech32 a)
+instance (SerialiseAsBech32 a, Typeable a) => FromJSONKey (UsingBech32 a)

--- a/cardano-api/src/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseUsing.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Raw binary serialisation
+--
+module Cardano.Api.SerialiseUsing
+  ( UsingRawBytesHex(..)
+  ) where
+
+import           Prelude
+
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BSC
+import           Data.String (IsString (..))
+import           Data.Typeable
+
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseRaw
+
+
+
+-- | For use with @deriving via@, to provide instances for any\/all of 'Show',
+-- 'IsString', 'ToJSON', 'FromJSON', 'ToJSONKey', FromJSONKey' using a hex
+-- encoding, based on the 'SerialiseAsRawBytes' instance.
+--
+-- > deriving (Show, IsString) via (UsingRawBytesHex Blah)
+-- > deriving (ToJSON, FromJSON) via (UsingRawBytesHex Blah)
+-- > deriving (ToJSONKey, FromJSONKey) via (UsingRawBytesHex Blah)
+--
+newtype UsingRawBytesHex a = UsingRawBytesHex a
+
+instance SerialiseAsRawBytes a => Show (UsingRawBytesHex a) where
+    show (UsingRawBytesHex x) = show (serialiseToRawBytesHex x)
+
+instance SerialiseAsRawBytes a => IsString (UsingRawBytesHex a) where
+    fromString str =
+      case Base16.decode (BSC.pack str) of
+        Right raw -> case deserialiseFromRawBytes ttoken raw of
+          Just x  -> UsingRawBytesHex x
+          Nothing -> error ("fromString: cannot deserialise " ++ show str)
+        Left msg -> error ("fromString: invalid hex " ++ show str ++ ", " ++ msg)
+      where
+        ttoken :: AsType a
+        ttoken = proxyToAsType Proxy

--- a/cardano-api/src/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseUsing.hs
@@ -17,7 +17,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable
 
-import           Data.Aeson (ToJSONKey(..), FromJSONKey(..))
 import qualified Data.Aeson.Types as Aeson
 
 import           Cardano.Api.Error

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -2096,7 +2096,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
     case txProtocolParams of
       BuildTxWith Nothing | not (Set.null languages)
         -> Left TxBodyMissingProtocolParams
-      _ -> return ()
+      _ -> return () --TODO alonzo: validate protocol params for the Alonzo era.
+                     --             All the necessary params must be provided.
 
     return $
       ShelleyTxBody era

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -72,11 +72,13 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Coin as Shelley
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Shelley
+import           Cardano.Ledger.Crypto (StandardCrypto)
 
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseRaw
-import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Api.SerialiseUsing
+
 
 -- ----------------------------------------------------------------------------
 -- Lovelace

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -137,7 +137,7 @@ quantityToLovelace (Quantity x) = Lovelace x
 
 newtype PolicyId = PolicyId ScriptHash
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex PolicyId
+  deriving (Show, IsString, ToJSON, FromJSON) via UsingRawBytesHex PolicyId
 
 instance HasTypeProxy PolicyId where
     data AsType PolicyId = AsPolicyId

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -76,6 +76,7 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Script
+import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseUsing
 
@@ -85,8 +86,8 @@ import           Cardano.Api.SerialiseUsing
 --
 
 newtype Lovelace = Lovelace Integer
-  deriving stock (Show)
-  deriving newtype (Eq, Ord, Enum, Num, ToJSON, FromJSON)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (Enum, Num, ToJSON, FromJSON, ToCBOR, FromCBOR)
 
 instance Semigroup Lovelace where
   Lovelace a <> Lovelace b = Lovelace (a + b)

--- a/cardano-api/test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/Test/Cardano/Api/KeysByron.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Api.KeysByron
+  ( tests
+  ) where
+
+import           Cardano.Api
+import           Cardano.Prelude
+import           Hedgehog (Gen, Property, discover)
+import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Tasty (TestTree)
+import           Test.Tasty.Hedgehog.Group (fromGroup)
+
+import qualified Hedgehog as H
+import qualified Test.Cardano.Crypto.Seed.Gen as Gen
+
+{- HLINT ignore "Use camelCase" -}
+
+prop_roundtrip_byron_key_CBOR :: Property
+prop_roundtrip_byron_key_CBOR =
+  roundtrip_CBOR (AsSigningKey AsByronKey) (deterministicSigningKey AsByronKey <$> Gen.genSeedForKey AsByronKey)
+
+roundtrip_CBOR
+  :: (SerialiseAsCBOR a, Eq a, Show a)
+  => AsType a -> Gen a -> Property
+roundtrip_CBOR typeProxy gen =
+  H.property $ do
+    val <- H.forAll gen
+    H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
+
+tests :: TestTree
+tests = fromGroup $$discover

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -147,6 +147,11 @@ prop_roundtrip_script_PlutusScriptV1_CBOR =
   roundtrip_CBOR (AsScript AsPlutusScriptV1)
                  (genScript (PlutusScriptLanguage PlutusScriptV1))
 
+prop_roundtrip_UpdateProposal_CBOR :: Property
+prop_roundtrip_UpdateProposal_CBOR =
+  roundtrip_CBOR AsUpdateProposal genUpdateProposal
+
+
 -- -----------------------------------------------------------------------------
 
 roundtrip_CBOR

--- a/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Gen.hs
@@ -7,6 +7,7 @@ module Test.Cardano.Api.Typed.Gen
   ( genAddressByron
   , genAddressShelley
   , genMaybePraosNonce
+  , genPraosNonce
   , genProtocolParameters
   , genValueNestedRep
   , genValueNestedBundle
@@ -693,9 +694,11 @@ genRational = Gen.realFrac_ (Range.linearFrac 0 1)
 genEpochNo :: Gen EpochNo
 genEpochNo = EpochNo <$> Gen.word64 (Range.linear 0 10)
 
+genPraosNonce :: Gen PraosNonce
+genPraosNonce = makePraosNonce <$> Gen.bytes (Range.linear 0 32)
+
 genMaybePraosNonce :: Gen (Maybe PraosNonce)
-genMaybePraosNonce =
-  Gen.maybe (makePraosNonce <$> Gen.bytes (Range.linear 0 32))
+genMaybePraosNonce = Gen.maybe genPraosNonce
 
 genProtocolParameters :: Gen ProtocolParameters
 genProtocolParameters =

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -1,22 +1,27 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
 import           Cardano.Prelude
-
 import           Data.Aeson
-
 import           Hedgehog (Property, discover, forAll, tripping)
-import qualified Hedgehog as H
-import qualified Hedgehog.Gen as Gen
+import           Test.Cardano.Api.Typed.Gen
+import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog.Group (fromGroup)
 
-import           Test.Cardano.Api.Typed.Gen
-
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Crypto/Seed/Gen.hs
+++ b/cardano-api/test/Test/Cardano/Crypto/Seed/Gen.hs
@@ -1,0 +1,22 @@
+module Test.Cardano.Crypto.Seed.Gen
+  ( genSeed
+  , genSeedForKey
+  ) where
+
+import           Cardano.Api (AsType, Key)
+import           Cardano.Crypto.Seed (Seed)
+import           Data.Functor ((<$>))
+import           Data.Int (Int)
+import           Hedgehog (MonadGen, Range)
+import           Prelude (fromIntegral)
+
+import qualified Cardano.Api as API
+import qualified Cardano.Crypto.Seed as C
+import qualified Hedgehog.Gen as G
+import qualified Hedgehog.Range as R
+
+genSeed :: MonadGen m => Range Int -> m Seed
+genSeed r = C.mkSeedFromBytes <$> G.bytes r
+
+genSeedForKey :: (Key key, MonadGen m) => AsType key -> m Seed
+genSeedForKey keyRole = genSeed (R.singleton (fromIntegral (API.deterministicSigningKeySeedSize keyRole)))

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -6,6 +6,7 @@ import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Json
+import qualified Test.Cardano.Api.KeysByron
 import qualified Test.Cardano.Api.Ledger
 import qualified Test.Cardano.Api.Metadata
 import qualified Test.Cardano.Api.Typed.Bech32
@@ -26,9 +27,9 @@ main = do
 tests :: TestTree
 tests =
   testGroup "Cardano.Api"
-    [ Test.Cardano.Api.Typed.Value.tests
-    , Test.Cardano.Api.Crypto.tests
+    [ Test.Cardano.Api.Crypto.tests
     , Test.Cardano.Api.Json.tests
+    , Test.Cardano.Api.KeysByron.tests
     , Test.Cardano.Api.Ledger.tests
     , Test.Cardano.Api.Metadata.tests
     , Test.Cardano.Api.Typed.Bech32.tests
@@ -36,6 +37,7 @@ tests =
     , Test.Cardano.Api.Typed.Envelope.tests
     , Test.Cardano.Api.Typed.JSON.tests
     , Test.Cardano.Api.Typed.Ord.tests
-    , Test.Cardano.Api.Typed.Script.tests
     , Test.Cardano.Api.Typed.RawBytes.tests
+    , Test.Cardano.Api.Typed.Script.tests
+    , Test.Cardano.Api.Typed.Value.tests
     ]


### PR DESCRIPTION
Add direct serialisation instances for UpdateProposal and related types. Extend the CLI for the new parameters.

Also refactor the "deriving via" machinery to make some of the instances simpler.

Add more round trip tests for the protocol params and related types.