### PR TITLE
Fix the cli parser for the --redeemer-value --execution-units flags

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -267,7 +267,7 @@ pScriptWitnessFiles witctx scriptFlagPrefix scriptFlagPrefixDeprecated help =
 
     pScriptDataFile dataFlagPrefix =
       Opt.strOption
-        (  Opt.long (dataFlagPrefix ++ "-file")
+        (  Opt.long (scriptFlagPrefix ++ "-" ++ dataFlagPrefix ++ "-file")
         <> Opt.metavar "FILE"
         <> Opt.help ("The file containing the script input "
                     ++ dataFlagPrefix ++ ".")
@@ -275,7 +275,7 @@ pScriptWitnessFiles witctx scriptFlagPrefix scriptFlagPrefixDeprecated help =
 
     pScriptDataValue dataFlagPrefix =
       Opt.option readerScriptData
-        (  Opt.long (dataFlagPrefix ++ "-value")
+        (  Opt.long (scriptFlagPrefix ++ "-" ++ dataFlagPrefix ++ "-value")
         <> Opt.metavar "JSON"
         <> Opt.help ("The value for the script input " ++ dataFlagPrefix ++ ".")
         )
@@ -290,7 +290,7 @@ pScriptWitnessFiles witctx scriptFlagPrefix scriptFlagPrefixDeprecated help =
     pExecutionUnits =
       uncurry ExecutionUnits <$>
       Opt.option Opt.auto
-        (  Opt.long "execution-units"
+        (  Opt.long (scriptFlagPrefix ++ "-execution-units")
         <> Opt.metavar "(INT, INT)"
         <> Opt.help "The time and space units needed by the script."
         )


### PR DESCRIPTION
The cli parser apparently cannot cope with the same flag name being
reused in different contexts, so fix it by prefix these flags with the
context, so instead of just --redeemer-file or --redeemer-value, it's
--tx-in-redeemer-file or --tx-in-redeemer-value.

Similarly for --mint-redeemer-value --mint-execution-units etc.