### PR TITLE
CAD 2907: Alonzo support in the workbench

### DIFF
--- a/nix/workbench/profile.sh
+++ b/nix/workbench/profile.sh
@@ -14,6 +14,7 @@ global_profile_eras=(
     shelley
     allegra
     mary
+    alonzo
 )
 
 profile() {

--- a/nix/workbench/profiles/defaults.jq
+++ b/nix/workbench/profiles/defaults.jq
@@ -91,4 +91,8 @@ def era_defaults($era):
 , mary:
   {
   }
+
+, alonzo:
+  {
+  }
 } | (.common * .[$era]);

--- a/nix/workbench/profiles/node-services.nix
+++ b/nix/workbench/profiles/node-services.nix
@@ -40,6 +40,7 @@ let
           shelley = { Shelley = 0; };
           allegra = { Shelley = 0; Allegra = 0; };
           mary    = { Shelley = 0; Allegra = 0; Mary = 0; };
+          alonzo  = { Shelley = 0; Allegra = 0; Mary = 0; Alonzo = 0; };
         }.${profile.value.era};
 
       nodeConfig =

--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,7 @@ let
     { useCabalRun }:
     callPackage ./nix/supervisord-cluster
       { inherit useCabalRun;
+        profileName = clusterProfile;
         workbench = pkgs.callPackage ./nix/workbench { inherit useCabalRun; };
       };
 


### PR DESCRIPTION
1. Add Alonzo profiles into the workbench and
2. Fix a small bug that prevented profile names from being properly passed through

Test with:

```make cls cluster-shell CLUSTER_PROFILE=default-alzo```