### PR TITLE
Add a missing case for Alonzo support for language simple script v1

### DIFF
--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -539,6 +539,9 @@ scriptLanguageSupportedInEra era lang =
       (MaryEra, SimpleScriptLanguage SimpleScriptV2) ->
         Just SimpleScriptV2InMary
 
+      (AlonzoEra, SimpleScriptLanguage SimpleScriptV1) ->
+        Just SimpleScriptV1InAlonzo
+
       (AlonzoEra, SimpleScriptLanguage SimpleScriptV2) ->
         Just SimpleScriptV2InAlonzo
 


### PR DESCRIPTION
Oops.
```
transaction build-raw Error: The script language SimpleScriptLanguage SimpleScriptV1 is not supported in the Alonzo era.
```
Fill in the missing case.