### PR TITLE
Add cardano-cli transaction hash-script-data

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -346,6 +346,7 @@ module Cardano.Api (
 
     -- * Script data
     ScriptData(..),
+    hashScriptData,
 
     -- ** Validation
     ScriptDataRangeError (..),

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -7,6 +7,9 @@ module Cardano.Api.ScriptData (
     -- * Script data
     ScriptData(..),
 
+    -- * Script data hashes
+    hashScriptData,
+
     -- * Validating metadata
     validateScriptData,
     ScriptDataRangeError (..),
@@ -57,7 +60,7 @@ import           Control.Applicative (Alternative (..))
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.SafeHash as Ledger
-import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto, StandardAlonzo)
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Plutus.V1.Ledger.Api as Plutus
 
@@ -108,6 +111,12 @@ instance SerialiseAsRawBytes (Hash ScriptData) where
 
     deserialiseFromRawBytes (AsHash AsScriptData) bs =
       ScriptDataHash . Ledger.unsafeMakeSafeHash <$> Crypto.hashFromBytes bs
+
+
+hashScriptData :: ScriptData -> Hash ScriptData
+hashScriptData = ScriptDataHash
+               . Alonzo.hashData
+               . (toAlonzoData :: ScriptData -> Alonzo.Data StandardAlonzo)
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -201,6 +201,8 @@ data TransactionCmd
   | TxCalculateMinValue
       ProtocolParamsSourceSpec
       Value
+  | TxHashScriptData
+      ScriptDataOrFile
   | TxGetTxId InputTxFile
   | TxView InputTxFile
   deriving Show
@@ -230,6 +232,7 @@ renderTransactionCmd cmd =
     TxMintedPolicyId {} -> "transaction policyid"
     TxCalculateMinFee {} -> "transaction calculate-min-fee"
     TxCalculateMinValue {} -> "transaction calculate-min-value"
+    TxHashScriptData {} -> "transaction hash-script-data"
     TxGetTxId {} -> "transaction txid"
     TxView {} -> "transaction view"
 


### PR DESCRIPTION
Needed as a util for helping to build txs that use Plutus scripts.

Example:
```
> cardano-cli transaction hash-script-data --script-data-value 42
9e1199a988ba72ffd6e9c269cadb3b53b5f360ff99f112d9b2ee30c4d74ad88b
```