### PR TITLE
Rename byron-shelley testnet to cardano-shelley testnet.

### DIFF
--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -42,7 +42,7 @@ common common-modules
   other-modules:        Test.Base
                         Test.Process
                         Testnet.Byron
-                        Testnet.ByronShelley
+                        Testnet.CardanoShelley
                         Testnet.Conf
                         Testnet.List
                         Testnet.Shelley
@@ -120,7 +120,7 @@ test-suite chairman-tests
 
   other-modules:        Spec.Chairman.Chairman
                         Spec.Chairman.Byron
-                        Spec.Chairman.ByronShelley
+                        Spec.Chairman.CardanoShelley
                         Spec.Chairman.Shelley
                         Spec.Network
 
@@ -160,7 +160,7 @@ executable cardano-testnet
   other-modules:        Paths_cardano_node_chairman
                         Testnet.Commands
                         Testnet.Commands.Byron
-                        Testnet.Commands.ByronShelley
+                        Testnet.Commands.CardanoShelley
                         Testnet.Commands.Shelley
                         Testnet.Commands.Version
                         Testnet.Run

--- a/cardano-node-chairman/src/Testnet/CardanoShelley.hs
+++ b/cardano-node-chairman/src/Testnet/CardanoShelley.hs
@@ -9,7 +9,7 @@
 #define UNIX
 #endif
 
-module Testnet.ByronShelley
+module Testnet.CardanoShelley
   ( ForkPoint(..)
   , TestnetOptions(..)
   , defaultTestnetOptions
@@ -248,14 +248,14 @@ testnet testnetOptions H.Conf {..} = do
 
     H.execCli
       [ "signing-key-address"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--secret", tempAbsPath </> "byron/payment-keys.00" <> show @Int (n - 1) <> ".key"
       ] >>= H.writeFile (tempAbsPath </> "byron/address-00" <> show @Int (n - 1))
 
     -- Write Genesis addresses to files
     H.execCli
       [ "signing-key-address"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--secret", tempAbsPath </> "byron/genesis-keys.00" <> show @Int (n - 1) <> ".key"
       ] >>= H.writeFile (tempAbsPath </> "byron/genesis-address-00" <> show @Int (n - 1))
 
@@ -268,7 +268,7 @@ testnet testnetOptions H.Conf {..} = do
     void $ H.execCli
       [ "issue-genesis-utxo-expenditure"
       , "--genesis-json", tempAbsPath </> "byron/genesis.json"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--tx", tempAbsPath </> "tx0.tx"
       , "--wallet-key", tempAbsPath </> "byron/delegate-keys.000.key"
       , "--rich-addr-from", richAddrFrom
@@ -279,7 +279,7 @@ testnet testnetOptions H.Conf {..} = do
   void $ H.execCli
     [ "byron", "governance", "create-update-proposal"
     , "--filepath", tempAbsPath </> "update-proposal"
-    , "--testnet-magic", "42"
+    , "--testnet-magic", show @Int testnetMagic
     , "--signing-key", tempAbsPath </> "byron/delegate-keys.000.key"
     , "--protocol-version-major", "1"
     , "--protocol-version-minor", "0"
@@ -294,7 +294,7 @@ testnet testnetOptions H.Conf {..} = do
     void $ H.execCli
       [ "byron", "governance", "create-proposal-vote"
       , "--proposal-filepath", tempAbsPath </> "update-proposal"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--signing-key", tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
       , "--vote-yes"
       , "--output-filepath", tempAbsPath </> "update-vote.00" <> show @Int (n - 1)
@@ -303,7 +303,7 @@ testnet testnetOptions H.Conf {..} = do
   void $ H.execCli
     [ "byron", "governance", "create-update-proposal"
     , "--filepath", tempAbsPath </> "update-proposal-1"
-    , "--testnet-magic", "42"
+    , "--testnet-magic", show @Int testnetMagic
     , "--signing-key", tempAbsPath </> "byron/delegate-keys.000.key"
     , "--protocol-version-major", "2"
     , "--protocol-version-minor", "0"
@@ -318,7 +318,7 @@ testnet testnetOptions H.Conf {..} = do
     void $ H.execCli
       [ "byron", "governance", "create-proposal-vote"
       , "--proposal-filepath", tempAbsPath </> "update-proposal-1"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--signing-key", tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
       , "--vote-yes"
       , "--output-filepath", tempAbsPath </> "update-vote-1.00" <> show @Int (n - 1)
@@ -332,7 +332,7 @@ testnet testnetOptions H.Conf {..} = do
 
   void $ H.execCli
     [ "genesis", "create"
-    , "--testnet-magic", "42"
+    , "--testnet-magic", show @Int testnetMagic
     , "--genesis-dir", tempAbsPath </> "shelley"
     , "--start-time", formatIso8601 startTime
     ]
@@ -356,7 +356,7 @@ testnet testnetOptions H.Conf {..} = do
   -- Now generate for real:
   void $ H.execCli
     [ "genesis", "create"
-    , "--testnet-magic", "42"
+    , "--testnet-magic", show @Int testnetMagic
     , "--genesis-dir", tempAbsPath </> "shelley"
     , "--gen-genesis-keys", show @Int (numBftNodes testnetOptions)
     , "--start-time", formatIso8601 startTime
@@ -455,7 +455,7 @@ testnet testnetOptions H.Conf {..} = do
       [ "address", "build"
       , "--payment-verification-key-file", tempAbsPath </> "addresses/" <> addr <> ".vkey"
       , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", tempAbsPath </> "addresses/" <> addr <> ".addr"
       ]
 
@@ -463,7 +463,7 @@ testnet testnetOptions H.Conf {..} = do
     void $ H.execCli
       [ "stake-address", "build"
       , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", tempAbsPath </> "addresses/" <> addr <> "-stake.addr"
       ]
 
@@ -495,7 +495,7 @@ testnet testnetOptions H.Conf {..} = do
   forM_ poolNodes $ \node -> do
     H.execCli
       [ "stake-pool", "registration-certificate"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--pool-pledge", "0", "--pool-cost", "0", "--pool-margin", "0"
       , "--cold-verification-key-file", tempAbsPath </> node </> "shelley/operator.vkey"
       , "--vrf-verification-key-file", tempAbsPath </> node </> "shelley/vrf.vkey"
@@ -519,7 +519,7 @@ testnet testnetOptions H.Conf {..} = do
     --  4. delegate from the user1 stake address to the stake pool
     txIn <- H.noteShow . S.strip =<< H.execCli
       [ "genesis", "initial-txin"
-      , "--testnet-magic", "42"
+      , "--testnet-magic", show @Int testnetMagic
       , "--verification-key-file", tempAbsPath </> "shelley/utxo-keys/utxo1.vkey"
       ]
 
@@ -586,7 +586,7 @@ testnet testnetOptions H.Conf {..} = do
     , "--signing-key-file", tempAbsPath </> "addresses/user1-stake.skey"
     , "--signing-key-file", tempAbsPath </> "node-pool1/owner.skey"
     , "--signing-key-file", tempAbsPath </> "node-pool1/shelley/operator.skey"
-    , "--testnet-magic", "42"
+    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", tempAbsPath </> "tx1.txbody"
     , "--out-file", tempAbsPath </> "tx1.tx"
     ]

--- a/cardano-node-chairman/test/Main.hs
+++ b/cardano-node-chairman/test/Main.hs
@@ -13,7 +13,7 @@ import qualified Test.Tasty.Hedgehog as H
 
 import qualified Spec.Network
 import qualified Spec.Chairman.Byron
-import qualified Spec.Chairman.ByronShelley
+import qualified Spec.Chairman.CardanoShelley
 import qualified Spec.Chairman.Shelley
 
 tests :: IO T.TestTree
@@ -21,14 +21,14 @@ tests = do
   let t0 = H.testProperty "isPortOpen False" Spec.Network.hprop_isPortOpen_False
   let t1 = H.testProperty "isPortOpen True" Spec.Network.hprop_isPortOpen_True
   let t2 = H.testProperty "chairman" Spec.Chairman.Byron.hprop_chairman
-  let t3 = H.testProperty "chairman" Spec.Chairman.ByronShelley.hprop_chairman
+  let t3 = H.testProperty "chairman" Spec.Chairman.CardanoShelley.hprop_chairman
   let t4 = H.testProperty "chairman" Spec.Chairman.Shelley.hprop_chairman
 
   pure $ T.testGroup "test/Spec.hs"
     [ T.testGroup "Spec"
       [ T.testGroup "Chairman"
         [ T.testGroup "Byron" [t2]
-        , T.testGroup "ByronShelley" [t3]
+        , T.testGroup "CardanoShelley" [t3]
         , T.testGroup "Shelley" [t4]
         ]
       , T.testGroup "Network" [t0, t1]

--- a/cardano-node-chairman/test/Spec/Chairman/CardanoShelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/CardanoShelley.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Spec.Chairman.ByronShelley
+module Spec.Chairman.CardanoShelley
   ( hprop_chairman
   ) where
 
@@ -11,7 +11,7 @@ import           Spec.Chairman.Chairman (chairmanOver)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Test.Base as H
-import qualified Testnet.ByronShelley as H
+import qualified Testnet.CardanoShelley as H
 import qualified Testnet.Conf as H
 
 {- HLINT ignore "Reduce duplication" -}

--- a/cardano-node-chairman/testnet/Testnet/Commands.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands.hs
@@ -5,7 +5,7 @@ import           Data.Monoid
 import           Options.Applicative
 import           System.IO (IO)
 import           Testnet.Commands.Byron
-import           Testnet.Commands.ByronShelley
+import           Testnet.Commands.CardanoShelley
 import           Testnet.Commands.Shelley
 import           Testnet.Commands.Version
 
@@ -18,7 +18,7 @@ commandsTestnet :: Parser (IO ())
 commandsTestnet = subparser $ mempty
   <>  commandGroup "Testnets:"
   <>  cmdByron
-  <>  cmdByronShelley
+  <>  cmdCardanoShelley
   <>  cmdShelley
 
 commandsGeneral :: Parser (IO ())

--- a/cardano-node-chairman/testnet/Testnet/Commands/CardanoShelley.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands/CardanoShelley.hs
@@ -1,7 +1,7 @@
-module Testnet.Commands.ByronShelley
-  ( ByronShelleyOptions(..)
-  , cmdByronShelley
-  , runByronShelleyOptions
+module Testnet.Commands.CardanoShelley
+  ( CardanoShelleyOptions(..)
+  , cmdCardanoShelley
+  , runCardanoShelleyOptions
   ) where
 
 import           Data.Eq
@@ -11,14 +11,14 @@ import           Data.Maybe
 import           Data.Semigroup
 import           Options.Applicative
 import           System.IO (IO)
-import           Testnet.ByronShelley
+import           Testnet.CardanoShelley
 import           Testnet.Run (runTestnet)
 import           Text.Read (readEither)
 import           Text.Show
 
 import qualified Options.Applicative as OA
 
-data ByronShelleyOptions = ByronShelleyOptions
+data CardanoShelleyOptions = CardanoShelleyOptions
   { maybeTestnetMagic :: Maybe Int
   , testnetOptions :: TestnetOptions
   } deriving (Eq, Show)
@@ -61,8 +61,8 @@ optsTestnet = TestnetOptions
       <>  OA.value (forkPoint defaultTestnetOptions)
       )
 
-optsByronShelley :: Parser ByronShelleyOptions
-optsByronShelley = ByronShelleyOptions
+optsCardanoShelley :: Parser CardanoShelleyOptions
+optsCardanoShelley = CardanoShelleyOptions
   <$> optional
       ( OA.option auto
         (   long "testnet-magic"
@@ -72,9 +72,9 @@ optsByronShelley = ByronShelleyOptions
       )
   <*> optsTestnet
 
-runByronShelleyOptions :: ByronShelleyOptions -> IO ()
-runByronShelleyOptions options = runTestnet (maybeTestnetMagic options) $
-  Testnet.ByronShelley.testnet (testnetOptions options)
+runCardanoShelleyOptions :: CardanoShelleyOptions -> IO ()
+runCardanoShelleyOptions options = runTestnet (maybeTestnetMagic options) $
+  Testnet.CardanoShelley.testnet (testnetOptions options)
 
-cmdByronShelley :: Mod CommandFields (IO ())
-cmdByronShelley = command "byron-shelley"  $ flip info idm $ runByronShelleyOptions <$> optsByronShelley
+cmdCardanoShelley :: Mod CommandFields (IO ())
+cmdCardanoShelley = command "cardano-shelley"  $ flip info idm $ runCardanoShelleyOptions <$> optsCardanoShelley

--- a/doc/getting-started/launching-a-testnet.md
+++ b/doc/getting-started/launching-a-testnet.md
@@ -26,21 +26,21 @@ Available options:
 
 Commands:
   byron
-  byron-shelley
+  cardano-shelley
   shelley
 ```
 
 Then create the testnet.  For example:
 
 ```bash
-$ cabal run cardano-testnet byron-shelley
+$ cabal run cardano-testnet cardano-shelley
   ✗ <interactive> failed at testnet/Testnet/Run.hs:34:3
     after 1 test.
 
-        ┏━━ src/Testnet/ByronShelley.hs ━━━
+        ┏━━ src/Testnet/CardanoShelley.hs ━━━
      68 ┃ testnet :: H.Conf -> H.Integration [String]
      69 ┃ testnet H.Conf {..} = do
-     70 ┃   -- This script sets up a cluster that starts out in Byron, and can transition to Shelley.
+     70 ┃   -- This script sets up a cluster that starts out in Cardano, and can transition to Shelley.
      71 ┃   --
 ...
        ┏━━ testnet/Testnet/Run.hs ━━━


### PR DESCRIPTION
Also Fix testnet magic.

This is in preparation for a new testnet `cardano-alonzo` which will be introduced in a follow up PR.