### PR TITLE
Fix the cli flag name --utxo-cost-per-word

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2523,7 +2523,7 @@ pExtraEntropy =
 pUTxOCostPerWord :: Parser Lovelace
 pUTxOCostPerWord =
     Opt.option (readerFromParsecParser parseLovelace)
-      (  Opt.long "min-utxo-value"
+      (  Opt.long "utxo-cost-per-word"
       <> Opt.metavar "LOVELACE"
       <> Opt.help "Cost in lovelace per unit of UTxO storage (from Alonzo era)."
       )


### PR DESCRIPTION
It was previously accidentally the same as the old flag --min-utxo-value