### PR TITLE
CAD-2907 workbench: Alonzo support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ profiles:
 profile-names:
 	@./nix/workbench/wb profile-names
 
-CLUSTER_PROFILE     = default-mary
+CLUSTER_PROFILE     = default-alzo
 CLUSTER_ARGS_EXTRA ?=
 
 cluster-shell:

--- a/custom-config/default.nix
+++ b/custom-config/default.nix
@@ -3,7 +3,7 @@ self: {
   localCluster = {
     cacheDir    = "${self.localCluster.stateDir}/.cache";
     stateDir    = "state-cluster";
-    profileName = "default-mary";
+    profileName = "default-alzo";
     basePort    = 30000;
     autoStartCluster = false;
     enableEKG        = true;

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -52,6 +52,7 @@ let
       finaliseNodeConfig =
         { port, ... }: cfg: recursiveUpdate cfg
           ({
+            AlonzoGenesisFile    = "../genesis/alonzo-genesis.json";
             ShelleyGenesisFile   = "../genesis/genesis.json";
             ByronGenesisFile     = "../genesis/byron/genesis.json";
           } // optionalAttrs enableEKG {

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -2,7 +2,7 @@ let
   basePortDefault    = 30000;
   cacheDirDefault    = "${__getEnv "HOME"}/.cache/cardano-workbench";
   stateDirDefault    = "state-cluster";
-  profileNameDefault = "default-mary";
+  profileNameDefault = "default-alzo";
 in
 { pkgs
 , workbench

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -139,6 +139,7 @@ let
     }
     export -f workbench-prebuild-executables
 
+    export CARDANO_NODE_SOCKET_PATH=run/current/node-0/node.socket
     '';
 
   generateProfiles =

--- a/nix/workbench/genesis.sh
+++ b/nix/workbench/genesis.sh
@@ -146,8 +146,8 @@ case "${op}" in
         cardano-cli genesis create-staked "${params[@]}"
 
         ## TODO: temporary step for Alonzo
-        jq_fmutate ""$dir"/genesis.json" '. *
-          { lovelacePerUTxOWord: 0
+        jq '
+          { adaPerUTxOWord: 0
           , executionPrices:
             { prMem:              1
             , prSteps:            1
@@ -163,7 +163,7 @@ case "${op}" in
           , maxValueSize:         1000
           , collateralPercentage: 100
           , maxCollateralInputs:  1
-          }'
+          }' --null-input > "$dir"/alonzo-genesis.json
 
         ## TODO: try to get rid of this step:
         Massage_the_key_file_layout_to_match_AWS "$profile_json" "$topo_dir" "$dir";;

--- a/nix/workbench/genesis.sh
+++ b/nix/workbench/genesis.sh
@@ -153,12 +153,12 @@ case "${op}" in
             , prSteps:            1
             }
           , maxTxExUnits:
-            { exUnitsMem:         1
-            , exUnitsSteps:       1
+            { exUnitsMem:         2000000000
+            , exUnitsSteps:       2000000000
             }
           , maxBlockExUnits:
-            { exUnitsMem:         1
-            , exUnitsSteps:       1
+            { exUnitsMem:         200000000000
+            , exUnitsSteps:       200000000000
             }
           , maxValueSize:         1000
           , collateralPercentage: 100

--- a/nix/workbench/profiles/node-services.nix
+++ b/nix/workbench/profiles/node-services.nix
@@ -76,7 +76,8 @@ let
                LastKnownBlockVersion-Minor = 0;
                LastKnownBlockVersion-Alt   = 0;
              })
-           [ "ByronGenesisHash"
+           [ "AlonzoGenesisHash"
+             "ByronGenesisHash"
              "ShelleyGenesisHash"
            ])
        //


### PR DESCRIPTION
This makes the `scripts/plutus/example-txin-locking-plutus-script.sh` script work with the workbench:

1. Alonzo-specific updates in the workbench genesis generation
2. Adaptations in the script
3. Small quality-of-life improvement: set `CARDANO_NODE_SOCKET_PATH` automatically inside the shell

Test with:

1. `make cls cluster-shell-dev CLUSTER_ARGS_EXTRA='--arg withHoogle false'`, and once inside the shell:
2. `./scripts/plutus/example-txin-locking-plutus-script.sh`
3. `cardano-cli transaction submit --tx-file example/work/alonzo.tx --testnet-magic 42`

The last command should output: `Transaction successfully submitted.`