### PR TITLE
Add API support for extra node queries

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,8 +131,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 810298f87d91a8ab6573d10710baedf35825a3b5
-  --sha256: 0msp9wm8vvz2yj5nzp3r48cf3b423w0qj8f10acamcyp6wfvlr61
+  tag: 8e8e8c890792fd935736dbc260e33c7e678fdcdc
+  --sha256: 0dd75944f1ww0bnr1l02igwkiwbwkvrlv6yldlgakdpqyfn1np9d
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -191,11 +191,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 47b94669555fb3e4f5f3b985f5d804090cfb60c4
-  --sha256: 1y20brl7scppf55037bq5rnq6vdab2f6x56nqsg8grj2gipihkdp
+  tag: b749bc878bb05478f924d6e2d4970d1bdaef94ef
+  --sha256: 1k1cc5sqq9h6jrr5psi4vzs1ay3wafj42gpfv8b67cpnxfivj4m6
   subdir:
     io-sim
     io-sim-classes
+    monoidal-synchronisation
     network-mux
     ouroboros-consensus
     ouroboros-consensus-byron
@@ -210,14 +211,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: bd0dec6dbbf87a14b54384cc083be2bfaf8d5ca6
-  --sha256: 09qhhiks1qj3x0h3vhr3j7p8kfnbrp2sqi2gc6d16s5zy2pyjbqh
+  tag: c89e13e66c5bef628a1f7ea3a3732951be8be8ba
+  --sha256: 0hdck39i4yv656phxjy5ppqgzrq7x3q4b5rf8vj7hrzcs0aggl8r
   subdir:
     plutus-core
     plutus-ledger-api
     plutus-tx
     prettyprinter-configurable
-    word-array
 
 -- Drops an instance breaking our code. Should be released to Hackage eventually.
 source-repository-package

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -500,6 +500,8 @@ module Cardano.Api (
     QueryInMode(..),
     QueryInEra(..),
     QueryInShelleyBasedEra(..),
+    QueryUTxOFilter(..),
+    UTxO(..),
     queryNodeLocalState,
 
     -- *** Common queries
@@ -572,7 +574,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
 import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.Query (SlotsInEpoch(..), SlotsToEpochEnd(..), slotToEpoch)
+import           Cardano.Api.Query
 import           Cardano.Api.Script
 import           Cardano.Api.ScriptData
 import           Cardano.Api.SerialiseBech32

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -30,6 +30,7 @@ module Cardano.Api.Certificate (
     toShelleyCertificate,
     fromShelleyCertificate,
     toShelleyPoolParams,
+    fromShelleyPoolParams,
 
     -- * Data family instances
     AsType(..)

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -22,6 +22,7 @@ module Cardano.Api.Query (
     QueryInMode(..),
     QueryInEra(..),
     QueryInShelleyBasedEra(..),
+    QueryUTxOFilter(..),
     UTxO(..),
 
     -- * Internal conversion functions

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -302,7 +302,7 @@ data QueryCmd =
   | QueryTip AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeDistribution' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeAddressInfo AnyConsensusModeParams StakeAddress NetworkId (Maybe OutputFile)
-  | QueryUTxO' AnyConsensusModeParams QueryFilter NetworkId (Maybe OutputFile)
+  | QueryUTxO' AnyConsensusModeParams QueryUTxOFilter NetworkId (Maybe OutputFile)
   | QueryDebugLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeSnapshot' AnyConsensusModeParams NetworkId (Hash StakePoolKey)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -802,7 +802,7 @@ pQueryCmd =
     pQueryUTxO =
       QueryUTxO'
         <$> pConsensusModeParams
-        <*> pQueryFilter
+        <*> pQueryUTxOFilter
         <*> pNetworkId
         <*> pMaybeOutputFile
 
@@ -1955,20 +1955,23 @@ pTxByronWitnessCount =
       <> Opt.value 0
       )
 
-pQueryFilter :: Parser QueryFilter
-pQueryFilter = pAddresses <|> pure NoFilter
+pQueryUTxOFilter :: Parser QueryUTxOFilter
+pQueryUTxOFilter =
+      pQueryUTxOWhole
+  <|> pQueryUTxOByAddress
   where
-    pAddresses :: Parser QueryFilter
-    pAddresses = FilterByAddress . Set.fromList <$>
-                   some pFilterByAddress
+    pQueryUTxOWhole = pure QueryUTxOWhole
 
-pFilterByAddress :: Parser AddressAny
-pFilterByAddress =
-    Opt.option (readerFromParsecParser parseAddressAny)
-      (  Opt.long "address"
-      <> Opt.metavar "ADDRESS"
-      <> Opt.help "Filter by Cardano address(es) (Bech32-encoded)."
-      )
+    pQueryUTxOByAddress :: Parser QueryUTxOFilter
+    pQueryUTxOByAddress = QueryUTxOByAddress . Set.fromList <$> some pByAddress
+
+    pByAddress :: Parser AddressAny
+    pByAddress =
+        Opt.option (readerFromParsecParser parseAddressAny)
+          (  Opt.long "address"
+          <> Opt.metavar "ADDRESS"
+          <> Opt.help "Filter by Cardano address(es) (Bech32-encoded)."
+          )
 
 pFilterByStakeAddress :: Parser StakeAddress
 pFilterByStakeAddress =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1959,6 +1959,7 @@ pQueryUTxOFilter :: Parser QueryUTxOFilter
 pQueryUTxOFilter =
       pQueryUTxOWhole
   <|> pQueryUTxOByAddress
+  <|> pQueryUTxOByTxIn
   where
     pQueryUTxOWhole = pure QueryUTxOWhole
 
@@ -1972,6 +1973,17 @@ pQueryUTxOFilter =
           <> Opt.metavar "ADDRESS"
           <> Opt.help "Filter by Cardano address(es) (Bech32-encoded)."
           )
+
+    pQueryUTxOByTxIn :: Parser QueryUTxOFilter
+    pQueryUTxOByTxIn = QueryUTxOByTxIn . Set.fromList <$> some pByTxIn
+
+    pByTxIn :: Parser TxIn
+    pByTxIn =
+      Opt.option (readerFromParsecParser parseTxIn)
+        (  Opt.long "tx-in"
+        <> Opt.metavar "TX-IN"
+        <> Opt.help "Filter by transaction input (TxId#TxIx)."
+        )
 
 pFilterByStakeAddress :: Parser StakeAddress
 pFilterByStakeAddress =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -773,8 +773,8 @@ pQueryCmd =
                                                         \reward accounts filtered by stake \
                                                         \address.")
     , subParser "utxo"
-        (Opt.info pQueryUTxO $ Opt.progDesc "Get the node's current UTxO with the option of \
-                                            \filtering by address(es)")
+        (Opt.info pQueryUTxO $ Opt.progDesc "Get a portion of the current UTxO: \
+                                            \by tx in, by address or the whole.")
     , subParser "ledger-state"
         (Opt.info pQueryLedgerState $ Opt.progDesc "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)")
     , subParser "protocol-state"
@@ -1961,7 +1961,11 @@ pQueryUTxOFilter =
   <|> pQueryUTxOByAddress
   <|> pQueryUTxOByTxIn
   where
-    pQueryUTxOWhole = pure QueryUTxOWhole
+    pQueryUTxOWhole =
+      Opt.flag' QueryUTxOWhole
+        (  Opt.long "--whole-utxo"
+        <> Opt.help "Return the whole UTxO (only appropriate on small testnets)."
+        )
 
     pQueryUTxOByAddress :: Parser QueryUTxOFilter
     pQueryUTxOByAddress = QueryUTxOByAddress . Set.fromList <$> some pByAddress

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -9,7 +9,6 @@ module Cardano.CLI.Types
   , CertificateFile (..)
   , GenesisFile (..)
   , OutputFormat (..)
-  , QueryFilter (..)
   , SigningKeyFile (..)
   , SocketPath (..)
   , ScriptFile (..)
@@ -67,12 +66,6 @@ instance FromJSON GenesisFile where
 data OutputFormat
   = OutputFormatHex
   | OutputFormatBech32
-  deriving (Eq, Show)
-
--- | UTxO query filtering options.
-data QueryFilter
-  = FilterByAddress !(Set AddressAny)
-  | NoFilter
   deriving (Eq, Show)
 
 -- | This data structure is used to allow nicely formatted output within the query stake-snapshot command.


### PR DESCRIPTION
Extended the QueryUTxO with a QueryUTxOFilter param which has a new case
for QueryUTxOByTxIn.

Added QueryStakePools and QueryStakePoolParameters.

Added top level query QuerySystemStart

Also extend the `cardano-cli query utxo` with a `--tx-in` flag to filter by txin, and change the default from returning the whole utxo to there being no default. Added a `--whole-utxo` flag for the case that you really do what the whole thing.

This change may affect some examples and scripts.