### PR TITLE
Improve cli help for script data options.

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -279,14 +279,14 @@ pScriptDataOrFile dataFlagPrefix =
       Opt.strOption
         (  Opt.long (dataFlagPrefix ++ "-file")
         <> Opt.metavar "FILE"
-        <> Opt.help "The file containing the script data."
+        <> Opt.help "The JSON file containing the script data."
         )
 
     pScriptDataValue =
       Opt.option readerScriptData
         (  Opt.long (dataFlagPrefix ++ "-value")
-        <> Opt.metavar "JSON"
-        <> Opt.help "The value (in JSON syntax) for the script data."
+        <> Opt.metavar "JSON VALUE"
+        <> Opt.help "The JSON value for the script data. Supported JSON data types: string, number, object & array."
         )
 
     readerScriptData = do


### PR DESCRIPTION
Clarify what is supported when using script data `file` or `value` options.

I decided it is worth listing the data types because bool and null are not supported.