### PR TITLE
fixed typos in comments from scripts and cardano-testnet directories

### DIFF
--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -539,7 +539,7 @@ testnet testnetOptions H.Conf {..} = do
     H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> show @Int n <> "-stake.skey") (tempAbsPath </> "node-pool" <> show @Int n </> "owner.skey")
 
   -- Generated payment address keys, stake address keys,
-  -- stake address regitration certs, and stake address delegatation certs
+  -- stake address registration certs, and stake address delegation certs
   H.noteEachM_ . H.listDirectory $ tempAbsPath </> "addresses"
 
   -- Next is to make the stake pool registration cert
@@ -628,7 +628,7 @@ testnet testnetOptions H.Conf {..} = do
 
   -- So we'll need to sign this with a bunch of keys:
   -- 1. the initial utxo spending key, for the funds
-  -- 2. the user1 stake address key, due to the delegatation cert
+  -- 2. the user1 stake address key, due to the delegation cert
   -- 3. the pool1 owner key, due to the pool registration cert
   -- 3. the pool1 operator key, due to the pool registration cert
   void $ H.execCli

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -292,7 +292,7 @@ testnet testnetOptions H.Conf {..} = do
     H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> n <> "-stake.skey") (tempAbsPath </> "node-pool" <> n </> "owner.skey")
 
   -- Generated payment address keys, stake address keys,
-  -- stake address regitration certs, and stake address delegatation certs
+  -- stake address registration certs, and stake address delegation certs
   H.noteShowM_ . H.listDirectory $ tempAbsPath </> "addresses"
 
   -- Next is to make the stake pool registration cert
@@ -346,7 +346,7 @@ testnet testnetOptions H.Conf {..} = do
 
     -- So we'll need to sign this with a bunch of keys:
     -- 1. the initial utxo spending key, for the funds
-    -- 2. the user n stake address key, due to the delegatation cert
+    -- 2. the user n stake address key, due to the delegation cert
     -- 3. the pool n owner key, due to the pool registration cert
     -- 3. the pool n operator key, due to the pool registration cert
 

--- a/scripts/byron-to-alonzo/mkfiles.sh
+++ b/scripts/byron-to-alonzo/mkfiles.sh
@@ -440,7 +440,7 @@ for N in ${USER_POOL_N}; do
 done
 
 echo "Generated payment address keys, stake address keys,"
-echo "stake address regitration certs, and stake address delegatation certs"
+echo "stake address registration certs, and stake address delegation certs"
 echo
 ls -1 addresses/
 echo "====================================================================="

--- a/scripts/byron-to-alonzo/update-1.sh
+++ b/scripts/byron-to-alonzo/update-1.sh
@@ -5,7 +5,7 @@ set -e
 
 # This script will
 # - move funds out of the Byron genesis address, so that we can use them later in Shelley
-# - iniate the transition to protocol version 1 (Byron, OBFT)
+# - initiate the transition to protocol version 1 (Byron, OBFT)
 
 ROOT=example
 

--- a/scripts/byron-to-alonzo/update-3.sh
+++ b/scripts/byron-to-alonzo/update-3.sh
@@ -8,7 +8,7 @@ set -e
 # It will also set up a working stake pool (including delegating to it).
 
 # You need to provide the current epoch as a positional argument (the Shelley
-# update system requires this to be includded in the update proposal).
+# update system requires this to be included in the update proposal).
 
 
 # In order for this to be successful, you need to already be in protocol version
@@ -77,7 +77,7 @@ cardano-cli transaction build-raw \
 
 # So we'll need to sign this with a bunch of keys:
 # 1. the initial utxo spending key, for the funds
-# 2. the user1 stake address key, due to the delegatation cert
+# 2. the user1 stake address key, due to the delegation cert
 # 3. the pool1 owner key, due to the pool registration cert
 # 4. the pool1 operator key, due to the pool registration cert
 # 5. the genesis delegate keys, due to the update proposal

--- a/scripts/byron-to-alonzo/update-5.sh
+++ b/scripts/byron-to-alonzo/update-5.sh
@@ -6,7 +6,7 @@ set -e
 # This script will initiate the transition to protocol version 5 (Alonzo).
 
 # You need to provide the current epoch as a positional argument (the Shelley
-# update system requires this to be includded in the update proposal).
+# update system requires this to be included in the update proposal).
 
 
 # In order for this to be successful, you need to already be in protocol version

--- a/scripts/byron-to-shelley/mkfiles.sh
+++ b/scripts/byron-to-shelley/mkfiles.sh
@@ -462,7 +462,7 @@ for N in ${USER_POOL_N}; do
 done
 
 echo "Generated payment address keys, stake address keys,"
-echo "stake address regitration certs, and stake address delegatation certs"
+echo "stake address registration certs, and stake address delegation certs"
 echo
 ls -1 addresses/
 echo "====================================================================="
@@ -522,7 +522,7 @@ cardano-cli transaction build-raw \
 
 # So we'll need to sign this with a bunch of keys:
 # 1. the initial utxo spending key, for the funds
-# 2. the user1 stake address key, due to the delegatation cert
+# 2. the user1 stake address key, due to the delegation cert
 # 3. the pool1 owner key, due to the pool registration cert
 # 3. the pool1 operator key, due to the pool registration cert
 

--- a/scripts/lite/shelley-testnet-2.sh
+++ b/scripts/lite/shelley-testnet-2.sh
@@ -236,7 +236,7 @@ for N in ${USER_POOL_N}; do
 done
 
 echo "Generated payment address keys, stake address keys,"
-echo "stake address regitration certs, and stake address delegatation certs"
+echo "stake address registration certs, and stake address delegation certs"
 echo
 ls -1 addresses/
 echo "====================================================================="
@@ -283,7 +283,7 @@ $cardano_cli transaction build-raw \
 
 # So we'll need to sign this with a bunch of keys:
 # 1. the initial utxo spending key, for the funds
-# 2. the user1 stake address key, due to the delegatation cert
+# 2. the user1 stake address key, due to the delegation cert
 # 3. the pool1 owner key, due to the pool registration cert
 # 3. the pool1 operator key, due to the pool registration cert
 

--- a/scripts/shelley-from-scratch/mkfiles.sh
+++ b/scripts/shelley-from-scratch/mkfiles.sh
@@ -244,7 +244,7 @@ for N in ${USER_POOL_N}; do
 done
 
 echo "Generated payment address keys, stake address keys,"
-echo "stake address regitration certs, and stake address delegatation certs"
+echo "stake address registration certs, and stake address delegation certs"
 echo
 ls -1 addresses/
 echo "====================================================================="
@@ -294,7 +294,7 @@ cardano-cli transaction build-raw \
 
 # So we'll need to sign this with a bunch of keys:
 # 1. the initial utxo spending key, for the funds
-# 2. the user1 stake address key, due to the delegatation cert
+# 2. the user1 stake address key, due to the delegation cert
 # 3. the pool1 owner key, due to the pool registration cert
 # 3. the pool1 operator key, due to the pool registration cert
 


### PR DESCRIPTION
fixed typos in shelley-from-scratch mkfiles.sh
