### PR TITLE
Update retire_stakepool.md

### DIFF
--- a/doc/stake-pool-operations/retire_stakepool.md
+++ b/doc/stake-pool-operations/retire_stakepool.md
@@ -2,8 +2,19 @@
 
 To retire a pool we need to:
 
-* Create a **deregistration certificate** and
-* Submit the certificate to the blockchain with a **transaction**
+0. Make sure that any pool owners are aware of your retirement intention and will not remove their Pledge until the pool has retired. 
+1. Create a **deregistration certificate** and specify an epoch when your pool will retire. There is a limit on how far in the future this can be (given by a protocol parameter - see below). Make sure you give sufficient time for delegators to switch pools
+2. Submit the certificate to the blockchain with a **transaction**
+3. Notify your delegators of your intention to retire the pool using your usual communication mechanisms. Wallets and other tools should highlight that the pool is retiring and discourage new delegations.
+4. Keep your system working normally until we reach the epoch you chose on the certificate for the pool to expire. Retirement takes place when the first block of the selected epoch is processed (before the transactions for that block are processed.) 
+5. Move your funds out from your pledge address to a different wallet.  
+6. When the pool is effectively retired, the pool deposit is sent back to the rewards account.
+7. **Wait for any pending rewards to be paid.**
+8. Withdraw any rewards and pool deposit from the rewards account.
+9. **Once you have successfullly withdrawn your rewards and deposit, de-register the stake key**
+
+**IMPORTANT:**
+**Do NOT deregister your stake key before the pool deposit is paid back to your rewards account or your pool deposit will have no place to go and will be sent to the treasury.**
 
 The deregistration certificate contains the _epoch_ in which we want to retire the pool. This epoch must be _after_ the current epoch and _not later than_ `eMax` epochs in the future, where `eMax` is a protocol parameter.
 


### PR DESCRIPTION
Laying out the process for retiring a stake pool. 

If the stake key is deregistered before the pool is retired or before the pool deposit is paid back, the deposit goes to treasury. 