### PR TITLE
Tidy up query tip output

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -73,6 +73,7 @@ library
                         Cardano.CLI.Shelley.Commands
                         Cardano.CLI.Shelley.Key
                         Cardano.CLI.Shelley.Orphans
+                        Cardano.CLI.Shelley.Output
                         Cardano.CLI.Shelley.Parsers
                         Cardano.CLI.Shelley.Run
                         Cardano.CLI.Shelley.Run.Address

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -1,0 +1,47 @@
+module Cardano.CLI.Shelley.Output
+  ( QueryTipOutput(..)
+  ) where
+
+import           Cardano.Api (AnyCardanoEra, ChainTip (..), EpochNo, serialiseToRawBytesHexText)
+import           Cardano.CLI.Shelley.Orphans ()
+import           Cardano.Prelude (Either, Eq, Show, Text)
+import           Cardano.Slotting.Block (BlockNo (..))
+import           Data.Aeson (ToJSON (..), (.=))
+import           Data.Either (either)
+import           Data.Function (($), id)
+import           Data.Monoid (mconcat)
+import           Shelley.Spec.Ledger.Scripts ()
+
+import qualified Data.Aeson as J
+import qualified Data.Aeson.Encoding as JE
+
+data QueryTipOutput = QueryTipOutput
+  { chainTip :: ChainTip
+  , era :: AnyCardanoEra
+  , epoch :: EpochNo
+  , syncProgress :: Either J.Value Text
+  } deriving (Eq, Show)
+
+instance ToJSON QueryTipOutput where
+  toJSON a = case chainTip a of
+    ChainTipAtGenesis -> J.Null
+    ChainTip slot headerHash (BlockNo bNum) ->
+      J.object
+        [ "slot" .= slot
+        , "hash" .= serialiseToRawBytesHexText headerHash
+        , "block" .= bNum
+        , "era" .= era a
+        , "epoch" .= epoch a
+        , "syncProgress" .= either id toJSON (syncProgress a)
+        ]
+  toEncoding a = case chainTip a of
+    ChainTipAtGenesis -> JE.null_
+    ChainTip slot headerHash (BlockNo bNum) ->
+      J.pairs $ mconcat
+        [ "slot" .= slot
+        , "hash" .= serialiseToRawBytesHexText headerHash
+        , "block" .= bNum
+        , "era" .= era a
+        , "epoch" .= epoch a
+        , "syncProgress" .= either id toJSON (syncProgress a)
+        ]


### PR DESCRIPTION
Remove unnecessary fields and ensure the output fields are in a sensible order using the `toEncoding` function.