### PR TITLE
CAD-2894 workbench:  fix for missing git repo commit description

### DIFF
--- a/nix/workbench/lib.sh
+++ b/nix/workbench/lib.sh
@@ -57,11 +57,11 @@ git_repo_commit_description() {
     local repo=$1
     local commit=$(git -C "$repo" rev-parse 'HEAD' 2>/dev/null || true)
 
-    test -d "$repo/.git" && {
+    test -n "$commit" && {
         git -C "$repo" fetch
         git -C "$repo" describe --match '[0-9].*' --tags $commit 2>/dev/null |
             cut -d'-' -f1,2 | tr -d '\n'
         git -C "$repo" diff --exit-code --quiet || echo '-modified'
-    } || true
+    } || echo "unknown-not-a-git-repo"
 }
 

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -145,12 +145,12 @@ case "$op" in
         local node_commit_desc=$(git_repo_commit_description '.')
 
         local args=(
-            --arg       tag              $tag
-            --arg       batch            $batch
-            --arg       profile          $prof
-            --argjson   timestamp        $timestamp
-            --arg       date             $date
-            --arg       node_commit_desc $node_commit_desc
+            --arg       tag              "$tag"
+            --arg       batch            "$batch"
+            --arg       profile          "$prof"
+            --argjson   timestamp        "$timestamp"
+            --arg       date             "$date"
+            --arg       node_commit_desc "$node_commit_desc"
             --slurpfile profile_content  "$dir"/profile.json
         )
         jq_fmutate "$dir"/meta.json '. *


### PR DESCRIPTION
Fix for the non-standard git setups, like `git-worktree`.