### PR TITLE
CAD-2907 workbench: block time budgeting support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ profiles:
 profile-names:
 	@./nix/workbench/wb profile-names
 
-CLUSTER_PROFILE     = default-alzo
+CLUSTER_PROFILE    ?= default-alzo
 CLUSTER_ARGS_EXTRA ?=
 
 cluster-shell:

--- a/bench/script/probe.sh
+++ b/bench/script/probe.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+hostmap=$(jq '
+  .public_ip
+  | values
+  | map({ "\(.hostname)": .public_ip})
+  | add' last-meta.json)
+
+echo 'obtaining latency matrix for the hostmap:'
+jq . -C <<<$hostmap
+
+nixops ssh-for-each --parallel -- "
+   self=\$(hostname)
+
+  function probe() {
+      local host=\$1 ip=\$2
+
+      ping -qAc21 \$ip                       |
+      grep 'rtt\|transmitted'                |
+      sed 's_, \|/_\n_g'                     |
+      sed 's_ packets transmitted\| received\| packet loss\|time \|rtt min\|avg\|max\|mdev = \|ipg\|ewma \| ms\|ms\|%__g'         |
+      grep -v '^$'                           |
+      jq '{ source: \"'\$self'\"
+          , target: \"'\$host'\"
+
+          , sent:          .[0]
+          , received:      .[1]
+          , percents_lost: .[2]
+          , duration_ms:   .[3]
+          , ipg:           .[8]
+          , ewma:          .[9]
+
+          , rtt: { min: .[4], avg: .[5], max: .[6], mdev: .[7] }
+          }' --slurp --compact-output
+   }
+
+   hostmap=${hostmap@Q}
+
+   for host in \$(jq 'keys | .[]' <<<\$hostmap --raw-output)
+   do ip=\$(jq '.[\$host]' --arg host \$host <<<\$hostmap --raw-output)
+      probe \$host \$ip\ &
+   done"

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -53,7 +53,7 @@ let
         { port, ... }: cfg: recursiveUpdate cfg
           ({
             AlonzoGenesisFile    = "../genesis/alonzo-genesis.json";
-            ShelleyGenesisFile   = "../genesis/genesis.json";
+            ShelleyGenesisFile   = "../genesis.json";
             ByronGenesisFile     = "../genesis/byron/genesis.json";
           } // optionalAttrs enableEKG {
             hasEKG               = port + supervisord.portShiftEkg;

--- a/nix/workbench/analyse.sh
+++ b/nix/workbench/analyse.sh
@@ -55,7 +55,7 @@ EOF
 
         msg "analysing.."
         local locli_args=(
-            --genesis         "$dir"/genesis/genesis.json
+            --genesis         "$dir"/genesis.json
             --run-metafile    "$dir"/meta.json
             ## ->
             # --logobjects-json "$adir"/logs-cluster.logobjects.json
@@ -84,7 +84,7 @@ EOF
         msg "analysing logs of:  $mach  (lines: $(wc -l "$consolidated"))"
 
         local locli_args=(
-            --genesis         "$dir"/genesis/genesis.json
+            --genesis         "$dir"/genesis.json
             --run-metafile    "$dir"/meta.json
             ## ->
             --logobjects-json "$adir"/logs-$mach.logobjects.json

--- a/nix/workbench/analyse.sh
+++ b/nix/workbench/analyse.sh
@@ -1,69 +1,112 @@
 usage_analyse() {
      usage "analyse" "Analyse cluster runs" <<EOF
     block-propagation RUN-NAME
-                          Block propagation analysis for the entire cluster
+                          Block propagation analysis for the entire cluster.
 
     machine-timeline RUN-NAME MACH-NAME
                           Produce a general performance timeline for MACH-NAME
 
+    Options of 'analyse' command:
+
+       --reanalyse        Skip the preparatory steps and launch 'locli' directly
+       --time             Time the 'locli' executable runs
 EOF
 }
 
 analyse() {
+local skip_preparation= time= dump_logobjects=
+while test $# -gt 0
+do case "$1" in
+       --reanalyse | --re ) skip_preparation='true';;
+       --dump-logobjects )  dump_logobjects='true';;
+       --time )             time='eval time';;
+       * ) break;; esac; shift; done
+
 local op=${1:-$(usage_analyse)}; shift
 
 case "$op" in
     block-propagation | bp )
         local usage="USAGE: wb analyse $op [RUN-NAME=current]"
+
         local name=${1:-current}
         local dir=$(run get "$name")
         local adir=$dir/analysis
 
+        msg "analysing run $(jq .meta.tag "$dir"/meta.json --raw-output)"
         mkdir -p "$adir"
 
         ## 0. subset what we care about into the keyfile
         local keyfile=$adir/substring-keys
         locli analyse substring-keys | grep -v 'Temporary modify' > "$keyfile"
-        cat >>"$keyfile" <<EOF
-TraceForgedBlock
-AddedToCurrentChain
-TraceChainSyncServerReadBlocked.AddBlock
-TraceChainSyncServerRead.AddBlock
-TraceBlockFetchServerSendBlock
-TraceDownloadedHeader
-CompletedBlockFetch
-EOF
+
         ## 1. enumerate logs, filter by keyfile & consolidate
         local logdirs=("$dir"/node-*/)
 
-        msg "filtering logs in: $dir/node-* "
-        local jq_args=(
-            --sort-keys
-            --compact-output
-            $(wb backend lostream-fixup-jqargs "$dir")
-            ' delpaths([["app"],["env"],["loc"],["msg"],["ns"],["sev"]])
-            '"$(wb backend lostream-fixup-jqexpr)"
-        )
-        for d in "${logdirs[@]}"
-        do ## TODO: supervisor-specific logfile layout
-           grep -hFf "$keyfile" $(ls "$d"/stdout* | tac) | jq "${jq_args[@]}" > \
+        if test -z "$skip_preparation" -o -z "$(ls "$adir"/logs-node-*.flt.json 2>/dev/null)"
+        then
+            msg "filtering logs in: $dir/node-* "
+            local jq_args=(
+                --sort-keys
+                --compact-output
+                $(wb backend lostream-fixup-jqargs "$dir")
+                ' delpaths([["app"],["env"],["loc"],["msg"],["ns"],["sev"]])
+                '"$(wb backend lostream-fixup-jqexpr)"
+            )
+            for d in "${logdirs[@]}"
+            do ## TODO: supervisor-specific logfile layout
+                grep -hFf "$keyfile" $(ls "$d"/stdout* | tac) | jq "${jq_args[@]}" --arg dirHostname "$(basename "$d")" > \
                 "$adir"/logs-$(basename "$d").flt.json &
-        done
-        wait
+            done
+            wait
+        fi
 
-        msg "log sizes:  (files: $(ls "$adir"/*.flt.json | wc -l), lines: $(cat "$adir"/*.flt.json | wc -l))"
+        msg "log sizes:  (files: $(ls "$adir"/*.flt.json 2>/dev/null | wc -l), lines: $(cat "$adir"/*.flt.json | wc -l))"
 
         msg "analysing.."
         local locli_args=(
             --genesis         "$dir"/genesis.json
             --run-metafile    "$dir"/meta.json
             ## ->
-            # --logobjects-json "$adir"/logs-cluster.logobjects.json
-            --analysis-json   "$adir"/block-event-stream.json
+            --timeline-pretty "$adir"/block-propagation.txt
+            --analysis-json   "$adir"/block-propagation.json
         )
+        if test -n "$dump_logobjects"; then
+            locli_args+=(--logobjects-json "$adir"/logs-cluster.logobjects.json); fi
 
-        locli 'analyse' 'block-propagation' \
+        ${time} locli 'analyse' 'block-propagation' \
             "${locli_args[@]}" "$adir"/*.flt.json;;
+
+    grep-filtered-logs | grep | g )
+        local usage="USAGE: wb analyse $op BLOCK [MACHSPEC=*] [RUN-NAME=current]"
+        local expr=$1
+        local mach=${2:-*}
+        local name=${3:-current}
+        local dir=$(run get "$name")
+        local adir=$dir/analysis
+
+        grep -h "$expr" "$adir"/logs-$mach.flt.json;;
+
+    list-blocks | blocks | bs )
+        local usage="USAGE: wb analyse $op [RUN-NAME=current]"
+        local name=${1:-current}
+        local dir=$(run get "$name")
+        local adir=$dir/analysis
+
+        fgrep -h "TraceForgedBlock" "$adir"/*.flt.json |
+            jq '{ at: .at, host: .host } * .data | del(.peer) | del(.slot)' -c |
+            sort | uniq;;
+
+    block-propagation-block | bpb )
+        local usage="USAGE: wb analyse $op BLOCK [RUN-NAME=current]"
+        local block=$1
+        local name=${2:-current}
+        local dir=$(run get "$name")
+        local adir=$dir/analysis
+
+        grep -h "$block" "$adir"/*.flt.json |
+            grep 'AddBlock\|TraceForgedBlock\|AddedToCurrentChain' |
+            jq '{ at: .at, host: .host } * .data | del(.peer) | del(.slot)' -c |
+            sort --stable | uniq;;
 
     machine-timeline | machine | mt )
         local usage="USAGE: wb analyse $op [RUN-NAME=current] [MACH-NAME=node-1]"
@@ -72,6 +115,7 @@ EOF
         local dir=$(run get "$name")
         local adir=$dir/analysis
 
+        msg "analysing run $(jq .meta.tag "$dir"/meta.json --raw-output)"
         mkdir -p "$adir"
 
         ## 0. subset what we care about into the keyfile
@@ -80,14 +124,16 @@ EOF
 
         ## 1. enumerate logs, filter by keyfile & consolidate
         local logs=("$dir"/$mach/stdout) consolidated="$adir"/logs-$mach.json
-        grep -hFf "$keyfile" "${logs[@]}"  > "$consolidated"
-        msg "analysing logs of:  $mach  (lines: $(wc -l "$consolidated"))"
+        if test -z "$skip_preparation" -o -z "$(ls "$adir"/logs-$mach.json 2>/dev/null)"
+        then
+            grep -hFf "$keyfile" "${logs[@]}"  > "$consolidated"
+        fi
 
+        msg "analysing logs of:  $mach  (lines: $(wc -l "$consolidated"))"
         local locli_args=(
             --genesis         "$dir"/genesis.json
             --run-metafile    "$dir"/meta.json
             ## ->
-            --logobjects-json "$adir"/logs-$mach.logobjects.json
             --slotstats-json  "$adir"/logs-$mach.slotstats.json
             --timeline-pretty "$adir"/logs-$mach.timeline.txt
             --stats-csv       "$adir"/logs-$mach.stats.csv
@@ -97,8 +143,10 @@ EOF
             # --derived-vectors-0-csv   "$adir"/logs-$mach".derived.1.csv
             # --derived-vectors-1-csv   "$adir"/logs-$mach.derived.1.csv
         )
+        if test -n "$dump_logobjects"; then
+            locli_args+=(--logobjects-json "$adir"/logs-$mach.logobjects.json); fi
 
-        locli 'analyse' 'machine-timeline' \
+        ${time} locli 'analyse' 'machine-timeline' \
             "${locli_args[@]}" "$consolidated";;
 
     * ) usage_analyse;; esac

--- a/nix/workbench/backend.sh
+++ b/nix/workbench/backend.sh
@@ -33,7 +33,8 @@ case "${op}" in
     record-extended-env-config ) $WORKBENCH_BACKEND "$@";;
     describe-run )               $WORKBENCH_BACKEND "$@";;
     pre-run-hook )               $WORKBENCH_BACKEND "$@";;
-    start-run )                  $WORKBENCH_BACKEND "$@";;
+    start-run )                  cp "$2"/genesis/genesis.json "$2"/genesis.json
+                                 $WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqargs )      $WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqexpr )      $WORKBENCH_BACKEND "$@";;
 

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -171,7 +171,7 @@ let
         with envArgs; rec {
           inherit cardanoLib stateDir;
 
-          JSON = runWorkbench "environment.json"
+          JSON = runWorkbenchJqOnly "environment.json"
           ''env compute-config \
             --cache-dir "${cacheDir}" \
             --base-port ${toString basePort} \
@@ -194,7 +194,7 @@ let
       profiles = genAttrs profile-names mkProfile;
 
       profilesJSON =
-        runWorkbench "all-profiles.json" "profiles generate-all";
+        runWorkbenchJqOnly "all-profiles.json" "profiles generate-all";
     };
 
   initialiseProfileRunDirShellScript =

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -69,7 +69,7 @@ let
   runWorkbenchJqOnly =
     name: command:
     runCommand name {} ''
-      ${workbench' [jq]}/bin/wb ${command} > $out
+      ${workbench' [jq moreutils]}/bin/wb ${command} > $out
     '';
 
   runJq =

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -133,7 +133,8 @@ let
     function workbench-prebuild-executables() {
       ${optionalString useCabalRun
         ''
-      git log -n1 --alternate-refs --pretty=format:"%Cblue%h %Cred%cr %Cgreen%D %Cblue%s%Creset"
+      git log -n1 --alternate-refs --pretty=format:"%Cred%cr %Cblue%h %Cgreen%D %Cblue%s%Creset" --color | sed "s/^/$(git diff --exit-code --quiet && echo ' ' || echo '[31mlocal changes + ')/"
+      echo
       echo -n "workbench:  prebuilding executables (because of useCabalRun):"
       for exe in cardano-cli cardano-node cardano-topology locli
       do echo -n " $exe"

--- a/nix/workbench/locli/locli.cabal
+++ b/nix/workbench/locli/locli.cabal
@@ -54,6 +54,7 @@ library
                      , process
                      , scientific
                      , split
+                     , statistics
                      , template-haskell
                      , text
                      , text-short

--- a/nix/workbench/locli/locli.cabal
+++ b/nix/workbench/locli/locli.cabal
@@ -20,7 +20,10 @@ library
                        Cardano.Analysis.Profile
                        Cardano.Analysis.TopHandler
 
-                       Cardano.Unlog.BlockProp
+                       Cardano.Analysis.BlockProp
+                       Cardano.Analysis.Driver
+                       Cardano.Analysis.MachTimeline
+
                        Cardano.Unlog.Commands
                        Cardano.Unlog.LogObject
                        Cardano.Unlog.Parsers
@@ -28,8 +31,6 @@ library
                        Cardano.Unlog.Resources
                        Cardano.Unlog.Run
                        Cardano.Unlog.SlotStats
-                       Cardano.Unlog.Summary
-                       Cardano.Unlog.Timeline
 
   other-modules:       Paths_locli
 

--- a/nix/workbench/locli/locli.cabal
+++ b/nix/workbench/locli/locli.cabal
@@ -24,6 +24,7 @@ library
                        Cardano.Unlog.Commands
                        Cardano.Unlog.LogObject
                        Cardano.Unlog.Parsers
+                       Cardano.Unlog.Render
                        Cardano.Unlog.Resources
                        Cardano.Unlog.Run
                        Cardano.Unlog.SlotStats

--- a/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
@@ -15,14 +15,19 @@ module Cardano.Analysis.BlockProp (module Cardano.Analysis.BlockProp) where
 import           Prelude (String, (!!), error, head, id, show, tail)
 import           Cardano.Prelude hiding (head, show)
 
-import           Control.Arrow ((&&&), (***))
+import           Control.Arrow ((***), (&&&))
 import           Control.Concurrent.Async (mapConcurrently)
-import           Data.Aeson (toJSON)
+import           Data.Aeson (ToJSON(..), FromJSON(..))
 import qualified Data.Aeson as AE
+import           Data.Bifunctor
 import           Data.Function (on)
-import           Data.Either (partitionEithers, isLeft, isRight)
-import           Data.List (dropWhileEnd)
-import           Data.Maybe (catMaybes, mapMaybe)
+import           Data.List (dropWhileEnd, intercalate)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes, mapMaybe, isNothing)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text as T
 import           Data.Tuple (swap)
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
@@ -52,6 +57,7 @@ data BlockPropagation
     , bpForgerAnnouncements :: !(Distribution Float NominalDiffTime)
     , bpForgerSends         :: !(Distribution Float NominalDiffTime)
     , bpPeerNotices         :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    , bpPeerRequests        :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
     , bpPeerFetches         :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
     , bpPeerAdoptions       :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
     , bpPeerAnnouncements   :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
@@ -65,22 +71,24 @@ instance RenderDistributions BlockPropagation where
     --  Width LeftPad
     [ Field 6 0 "forged"        (f!!0) "Forge"   $ DDeltaT bpForgerForges
     , Field 6 0 "fAdopted"      (f!!1) "Adopt"   $ DDeltaT bpForgerAdoptions
-    , Field 6 0 "fAnnounced"    (f!!2) "Ann-ce"  $ DDeltaT bpForgerAnnouncements
-    , Field 6 0 "fSendStart"    (f!!3) "Sending" $ DDeltaT bpForgerSends
+    , Field 6 0 "fAnnounced"    (f!!2) "Announ"  $ DDeltaT bpForgerAnnouncements
+    , Field 6 0 "fSendStart"    (f!!3) "Sendin"  $ DDeltaT bpForgerSends
     , Field 4 1 "noticedVal"    (p!!0) " Noti"   $ DDeltaT (fst . bpPeerNotices)
     , Field 4 0 "noticedCoV"    (p!!1) "ced  "   $ DDeltaT (snd . bpPeerNotices)
-    , Field 4 1 "fetchedVal"    (p!!2) " Fetc"   $ DDeltaT (fst . bpPeerFetches)
-    , Field 4 0 "fetchedCoV"    (p!!3) "hed  "   $ DDeltaT (snd . bpPeerFetches)
-    , Field 4 1 "pAdoptedVal"   (p!!4) " Adop"   $ DDeltaT (fst . bpPeerAdoptions)
-    , Field 4 0 "pAdoptedCoV"   (p!!5) "ted  "   $ DDeltaT (snd . bpPeerAdoptions)
-    , Field 4 1 "pAnnouncedVal" (p!!6) "Annou" $ DDeltaT (fst . bpPeerAnnouncements)
-    , Field 4 0 "pAnnouncedCoV" (p!!7) "nced " $ DDeltaT (snd . bpPeerAnnouncements)
-    , Field 4 1 "pSendStartVal" (p!!8) " Send" $ DDeltaT (fst . bpPeerSends)
-    , Field 4 0 "pSendStartCoV" (p!!9) "ing  " $ DDeltaT (snd . bpPeerSends)
+    , Field 4 1 "requestedVal"  (p!!2) "Reque"   $ DDeltaT (fst . bpPeerRequests)
+    , Field 4 0 "requestedVal"  (p!!3) "sted "   $ DDeltaT (snd . bpPeerRequests)
+    , Field 4 1 "fetchedVal"    (p!!4) " Fetc"   $ DDeltaT (fst . bpPeerFetches)
+    , Field 4 0 "fetchedCoV"    (p!!5) "hed  "   $ DDeltaT (snd . bpPeerFetches)
+    , Field 4 1 "pAdoptedVal"   (p!!6) " Adop"   $ DDeltaT (fst . bpPeerAdoptions)
+    , Field 4 0 "pAdoptedCoV"   (p!!7) "ted  "   $ DDeltaT (snd . bpPeerAdoptions)
+    , Field 4 1 "pAnnouncedVal" (p!!8) "Annou"  $ DDeltaT (fst . bpPeerAnnouncements)
+    , Field 4 0 "pAnnouncedCoV" (p!!9) "nced "  $ DDeltaT (snd . bpPeerAnnouncements)
+    , Field 4 1 "pSendStartVal" (p!!10) " Send" $ DDeltaT (fst . bpPeerSends)
+    , Field 4 0 "pSendStartCoV" (p!!11) "ing  " $ DDeltaT (snd . bpPeerSends)
     ]
    where
      f = nChunksEachOf  4 7 "Forger event Δt:"
-     p = nChunksEachOf 10 5 "Peer event Δt, and coefficients of variation:"
+     p = nChunksEachOf 12 5 "Peer event Δt, and coefficients of variation:"
 
 instance AE.ToJSON BlockPropagation where
   toJSON BlockPropagation{..} = AE.Array $ Vec.fromList
@@ -90,6 +98,8 @@ instance AE.ToJSON BlockPropagation where
     , extendObject "kind" "forgerSends"         $ toJSON bpForgerSends
     , extendObject "kind" "peerNoticesMean"       $ toJSON (fst bpPeerNotices)
     , extendObject "kind" "peerNoticesCoV"        $ toJSON (snd bpPeerNotices)
+    , extendObject "kind" "peerRequestsMean"      $ toJSON (fst bpPeerRequests)
+    , extendObject "kind" "peerRequestsCoV"       $ toJSON (snd bpPeerRequests)
     , extendObject "kind" "peerFetchesMean"       $ toJSON (fst bpPeerFetches)
     , extendObject "kind" "peerFetchesCoV"        $ toJSON (snd bpPeerFetches)
     , extendObject "kind" "peerAdoptionsMean"     $ toJSON (fst bpPeerAdoptions)
@@ -100,98 +110,235 @@ instance AE.ToJSON BlockPropagation where
     , extendObject "kind" "peerSendsCoV"          $ toJSON (snd bpPeerSends)
     ]
 
+data BPError
+  = BPError
+  { eBlock :: !Hash
+  , eFile  :: !(Maybe FilePath)
+  , eLO    :: !(Maybe LogObject)
+  , eDesc  :: !BPErrorKind
+  }
+  deriving (FromJSON, Generic, Show, ToJSON)
+
+data BPErrorKind
+  = BPEBefore                !Phase !Phase
+  | BPEUnexpectedForObserver !Phase
+  | BPEUnexpectedForForger   !Phase
+  | BPEUnexpectedAsFirst     !Phase
+  | BPEDuplicateForge
+  | BPEMissingPhase          !Phase
+  | BPENegativePhase         !Phase !NominalDiffTime
+  | BPEFork                  !Hash
+  deriving (FromJSON, Generic, Show, ToJSON)
+
+bpeIsFork, bpeIsMissingAny, bpeIsNegativeAny  :: BPError -> Bool
+bpeIsFork BPError{eDesc=BPEFork{}} = True
+bpeIsFork _ = False
+bpeIsMissingAny BPError{eDesc=BPEMissingPhase{}} = True
+bpeIsMissingAny _ = False
+bpeIsNegativeAny BPError{eDesc=BPENegativePhase{}} = True
+bpeIsNegativeAny _ = False
+
+bpeIsMissing, bpeIsNegative  :: Phase -> BPError -> Bool
+bpeIsMissing  p BPError{eDesc=BPEMissingPhase p'} = p == p'
+bpeIsMissing  _ _ = False
+bpeIsNegative p BPError{eDesc=BPENegativePhase p' _} = p == p'
+bpeIsNegative _ _ = False
+
+data Phase
+  = Notice
+  | Request
+  | Fetch
+  | Forge
+  | Acquire
+  | Adopt
+  | Announce
+  | Send
+  deriving (FromJSON, Eq, Generic, Ord, Show, ToJSON)
+
 -- | Block's events, as seen by its forger.
-data BlockForgerEvents
-  =  BlockForgerEvents
+data ForgerEvents a
+  =  ForgerEvents
   { bfeHost       :: !Host
   , bfeBlock      :: !Hash
   , bfeBlockPrev  :: !Hash
   , bfeBlockNo    :: !BlockNo
   , bfeSlotNo     :: !SlotNo
-  , bfeSlotStart  :: !UTCTime
-  , bfeForged     :: !(Maybe NominalDiffTime)
-  , bfeAdopted    :: !(Maybe NominalDiffTime)
+  , bfeSlotStart  :: !SlotStart
+  , bfeForged     :: !(Maybe a)
+  , bfeAdopted    :: !(Maybe a)
   , bfeChainDelta :: !Int
-  , bfeAnnounced  :: !(Maybe NominalDiffTime)
-  , bfeSending    :: !(Maybe NominalDiffTime)
+  , bfeAnnounced  :: !(Maybe a)
+  , bfeSending    :: !(Maybe a)
+  , bfeErrs       :: [BPError]
   }
   deriving (Generic, AE.FromJSON, AE.ToJSON, Show)
 
-bfePrevBlock :: BlockForgerEvents -> Maybe Hash
+type ForgerEventsAbs = ForgerEvents UTCTime
+type ForgerEventsRel = ForgerEvents NominalDiffTime
+
+bfePrevBlock :: ForgerEvents a -> Maybe Hash
 bfePrevBlock x = case bfeBlockNo x of
   0 -> Nothing
   _ -> Just $ bfeBlockPrev x
 
 -- | Block's events, as seen by an observer.
-data BlockObserverEvents
-  =  BlockObserverEvents
+data ObserverEvents a
+  =  ObserverEvents
   { boeHost       :: !Host
   , boeBlock      :: !Hash
   , boeBlockNo    :: !BlockNo
   , boeSlotNo     :: !SlotNo
-  , boeSlotStart  :: !UTCTime
-  , boeNoticed    :: !(Maybe NominalDiffTime)
-  , boeFetched    :: !(Maybe NominalDiffTime)
-  , boeAdopted    :: !(Maybe NominalDiffTime)
+  , boeSlotStart  :: !SlotStart
+  , boeNoticed    :: !(Maybe a)
+  , boeRequested  :: !(Maybe a)
+  , boeFetched    :: !(Maybe a)
+  , boeAdopted    :: !(Maybe a)
   , boeChainDelta :: !Int
-  , boeAnnounced  :: !(Maybe NominalDiffTime)
-  , boeSending    :: !(Maybe NominalDiffTime)
+  , boeAnnounced  :: !(Maybe a)
+  , boeSending    :: !(Maybe a)
+  , boeErrs       :: [BPError]
   }
   deriving (Generic, AE.FromJSON, AE.ToJSON, Show)
 
+type ObserverEventsAbs = ObserverEvents UTCTime
+type ObserverEventsRel = ObserverEvents NominalDiffTime
+
+mbePhaseIndex :: Map Phase (MachBlockEvents a -> Maybe a)
+mbePhaseIndex = Map.fromList
+  [ (Notice,     mbeNoticed)
+  , (Request,    mbeRequested)
+  , (Fetch,      mbeAcquired)
+  , (Forge,      mbeAcquired)
+  , (Acquire,    mbeAcquired)
+  , (Adopt,      mbeAdopted)
+  , (Announce,   mbeAnnounced)
+  , (Send,       mbeSending)
+  ]
+
+mbeGetProjection :: Phase -> (MachBlockEvents a -> Maybe a)
+mbeGetProjection k =
+  Map.lookup k mbePhaseIndex
+  & fromMaybe (error $ "Unknown phase: " <> show k)
+
 -- | Sum of observer and forger events alike.
-type MachBlockEvents = Either BlockObserverEvents BlockForgerEvents
+data MachBlockEvents a
+  = MFE (ForgerEvents a)
+  | MOE (ObserverEvents a)
+  | MBE  BPError
 
-ordBlockEv :: MachBlockEvents -> MachBlockEvents -> Ordering
+mbeForgP, mbeObsvP, mbeErrP :: MachBlockEvents a -> Bool
+mbeForgP = \case
+  MFE{} -> True
+  _ -> False
+mbeObsvP = \case
+  MOE{} -> True
+  _ -> False
+mbeErrP = \case
+  MBE{} -> True
+  _ -> False
+
+mapMbe :: (ForgerEvents a -> b) -> (ObserverEvents a -> b) -> (BPError -> b)
+       -> MachBlockEvents a -> b
+mapMbe f o e = \case
+  MFE x -> f x
+  MOE x -> o x
+  MBE x -> e x
+
+mapMbeErrs :: ([BPError] -> [BPError]) -> MachBlockEvents a -> MachBlockEvents a
+mapMbeErrs f = mapMbe (\x -> MFE x { bfeErrs=f $ bfeErrs x } )
+                      (\x -> MOE x { boeErrs=f $ boeErrs x } )
+                      MBE
+
+partitionMbes :: [MachBlockEvents a] -> ([ForgerEvents a], [ObserverEvents a], [BPError])
+partitionMbes = go [] [] []
+  where
+    go :: [ForgerEvents a] -> [ObserverEvents a] -> [BPError] -> [MachBlockEvents a] -> ([ForgerEvents a], [ObserverEvents a], [BPError])
+    go as bs cs [] = (reverse as, reverse bs, reverse cs)
+    go as bs cs (MFE a:xs) = go (a:as) bs cs xs
+    go as bs cs (MOE b:xs) = go as (b:bs) cs xs
+    go as bs cs (MBE c:xs) = go as bs (c:cs) xs
+
+errorMbes :: [MachBlockEvents a] -> [BPError]
+errorMbes = go []
+  where
+    go :: [BPError] -> [MachBlockEvents a] -> [BPError]
+    go cs [] = reverse cs
+    go cs (MBE c:xs) = go (c:cs) xs
+    go cs (_:xs)     = go    cs  xs
+
+trimapMbe ::
+     (ForgerEvents a -> ForgerEvents a)
+  -> (ObserverEvents a -> ObserverEvents a)
+  -> (BPError -> BPError)
+  -> MachBlockEvents a -> MachBlockEvents a
+trimapMbe f o e = mapMbe (MFE . f) (MOE . o) (MBE . e)
+
+bimapMbe ::
+     (ForgerEvents a -> ForgerEvents a)
+  -> (ObserverEvents a -> ObserverEvents a)
+  -> MachBlockEvents a -> MachBlockEvents a
+bimapMbe f o = trimapMbe f o id
+
+bimapMbe' ::
+     (ForgerEvents   a -> Either BPError (ForgerEvents   a))
+  -> (ObserverEvents a -> Either BPError (ObserverEvents a))
+  -> MachBlockEvents a -> MachBlockEvents a
+bimapMbe' f o = \case
+  MFE x -> either MBE MFE (f x)
+  MOE x -> either MBE MOE (o x)
+  x@MBE{} -> x
+
+ordBlockEv :: MachBlockEvents a -> MachBlockEvents a -> Ordering
 ordBlockEv l r
-  | (on (>) $ either boeBlockNo bfeBlockNo) l r = GT
-  | (on (>) $ either boeBlockNo bfeBlockNo) r l = LT
-  | isRight l = GT
-  | isRight r = LT
-  | otherwise = EQ
+  | (on (>) $ mapMbe bfeBlockNo boeBlockNo (const 0)) l r = GT
+  | (on (>) $ mapMbe bfeBlockNo boeBlockNo (const 0)) r l = LT
+  | mbeForgP l = GT
+  | mbeForgP r = LT
+  | mbeObsvP l = GT
+  | mbeObsvP r = LT
+  | otherwise  = EQ
 
-mbeSlotStart :: MachBlockEvents -> UTCTime
-mbeSlotStart = either boeSlotStart bfeSlotStart
+mbeSlotStart :: MachBlockEvents a -> SlotStart
+mbeSlotStart = mapMbe bfeSlotStart boeSlotStart (SlotStart . const zeroUTCTime)
 
-mbeNoticed, mbeAcquired, mbeAdopted, mbeAnnounced, mbeSending :: MachBlockEvents -> Maybe NominalDiffTime
-mbeNoticed   = either boeNoticed   (const $ Just 0)
-mbeAcquired  = either boeFetched   bfeForged
-mbeAdopted   = either boeAdopted   bfeAdopted
-mbeAnnounced = either boeAnnounced bfeAnnounced
-mbeSending   = either boeSending   bfeSending
+mbeNoticed, mbeRequested, mbeAcquired, mbeAdopted, mbeAnnounced, mbeSending :: MachBlockEvents a -> Maybe a
+mbeNoticed   = mapMbe (const Nothing)  boeNoticed   (const Nothing)
+mbeRequested = mapMbe (const Nothing)  boeRequested (const Nothing)
+mbeAcquired  = mapMbe bfeForged        boeFetched   (const Nothing)
+mbeAdopted   = mapMbe bfeAdopted       boeAdopted   (const Nothing)
+mbeAnnounced = mapMbe bfeAnnounced     boeAnnounced (const Nothing)
+mbeSending   = mapMbe bfeSending       boeSending   (const Nothing)
 
-mbeBlockHash :: MachBlockEvents -> Hash
-mbeBlockHash = either boeBlock bfeBlock
+mbeBlock :: MachBlockEvents a -> Hash
+mbeBlock = mapMbe bfeBlock boeBlock eBlock
 
-mbeSetAdopted :: MachBlockEvents -> Int -> NominalDiffTime -> MachBlockEvents
-mbeSetAdopted   mbe d v = either (\x -> Left x { boeAdopted=Just v, boeChainDelta=d })   (\x -> Right x { bfeAdopted=Just v, bfeChainDelta=d }) mbe
+mbeBlockNo :: MachBlockEvents a -> BlockNo
+mbeBlockNo = mapMbe bfeBlockNo boeBlockNo (const (-1))
 
-mbeSetAnnounced, mbeSetSending, mbeSetNoticed, mbeSetFetched :: MachBlockEvents -> NominalDiffTime -> MachBlockEvents
-mbeSetAnnounced mbe v = either (\x -> Left x { boeAnnounced=Just v }) (\x -> Right x { bfeAnnounced=Just v }) mbe
-mbeSetSending   mbe v = either (\x -> Left x { boeSending=Just v })   (\x -> Right x { bfeSending=Just v }) mbe
-mbeSetNoticed   mbe v = either (\x -> Left x { boeNoticed=Just v })   (const $ error "mbeSetNoticed on a BFE.") mbe
-mbeSetFetched   mbe v = either (\x -> Left x { boeFetched=Just v })   (const $ error "mbeSetFetched on a BFE.") mbe
+mbeError :: MachBlockEvents a -> Maybe BPError
+mbeError = mapMbe (const Nothing) (const Nothing) Just
+
+mbeFailed :: MachBlockEvents a -> Bool
+mbeFailed = isJust . mbeError
 
 -- | Machine's private view of all the blocks.
-type MachBlockMap
-  =  Map.Map Hash MachBlockEvents
+type MachBlockMap a
+  =  Map.Map Hash (MachBlockEvents a)
 
-blockMapHost :: MachBlockMap -> Host
-blockMapHost = either boeHost bfeHost . head . Map.elems
-
-blockMapMaxBlock :: MachBlockMap -> MachBlockEvents
+blockMapMaxBlock :: MachBlockMap a -> MachBlockEvents a
 blockMapMaxBlock = maximumBy ordBlockEv . Map.elems
 
-blockMapBlock :: Hash -> MachBlockMap -> MachBlockEvents
+blockMapBlock :: Hash -> MachBlockMap a -> MachBlockEvents a
 blockMapBlock h =
   fromMaybe (error $ "Invariant failed:  missing hash " <> show h) . Map.lookup h
 
--- | A completed, compactified version of BlockObserverEvents.
+-- | A completed, compactified version of ObserverEvents.
 data BlockObservation
   =  BlockObservation
   { boObserver   :: !Host
-  , boSlotStart  :: !UTCTime
+  , boSlotStart  :: !SlotStart
   , boNoticed    :: !NominalDiffTime
+  , boRequested  :: !NominalDiffTime
   , boFetched    :: !NominalDiffTime
   , boAdopted    :: !(Maybe NominalDiffTime)
   , boChainDelta :: !Int -- ^ ChainDelta during adoption
@@ -208,25 +355,40 @@ data BlockEvents
   , beBlockPrev    :: !Hash
   , beBlockNo      :: !BlockNo
   , beSlotNo       :: !SlotNo
-  , beSlotStart    :: !UTCTime
+  , beSlotStart    :: !SlotStart
   , beForged       :: !NominalDiffTime
   , beAdopted      :: !NominalDiffTime
   , beChainDelta   :: !Int -- ^ ChainDelta during adoption
   , beAnnounced    :: !NominalDiffTime
   , beSending      :: !NominalDiffTime
   , beObservations :: [BlockObservation]
+  , beOtherBlocks  :: [Hash]
+  , beErrors       :: [BPError]
   }
   deriving (Generic, AE.FromJSON, AE.ToJSON, Show)
 
 instance RenderTimeline BlockEvents where
   rtFields =
     --  Width LeftPad
-    [ Field 5 0 "block"     "block" "no."     $ IWord64 (unBlockNo . beBlockNo)
-    , Field 5 0 "abs.slot"  "abs."  "slot#"   $ IWord64 (unSlotNo . beSlotNo)
+    [ Field 5 0 "block"       "block" "no."    $ IWord64 (unBlockNo . beBlockNo)
+    , Field 5 0 "abs.slot"    "abs."  "slot#"  $ IWord64 (unSlotNo . beSlotNo)
+    , Field 6 0 "hash"        "block" "hash"   $ IText   (shortHash . beBlock)
+    , Field 6 0 "hashPrev"    "prev"  "hash"   $ IText   (shortHash . beBlockPrev)
+    , Field 5 0 "peer.observ" "valid" "obsrv"  $ IInt    (length . beObservations)
+    , Field 5 0 "errors"      "all"   "errs"   $ IInt    (length . beErrors)
+    , Field 5 0 "forks"       ""      "forks"  $ IInt    (count bpeIsFork . beErrors)
+    , Field 5 0 "missAdopt"   (m!!0) "adopt"   $ IInt    (count (bpeIsMissing Adopt) . beErrors)
+    , Field 5 0 "missAnnou"   (m!!1) "annou"   $ IInt    (count (bpeIsMissing Announce) . beErrors)
+    , Field 5 0 "missSend"    (m!!2) "send"    $ IInt    (count (bpeIsMissing Send) . beErrors)
+    , Field 5 0 "negAnnou"    (n!!0) "annou"   $ IInt    (count (bpeIsNegative Announce) . beErrors)
+    , Field 5 0 "negSend"     (n!!1) "send"    $ IInt    (count (bpeIsNegative Send) . beErrors)
     ]
    where
-     f w = nChunksEachOf 4 (w + 1) "Block forging events"
-     p w = nChunksEachOf 4 (w + 1) "Non-forging peer observation events"
+     m = nChunksEachOf 3 6 "Missing phase"
+     n = nChunksEachOf 2 6 "Negative phase"
+     count :: (a -> Bool) -> [a] -> Int
+     count f = length . filter f
+  rtCommentary BlockEvents{..} = ("    " <>) . T.pack . show <$> beErrors
 
 mapChainToForgerEventCDF ::
      [PercSpec Float]
@@ -263,9 +425,11 @@ mapChainToPeerBlockObservationCDFs percs cbe proj desc =
 blockProp :: ChainInfo -> [(JsonLogfile, [LogObject])] -> IO BlockPropagation
 blockProp ci xs = do
   putStrLn ("blockProp: recovering block event maps" :: String)
-  doBlockProp =<< mapConcurrently (pure . blockEventsFromLogObjects ci) xs
+  doBlockProp =<< mapConcurrently (pure
+                                   . fmap deltifyEvents
+                                   . blockEventMapsFromLogObjects ci) xs
 
-doBlockProp :: [MachBlockMap] -> IO BlockPropagation
+doBlockProp :: [MachBlockMap NominalDiffTime] -> IO BlockPropagation
 doBlockProp eventMaps = do
   putStrLn ("tip block: " <> show tipBlock :: String)
   putStrLn ("chain length: " <> show (length chain) :: String)
@@ -276,6 +440,7 @@ doBlockProp eventMaps = do
     (forgerEventsCDF    (Just . beAnnounced))
     (forgerEventsCDF    (Just . beSending))
     (observerEventsCDFs (Just . boNoticed) "peer noticed")
+    (observerEventsCDFs (Just . boRequested) "peer requested")
     (observerEventsCDFs (Just . boFetched) "peer fetched")
     (observerEventsCDFs (\x -> if boChainDelta x == 1 then boAdopted x
                                else Nothing) "peer adopted")
@@ -286,38 +451,52 @@ doBlockProp eventMaps = do
    forgerEventsCDF    = mapChainToForgerEventCDF           stdPercentiles chain
    observerEventsCDFs = mapChainToPeerBlockObservationCDFs stdPercentiles chain
 
+   chain          :: [BlockEvents]
    chain          = rebuildChain eventMaps tipHash
+   heightMap      :: Map BlockNo (Set Hash)
+   heightMap      = foldr (\em acc ->
+                             Map.foldr
+                             (\mbe -> Map.alter
+                                      (maybe (Just $ Set.singleton (mbeBlock mbe))
+                                             (Just . Set.insert (mbeBlock mbe)))
+                                      (mbeBlockNo mbe))
+                             acc em)
+                    mempty eventMaps
    tipBlock       = getBlockForge eventMaps tipHash
-   tipHash        = rewindChain eventMaps 1 (mbeBlockHash finalBlockEv)
+   tipHash        = rewindChain eventMaps 1 (mbeBlock finalBlockEv)
    finalBlockEv   = maximumBy ordBlockEv $ blockMapMaxBlock <$> eventMaps
 
-   rewindChain :: [MachBlockMap] -> Int -> Hash -> Hash
+   rewindChain :: [MachBlockMap a] -> Int -> Hash -> Hash
    rewindChain eventMaps count tip = go tip count
     where go tip = \case
             0 -> tip
             n -> go (bfeBlockPrev $ getBlockForge eventMaps tip) (n - 1)
 
-   getBlockForge :: [MachBlockMap] -> Hash -> BlockForgerEvents
+   getBlockForge :: [MachBlockMap a] -> Hash -> ForgerEvents a
    getBlockForge xs h =
-     either (error "Invariant failed: finalBlockEv isn't a forge.") id $
-            maximumBy ordBlockEv $
-            mapMaybe (Map.lookup h) xs
+     mapMaybe (Map.lookup h) xs
+     & find mbeForgP
+     & fromMaybe
+        (error $ mconcat
+         [ "Invariant failed: couldn't find a forge for hash ", show h
+         , "\nErrors:\n", show (intercalate "\n" $ fmap show $ errorMbes $ mapMaybe (Map.lookup h) xs)
+         ])
+     & mapMbe id (error "Silly invariant failed.") (error "Silly invariant failed.")
 
-   rebuildChain :: [MachBlockMap] -> Hash -> [BlockEvents]
+   rebuildChain :: [MachBlockMap NominalDiffTime] -> Hash -> [BlockEvents]
    rebuildChain machBlockMaps tip = go (Just tip) []
     where go Nothing  acc = acc
           go (Just h) acc =
-            let blkEvs@(forgerEv, _) = collectAllBlockEvents machBlockMaps h
-            in go (bfePrevBlock forgerEv)
-                  (liftBlockEvents blkEvs : acc)
+            case partitionMbes $ mapMaybe (Map.lookup h) machBlockMaps of
+              ([], _, ers) -> error $ mconcat
+                [ "No forger for hash ", show h
+                , "\nErrors:\n"
+                ] ++ intercalate "\n" (show <$> ers)
+              blkEvs@(forgerEv:_, oEvs, ers) ->
+                go (bfePrevBlock forgerEv) (liftBlockEvents forgerEv oEvs ers : acc)
 
-   collectAllBlockEvents :: [MachBlockMap] -> Hash -> (BlockForgerEvents, [BlockObserverEvents])
-   collectAllBlockEvents xs blk =
-     partitionEithers (mapMaybe (Map.lookup blk) xs)
-     & swap & first head
-
-   liftBlockEvents :: (BlockForgerEvents, [BlockObserverEvents]) -> BlockEvents
-   liftBlockEvents (BlockForgerEvents{..}, os) =
+   liftBlockEvents :: ForgerEventsRel -> [ObserverEvents NominalDiffTime] -> [BPError] -> BlockEvents
+   liftBlockEvents ForgerEvents{..} os errs =
      BlockEvents
      { beForger     = bfeHost
      , beBlock      = bfeBlock
@@ -325,109 +504,209 @@ doBlockProp eventMaps = do
      , beBlockNo    = bfeBlockNo
      , beSlotNo     = bfeSlotNo
      , beSlotStart  = bfeSlotStart
-     , beForged     = bfeForged    & miss "Forged"
-     , beAdopted    = bfeAdopted   & miss "Adopted (forger)"
+     , beForged     = bfeForged    & handleMiss "Δt Forged"
+     , beAdopted    = bfeAdopted   & handleMiss "Δt Adopted (forger)"
      , beChainDelta = bfeChainDelta
-     , beAnnounced  = bfeAnnounced & miss "Announced (forger)"
-     , beSending    = bfeSending   & miss "Sending (forger)"
+     , beAnnounced  = bfeAnnounced & handleMiss "Δt Announced (forger)"
+     , beSending    = bfeSending   & handleMiss "Δt Sending (forger)"
      , beObservations = catMaybes $
-       os <&> \BlockObserverEvents{..}->
+       os <&> \ObserverEvents{..}->
          BlockObservation
            <$> Just boeHost
            <*> Just bfeSlotStart
            <*> boeNoticed
+           <*> boeRequested
            <*> boeFetched
            <*> Just boeAdopted
            <*> Just boeChainDelta
            <*> Just boeAnnounced
            <*> Just boeSending
+     , beOtherBlocks = otherBlocks
+     , beErrors =
+         errs
+         <> (fail' bfeBlock . BPEFork <$> otherBlocks)
+         <> bfeErrs
+         <> concatMap boeErrs os
      }
     where
-      miss :: String -> Maybe a -> a
-      miss slotDesc = fromMaybe $ error $ mconcat
+      otherBlocks = Map.lookup bfeBlockNo heightMap
+                    & handleMiss "height map"
+                    & Set.delete bfeBlock
+                    & Set.toList
+      fail' :: Hash -> BPErrorKind -> BPError
+      fail' hash desc = BPError hash Nothing Nothing desc
+
+      handleMiss :: String -> Maybe a -> a
+      handleMiss slotDesc = fromMaybe $ error $ mconcat
        [ "While processing ", show bfeBlockNo, " hash ", show bfeBlock
        , " forged by ", show bfeHost
-       , " -- missing slot: ", slotDesc
+       , " -- missing: ", slotDesc
        ]
 
 -- | Given a single machine's log object stream, recover its block map.
-blockEventsFromLogObjects :: ChainInfo -> (JsonLogfile, [LogObject]) -> MachBlockMap
-blockEventsFromLogObjects ci (fp, xs) =
-  foldl (blockPropMachEventsStep ci fp) mempty xs
+blockEventMapsFromLogObjects :: ChainInfo -> (JsonLogfile, [LogObject]) -> MachBlockMap UTCTime
+blockEventMapsFromLogObjects ci (f@(unJsonLogfile -> fp), xs) =
+  trace ("processing " <> fp)
+  $ if Map.size machBlockMap == 0
+    then error $ mconcat
+         ["No block events in ",fp," : ","LogObject count: ",show (length xs)]
+    else machBlockMap
+ where
+   machBlockMap = foldl (blockPropMachEventsStep ci f) mempty xs
 
-blockPropMachEventsStep :: ChainInfo -> JsonLogfile -> MachBlockMap -> LogObject -> MachBlockMap
-blockPropMachEventsStep ci fp bMap = \case
-  LogObject{loAt, loHost, loBody=LOBlockForged{loBlock,loPrev,loBlockNo,loSlotNo}} ->
-    mbmGetForger loHost loBlock bMap "LOBlockForged"
-    & fromMaybe
-      (Right $ BlockForgerEvents
-        loHost loBlock loPrev loBlockNo loSlotNo (slotStart ci loSlotNo)
-        (Just $ loAt `diffUTCTime` slotStart ci loSlotNo) Nothing 0 Nothing Nothing)
-    & doInsert loBlock
+blockPropMachEventsStep :: ChainInfo -> JsonLogfile -> MachBlockMap UTCTime -> LogObject -> MachBlockMap UTCTime
+blockPropMachEventsStep ci (JsonLogfile fp) bMap lo = case lo of
+  -- 0. Notice (observer only)
   LogObject{loAt, loHost, loBody=LOChainSyncClientSeenHeader{loBlock,loBlockNo,loSlotNo}} ->
     let mbe0 = Map.lookup loBlock bMap
     in if isJust mbe0 then bMap else
-      (Left $
-       BlockObserverEvents
-         loHost loBlock loBlockNo loSlotNo (slotStart ci loSlotNo)
-         (Just $ loAt `diffUTCTime` slotStart ci loSlotNo) Nothing Nothing 0 Nothing Nothing)
+      (MOE $
+       ObserverEvents
+         loHost loBlock loBlockNo loSlotNo
+         (slotStart ci loSlotNo) (Just loAt)
+         Nothing Nothing Nothing 0 Nothing Nothing [])
       & doInsert loBlock
-  LogObject{loAt, loHost, loBody=LOBlockFetchClientCompletedFetch{loBlock}} ->
-    let mbe0 = Left $ mbmGetObserver loHost loBlock bMap "LOBlockFetchClientCompletedFetch"
-    in
-      mDeltaT loAt mbe0 [mbeNoticed]
-      & fromMaybe (err loHost loBlock "LOBlockFetchClientCompletedFetch leads fetching")
-      & mbeSetFetched mbe0
-      & doInsert loBlock
-  LogObject{loAt, loHost, loBody=LOBlockAddedToCurrentChain{loBlock,loChainLengthDelta}} ->
+  -- 1. Request (observer only)
+  LogObject{loAt, loHost, loBody=LOBlockFetchClientRequested{loBlock,loLength}} ->
     let mbe0 = Map.lookup loBlock bMap
-               & fromMaybe (err loHost loBlock "LOBlockAddedToCurrentChain leads")
-    in if isJust (mbeAdopted mbe0) then bMap else
-      mDeltaT loAt mbe0 [mbeNoticed, mbeAcquired]
-      & fromMaybe (err loHost loBlock "LOBlockAddedToCurrentChain leads acquirement")
-      & mbeSetAdopted mbe0 loChainLengthDelta
+               & fromMaybe (fail loBlock $ BPEUnexpectedAsFirst Request)
+    in if isJust (mbeRequested mbe0) then bMap else
+      bimapMbe'
+      (const . Left $ fail' loBlock $ BPEUnexpectedForForger Request)
+      (\x -> Right x { boeRequested=Just loAt, boeChainDelta=loLength `max` boeChainDelta x })
+      mbe0
       & doInsert loBlock
+  -- 2. Acquire:Fetch (observer only)
+  LogObject{loAt, loHost, loBody=LOBlockFetchClientCompletedFetch{loBlock}} ->
+    let mbe0 = Map.lookup loBlock bMap
+               & fromMaybe (fail loBlock $ BPEUnexpectedAsFirst Fetch)
+    in if isJust (mbeAcquired mbe0) then bMap else
+      bimapMbe'
+      (const . Left $ fail' loBlock (BPEUnexpectedForForger Fetch))
+      (\x -> Right x { boeFetched=Just loAt })
+      mbe0
+      & doInsert loBlock
+  -- 2. Acquire:Forge (forger only)
+  LogObject{loAt, loHost, loBody=LOBlockForged{loBlock,loPrev,loBlockNo,loSlotNo}} ->
+    Map.lookup loBlock bMap
+    <&> bimapMbe'
+          (const.Left $
+           BPError loBlock (Just fp) (Just lo) BPEDuplicateForge)
+          (const.Left $
+           BPError loBlock (Just fp) (Just lo) (BPEUnexpectedForObserver Forge))
+    & fromMaybe
+      (MFE $ ForgerEvents
+        loHost loBlock loPrev loBlockNo loSlotNo
+        (slotStart ci loSlotNo) (Just loAt)
+        Nothing 0 Nothing Nothing [])
+    & doInsert loBlock
+  -- 3. Adopt
+  LogObject{loAt, loHost, loBody=LOBlockAddedToCurrentChain{loBlock,loLength}} ->
+    let mbe0 = Map.lookup loBlock bMap
+               & fromMaybe (fail loBlock $ BPEUnexpectedAsFirst Adopt)
+    in if isJust (mbeAdopted mbe0) then bMap else
+      bimapMbe
+      (\x -> x { bfeAdopted=Just loAt, bfeChainDelta=loLength })
+      (\x -> x { boeAdopted=Just loAt, boeChainDelta=loLength `max` boeChainDelta x})
+      mbe0
+      & doInsert loBlock
+  -- 4. Announce
   LogObject{loAt, loHost, loBody=LOChainSyncServerSendHeader{loBlock}} ->
     let mbe0 = Map.lookup loBlock bMap
-               & fromMaybe (err loHost loBlock "LOChainSyncServerSendHeader leads")
+               & fromMaybe (fail loBlock $ BPEUnexpectedAsFirst Announce)
     in if isJust (mbeAnnounced mbe0) then bMap else
-      mDeltaT loAt mbe0 [mbeNoticed, mbeAcquired, mbeAdopted]
-      & fromMaybe (err loHost loBlock "LOChainSyncServerSendHeader leads adoption")
-      & mbeSetAnnounced mbe0
+      bimapMbe
+      (\x -> x { bfeAnnounced=Just loAt })
+      (\x -> x { boeAnnounced=Just loAt })
+      mbe0
       & doInsert loBlock
+  -- 5. Sending started
   LogObject{loAt, loHost, loBody=LOBlockFetchServerSending{loBlock}} ->
     let mbe0 = Map.lookup loBlock bMap
-               & fromMaybe (err loHost loBlock "LOBlockFetchServerSending leads")
+               & fromMaybe (fail loBlock $ BPEUnexpectedAsFirst Send)
     in if isJust (mbeSending mbe0) then bMap else
-      mDeltaT loAt mbe0 [mbeNoticed, mbeAcquired, mbeAdopted, mbeAnnounced]
-      & fromMaybe (err loHost loBlock "LOBlockFetchServerSending leads announcement")
-      & mbeSetSending mbe0
+      bimapMbe
+      (\x -> x { bfeSending=Just loAt })
+      (\x -> x { boeSending=Just loAt })
+      mbe0
       & doInsert loBlock
   _ -> bMap
  where
-   doInsert :: Hash -> MachBlockEvents -> MachBlockMap
+   fail' :: Hash -> BPErrorKind -> BPError
+   fail' hash desc = BPError hash (Just fp) (Just lo) desc
+
+   fail :: Hash -> BPErrorKind -> MachBlockEvents a
+   fail hash desc = MBE $ fail' hash desc
+
+   doInsert :: Hash -> MachBlockEvents UTCTime -> MachBlockMap UTCTime
    doInsert k x = Map.insert k x bMap
 
-   mDeltaT :: UTCTime -> MachBlockEvents -> [MachBlockEvents -> Maybe NominalDiffTime] -> Maybe NominalDiffTime
-   mDeltaT t mbe mdtProjs =
-     (t `diffUTCTime`) <$> foldM (\tv mdt -> flip addUTCTime tv <$> mdt)
-                                 (mbeSlotStart mbe)
-                                 (($ mbe) <$> mdtProjs)
+deltifyEvents :: MachBlockEvents UTCTime -> MachBlockEvents NominalDiffTime
+deltifyEvents (MBE e) = MBE e
+deltifyEvents (MFE x@ForgerEvents{..}) =
+  MFE x
+  { bfeForged    = bfeForged <&> (`sinceSlot` bfeSlotStart)
+  , bfeAdopted   = diffUTCTime <$> bfeAdopted   <*> bfeForged
+  , bfeAnnounced = diffUTCTime <$> bfeAnnounced <*> bfeAdopted
+  , bfeSending   = diffUTCTime <$> bfeSending   <*> bfeAnnounced
+  } & \case
+  v@(MFE x') -> MFE x' { bfeErrs = collectEventErrors v
+                         [Forge, Adopt, Announce, Send] }
+  _ -> error "Impossible"
+deltifyEvents (MOE x@ObserverEvents{..}) =
+  MOE x
+  { boeNoticed   = boeNoticed <&> (`sinceSlot` boeSlotStart)
+  , boeRequested = diffUTCTime <$> boeRequested <*> boeNoticed
+  , boeFetched   = diffUTCTime <$> boeFetched   <*> boeRequested
+  , boeAdopted   = diffUTCTime <$> boeAdopted   <*> boeFetched
+  , boeAnnounced = diffUTCTime <$> boeAnnounced <*> boeAdopted
+  , boeSending   = diffUTCTime <$> boeSending   <*> boeAnnounced
+  } & \case
+  v@(MOE x') -> MOE x' { boeErrs = collectEventErrors v
+                         [Notice, Request, Fetch, Adopt, Announce, Send] }
+  _ -> error "Impossible"
 
-   err :: Host -> Hash -> String -> a
-   err ho ha desc = error $ mconcat
-     [ "In file ", show fp
-     , ", for host ", show ho
-     , ", for block ", show ha
-     , ": ", desc
-     ]
+collectEventErrors :: MachBlockEvents NominalDiffTime -> [Phase] -> [BPError]
+collectEventErrors mbe phases =
+  [ BPError (mbeBlock mbe) Nothing Nothing $
+    case (miss, proj) of
+      (,) True _       -> BPEMissingPhase phase
+      (,) _ (Just neg) -> BPENegativePhase phase neg
+      _ -> error "Impossible."
+  | phase <- phases
+  , let proj = mbeGetProjection phase mbe
+  , let miss = isNothing proj
+  , let neg  = ((< 0) <$> proj) == Just True
+  , miss || neg
+  ]
+   -- deltaTStrict :: Phase -> UTCTime -> MachBlockEvents NominalDiffTime -> [Phase] -> Either (MachBlockEvents NominalDiffTime) ([BPError], NominalDiffTime)
+   -- deltaTStrict desc t mbe = deltaT desc t mbe . fmap Right
 
-   mbmGetForger :: Host -> Hash -> MachBlockMap -> String -> Maybe MachBlockEvents
-   mbmGetForger ho ha m eDesc = Map.lookup ha m <&>
-     either (const $ err ho ha (eDesc <> " after a BlockObserverEvents")) Right
+   -- deltaT :: Phase -> UTCTime -> MachBlockEvents NominalDiffTime -> [Either Phase Phase] -> Either (MachBlockEvents NominalDiffTime) ([BPError], NominalDiffTime)
+   -- deltaT ph t mbe mdtProjs =
+   --   maybeReportNegativeDelta . fmap (t `diffUTCTime`) <$>
+   --     foldM (\(ers,tv) eiProjs@(join either id -> proj) ->
+   --               either
+   --                (Right .
+   --                 maybe (fail' block (ph `BPEBefore` proj):ers, 0)
+   --                       (ers,))
+   --                (maybe (Left $ fail block (ph `BPEBefore` proj))
+   --                       (Right . (ers,)))
+   --                (join bimap (($ mbe) . mbeGetProjection) eiProjs)
+   --              <&> fmap (flip addUTCTime tv))
+   --           ([], unSlotStart slStart)
+   --           mdtProjs
+   --  where
+   --    slStart = mbeSlotStart mbe
+   --    block   = mbeBlock mbe
 
-   mbmGetObserver :: Host -> Hash -> MachBlockMap -> String -> BlockObserverEvents
-   mbmGetObserver ho ha m eDesc = case Map.lookup ha m of
-     Just (Left x) -> x
-     Just (Right x) -> err ho ha (eDesc <> " after a BlockForgerEvents")
-     Nothing ->  err ho ha (eDesc <> " leads")
+   --    maybeReportNegativeDelta
+   --      :: ([BPError], NominalDiffTime) -> ([BPError], NominalDiffTime)
+   --    maybeReportNegativeDelta v@(ers, d) =
+   --      if d >= 0 then v else
+   --      ((fail' block $
+   --        BPENegativeDelta
+   --          ph t slStart d
+   --          (join either (id &&& (fromMaybe 0 . ($ mbe) . mbeGetProjection))
+   --            <$> mdtProjs))
+   --        :ers, d)

--- a/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-imports -Wno-partial-fields -Wno-unused-matches -Wno-deprecations -Wno-unused-local-binds -Wno-incomplete-record-updates #-}
-module Cardano.Unlog.BlockProp (module Cardano.Unlog.BlockProp) where
+module Cardano.Analysis.BlockProp (module Cardano.Analysis.BlockProp) where
 
 import           Prelude (String, (!!), error, head, id, show, tail)
 import           Cardano.Prelude hiding (head, show)

--- a/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
@@ -63,20 +63,20 @@ data BlockPropagation
 instance RenderDistributions BlockPropagation where
   rdFields =
     --  Width LeftPad
-    [ Field 6 0 (f!!0) "Forge"   $ DDeltaT bpForgerForges
-    , Field 6 0 (f!!1) "Adopt"   $ DDeltaT bpForgerAdoptions
-    , Field 6 0 (f!!2) "Ann-ce"  $ DDeltaT bpForgerAnnouncements
-    , Field 6 0 (f!!3) "Sent"    $ DDeltaT bpForgerSends
-    , Field 4 1 (p!!0) " Noti" $ DDeltaT (fst . bpPeerNotices)
-    , Field 4 0 (p!!1) "ced  " $ DDeltaT (snd . bpPeerNotices)
-    , Field 4 1 (p!!2) " Fetc" $ DDeltaT (fst . bpPeerFetches)
-    , Field 4 0 (p!!3) "hed  " $ DDeltaT (snd . bpPeerFetches)
-    , Field 4 1 (p!!4) " Adop" $ DDeltaT (fst . bpPeerAdoptions)
-    , Field 4 0 (p!!5) "ted  " $ DDeltaT (snd . bpPeerAdoptions)
-    , Field 4 1 (p!!6) "Annou" $ DDeltaT (fst . bpPeerAnnouncements)
-    , Field 4 0 (p!!7) "nced " $ DDeltaT (snd . bpPeerAnnouncements)
-    , Field 4 1 (p!!8) "   Se" $ DDeltaT (fst . bpPeerSends)
-    , Field 4 0 (p!!9) "nt   " $ DDeltaT (snd . bpPeerSends)
+    [ Field 6 0 "forged"        (f!!0) "Forge"   $ DDeltaT bpForgerForges
+    , Field 6 0 "fAdopted"      (f!!1) "Adopt"   $ DDeltaT bpForgerAdoptions
+    , Field 6 0 "fAnnounced"    (f!!2) "Ann-ce"  $ DDeltaT bpForgerAnnouncements
+    , Field 6 0 "fSendStart"    (f!!3) "Sending" $ DDeltaT bpForgerSends
+    , Field 4 1 "noticedVal"    (p!!0) " Noti"   $ DDeltaT (fst . bpPeerNotices)
+    , Field 4 0 "noticedCoV"    (p!!1) "ced  "   $ DDeltaT (snd . bpPeerNotices)
+    , Field 4 1 "fetchedVal"    (p!!2) " Fetc"   $ DDeltaT (fst . bpPeerFetches)
+    , Field 4 0 "fetchedCoV"    (p!!3) "hed  "   $ DDeltaT (snd . bpPeerFetches)
+    , Field 4 1 "pAdoptedVal"   (p!!4) " Adop"   $ DDeltaT (fst . bpPeerAdoptions)
+    , Field 4 0 "pAdoptedCoV"   (p!!5) "ted  "   $ DDeltaT (snd . bpPeerAdoptions)
+    , Field 4 1 "pAnnouncedVal" (p!!6) "Annou" $ DDeltaT (fst . bpPeerAnnouncements)
+    , Field 4 0 "pAnnouncedCoV" (p!!7) "nced " $ DDeltaT (snd . bpPeerAnnouncements)
+    , Field 4 1 "pSendStartVal" (p!!8) " Send" $ DDeltaT (fst . bpPeerSends)
+    , Field 4 0 "pSendStartCoV" (p!!9) "ing  " $ DDeltaT (snd . bpPeerSends)
     ]
    where
      f = nChunksEachOf  4 7 "Forger event Δt:"
@@ -170,9 +170,9 @@ mbeBlockHash = either boeBlock bfeBlock
 mbeSetAdoptedDelta :: UTCTime -> Int -> MachBlockEvents -> MachBlockEvents
 mbeSetAdoptedDelta   v d = either (\x -> Left x { boeAdopted=Just v, boeChainDelta=d })   (\x -> Right x { bfeAdopted=Just v, bfeChainDelta=d })
 
-mbeSetAnnounced, mbeSetSent :: UTCTime -> MachBlockEvents -> MachBlockEvents
+mbeSetAnnounced, mbeSetSending :: UTCTime -> MachBlockEvents -> MachBlockEvents
 mbeSetAnnounced v = either (\x -> Left x { boeAnnounced=Just v }) (\x -> Right x { bfeAnnounced=Just v })
-mbeSetSent      v = either (\x -> Left x { boeSent=Just v })      (\x -> Right x { bfeSent=Just v })
+mbeSetSending   v = either (\x -> Left x { boeSent=Just v })      (\x -> Right x { bfeSent=Just v })
 
 -- | Machine's private view of all the blocks.
 type MachBlockMap
@@ -369,12 +369,12 @@ blockPropMachEventsStep ci fp bMap = \case
                (err loHost loBlock "LOChainSyncServerSendHeader leads")
     in if isJust $ mbeAnnounced mbe0 then bMap
        else Map.insert loBlock (mbeSetAnnounced loAt mbe0) bMap
-  LogObject{loAt, loHost, loBody=LOBlockFetchServerSend{loBlock}} ->
-    -- D.trace (printf "mbeSetSent %s %s" (show loHost :: String) (show loBlock :: String)) $
+  LogObject{loAt, loHost, loBody=LOBlockFetchServerSending{loBlock}} ->
+    -- D.trace (printf "mbeSetSending %s %s" (show loHost :: String) (show loBlock :: String)) $
     let mbe0 = Map.lookup loBlock bMap & fromMaybe
-               (err loHost loBlock "LOBlockFetchServerSend leads")
+               (err loHost loBlock "LOBlockFetchServerSending leads")
     in if isJust $ mbeSent mbe0 then bMap
-       else Map.insert loBlock (mbeSetSent loAt mbe0) bMap
+       else Map.insert loBlock (mbeSetSending loAt mbe0) bMap
   LogObject{loAt, loHost, loBody=LOChainSyncClientSeenHeader{loBlock,loBlockNo,loSlotNo}} ->
     let mbe0 = Map.lookup loBlock bMap
     in if isJust mbe0 then bMap

--- a/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/BlockProp.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-imports -Wno-partial-fields -Wno-unused-matches -Wno-deprecations -Wno-unused-local-binds -Wno-incomplete-record-updates #-}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Avoid lambda" -}
 module Cardano.Analysis.BlockProp (module Cardano.Analysis.BlockProp) where
 
 import           Prelude (String, (!!), error, head, id, show, tail)
@@ -31,7 +33,6 @@ import qualified Data.Text as T
 import           Data.Tuple (swap)
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
-import qualified Data.Map.Strict as Map
 
 import           Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime)
 
@@ -579,11 +580,11 @@ blockPropMachEventsStep ci (JsonLogfile fp) bMap lo = case lo of
   LogObject{loAt, loHost, loBody=LOChainSyncClientSeenHeader{loBlock,loBlockNo,loSlotNo}} ->
     let mbe0 = Map.lookup loBlock bMap
     in if isJust mbe0 then bMap else
-      (MOE $
-       ObserverEvents
-         loHost loBlock loBlockNo loSlotNo
-         (slotStart ci loSlotNo) (Just loAt)
-         Nothing Nothing Nothing 0 Nothing Nothing [])
+      MOE
+       (ObserverEvents
+        loHost loBlock loBlockNo loSlotNo
+        (slotStart ci loSlotNo) (Just loAt)
+        Nothing Nothing Nothing 0 Nothing Nothing [])
       & doInsert loBlock
   -- 1. Request (observer only)
   LogObject{loAt, loHost, loBody=LOBlockFetchClientRequested{loBlock,loLength}} ->

--- a/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
@@ -115,7 +115,10 @@ runBlockPropagation chainInfo logfiles BlockPropagationOutputFiles{..} = do
         withFile f WriteMode $ \hnd -> do
           putStrLn ("runBlockPropagation: dumping pretty timeline" :: Text)
           hPutStrLn hnd . T.pack $ printf "--- input: %s" f
-          mapM_ (T.hPutStrLn hnd) (renderDistributions RenderPretty blockPropagation)
+          mapM_ (T.hPutStrLn hnd)
+            (renderDistributions RenderPretty blockPropagation)
+          mapM_ (T.hPutStrLn hnd)
+            (renderTimeline $ bpChainBlockEvents blockPropagation)
 
     forM_ bpofAnalysis $
       \(JsonOutputFile f) ->

--- a/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
@@ -188,13 +188,14 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
      withFile (unTextOutputFile o) WriteMode $ \hnd -> do
        hPutStrLn hnd . T.pack $
          printf "--- input: %s" (intercalate " " $ unJsonLogfile <$> srcs)
-       renderMachTimelineCDF  statsHeadP statsFormatP statsFormatPF s hnd
+       mapM_ (T.hPutStrLn hnd) (renderDistributions s)
+       -- renderMachTimelineCDF  statsHeadP statsFormatP statsFormatPF s hnd
        renderSlotTimeline slotHeadP slotFormatP False xs hnd
    renderExportStats :: RunScalars -> MachTimeline -> CsvOutputFile -> IO ()
-   renderExportStats rs s (CsvOutputFile o) =
+   renderExportStats rs _s (CsvOutputFile o) =
      withFile o WriteMode $
        \h -> do
-         renderMachTimelineCDF statsHeadE statsFormatE statsFormatEF s h
+         -- renderMachTimelineCDF statsHeadE statsFormatE statsFormatEF s h
          mapM_ (hPutStrLn h) $
            renderChainInfoExport chainInfo
            <>
@@ -203,12 +204,6 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
    renderExportTimeline xs (CsvOutputFile o) =
      withFile o WriteMode $
        renderSlotTimeline slotHeadE slotFormatE True xs
-
-   renderMachTimelineCDF :: Text -> Text -> Text -> MachTimeline -> Handle -> IO ()
-   renderMachTimelineCDF statHead statFmt propFmt timeline hnd = do
-       hPutStrLn hnd statHead
-       forM_ (toDistribLines statFmt propFmt timeline) $
-         hPutStrLn hnd
 
    renderDerivedSlots :: [DerivedSlot] -> CsvOutputFile -> IO ()
    renderDerivedSlots slots (CsvOutputFile o) = do

--- a/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
@@ -74,19 +74,23 @@ runAnalysisCommand :: AnalysisCommand -> ExceptT AnalysisCmdError IO ()
 runAnalysisCommand (MachineTimelineCmd genesisFile metaFile logfiles oFiles) = do
   chainInfo <-
     ChainInfo
-      <$> (firstExceptT (RunMetaParseError metaFile . T.pack) $ newExceptT $
-             AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
-      <*> (firstExceptT (GenesisParseError genesisFile . T.pack) $ newExceptT $
-             AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
+      <$> firstExceptT (RunMetaParseError metaFile . T.pack)
+                       (newExceptT $
+                        AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
+      <*> firstExceptT (GenesisParseError genesisFile . T.pack)
+                       (newExceptT $
+                        AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
   firstExceptT AnalysisCmdError $
     runMachineTimeline chainInfo logfiles oFiles
 runAnalysisCommand (BlockPropagationCmd genesisFile metaFile logfiles oFiles) = do
   chainInfo <-
     ChainInfo
-      <$> (firstExceptT (RunMetaParseError metaFile . T.pack) $ newExceptT $
-             AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
-      <*> (firstExceptT (GenesisParseError genesisFile . T.pack) $ newExceptT $
-             AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
+      <$> firstExceptT (RunMetaParseError metaFile . T.pack)
+                       (newExceptT $
+                         AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
+      <*> firstExceptT (GenesisParseError genesisFile . T.pack)
+                       (newExceptT $
+                        AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
   firstExceptT AnalysisCmdError $
     runBlockPropagation chainInfo logfiles oFiles
 runAnalysisCommand SubstringKeysCmd =

--- a/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ImpredicativeTypes #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing #-}
 module Cardano.Analysis.Driver
   ( AnalysisCmdError

--- a/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/Driver.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing #-}
+module Cardano.Analysis.Driver
+  ( AnalysisCmdError
+  , renderAnalysisCmdError
+  , runAnalysisCommand
+  ) where
+
+import           Prelude (String)
+import           Cardano.Prelude
+
+import           Control.Arrow ((&&&))
+import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+import           Control.Concurrent.Async (mapConcurrently)
+
+import qualified Data.Aeson as AE
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import qualified System.FilePath as F
+
+import qualified Graphics.Histogram as Hist
+import qualified Graphics.Gnuplot.Frame.OptionSet as Opts
+
+import           Text.Printf
+
+import           Cardano.Analysis.BlockProp
+import           Cardano.Analysis.MachTimeline
+import           Cardano.Analysis.Profile
+import           Cardano.Unlog.Commands
+import           Cardano.Unlog.LogObject hiding (Text)
+import           Cardano.Unlog.Render
+import           Cardano.Unlog.SlotStats
+
+
+data AnalysisCmdError
+  = AnalysisCmdError  !Text
+  | RunMetaParseError !JsonRunMetafile !Text
+  | GenesisParseError !JsonGenesisFile !Text
+  deriving Show
+
+renderAnalysisCmdError :: AnalysisCommand -> AnalysisCmdError -> Text
+renderAnalysisCmdError cmd err =
+  case err of
+    AnalysisCmdError  err' -> renderError cmd err'
+      "Analysis command failed"
+      pure
+    RunMetaParseError (JsonRunMetafile fp) err' -> renderError cmd err'
+      ("Benchmark run metafile parse failed: " <> T.pack fp)
+      pure
+    GenesisParseError (JsonGenesisFile fp) err' -> renderError cmd err'
+      ("Genesis parse failed: " <> T.pack fp)
+      pure
+ where
+   renderError :: AnalysisCommand -> a -> Text -> (a -> [Text]) -> Text
+   renderError cmd' cmdErr desc renderer =
+      mconcat [ desc, ": "
+              , renderAnalysisCommand cmd'
+              , "  Error: "
+              , mconcat (renderer cmdErr)
+              ]
+
+--
+-- CLI shelley command dispatch
+--
+
+runAnalysisCommand :: AnalysisCommand -> ExceptT AnalysisCmdError IO ()
+runAnalysisCommand (MachineTimelineCmd genesisFile metaFile logfiles oFiles) = do
+  chainInfo <-
+    ChainInfo
+      <$> (firstExceptT (RunMetaParseError metaFile . T.pack) $ newExceptT $
+             AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
+      <*> (firstExceptT (GenesisParseError genesisFile . T.pack) $ newExceptT $
+             AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
+  firstExceptT AnalysisCmdError $
+    runMachineTimeline chainInfo logfiles oFiles
+runAnalysisCommand (BlockPropagationCmd genesisFile metaFile logfiles oFiles) = do
+  chainInfo <-
+    ChainInfo
+      <$> (firstExceptT (RunMetaParseError metaFile . T.pack) $ newExceptT $
+             AE.eitherDecode @Profile <$> LBS.readFile (unJsonRunMetafile metaFile))
+      <*> (firstExceptT (GenesisParseError genesisFile . T.pack) $ newExceptT $
+             AE.eitherDecode @Genesis <$> LBS.readFile (unJsonGenesisFile genesisFile))
+  firstExceptT AnalysisCmdError $
+    runBlockPropagation chainInfo logfiles oFiles
+runAnalysisCommand SubstringKeysCmd =
+  liftIO $ mapM_ putStrLn logObjectStreamInterpreterKeys
+
+runBlockPropagation ::
+  ChainInfo -> [JsonLogfile] -> BlockPropagationOutputFiles -> ExceptT Text IO ()
+runBlockPropagation chainInfo logfiles BlockPropagationOutputFiles{..} = do
+  liftIO $ do
+    putStrLn ("runBlockPropagation: lifting LO streams" :: Text)
+    -- 0. Recover LogObjects
+    objLists :: [(JsonLogfile, [LogObject])] <- flip mapConcurrently logfiles
+      (joinT . (pure &&& readLogObjectStream))
+
+    forM_ bpofLogObjects . const $ do
+      flip mapConcurrently objLists $
+        \(JsonLogfile f, objs) -> do
+            putStrLn ("runBlockPropagation: dumping LO streams" :: Text)
+            dumpLOStream objs
+              (JsonOutputFile $ F.dropExtension f <> ".logobjects.json")
+
+    blockPropagation <- blockProp chainInfo objLists
+
+    forM_ bpofTimelinePretty $
+      \(TextOutputFile f) ->
+        withFile f WriteMode $ \hnd -> do
+          putStrLn ("runBlockPropagation: dumping pretty timeline" :: Text)
+          hPutStrLn hnd . T.pack $ printf "--- input: %s" f
+          mapM_ (T.hPutStrLn hnd) (renderDistributions blockPropagation)
+
+    forM_ bpofAnalysis $
+      \(JsonOutputFile f) ->
+        withFile f WriteMode $ \hnd -> do
+          putStrLn ("runBlockPropagation: dumping analysis core" :: Text)
+          LBS.hPutStrLn hnd (AE.encode blockPropagation)
+ where
+   joinT :: (IO a, IO b) -> IO (a, b)
+   joinT (a, b) = (,) <$> a <*> b
+
+runMachineTimeline ::
+  ChainInfo -> [JsonLogfile] -> MachineTimelineOutputFiles -> ExceptT Text IO ()
+runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
+  liftIO $ do
+    -- 0. Recover LogObjects
+    objs :: [LogObject] <- concat <$> mapM readLogObjectStream logfiles
+    forM_ mtofLogObjects
+      (dumpLOStream objs)
+
+    -- 1. Derive the basic scalars and vectors
+    let (,) runStats noisySlotStats = timelineFromLogObjects chainInfo objs
+    forM_ mtofSlotStats $
+      \(JsonOutputFile f) ->
+        withFile f WriteMode $ \hnd ->
+          forM_ noisySlotStats $ LBS.hPutStrLn hnd . AE.encode
+
+    -- 2. Reprocess the slot stats
+    let slotStats = cleanupSlotStats noisySlotStats
+
+    -- 3. Derive the timeline
+    let drvVectors0, _drvVectors1 :: [DerivedSlot]
+        (,) drvVectors0 _drvVectors1 = computeDerivedVectors slotStats
+        timeline :: MachTimeline
+        timeline = slotStatsMachTimeline chainInfo slotStats
+        timelineOutput :: LBS.ByteString
+        timelineOutput = AE.encode timeline
+
+    -- 4. Render various outputs
+    forM_ mtofTimelinePretty
+      (renderPrettyMachTimeline slotStats timeline logfiles)
+    forM_ mtofStatsCsv
+      (renderExportStats runStats timeline)
+    forM_ mtofTimelineCsv
+       (renderExportTimeline slotStats)
+    forM_ mtofDerivedVectors0Csv
+       (renderDerivedSlots drvVectors0)
+    forM_ mtofHistogram
+      (renderHistogram "CPU usage spans over 85%" "Span length"
+        (toList $ sort $ sSpanLensCPU85 timeline))
+
+    flip (maybe $ LBS.putStrLn timelineOutput) mtofAnalysis $
+      \case
+        JsonOutputFile f ->
+          withFile f WriteMode $ \hnd ->
+            LBS.hPutStrLn hnd timelineOutput
+ where
+   renderHistogram :: Integral a
+     => String -> String -> [a] -> OutputFile -> IO ()
+   renderHistogram desc ylab xs (OutputFile f) =
+     Hist.plotAdv f opts hist >> pure ()
+    where
+      hist = Hist.histogram Hist.binFreedmanDiaconis $ fromIntegral <$> xs
+      opts = Opts.title desc $ Opts.yLabel ylab $ Opts.xLabel "Population" $
+             Hist.defOpts hist
+
+   renderPrettyMachTimeline ::
+        [SlotStats] -> MachTimeline -> [JsonLogfile] -> TextOutputFile -> IO ()
+   renderPrettyMachTimeline xs s srcs o =
+     withFile (unTextOutputFile o) WriteMode $ \hnd -> do
+       hPutStrLn hnd . T.pack $
+         printf "--- input: %s" (intercalate " " $ unJsonLogfile <$> srcs)
+       renderMachTimelineCDF  statsHeadP statsFormatP statsFormatPF s hnd
+       renderSlotTimeline slotHeadP slotFormatP False xs hnd
+   renderExportStats :: RunScalars -> MachTimeline -> CsvOutputFile -> IO ()
+   renderExportStats rs s (CsvOutputFile o) =
+     withFile o WriteMode $
+       \h -> do
+         renderMachTimelineCDF statsHeadE statsFormatE statsFormatEF s h
+         mapM_ (hPutStrLn h) $
+           renderChainInfoExport chainInfo
+           <>
+           renderRunScalars rs
+   renderExportTimeline :: [SlotStats] -> CsvOutputFile -> IO ()
+   renderExportTimeline xs (CsvOutputFile o) =
+     withFile o WriteMode $
+       renderSlotTimeline slotHeadE slotFormatE True xs
+
+   renderMachTimelineCDF :: Text -> Text -> Text -> MachTimeline -> Handle -> IO ()
+   renderMachTimelineCDF statHead statFmt propFmt timeline hnd = do
+       hPutStrLn hnd statHead
+       forM_ (toDistribLines statFmt propFmt timeline) $
+         hPutStrLn hnd
+
+   renderDerivedSlots :: [DerivedSlot] -> CsvOutputFile -> IO ()
+   renderDerivedSlots slots (CsvOutputFile o) = do
+     withFile o WriteMode $ \hnd -> do
+       hPutStrLn hnd derivedSlotsHeader
+       forM_ slots $
+         hPutStrLn hnd . renderDerivedSlot
+
+dumpLOStream :: [LogObject] -> JsonOutputFile -> IO ()
+dumpLOStream objs o =
+  withFile (unJsonOutputFile o) WriteMode $ \hnd -> do
+    forM_ objs $ LBS.hPutStrLn hnd . AE.encode
+
+renderRunScalars :: RunScalars -> [Text]
+renderRunScalars RunScalars{..} =
+  T.intercalate "," <$>
+  [[ "Run time",       maybe "---" show rsElapsed ]
+  ,[ "Txs submitted",  maybe "---" show rsSubmitted ]
+  ,[ "Submission TPS", maybe "---" (show . sum) rsThreadwiseTps]
+  ]

--- a/nix/workbench/locli/src/Cardano/Analysis/MachTimeline.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/MachTimeline.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing -Wno-orphans #-}
+{- HLINT ignore "Use head" -}
 module Cardano.Analysis.MachTimeline (module Cardano.Analysis.MachTimeline) where
 
 import           Prelude (String, (!!), error)

--- a/nix/workbench/locli/src/Cardano/Analysis/MachTimeline.hs
+++ b/nix/workbench/locli/src/Cardano/Analysis/MachTimeline.hs
@@ -1,0 +1,523 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-name-shadowing #-}
+module Cardano.Analysis.MachTimeline (module Cardano.Analysis.MachTimeline) where
+
+import           Prelude (String, error)
+import           Cardano.Prelude
+
+import           Control.Arrow ((&&&), (***))
+import qualified Data.Aeson as AE
+import           Data.Aeson
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text as T
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vec
+import qualified Data.Map.Strict as Map
+import           Text.Printf (printf)
+
+import           Data.Time.Clock (NominalDiffTime, UTCTime)
+import qualified Data.Time.Clock as Time
+
+import           Ouroboros.Network.Block (SlotNo(..))
+
+import           Data.Accum
+import           Data.Distribution
+
+import           Cardano.Analysis.Profile
+import           Cardano.Unlog.LogObject hiding (Text)
+import           Cardano.Unlog.Resources
+import           Cardano.Unlog.SlotStats
+
+-- | The top-level representation of the machine timeline analysis results.
+data MachTimeline
+  = MachTimeline
+    { sMaxChecks         :: !Word64
+    , sSlotMisses        :: ![Word64]
+    , sSpanLensCPU85     :: ![Int]
+    , sSpanLensCPU85EBnd :: ![Int]
+    , sSpanLensCPU85Rwd  :: ![Int]
+    -- distributions
+    , sMissDistrib       :: !(Distribution Float Float)
+    , sLeadsDistrib      :: !(Distribution Float Word64)
+    , sUtxoDistrib       :: !(Distribution Float Word64)
+    , sDensityDistrib    :: !(Distribution Float Float)
+    , sSpanCheckDistrib  :: !(Distribution Float NominalDiffTime)
+    , sSpanLeadDistrib   :: !(Distribution Float NominalDiffTime)
+    , sBlocklessDistrib  :: !(Distribution Float Word64)
+    , sSpanLensCPU85Distrib
+                         :: !(Distribution Float Int)
+    , sSpanLensCPU85EBndDistrib :: !(Distribution Float Int)
+    , sSpanLensCPU85RwdDistrib  :: !(Distribution Float Int)
+    , sResourceDistribs  :: !(Resources (Distribution Float Word64))
+    }
+  deriving Show
+
+instance ToJSON MachTimeline where
+  toJSON MachTimeline{..} = AE.Array $ Vec.fromList
+    [ AE.Object $ HashMap.fromList
+        [ "kind" .= String "spanLensCPU85EBnd"
+        , "xs" .= toJSON sSpanLensCPU85EBnd]
+    , AE.Object $ HashMap.fromList
+        [ "kind" .= String "spanLensCPU85Rwd"
+        , "xs" .= toJSON sSpanLensCPU85Rwd]
+    , AE.Object $ HashMap.fromList
+        [ "kind" .= String "spanLensCPU85"
+        , "xs" .= toJSON sSpanLensCPU85]
+    , AE.Object $ HashMap.fromList
+        [ "kind" .= String "spanLensCPU85Sorted"
+        , "xs" .= toJSON (sort sSpanLensCPU85)]
+    , extendObject "kind" "spancheck" $ toJSON sSpanCheckDistrib
+    , extendObject "kind" "spanlead"  $ toJSON sSpanLeadDistrib
+    , extendObject "kind" "cpu"       $ toJSON (rCentiCpu sResourceDistribs)
+    , extendObject "kind" "gc"        $ toJSON (rCentiGC  sResourceDistribs)
+    , extendObject "kind" "density"   $ toJSON sDensityDistrib
+    , extendObject "kind" "utxo"      $ toJSON sUtxoDistrib
+    , extendObject "kind" "leads"     $ toJSON sLeadsDistrib
+    , extendObject "kind" "misses"    $ toJSON sMissDistrib
+    , extendObject "kind" "blockless" $ toJSON sBlocklessDistrib
+    , extendObject "kind" "rss"       $ toJSON (rRSS      sResourceDistribs)
+    , extendObject "kind" "heap"      $ toJSON (rHeap     sResourceDistribs)
+    , extendObject "kind" "live"      $ toJSON (rLive     sResourceDistribs)
+    , extendObject "kind" "spanLensCPU85Distrib"  $
+                                        toJSON sSpanLensCPU85Distrib
+    , extendObject "kind" "spanLensCPU85EBndDistrib"  $
+                                        toJSON sSpanLensCPU85EBndDistrib
+    , extendObject "kind" "spanLensCPU85RwdDistrib"  $
+                                        toJSON sSpanLensCPU85RwdDistrib
+    ]
+
+statsHeadE, statsFormatE, statsFormatEF :: Text
+statsHeadP, statsFormatP, statsFormatPF :: Text
+statsHeadP =
+  "%tile Count MissR  CheckΔt  LeadΔt BlkLess Density  CPU  GC MUT Maj Min   RSS  Heap  Live Alloc CPU85%Lens/EBnd/Rwd"
+statsHeadE =
+  "%tile,Count,MissR,CheckΔ,LeadΔ,Blockless,ChainDensity,CPU,GC,MUT,GcMaj,GcMin,RSS,Heap,Live,Alloc,CPU85%Lens,/EpochBoundary,/Rewards"
+statsFormatP =
+  "%6s %5d %0.2f   %6s   %6s  %3d     %0.3f  %3d %3d %3d  %2d %3d %5d %5d %5d %5d    %4d   %4d %4d"
+statsFormatE =
+  "%s,%d,%0.2f,%s,%s,%d,%0.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d"
+statsFormatPF =
+  "%6s %.2f %.2f   %.2f   %.2f  %.2f     %.2f  %.2f %.2f %.2f %.2f %.2f %.2f      %.2f %.2f %.2f %.2f %.2f"
+statsFormatEF =
+  "%s,0,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f"
+
+slotStatsMachTimeline :: ChainInfo -> [SlotStats] -> MachTimeline
+slotStatsMachTimeline CInfo{} slots =
+  MachTimeline
+  { sMaxChecks        = maxChecks
+  , sSlotMisses       = misses
+  , sSpanLensCPU85    = spanLensCPU85
+  , sSpanLensCPU85EBnd = sSpanLensCPU85EBnd
+  , sSpanLensCPU85Rwd  = sSpanLensCPU85Rwd
+  --
+  , sMissDistrib      = computeDistribution stdPercentiles missRatios
+  , sLeadsDistrib     =
+      computeDistribution stdPercentiles (slCountLeads <$> slots)
+  , sUtxoDistrib      =
+      computeDistribution stdPercentiles (slUtxoSize <$> slots)
+  , sDensityDistrib   =
+      computeDistribution stdPercentiles (slDensity <$> slots)
+  , sSpanCheckDistrib =
+      computeDistribution stdPercentiles (slSpanCheck <$> slots)
+  , sSpanLeadDistrib =
+      computeDistribution stdPercentiles (slSpanLead <$> slots)
+  , sBlocklessDistrib =
+      computeDistribution stdPercentiles (slBlockless <$> slots)
+  , sSpanLensCPU85Distrib
+                      = computeDistribution stdPercentiles spanLensCPU85
+  , sResourceDistribs =
+      computeResDistrib stdPercentiles resDistProjs slots
+  , sSpanLensCPU85EBndDistrib = computeDistribution stdPercentiles sSpanLensCPU85EBnd
+  , sSpanLensCPU85RwdDistrib  = computeDistribution stdPercentiles sSpanLensCPU85Rwd
+  }
+ where
+   sSpanLensCPU85EBnd = Vec.length <$>
+                        filter (spanContainsEpochSlot 3) spansCPU85
+   sSpanLensCPU85Rwd  = Vec.length <$>
+                        filter (spanContainsEpochSlot 803) spansCPU85
+
+   checkCounts      = slCountChecks <$> slots
+   maxChecks        = if length checkCounts == 0
+                      then 0 else maximum checkCounts
+   misses           = (maxChecks -) <$> checkCounts
+   missRatios       = missRatio <$> misses
+   spansCPU85 :: [Vector SlotStats]
+   spansCPU85       = spans
+                        ((/= Just False) . fmap (>=85) . rCentiCpu . slResources)
+                        (toList slots)
+   spanLensCPU85    = spanLen <$> spansCPU85
+   spanContainsEpochSlot :: Word64 -> Vector SlotStats -> Bool
+   spanContainsEpochSlot s =
+     uncurry (&&)
+     . ((s >) . slEpochSlot . Vec.head &&&
+        (s <) . slEpochSlot . Vec.last)
+   spanLen :: Vector SlotStats -> Int
+   spanLen = fromIntegral . unSlotNo . uncurry (-) . (slSlot *** slSlot) . (Vec.last &&& Vec.head)
+   resDistProjs     =
+     Resources
+     { rCentiCpu    = rCentiCpu   . slResources
+     , rCentiGC     = rCentiGC    . slResources
+     , rCentiMut    = rCentiMut   . slResources
+     , rGcsMajor    = rGcsMajor   . slResources
+     , rGcsMinor    = rGcsMinor   . slResources
+     , rRSS         = rRSS        . slResources
+     , rHeap        = rHeap       . slResources
+     , rLive        = rLive       . slResources
+     , rAlloc       = rAlloc      . slResources
+     , rCentiBlkIO  = rCentiBlkIO . slResources
+     , rThreads     = rThreads    . slResources
+     }
+
+   missRatio :: Word64 -> Float
+   missRatio = (/ fromIntegral maxChecks) . fromIntegral
+
+mapMachTimeline ::
+     Text
+  -> MachTimeline
+  -> Text
+  -> (forall a. Num a => Distribution Float a -> Float)
+  -> Text
+mapMachTimeline statsF MachTimeline{..} desc f =
+  distribPropertyLine desc
+    (f sMissDistrib)
+    (f sSpanCheckDistrib)
+    (f sSpanLeadDistrib)
+    (f sBlocklessDistrib)
+    (f sDensityDistrib)
+    (f (rCentiCpu sResourceDistribs))
+    (f (rCentiGC sResourceDistribs))
+    (f (rCentiMut sResourceDistribs))
+    (f (rGcsMajor sResourceDistribs))
+    (f (rGcsMinor sResourceDistribs))
+    (f (rRSS sResourceDistribs))
+    (f (rHeap sResourceDistribs))
+    (f (rLive sResourceDistribs))
+    (f (rAlloc sResourceDistribs))
+    (f sSpanLensCPU85Distrib)
+    (f sSpanLensCPU85EBndDistrib)
+    (f sSpanLensCPU85RwdDistrib)
+ where
+   distribPropertyLine ::
+        Text
+     -> Float -> Float -> Float -> Float
+     -> Float -> Float -> Float
+     -> Float -> Float
+     -> Float -> Float -> Float -> Float
+     -> Float -> Float -> Float
+     -> Float
+     -> Text
+   distribPropertyLine descr miss chkdt leaddt blkl dens cpu gc mut majg ming rss hea liv alc cpu85Sp cpu85SpEBnd cpu85SpRwd = T.pack $
+     printf (T.unpack statsF)
+    descr miss chkdt leaddt blkl dens cpu gc mut majg ming     rss hea liv alc cpu85Sp cpu85SpEBnd cpu85SpRwd
+
+toDistribLines :: Text -> Text -> MachTimeline -> [Text]
+toDistribLines statsF distPropsF s@MachTimeline{..} =
+  distribLine
+   <$> ZipList (pctSpec <$> dPercentiles sMissDistrib)
+   <*> ZipList (max 1 . ceiling . (* fromIntegral (dSize sMissDistrib))
+                    . (1.0 -) . pctFrac
+                    <$> dPercentiles sMissDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sMissDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sSpanCheckDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sSpanLeadDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sBlocklessDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sDensityDistrib)
+   <*> ZipList (pctSample <$> dPercentiles (rCentiCpu sResourceDistribs))
+   <*> ZipList (min 999 . -- workaround for ghc-8.10.x
+                pctSample <$> dPercentiles (rCentiGC sResourceDistribs))
+   <*> ZipList (min 999 . -- workaround for ghc-8.10.x
+                pctSample <$> dPercentiles (rCentiMut sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rGcsMajor sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rGcsMinor sResourceDistribs))
+    -- <*> ZipList (pctSample <$> dPercentiles ( sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rRSS sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rHeap sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rLive sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles (rAlloc sResourceDistribs))
+   <*> ZipList (pctSample <$> dPercentiles sSpanLensCPU85Distrib)
+   <*> ZipList (pctSample <$> dPercentiles sSpanLensCPU85EBndDistrib)
+   <*> ZipList (pctSample <$> dPercentiles sSpanLensCPU85RwdDistrib)
+  & getZipList
+  & (<> [ mapMachTimeline distPropsF s "size" (fromIntegral . dSize)
+        , mapMachTimeline distPropsF s "avg"  dAverage
+        ])
+ where
+   distribLine ::
+        PercSpec Float -> Int
+     -> Float -> NominalDiffTime -> NominalDiffTime -> Word64 -> Float
+     -> Word64 -> Word64 -> Word64
+     -> Word64 -> Word64
+     -> Word64 -> Word64 -> Word64 -> Word64
+     -> Int -> Int -> Int
+     -> Text
+   distribLine ps count miss chkdt' leaddt' blkl dens cpu gc mut
+     majg ming rss hea liv alc cpu85Sp cpu85SpEBnd cpu85SpRwd = T.pack $
+     printf (T.unpack statsF)
+    (renderPercSpec 6 ps) count miss chkdt leaddt blkl dens cpu gc mut majg ming     rss hea liv alc cpu85Sp cpu85SpEBnd cpu85SpRwd
+    where chkdt  = T.init $ show chkdt' :: Text
+          leaddt = T.init $ show leaddt' :: Text
+
+-- The "fold" state that accumulates as we process 'LogObject's into a stream
+-- of 'SlotStats'.
+data TimelineAccum
+  = TimelineAccum
+  { aResAccums     :: ResAccums
+  , aResTimestamp  :: UTCTime
+  , aMempoolTxs    :: Word64
+  , aBlockNo       :: Word64
+  , aLastBlockSlot :: SlotNo
+  , aSlotStats     :: [SlotStats]
+  , aRunScalars    :: RunScalars
+  , aTxsCollectedAt:: Map.Map TId UTCTime
+  }
+
+data RunScalars
+  = RunScalars
+  { rsElapsed       :: Maybe NominalDiffTime
+  , rsSubmitted     :: Maybe Word64
+  , rsThreadwiseTps :: Maybe (Vector Float)
+  }
+
+timelineFromLogObjects :: ChainInfo -> [LogObject] -> (RunScalars, [SlotStats])
+timelineFromLogObjects ci =
+  (aRunScalars &&& reverse . aSlotStats)
+  . foldl (timelineStep ci) zeroTimelineAccum
+ where
+   zeroTimelineAccum :: TimelineAccum
+   zeroTimelineAccum =
+     TimelineAccum
+     { aResAccums     = mkResAccums
+     , aResTimestamp  = zeroUTCTime
+     , aMempoolTxs    = 0
+     , aBlockNo       = 0
+     , aLastBlockSlot = 0
+     , aSlotStats     = [zeroSlotStats]
+     , aRunScalars    = zeroRunScalars
+     , aTxsCollectedAt= mempty
+     }
+   zeroRunScalars :: RunScalars
+   zeroRunScalars = RunScalars Nothing Nothing Nothing
+
+timelineStep :: ChainInfo -> TimelineAccum -> LogObject -> TimelineAccum
+timelineStep ci a@TimelineAccum{aSlotStats=cur:rSLs, ..} = \case
+  lo@LogObject{loAt, loBody=LOTraceStartLeadershipCheck slot _ _} ->
+    if slSlot cur > slot
+    -- Slot log entry for a slot we've supposedly done processing.
+    then a { aSlotStats = cur
+             { slOrderViol = slOrderViol cur + 1
+             } : case (slSlot cur - slot, rSLs) of
+                   -- Limited back-patching:
+                   (1, p1:rest)       ->       onLeadershipCheck loAt p1:rest
+                   (2, p1:p2:rest)    ->    p1:onLeadershipCheck loAt p2:rest
+                   (3, p1:p2:p3:rest) -> p1:p2:onLeadershipCheck loAt p3:rest
+                   _ -> rSLs -- Give up.
+           }
+    else if slSlot cur == slot
+    then a { aSlotStats = onLeadershipCheck loAt cur : rSLs
+           }
+    else if slot - slSlot cur > 1
+    then let gap = unSlotNo $ slot - slSlot cur - 1
+             gapStartSlot = slSlot cur + 1 in
+         updateOnNewSlot lo $ -- We have a slot check gap to patch:
+         patchSlotCheckGap gap gapStartSlot a
+    else updateOnNewSlot lo a
+  LogObject{loAt, loBody=LOTraceNodeIsLeader _} ->
+    a { aSlotStats = onLeadershipCertainty loAt True cur : rSLs
+      }
+  LogObject{loAt, loBody=LOTraceNodeNotLeader _} ->
+    a { aSlotStats = onLeadershipCertainty loAt False cur : rSLs
+      }
+  LogObject{loAt, loBody=LOResources rs} ->
+    -- Update resource stats accumulators & record values current slot.
+    a { aResAccums = accs
+      , aResTimestamp = loAt
+      , aSlotStats = cur { slResources = Just <$> extractResAccums accs
+                     } : rSLs
+      }
+   where accs = updateResAccums loAt rs aResAccums
+  LogObject{loBody=LOMempoolTxs txCount} ->
+    a { aMempoolTxs     = txCount
+      , aSlotStats      = cur { slMempoolTxs = txCount
+                          } : rSLs
+      }
+  LogObject{loBody=LOBlockContext blockNo} ->
+    let newBlock = aBlockNo /= blockNo in
+    a { aBlockNo        = blockNo
+      , aLastBlockSlot  = if newBlock
+                          then slSlot cur
+                          else aLastBlockSlot
+      , aSlotStats      = cur { slBlockNo = blockNo
+                              , slBlockless = if newBlock
+                                              then 0
+                                              else slBlockless cur
+                              } : rSLs
+      }
+  LogObject{loBody=LOLedgerTookSnapshot} ->
+    a { aSlotStats      = cur { slChainDBSnap = slChainDBSnap cur + 1
+                              } : rSLs
+      }
+  LogObject{loBody=LOMempoolRejectedTx} ->
+    a { aSlotStats      = cur { slRejectedTx = slRejectedTx cur + 1
+                              } : rSLs
+      }
+  LogObject{loBody=LOGeneratorSummary _noFails sent elapsed threadwiseTps} ->
+    a { aRunScalars       =
+        aRunScalars
+        { rsThreadwiseTps = Just threadwiseTps
+        , rsElapsed       = Just elapsed
+        , rsSubmitted     = Just sent
+        }
+      }
+  LogObject{loBody=LOTxsCollected tid coll, loAt} ->
+    a { aTxsCollectedAt =
+        aTxsCollectedAt &
+        (\case
+            Just{} -> Just loAt
+            --   error $ mconcat
+            --   ["Duplicate LOTxsCollected for tid ", show tid, " at ", show loAt]
+            Nothing -> Just loAt)
+        `Map.alter` tid
+      , aSlotStats      =
+        cur
+        { slTxsCollected = slTxsCollected cur + max 0 (fromIntegral coll)
+        } : rSLs
+      }
+  LogObject{loBody=LOTxsProcessed tid acc rej, loAt} ->
+    a { aTxsCollectedAt = tid `Map.delete` aTxsCollectedAt
+      , aSlotStats      =
+        cur
+        { slTxsMemSpan =
+          case tid `Map.lookup` aTxsCollectedAt of
+            Nothing ->
+              -- error $ mconcat
+              -- ["LOTxsProcessed missing LOTxsCollected for tid", show tid, " at ", show loAt]
+              Just $
+              1.0
+              +
+              fromMaybe 0 (slTxsMemSpan cur)
+            Just base ->
+              Just $
+              (loAt `Time.diffUTCTime` base)
+              +
+              fromMaybe 0 (slTxsMemSpan cur)
+        , slTxsAccepted = slTxsAccepted cur + acc
+        , slTxsRejected = slTxsRejected cur + max 0 (fromIntegral rej)
+        } : rSLs
+      }
+  _ -> a
+ where
+   updateOnNewSlot :: LogObject -> TimelineAccum -> TimelineAccum
+   updateOnNewSlot LogObject{loAt, loBody=LOTraceStartLeadershipCheck slot utxo density} a' =
+     extendTimelineAccum ci slot loAt 1 utxo density a'
+   updateOnNewSlot _ _ =
+     error "Internal invariant violated: updateSlot called for a non-LOTraceStartLeadershipCheck LogObject."
+
+   onLeadershipCheck :: UTCTime -> SlotStats -> SlotStats
+   onLeadershipCheck now sl@SlotStats{..} =
+     sl { slCountChecks = slCountChecks + 1
+        , slSpanCheck = max 0 $ now `Time.diffUTCTime` slStart
+        }
+
+   onLeadershipCertainty :: UTCTime -> Bool -> SlotStats -> SlotStats
+   onLeadershipCertainty now lead sl@SlotStats{..} =
+     sl { slCountLeads = slCountLeads + if lead then 1 else 0
+        , slSpanLead  = max 0 $ now `Time.diffUTCTime` (slSpanCheck `Time.addUTCTime` slStart)
+        }
+
+   patchSlotCheckGap :: Word64 -> SlotNo -> TimelineAccum -> TimelineAccum
+   patchSlotCheckGap 0 _ a' = a'
+   patchSlotCheckGap n slot a'@TimelineAccum{aSlotStats=cur':_} =
+     patchSlotCheckGap (n - 1) (slot + 1) $
+     extendTimelineAccum ci slot (slotStart ci slot) 0 (slUtxoSize cur') (slDensity cur') a'
+   patchSlotCheckGap _ _ _ =
+     error "Internal invariant violated: patchSlotCheckGap called with empty TimelineAccum chain."
+timelineStep _ a = const a
+
+extendTimelineAccum ::
+     ChainInfo
+  -> SlotNo -> UTCTime -> Word64 -> Word64 -> Float
+  -> TimelineAccum -> TimelineAccum
+extendTimelineAccum ci@CInfo{..} slot time checks utxo density a@TimelineAccum{..} =
+  let (epoch, epochSlot) = unSlotNo slot `divMod` epoch_length gsis in
+    a { aSlotStats = SlotStats
+        { slSlot        = slot
+        , slEpoch       = epoch
+        , slEpochSlot   = epochSlot
+        , slStart       = slotStart ci slot
+        , slEarliest    = time
+        , slOrderViol   = 0
+          -- Updated as we see repeats:
+        , slCountChecks = checks
+        , slCountLeads  = 0
+        , slSpanCheck   = max 0 $ time `Time.diffUTCTime` slotStart ci slot
+        , slSpanLead    = 0
+        , slTxsMemSpan  = Nothing
+        , slTxsCollected= 0
+        , slTxsAccepted = 0
+        , slTxsRejected = 0
+        , slMempoolTxs  = aMempoolTxs
+        , slUtxoSize    = utxo
+        , slDensity     = density
+        , slChainDBSnap = 0
+        , slRejectedTx  = 0
+        , slBlockNo     = aBlockNo
+        , slBlockless   = unSlotNo $ slot - aLastBlockSlot
+        , slResources   = maybeDiscard
+                          <$> discardObsoleteValues
+                          <*> extractResAccums aResAccums
+        } : aSlotStats
+      }
+    where maybeDiscard :: (Word64 -> Maybe Word64) -> Word64 -> Maybe Word64
+          maybeDiscard f = f
+
+data DerivedSlot
+  = DerivedSlot
+  { dsSlot      :: SlotNo
+  , dsBlockless :: Word64
+  }
+
+derivedSlotsHeader :: String
+derivedSlotsHeader =
+  "Slot,Blockless span"
+
+renderDerivedSlot :: DerivedSlot -> String
+renderDerivedSlot DerivedSlot{..} =
+  mconcat
+  [ show (unSlotNo dsSlot), ",", show dsBlockless
+  ]
+
+computeDerivedVectors :: [SlotStats] -> ([DerivedSlot], [DerivedSlot])
+computeDerivedVectors ss =
+  (\(_,_,d0,d1) -> (d0, d1)) $
+  foldr step (0, 0, [], []) ss
+ where
+   step ::
+        SlotStats
+     -> (Word64, Word64, [DerivedSlot], [DerivedSlot])
+     -> (Word64, Word64, [DerivedSlot], [DerivedSlot])
+   step SlotStats{..} (lastBlockless, spanBLSC, accD0, accD1) =
+     if lastBlockless < slBlockless
+     then ( slBlockless
+          , slBlockless
+          , DerivedSlot
+            { dsSlot = slSlot
+            , dsBlockless = slBlockless
+            }:accD0
+          , DerivedSlot
+            { dsSlot = slSlot
+            , dsBlockless = slBlockless
+            }:accD1
+          )
+     else ( slBlockless
+          , spanBLSC
+          , DerivedSlot
+            { dsSlot = slSlot
+            , dsBlockless = spanBLSC
+            }:accD0
+          , accD1
+          )

--- a/nix/workbench/locli/src/Cardano/Unlog/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/BlockProp.hs
@@ -20,7 +20,6 @@ import qualified Data.Aeson as AE
 import           Data.Function (on)
 import           Data.Either (partitionEithers, isLeft, isRight)
 import           Data.Maybe (catMaybes, mapMaybe)
-import qualified Data.Sequence as Seq
 import           Data.Tuple (swap)
 import           Data.Vector (Vector)
 import qualified Data.Map.Strict as Map
@@ -151,6 +150,25 @@ data BlockEvents
 -- | Ordered list of all block events of a chain.
 type ChainBlockEvents
   =  [BlockEvents]
+
+mapChainToBlockObservationCDF ::
+     (BlockObservation -> Maybe UTCTime)
+  -> ChainBlockEvents
+  -> [PercSpec Float]
+  -> Distribution Float NominalDiffTime
+mapChainToBlockObservationCDF proj cbe percs =
+  undefined
+ where
+   allDistributions :: [(BlockEvents, Distribution Float NominalDiffTime)]
+   allDistributions = fmap (fmap $ computeDistribution percs) allObservations
+
+   allObservations :: [(BlockEvents, [NominalDiffTime])]
+   allObservations = mapMaybe blockObservations cbe
+
+   blockObservations :: BlockEvents -> Maybe (BlockEvents, [NominalDiffTime])
+   blockObservations be =
+     (be,)
+     . fmap (`Time.diffUTCTime` beSlotStart be) <$> mapM proj (beObservations be)
 
 blockProp :: ChainInfo -> [(JsonLogfile, [LogObject])] -> IO ChainBlockEvents
 blockProp ci xs = do

--- a/nix/workbench/locli/src/Cardano/Unlog/BlockProp.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/BlockProp.hs
@@ -16,12 +16,14 @@ import           Cardano.Prelude hiding (head)
 
 import           Control.Arrow ((&&&), (***))
 import           Control.Concurrent.Async (mapConcurrently)
+import           Data.Aeson (toJSON)
 import qualified Data.Aeson as AE
 import           Data.Function (on)
 import           Data.Either (partitionEithers, isLeft, isRight)
 import           Data.Maybe (catMaybes, mapMaybe)
 import           Data.Tuple (swap)
 import           Data.Vector (Vector)
+import qualified Data.Vector as Vec
 import qualified Data.Map.Strict as Map
 
 import           Data.Time.Clock (NominalDiffTime, UTCTime)
@@ -30,6 +32,7 @@ import qualified Data.Time.Clock as Time
 import           Ouroboros.Network.Block (BlockNo(..), SlotNo(..))
 
 import           Data.Accum
+import           Data.Distribution
 import           Cardano.Analysis.Profile
 import           Cardano.Unlog.LogObject
 import           Cardano.Unlog.Resources
@@ -38,6 +41,38 @@ import           Cardano.Unlog.SlotStats
 import qualified Debug.Trace as D
 import qualified Text.Printf as D
 
+
+data BlockPropagation
+  = BlockPropagation
+    { sForgerForges        :: !(Distribution Float NominalDiffTime)
+    , sForgerAdoptions     :: !(Distribution Float NominalDiffTime)
+    , sForgerAnnouncements :: !(Distribution Float NominalDiffTime)
+    , sForgerSends         :: !(Distribution Float NominalDiffTime)
+    , sPeerNotices         :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    , sPeerFetches         :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    , sPeerAdoptions       :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    , sPeerAnnouncements   :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    , sPeerSends           :: !(Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+    }
+  deriving Show
+
+instance AE.ToJSON BlockPropagation where
+  toJSON BlockPropagation{..} = AE.Array $ Vec.fromList
+    [ extendObject "kind" "forgerForges"        $ toJSON sForgerForges
+    , extendObject "kind" "forgerAdoptions"     $ toJSON sForgerAdoptions
+    , extendObject "kind" "forgerAnnouncements" $ toJSON sForgerAnnouncements
+    , extendObject "kind" "forgerSends"         $ toJSON sForgerSends
+    , extendObject "kind" "peerNoticesMean"       $ toJSON (fst sPeerNotices)
+    , extendObject "kind" "peerNoticesCoV"        $ toJSON (snd sPeerNotices)
+    , extendObject "kind" "peerFetchesMean"       $ toJSON (fst sPeerFetches)
+    , extendObject "kind" "peerFetchesCoV"        $ toJSON (snd sPeerFetches)
+    , extendObject "kind" "peerAdoptionsMean"     $ toJSON (fst sPeerAdoptions)
+    , extendObject "kind" "peerAdoptionsCoV"      $ toJSON (snd sPeerAdoptions)
+    , extendObject "kind" "peerAnnouncementsMean" $ toJSON (fst sPeerAnnouncements)
+    , extendObject "kind" "peerAnnouncementsCoV"  $ toJSON (snd sPeerAnnouncements)
+    , extendObject "kind" "peerSendsMean"         $ toJSON (fst sPeerSends)
+    , extendObject "kind" "peerSendsCoV"          $ toJSON (snd sPeerSends)
+    ]
 
 -- | Block's events, as seen by its forger.
 data BlockForgerEvents
@@ -151,37 +186,70 @@ data BlockEvents
 type ChainBlockEvents
   =  [BlockEvents]
 
-mapChainToBlockObservationCDF ::
-     (BlockObservation -> Maybe UTCTime)
+mapChainToForgerEventCDF ::
+     [PercSpec Float]
   -> ChainBlockEvents
-  -> [PercSpec Float]
+  -> (BlockEvents -> Maybe UTCTime)
   -> Distribution Float NominalDiffTime
-mapChainToBlockObservationCDF proj cbe percs =
-  undefined
+mapChainToForgerEventCDF percs cbe proj =
+  computeDistribution percs (mapMaybe blockDelta cbe)
  where
-   allDistributions :: [(BlockEvents, Distribution Float NominalDiffTime)]
-   allDistributions = fmap (fmap $ computeDistribution percs) allObservations
+   blockDelta :: BlockEvents -> Maybe NominalDiffTime
+   blockDelta be = (`Time.diffUTCTime` beSlotStart be) <$> proj be
 
-   allObservations :: [(BlockEvents, [NominalDiffTime])]
+mapChainToPeerBlockObservationCDFs ::
+     [PercSpec Float]
+  -> ChainBlockEvents
+  -> (BlockObservation -> Maybe UTCTime)
+  -> (Distribution Float NominalDiffTime, Distribution Float NominalDiffTime)
+mapChainToPeerBlockObservationCDFs percs cbe proj =
+  (means, covs)
+ where
+   means, covs :: Distribution Float NominalDiffTime
+   (,) means covs = computeDistributionStats (fmap realToFrac <$> allDistributions)
+                    & either error id
+                    & join (***) (fmap realToFrac)
+
+   allDistributions :: [Distribution Float NominalDiffTime]
+   allDistributions = computeDistribution percs <$> allObservations
+
+   allObservations :: [[NominalDiffTime]]
    allObservations = mapMaybe blockObservations cbe
 
-   blockObservations :: BlockEvents -> Maybe (BlockEvents, [NominalDiffTime])
+   blockObservations :: BlockEvents -> Maybe [NominalDiffTime]
    blockObservations be =
-     (be,)
-     . fmap (`Time.diffUTCTime` beSlotStart be) <$> mapM proj (beObservations be)
+     fmap (`Time.diffUTCTime` beSlotStart be) <$> mapM proj (beObservations be)
 
-blockProp :: ChainInfo -> [(JsonLogfile, [LogObject])] -> IO ChainBlockEvents
+blockProp :: ChainInfo -> [(JsonLogfile, [LogObject])] -> IO BlockPropagation
 blockProp ci xs = do
   putStrLn ("blockProp: recovering block event maps" :: String)
-  eventMaps <- mapConcurrently (pure . blockEventsFromLogObjects ci) xs
-  let finalBlockEv   = maximumBy ordBlockEv $ blockMapMaxBlock <$> eventMaps
-      tipHash        = rewindChain eventMaps 1 (mbeBlockHash finalBlockEv)
-      tipBlock       = getBlockForge eventMaps tipHash
-      chain          = rebuildChain eventMaps tipHash
+  doBlockProp =<< mapConcurrently (pure . blockEventsFromLogObjects ci) xs
+
+doBlockProp :: [MachBlockMap] -> IO BlockPropagation
+doBlockProp eventMaps = do
   putStrLn ("tip block: " <> show tipBlock :: String)
   putStrLn ("chain length: " <> show (length chain) :: String)
-  pure chain
+  pure $ BlockPropagation
+    (forgerEventsCDF    (Just . beForged))
+    (forgerEventsCDF    (\x -> if beChainDelta x == 1 then Just (beAdopted x)
+                               else Nothing))
+    (forgerEventsCDF    (Just . beAnnounced))
+    (forgerEventsCDF    (Just . beSent))
+    (observerEventsCDFs (Just . boNoticed))
+    (observerEventsCDFs (Just . boFetched))
+    (observerEventsCDFs (\x -> if boChainDelta x == 1 then boAdopted x
+                               else Nothing))
+    (observerEventsCDFs boAnnounced)
+    (observerEventsCDFs boSent)
  where
+   forgerEventsCDF    = mapChainToForgerEventCDF           stdPercentiles chain
+   observerEventsCDFs = mapChainToPeerBlockObservationCDFs stdPercentiles chain
+
+   chain          = rebuildChain eventMaps tipHash
+   tipBlock       = getBlockForge eventMaps tipHash
+   tipHash        = rewindChain eventMaps 1 (mbeBlockHash finalBlockEv)
+   finalBlockEv   = maximumBy ordBlockEv $ blockMapMaxBlock <$> eventMaps
+
    rewindChain :: [MachBlockMap] -> Int -> Hash -> Hash
    rewindChain eventMaps count tip = go tip count
     where go tip = \case

--- a/nix/workbench/locli/src/Cardano/Unlog/Commands.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Commands.hs
@@ -20,17 +20,17 @@ import           Cardano.Unlog.LogObject hiding (Text)
 -- | All the CLI subcommands under \"analysis\".
 --
 data AnalysisCommand
-  = MachineTimeline
+  = MachineTimelineCmd
       JsonGenesisFile
       JsonRunMetafile
       [JsonLogfile]
       MachineTimelineOutputFiles
-  | BlockPropagation
+  | BlockPropagationCmd
       JsonGenesisFile
       JsonRunMetafile
       [JsonLogfile]
       BlockPropagationOutputFiles
-  | SubstringKeys
+  | SubstringKeysCmd
   deriving (Show)
 
 data MachineTimelineOutputFiles
@@ -58,9 +58,9 @@ data BlockPropagationOutputFiles
 renderAnalysisCommand :: AnalysisCommand -> Text
 renderAnalysisCommand sc =
   case sc of
-    MachineTimeline {}  -> "analyse machine-timeline"
-    BlockPropagation {} -> "analyse block-propagation"
-    SubstringKeys {}    -> "analyse substring-keys"
+    MachineTimelineCmd {}  -> "analyse machine-timeline"
+    BlockPropagationCmd {} -> "analyse block-propagation"
+    SubstringKeysCmd {}    -> "analyse substring-keys"
 
 parseMachineTimelineOutputFiles :: Parser MachineTimelineOutputFiles
 parseMachineTimelineOutputFiles =
@@ -111,7 +111,7 @@ parseAnalysisCommands =
   Opt.subparser $
     mconcat
       [ Opt.command "machine-timeline"
-          (Opt.info (MachineTimeline
+          (Opt.info (MachineTimelineCmd
                        <$> argJsonGenesisFile "genesis"
                               "Genesis file of the run"
                        <*> argJsonRunMetafile "run-metafile"
@@ -120,7 +120,7 @@ parseAnalysisCommands =
                        <*> parseMachineTimelineOutputFiles) $
             Opt.progDesc "Analyse leadership checks")
       , Opt.command "block-propagation"
-          (Opt.info (BlockPropagation
+          (Opt.info (BlockPropagationCmd
                        <$> argJsonGenesisFile "genesis"
                               "Genesis file of the run"
                        <*> argJsonRunMetafile "run-metafile"
@@ -129,7 +129,7 @@ parseAnalysisCommands =
                        <*> parseBlockPropagationOutputFiles) $
             Opt.progDesc "Analyse leadership checks")
       , Opt.command "substring-keys"
-          (Opt.info (pure SubstringKeys) $
+          (Opt.info (pure SubstringKeysCmd) $
             Opt.progDesc "Dump substrings that narrow logs to relevant subset")
       ]
 

--- a/nix/workbench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/LogObject.hs
@@ -197,7 +197,7 @@ interpreters = Map.fromList
             <*> v .: "slot"
   -- v, but not ^ -- how is that possible?
   , (,) "TraceBlockFetchServerSendBlock" $
-    \v _ -> LOBlockFetchServerSend
+    \v _ -> LOBlockFetchServerSending
             <$> v .: "block"
   , (,) "ChainSyncClientEvent.TraceDownloadedHeader" $
     \v _ -> LOChainSyncClientSeenHeader
@@ -243,7 +243,7 @@ data LOBody
     , loBlockNo          :: !BlockNo
     , loSlotNo           :: !SlotNo
     }
-  | LOBlockFetchServerSend
+  | LOBlockFetchServerSending
     { loBlock            :: !Hash
     }
   | LOChainSyncClientSeenHeader

--- a/nix/workbench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/LogObject.hs
@@ -195,6 +195,7 @@ interpreters = Map.fromList
             <$> v .: "block"
             <*> v .: "blockNo"
             <*> v .: "slot"
+  -- v, but not ^ -- how is that possible?
   , (,) "TraceBlockFetchServerSendBlock" $
     \v _ -> LOBlockFetchServerSend
             <$> v .: "block"

--- a/nix/workbench/locli/src/Cardano/Unlog/Render.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Render.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
+module Cardano.Unlog.Render (module Cardano.Unlog.Render) where
+
+import           Prelude (head, show)
+import           Cardano.Prelude hiding (head, show)
+
+import           Data.List (dropWhileEnd)
+import qualified Data.Text as T
+import           Data.Time.Clock (NominalDiffTime)
+import           Text.Printf (printf)
+
+import           Data.Distribution
+
+
+class Show a => RenderDistributions a where
+  rdFields :: [Field a]
+
+class Show a => RenderTimeline a where
+  rtFields :: [Field a]
+
+-- | Incapsulate all information necessary to render a column.
+data Field a
+  = Field
+  { fWidth   :: Int
+  , fLeftPad :: Int
+  , fHead1   :: Text
+  , fHead2   :: Text
+  , fSelect  :: DSelect a
+  }
+
+data DSelect a
+  = DInt    (a -> Distribution Float Int)
+  | DWord64 (a -> Distribution Float Word64)
+  | DFloat  (a -> Distribution Float Float)
+  | DDeltaT (a -> Distribution Float NominalDiffTime)
+
+mapSomeFieldDistribution :: (forall b. Distribution Float b -> c) -> a -> DSelect a -> c
+mapSomeFieldDistribution f a = \case
+  DInt    s -> f (s a)
+  DWord64 s -> f (s a)
+  DFloat  s -> f (s a)
+  DDeltaT s -> f (s a)
+
+renderDistributions :: forall a. RenderDistributions a => a -> [Text]
+renderDistributions x = (catMaybes [head1, head2]) <> pLines
+  where
+    pLines :: [Text]
+    pLines = fLine <$> [0..(nPercs - 1)]
+
+    fLine :: Int -> Text
+    fLine pctIx = renderLineDist $
+     \Field{..} ->
+       let w = show fWidth
+           getCapPerc :: forall b c. Distribution b c -> c
+           getCapPerc d = dPercIx d pctIx
+       in T.pack $ case fSelect of
+         DInt    (($x)->d) -> printf ('%':(w++"d")) (getCapPerc d)
+         DWord64 (($x)->d) -> printf ('%':(w++"d")) (getCapPerc d)
+         DFloat  (($x)->d) -> printf ('%':(w++"f")) (getCapPerc d)
+         DDeltaT (($x)->d) -> printf ('%':(w++"s"))
+                              (take fWidth . dropWhileEnd (== 's')
+                               . show $ getCapPerc d)
+
+    head1, head2 :: Maybe Text
+    head1 = if all ((== 0) . T.length . fHead1) fields then Nothing
+            else Just (renderLineHead1 fHead1)
+    head2 = if all ((== 0) . T.length . fHead2) fields then Nothing
+            else Just (renderLineHead2 fHead2)
+
+    renderLineHead1 = mconcat . renderLine' (const 0) ((+ 1) . fWidth)
+    renderLineHead2 = mconcat . renderLine' fLeftPad  ((+ 1) . fWidth)
+    renderLineDist = T.intercalate " " . renderLine' fLeftPad fWidth
+
+    renderLine' ::
+      (Field a -> Int) -> (Field a -> Int) -> (Field a -> Text) -> [Text]
+    renderLine' lpfn wfn rfn = flip fmap fields $
+      \f ->
+        (T.replicate (lpfn f) " ") <> T.center (wfn f) ' ' (rfn f)
+
+    fields :: [Field a]
+    fields = percField : rdFields
+    percField :: Field a
+    percField = Field 6 0 "" "%tile" (DFloat $ const percsDistrib)
+    nPercs = length $ dPercentiles percsDistrib
+    percsDistrib = mapSomeFieldDistribution
+                     distribPercsAsDistrib x (fSelect $ head rdFields)
+
+-- * Auxiliaries
+--
+distribPercsAsDistrib :: Distribution Float b -> Distribution Float Float
+distribPercsAsDistrib Distribution{..} = Distribution 1 0.5 $
+  (\p -> p {pctSample = psFrac (pctSpec p)}) <$> dPercentiles
+
+nChunksEachOf :: Int -> Int -> Text -> [Text]
+nChunksEachOf chunks each center =
+  T.chunksOf each (T.center (each * chunks) ' ' center)

--- a/nix/workbench/locli/src/Cardano/Unlog/Render.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Render.hs
@@ -26,7 +26,9 @@ class Show a => RenderDistributions a where
   rdFields :: [DField a]
 
 class Show a => RenderTimeline a where
-  rtFields :: [IField a]
+  rtFields     :: [IField a]
+  rtCommentary :: a -> [Text]
+  rtCommentary _ = []
 
 -- | Incapsulate all information necessary to render a column.
 data Field s a
@@ -68,7 +70,7 @@ renderTimeline xs =
  where
    fLine :: a -> Int -> [Text]
    fLine l i = (if i `mod` 33 == 0 then catMaybes [head1, head2] else [])
-               <> [ entry l ]
+               <> (entry l : rtCommentary l)
 
    entry :: a -> Text
    entry v = renderLineDist $

--- a/nix/workbench/locli/src/Cardano/Unlog/Render.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Render.hs
@@ -80,8 +80,8 @@ renderTimeline xs =
          IInt    (($v)->x) -> T.pack $ printf ('%':(w++"d")) x
          IWord64 (($v)->x) -> T.pack $ printf ('%':(w++"d")) x
          IFloat  (($v)->x) -> T.take fWidth $ T.pack $
-                              printf ('%':'.':((show $ fWidth - 2)++"F")) x
-         IDeltaT (($v)->x) -> T.take fWidth . T.dropWhileEnd (== 's') $ show $ x
+                              printf ('%':'.':(show (fWidth - 2)++"F")) x
+         IDeltaT (($v)->x) -> T.take fWidth . T.dropWhileEnd (== 's') $ show x
          IText   (($v)->x) -> T.take fWidth . T.dropWhileEnd (== 's') $ x
 
    fields :: [IField a]
@@ -100,12 +100,12 @@ renderTimeline xs =
    renderLine' ::
      (IField a -> Int) -> (IField a -> Int) -> (IField a -> Text) -> [Text]
    renderLine' lpfn wfn rfn = renderField lpfn wfn rfn <$> fields
-   renderField lpfn wfn rfn f = (T.replicate (lpfn f) " ") <> T.center (wfn f) ' ' (rfn f)
+   renderField lpfn wfn rfn f = T.replicate (lpfn f) " " <> T.center (wfn f) ' ' (rfn f)
 
 renderDistributions :: forall a. RenderDistributions a => RenderMode -> a -> [Text]
 renderDistributions mode x =
   case mode of
-    RenderPretty -> (catMaybes [head1, head2]) <> pLines <> sizeAvg
+    RenderPretty -> catMaybes [head1, head2] <> pLines <> sizeAvg
     RenderCsv    -> headCsv : pLines
  where
    pLines :: [Text]
@@ -161,7 +161,7 @@ renderDistributions mode x =
    renderLine' ::
      (DField a -> Int) -> (DField a -> Int) -> (DField a -> Text) -> [Text]
    renderLine' lpfn wfn rfn = renderField lpfn wfn rfn <$> fields
-   renderField lpfn wfn rfn f = (T.replicate (lpfn f) " ") <> T.center (wfn f) ' ' (rfn f)
+   renderField lpfn wfn rfn f = T.replicate (lpfn f) " " <> T.center (wfn f) ' ' (rfn f)
 
    fields :: [DField a]
    fields = percField : rdFields

--- a/nix/workbench/locli/src/Cardano/Unlog/Resources.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Resources.hs
@@ -17,7 +17,6 @@ import           Cardano.Prelude
 
 import           Data.Accum
 import           Data.Distribution
-import qualified Data.Sequence as Seq
 import           Data.Time.Clock (UTCTime)
 
 import           Cardano.BM.Stats.Resources
@@ -55,14 +54,14 @@ computeResDistrib ::
   forall a
   .  [PercSpec Float]
   -> ResDistribProjections a
-  -> Seq.Seq a
+  -> [a]
   -> Resources (Distribution Float Word64)
 computeResDistrib percentiles projs xs =
   compDist <$> projs
  where
    compDist :: (a -> Maybe Word64) -> Distribution Float Word64
    compDist proj = computeDistribution percentiles
-     (Seq.fromList . catMaybes . toList $ proj <$> xs)
+     (catMaybes . toList $ proj <$> xs)
 
 type ResContinuity a = Resources (a -> Maybe a)
 

--- a/nix/workbench/locli/src/Cardano/Unlog/Run.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Run.hs
@@ -12,9 +12,9 @@ import           Cardano.Prelude
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 import qualified Data.Text as Text
 
-import           Cardano.Unlog.Commands (AnalysisCommand)
-import           Cardano.Unlog.Summary (AnalysisCmdError, renderAnalysisCmdError,
+import           Cardano.Analysis.Driver (AnalysisCmdError, renderAnalysisCmdError,
                      runAnalysisCommand)
+import           Cardano.Unlog.Commands (AnalysisCommand)
 
 import           Cardano.Config.Git.Rev (gitRev)
 import           Data.Version (showVersion)

--- a/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
@@ -10,8 +10,8 @@ import qualified Prelude as P
 import           Cardano.Prelude
 
 import           Data.Aeson
-import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
+import           Data.List (dropWhileEnd)
 import           Data.List.Split (splitOn)
 
 import           Data.Time.Clock (UTCTime, NominalDiffTime)
@@ -118,7 +118,7 @@ slotLine exportMode leadershipF SlotStats{..} = Text.pack $
          Just x  -> Text.pack $ printf ("%0."<>show width<>"f") x
          Nothing -> mconcat (replicate width "-")
 
-renderSlotTimeline :: Text -> Text -> Bool -> Seq SlotStats -> Handle -> IO ()
+renderSlotTimeline :: Text -> Text -> Bool -> [SlotStats] -> Handle -> IO ()
 renderSlotTimeline leadHead fmt exportMode slotStats hnd = do
   forM_ (zip (toList slotStats) [(0 :: Int)..]) $ \(l, i) -> do
     when (i `mod` 33 == 0 && (i == 0 || not exportMode)) $
@@ -132,11 +132,11 @@ renderSlotTimeline leadHead fmt exportMode slotStats hnd = do
 --   they start getting non-zero chain density reported.
 --
 --   On the trailing part, we drop everything since the last leadership check.
-cleanupSlotStats :: Seq SlotStats -> Seq SlotStats
+cleanupSlotStats :: [SlotStats] -> [SlotStats]
 cleanupSlotStats =
-  -- Seq.dropWhileL ((== 0) . slDensity) .
-  Seq.dropWhileL ((/= 500) . slSlot) .
-  Seq.dropWhileR ((== 0)   . slCountChecks)
+  -- dropWhile ((== 0) . slDensity) .
+  dropWhile    ((/= 500) . slSlot) .
+  dropWhileEnd ((== 0)   . slCountChecks)
 
 zeroSlotStats :: SlotStats
 zeroSlotStats =

--- a/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
+{- HLINT ignore "Use head" -}
 module Cardano.Unlog.SlotStats (module Cardano.Unlog.SlotStats) where
 
 import           Prelude ((!!))

--- a/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/SlotStats.hs
@@ -20,6 +20,7 @@ import           Text.Printf
 import           Ouroboros.Network.Block (SlotNo(..))
 
 import           Data.Accum
+import           Cardano.Analysis.Profile
 import           Cardano.Unlog.Render
 import           Cardano.Unlog.Resources
 
@@ -31,7 +32,7 @@ data SlotStats
     { slSlot         :: !SlotNo
     , slEpoch        :: !Word64
     , slEpochSlot    :: !Word64
-    , slStart        :: !UTCTime
+    , slStart        :: !SlotStart
     , slCountChecks  :: !Word64
     , slCountLeads   :: !Word64
     , slChainDBSnap  :: !Word64
@@ -137,7 +138,7 @@ zeroSlotStats =
   { slSlot = 0
   , slEpoch = 0
   , slEpochSlot = 0
-  , slStart = zeroUTCTime
+  , slStart = SlotStart zeroUTCTime
   , slCountChecks = 0
   , slCountLeads = 0
   , slOrderViol = 0

--- a/nix/workbench/locli/src/Cardano/Unlog/Summary.hs
+++ b/nix/workbench/locli/src/Cardano/Unlog/Summary.hs
@@ -22,7 +22,6 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
@@ -152,7 +151,7 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
     let slotStats = cleanupSlotStats noisySlotStats
 
     -- 3. Derive the summary
-    let drvVectors0, _drvVectors1 :: Seq DerivedSlot
+    let drvVectors0, _drvVectors1 :: [DerivedSlot]
         (,) drvVectors0 _drvVectors1 = computeDerivedVectors slotStats
         summary :: Summary
         summary = slotStatsSummary chainInfo slotStats
@@ -170,7 +169,7 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
        (renderDerivedSlots drvVectors0)
     forM_ mtofHistogram
       (renderHistogram "CPU usage spans over 85%" "Span length"
-        (toList $ Seq.sort $ sSpanLensCPU85 summary))
+        (toList $ sort $ sSpanLensCPU85 summary))
 
     flip (maybe $ LBS.putStrLn timelineOutput) mtofAnalysis $
       \case
@@ -188,7 +187,7 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
              Hist.defOpts hist
 
    renderPrettySummary ::
-        Seq SlotStats -> Summary -> [JsonLogfile] -> TextOutputFile -> IO ()
+        [SlotStats] -> Summary -> [JsonLogfile] -> TextOutputFile -> IO ()
    renderPrettySummary xs s srcs o =
      withFile (unTextOutputFile o) WriteMode $ \hnd -> do
        hPutStrLn hnd . Text.pack $
@@ -204,7 +203,7 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
            renderChainInfoExport chainInfo
            <>
            renderRunScalars rs
-   renderExportTimeline :: Seq SlotStats -> CsvOutputFile -> IO ()
+   renderExportTimeline :: [SlotStats] -> CsvOutputFile -> IO ()
    renderExportTimeline xs (CsvOutputFile o) =
      withFile o WriteMode $
        renderSlotTimeline slotHeadE slotFormatE True xs
@@ -215,7 +214,7 @@ runMachineTimeline chainInfo logfiles MachineTimelineOutputFiles{..} = do
        forM_ (toDistribLines statFmt propFmt summary) $
          hPutStrLn hnd
 
-   renderDerivedSlots :: Seq DerivedSlot -> CsvOutputFile -> IO ()
+   renderDerivedSlots :: [DerivedSlot] -> CsvOutputFile -> IO ()
    renderDerivedSlots slots (CsvOutputFile o) = do
      withFile o WriteMode $ \hnd -> do
        hPutStrLn hnd derivedSlotsHeader
@@ -230,10 +229,10 @@ dumpLOStream objs o =
 data Summary
   = Summary
     { sMaxChecks         :: !Word64
-    , sSlotMisses        :: !(Seq Word64)
-    , sSpanLensCPU85     :: !(Seq Int)
-    , sSpanLensCPU85EBnd :: !(Seq Int)
-    , sSpanLensCPU85Rwd  :: !(Seq Int)
+    , sSlotMisses        :: ![Word64]
+    , sSpanLensCPU85     :: ![Int]
+    , sSpanLensCPU85EBnd :: ![Int]
+    , sSpanLensCPU85Rwd  :: ![Int]
     -- distributions
     , sMissDistrib       :: !(Distribution Float Float)
     , sLeadsDistrib      :: !(Distribution Float Word64)
@@ -271,7 +270,7 @@ instance ToJSON Summary where
         , "xs" .= toJSON sSpanLensCPU85]
     , Aeson.Object $ HashMap.fromList
         [ "kind" .= String "spanLensCPU85Sorted"
-        , "xs" .= toJSON (Seq.sort sSpanLensCPU85)]
+        , "xs" .= toJSON (sort sSpanLensCPU85)]
     , extendObject "kind" "spancheck" $ toJSON sSpanCheckDistrib
     , extendObject "kind" "spanlead"  $ toJSON sSpanLeadDistrib
     , extendObject "kind" "cpu"       $ toJSON (rCentiCpu sResourceDistribs)
@@ -292,7 +291,7 @@ instance ToJSON Summary where
                                         toJSON sSpanLensCPU85RwdDistrib
     ]
 
-slotStatsSummary :: ChainInfo -> Seq SlotStats -> Summary
+slotStatsSummary :: ChainInfo -> [SlotStats] -> Summary
 slotStatsSummary CInfo{} slots =
   Summary
   { sMaxChecks        = maxChecks
@@ -322,9 +321,9 @@ slotStatsSummary CInfo{} slots =
   , sSpanLensCPU85RwdDistrib  = computeDistribution pctiles sSpanLensCPU85Rwd
   }
  where
-   sSpanLensCPU85EBnd = Seq.fromList $ Vec.length <$>
+   sSpanLensCPU85EBnd = Vec.length <$>
                         filter (spanContainsEpochSlot 3) spansCPU85
-   sSpanLensCPU85Rwd  = Seq.fromList $ Vec.length <$>
+   sSpanLensCPU85Rwd  = Vec.length <$>
                         filter (spanContainsEpochSlot 803) spansCPU85
    pctiles = sortBy (compare `on` psFrac)
      [ Perc 0.01, Perc 0.05
@@ -346,7 +345,7 @@ slotStatsSummary CInfo{} slots =
    spansCPU85       = spans
                         ((/= Just False) . fmap (>=85) . rCentiCpu . slResources)
                         (toList slots)
-   spanLensCPU85    = Seq.fromList $ spanLen <$> spansCPU85
+   spanLensCPU85    = spanLen <$> spansCPU85
    spanContainsEpochSlot :: Word64 -> Vector SlotStats -> Bool
    spanContainsEpochSlot s =
      uncurry (&&)

--- a/nix/workbench/locli/src/Data/Distribution.hs
+++ b/nix/workbench/locli/src/Data/Distribution.hs
@@ -18,15 +18,13 @@ module Data.Distribution
   , spans
   ) where
 
-import           Prelude (String, id)
+import           Prelude (String, (!!), id)
 import           Cardano.Prelude
 
 import           Control.Arrow
 import           Data.Aeson (ToJSON(..))
 import qualified Data.Foldable as F
 import           Data.List (span)
-import qualified Data.Sequence as Seq
-import           Data.Sequence (index)
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vec
 import           Text.Printf (PrintfArg, printf)
@@ -70,11 +68,11 @@ zeroDistribution =
   , dPercentiles = mempty
   }
 
-countSeq :: Eq a => a -> Seq a -> Int
+countSeq :: Eq a => a -> [a] -> Int
 countSeq x = foldl' (\n e -> if e == x then n + 1 else n) 0
 
-computeDistribution :: (RealFrac a, Real v, ToRealFrac v a) => [PercSpec a] -> Seq v -> Distribution a v
-computeDistribution percentiles (Seq.sort -> sorted) =
+computeDistribution :: (RealFrac a, Real v, ToRealFrac v a) => [PercSpec a] -> [v] -> Distribution a v
+computeDistribution percentiles (sort -> sorted) =
   Distribution
   { dAverage     = toRealFrac (F.sum sorted) / fromIntegral (size `max` 1)
   , dCount       = size
@@ -87,18 +85,18 @@ computeDistribution percentiles (Seq.sort -> sorted) =
               if size == 0
               then (0, 0)
               else floor (fromIntegral (size - 1) * psFrac spec) &
-                   (id &&& Seq.index sorted)
+                   (id &&& (sorted !!))
         in Percentile
              spec
              (size - sampleIndex)
              (countSeq sample sorted)
              sample
   }
-  where size   = Seq.length sorted
+  where size = length sorted
         (,) mini maxi =
           if size == 0
           then (0, 0)
-          else (index sorted 0, index sorted $ size - 1)
+          else (sorted !! 0, sorted !! (size - 1))
 
 class RealFrac b => ToRealFrac a b where
   toRealFrac :: a -> b

--- a/nix/workbench/locli/src/Data/Distribution.hs
+++ b/nix/workbench/locli/src/Data/Distribution.hs
@@ -27,7 +27,7 @@ module Data.Distribution
   , spans
   ) where
 
-import Prelude (String, (!!), id, head, last, show)
+import Prelude (String, (!!), head, last, show)
 import Cardano.Prelude hiding (head, show)
 
 import Control.Arrow

--- a/nix/workbench/locli/src/Data/Distribution.hs
+++ b/nix/workbench/locli/src/Data/Distribution.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
@@ -114,7 +113,7 @@ computeDistributionStats desc xs = do
    pctLen = length . dPercentiles $ head xs
 
    pctsMeanCoV :: [Percentile a v] -> (Percentile a v, Percentile a v)
-   pctsMeanCoV xs' = (join (***) (Percentile . pctSpec $ head xs'))
+   pctsMeanCoV xs' = join (***) (Percentile . pctSpec $ head xs')
      (mean, Stat.stdDev vec / mean)
     where
       vec = Vec.fromList $ pctSample <$> xs'
@@ -135,7 +134,7 @@ computeDistribution percentiles (sort -> sorted) =
       \spec ->
         let sample = if size == 0
                      then 0
-                     else sorted !! (indexAtFrac (psFrac spec))
+                     else sorted !! indexAtFrac (psFrac spec)
         in Percentile spec sample
   }
  where size = length sorted

--- a/nix/workbench/profiles/adhoc.jq
+++ b/nix/workbench/profiles/adhoc.jq
@@ -12,6 +12,16 @@ def adhoc_profiles:
                , init_cooldown: 25 }
   , tolerances: { finish_patience: 4 }
   }
+, { name: "10"
+  , composition:
+    { n_singular_hosts:               10
+    , n_dense_hosts:                  0
+    }
+  , genesis:
+    { genesis_future_offset: "10 seconds"
+    , utxo:                  0
+    }
+  }
 , { name: "default"
   , genesis:
     { verbatim:

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -158,6 +158,6 @@ EOF
     lostream-fixup-jqexpr )
         usage="USAGE: wb supervisor $op"
 
-        echo '| $mapp2n[0] as $map | . * { host: $map[.pid] }';;
+        echo '| $mapp2n[0] as $map | . * { host: ($map[.pid] // $dirHostname) }';;
 
     * ) usage_supervisor;; esac

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -62,7 +62,8 @@ case "$op" in
             --argjson port_shift_prometheus "$port_shift_prometheus"
         )
         jq_fmutate "$env_json" '. *
-          { port_shift_ekg:        $port_shift_ekg
+          { type:                  "supervisor"
+          , port_shift_ekg:        $port_shift_ekg
           , port_shift_prometheus: $port_shift_prometheus
           }
         ' "${args[@]}"

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -152,7 +152,8 @@ EOF
         usage="USAGE: wb supervisor $op RUN-DIR"
         dir=${1:?$usage}
 
-        echo --compact-output --slurpfile mapp2n "$dir"/supervisor/pid2node.map;;
+        echo --compact-output --argjson mapp2n '[{}]';;# --slurpfile mapp2n "$dir"/supervisor/pid2node.map;;
+        #echo --compact-output --slurpfile mapp2n "$dir"/supervisor/pid2node.map;;
 
     lostream-fixup-jqexpr )
         usage="USAGE: wb supervisor $op"

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -43,6 +43,7 @@ usage_extra() {
     cat >&2 <<EOF
   Other OPs:
 
+    reanalyse    (rea)    Re-analyse a cluster run (synonym for analyse --re)
     call ARGS..           Call internal functions with arguments
     mode                  Report mode set by --set-mode
 
@@ -95,6 +96,8 @@ main() {
 
         ## Internals:
         #
+        reanalyse | rea | re )
+            analyse --reanalyse "$@";;
         backend )
             backend "$@";;
         call )

--- a/shell.nix
+++ b/shell.nix
@@ -93,6 +93,7 @@ let
       tmux
       pkgs.git
       pkgs.hlint
+      pkgs.moreutils
     ] ++ lib.optional haveGlibcLocales pkgs.glibcLocales
     ## Workbench's main script is called directly in dev mode.
     ++ lib.optionals (!workbenchDevMode)


### PR DESCRIPTION
Workbench & `locli` improvements, primarily aimed at block time budgeting analysis support

- assorted fixes & cleanups
- `10-*` profiles, for a local 10-node cluster
- `wb reanalyse *` re-analysis invocation fast path
- locli: drop `Seq`, reverting to lists
- block propagation event CDFs
- generic, data-driven rendering of summaries and timelines
- module reorganisation
- block propagation timeline
- thorough log anomaly processing:  accumulation and attributed reporting
- block propagation event filtering
- cluster latency probe script
- support processing of the legacy, AWS benchmark runs
- support side-loaded alternate benchmark run roots, for direct on-AWS processing
- parallel processing for the machine performance timeline analysis