### PR TITLE
Update register_stakepool.md

### DIFF
--- a/doc/stake-pool-operations/register_stakepool.md
+++ b/doc/stake-pool-operations/register_stakepool.md
@@ -38,7 +38,7 @@ To register your stake pool you will need to:
       "homepage": "https://teststakepool.com"
       }
 
-Store the file in the url you control. For example [https://teststakepool.com/poolMetadata.json](https://git.io/JJWdJ). You can use a GIST in Github to store the definition and git.io to make it short. Ensure that the URL is less than 65 characters long.
+Store the file in the url you control. For example [https://teststakepool.com/poolMetadata.json](https://git.io/JJWdJ). You can use a GIST in Github to store the definition and git.io to make it short. Ensure that the Stake pool metadata consists of at most 512 bytes, with the URL being less than 65 characters long.
 
 Example:
 


### PR DESCRIPTION
I think this can be avoided if the limitations are mentioned
```
cardano-cli stake-pool metadata-hash --pool-metadata-file poolMetadata.json
Command failed: stake-pool metadata-hash  Error: Error validating stake pool metadata: Stake pool metadata must consist of at most 512 bytes, but it consists of 556 bytes
```