### PR TITLE
API additions for automating transaction building

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -94,6 +94,7 @@ library
   build-depends:        aeson             >= 1.5.6.0
                       , aeson-pretty      >= 0.8.5
                       , attoparsec
+                      , array
                       , base16-bytestring >= 1.0
                       , base58-bytestring
                       , bech32 >= 1.1.0
@@ -127,6 +128,7 @@ library
                       , ouroboros-network
                       , ouroboros-network-framework
                       , plutus-ledger-api
+                      , prettyprinter
                       , scientific
                       , shelley-spec-ledger
                       , small-steps

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -243,6 +243,7 @@ module Cardano.Api (
     transactionFee,
     estimateTransactionFee,
     evaluateTransactionFee,
+    estimateTransactionKeyWitnessCount,
     evaluateTransactionBalance,
 
     -- * Transaction metadata

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -221,6 +221,24 @@ module Cardano.Api (
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
 
+    -- ** Fee calculation
+    transactionFee,
+    estimateTransactionFee,
+    evaluateTransactionFee,
+    estimateTransactionKeyWitnessCount,
+
+    -- ** Script execution units
+    evaluateTransactionExecutionUnits,
+    ScriptExecutionError(..),
+    TransactionValidityIntervalError,
+
+    -- ** Transaction balance
+    evaluateTransactionBalance,
+
+    -- ** Building transactions with automated fees and balancing
+    makeTransactionBodyAutoBalance,
+    TxBodyErrorAutoBalance(..),
+
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.
     Tx(Tx),
@@ -238,20 +256,6 @@ module Cardano.Api (
     ShelleyWitnessSigningKey(..),
     makeShelleyKeyWitness,
     makeShelleyBootstrapWitness,
-
-    -- * Fee calculation
-    transactionFee,
-    estimateTransactionFee,
-    evaluateTransactionFee,
-    estimateTransactionKeyWitnessCount,
-
-    -- ** Script execution units
-    evaluateTransactionExecutionUnits,
-    ScriptExecutionError(..),
-    TransactionValidityIntervalError,
-
-    -- ** Transaction balance
-    evaluateTransactionBalance,
 
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -244,6 +244,13 @@ module Cardano.Api (
     estimateTransactionFee,
     evaluateTransactionFee,
     estimateTransactionKeyWitnessCount,
+
+    -- ** Script execution units
+    evaluateTransactionExecutionUnits,
+    ScriptExecutionError(..),
+    TransactionValidityIntervalError,
+
+    -- ** Transaction balance
     evaluateTransactionBalance,
 
     -- * Transaction metadata

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -242,6 +242,7 @@ module Cardano.Api (
     -- * Fee calculation
     transactionFee,
     estimateTransactionFee,
+    evaluateTransactionFee,
     evaluateTransactionBalance,
 
     -- * Transaction metadata

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -242,6 +242,7 @@ module Cardano.Api (
     -- * Fee calculation
     transactionFee,
     estimateTransactionFee,
+    evaluateTransactionBalance,
 
     -- * Transaction metadata
     -- | Embedding additional structured data within transactions.

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -1,28 +1,60 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 -- | Fee calculation
 --
 module Cardano.Api.Fees (
+
+    -- * Transaction fees
     transactionFee,
     estimateTransactionFee,
+
+    -- * Transaction balance
+    evaluateTransactionBalance,
   ) where
 
 import           Prelude
 
 import qualified Data.ByteString as BS
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import           GHC.Records (HasField (..))
 import           Numeric.Natural
+import           Data.Sequence.Strict (StrictSeq(..))
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Byron
 
+import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Core as Ledger
+import qualified Cardano.Ledger.Era  as Ledger.Era (Crypto)
+import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Ledger.Crypto as Ledger
+
+import qualified Shelley.Spec.Ledger.API as Ledger (CLI, TxIn, DCert, Wdrl)
+import qualified Shelley.Spec.Ledger.API.Wallet as Ledger
+                   (evaluateTransactionBalance)
+
+import           Shelley.Spec.Ledger.PParams (PParams'(..))
+import qualified Cardano.Ledger.Mary.Value as Mary
+import           Cardano.Ledger.Alonzo.PParams (PParams'(..))
+
+import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.NetworkId
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Query
+import           Cardano.Api.Script
 import           Cardano.Api.Tx
+import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 
 
@@ -125,3 +157,109 @@ estimateTransactionFee nw txFeeFixed txFeePerByte (ShelleyTx era tx) =
 estimateTransactionFee _ _ _ (ByronTx _) =
     case shelleyBasedEra :: ShelleyBasedEra era of {}
 
+
+-- ----------------------------------------------------------------------------
+-- Transaction balance
+--
+
+-- | Compute the total balance of the proposed transaction. Ultimately a valid
+-- transaction must be fully balanced: that is have a total value of zero.
+--
+-- Finding the (non-zero) balance of partially constructed transaction is
+-- useful for adjusting a transaction to be fully balanced.
+--
+evaluateTransactionBalance :: forall era.
+                              IsShelleyBasedEra era
+                           => ProtocolParameters
+                           -> Set PoolId
+                           -> UTxO era
+                           -> TxBody era
+                           -> TxOutValue era
+evaluateTransactionBalance _ _ _ (ByronTxBody _) =
+    case shelleyBasedEra :: ShelleyBasedEra era of {}
+    --TODO: we could actually support Byron here, it'd be different but simpler
+
+evaluateTransactionBalance pparams poolids utxo
+                           (ShelleyTxBody era txbody _ _ _) =
+    withLedgerConstraints era evalAdaOnly evalMultiAsset
+  where
+    isNewPool :: Ledger.KeyHash Ledger.StakePool Ledger.StandardCrypto -> Bool
+    isNewPool kh = StakePoolKeyHash kh `Set.notMember` poolids
+
+    evalMultiAsset :: forall ledgerera.
+                      ShelleyLedgerEra era ~ ledgerera
+                   => LedgerEraConstraints ledgerera
+                   => LedgerMultiAssetConstraints ledgerera
+                   => MultiAssetSupportedInEra era
+                   -> TxOutValue era
+    evalMultiAsset evidence =
+      TxOutValue evidence . fromMaryValue $
+         Ledger.evaluateTransactionBalance
+           (toLedgerPParams era pparams)
+           (toLedgerUTxO era utxo)
+           isNewPool
+           txbody
+
+    evalAdaOnly :: forall ledgerera.
+                   ShelleyLedgerEra era ~ ledgerera
+                => LedgerEraConstraints ledgerera
+                => LedgerAdaOnlyConstraints ledgerera
+                => OnlyAdaSupportedInEra era
+                -> TxOutValue era
+    evalAdaOnly evidence =
+     TxOutAdaOnly evidence . fromShelleyLovelace
+       $ Ledger.evaluateTransactionBalance
+           (toLedgerPParams era pparams)
+           (toLedgerUTxO era utxo)
+           isNewPool
+           txbody
+
+    -- Conjur up all the necessary class instances and evidence
+    withLedgerConstraints
+      :: ShelleyLedgerEra era ~ ledgerera
+      => ShelleyBasedEra era
+      -> (   LedgerEraConstraints ledgerera
+          => LedgerAdaOnlyConstraints ledgerera
+          => LedgerPParamsConstraints ledgerera
+          => LedgerTxBodyConstraints ledgerera
+          => OnlyAdaSupportedInEra era
+          -> a)
+      -> (   LedgerEraConstraints ledgerera
+          => LedgerMultiAssetConstraints ledgerera
+          => LedgerPParamsConstraints ledgerera
+          => LedgerTxBodyConstraints ledgerera
+          => MultiAssetSupportedInEra era
+          -> a)
+      -> a
+    withLedgerConstraints ShelleyBasedEraShelley f _ = f AdaOnlyInShelleyEra
+    withLedgerConstraints ShelleyBasedEraAllegra f _ = f AdaOnlyInAllegraEra
+    withLedgerConstraints ShelleyBasedEraMary    _ f = f MultiAssetInMaryEra
+    withLedgerConstraints ShelleyBasedEraAlonzo  _ f = f MultiAssetInAlonzoEra
+
+type LedgerEraConstraints ledgerera =
+       ( Ledger.Era.Crypto ledgerera ~ Ledger.StandardCrypto
+       , Ledger.CLI ledgerera
+       )
+
+type LedgerAdaOnlyConstraints ledgerera =
+         Ledger.Value ledgerera ~ Ledger.Coin
+
+type LedgerMultiAssetConstraints ledgerera =
+       ( Ledger.Value ledgerera ~ Mary.Value Ledger.StandardCrypto
+       , HasField "mint" (Ledger.TxBody ledgerera) (Ledger.Value ledgerera)
+       )
+
+type LedgerPParamsConstraints ledgerera =
+       ( HasField "_minfeeA"     (Ledger.PParams ledgerera) Natural
+       , HasField "_minfeeB"     (Ledger.PParams ledgerera) Natural
+       , HasField "_keyDeposit"  (Ledger.PParams ledgerera) Ledger.Coin
+       , HasField "_poolDeposit" (Ledger.PParams ledgerera) Ledger.Coin
+       )
+
+type LedgerTxBodyConstraints ledgerera =
+       ( HasField "certs" (Ledger.TxBody ledgerera)
+                          (StrictSeq (Ledger.DCert Ledger.StandardCrypto))
+       , HasField "inputs" (Ledger.TxBody ledgerera)
+                           (Set (Ledger.TxIn Ledger.StandardCrypto))
+       , HasField "wdrls" (Ledger.TxBody ledgerera) (Ledger.Wdrl Ledger.StandardCrypto)
+       )

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -94,6 +94,7 @@ import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 
+{- HLINT ignore "Redundant return" -}
 
 -- ----------------------------------------------------------------------------
 -- Transaction fees

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -46,6 +46,10 @@ module Cardano.Api.ProtocolParameters (
     fromShelleyPParams,
     toAlonzoPrices,
     fromAlonzoPrices,
+    toAlonzoScriptLanguage,
+    fromAlonzoScriptLanguage,
+    toAlonzoCostModel,
+    fromAlonzoCostModel,
 
     -- * Data family instances
     AsType(..)

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -107,12 +107,11 @@ module Cardano.Api.TxBody (
     fromShelleyTxOut,
     toAlonzoRdmrPtr,
     fromAlonzoRdmrPtr,
+    fromByronTxIn,
+    renderTxIn,
 
     -- * Data family instances
     AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
-
-    -- * Conversion functions
-    fromByronTxIn,
   ) where
 
 import           Prelude


### PR DESCRIPTION
* Add API evaluateTransactionBalance

  Compute the total balance of the proposed transaction. Ultimately a
  valid transaction must be fully balanced: that is have a total value
  of zero.
    
  Finding the (non-zero) balance of partially constructed transaction
  is useful for adjusting a transaction to be fully balanced.