### PR TITLE
Update building-the-node-using-nix.md

### DIFF
--- a/doc/getting-started/building-the-node-using-nix.md
+++ b/doc/getting-started/building-the-node-using-nix.md
@@ -26,7 +26,7 @@ Once Nix is installed, log out and then log back in then:
 git clone https://github.com/input-output-hk/cardano-node
 cd cardano-node
 nix-build -A scripts.mainnet.node -o mainnet-node-local
-./mainnet-node-local
+./mainnet-node-local/bin/cardano-node-mainnet
 ```
 
 [nix]: https://nixos.org/nix/


### PR DESCRIPTION
The last line on how to run mainnet-node-local now points to a directory.

Replacement for https://github.com/input-output-hk/cardano-node/pull/2898