### PR TITLE
CAD-3098: integrate generator into the workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 \.#*
 *.swp
 .dir-locals.el
+.Rhistory
 result*
 /launch-*
 stack.yaml.lock

--- a/bench/tx-generator-config-base.json
+++ b/bench/tx-generator-config-base.json
@@ -1,0 +1,72 @@
+{
+  "LastKnownBlockVersion-Alt": 0,
+  "LastKnownBlockVersion-Major": 0,
+  "LastKnownBlockVersion-Minor": 2,
+  "Protocol": "RealPBFT",
+  "RequiresNetworkMagic": "RequiresMagic",
+
+  "TurnOnLogging": true,
+  "TurnOnLogMetrics": false,
+  "setupBackends": [
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scFormat": "ScJson",
+      "scKind": "FileSK",
+      "scName": "logs/generator.json"
+    },
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ],
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "FileSK",
+      "logs/generator.json"
+    ],
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+
+  "minSeverity": "Debug",
+
+  "TraceBlockFetchClient": true,
+  "TraceBlockFetchDecisions": false,
+  "TraceBlockFetchProtocol": false,
+  "TraceBlockFetchProtocolSerialised": false,
+  "TraceBlockFetchServer": false,
+  "TraceChainDb": false,
+  "TraceChainSyncBlockServer": false,
+  "TraceChainSyncClient": false,
+  "TraceChainSyncHeaderServer": false,
+  "TraceChainSyncProtocol": false,
+  "TraceDNSResolver": false,
+  "TraceDNSSubscription": false,
+  "TraceErrorPolicy": false,
+  "TraceForge": false,
+  "TraceIpSubscription": false,
+  "TraceLocalChainSyncProtocol": false,
+  "TraceLocalErrorPolicy": false,
+  "TraceLocalTxSubmissionProtocol": false,
+  "TraceLocalTxSubmissionServer": false,
+  "TraceMempool": false,
+  "TraceMux": false,
+  "TraceTxInbound": false,
+  "TraceTxOutbound": false,
+  "TraceTxSubmissionProtocol": false,
+  "TracingVerbosity": "NormalVerbosity",
+
+  "options": {
+    "mapBackends": {},
+    "mapSubtrace": {}
+  }
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,6 +44,7 @@ let
         # commonLib: mix pkgs.lib with iohk-nix utils and our own:
         commonLib = with pkgs; lib // cardanoLib // iohk-nix.lib
           // import ./util.nix { inherit haskell-nix; }
+          // import ./svclib.nix { inherit pkgs; }
           # also expose our sources, nixpkgs and overlays
           // { inherit overlays sources nixpkgs; };
       })

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,4 +1,5 @@
 [
  ./cardano-node-service.nix
  ./cardano-submit-api-service.nix
+ ./tx-generator-service.nix
 ]

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -1,0 +1,81 @@
+(import ../. {}).commonLib.defServiceModule
+  (lib: with lib;
+    { svcName = "tx-generator";
+      svcDesc = "configurable transaction generator";
+
+      svcPackageSelector =
+        pkgs: ## Local:
+              pkgs.cardanoNodeHaskellPackages.tx-generator
+              ## Imported by another repo, that adds an overlay:
+                or pkgs.tx-generator;
+              ## TODO:  that's actually a bit ugly and could be improved.
+      ## This exe has to be available in the selected package.
+      exeName = "tx-generator";
+
+      extraOptionDecls = {
+        ## TODO: the defaults should be externalised to a file.
+        ##
+        tx_count        =  intOpt 1000       "How many Txs to send, total.";
+        add_tx_size     =  intOpt 100        "Extra Tx payload, in bytes.";
+        inputs_per_tx   =  intOpt 4          "Inputs per Tx.";
+        outputs_per_tx  =  intOpt 4          "Outputs per Tx.";
+        tx_fee          =  intOpt 10000000   "Tx fee, in Lovelace.";
+        tps             =  intOpt 100        "Strength of generated load, in TPS.";
+        init_cooldown   =  intOpt 100        "Delay between init and main submissions.";
+
+        nodeConfigFile  =  strOpt null       "Node-style config file path.";
+        nodeConfig      = attrOpt {}         "Node-style config, overrides the default.";
+        sigKey          =  strOpt null       "Key with funds";
+
+        localNodeSocketPath =
+                           strOpt null       "Local node socket path";
+        localNodeConf   = attrOpt null       "Config of the local node";
+
+        targetNodes     = attrOpt null       "Targets: { name = { ip, port } }";
+
+        era             = enumOpt [ "shelley"
+                                    "allegra"
+                                    "mary"
+                                    "alonzo"
+                                  ]
+                                  "shelley"
+                                  "Cardano era to generate transactions for.";
+      };
+
+      configExeArgsFn =
+        cfg: with cfg;
+          [ "cliArguments"
+
+            "--config"                 nodeConfigFile
+
+            "--socket-path"            localNodeSocketPath
+
+            ## XXX
+            "--${if era == "alonzo" then "mary" else era}"
+
+            "--num-of-txs"             tx_count
+            "--add-tx-size"            add_tx_size
+            "--inputs-per-tx"          inputs_per_tx
+            "--outputs-per-tx"         outputs_per_tx
+            "--tx-fee"                 tx_fee
+            "--tps"                    tps
+            "--init-cooldown"          init_cooldown
+
+            "--genesis-funds-key"      sigKey
+          ] ++
+          __attrValues
+            (__mapAttrs (name: { ip, port }: "--target-node '(\"${ip}\",${toString port})'")
+              targetNodes);
+
+      configSystemdExtraConfig = _: {};
+
+      configSystemdExtraServiceConfig =
+        cfg: with cfg; {
+          Type = "exec";
+          User = "cardano-node";
+          Group = "cardano-node";
+          Restart = "no";
+          RuntimeDirectory = localNodeConf.runtimeDir;
+          WorkingDirectory = localNodeConf.stateDir;
+        };
+    })

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -72,6 +72,7 @@ let
           ({
             sigKey         = "../genesis/utxo-keys/utxo1.skey";
             nodeConfigFile = "config.json";
+            runScriptFile  = "run-script.json";
           } // optionalAttrs useCabalRun {
             executable     = "cabal run exe:tx-generator --";
           });

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -33,6 +33,10 @@ let
            then "topology for-local-node     ${toString i}   ${profile.topology.files} ${toString basePort}"
            else "topology for-local-observer ${profile.name} ${profile.topology.files} ${toString basePort}");
 
+      nodePublicIP =
+        { i, name, ... }@nodeSpec:
+        "127.0.0.1";
+
       finaliseNodeService =
         { name, i, isProducer, ... }: svc: recursiveUpdate svc
           ({
@@ -63,6 +67,23 @@ let
             ];
           });
 
+      finaliseGeneratorService =
+        svc: recursiveUpdate svc
+          ({
+            sigKey         = "../genesis/utxo-keys/utxo1.skey";
+            nodeConfigFile = "config.json";
+          } // optionalAttrs useCabalRun {
+            executable     = "cabal run exe:tx-generator --";
+          });
+
+      finaliseGeneratorConfig =
+        cfg: recursiveUpdate cfg
+          ({
+            AlonzoGenesisFile    = "../genesis/alonzo-genesis.json";
+            ShelleyGenesisFile   = "../genesis.json";
+            ByronGenesisFile     = "../genesis/byron/genesis.json";
+          });
+
       ## Backend-specific Nix bits:
       supervisord =
         {
@@ -75,7 +96,7 @@ let
           mkSupervisorConf =
             profile:
             pkgs.callPackage ./supervisor-conf.nix
-            { inherit (profile) node-services;
+            { inherit (profile) node-services generator-service;
               inherit
                 pkgs lib stateDir
                 basePort

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -1,0 +1,246 @@
+{ pkgs }:
+with pkgs.lib;
+let
+  inherit (pkgs) lib;
+
+  id = x: x;
+
+  ## Make a launch script for a service,
+  ## given:
+  ##  - service name
+  ##  - package containing the service binary
+  ##  - name of the service binary
+  ##  - service configuration
+  ##  - transformation from service configuration to binary arglist
+  ##  - optional pre-start shell snippet
+  ##
+  mkServiceScript =
+    { svcName
+    , package
+    , exeName
+    , config
+    , configExeArgsFn
+    , configScriptPreambleFn
+    , traceServiceStartup ? false
+    }:
+    let cmd = map normaliseCmdArg ([
+          config.executable
+        ] ++ configExeArgsFn config);
+        normaliseCmdArg = x:
+          ({ int = toString; float = toString; string = id;
+             ## TODO: ugh, why oh why:
+             ## while evaluating 'normaliseCmdArg' at svclib.nix:32:27:
+             ## while evaluating anonymous function at tx-generator-service.nix:98:16:
+             ## file '/dev/null' has an unsupported type
+
+             path = x: "${x}";
+           }."${__typeOf x}" or
+            (_: throw "\nWhile processing service declaration for '${svcName}':  Unsupported type of command arg: ${__typeOf x}\n")) x;
+    in  ''
+        ${if traceServiceStartup then "set -x" else ""}
+        ${configScriptPreambleFn config}
+        CMD=(
+            '' + concatStringsSep "\n     " cmd +
+        ''
+
+        )
+        echo -e "Starting service ${svcName}:\n"
+
+        for x in "''${CMD[@]}"
+        do echo "    ''${x}"; done
+
+        echo -e "\n..or, once again, in a single line:\n"
+        echo -e "    ''${CMD[@]@Q}\n"
+
+        "''${CMD[@]}"
+        status=$?
+
+        echo "Service binary '${exeName}' returned status: $status" >&2
+        exit $status'';
+
+  ## Define a typical service module,
+  ## given:
+  ##  - service name (must be a valid NixOS & systemd service name & Unix username)
+  ##  - free-form, one-line service description
+  ##  - package selector function, of type (NixPkgs -> Package)
+  ##  - executable name (must be a valid cabal project executable)
+  ##  - extra NixOS module option declarations (default: {})
+  ##  - executable's arglist (default: _: [])
+  ##  - script preamble shell snippet (default: _: "")
+  ##  - systemd extra config (see defaults below)
+  ##  - systemd extra service config (see defaults below)
+  defServiceModule = argClosure:
+    let dsmDeclSpec = argClosure (pkgs.lib // serviceDeclarationLib);
+    in defServiceModule__ dsmDeclSpec;
+  defServiceModule__ =
+    { ## WARNING: when changing this arglist,
+      ## make sure to update 'unhandledArgs' below.
+      svcName
+    , svcDesc
+    , svcPackageSelector
+    , extraOptionDecls ? {}
+    , exeName
+    , configExeArgsFn ? (config: ["--help"])
+    , configRtsOpts ? (config: [])
+    , configScriptPreambleFn ? (config: "")
+    , configSystemdExtraConfig ? null
+    , configSystemdExtraServiceConfig ? null
+    , configAssertions ? ({ config, lib }: [])
+    }@args:
+    { config
+    , lib
+    , pkgs
+    , ... }:
+    let svcConfig = config.services."${svcName}";
+        systemdDefaults = _: {
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+        };
+        systemdServiceDefaults = _: {
+          Restart = "yes";
+          # WorkingDirectory = ncfg.stateDir;
+          # StateDirectory =  lib.removePrefix stateDirBase ncfg.stateDir;
+        };
+        systemdExtraConfig =
+          (if configSystemdExtraConfig == null
+           then systemdDefaults else configSystemdExtraConfig)
+            svcConfig;
+        systemdExtraServiceConfig =
+          (if configSystemdExtraServiceConfig == null
+           then systemdServiceDefaults else configSystemdExtraServiceConfig)
+            svcConfig;
+        unhandledArgs = attrNames (removeAttrs args
+          [ "svcName" "svcDesc" "svcPackageSelector" "extraOptionDecls"
+            "exeName" "configExeArgsFn"
+            "configScriptPreambleFn" "configSystemdExtraConfig"
+            "configSystemdExtraServiceConfig" "configAssertions"
+            "configRtsOpts"
+            "traceServiceStartup"
+          ]);
+        handleUnhandledArgs = rest:
+          if unhandledArgs == [] then rest
+          else throw "Unhandled args to defServiceModule ${toString unhandledArgs}";
+    in handleUnhandledArgs {
+      options = {
+        services."${svcName}" = {
+          enable = mkOption { type = types.bool; default = false; description = ''Enable ${svcName}, ${svcDesc}.''; };
+          package = mkOption {
+            type = types.package;
+            default = pkgs.${svcName} or
+              (throw "the 'pkgs' does not have ${svcName} -- please adjust service configuration.");
+            description = ''The package for ${svcName} that should be used.'';
+          };
+          executable = mkOption {
+            type = types.str;
+            default = "${svcConfig.package.components.exes.${exeName}}/bin/${exeName}" or
+              (throw "the package for ${svcName} not have the components.exes.${exeName} attribute -- please adjust service configuration.");
+            description = ''The executable for ${svcName} that should be used.'';
+          };
+          script = mkOption { type = types.str;  default =
+            mkServiceScript {
+              inherit svcName exeName configScriptPreambleFn;
+              config = svcConfig;
+              package = svcPackageSelector pkgs;
+              traceServiceStartup =
+                svcConfig.dsmPassthrough.traceServiceStartup or false;
+              configExeArgsFn = cfg:
+                configExeArgsFn cfg
+                ++ (let rts = configRtsOpts cfg
+                              ++ svcConfig.dsmPassthrough.rtsOpts or [];
+                    in if rts == []
+                       then [] else ["+RTS"] ++ rts ++ ["-RTS"]);
+            };
+          };
+          dsmPassthrough = mkOption {
+            type = types.attrs; default = {};
+            description = "Pass through generic args to defServiceModule.";
+          };
+        } // extraOptionDecls;
+      };
+      config = mkIf svcConfig.enable ({
+        systemd.services."${svcName}" = {
+          enable        = true;
+          description   = "${svcName}, ${svcDesc}.";
+          script        = svcConfig.script;
+          serviceConfig = {
+            User = "${svcName}";
+            Group = "${svcName}";
+          } // systemdExtraServiceConfig;
+        } // systemdExtraConfig;
+        assertions = configAssertions { inherit lib; config = svcConfig; };
+      });
+    };
+
+  ## A small library of helpers, to establish comfortable
+  ## and compact definition of services.
+  serviceDeclarationLib = with pkgs.lib; rec {
+    opt = type: default: description:
+              mkOption { inherit type default description; };
+    intOpt  = opt types.int;
+    pathOpt = opt (types.or types.path types.str);
+    strOpt  = opt types.str;
+    attrOpt = opt types.attrs;
+    listOpt = opt (types.listOf types.attrs);
+    enumOpt = set: default: description:
+      mkOption { inherit default description;
+                 type = types.enum set; };
+  };
+
+  ## Make a script equivalent to a startup script of a NixOS service,
+  ## given:
+  ##  - a NixOS service name,
+  ##  - its module dependency list
+  ##  - its optional configuration
+  ## mkScriptOfService
+  ##   :: String ServiceName
+  ##   -> Attrs ServiceConfig
+  ##   -> [NixPath NixOSModule]  -- Modules used by service
+  ##   -> String ShellCmd
+  extractServiceScript =
+    { svcName
+    , svcModules
+    , config ? {}
+    }:
+   let
+    script = svcConfig.script;
+    svcConfig = combinedModule.config.services."${svcName}";
+      ## TODO:  sadly this obscures argument errors.
+      # let r = tryEval combinedModule.config.services."${svcName}";
+      # in if r.success == true
+      #    then r.value
+      #    else throw "Service '${svcName}' not defined by modules:  ${toString svcModules}";
+    combinedModule = modules.evalModules {
+      modules = svcModules ++ [
+        systemdCompat
+        injectServiceConfigs
+        pkgsModule
+      ];
+    };
+    injectServiceConfigs = {
+      config.services."${svcName}" = { enable = true; } // config;
+    };
+    pkgsModule = {
+      config._module.args.pkgs = mkDefault pkgs;
+    };
+    systemdCompat.options = {
+      systemd.services = mkOption {};
+      assertions = [];
+      users = mkOption {};
+    };
+  in pkgs.writeScript "run-${svcName}" ''
+    #!${pkgs.runtimeShell}
+
+    ${script} "$@"
+  '';
+
+  processScriptDeclaration =
+    name: decl:
+    extractServiceScript (decl // { svcName = name; });
+in
+{
+  inherit
+  defServiceModule
+  mkScriptOfService
+  mkServiceScript
+  ;
+}

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -23,19 +23,16 @@ let
     , configScriptPreambleFn
     , traceServiceStartup ? false
     }:
-    let cmd = map normaliseCmdArg ([
-          config.executable
-        ] ++ configExeArgsFn config);
+    let cmd = map normaliseCmdArg
+                  ([config.executable] ++ configExeArgsFn config);
         normaliseCmdArg = x:
-          ({ int = toString; float = toString; string = id;
-             ## TODO: ugh, why oh why:
-             ## while evaluating 'normaliseCmdArg' at svclib.nix:32:27:
-             ## while evaluating anonymous function at tx-generator-service.nix:98:16:
-             ## file '/dev/null' has an unsupported type
-
-             path = x: "${x}";
-           }."${__typeOf x}" or
-            (_: throw "\nWhile processing service declaration for '${svcName}':  Unsupported type of command arg: ${__typeOf x}\n")) x;
+          __trace "normaliseCmdArg on ${__typeOf x}"
+            (({ float  = toString;
+                int    = toString;
+                path   = toString;
+                string = toString;
+              }."${__typeOf x}" or
+              (_: throw "\nWhile processing service declaration for '${svcName}':  Unsupported type of command arg: ${__typeOf x}\n")) x);
     in  ''
         ${if traceServiceStartup then "set -x" else ""}
         ${configScriptPreambleFn config}
@@ -179,6 +176,7 @@ let
     intOpt  = opt types.int;
     pathOpt = opt (types.or types.path types.str);
     strOpt  = opt types.str;
+    boolOpt = opt types.bool;
     attrOpt = opt types.attrs;
     listOpt = opt (types.listOf types.attrs);
     enumOpt = set: default: description:

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -126,7 +126,11 @@ let
       ${exeCabalOp "run" "locli"} "$@"
     }
 
-    export -f cardano-cli cardano-node cardano-topology locli
+    function tx-generator() {
+      ${exeCabalOp "run" "tx-generator"} "$@"
+    }
+
+    export -f cardano-cli cardano-node cardano-topology locli tx-generator
 
     ''}
 
@@ -209,7 +213,16 @@ let
           cp -f ${svc.topology.JSON}      ${runDir}/${name}/topology.json
           cp -f ${svc.startupScript}      ${runDir}/${name}/start.sh
           ''
-        ));
+        )
+      ++
+      [ (let svc = profile.generator-service;
+         in
+          ''
+          cp -f ${svc.serviceConfig.JSON} ${runDir}/generator/service-config.json
+          cp -f ${svc.nodeConfig.JSON}    ${runDir}/generator/config.json
+          cp -f ${svc.startupScript}      ${runDir}/generator/start.sh
+          '')
+      ]);
 in
 {
   inherit workbench runWorkbench runJq;

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -218,6 +218,7 @@ let
       [ (let svc = profile.generator-service;
          in
           ''
+          cp -f ${svc.runScript.JSON}     ${runDir}/generator/run-script.json
           cp -f ${svc.serviceConfig.JSON} ${runDir}/generator/service-config.json
           cp -f ${svc.nodeConfig.JSON}    ${runDir}/generator/config.json
           cp -f ${svc.startupScript}      ${runDir}/generator/start.sh

--- a/nix/workbench/profiles/adhoc.jq
+++ b/nix/workbench/profiles/adhoc.jq
@@ -1,16 +1,19 @@
 def adhoc_profiles:
 [ { name: "short"
   , generator: { tx_count: 10000, inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100 }
+  , genesis: { genesis_future_offset: "3 minutes" }
   }
 , { name: "small"
   , generator: { tx_count: 1000,  inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100
                , init_cooldown: 25 }
   , tolerances: { finish_patience: 4 }
+  , genesis: { genesis_future_offset: "3 minutes" }
   }
 , { name: "smoke"
   , generator: { tx_count: 100,   add_tx_size: 0, inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100
                , init_cooldown: 25 }
   , tolerances: { finish_patience: 4 }
+  , genesis: { genesis_future_offset: "3 minutes" }
   }
 , { name: "10"
   , composition:

--- a/nix/workbench/profiles/default.nix
+++ b/nix/workbench/profiles/default.nix
@@ -30,7 +30,7 @@ let
   value = __fromJSON (__readFile JSON);
 
   profile =
-    {
+    rec {
       name = profileName;
 
       inherit environment;
@@ -50,10 +50,15 @@ let
           value = __fromJSON (__readFile JSON);
         };
 
-     inherit (pkgs.callPackage
+      inherit (pkgs.callPackage
                ./node-services.nix
                { inherit runJq backend environment profile; })
         node-services;
+
+      inherit (pkgs.callPackage
+               ./generator-service.nix
+               { inherit runJq backend environment profile; })
+        generator-service;
     };
 
 in profile

--- a/nix/workbench/profiles/defaults.jq
+++ b/nix/workbench/profiles/defaults.jq
@@ -26,7 +26,7 @@ def era_defaults($era):
     ## UTxO & delegation
     , total_balance:                  900000000000000
     , pools_balance:                  800000000000000
-    , utxo:                           1000000
+    , utxo:                           0
     , decentralisation_param:         0
 
     ## Blockchain time & block density

--- a/nix/workbench/profiles/derived.jq
+++ b/nix/workbench/profiles/derived.jq
@@ -50,6 +50,8 @@ def add_derived_params:
 | .tolerances                                as $tolr
 | ($gsis.epoch_length * $gsis.slot_duration) as $epoch_duration
 | ($epoch_duration * $gtor.epochs)           as $duration
+| ($gtor.tx_count // ($duration * $gtor.tps))
+                                             as $tx_count
 | (if $compo.dense_pool_density > 1
    then { singular:  $compo.n_singular_hosts
         , dense:     $compo.n_dense_hosts }
@@ -94,7 +96,7 @@ def add_derived_params:
            }
          }
      , generator:
-         { tx_count:              ($duration * ([$gtor.tps, 7] | min))
+         { tx_count:              $tx_count
          }
      , node:
          {

--- a/nix/workbench/profiles/generator-service.nix
+++ b/nix/workbench/profiles/generator-service.nix
@@ -1,0 +1,153 @@
+{ pkgs
+, runJq
+
+## The backend is an attrset of AWS/supervisord-specific methods and parameters.
+, backend
+
+## Environmental settings:
+##   - either affect semantics on all backends equally,
+##   - or have no semantic effect
+, environment
+
+, profile
+}:
+
+with pkgs.lib;
+
+let
+  # We're reusing configuration from a cluster node.
+  exemplarNode = profile.node-services."node-0";
+
+  ##
+  ## generatorServiceConfig :: Map NodeId NodeSpec -> ServiceConfig
+  ##
+  generatorServiceConfig =
+    nodeSpecs:
+    let
+      generatorNodeConfigDefault =
+        (__fromJSON (__readFile ../../../bench/tx-generator-config-base.json))
+        // { inherit (exemplarNode.nodeConfig.value)
+               Protocol
+               ShelleyGenesisFile ByronGenesisFile;
+           };
+    in
+    backend.finaliseGeneratorService
+    {
+      enable = true;
+
+      era = profile.value.era;
+
+      targetNodes = __mapAttrs
+        (name: { name, port, ...}@nodeSpec:
+          { inherit port;
+            ip = let ip = backend.nodePublicIP nodeSpec; # getPublicIp resources nodes name
+                 in __trace "generator target:  ${name}/${ip}:${toString port}" ip;
+          })
+        nodeSpecs;
+
+      ## path to the socket of the locally running node.
+      localNodeSocketPath = "../node-0/node.socket";
+
+      ## nodeConfig of the locally running node.
+      localNodeConf = exemplarNode.serviceConfig.value;
+
+      ## The nodeConfig of the Tx generator itself.
+      nodeConfig =
+        backend.finaliseGeneratorConfig
+        (recursiveUpdate generatorNodeConfigDefault
+        {
+          minSeverity = "Debug";
+          TracingVerbosity = "MaximalVerbosity";
+          defaultScribes = [
+            [ "StdoutSK" "stdout" ]
+            [ "FileSK"   "logs/generator.json" ]
+          ];
+          setupScribes = [
+            { scKind = "StdoutSK"; scName = "stdout"; scFormat = "ScJson"; }
+            { scKind = "FileSK"; scName = "logs/generator.json"; scFormat = "ScJson";
+              scRotation = {
+                rpLogLimitBytes = 300000000;
+                rpMaxAgeHours   = 24;
+                rpKeepFilesNum  = 20;
+              }; }
+          ];
+        });
+
+      dsmPassthrough = {
+        # rtsOpts = ["-xc"];
+      };
+    } // profile.value.generator;
+
+  ## Given an env config, evaluate it and produce the node service.
+  ## Call the given function on this service.
+  ##
+  ## generatorServiceConfigServiced :: GeneratorServiceConfig -> GeneratorService
+  ##
+  generatorServiceConfigService =
+    serviceConfig:
+    let
+    systemdCompat.options = {
+      systemd.services = mkOption {};
+      systemd.sockets = mkOption {};
+      users = mkOption {};
+      assertions = mkOption {};
+    };
+    eval = let
+      extra = {
+        services.tx-generator = {
+          enable = true;
+        } // serviceConfig;
+      };
+    in evalModules {
+      prefix = [];
+      modules = import ../../nixos/module-list.nix ++ [ systemdCompat extra ];
+      args = { inherit pkgs; };
+    };
+    in eval.config.services.tx-generator;
+
+  ##
+  ## generator-service :: (ServiceConfig, Service, NodeConfig, Script)
+  ##
+  generator-service =
+    (nodeSpecs:
+    let
+      serviceConfig = generatorServiceConfig nodeSpecs;
+      service       = generatorServiceConfigService serviceConfig;
+    in {
+      serviceConfig = {
+        value = serviceConfig;
+        JSON  = runJq "generator-service-config.json"
+                  ''--null-input --sort-keys
+                    --argjson x '${__toJSON serviceConfig}'
+                  '' "$x";
+      };
+
+      service = {
+        value = service;
+        JSON  = runJq "generator-service.json"
+                  ''--null-input --sort-keys
+                    --argjson x '${__toJSON service}'
+                  '' "$x";
+      };
+
+      nodeConfig = {
+        value = service.nodeConfig;
+        JSON  = runJq "generator-config.json"
+                  ''--null-input --sort-keys
+                    --argjson x '${__toJSON service.nodeConfig}'
+                  '' "$x";
+      };
+
+      startupScript =
+        pkgs.writeScript "startup-generator.sh"
+          ''
+          #!${pkgs.stdenv.shell}
+
+          ${service.script}
+          '';
+    })
+    profile.node-specs.value;
+in
+{
+  inherit generator-service;
+}

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -207,6 +207,9 @@ case "$op" in
            jq '.["'"$node"'"]' "$dir"/node-specs.json > "$node_dir"/node-spec.json
         done
 
+        gen_dir="$dir"/generator
+        mkdir -p "$gen_dir"
+
         run     describe "$tag"
         profile describe "$dir"/profile.json
 

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -220,7 +220,9 @@ case "$op" in
         local tag=${1:?$usage}
         local dir=$global_rundir/$tag
 
-        jq '.hostname | keys | .[]' -r "$dir"/meta.json;;
+        if test -f "$dir"/node-specs.json
+        then jq             'keys | .[]' -r "$dir"/node-specs.json
+        else jq '.hostname | keys | .[]' -r "$dir"/meta.json; fi;;
 
     describe )
         local usage="USAGE: wb run $op TAG"

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -147,6 +147,8 @@ EOF
            sleep 5
         done
 
+        supervisorctl start generator
+
         $0 save-pids "$dir";;
 
     lostream-fixup-jqargs )

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ in
 , pkgs ? import ./nix {
     inherit config sourcesOverride customConfig;
   }
+, origPkgs ? import (builtins.getFlake (toString ./.)).inputs.nixpkgs {}
 }:
 with pkgs;
 let
@@ -62,7 +63,7 @@ let
       };
 
   rstudio = pkgs.rstudioWrapper.override {
-    packages = with pkgs.rPackages; [ car dplyr ggplot2 reshape2 ];
+    packages = with origPkgs.rPackages; [ car dplyr ggplot2 reshape2 ];
   };
 
   shell =

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ in
 , clusterProfile ? defaultCustomConfig.localCluster.profileName
 , autoStartCluster ? defaultCustomConfig.localCluster.autoStartCluster
 , workbenchDevMode ? defaultCustomConfig.localCluster.workbenchDevMode
+, withR ? false
 , customConfig ? {
     inherit withHoogle;
     localCluster =  {
@@ -60,6 +61,10 @@ let
         workbench = pkgs.callPackage ./nix/workbench { inherit useCabalRun; };
       };
 
+  rstudio = pkgs.rstudioWrapper.override {
+    packages = with pkgs.rPackages; [ car dplyr ggplot2 reshape2 ];
+  };
+
   shell =
     let cluster = mkCluster { useCabalRun = true; };
     in cardanoNodeProject.shellFor {
@@ -99,6 +104,10 @@ let
     ++ lib.optionals (!workbenchDevMode)
     [
       cluster.workbench.workbench
+    ]
+    ++ lib.optionals withR
+    [
+      rstudio
     ]
     ## Local cluster not available on Darwin,
     ## because psmisc fails to build on Big Sur.


### PR DESCRIPTION
This implements the initial transaction generation integration into the workbench.

The transaction generator is started once the local cluster comes online (there is no sophisticated run sense/control as in `cardano-ops` yet).

In addition, this also optionally provides the R Studio inside `nix-shell` (only when `withR` is `true`).