### PR TITLE
CAD-3098: shell fix and ci

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,11 +22,20 @@ let
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages cardanoNodeHaskellPackages);
 
+
+  shell = import ./shell.nix {
+    inherit pkgs;
+    withHoogle = true;
+  };
+
   packages = {
-    inherit haskellPackages
+    inherit haskellPackages shell
       cardano-node cardano-node-profiled cardano-node-eventlogged
       cardano-cli db-converter cardano-ping tx-generator
       scripts environments dockerImage submitApiDockerImage bech32;
+
+    devopsShell = shell.devops;
+
     nixosTests = recRecurseIntoAttrs nixosTests;
 
     # so that eval time gc roots are cached (nix-tools stuff)
@@ -50,9 +59,5 @@ let
       };
     };
 
-    shell = import ./shell.nix {
-      inherit pkgs;
-      withHoogle = true;
-    };
 };
 in packages

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -26,7 +26,6 @@ let
     let cmd = map normaliseCmdArg
                   ([config.executable] ++ configExeArgsFn config);
         normaliseCmdArg = x:
-          __trace "normaliseCmdArg on ${__typeOf x}"
             (({ float  = toString;
                 int    = toString;
                 path   = toString;
@@ -129,8 +128,10 @@ let
           };
           executable = mkOption {
             type = types.str;
-            default = "${svcConfig.package.components.exes.${exeName}}/bin/${exeName}" or
-              (throw "the package for ${svcName} not have the components.exes.${exeName} attribute -- please adjust service configuration.");
+            default ="${if __hasAttr "components" svcConfig.package
+                        then svcConfig.package.components.exes.${exeName} or
+                          (throw "the package for ${svcName} not have the 'components.exes.${exeName}' attribute -- please set service 'executable'.")
+                        else svcConfig.package}/bin/${exeName}";
             description = ''The executable for ${svcName} that should be used.'';
           };
           script = mkOption { type = types.str;  default =

--- a/nix/workbench/analyse.sh
+++ b/nix/workbench/analyse.sh
@@ -176,7 +176,7 @@ case "$op" in
 }
 
 num_jobs="\j"
-num_threads=$(grep processor /proc/cpuinfo | wc -l)
+num_threads=$(grep processor /proc/cpuinfo 2>/dev/null || echo -e '\n\n\n' | wc -l)
 
 throttle_shell_job_spawns() {
     sleep 0.5s

--- a/release.nix
+++ b/release.nix
@@ -130,7 +130,7 @@ let
   ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [
-    ["shell"] ["cardano-ping"] ["roots"]
+    ["shell"] ["devopsShell"] ["cardano-ping"] ["roots"]
     [ "haskellPackages" "cardano-testnet" ]
     [ "checks" "tests" "cardano-testnet" ]
     [ "tests" "cardano-testnet" ]

--- a/release.nix
+++ b/release.nix
@@ -195,6 +195,8 @@ let
       (collectJobs jobs.linux.native.nixosTests)
       (collectJobs jobs.linux.native.benchmarks)
       (collectJobs jobs.linux.native.exes)
+      (collectJobs jobs.linux.native.shell)
+      (collectJobs jobs.linux.native.devopsShell)
       [ jobs.cardano-node-linux ]
     ]))
     # macOS builds:

--- a/shell.nix
+++ b/shell.nix
@@ -151,8 +151,11 @@ let
 
   devops =
     let cluster = mkCluster { useCabalRun = false; };
-    in stdenv.mkDerivation {
+    in cardanoNodeProject.shellFor {
     name = "devops-shell";
+
+    packages = lib.attrVals cardanoNodeProject.projectPackages;
+
     nativeBuildInputs = [
       nixWrapped
       cardano-cli
@@ -165,6 +168,11 @@ let
       cardanolib-py
       cluster.workbench.workbench
     ];
+
+    # Prevents cabal from choosing alternate plans, so that
+    # *all* dependencies are provided by Nix.
+    exactDeps = true;
+
     shellHook = ''
       echo "DevOps Tools" \
       | ${figlet}/bin/figlet -f banner -c \


### PR DESCRIPTION
1. fixes the non-dev shells (both the regular and `devops` ones)
2. add both shells to CI