### PR TITLE
Add 'unsafeMakeShelleyTransactionBody'

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -94,7 +94,7 @@ metadataSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMeta
 metadataSize p m = dummyTxSize p m - dummyTxSize p Nothing
 
 dummyTxSizeInEra :: forall era . IsShelleyBasedEra era => TxMetadataInEra era -> Int
-dummyTxSizeInEra metadata = case makeTransactionBody dummyTx of
+dummyTxSizeInEra metadata = case validateTransactionBody dummyTx of
   Right b -> BS.length $ serialiseToCBOR b
   Left err -> error $ "metaDataSize " ++ show err
  where

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -61,7 +61,7 @@ mkGenesisTransaction :: forall era .
   -> [TxOut era]
   -> Tx era
 mkGenesisTransaction key _payloadSize ttl fee txins txouts
-  = case makeTransactionBody txBodyContent of
+  = case validateTransactionBody txBodyContent of
     Right b -> signShelleyTransaction b [WitnessGenesisUTxOKey key]
     Left err -> error $ show err
  where
@@ -102,7 +102,7 @@ mkTransaction :: forall era .
   -> [TxOut era]
   -> Tx era
 mkTransaction key metadata ttl fee txins txouts
-  = case makeTransactionBody txBodyContent of
+  = case validateTransactionBody txBodyContent of
     Right b -> signShelleyTransaction b [WitnessPaymentKey key]
     Left err -> error $ show err
  where

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -98,7 +98,7 @@ genTx :: forall era. IsShelleyBasedEra era
   -> [Lovelace]
   -> Either String (Tx era, TxId)
 genTx key networkId inFunds outValues
-  = case makeTransactionBody txBodyContent of
+  = case validateTransactionBody txBodyContent of
       Left err -> error $ show err
       Right b -> Right ( signShelleyTransaction b (map (WitnessPaymentKey . getFundKey) inFunds)
                        , getTxId b

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -530,7 +530,7 @@ genTxFee era =
 
 genTxBody :: IsCardanoEra era => CardanoEra era -> Gen (TxBody era)
 genTxBody era = do
-  res <- makeTransactionBody <$> genTxBodyContent era
+  res <- validateTransactionBody <$> genTxBodyContent era
   case res of
     Left err -> fail (displayError err)
     Right txBody -> pure txBody

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -150,7 +150,8 @@ module Cardano.Api (
 
     -- ** Transaction bodies
     TxBody(TxBody),
-    makeTransactionBody,
+    validateTransactionBody,
+    makeShelleyTransactionBody,
     TxBodyContent(..),
     TxBodyError(..),
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -624,7 +624,7 @@ type LedgerTxBodyConstraints ledgerera =
 --
 data TxBodyErrorAutoBalance era =
 
-       -- | The same errors that can arise from 'makeTransactionBody'.
+       -- | The same errors that can arise from 'validateTransactionBody'.
        TxBodyError (TxBodyError era)
 
        -- | One or more of the scripts fails to execute correctly.
@@ -705,7 +705,7 @@ instance Error (TxBodyErrorAutoBalance era) where
       displayError err
 
 
--- | This is much like 'makeTransactionBody' but with greater automation to
+-- | This is much like 'validateTransactionBody' but with greater automation to
 -- calculate suitable values for several things.
 --
 -- In particular:
@@ -724,7 +724,7 @@ instance Error (TxBodyErrorAutoBalance era) where
 -- * It also checks that the balance is positive and the change is above the
 --   minimum threshold.
 --
--- To do this it needs more information than 'makeTransactionBody', all of
+-- To do this it needs more information than 'validateTransactionBody', all of
 -- which can be queried from a local node.
 --
 makeTransactionBodyAutoBalance
@@ -751,7 +751,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- 4. balance the transaction and update tx change output
 
     txbody0 <- first TxBodyError $
-                 makeTransactionBody txbodycontent
+                 validateTransactionBody txbodycontent
 
     exUnitsMap <- first TxBodyErrorValidityInterval $
                     evaluateTransactionExecutionUnits
@@ -773,7 +773,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
 
     -- Insert change address and set tx fee to 0
     txbody1 <- first TxBodyError $ -- TODO: impossible to fail now
-               makeTransactionBody txbodycontent1 {
+               validateTransactionBody txbodycontent1 {
                  txFee  = TxFeeExplicit explicitTxFees 0,
                  txOuts = TxOut changeaddr
                                 (lovelaceToTxOutValue 0)
@@ -788,7 +788,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
         fee   = evaluateTransactionFee pparams txbody1 nkeys 0 --TODO: byron keys
 
     txbody2 <- first TxBodyError $ -- TODO: impossible to fail now
-               makeTransactionBody txbodycontent1 {
+               validateTransactionBody txbodycontent1 {
                  txFee = TxFeeExplicit explicitTxFees fee
                }
 
@@ -807,7 +807,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- now that we know the magnitude of the change: i.e. 1-8 bytes extra.
 
     txbody3 <- first TxBodyError $ -- TODO: impossible to fail now
-               makeTransactionBody txbodycontent {
+               validateTransactionBody txbodycontent {
                  txFee  = TxFeeExplicit explicitTxFees fee,
                  txOuts = TxOut changeaddr balance TxOutDatumHashNone
                         : txOuts txbodycontent

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -167,7 +167,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             TxCertificatesNone
             TxUpdateProposalNone
             TxMintNone
-    case makeTransactionBody txBodyCont of
+    case validateTransactionBody txBodyCont of
       Left err -> error $ "Error occured while creating a Byron genesis based UTxO transaction: " <> show err
       Right txBody -> let bWit = fromByronWitness sk nId txBody
                       in makeSignedTransaction [bWit] txBody
@@ -206,7 +206,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                      TxCertificatesNone
                      TxUpdateProposalNone
                      TxMintNone
-  case makeTransactionBody txBodyCont of
+  case validateTransactionBody txBodyCont of
     Left err -> error $ "Error occured while creating a Byron genesis based UTxO transaction: " <> show err
     Right txBody -> let bWit = fromByronWitness sk nId txBody
                     in makeSignedTransaction [bWit] txBody

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -316,7 +316,7 @@ runTxBuildRaw (AnyCardanoEra era)
 
     txBody <-
       firstExceptT (ShelleyTxCmdTxBodyError . SomeTxBodyError) . hoistEither $
-        makeTransactionBody txBodyContent
+        validateTransactionBody txBodyContent
 
     firstExceptT ShelleyTxCmdWriteFileError . newExceptT $
       writeFileTextEnvelope fpath Nothing txBody


### PR DESCRIPTION
* Separate the validity checks in `makeShelleyTransactionBody` from the actual construction of the tx body
* The wallet backend is adding an endpoint for balancing partial transactions. When a partial transaction is sent to the endpoint, the wallet backend adds inputs, outputs and signatures as required to make the transaction valid. So we intentionally want to construct transactions with, for example, zero inputs, or missing protocol parameters.