### PR TITLE
Workbench: optional generator startup

### DIFF
--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -137,16 +137,19 @@ let
   start = pkgs.writeScriptBin "start-cluster" ''
     set -euo pipefail
 
-    workbench-prebuild-executables
-
     batch_name=${batchName}
+    run_start_flags=()
 
     while test $# -gt 0
     do case "$1" in
-        --batch-name ) batch_name=$2; shift;;
-        --trace | --debug ) set -x;;
+        --batch-name )                   batch_name=$2; shift;;
+        --no-generator | --no-gen )      run_start_flags+=($1);;
+
+        --trace | --debug )              set -x;;
         --trace-wb | --trace-workbench ) export WORKBENCH_EXTRA_FLAGS=--trace;;
         * ) break;; esac; shift; done
+
+    workbench-prebuild-executables
 
     export PATH=$PATH:${path}
 
@@ -170,7 +173,7 @@ let
     wb_run_start_args=(
         --supervisor-conf      "${backend.supervisord.mkSupervisorConf profile}"
       )
-    wb run start $(wb run current-tag) "''${wb_run_start_args[@]}"
+    wb run start "''${run_start_flags[@]}" $(wb run current-tag) "''${wb_run_start_args[@]}"
 
     echo 'workbench:  cluster started. Run `stop-cluster` to stop'
   '';

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -134,6 +134,20 @@ let
     ++ optionals (!workbenchDevMode)
     [ workbench.workbench ];
 
+  startClusterUsage = ''
+Usage:
+   start-cluster [FLAGS..]
+
+   Flags:
+
+      --batch-name NAME               Override the batch name (default: ${batchName})
+      --no-generator | --no-gen       Don't auto-start the tx-generator
+
+      --trace | --debug               Trace the start-cluster script
+      --trace-wb | --trace-workbench  Trace the workbench script
+      --help                          This help message
+'';
+
   start = pkgs.writeScriptBin "start-cluster" ''
     set -euo pipefail
 
@@ -147,6 +161,10 @@ let
 
         --trace | --debug )              set -x;;
         --trace-wb | --trace-workbench ) export WORKBENCH_EXTRA_FLAGS=--trace;;
+        --help )                         cat <<EOF
+${startClusterUsage}
+EOF
+                                         exit 1;;
         * ) break;; esac; shift; done
 
     workbench-prebuild-executables

--- a/nix/workbench/backend.sh
+++ b/nix/workbench/backend.sh
@@ -15,7 +15,10 @@ usage_backend() {
     lostream-fixup-jqargs RUNDIR
     lostream-fixup-jqexpr
 
-    start-run RUNDIR Start an allocated run
+    start-cluster RUNDIR
+                     Start the cluster nodes
+    start-generator RUNDIR
+                     Start generator
 
     assert-is BACKEND-NAME
                      Check that the current backend is as expected
@@ -33,8 +36,8 @@ case "${op}" in
     record-extended-env-config ) $WORKBENCH_BACKEND "$@";;
     describe-run )               $WORKBENCH_BACKEND "$@";;
     pre-run-hook )               $WORKBENCH_BACKEND "$@";;
-    start-run )                  cp "$2"/genesis/genesis.json "$2"/genesis.json
-                                 $WORKBENCH_BACKEND "$@";;
+    start-cluster )              $WORKBENCH_BACKEND "$@";;
+    start-generator )            $WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqargs )      $WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqexpr )      $WORKBENCH_BACKEND "$@";;
 

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -139,10 +139,10 @@ let
         ''
       git log -n1 --alternate-refs --pretty=format:"%Cred%cr %Cblue%h %Cgreen%D %Cblue%s%Creset" --color | sed "s/^/$(git diff --exit-code --quiet && echo ' ' || echo '[31mlocal changes + ')/"
       echo
-      echo -n "workbench:  prebuilding executables (because of useCabalRun):"
-      for exe in cardano-cli cardano-node cardano-topology locli
-      do echo -n " $exe"
-         ${exeCabalOp "run" "$exe"} --help >/dev/null || return 1
+      echo -n "workbench:  prebuilding executables (because of useCabalRun): "
+      for exe in tx-generator cardano-cli cardano-node cardano-topology locli
+      do echo -n "$exe "
+         ${exeCabalOp "build" "$exe"} 2>&1 >/dev/null | { grep -v 'Temporary modify'; true; } || return 1
       done
       echo
         ''}

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -16,7 +16,8 @@ usage_supervisor() {
 
     describe-run RUN-DIR
     pre-run-hook RUN-DIR
-    start-run RUN-DIR
+    start-cluster RUN-DIR
+    start-generator RUN-DIR
 
     Supervisor-specific:
 
@@ -121,7 +122,7 @@ EOF
         msg "supervisor:  node pid maps: $mapn2p $mapp2n"
         ;;
 
-    start-run )
+    start-cluster )
         usage="USAGE: wb supervisor $op RUN-DIR"
         dir=${1:?$usage}; shift
 
@@ -147,9 +148,18 @@ EOF
            sleep 5
         done
 
-        supervisorctl start generator
-
         $0 save-pids "$dir";;
+
+    start-generator )
+        usage="USAGE: wb supervisor $op RUN-DIR"
+        dir=${1:?$usage}; shift
+
+        while test $# -gt 0
+        do case "$1" in
+               --* ) msg "FATAL:  unknown flag '$1'"; usage_supervisor;;
+               * ) break;; esac; shift; done
+
+        supervisorctl start generator;;
 
     lostream-fixup-jqargs )
         usage="USAGE: wb supervisor $op RUN-DIR"

--- a/shell.nix
+++ b/shell.nix
@@ -123,6 +123,8 @@ let
     exactDeps = true;
 
     shellHook = ''
+      echo 'nix-shell options & flags:  withHoogle=${toString withHoogle} clusterProfile=${clusterProfile} autoStartCluster=${toString autoStartCluster} workbenchDevMode=${toString workbenchDevMode}'
+
       ${cluster.workbench.shellHook}
 
       ${lib.optionalString autoStartCluster ''


### PR DESCRIPTION
Workbench changes:

1. add `--no-generator` to `start-cluster`, to skip the automatic `tx-generator` startup
2. add `--help` to `start-cluster`