### PR TITLE
Deploy Haddock for merge to master only

### DIFF
--- a/plutus-example/plutus-example/plutus-example.cabal
+++ b/plutus-example/plutus-example/plutus-example.cabal
@@ -58,6 +58,8 @@ library
                       , plutus-tx-plugin
                       , serialise
 
+  ghc-options: -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+
 executable plutus-example
   import:               base, project-config
   hs-source-dirs:       app


### PR DESCRIPTION
The readme says "The documentation is built with each push, but is only published from master branch" yet it is configured to publish on every push. This changes it to publish on every push to master.