### PR TITLE
Proper TxOut datum support

### DIFF
--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -380,7 +380,7 @@ genTxOutValue era =
     Left adaOnlyInEra     -> TxOutAdaOnly adaOnlyInEra <$> genLovelace
     Right multiAssetInEra -> TxOutValue multiAssetInEra <$> genValueForTxOut
 
-genTxOut :: CardanoEra era -> Gen (TxOut era)
+genTxOut :: CardanoEra era -> Gen (TxOut CtxTx era)
 genTxOut era =
   TxOut <$> genAddressInEra era
         <*> genTxOutValue era
@@ -488,7 +488,6 @@ genTxBodyContent era = do
   txValidityRange <- genTxValidityRange era
   txMetadata <- genTxMetadataInEra era
   txAuxScripts <- genTxAuxScripts era
-  let txExtraScriptData = BuildTxWith TxExtraScriptDataNone --TODO: Alonzo era: Generate extra script data
   let txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
   txProtocolParams <- BuildTxWith <$> Gen.maybe genProtocolParameters
   txWithdrawals <- genTxWithdrawals era
@@ -504,7 +503,6 @@ genTxBodyContent era = do
     , Api.txValidityRange
     , Api.txMetadata
     , Api.txAuxScripts
-    , Api.txExtraScriptData
     , Api.txExtraKeyWits
     , Api.txProtocolParams
     , Api.txWithdrawals
@@ -738,16 +736,17 @@ genExecutionUnits = ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
 genExecutionUnitPrices :: Gen ExecutionUnitPrices
 genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
 
-genTxOutDatumHash :: CardanoEra era -> Gen (TxOutDatumHash era)
+genTxOutDatumHash :: CardanoEra era -> Gen (TxOutDatum CtxTx era)
 genTxOutDatumHash era = case era of
-    ByronEra -> pure TxOutDatumHashNone
-    ShelleyEra -> pure TxOutDatumHashNone
-    AllegraEra -> pure TxOutDatumHashNone
-    MaryEra -> pure TxOutDatumHashNone
-    AlonzoEra -> Gen.choice
-      [ pure TxOutDatumHashNone
-      , TxOutDatumHash ScriptDataInAlonzoEra <$> genHashScriptData
-      ]
+    ByronEra   -> pure TxOutDatumNone
+    ShelleyEra -> pure TxOutDatumNone
+    AllegraEra -> pure TxOutDatumNone
+    MaryEra    -> pure TxOutDatumNone
+    AlonzoEra  -> Gen.choice
+                    [ pure TxOutDatumNone
+                    , TxOutDatumHash ScriptDataInAlonzoEra <$> genHashScriptData
+                    , TxOutDatum     ScriptDataInAlonzoEra <$> genScriptData
+                    ]
 
 mkDummyHash :: forall h a. CRYPTO.HashAlgorithm h => Int -> CRYPTO.Hash h a
 mkDummyHash = coerce . CRYPTO.hashWithSerialiser @h CBOR.toCBOR

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -165,10 +165,10 @@ module Cardano.Api (
     TxIx(TxIx),
 
     -- ** Transaction outputs
+    CtxTx, CtxUTxO,
     TxOut(TxOut),
     TxOutValue(..),
-    serialiseAddressForTxOut,
-    TxOutDatumHash(..),
+    TxOutDatum(..),
 
     -- ** Other transaction body types
     TxInsCollateral(..),
@@ -179,7 +179,6 @@ module Cardano.Api (
     EpochSlots(..),
     TxMetadataInEra(..),
     TxAuxScripts(..),
-    TxExtraScriptData(..),
     TxExtraKeyWitnesses(..),
     TxWithdrawals(..),
     TxCertificates(..),

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -769,7 +769,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
                makeTransactionBody txbodycontent {
                  txOuts = TxOut changeaddr
                                 (lovelaceToTxOutValue 0)
-                                TxOutDatumHashNone
+                                TxOutDatumNone
                         : txOuts txbodycontent
                                 --TODO: think about the size of the change output
                                 -- 1,2,4 or 8 bytes?
@@ -825,7 +825,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     txbody3 <- first TxBodyError $ -- TODO: impossible to fail now
                makeTransactionBody txbodycontent1 {
                  txFee  = TxFeeExplicit explicitTxFees fee,
-                 txOuts = TxOut changeaddr balance TxOutDatumHashNone
+                 txOuts = TxOut changeaddr balance TxOutDatumNone
                         : txOuts txbodycontent
                }
 

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -240,7 +240,7 @@ data QueryUTxOFilter =
 newtype ByronUpdateState = ByronUpdateState Byron.Update.State
   deriving Show
 
-newtype UTxO era = UTxO (Map TxIn (TxOut era))
+newtype UTxO era = UTxO (Map TxIn (TxOut CtxUTxO era))
   deriving (Eq, Show)
 
 data UTxOInAnyEra where

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -873,17 +873,38 @@ lovelaceToTxOutValue l =
 -- Transaction output datum (era-dependent)
 --
 
-data TxOutDatumHash era where
+data TxOutDatum ctx era where
 
-     TxOutDatumHashNone :: TxOutDatumHash era
+     TxOutDatumNone :: TxOutDatum ctx era
 
-     TxOutDatumHash     :: ScriptDataSupportedInEra era
-                        -> Hash ScriptData
-                        -> TxOutDatumHash era
+     -- | A transaction output that only specifies the hash of the datum, but
+     -- not the full datum value.
+     --
+     TxOutDatumHash :: ScriptDataSupportedInEra era
+                    -> Hash ScriptData
+                    -> TxOutDatum ctx era
 
-deriving instance Eq   (TxOutDatumHash era)
-deriving instance Show (TxOutDatumHash era)
-deriving instance Generic (TxOutDatumHash era)
+     -- | A transaction output that specifies the whole datum value. This can
+     -- only be used in the context of the transaction body, and does not occur
+     -- in the UTxO. The UTxO only contains the datum hash.
+     --
+     TxOutDatum'    :: ScriptDataSupportedInEra era
+                    -> Hash ScriptData
+                    -> ScriptData
+                    -> TxOutDatum CtxTx era
+
+deriving instance Eq   (TxOutDatum ctx era)
+deriving instance Show (TxOutDatum ctx era)
+
+pattern TxOutDatum :: ScriptDataSupportedInEra era
+                   -> ScriptData
+                   -> TxOutDatum CtxTx era
+pattern TxOutDatum s d  <- TxOutDatum' s _ d
+  where
+    TxOutDatum s d = TxOutDatum' s (hashScriptData d) d
+
+{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatum' #-}
+{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatum  #-}
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -37,11 +37,11 @@ module Cardano.Api.TxBody (
     genesisUTxOPseudoTxIn,
 
     -- * Transaction outputs
+    CtxTx, CtxUTxO,
     TxOut(..),
     TxOutValue(..),
+    TxOutDatum(TxOutDatumNone, TxOutDatumHash, TxOutDatum),
     lovelaceToTxOutValue,
-    serialiseAddressForTxOut,
-    TxOutDatumHash(..),
     TxOutInAnyEra(..),
     txOutInAnyEra,
 
@@ -52,7 +52,6 @@ module Cardano.Api.TxBody (
     TxValidityUpperBound(..),
     TxMetadataInEra(..),
     TxAuxScripts(..),
-    TxExtraScriptData(..),
     TxExtraKeyWitnesses(..),
     TxWithdrawals(..),
     TxCertificates(..),
@@ -175,6 +174,7 @@ import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
+import qualified Cardano.Ledger.Mary.Value       as Mary
 import           Cardano.Ledger.Val (isZero)
 
 import qualified Cardano.Ledger.Alonzo as Alonzo
@@ -199,7 +199,7 @@ import           Cardano.Api.KeysShelley
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Script
-import           Cardano.Api.SerialiseBech32
+import           Cardano.Api.ScriptData
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
@@ -324,52 +324,54 @@ fromShelleyTxIn (Shelley.TxIn txid txix) =
 -- Transaction outputs
 --
 
-data TxOut era = TxOut (AddressInEra era)
-                       (TxOutValue era)
-                       (TxOutDatumHash era)
-  deriving Generic
+data CtxTx   -- ^ The context is a transaction body
+data CtxUTxO -- ^ The context is the UTxO
 
-deriving instance Eq   (TxOut era)
-deriving instance Show (TxOut era)
+data TxOut ctx era = TxOut (AddressInEra   era)
+                           (TxOutValue     era)
+                           (TxOutDatum ctx era)
+
+deriving instance Eq   (TxOut ctx era)
+deriving instance Show (TxOut ctx era)
 
 data TxOutInAnyEra where
      TxOutInAnyEra :: CardanoEra era
-                   -> TxOut era
+                   -> TxOut CtxTx era
                    -> TxOutInAnyEra
 
 deriving instance Show TxOutInAnyEra
 
 -- | Convenience constructor for 'TxOutInAnyEra'
-txOutInAnyEra :: IsCardanoEra era => TxOut era -> TxOutInAnyEra
+txOutInAnyEra :: IsCardanoEra era => TxOut CtxTx era -> TxOutInAnyEra
 txOutInAnyEra = TxOutInAnyEra cardanoEra
 
-instance IsCardanoEra era => ToJSON (TxOut era) where
-  toJSON (TxOut addr val TxOutDatumHashNone) =
-    object [ "address" .= serialiseAddressForTxOut addr
-           , "value"   .= toJSON val
+instance IsCardanoEra era => ToJSON (TxOut ctx era) where
+  toJSON (TxOut addr val TxOutDatumNone) =
+    object [ "address" .= addr
+           , "value"   .= val
            ]
-  toJSON (TxOut addr val (TxOutDatumHash _ d)) =
-    object [ "address" .= serialiseAddressForTxOut addr
-           , "value"   .= toJSON val
-           , "data"    .= toJSON d
+  toJSON (TxOut addr val (TxOutDatumHash _ h)) =
+    object [ "address"   .= addr
+           , "value"     .= val
+           , "datumhash" .= h
+           ]
+  toJSON (TxOut addr val (TxOutDatum' _ h d)) =
+    object [ "address"   .= addr
+           , "value"     .= val
+           , "datumhash" .= h
+           , "datum"     .= scriptDataToJson ScriptDataJsonDetailedSchema d
            ]
 
-serialiseAddressForTxOut :: AddressInEra era -> Text
-serialiseAddressForTxOut (AddressInEra addrType addr) =
-  case addrType of
-    ByronAddressInAnyEra  -> serialiseToRawBytesHexText addr
-    ShelleyAddressInEra _ -> serialiseToBech32 addr
 
-
-fromByronTxOut :: Byron.TxOut -> TxOut ByronEra
+fromByronTxOut :: Byron.TxOut -> TxOut ctx ByronEra
 fromByronTxOut (Byron.TxOut addr value) =
   TxOut
     (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
     (TxOutAdaOnly AdaOnlyInByronEra (fromByronLovelace value))
-     TxOutDatumHashNone
+     TxOutDatumNone
 
 
-toByronTxOut :: TxOut ByronEra -> Maybe Byron.TxOut
+toByronTxOut :: TxOut ctx ByronEra -> Maybe Byron.TxOut
 toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
                     (TxOutAdaOnly AdaOnlyInByronEra value) _) =
     Byron.TxOut addr <$> toByronLovelace value
@@ -384,7 +386,7 @@ toByronTxOut (TxOut (AddressInEra (ShelleyAddressInEra era) ShelleyAddress{})
 toShelleyTxOut :: forall era ledgerera.
                   ShelleyLedgerEra era ~ ledgerera
                => ShelleyBasedEra era
-               -> TxOut era
+               -> TxOut CtxUTxO era
                -> Ledger.TxOut ledgerera
 toShelleyTxOut era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _) =
     case era of {}
@@ -405,14 +407,14 @@ toShelleyTxOut _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata)
 fromShelleyTxOut :: ShelleyLedgerEra era ~ ledgerera
                  => ShelleyBasedEra era
                  -> Core.TxOut ledgerera
-                 -> TxOut era
+                 -> TxOut ctx era
 fromShelleyTxOut era ledgerTxOut =
   case era of
     ShelleyBasedEraShelley ->
         TxOut (fromShelleyAddr addr)
               (TxOutAdaOnly AdaOnlyInShelleyEra
                             (fromShelleyLovelace value))
-               TxOutDatumHashNone
+               TxOutDatumNone
       where
         Shelley.TxOut addr value = ledgerTxOut
 
@@ -420,7 +422,7 @@ fromShelleyTxOut era ledgerTxOut =
         TxOut (fromShelleyAddr addr)
               (TxOutAdaOnly AdaOnlyInAllegraEra
                             (fromShelleyLovelace value))
-               TxOutDatumHashNone
+               TxOutDatumNone
       where
         Shelley.TxOut addr value = ledgerTxOut
 
@@ -428,7 +430,7 @@ fromShelleyTxOut era ledgerTxOut =
         TxOut (fromShelleyAddr addr)
               (TxOutValue MultiAssetInMaryEra
                           (fromMaryValue value))
-               TxOutDatumHashNone
+               TxOutDatumNone
       where
         Shelley.TxOut addr value = ledgerTxOut
 
@@ -440,15 +442,15 @@ fromShelleyTxOut era ledgerTxOut =
       where
         Alonzo.TxOut addr value datahash = ledgerTxOut
 
-toAlonzoTxOutDataHash :: TxOutDatumHash era
+toAlonzoTxOutDataHash :: TxOutDatum CtxUTxO era
                       -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-toAlonzoTxOutDataHash TxOutDatumHashNone    = SNothing
+toAlonzoTxOutDataHash  TxOutDatumNone                        = SNothing
 toAlonzoTxOutDataHash (TxOutDatumHash _ (ScriptDataHash dh)) = SJust dh
 
 fromAlonzoTxOutDataHash :: ScriptDataSupportedInEra era
                         -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-                        -> TxOutDatumHash era
-fromAlonzoTxOutDataHash _    SNothing  = TxOutDatumHashNone
+                        -> TxOutDatum ctx era
+fromAlonzoTxOutDataHash _    SNothing  = TxOutDatumNone
 fromAlonzoTxOutDataHash era (SJust dh) = TxOutDatumHash era (ScriptDataHash dh)
 
 
@@ -999,22 +1001,6 @@ deriving instance Eq   (TxExtraKeyWitnesses era)
 deriving instance Show (TxExtraKeyWitnesses era)
 
 -- ----------------------------------------------------------------------------
--- Auxiliary script data (era-dependent)
---
-
-data TxExtraScriptData era where
-
-     TxExtraScriptDataNone :: TxExtraScriptData era
-
-     TxExtraScriptData     :: ScriptDataSupportedInEra era
-                           -> [ScriptData]
-                           -> TxExtraScriptData era
-
-deriving instance Eq   (TxExtraScriptData era)
-deriving instance Show (TxExtraScriptData era)
-
-
--- ----------------------------------------------------------------------------
 -- Withdrawals within transactions (era-dependent)
 --
 
@@ -1091,13 +1077,12 @@ data TxBodyContent build era =
      TxBodyContent {
        txIns            :: TxIns build era,
        txInsCollateral  :: TxInsCollateral era,
-       txOuts           :: [TxOut era],
+       txOuts           :: [TxOut CtxTx era],
        txFee            :: TxFee era,
        txValidityRange  :: (TxValidityLowerBound era,
                             TxValidityUpperBound era),
        txMetadata       :: TxMetadataInEra era,
        txAuxScripts     :: TxAuxScripts era,
-       txExtraScriptData:: BuildTxWith build (TxExtraScriptData era),
        txExtraKeyWits   :: TxExtraKeyWitnesses era,
        txProtocolParams :: BuildTxWith build (Maybe ProtocolParameters),
        txWithdrawals    :: TxWithdrawals  build era,
@@ -1450,20 +1435,21 @@ pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)
 
 getTxBodyContent :: TxBody era -> TxBodyContent ViewTx era
 getTxBodyContent (ByronTxBody body) = getByronTxBodyContent body
-getTxBodyContent (ShelleyTxBody era body _scripts _redeemers mAux) =
-    fromLedgerTxBody era body mAux
+getTxBodyContent (ShelleyTxBody era body _scripts scriptdata mAux) =
+    fromLedgerTxBody era body scriptdata mAux
 
 
 fromLedgerTxBody
   :: ShelleyBasedEra era
   -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> TxBodyScriptData era
   -> Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era))
   -> TxBodyContent ViewTx era
-fromLedgerTxBody era body mAux =
+fromLedgerTxBody era body scriptdata mAux =
     TxBodyContent
       { txIns            = fromLedgerTxIns            era body
       , txInsCollateral  = fromLedgerTxInsCollateral  era body
-      , txOuts           = fromLedgerTxOuts           era body
+      , txOuts           = fromLedgerTxOuts           era body scriptdata
       , txFee            = fromLedgerTxFee            era body
       , txValidityRange  = fromLedgerTxValidityRange  era body
       , txWithdrawals    = fromLedgerTxWithdrawals    era body
@@ -1474,7 +1460,6 @@ fromLedgerTxBody era body mAux =
       , txProtocolParams = ViewTx
       , txMetadata
       , txAuxScripts
-      , txExtraScriptData = ViewTx
       }
   where
     (txMetadata, txAuxScripts) = fromLedgerTxAuxiliaryData era mAux
@@ -1520,14 +1505,60 @@ fromLedgerTxInsCollateral era body =
 
 
 fromLedgerTxOuts
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> [TxOut era]
-fromLedgerTxOuts era body =
-  fromShelleyTxOut era <$>
+  :: forall era.
+     ShelleyBasedEra era
+  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> TxBodyScriptData era
+  -> [TxOut CtxTx era]
+fromLedgerTxOuts era body scriptdata =
   case era of
-    ShelleyBasedEraShelley -> toList $ Shelley._outputs body
-    ShelleyBasedEraAllegra -> toList $ Allegra.outputs' body
-    ShelleyBasedEraMary    -> toList $ Mary.outputs'    body
-    ShelleyBasedEraAlonzo  -> toList $ Alonzo.outputs'  body
+    ShelleyBasedEraShelley ->
+      [ fromShelleyTxOut era txout | txout <- toList (Shelley._outputs body) ]
+
+    ShelleyBasedEraAllegra ->
+      [ fromShelleyTxOut era txout | txout <- toList (Allegra.outputs' body) ]
+
+    ShelleyBasedEraMary ->
+      [ fromShelleyTxOut era txout | txout <- toList (Mary.outputs' body) ]
+
+    ShelleyBasedEraAlonzo ->
+      [ fromAlonzoTxOut
+          MultiAssetInAlonzoEra
+          ScriptDataInAlonzoEra
+          txdatums
+          txout
+      | let txdatums = selectTxDatums scriptdata
+      , txout <- toList (Alonzo.outputs' body) ]
+  where
+    selectTxDatums  TxBodyNoScriptData                            = Map.empty
+    selectTxDatums (TxBodyScriptData _ (Alonzo.TxDats' datums) _) = datums
+
+fromAlonzoTxOut :: forall era ledgerera.
+                   IsShelleyBasedEra era
+                => Ledger.Era ledgerera
+                => Ledger.Crypto ledgerera ~ StandardCrypto
+                => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
+                => MultiAssetSupportedInEra era
+                -> ScriptDataSupportedInEra era
+                -> Map (Alonzo.DataHash StandardCrypto)
+                       (Alonzo.Data ledgerera)
+                -> Alonzo.TxOut ledgerera
+                -> TxOut CtxTx era
+fromAlonzoTxOut multiAssetInEra scriptDataInEra txdatums
+                (Alonzo.TxOut addr value datahash) =
+   TxOut (fromShelleyAddr addr)
+         (TxOutValue multiAssetInEra (fromMaryValue value))
+         (fromAlonzoTxOutDatum scriptDataInEra datahash)
+  where
+    fromAlonzoTxOutDatum :: ScriptDataSupportedInEra era
+                         -> StrictMaybe (Alonzo.DataHash StandardCrypto)
+                         -> TxOutDatum CtxTx era
+    fromAlonzoTxOutDatum _          SNothing = TxOutDatumNone
+    fromAlonzoTxOutDatum supported (SJust dh)
+      | Just d <- Map.lookup dh txdatums
+                  = TxOutDatum'    supported (ScriptDataHash dh)
+                                             (fromAlonzoData d)
+      | otherwise = TxOutDatumHash supported (ScriptDataHash dh)
 
 
 fromLedgerTxFee
@@ -1828,7 +1859,7 @@ makeByronTransactionBody TxBodyContent { txIns, txOuts } = do
             (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
             ()
   where
-    classifyRangeError :: TxOut ByronEra -> TxBodyError
+    classifyRangeError :: TxOut CtxTx ByronEra -> TxBodyError
     classifyRangeError
       txout@(TxOut (AddressInEra ByronAddressInAnyEra ByronAddress{})
                    (TxOutAdaOnly AdaOnlyInByronEra value) _)
@@ -1859,7 +1890,6 @@ getByronTxBodyContent (Annotated Byron.UnsafeTx{txInputs, txOutputs} _) =
                             ValidityNoUpperBoundInByronEra),
       txMetadata       = TxMetadataNone,
       txAuxScripts     = TxAuxScriptsNone,
-      txExtraScriptData= ViewTx,
       txExtraKeyWits   = TxExtraKeyWitnessesNone,
       txProtocolParams = ViewTx,
       txWithdrawals    = TxWithdrawalsNone,
@@ -1899,7 +1929,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraShelley
       ShelleyTxBody era
         (Shelley.TxBody
           (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOut era) txOuts))
+          (Seq.fromList (map (toShelleyTxOut' era) txOuts))
           (case txCertificates of
              TxCertificatesNone    -> Seq.empty
              TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
@@ -1967,7 +1997,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAllegra
       ShelleyTxBody era
         (Allegra.TxBody
           (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOut era) txOuts))
+          (Seq.fromList (map (toShelleyTxOut' era) txOuts))
           (case txCertificates of
              TxCertificatesNone    -> Seq.empty
              TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
@@ -2055,7 +2085,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraMary
       ShelleyTxBody era
         (Allegra.TxBody
           (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOut era) txOuts))
+          (Seq.fromList (map (toShelleyTxOut' era) txOuts))
           (case txCertificates of
              TxCertificatesNone    -> Seq.empty
              TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
@@ -2114,7 +2144,6 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
                              txValidityRange = (lowerBound, upperBound),
                              txMetadata,
                              txAuxScripts,
-                             txExtraScriptData,
                              txExtraKeyWits,
                              txProtocolParams,
                              txWithdrawals,
@@ -2161,7 +2190,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
           (case txInsCollateral of
              TxInsCollateralNone     -> Set.empty
              TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins))
-          (Seq.fromList (map (toShelleyTxOut era) txOuts))
+          (Seq.fromList (map (toShelleyTxOut' era) txOuts))
           (case txCertificates of
              TxCertificatesNone    -> Seq.empty
              TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
@@ -2225,7 +2254,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
 
     scriptdata :: [ScriptData]
     scriptdata =
-        [ d | BuildTxWith (TxExtraScriptData _ ds) <- [txExtraScriptData], d <- ds ]
+        [ d | TxOut _ _ (TxOutDatum _ d) <- txOuts ]
      ++ [ d | (_, AnyScriptWitness
                     (PlutusScriptWitness
                        _ _ _ (ScriptDatumForTxIn d) _ _)) <- witnesses
@@ -2259,6 +2288,37 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
         ss = case txAuxScripts of
                TxAuxScriptsNone   -> []
                TxAuxScripts _ ss' -> ss'
+
+-- | A variant of 'toShelleyTxOut' that is used only internally to this module
+-- that works with a 'TxOut' in any context (including CtxTx) by ignoring
+-- embedded datums (taking only their hash).
+--
+toShelleyTxOut' :: forall ctx era ledgerera.
+                   ShelleyLedgerEra era ~ ledgerera
+                => ShelleyBasedEra era
+                -> TxOut ctx era
+                -> Ledger.TxOut ledgerera
+toShelleyTxOut' era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _) =
+    case era of {}
+
+toShelleyTxOut' _ (TxOut addr (TxOutAdaOnly AdaOnlyInShelleyEra value) _) =
+    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+
+toShelleyTxOut' _ (TxOut addr (TxOutAdaOnly AdaOnlyInAllegraEra value) _) =
+    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+
+toShelleyTxOut' _ (TxOut addr (TxOutValue MultiAssetInMaryEra value) _) =
+    Shelley.TxOut (toShelleyAddr addr) (toMaryValue value)
+
+toShelleyTxOut' _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata) =
+    Alonzo.TxOut (toShelleyAddr addr) (toMaryValue value)
+                 (toAlonzoTxOutDataHash' txoutdata)
+
+toAlonzoTxOutDataHash' :: TxOutDatum ctx era
+                      -> StrictMaybe (Alonzo.DataHash StandardCrypto)
+toAlonzoTxOutDataHash'  TxOutDatumNone                          = SNothing
+toAlonzoTxOutDataHash' (TxOutDatumHash _ (ScriptDataHash dh))   = SJust dh
+toAlonzoTxOutDataHash' (TxOutDatum'    _ (ScriptDataHash dh) _) = SJust dh
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -14,9 +14,8 @@ import           Cardano.Prelude
 import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
                      SoftwareVersion (..), SystemTag (..))
 
-import           Cardano.Api (NetworkId, TxIn)
-import           Cardano.Api.Byron (Address (..), ByronAddr, ByronEra,
-                     ByronProtocolParametersUpdate (..), TxOut)
+import           Cardano.Api       hiding (GenesisParameters)
+import           Cardano.Api.Byron hiding (GenesisParameters)
 
 import           Cardano.CLI.Byron.Genesis
 import           Cardano.CLI.Byron.Key
@@ -82,7 +81,7 @@ data ByronCommand =
         -- ^ Signing key of genesis UTxO owner.
         (Address ByronAddr)
         -- ^ Genesis UTxO address.
-        [TxOut ByronEra]
+        [TxOut CtxTx ByronEra]
         -- ^ Tx output.
   | SpendUTxO
         NetworkId
@@ -93,7 +92,7 @@ data ByronCommand =
         -- ^ Signing key of Tx underwriter.
         [TxIn]
         -- ^ Inputs available for spending to the Tx underwriter's key.
-        [TxOut ByronEra]
+        [TxOut CtxTx ByronEra]
         -- ^ Genesis UTxO output Address.
 
   | GetTxId TxFile

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -284,12 +284,12 @@ parseTxIdAtto = (<?> "Transaction ID (hexadecimal)") $ do
 parseTxIxAtto :: Atto.Parser TxIx
 parseTxIxAtto = toEnum <$> Atto.decimal
 
-parseTxOut :: Parser (TxOut ByronEra)
+parseTxOut :: Parser (TxOut CtxTx ByronEra)
 parseTxOut =
   option
     ( (\(addr, lovelace) -> TxOut (pAddressInEra addr)
                                   (pLovelaceTxOut lovelace)
-                                  TxOutDatumHashNone)
+                                  TxOutDatumNone)
       <$> auto
     )
     $ long "txout"

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -197,7 +197,7 @@ runSpendGenesisUTxO
   -> NewTxFile
   -> SigningKeyFile
   -> Address ByronAddr
-  -> [TxOut ByronEra]
+  -> [TxOut CtxTx ByronEra]
   -> ExceptT ByronClientCmdError IO ()
 runSpendGenesisUTxO genesisFile nw bKeyFormat (NewTxFile ctTx) ctKey genRichAddr outs = do
     genesis <- firstExceptT ByronCmdGenesisError $ readGenesis genesisFile nw
@@ -212,7 +212,7 @@ runSpendUTxO
   -> NewTxFile
   -> SigningKeyFile
   -> [TxIn]
-  -> [TxOut ByronEra]
+  -> [TxOut CtxTx ByronEra]
   -> ExceptT ByronClientCmdError IO ()
 runSpendUTxO nw bKeyFormat (NewTxFile ctTx) ctKey ins outs = do
     sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat ctKey

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -144,7 +144,7 @@ txSpendGenesisUTxOByronPBFT
   -> NetworkId
   -> SomeByronSigningKey
   -> Address ByronAddr
-  -> [TxOut ByronEra]
+  -> [TxOut CtxTx ByronEra]
   -> Tx ByronEra
 txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
     let txBodyCont =
@@ -160,7 +160,6 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             )
             TxMetadataNone
             TxAuxScriptsNone
-            (BuildTxWith TxExtraScriptDataNone)
             TxExtraKeyWitnessesNone
             (BuildTxWith Nothing)
             TxWithdrawalsNone
@@ -183,7 +182,7 @@ txSpendUTxOByronPBFT
   :: NetworkId
   -> SomeByronSigningKey
   -> [TxIn]
-  -> [TxOut ByronEra]
+  -> [TxOut CtxTx ByronEra]
   -> Tx ByronEra
 txSpendUTxOByronPBFT nId sk txIns outs = do
   let txBodyCont = TxBodyContent
@@ -199,7 +198,6 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                      )
                      TxMetadataNone
                      TxAuxScriptsNone
-                     (BuildTxWith TxExtraScriptDataNone)
                      TxExtraKeyWitnessesNone
                      (BuildTxWith Nothing)
                      TxWithdrawalsNone

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -259,12 +259,17 @@ pScriptWitnessFiles witctx autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefi
     pScriptDatumOrFile =
       case witctx of
         WitCtxTxIn  -> ScriptDatumOrFileForTxIn <$>
-                         pScriptDataOrFile (scriptFlagPrefix ++ "-datum")
+                         pScriptDataOrFile
+                           (scriptFlagPrefix ++ "-datum")
+                           "The script datum, in JSON syntax."
+                           "The script datum, in the given JSON file."
         WitCtxMint  -> pure NoScriptDatumOrFileForMint
         WitCtxStake -> pure NoScriptDatumOrFileForStake
 
     pScriptRedeemerOrFile :: Parser ScriptDataOrFile
     pScriptRedeemerOrFile = pScriptDataOrFile (scriptFlagPrefix ++ "-redeemer")
+                           "The script redeemer, in JSON syntax."
+                           "The script redeemer, in the given JSON file."
 
     pExecutionUnits :: Parser ExecutionUnits
     pExecutionUnits =
@@ -276,8 +281,8 @@ pScriptWitnessFiles witctx autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefi
           )
 
 
-pScriptDataOrFile :: String -> Parser ScriptDataOrFile
-pScriptDataOrFile dataFlagPrefix =
+pScriptDataOrFile :: String -> String -> String -> Parser ScriptDataOrFile
+pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
       ScriptDataFile  <$> pScriptDataFile
   <|> ScriptDataValue <$> pScriptDataValue
   where
@@ -285,14 +290,17 @@ pScriptDataOrFile dataFlagPrefix =
       Opt.strOption
         (  Opt.long (dataFlagPrefix ++ "-file")
         <> Opt.metavar "FILE"
-        <> Opt.help "The JSON file containing the script data."
+        <> Opt.help (helpTextForFile ++ " The file must follow the special \
+                                         \JSON schema for script data.")
         )
 
     pScriptDataValue =
       Opt.option readerScriptData
         (  Opt.long (dataFlagPrefix ++ "-value")
         <> Opt.metavar "JSON VALUE"
-        <> Opt.help "The JSON value for the script data. Supported JSON data types: string, number, object & array."
+        <> Opt.help (helpTextForValue ++ " There is no schema: (almost) any \
+                                         \JSON value is supported, including \
+                                         \top-level strings and numbers.")
         )
 
     readerScriptData = do
@@ -707,7 +715,11 @@ pTransaction =
     ParamsFromFile <$> pProtocolParamsFile
 
   pTxHashScriptData :: Parser TransactionCmd
-  pTxHashScriptData = TxHashScriptData <$> pScriptDataOrFile "script-data"
+  pTxHashScriptData = TxHashScriptData <$>
+                        pScriptDataOrFile
+                          "script-data"
+                          "The script data, in JSON syntax."
+                          "The script data, in the given JSON file."
 
   pTransactionId  :: Parser TransactionCmd
   pTransactionId = TxGetTxId <$> pInputTxFile
@@ -1808,22 +1820,46 @@ pTxOut =
           (  Opt.long "tx-out"
           <> Opt.metavar "ADDRESS VALUE"
           -- TODO alonzo: Update the help text to describe the new syntax as well.
-          <> Opt.help "The transaction output as Address+Lovelace where Address is \
-                      \the Bech32-encoded address followed by the amount in \
-                      \Lovelace."
+          <> Opt.help "The transaction output as ADDRESS VALUE where ADDRESS is \
+                      \the Bech32-encoded address followed by the value in \
+                      \the multi-asset syntax (including simply Lovelace)."
           )
-    <*> optional pDatumHash
+    <*> optional pTxOutDatum
 
 
-pDatumHash :: Parser (Hash ScriptData)
-pDatumHash  =
-  Opt.option (readerFromParsecParser parseHashScriptData)
-    (  Opt.long "tx-out-datum-hash"
-    <> Opt.metavar "HASH"
-    <> Opt.help "Required datum hash for tx inputs intended \
-               \to be utilizied by a Plutus script."
-    )
+pTxOutDatum :: Parser TxOutDatumAnyEra
+pTxOutDatum =
+      pTxOutDatumByHashOnly
+  <|> pTxOutDatumByHashOf
+  <|> pTxOutDatumByValue
   where
+    pTxOutDatumByHashOnly =
+      TxOutDatumByHashOnly <$>
+        Opt.option (readerFromParsecParser parseHashScriptData)
+          (  Opt.long "tx-out-datum-hash"
+          <> Opt.metavar "HASH"
+          <> Opt.help "The script datum hash for this tx output, as \
+                     \the raw datum hash (in hex)."
+          )
+
+    pTxOutDatumByHashOf =
+      TxOutDatumByHashOf <$>
+        pScriptDataOrFile
+          "tx-out-datum-hash"
+          "The script datum hash for this tx output, by hashing the \
+          \script datum given here in JSON syntax."
+          "The script datum hash for this tx output, by hashing the \
+          \script datum in the given JSON file."
+
+    pTxOutDatumByValue =
+      TxOutDatumByValue <$>
+        pScriptDataOrFile
+          "tx-out-datum-embed"
+          "The script datum to embed in the tx for this output, \
+          \given here in JSON syntax."
+          "The script datum to embed in the tx for this output, \
+          \in the given JSON file."
+
     parseHashScriptData :: Parsec.Parser (Hash ScriptData)
     parseHashScriptData = do
       str <- Parsec.many1 Parsec.hexDigit Parsec.<?> "script data hash"
@@ -2751,7 +2787,7 @@ parseStakeAddress = do
       Nothing   -> fail $ "invalid address: " <> Text.unpack str
       Just addr -> pure addr
 
-parseTxOutAnyEra :: Parsec.Parser (Maybe (Hash ScriptData) -> TxOutAnyEra)
+parseTxOutAnyEra :: Parsec.Parser (Maybe TxOutDatumAnyEra -> TxOutAnyEra)
 parseTxOutAnyEra = do
     addr <- parseAddressAny
     Parsec.spaces

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -666,7 +666,7 @@ printFilteredUTxOs shelleyBasedEra' (UTxO utxo) = do
 
 printUtxo
   :: ShelleyBasedEra era
-  -> (TxIn, TxOut era)
+  -> (TxIn, TxOut CtxUTxO era)
   -> IO ()
 printUtxo shelleyBasedEra' txInOutTuple =
   case shelleyBasedEra' of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -341,7 +341,6 @@ runTxBuildRaw (AnyCardanoEra era)
                  <*> validateTxValidityUpperBound era mUpperBound)
         <*> validateTxMetadataInEra  era metadataSchema metadataFiles
         <*> validateTxAuxScripts     era scriptFiles
-        <*> pure (BuildTxWith TxExtraScriptDataNone) --TODO alonzo: support this
         <*> pure TxExtraKeyWitnessesNone --TODO alonzo: support this
         <*> validateProtocolParameters era mpparams
         <*> validateTxWithdrawals    era withdrawals
@@ -405,7 +404,6 @@ runTxBuild (AnyCardanoEra era) (AnyConsensusModeParams cModeParams) networkId tx
                    <*> validateTxValidityUpperBound era mUpperBound)
           <*> validateTxMetadataInEra     era metadataSchema metadataFiles
           <*> validateTxAuxScripts        era scriptFiles
-          <*> pure (BuildTxWith TxExtraScriptDataNone) --TODO alonzo: support this
           <*> pure TxExtraKeyWitnessesNone --TODO alonzo: support this
           <*> validateProtocolParameters  era mpparams
           <*> validateTxWithdrawals       era withdrawals
@@ -560,26 +558,25 @@ validateTxInsCollateral era txins =
 validateTxOuts :: forall era.
                   CardanoEra era
                -> [TxOutAnyEra]
-               -> ExceptT ShelleyTxCmdError IO [TxOut era]
-validateTxOuts era = mapM toTxOutInAnyEra
+               -> ExceptT ShelleyTxCmdError IO [TxOut CtxTx era]
+validateTxOuts era = mapM toTxOut
   where
-    toTxOutInAnyEra :: TxOutAnyEra
-                    -> ExceptT ShelleyTxCmdError IO (TxOut era)
-    toTxOutInAnyEra (TxOutAnyEra addr val mDatumHash) =
+    toTxOut :: TxOutAnyEra -> ExceptT ShelleyTxCmdError IO (TxOut CtxTx era)
+    toTxOut (TxOutAnyEra addr val mDatumHash) =
       case (scriptDataSupportedInEra era, mDatumHash) of
         (_, Nothing) ->
-          TxOut <$> toAddressInAnyEra addr
-                <*> toTxOutValueInAnyEra val
-                <*> pure TxOutDatumHashNone
-        (Just supported, Just dh) ->
-          TxOut <$> toAddressInAnyEra addr
-                <*> toTxOutValueInAnyEra val
-                <*> pure (TxOutDatumHash supported dh)
+          TxOut <$> toAddressInEra addr
+                <*> toTxOutValue val
+                <*> pure TxOutDatumNone
+        (Just supported, Just d) ->
+          TxOut <$> toAddressInEra addr
+                <*> toTxOutValue val
+                <*> toTxOutDatum supported d
         (Nothing, Just _) ->
           txFeatureMismatch era TxFeatureTxOutDatum
 
-    toAddressInAnyEra :: AddressAny -> ExceptT ShelleyTxCmdError IO (AddressInEra era)
-    toAddressInAnyEra addrAny =
+    toAddressInEra :: AddressAny -> ExceptT ShelleyTxCmdError IO (AddressInEra era)
+    toAddressInEra addrAny =
       case addrAny of
         AddressByron   bAddr -> return (AddressInEra ByronAddressInAnyEra bAddr)
         AddressShelley sAddr ->
@@ -589,14 +586,26 @@ validateTxOuts era = mapM toTxOutInAnyEra
             ShelleyBasedEra era' ->
               return (AddressInEra (ShelleyAddressInEra era') sAddr)
 
-    toTxOutValueInAnyEra :: Value -> ExceptT ShelleyTxCmdError IO (TxOutValue era)
-    toTxOutValueInAnyEra val =
+    toTxOutValue :: Value -> ExceptT ShelleyTxCmdError IO (TxOutValue era)
+    toTxOutValue val =
       case multiAssetSupportedInEra era of
         Left adaOnlyInEra ->
           case valueToLovelace val of
             Just l  -> return (TxOutAdaOnly adaOnlyInEra l)
             Nothing -> txFeatureMismatch era TxFeatureMultiAssetOutputs
         Right multiAssetInEra -> return (TxOutValue multiAssetInEra val)
+
+    toTxOutDatum :: ScriptDataSupportedInEra era
+                 -> TxOutDatumAnyEra
+                 -> ExceptT ShelleyTxCmdError IO (TxOutDatum CtxTx era)
+    toTxOutDatum supported (TxOutDatumByHashOnly dh) =
+      pure (TxOutDatumHash supported dh)
+
+    toTxOutDatum supported (TxOutDatumByHashOf df) =
+      TxOutDatumHash supported . hashScriptData <$> readScriptDataOrFile df
+
+    toTxOutDatum supported (TxOutDatumByValue df) =
+      TxOutDatum supported  <$> readScriptDataOrFile df
 
 
 validateTxFee :: CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -20,6 +20,7 @@ module Cardano.CLI.Types
   , TransferDirection(..)
   , TxOutAnyEra (..)
   , TxOutChangeAddress (..)
+  , TxOutDatumAnyEra (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
   , Stakes (..)
@@ -191,7 +192,12 @@ data TransferDirection = TransferToReserves | TransferToTreasury
 data TxOutAnyEra = TxOutAnyEra
                      AddressAny
                      Value
-                     (Maybe (Hash ScriptData))
+                     (Maybe TxOutDatumAnyEra)
+  deriving (Eq, Show)
+
+data TxOutDatumAnyEra = TxOutDatumByHashOnly (Hash ScriptData)
+                      | TxOutDatumByHashOf    ScriptDataOrFile
+                      | TxOutDatumByValue     ScriptDataOrFile
   deriving (Eq, Show)
 
 -- | A partially-specified transaction output indented to use as a change


### PR DESCRIPTION
The datums are now annotated into the transaction's TxOut values.

This change is a bit tricky since TxOut is used both in the TxBody
(where we want to annotate the datums) and also in the UTxO. We resolve
this with an extra context type arg to TxOut.

TODOs:
 * [ ] split this commit into two: the API changes and the CLI changes.
 * [x] rebase on top of the other API & CLI changes for automation of tx building.