### PR TITLE
Improves readability by clarifying how a UTXO should be spent.

### DIFF
--- a/doc/stake-pool-operations/simple_transaction.md
+++ b/doc/stake-pool-operations/simple_transaction.md
@@ -1,4 +1,4 @@
-# Create a simple transaction
+# Creating a simple transaction
 
 Creating a transaction requires multiple steps:
 
@@ -32,7 +32,7 @@ Which produces the following payment address:
     cat payment.addr 
     addr_test1vqvlku0ytscqg32rpv660uu4sgxlje25s5xrpz7zjqsva3c8pfckz
 
-Query all UTXOs belonging to our payment.addr and choose one (or more) that cover the amount you wish to send in the transaction
+Query all UTXOs belonging to this payment.addr and choose one (or more) that cover the amount you wish to send in the transaction:
 
     cardano-cli query utxo \
         --address $(cat payment.addr) \
@@ -45,15 +45,15 @@ Query all UTXOs belonging to our payment.addr and choose one (or more) that cove
 
 ## Draft the transaction
 
-Because Cardano uses a version of the UTXO model (similar to Bitcoin)
+Because Cardano uses an [extended UTXO model](https://docs.cardano.org/learn/eutxo-explainer),
 a simple transaction requires at least one input and one output, but the most
 common case is to use one input and two outputs (you'll see why):
 
-* Input: A valid UTXO (unspent and with enough token(s) Amount) from `payment.addr`. (see above)
-* Output1: The address that receives the value of the transaction (receiver.addr).
-* Output2: The address that receives the change of the transaction (change.addr - if you want to use the original payment.addr to get your change back, simply copy payment.addr to change.addr).
+* input: a valid UTXO (unspent and with enough token(s) amount) from `payment.addr`. (see above)
+* output1: the address that receives the value of the transaction (receiver.addr).
+* output2: the address that receives the change of the transaction (change.addr - if you want to use the original payment.addr to get your change back, simply copy payment.addr to change.addr).
 
-Create a draft of the transaction and save it as tx.draft
+Create a draft of the transaction and save it as tx.draft.
 
 Note that for `--tx-in` we use the following syntax: `TxHash#TxIx` where `TxHash` is the transaction hash and `TxIx` is the index; for `--tx-out` we use: `TxOut+Lovelace` where `TxOut` is the hex encoded address followed by the amount in `Lovelace`. For the transaction draft --tx-out, --invalid-hereafter and --fee can be set to zero.
 
@@ -67,7 +67,7 @@ Note that for `--tx-in` we use the following syntax: `TxHash#TxIx` where `TxHash
 
 ## Calculate the fee
 
-We use the draft transaction to calculate the fee
+This is a draft transaction to calculate the fee:
 
     cardano-cli transaction calculate-min-fee \
         --tx-body-file tx.draft \
@@ -82,19 +82,19 @@ We use the draft transaction to calculate the fee
 
 ## Calculate the change to send back to change.addr
 
-All amounts must be in Lovelace:
+All amounts must be in lovelace:
 
     expr <UTXO BALANCE> - <AMOUNT TO SEND> - <TRANSACTION FEE>
 
-For example, if we send 10 ADA from a UTxO containing 20 ADA, the change to send back to `change.addr` after paying the fee is: 9.832035 ADA
+For example, if we send 10 ada from a UTXO containing 20 ada, the change to send back to `change.addr` after paying the fee is: 9.832035 ada
 
     expr 20000000 - 10000000 - 167965
 
     > 9832035
 
-## Determine the TTL (time to Live) for the transaction
+## Determine the TTL (time to live) for the transaction
 
-To build the transaction we need to specify the **TTL (Time to live)**, this is the slot (unit of time in Cardano) height limit for our transaction to be included in a block. If it is not in a block by that slot the transaction will be cancelled. So **TTL = slot + N slots**. Where **slot** is the current blockchain slot and **N** is the amount of slots you want to add to give the transaction a window to be included in a block.
+To build the transaction we need to specify the **TTL**, which is the slot (unit of time in Cardano) height limit for our transaction to be included in a block. If it is not in a block by that slot, the transaction will be cancelled. So **TTL = slot + N slots**. Where **slot** is the current blockchain slot and **N** is the amount of slots you want to add to give the transaction a window to be included in a block.
 
 Query the tip of the blockchain:
 
@@ -113,7 +113,7 @@ Calculate your `invalid-hereafter`, for example:  26633911 + 200 slots = 2663411
 
 ## Build the transaction
 
-We write the transaction in a file, we will name it `tx.raw`.
+We write the transaction in a file, we will name it `tx.raw`:
 
     cardano-cli transaction build-raw \
         --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \

--- a/doc/stake-pool-operations/simple_transaction.md
+++ b/doc/stake-pool-operations/simple_transaction.md
@@ -1,8 +1,9 @@
 # Create a simple transaction
 
-Creating a transaction requires various steps:
+Creating a transaction requires multiple steps:
 
 * Get the protocol parameters
+* Get the UTXO to spend
 * Calculate the fee
 * Define the time-to-live (TTL) for the transaction
 * Build the transaction
@@ -13,74 +14,87 @@ Creating a transaction requires various steps:
 
 Get the protocol parameters and save them to `protocol.json` with:
 
-```
-cardano-cli query protocol-parameters \
-  --mainnet \
-  --out-file protocol.json
-```
+    cardano-cli query protocol-parameters \
+        --mainnet \
+        --out-file protocol.json
 
-#### Get the transaction hash and index of the **UTXO** to spend:
+## Get the **UTXO** to spend:
 
-```
-cardano-cli query utxo \
-  --address $(cat payment.addr) \
-  --mainnet
-```
+Generate the payment address from your payment verification key (see [getting started docs](https://docs.cardano.org/native-tokens/getting-started)):
 
-```
-                            TxHash                                 TxIx        Amount
-----------------------------------------------------------------------------------------
-4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99     4         20000000 lovelace
-```
+    cardano-cli address build \
+        --payment-verification-key-file payment.vkey \
+        --out-file payment.addr \
+        --mainnet
 
-#### Draft the transaction
+Which produces the following payment address:
 
-Create a draft for the transaction and save it in tx.draft
+    cat payment.addr 
+    addr_test1vqvlku0ytscqg32rpv660uu4sgxlje25s5xrpz7zjqsva3c8pfckz
+
+Query all UTXOs belonging to our payment.addr and choose one (or more) that cover the amount you wish to send in the transaction
+
+    cardano-cli query utxo \
+        --address $(cat payment.addr) \
+        --mainnet
+
+    
+                              TxHash                                 TxIx        Amount
+    ---------------------------------------------------------------------------------------
+    4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99     4         20000000 lovelace
+
+## Draft the transaction
+
+Because Cardano uses a version of the UTXO model (similar to Bitcoin)
+a simple transaction requires at least one input and one output, but the most
+common case is to use one input and two outputs (you'll see why):
+
+* Input: A valid UTXO (unspent and with enough token(s) Amount) from `payment.addr`. (see above)
+* Output1: The address that receives the value of the transaction (receiver.addr).
+* Output2: The address that receives the change of the transaction (change.addr - if you want to use the original payment.addr to get your change back, simply copy payment.addr to change.addr).
+
+Create a draft of the transaction and save it as tx.draft
 
 Note that for `--tx-in` we use the following syntax: `TxHash#TxIx` where `TxHash` is the transaction hash and `TxIx` is the index; for `--tx-out` we use: `TxOut+Lovelace` where `TxOut` is the hex encoded address followed by the amount in `Lovelace`. For the transaction draft --tx-out, --invalid-hereafter and --fee can be set to zero.
 
     cardano-cli transaction build-raw \
-    --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
-    --tx-out $(cat payment2.addr)+0 \
-    --tx-out $(cat payment.addr)+0 \
-    --invalid-hereafter 0 \
-    --fee 0 \
-    --out-file tx.draft
+        --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
+        --tx-out $(cat receiver.addr)+0 \
+        --tx-out $(cat change.addr)+0 \
+        --invalid-hereafter 0 \
+        --fee 0 \
+        --out-file tx.draft
 
-#### Calculate the fee
+## Calculate the fee
 
-A simple transaction needs one input, a valid UTXO from `payment.addr`, and two outputs:
-
-* Output1: The address that receives the transaction.
-* Output2: The address that receives the change of the transaction.
-
-Note that to calculate the fee you need to include the draft transaction
+We use the draft transaction to calculate the fee
 
     cardano-cli transaction calculate-min-fee \
-    --tx-body-file tx.draft \
-    --tx-in-count 1 \
-    --tx-out-count 2 \
-    --witness-count 1 \
-    --byron-witness-count 0 \
-    --mainnet \
-    --protocol-params-file protocol.json
+        --tx-body-file tx.draft \
+        --tx-in-count 1 \
+        --tx-out-count 2 \
+        --witness-count 1 \
+        --byron-witness-count 0 \
+        --mainnet \
+        --protocol-params-file protocol.json
 
     > 167965
 
-#### Calculate the change to send back to payment.addr,
-all amounts must be in Lovelace:
+## Calculate the change to send back to change.addr
+
+All amounts must be in Lovelace:
 
     expr <UTXO BALANCE> - <AMOUNT TO SEND> - <TRANSACTION FEE>
 
-For example, if we send 10 ADA from a UTxO containing 20 ADA, the change to send back to `payment.addr` after paying the fee is: 9.832035 ADA
+For example, if we send 10 ADA from a UTxO containing 20 ADA, the change to send back to `change.addr` after paying the fee is: 9.832035 ADA
 
     expr 20000000 - 10000000 - 167965
 
     > 9832035
 
-#### Determine the TTL (time to Live) for the transaction
+## Determine the TTL (time to Live) for the transaction
 
-To build the transaction we need to specify the **TTL (Time to live)**, this is the slot height limit for our transaction to be included in a block, if it is not in a block by that slot the transaction will be cancelled. So TTL = slot + N slots. Where N is the amount of slots you want to add to give the transaction a window to be included in a block.
+To build the transaction we need to specify the **TTL (Time to live)**, this is the slot (unit of time in Cardano) height limit for our transaction to be included in a block. If it is not in a block by that slot the transaction will be cancelled. So **TTL = slot + N slots**. Where **slot** is the current blockchain slot and **N** is the amount of slots you want to add to give the transaction a window to be included in a block.
 
 Query the tip of the blockchain:
 
@@ -97,53 +111,53 @@ Look for the value of `slot`
 
 Calculate your `invalid-hereafter`, for example:  26633911 + 200 slots = 26634111
 
-#### Build the transaction
+## Build the transaction
 
 We write the transaction in a file, we will name it `tx.raw`.
 
     cardano-cli transaction build-raw \
-    --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
-    --tx-out $(cat payment2.addr)+10000000 \
-    --tx-out $(cat payment.addr)+9832035 \
-    --invalid-hereafter 26634111 \
-    --fee 167965 \
-    --out-file tx.raw
+        --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
+        --tx-out $(cat receiver.addr)+10000000 \
+        --tx-out $(cat change.addr)+9832035 \
+        --invalid-hereafter 26634111 \
+        --fee 167965 \
+        --out-file tx.raw
 
-#### Sign the transaction
+## Sign the transaction
 
 Sign the transaction with the signing key **payment.skey** and save the signed transaction in **tx.signed**
 
     cardano-cli transaction sign \
-    --tx-body-file tx.raw \
-    --signing-key-file payment.skey \
-    --mainnet \
-    --out-file tx.signed
+        --tx-body-file tx.raw \
+        --signing-key-file payment.skey \
+        --mainnet \
+        --out-file tx.signed
 
-#### Submit the transaction
+## Submit the transaction
 
     cardano-cli transaction submit \
-    --tx-file tx.signed \
-    --mainnet
+        --tx-file tx.signed \
+        --mainnet
 
-#### Check the balances
+## Check the balances
 
 We must give it some time to get incorporated into the blockchain, but eventually, we will see the effect:
 
     cardano-cli query utxo \
-        --address $(cat payment.addr) \
+        --address $(cat change.addr) \
         --mainnet
 
-    >                            TxHash                                 TxIx         Amount
-    > ----------------------------------------------------------------------------------------
-    > b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee     1         9832035 lovelace
+                               TxHash                                 TxIx         Amount
+    ----------------------------------------------------------------------------------------
+    b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee     1         9832035 lovelace
 
     cardano-cli query utxo \
-        --address $(cat payment2.addr) \
+        --address $(cat receiver.addr) \
         --mainnet
 
-    >                            TxHash                                 TxIx         Amount
-    > ----------------------------------------------------------------------------------------
-    > b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee     0         10000000 lovelace
+                               TxHash                                 TxIx         Amount
+    ----------------------------------------------------------------------------------------
+    b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee     0         10000000 lovelace
 
 
 **Note**`--mainnet` identifies the Cardano mainnet, for testnets use `--testnet-magic 1097911063` instead.


### PR DESCRIPTION
Fixes #2794 where users may be confused why we can/should use two output addresses when building a transaction.