### PR TITLE
Make monadic queries easier to access

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -597,8 +597,8 @@ module Cardano.Api (
 
     -- ** Monadic queries
     LocalStateQueryExpr,
-    executeQueryLocalState,
-    executeQueryLocalStateWithChainSync,
+    executeLocalStateQueryExpr,
+    executeLocalStateQueryExprWithChainSync,
     queryExpr,
     determineEraExpr
   ) where

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -596,9 +596,10 @@ module Cardano.Api (
     NodeToClientVersion(..),
 
     -- ** Monadic queries
-    LocalStateQueryScript,
+    LocalStateQueryExpr,
     sendMsgQuery,
-    setupLocalStateQueryScript
+    executeQueryLocalState,
+    executeQueryLocalStateWithChainSync
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -597,9 +597,10 @@ module Cardano.Api (
 
     -- ** Monadic queries
     LocalStateQueryExpr,
-    sendMsgQuery,
     executeQueryLocalState,
-    executeQueryLocalStateWithChainSync
+    executeQueryLocalStateWithChainSync,
+    queryExpr,
+    determineEraExpr
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -2,9 +2,10 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 module Cardano.Api.IPC.Monad
-  ( LocalStateQueryScript
+  ( LocalStateQueryExpr
   , sendMsgQuery
-  , setupLocalStateQueryScript
+  , executeQueryLocalState
+  , executeQueryLocalStateWithChainSync
   ) where
 
 import Cardano.Api.Block
@@ -21,40 +22,113 @@ import Data.Ord
 import Shelley.Spec.Ledger.Scripts ()
 import System.IO
 
+import qualified Ouroboros.Network.Protocol.ChainSync.Client as Net.Sync
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Net.Query
 
 -- | Monadic type for constructing local state queries.
 --
 -- Use 'sendMsgQuery' in a do block to construct queries of this type and convert
--- the expression to a 'Net.Query.LocalStateQueryClient' with 'setupLocalStateQueryScript'.
-newtype LocalStateQueryScript block point query r m a = LocalStateQueryScript
-  { runLocalStateQueryScript :: ContT (Net.Query.ClientStAcquired block point query m r) m a
+-- the expression to a 'Net.Query.LocalStateQueryClient' with 'setupLocalStateQueryExpr'.
+newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
+  { runLocalStateQueryExpr :: ContT (Net.Query.ClientStAcquired block point query m r) m a
   } deriving (Functor, Applicative, Monad, MonadIO)
 
 -- | Use 'sendMsgQuery' in a do block to construct monadic local state queries.
-sendMsgQuery :: Monad m => query a -> LocalStateQueryScript block point query r m a
-sendMsgQuery q = LocalStateQueryScript . ContT $ \f -> pure $
+sendMsgQuery :: Monad m => query a -> LocalStateQueryExpr block point query r m a
+sendMsgQuery q = LocalStateQueryExpr . ContT $ \f -> pure $
   Net.Query.SendMsgQuery q $
     Net.Query.ClientStQuerying
     { Net.Query.recvMsgResult = f
     }
 
+-- | Execute a local state query expression.
+executeQueryLocalState
+  :: LocalNodeConnectInfo CardanoMode
+  -> Maybe ChainPoint
+  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a)
+  -> IO (Either AcquireFailure (Maybe a))
+executeQueryLocalState connectInfo mpoint f = do
+  resultVarQueryTipLocalState <- newEmptyTMVarIO
+  waitResult <- pure $ sequence <$> readTMVar resultVarQueryTipLocalState
+
+  connectToLocalNodeWithVersion
+    connectInfo
+    (\ntcVersion ->
+      LocalNodeClientProtocols
+      { localChainSyncClient    = NoLocalChainSyncClient
+      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint ntcVersion resultVarQueryTipLocalState (f ntcVersion)
+      , localTxSubmissionClient = Nothing
+      }
+    )
+
+  atomically waitResult
+
+-- | Execute a local state query expression concurrently with a chain sync.
+executeQueryLocalStateWithChainSync
+  :: LocalNodeConnectInfo CardanoMode
+  -> Maybe ChainPoint
+  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a)
+  -> IO (ChainTip, Either AcquireFailure (Maybe a))
+executeQueryLocalStateWithChainSync connectInfo mpoint f = do
+  resultVarQueryTipLocalState <- newEmptyTMVarIO
+  resultVarChainTip <- newEmptyTMVarIO
+
+  waitResult <- pure $ (,)
+    <$> readTMVar resultVarChainTip
+    <*> (sequence <$> readTMVar resultVarQueryTipLocalState)
+
+  connectToLocalNodeWithVersion
+    connectInfo
+    (\ntcVersion ->
+      LocalNodeClientProtocols
+      { localChainSyncClient    = LocalChainSyncClient $ chainSyncGetCurrentTip waitResult resultVarChainTip
+      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint ntcVersion resultVarQueryTipLocalState (f ntcVersion)
+      , localTxSubmissionClient = Nothing
+      }
+    )
+
+  atomically waitResult
+
+  where
+    chainSyncGetCurrentTip
+      :: STM b
+      -> TMVar  ChainTip
+      -> ChainSyncClient (BlockInMode mode) ChainPoint ChainTip IO ()
+    chainSyncGetCurrentTip waitDone tipVar =
+      ChainSyncClient $ pure clientStIdle
+      where
+        clientStIdle :: Net.Sync.ClientStIdle (BlockInMode mode) ChainPoint ChainTip IO ()
+        clientStIdle =
+          Net.Sync.SendMsgRequestNext clientStNext (pure clientStNext)
+
+        clientStNext :: Net.Sync.ClientStNext (BlockInMode mode) ChainPoint ChainTip IO ()
+        clientStNext = Net.Sync.ClientStNext
+          { Net.Sync.recvMsgRollForward = \_block tip -> ChainSyncClient $ do
+              void . atomically $ putTMVar tipVar tip
+              void $ atomically waitDone
+              pure $ Net.Sync.SendMsgDone ()
+          , Net.Sync.recvMsgRollBackward = \_point tip -> ChainSyncClient $ do
+              void . atomically $ putTMVar tipVar tip
+              void $ atomically waitDone
+              pure $ Net.Sync.SendMsgDone ()
+          }
+
 -- | Use 'sendMsgQuery' in a do block to construct monadic local state queries.
-setupLocalStateQueryScript ::
+setupLocalStateQueryExpr ::
      STM x
   -> Maybe ChainPoint
   -> NodeToClientVersion
   -> TMVar (Maybe (Either Net.Query.AcquireFailure a))
-  -> LocalStateQueryScript (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
+  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
   -> Net.Query.LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) IO ()
-setupLocalStateQueryScript waitDone mPointVar' ntcVersion resultVar' f =
+setupLocalStateQueryExpr waitDone mPointVar' ntcVersion resultVar' f =
   LocalStateQueryClient $
     if ntcVersion >= NodeToClientV_8
       then do
         pure . Net.Query.SendMsgAcquire mPointVar' $
           Net.Query.ClientStAcquiring
-          { Net.Query.recvMsgAcquired = runContT (runLocalStateQueryScript f) $ \result -> do
+          { Net.Query.recvMsgAcquired = runContT (runLocalStateQueryExpr f) $ \result -> do
               atomically $ putTMVar resultVar' (Just (Right result))
               void $ atomically waitDone
               pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -150,7 +150,7 @@ setupLocalStateQueryExpr
     }
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: query a -> LocalStateQueryExpr block point query r IO a
+queryExpr :: QueryInMode mode a -> LocalStateQueryExpr block point (QueryInMode mode) r IO a
 queryExpr q =
   LocalStateQueryExpr . ContT $ \f -> pure $
     Net.Query.SendMsgQuery q $

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -4,8 +4,8 @@
 
 module Cardano.Api.IPC.Monad
   ( LocalStateQueryExpr
-  , executeQueryLocalState
-  , executeQueryLocalStateWithChainSync
+  , executeLocalStateQueryExpr
+  , executeLocalStateQueryExprWithChainSync
   , queryExpr
   , determineEraExpr
   ) where
@@ -47,12 +47,12 @@ newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
   } deriving (Functor, Applicative, Monad, MonadIO)
 
 -- | Execute a local state query expression.
-executeQueryLocalState
+executeLocalStateQueryExpr
   :: LocalNodeConnectInfo mode
   -> Maybe ChainPoint
   -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a)
   -> IO (Either AcquireFailure a)
-executeQueryLocalState connectInfo mpoint f = do
+executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
   let waitResult = readTMVar tmvResultLocalState
 
@@ -69,12 +69,12 @@ executeQueryLocalState connectInfo mpoint f = do
   atomically waitResult
 
 -- | Execute a local state query expression concurrently with a chain sync.
-executeQueryLocalStateWithChainSync
+executeLocalStateQueryExprWithChainSync
   :: LocalNodeConnectInfo mode
   -> Maybe ChainPoint
   -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a)
   -> IO (ChainTip, Either AcquireFailure a)
-executeQueryLocalStateWithChainSync connectInfo mpoint f = do
+executeLocalStateQueryExprWithChainSync connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
   tmvResultChainTip <- newEmptyTMVarIO
 

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -140,7 +140,7 @@ setupLocalStateQueryExpr waitDone mPointVar' resultVar' f =
     }
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: Monad m => query a -> LocalStateQueryExpr block point query r m a
+queryExpr :: query a -> LocalStateQueryExpr block point query r IO a
 queryExpr q =
   LocalStateQueryExpr . ContT $ \f -> pure $
     Net.Query.SendMsgQuery q $
@@ -149,9 +149,9 @@ queryExpr q =
       }
 
 -- | A monad expresion that determines what era the node is in.
-determineEraExpr :: Monad m
-  => ConsensusModeParams mode
-  -> LocalStateQueryExpr block point (QueryInMode mode) r m AnyCardanoEra
+determineEraExpr ::
+     ConsensusModeParams mode
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO AnyCardanoEra
 determineEraExpr cModeParams =
   case consensusModeOnly cModeParams of
     ByronMode -> return $ AnyCardanoEra ByronEra

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -19,7 +19,6 @@ import Control.Concurrent.STM
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Except
 import Data.Either
 import Data.Function
 import Data.Maybe
@@ -141,19 +140,18 @@ setupLocalStateQueryExpr waitDone mPointVar' resultVar' f =
     }
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: Monad m => query a -> ExceptT e (LocalStateQueryExpr block point query r m) a
-queryExpr q = ExceptT $ do
-  r <- LocalStateQueryExpr . ContT $ \f -> pure $
+queryExpr :: Monad m => query a -> LocalStateQueryExpr block point query r m a
+queryExpr q =
+  LocalStateQueryExpr . ContT $ \f -> pure $
     Net.Query.SendMsgQuery q $
       Net.Query.ClientStQuerying
       { Net.Query.recvMsgResult = f
       }
-  return (Right r)
 
 -- | A monad expresion that determines what era the node is in.
 determineEraExpr :: Monad m
   => ConsensusModeParams mode
-  -> ExceptT e (LocalStateQueryExpr block point (QueryInMode mode) r m) AnyCardanoEra
+  -> LocalStateQueryExpr block point (QueryInMode mode) r m AnyCardanoEra
 determineEraExpr cModeParams =
   case consensusModeOnly cModeParams of
     ByronMode -> return $ AnyCardanoEra ByronEra

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -25,10 +25,17 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Client as Net.Sync
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Net.Query
 
--- | Monadic type for constructing local state queries.
+-- | Monadic type for constructing local state query expressions.
 --
 -- Use 'sendMsgQuery' in a do block to construct queries of this type and convert
 -- the expression to a 'Net.Query.LocalStateQueryClient' with 'setupLocalStateQueryExpr'.
+--
+-- Some consideration was made to use Applicative instead of Monad as the abstraction in
+-- order to support pipelining, but we actually have a fair amount of code where the next
+-- query depends on the result of the former and therefore actually need Monad.
+--
+-- In order to make pipelining still possible we can explore the use of Selective Functors
+-- which would allow us to straddle both worlds.
 newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
   { runLocalStateQueryExpr :: ContT (Net.Query.ClientStAcquired block point query m r) m a
   } deriving (Functor, Applicative, Monad, MonadIO)

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -44,9 +44,9 @@ sendMsgQuery q = LocalStateQueryExpr . ContT $ \f -> pure $
 
 -- | Execute a local state query expression.
 executeQueryLocalState
-  :: LocalNodeConnectInfo CardanoMode
+  :: LocalNodeConnectInfo mode
   -> Maybe ChainPoint
-  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a)
+  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a)
   -> IO (Either AcquireFailure (Maybe a))
 executeQueryLocalState connectInfo mpoint f = do
   resultVarQueryTipLocalState <- newEmptyTMVarIO
@@ -66,9 +66,9 @@ executeQueryLocalState connectInfo mpoint f = do
 
 -- | Execute a local state query expression concurrently with a chain sync.
 executeQueryLocalStateWithChainSync
-  :: LocalNodeConnectInfo CardanoMode
+  :: LocalNodeConnectInfo mode
   -> Maybe ChainPoint
-  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a)
+  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a)
   -> IO (ChainTip, Either AcquireFailure (Maybe a))
 executeQueryLocalStateWithChainSync connectInfo mpoint f = do
   resultVarQueryTipLocalState <- newEmptyTMVarIO
@@ -120,8 +120,8 @@ setupLocalStateQueryExpr ::
   -> Maybe ChainPoint
   -> NodeToClientVersion
   -> TMVar (Maybe (Either Net.Query.AcquireFailure a))
-  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
-  -> Net.Query.LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) IO ()
+  -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
+  -> Net.Query.LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) IO ()
 setupLocalStateQueryExpr waitDone mPointVar' ntcVersion resultVar' f =
   LocalStateQueryClient $
     if ntcVersion >= NodeToClientV_8

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -161,9 +161,8 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
           Nothing -> return $ Left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
   case result of
-    Right (Just (Right a)) -> writeProtocolParameters mOutFile a
-    Right (Just (Left e)) -> left e
-    Right Nothing -> left ShelleyQueryCmdResultUnavailable
+    Right (Right a) -> writeProtocolParameters mOutFile a
+    Right (Left e) -> left e
     Left e -> left (ShelleyQueryCmdAcquireFailure e)
  where
   writeProtocolParameters
@@ -214,7 +213,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
     CardanoMode -> do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-      (chainTip, emLocalState) <- liftIO $
+      (chainTip, eLocalState) <- liftIO $
         executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> do
           era <- sendMsgQuery (QueryCurrentEra CardanoModeIsMultiEra)
           eraHistory <- sendMsgQuery (QueryEraHistory CardanoModeIsMultiEra)
@@ -227,7 +226,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
             , O.mSystemStart = mSystemStart
             }
 
-      mLocalState <- fmap join . hushM emLocalState $ \e -> do
+      mLocalState <- hushM eLocalState $ \e -> do
         liftIO . T.hPutStrLn IO.stderr $
           "Warning: Local state unavailable: " <> renderShelleyQueryCmdError (ShelleyQueryCmdAcquireFailure e)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -142,7 +142,7 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
                            readEnvSocketPath
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  result <- liftIO $ executeQueryLocalState localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
+  result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
     anyE@(AnyCardanoEra era) <- lift $ determineEraExpr cModeParams
 
     case cardanoEraStyle era of
@@ -208,7 +208,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
       (chainTip, eLocalState) <- liftIO $
-        executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> do
+        executeLocalStateQueryExprWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> do
           era <- queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
           eraHistory <- queryExpr (QueryEraHistory CardanoModeIsMultiEra)
           mSystemStart <- if ntcVersion >= NodeToClientV_9

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -143,7 +143,7 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
   result <- liftIO $ executeQueryLocalState localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
-    anyE@(AnyCardanoEra era) <- determineEraExpr cModeParams
+    anyE@(AnyCardanoEra era) <- lift $ determineEraExpr cModeParams
 
     case cardanoEraStyle era of
       LegacyByronEra -> left ShelleyQueryCmdByronEra
@@ -153,7 +153,7 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
         eInMode <- toEraInMode era cMode
           & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        ppResult <- queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+        ppResult <- lift . queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
         except ppResult & firstExceptT ShelleyQueryCmdEraMismatch
 
@@ -208,7 +208,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
       (chainTip, eLocalState) <- liftIO $
-        executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> runExceptT $ do
+        executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> do
           era <- queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
           eraHistory <- queryExpr (QueryEraHistory CardanoModeIsMultiEra)
           mSystemStart <- if ntcVersion >= NodeToClientV_9
@@ -220,7 +220,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
             , O.mSystemStart = mSystemStart
             }
 
-      mLocalState <- hushM (join (first ShelleyQueryCmdAcquireFailure eLocalState)) $ \e ->
+      mLocalState <- hushM (first ShelleyQueryCmdAcquireFailure eLocalState) $ \e ->
         liftIO . T.hPutStrLn IO.stderr $ "Warning: Local state unavailable: " <> renderShelleyQueryCmdError e
 
       let tipSlotNo = case chainTip of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -88,7 +88,6 @@ data ShelleyQueryCmdError
   | ShelleyQueryCmdUnsupportedMode !AnyConsensusMode
   | ShelleyQueryCmdPastHorizon !Qry.PastHorizonException
   | ShelleyQueryCmdSystemStartUnavailable
-  | ShelleyQueryCmdResultUnavailable -- TODO Remove
   deriving Show
 
 renderShelleyQueryCmdError :: ShelleyQueryCmdError -> Text
@@ -110,7 +109,6 @@ renderShelleyQueryCmdError err =
     ShelleyQueryCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
     ShelleyQueryCmdPastHorizon e -> "Past horizon: " <> show e
     ShelleyQueryCmdSystemStartUnavailable -> "System start unavailable"
-    ShelleyQueryCmdResultUnavailable -> "Result unavailable"
 
 runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmd cmd =
@@ -153,8 +151,7 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
         let cMode = consensusModeOnly cModeParams
         case toEraInMode era cMode of
           Just eInMode -> do
-            ppResult :: Either EraMismatch ProtocolParameters <- sendMsgQuery $
-              QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+            ppResult <- sendMsgQuery $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
             case ppResult of
               Right pp -> return (Right pp)
               Left e -> return (Left (ShelleyQueryCmdEraMismatch e))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -142,7 +142,7 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
                            readEnvSocketPath
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  result <- liftIO $ executeQueryLocalState localNodeConnInfo Nothing $ \_ntcVersion -> do
+  result <- liftIO $ executeQueryLocalState localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
     anyE@(AnyCardanoEra era) <- determineEraExpr cModeParams
 
     case cardanoEraStyle era of
@@ -208,7 +208,7 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
       (chainTip, eLocalState) <- liftIO $
-        executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> do
+        executeQueryLocalStateWithChainSync localNodeConnInfo Nothing $ \ntcVersion -> runExceptT $ do
           era <- queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
           eraHistory <- queryExpr (QueryEraHistory CardanoModeIsMultiEra)
           mSystemStart <- if ntcVersion >= NodeToClientV_9


### PR DESCRIPTION
Hides away the STM details so callers don't have to deal with them anymore.  Reduces the layers of errors types and streamlines error handling.  Renamed Script to Expr to avoid confusion with things like Plutus Scripts. 