### PR TITLE
WIP import cardano-ops as a library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,17 @@ CLUSTER_PROFILE    ?= default-alzo
 CLUSTER_ARGS_EXTRA ?=
 
 cluster-shell:
-	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr clusterProfile ${CLUSTER_PROFILE} --arg 'autoStartCluster' true ${CLUSTER_ARGS_EXTRA}
+	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr clusterProfile ${CLUSTER_PROFILE} --arg 'autoStartCluster' true
 
-cluster-shell-dev:       CLUSTER_ARGS_EXTRA += --arg 'workbenchDevMode' true
-cluster-shell-trace:     CLUSTER_ARGS_EXTRA += --argstr 'autoStartClusterArgs' '--trace --trace-workbench'
-cluster-shell-dev-trace: CLUSTER_ARGS_EXTRA += --arg 'workbenchDevMode' true --argstr 'autoStartClusterArgs' '--trace --trace-workbench'
-cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace: cluster-shell
+shell-dev:               CLUSTER_ARGS_EXTRA += --arg 'workbenchDevMode' true
+cluster-shell:           CLUSTER_ARGS_EXTRA += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true
+cluster-shell-dev:       CLUSTER_ARGS_EXTRA += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true
+cluster-shell-trace:     CLUSTER_ARGS_EXTRA += --arg 'autoStartCluster' true --argstr 'autoStartClusterArgs' '--trace --trace-workbench'
+cluster-shell-dev-trace: CLUSTER_ARGS_EXTRA += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true --argstr 'autoStartClusterArgs' '--trace --trace-workbench'
+shell-dev cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace: shell
+
+shell:
+	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr clusterProfile ${CLUSTER_PROFILE} ${CLUSTER_ARGS_EXTRA}
 
 cli node:
 	cabal --ghc-options="+RTS -qn8 -A32M -RTS" build cardano-$@

--- a/custom-config/default.nix
+++ b/custom-config/default.nix
@@ -3,7 +3,7 @@ self: {
   withR = false;
   localCluster = {
     cacheDir    = "${self.localCluster.stateDir}/.cache";
-    stateDir    = "state-cluster";
+    stateDir    = "run/current";
     profileName = "default-alzo";
     basePort    = 30000;
     autoStartCluster = false;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -22,6 +22,8 @@ let
   # IMPORTANT: report any change to nixpkgs channel in flake.nix:
   nixpkgs = haskellNix.sources.nixpkgs-2105;
   iohkNix = import sources.iohk-nix { inherit system; };
+  cardanoOps = import sources.cardano-ops
+    { inherit system;  deploymentGlobalsFn = pkgs: {}; };
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
@@ -32,6 +34,8 @@ let
     # iohkNix: nix utilities:
     ++ iohkNix.overlays.iohkNix
     ++ iohkNix.overlays.utils
+    # cardanoOps: deployment capability:
+    ++ cardanoOps.overlays
     # our own overlays:
     ++ [
       (pkgs: _: {

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -1,7 +1,7 @@
 let
   basePortDefault    = 30000;
   cacheDirDefault    = "${__getEnv "HOME"}/.cache/cardano-workbench";
-  stateDirDefault    = "state-cluster";
+  stateDirDefault    = "run/current";
   profileNameDefault = "default-alzo";
 in
 { pkgs


### PR DESCRIPTION
Import `cardano-ops` as a library to enable the AWS backend for the workbench.