### PR TITLE
Run all tests in nightly build

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,17 @@
 name: Haskell CI
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason'
+        required: false
+        default: manual
+      tests:
+        description: 'Tests'
+        required: false
+        default: some
 
 jobs:
   build:
@@ -89,7 +100,14 @@ jobs:
       run: retry 2 cabal update
 
     - name: Configure build
-      run: cp .github/workflows/cabal.project.local.$RUNNER_OS cabal.project.local
+      run: |
+        if [ "${{github.event.inputs.tests}}" == "all" ]; then
+          echo "Reconfigure cabal projects to run tests for all dependencies"
+          cat cabal.project | sed 's|tests: False|tests: True|g' > cabal.project.new
+          mv cabal.project.new cabal.project
+        fi
+
+        cp .github/workflows/cabal.project.local.$RUNNER_OS cabal.project.local
 
     - name: Record dependencies
       run: |

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -1,0 +1,23 @@
+name: Nightly Trigger
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 5 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+
+    - name: Invoke workflow
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Haskell CI
+        token: ${{ secrets.MACHINE_TOKEN }}
+        inputs: '{ "reason": "nightly", "tests": "all" }'


### PR DESCRIPTION
This sets up a new scheduled "Nightly Trigger" workflow which triggers the `Haskell CI` workflow with a parameter that enables all tests including that of dependencies.