### PR TITLE
Fix nightly build trigger

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
 
     - name: Invoke workflow
-      uses: benc-uk/workflow-dispatch@v1
+      uses: input-output-hk/workflow-dispatch@v1
       with:
-        workflow: Haskell CI
+        workflow: .github/workflows/haskell.yml
         token: ${{ secrets.MACHINE_TOKEN }}
         inputs: '{ "reason": "nightly", "tests": "all" }'


### PR DESCRIPTION
Previously the build trigger did not work because two workflows had the name `Haskell CI` and the trigger picked the wrong one.

I've forked the Github Action to support supplying a path to the workflow file instead of a name which removes the ambiguity.