### PR TITLE
CAD-3257 generator service:  absorb defaultGeneratorScriptFn

### DIFF
--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -1,4 +1,48 @@
-pkgs: pkgs.commonLib.defServiceModule
+pkgs:
+let
+  ## Standard, simplest possible value transaction workload.
+  ##
+  ## For definitions of the cfg attributes referred here,
+  ## please see the 'defServiceModule.extraOptionDecls' attset below.
+  defaultGeneratorScriptFn =
+    cfg: with cfg;
+    [
+      { setNumberOfInputsPerTx   = 2; } ## XXX: inputs_per_tx
+      { setNumberOfOutputsPerTx  = 2; } ## XXX: outputs_per_tx
+      { setNumberOfTxs           = tx_count; }
+      { setTxAdditionalSize      = 0; } ## XXX: add_tx_size
+      { setFee                   = tx_fee; }
+      { setTTL                   = 1000000; }
+      { startProtocol            = nodeConfigFile; }
+      { setEra                   = "Mary"; } ## XXX: era
+      { setTargets =
+           __attrValues
+             (__mapAttrs (name: { ip, port }:
+                            { addr = ip; port = port; })
+                         targetNodes);
+      }
+      { setLocalSocket    = localNodeSocketPath; }
+      { readSigningKey    = "pass-partout"; filePath = sigKey; }
+      { importGenesisFund = "pass-partout"; fundKey  = "pass-partout"; }
+      { delay             = init_cooldown; }
+      { createChange      = 1000; count = tx_count * 2; }
+      { runBenchmark      = "walletBasedBenchmark";
+                               txCount = tx_count; tps = tps; }
+      { waitBenchmark     = "walletBasedBenchmark"; }
+    ];
+
+  ## The standard decision procedure for the run script:
+  ##
+  ##  - if the config explicitly specifies a script, take that,
+  ##  - otherwise compute it from the configuration.
+  defaultDecideRunScript =
+    cfg: with cfg;
+      __toJSON
+        (if runScript != null
+         then runScript
+         else runScriptFn cfg);
+
+in pkgs.commonLib.defServiceModule
   (lib: with lib;
     { svcName = "tx-generator";
       svcDesc = "configurable transaction generator";
@@ -13,51 +57,58 @@ pkgs: pkgs.commonLib.defServiceModule
       exeName = "tx-generator";
 
       extraOptionDecls = {
-        scriptMode      = boolOpt true       "Whether to use the modern script parametrisation mode of the generator.";
+        scriptMode      = opt bool true      "Whether to use the modern script parametrisation mode of the generator.";
 
         ## TODO: the defaults should be externalised to a file.
         ##
-        tx_count        =  intOpt 1000       "How many Txs to send, total.";
-        add_tx_size     =  intOpt 100        "Extra Tx payload, in bytes.";
-        inputs_per_tx   =  intOpt 4          "Inputs per Tx.";
-        outputs_per_tx  =  intOpt 4          "Outputs per Tx.";
-        tx_fee          =  intOpt 10000000   "Tx fee, in Lovelace.";
-        tps             =  intOpt 100        "Strength of generated load, in TPS.";
-        init_cooldown   =  intOpt 100        "Delay between init and main submissions.";
+        tx_count        = opt int 1000       "How many Txs to send, total.";
+        add_tx_size     = opt int 100        "Extra Tx payload, in bytes.";
+        inputs_per_tx   = opt int 4          "Inputs per Tx.";
+        outputs_per_tx  = opt int 4          "Outputs per Tx.";
+        tx_fee          = opt int 10000000   "Tx fee, in Lovelace.";
+        tps             = opt int 100        "Strength of generated load, in TPS.";
+        init_cooldown   = opt int 100        "Delay between init and main submissions.";
 
-        runScriptFile   =  strOpt null       "Generator config script file.";
-        runScript       = listOpt null       "Generator config script.";
+        runScriptFn     = opt (functionTo (listOf attrs)) defaultGeneratorScriptFn
+          "Function accepting this service config and producing the generator run script (a list of command attrsets).  Takes effect unless runScript or runScriptFile are specified.";
+        runScript       = mayOpt (listOf attrs)
+          "Generator run script (a list of command attrsets).  Takes effect unless runScriptFile is specified.";
+        runScriptFile   = mayOpt str         "Generator config script file.";
 
-        nodeConfigFile  =  strOpt null       "Node-style config file path.";
-        nodeConfig      = attrOpt {}         "Node-style config, overrides the default.";
+        nodeConfigFile  = mayOpt str         "Node-style config file path.";
+        nodeConfig      = mayOpt attrs       "Node-style config, overrides the default.";
 
-        sigKey          =  strOpt null       "Key with funds";
+        sigKey          = mayOpt str         "Key with funds";
 
         localNodeSocketPath =
-                           strOpt null       "Local node socket path";
-        localNodeConf   = attrOpt null       "Config of the local node";
+                           mayOpt str        "Local node socket path";
+        localNodeConf   = mayOpt attrs       "Config of the local node";
 
-        targetNodes     = attrOpt null       "Targets: { name = { ip, port } }";
+        targetNodes     = mayOpt attrs       "Targets: { name = { ip, port } }";
 
-        era             = enumOpt [ "shelley"
-                                    "allegra"
-                                    "mary"
-                                    "alonzo"
-                                  ]
-                                  "shelley"
-                                  "Cardano era to generate transactions for.";
+        era             = opt (enum [ "shelley"
+                                      "allegra"
+                                      "mary"
+                                      "alonzo"
+                                    ])
+                              "mary"
+                              "Cardano era to generate transactions for.";
+
+        ## Internals: not user-serviceable.
+        decideRunScript = opt (functionTo str) defaultDecideRunScript
+          "Decision procedure for the run script content.";
       };
 
       configExeArgsFn =
         cfg: with cfg;
           if scriptMode
           then
-            let json = if runScriptFile != null then runScriptFile
-                       else writeText "run-script.json" (__toJSON runScript);
-            in
-          [ "json" json ]
+            let jsonFile =
+                  if runScriptFile != null then runScriptFile
+                  else "${pkgs.writeText "run-script.json" (decideRunScript cfg)}";
+            in ["json" jsonFile]
           else
-          ([ "cliArguments"
+          (["cliArguments"
 
             "--config"                 nodeConfigFile
 

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -31,7 +31,7 @@ let
                 path   = toString;
                 string = toString;
               }."${__typeOf x}" or
-              (_: throw "\nWhile processing service declaration for '${svcName}':  Unsupported type of command arg: ${__typeOf x}\n")) x);
+              (_: throw "\nWhile computing the stringified arglist for service '${svcName}':  Unsupported type of command arg: ${__typeOf (traceValSeqN 2 x)}\n")) x);
     in  ''
         ${if traceServiceStartup then "set -x" else ""}
         ${configScriptPreambleFn config}
@@ -66,8 +66,8 @@ let
   ##  - systemd extra config (see defaults below)
   ##  - systemd extra service config (see defaults below)
   defServiceModule = argClosure:
-    let dsmDeclSpec = argClosure (pkgs.lib // serviceDeclarationLib);
-    in defServiceModule__ dsmDeclSpec;
+    traceValSeqN 2
+    (defServiceModule__ (argClosure (pkgs.lib // serviceDeclarationLib)));
   defServiceModule__ =
     { ## WARNING: when changing this arglist,
       ## make sure to update 'unhandledArgs' below.
@@ -155,9 +155,9 @@ let
           };
         } // extraOptionDecls;
       };
-      config = mkIf svcConfig.enable ({
+      config = {
         systemd.services."${svcName}" = {
-          enable        = true;
+          enable        = svcConfig.enable;
           description   = "${svcName}, ${svcDesc}.";
           script        = svcConfig.script;
           serviceConfig = {
@@ -166,24 +166,18 @@ let
           } // systemdExtraServiceConfig;
         } // systemdExtraConfig;
         assertions = configAssertions { inherit lib; config = svcConfig; };
-      });
+      };
     };
 
   ## A small library of helpers, to establish comfortable
   ## and compact definition of services.
-  serviceDeclarationLib = with pkgs.lib; rec {
-    opt = type: default: description:
-              mkOption { inherit type default description; };
-    intOpt  = opt types.int;
-    pathOpt = opt (types.or types.path types.str);
-    strOpt  = opt types.str;
-    boolOpt = opt types.bool;
-    attrOpt = opt types.attrs;
-    listOpt = opt (types.listOf types.attrs);
-    enumOpt = set: default: description:
-      mkOption { inherit default description;
-                 type = types.enum set; };
-  };
+  serviceDeclarationLib = with pkgs.lib; with types;
+    types // rec {
+      opt    = type: default: description:
+               mkOption { inherit type default description; };
+      mayOpt = type: description:
+               opt (nullOr type) null description;
+    };
 
   ## Make a script equivalent to a startup script of a NixOS service,
   ## given:

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -173,8 +173,10 @@ let
   ## and compact definition of services.
   serviceDeclarationLib = with pkgs.lib; with types;
     types // rec {
+      ## A shorter alternative to mkOption.
       opt    = type: default: description:
                mkOption { inherit type default description; };
+      ## Maybe `opt`: same as `opt`, but nullable and defaults to `null`.
       mayOpt = type: description:
                opt (nullOr type) null description;
     };

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -329,6 +329,9 @@ EOF
         local tag=$(run current-tag)
         local dir=$(run get "$tag")
 
+        test -d "$dir" ||
+            fail "no valid current run to restart:  please set run/current appropriately"
+
         msg "restarting cluster in the same run directory: $dir"
 
         run stop                "$tag"


### PR DESCRIPTION
This moves the (configuration -> generator run script) translation function into `tx-generator-service.nix` from the workbench into the NixOS service definition.