### PR TITLE
Export shelleyBasedToCardanoEra from Cardano.Api

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -29,6 +29,7 @@ module Cardano.Api (
     InAnyShelleyBasedEra(..),
     CardanoEraStyle(..),
     cardanoEraStyle,
+    shelleyBasedToCardanoEra,
 
     -- ** Deprecated
     Byron,

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -276,6 +276,7 @@ data InAnyShelleyBasedEra thing where
                           -> InAnyShelleyBasedEra thing
 
 
+-- | Converts a 'ShelleyBasedEra' to the broader 'CardanoEra'.
 shelleyBasedToCardanoEra :: ShelleyBasedEra era -> CardanoEra era
 shelleyBasedToCardanoEra ShelleyBasedEraShelley = ShelleyEra
 shelleyBasedToCardanoEra ShelleyBasedEraAllegra = AllegraEra


### PR DESCRIPTION
This little function is handy to have.

Actually, it would be extremely helpful if every Cardano.Api.* module were exposed from the cardano-api package, unless there's a really good reason for it to be private.
