### PR TITLE
Deploy Haddock for merge to master only

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,6 +1,9 @@
 name: "Haddock documentation"
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
The readme says "The documentation is built with each push, but is only published from master branch" yet it is configured to publish on every push. This changes it to publish on every push to master.