### PR TITLE
Remove http server running on a public port.

### DIFF
--- a/nix/supervisord-cluster/supervisor-conf.nix
+++ b/nix/supervisord-cluster/supervisor-conf.nix
@@ -43,10 +43,6 @@ let
         stderr_logfile = "${stateDir}/generator/stderr";
         autostart      = false;
       };
-      "program:webserver" = {
-        command = "${pkgs.python3}/bin/python -m http.server ${toString (basePort - 1)}";
-        directory = "${stateDir}/shelley/webserver";
-      };
     }
     //
     extraSupervisorConfig;


### PR DESCRIPTION
A webserver was started by the workbench.
It is unclear why it would be needed.
It could be a possible security risk.