### PR TITLE
git:  ignore cabalWrapped-created .nix-shell-cabal.project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .stack-work/
 .ghc.environment.*
+.nix-shell-cabal.project
 /cabal.project.diff
 /cabal.project.local
 /cabal.project.old


### PR DESCRIPTION
git: ignore cabalWrapped-created `.nix-shell-cabal.project`

This file is created in the cabal-inside-`nix-shell` mode, as an alternative to the `cabal.project` in-place mutation.