### PR TITLE
New --script-valid and --script-invalid flags

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -115,6 +115,7 @@ dummyTxSizeInEra metadata = case makeTransactionBody dummyTx of
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
 
 dummyTxSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMetadata -> Int

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -80,6 +80,7 @@ mkGenesisTransaction key _payloadSize ttl fee txins txouts
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
   fees = case shelleyBasedEra @ era of
     ShelleyBasedEraShelley -> TxFeeExplicit TxFeesExplicitInShelleyEra fee
@@ -121,6 +122,7 @@ mkTransaction key metadata ttl fee txins txouts
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
 
 mkFee :: forall era .

--- a/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
@@ -20,7 +20,7 @@ import Cardano.Benchmarking.GeneratorTx.Tx as Tx (mkFee, mkTxOutValueAdaOnly, ke
 import Cardano.Benchmarking.Wallet
 
 payToScript ::
-      SigningKey PaymentKey
+     SigningKey PaymentKey
   -> (Script PlutusScriptV1, Hash ScriptData)
   -> NetworkId
   -> TxGenerator AlonzoEra
@@ -28,7 +28,8 @@ payToScript key (script, txOutDatumHash) networkId inFunds outValues validity
   = case makeTransactionBody txBodyContent of
       Left err -> error $ show err
       Right b -> Right ( signShelleyTransaction b (map (WitnessPaymentKey . getFundKey) inFunds)
-                         , newFunds $ getTxId b                       )
+                       , newFunds $ getTxId b
+                       )
  where
   txBodyContent = TxBodyContent {
       txIns = map (\f -> (getFundTxIn f, BuildTxWith $ KeyWitness KeyWitnessForSpending)) inFunds
@@ -45,6 +46,7 @@ payToScript key (script, txOutDatumHash) networkId inFunds outValues validity
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
 
   mkTxOut v = TxOut plutusScriptAddr (mkTxOutValueAdaOnly v) (TxOutDatumHash ScriptDataInAlonzoEra txOutDatumHash)
@@ -83,7 +85,7 @@ toScriptHash str
     Nothing  -> error $ "Invalid datum hash: " ++ show str
 
 spendFromScript ::
-      SigningKey PaymentKey
+     SigningKey PaymentKey
   -> PlutusScript PlutusScriptV1
   -> NetworkId
   -> ProtocolParameters
@@ -95,7 +97,8 @@ spendFromScript key script networkId protocolParameters collateral inFunds valid
   = case makeTransactionBody txBodyContent of
       Left err -> error $ show err
       Right b -> Right ( signShelleyTransaction b (map (WitnessPaymentKey . getFundKey) inFunds)
-                         , newFunds $ getTxId b                       )
+                       , newFunds $ getTxId b
+                       )
  where
   txBodyContent = TxBodyContent {
       txIns = map (\f -> (getFundTxIn f, BuildTxWith $ ScriptWitness ScriptWitnessForSpending plutusScriptWitness )) inFunds
@@ -112,6 +115,7 @@ spendFromScript key script networkId protocolParameters collateral inFunds valid
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
   requiredMemory = 700000000
   requiredSteps  = 700000000

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -119,6 +119,7 @@ genTx key networkId fee metadata inFunds outValues validity
     , txCertificates = TxCertificatesNone
     , txUpdateProposal = TxUpdateProposalNone
     , txMintValue = TxMintNone
+    , txScriptValidity = BuildTxWith TxScriptValidityNone
     }
 
   mkTxOut v = TxOut (Tx.keyAddress @ era networkId key) (mkTxOutValueAdaOnly v) TxOutDatumHashNone

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -495,6 +495,7 @@ genTxBodyContent era = do
   txCertificates <- genTxCertificates era
   txUpdateProposal <- genTxUpdateProposal era
   txMintValue <- genTxMintValue era
+  txScriptValidity <- BuildTxWith <$> genTxScriptValidity era
 
   pure $ TxBodyContent
     { Api.txIns
@@ -511,6 +512,7 @@ genTxBodyContent era = do
     , Api.txCertificates
     , Api.txUpdateProposal
     , Api.txMintValue
+    , Api.txScriptValidity
     }
 
 genTxInsCollateral :: CardanoEra era -> Gen (TxInsCollateral era)
@@ -534,6 +536,14 @@ genTxBody era = do
   case res of
     Left err -> fail (displayError err)
     Right txBody -> pure txBody
+
+genTxScriptValidity :: CardanoEra era -> Gen (TxScriptValidity era)
+genTxScriptValidity era = case txScriptValiditySupportedInCardanoEra era of
+  Nothing -> pure TxScriptValidityNone
+  Just witness -> TxScriptValidity witness <$> genScriptValidity
+
+genScriptValidity :: Gen ScriptValidity
+genScriptValidity = Gen.element [ScriptInvalid, ScriptValid]
 
 genTx :: forall era. IsCardanoEra era => CardanoEra era -> Gen (Tx era)
 genTx era =

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -240,6 +240,12 @@ module Cardano.Api (
     -- ** Building transactions with automated fees and balancing
     makeTransactionBodyAutoBalance,
     TxBodyErrorAutoBalance(..),
+    TxScriptValidity(..),
+    ScriptValidity(..),
+    TxScriptValiditySupportedInEra(..),
+    scriptValidityToTxScriptValidity,
+    txScriptValiditySupportedInShelleyBasedEra,
+    txScriptValiditySupportedInCardanoEra,
 
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -17,6 +17,8 @@ module Cardano.CLI.Byron.Tx
     --TODO: remove when they are exported from the ledger
   , fromCborTxAux
   , toCborTxAux
+
+  , ScriptValidity(..)
   )
 where
 
@@ -167,6 +169,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             TxCertificatesNone
             TxUpdateProposalNone
             TxMintNone
+            (BuildTxWith TxScriptValidityNone)
     case makeTransactionBody txBodyCont of
       Left err -> error $ "Error occured while creating a Byron genesis based UTxO transaction: " <> show err
       Right txBody -> let bWit = fromByronWitness sk nId txBody
@@ -206,6 +209,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                      TxCertificatesNone
                      TxUpdateProposalNone
                      TxMintNone
+                     (BuildTxWith TxScriptValidityNone)
   case makeTransactionBody txBodyCont of
     Left err -> error $ "Error occured while creating a Byron genesis based UTxO transaction: " <> show err
     Right txBody -> let bWit = fromByronWitness sk nId txBody

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -44,13 +44,13 @@ friendlyTxBody era txbody =
     <>
     case txbody of
       ByronTxBody body -> friendlyTxBodyByron body
-      ShelleyTxBody ShelleyBasedEraShelley body _scripts _ aux ->
+      ShelleyTxBody ShelleyBasedEraShelley body _scripts _ aux _ ->
         addAuxData aux $ friendlyTxBodyShelley body
-      ShelleyTxBody ShelleyBasedEraAllegra body _scripts _ aux ->
+      ShelleyTxBody ShelleyBasedEraAllegra body _scripts _ aux _ ->
         addAuxData aux $ friendlyTxBodyAllegra body
-      ShelleyTxBody ShelleyBasedEraMary body _scripts _ aux ->
+      ShelleyTxBody ShelleyBasedEraMary body _scripts _ aux _ ->
         addAuxData aux $ friendlyTxBodyMary body
-      ShelleyTxBody ShelleyBasedEraAlonzo _ _ _ _ ->
+      ShelleyTxBody ShelleyBasedEraAlonzo _ _ _ _ _ ->
         panic "friendlyTxBody: Alonzo not implemented yet" -- TODO alonzo
 
 addAuxData :: Show a => Maybe a -> Object -> Object

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -162,6 +162,7 @@ renderKeyCmd cmd =
 data TransactionCmd
   = TxBuildRaw
       AnyCardanoEra
+      (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
       [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
@@ -191,6 +192,7 @@ data TransactionCmd
       AnyCardanoEra
       AnyConsensusModeParams
       NetworkId
+      (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
       (Maybe Word)
       -- ^ Override the required number of tx witnesses
       [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -609,11 +609,28 @@ pTransaction =
     Opt.subparser
       $ Opt.command "sign-witness" assembleInfo <> Opt.internal
 
+  pScriptValidity :: Parser ScriptValidity
+  pScriptValidity = asum
+    [ Opt.flag' ScriptValid $ mconcat
+      [ Opt.long "script-valid"
+      , Opt.help "Assertion that the script is valid. (default)"
+      ]
+    , Opt.flag' ScriptInvalid $ mconcat
+      [ Opt.long "script-invalid"
+      , Opt.help $ mconcat
+        [ "Assertion that the script is invalid.  "
+        , "If a transaction is submitted with such a script, "
+        , "the script will fail and the collateral taken"
+        ]
+      ]
+    ]
+
   pTransactionBuild :: Parser TransactionCmd
   pTransactionBuild =
     TxBuild <$> pCardanoEra
             <*> pConsensusModeParams
             <*> pNetworkId
+            <*> optional pScriptValidity
             <*> optional pWitnessOverride
             <*> some (pTxIn AutoBalance)
             <*> many pTxInCollateral
@@ -646,6 +663,7 @@ pTransaction =
   pTransactionBuildRaw :: Parser TransactionCmd
   pTransactionBuildRaw =
     TxBuildRaw <$> pCardanoEra
+               <*> optional pScriptValidity
                <*> some (pTxIn ManualBalance)
                <*> many pTxInCollateral
                <*> many pTxOut

--- a/scripts/plutus/always-fails.sh
+++ b/scripts/plutus/always-fails.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+# Unoffiical bash strict mode.
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -e
+set -o pipefail
+
+export WORK="${WORK:-example/work}"
+export BASE="${BASE:-.}"
+export CARDANO_CLI="${CARDANO_CLI:-cardano-cli}"
+export CARDANO_NODE_SOCKET_PATH="${CARDANO_NODE_SOCKET_PATH:-example/node-bft1/node.sock}"
+export TESTNET_MAGIC="${TESTNET_MAGIC:-42}"
+export UTXO_VKEY="${UTXO_VKEY:-example/shelley/utxo-keys/utxo1.vkey}"
+export UTXO_SKEY="${UTXO_SKEY:-example/shelley/utxo-keys/utxo1.skey}"
+export RESULT_FILE="${RESULT_FILE:-$WORK/result.out}"
+
+echo "Socket path: $CARDANO_NODE_SOCKET_PATH"
+echo "Socket path: $(pwd)"
+
+ls -al "$CARDANO_NODE_SOCKET_PATH"
+
+plutusscriptinuse="$BASE/scripts/plutus/scripts/always-fails.plutus"
+# This datum hash is the hash of the untyped 42
+scriptdatumhash="9e1199a988ba72ffd6e9c269cadb3b53b5f360ff99f112d9b2ee30c4d74ad88b"
+#ExUnits {exUnitsMem = 11300, exUnitsSteps = 45070000}))
+datumfilepath="$BASE/scripts/plutus/data/42.datum"
+redeemerfilepath="$BASE/scripts/plutus/data/42.redeemer"
+echo "Always succeeds Plutus script in use. Any datum and redeemer combination will succeed."
+echo "Script at: $plutusscriptinuse"
+
+# Step 1: Create a tx ouput with a datum hash at the script address. In order for a tx ouput to be locked
+# by a plutus script, it must have a datahash. We also need collateral tx inputs so we split the utxo
+# in order to accomodate this.
+
+plutusscriptaddr=$($CARDANO_CLI address build --payment-script-file "$plutusscriptinuse"  --testnet-magic "$TESTNET_MAGIC")
+
+mkdir -p "$WORK"
+
+utxoaddr=$($CARDANO_CLI address build --testnet-magic "$TESTNET_MAGIC" --payment-verification-key-file "$UTXO_VKEY")
+
+$CARDANO_CLI query utxo --address "$utxoaddr" --cardano-mode --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/utxo-1.json
+cat $WORK/utxo-1.json
+
+txin=$(jq -r 'keys[]' $WORK/utxo-1.json)
+lovelaceattxin=$(jq -r ".[\"$txin\"].value.lovelace" $WORK/utxo-1.json)
+lovelaceattxindiv3=$(expr $lovelaceattxin / 3)
+
+$CARDANO_CLI query protocol-parameters --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/pparams.json
+
+$CARDANO_CLI transaction hash-script-data --script-data-value 42 > $WORK/datum.hash
+
+$CARDANO_CLI transaction build --alonzo-era \
+  --tx-in "$txin" \
+  --tx-out "$plutusscriptaddr+$lovelaceattxindiv3" \
+  --tx-out-datum-hash "$scriptdatumhash" \
+  --change-address "$utxoaddr" \
+  --protocol-params-file "$WORK/pparams.json" \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --out-file $WORK/create-datum-output.body
+
+$CARDANO_CLI transaction sign \
+  --tx-body-file $WORK/create-datum-output.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file $UTXO_SKEY \
+  --out-file $WORK/create-datum-output.tx
+
+# SUBMIT
+$CARDANO_CLI transaction submit --tx-file $WORK/create-datum-output.tx --testnet-magic "$TESTNET_MAGIC"
+echo "Pausing for 5 seconds..."
+sleep 5
+
+# Step 2
+# After "locking" the tx output at the script address, we can now can attempt to spend
+# the "locked" tx output below.
+
+$CARDANO_CLI query utxo --address $plutusscriptaddr --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/plutusutxo.json
+
+plutusutxotxin=$(jq -r 'keys[]' $WORK/plutusutxo.json)
+
+$CARDANO_CLI query utxo --address $utxoaddr --cardano-mode --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/utxo-2.json
+cat $WORK/utxo-2.json
+txinCollateral=$(jq -r 'keys[0]' $WORK/utxo-2.json)
+
+
+dummyaddress=addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4
+
+lovelaceatplutusscriptaddr=$(jq -r ".[\"$plutusutxotxin\"].value.lovelace" $WORK/plutusutxo.json)
+
+echo "Plutus txin"
+echo "$plutusutxotxin"
+
+echo "Collateral"
+echo "$txinCollateral"
+
+$CARDANO_CLI transaction build \
+  --alonzo-era \
+  --cardano-mode \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --change-address "$utxoaddr" \
+  --tx-in "$plutusutxotxin" \
+  --tx-in-collateral "$txinCollateral" \
+  --tx-out "$dummyaddress+100000" \
+  --tx-in-script-file "$plutusscriptinuse" \
+  --tx-in-datum-file "$datumfilepath"  \
+  --protocol-params-file "$WORK/pparams.json" \
+  --tx-in-redeemer-file "$redeemerfilepath" \
+  --script-invalid \
+  --out-file $WORK/test-alonzo.body
+
+$CARDANO_CLI transaction sign \
+  --tx-body-file $WORK/test-alonzo.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file "${UTXO_SKEY}" \
+  --out-file $WORK/alonzo.tx
+
+echo "UTxO for collateral address before submission"
+$CARDANO_CLI query utxo --address "$utxoaddr"  --testnet-magic "$TESTNET_MAGIC"
+
+# SUBMIT $WORK/alonzo.tx
+echo "Submit the tx with plutus script and wait 5 seconds..."
+$CARDANO_CLI transaction submit --tx-file $WORK/alonzo.tx --testnet-magic "$TESTNET_MAGIC"
+
+sleep 5
+
+echo ""
+echo "UTxO for collateral address after submission.  If there is no ADA at the address the collateral was successfully taken!"
+$CARDANO_CLI query utxo --address "$utxoaddr"  --testnet-magic "$TESTNET_MAGIC"
+echo ""
+
+echo ""
+echo "Querying UTxO at $dummyaddress."
+echo ""
+$CARDANO_CLI query utxo --address "$dummyaddress"  --testnet-magic "$TESTNET_MAGIC" \
+  | tee "$RESULT_FILE"


### PR DESCRIPTION
So that transactions containing Plutus scripts that are expected to fail validation can still be submitted.