### PR TITLE
Export TxBodyScriptData from Cardano.Api

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -155,6 +155,7 @@ module Cardano.Api (
     makeTransactionBody,
     TxBodyContent(..),
     TxBodyError(..),
+    TxBodyScriptData(..),
 
     -- ** Transaction Ids
     TxId(..),


### PR DESCRIPTION
For now I need this for a work around for #2936, but it seems useful to export this in any case.