### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -144,7 +144,22 @@ jobs:
       run: git clone https://github.com/input-output-hk/cardano-mainnet-mirror
 
     - name: Run tests
-      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 cabal test all
+      run: |
+        if [ "${{github.event.inputs.tests}}" == "all" ]; then
+          TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 cabal all
+        fi
+
+    - name: "Run tests: cardano-testnet"
+      run: |
+        if [ "${{github.event.inputs.tests}}" != "all" ]; then
+          TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" KEEP_WORKSPACE=1 cabal test \
+            cardano-testnet \
+            cardano-api \
+            cardano-node \
+            cardano-node-chairman \
+            cardano-cli \
+            cardano-submit-api
+        fi
 
     - name: Build & Test
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -127,8 +127,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
-  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
+  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
+  --sha256: 0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq
   subdir:
     base-deriving-via
     binary
@@ -150,8 +150,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 309178369eebe9ce02171987f6d23c7778f7db26
-  --sha256: 1a9cm3ykz9dzfrfv4yk8a2rw5pj4frlwrd6rpp97j5n8rrx34v5k
+  tag: 12a0ef69d64a55e737fbf4e846bd8ed9fb30a956
+  --sha256: 0mx1g18ypdd5m8ijc2cl9m1xmymlqfbwl1r362f92vxrmziacifv
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -210,8 +210,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f06018002f5fd3d68569e194085d35159bebaebb
-  --sha256: 1fnzsls3ml12zzr43fc9bw33f162fis3pi9j4wza4cib6mz5fsak
+  tag: f149c1c1e4e4bb5bab51fa055e9e3a7084ddc30e
+  --sha256: 1szh3xr7qnx56kyxd554yswpddbavb7m7k2mk3dqdn7xbg7s8b8w
   subdir:
     io-sim
     io-classes
@@ -230,8 +230,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 985bd37845cd0996fc38eaccd1db1a9ad3edab3a
-  --sha256: 01rar14075b1privhpyhch1qvv1j7d36nbv1frha864w6pr8zmkx
+  tag: 2c8161ad142f56b14611cc0f66b0a2803016fe37
+  --sha256: 19sj9f4pxfjcqkdxq46kx7qiv0qw4lf670jy8jyzvkmwyjl5agwm
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cabal.project
+++ b/cabal.project
@@ -58,6 +58,9 @@ package cardano-node
 package cardano-node-chairman
   tests: True
 
+package cardano-submit-api
+  tests: True
+
 package cardano-testnet
   tests: True
 

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -2351,7 +2351,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
           (case txProtocolParams of
              BuildTxWith Nothing        -> SNothing
              BuildTxWith (Just pparams) ->
-               Alonzo.hashWitnessPPData
+               Alonzo.hashScriptIntegrity
                  (toLedgerPParams ShelleyBasedEraAlonzo pparams)
                  languages
                  redeemers

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -298,9 +298,9 @@ instance ( ShelleyBasedEra era
 instance ToObject (AlonzoPredFail (Alonzo.AlonzoEra StandardCrypto)) where
   toObject v (WrappedShelleyEraFailure utxoPredFail) =
     toObject v utxoPredFail
-  toObject _ (UnRedeemableScripts scripts) =
-    mkObject [ "kind" .= String "UnRedeemableScripts"
-             , "scripts" .= renderUnredeemableScripts scripts
+  toObject _ (MissingRedeemers scripts) =
+    mkObject [ "kind" .= String "MissingRedeemers"
+             , "scripts" .= renderMissingRedeemers scripts
              ]
   toObject _ (MissingRequiredDatums required received) =
     mkObject [ "kind" .= String "MissingRequiredDatums"
@@ -311,8 +311,8 @@ instance ToObject (AlonzoPredFail (Alonzo.AlonzoEra StandardCrypto)) where
              ]
   toObject _ (PPViewHashesDontMatch ppHashInTxBody ppHashFromPParams) =
     mkObject [ "kind" .= String "PPViewHashesDontMatch"
-             , "fromTxBody" .= renderWitnessPPDataHash (strictMaybeToMaybe ppHashInTxBody)
-             , "fromPParams" .= renderWitnessPPDataHash (strictMaybeToMaybe ppHashFromPParams)
+             , "fromTxBody" .= renderScriptIntegrityHash (strictMaybeToMaybe ppHashInTxBody)
+             , "fromPParams" .= renderScriptIntegrityHash (strictMaybeToMaybe ppHashFromPParams)
              ]
   toObject _ (MissingRequiredSigners missingKeyWitnesses) =
     mkObject [ "kind" .= String "MissingRequiredSigners"
@@ -332,16 +332,16 @@ instance ToObject (AlonzoPredFail (Alonzo.AlonzoEra StandardCrypto)) where
              , "rdmrs" .= map (Api.renderScriptWitnessIndex . Api.fromAlonzoRdmrPtr) rdmrs
              ]
 
-renderWitnessPPDataHash :: Maybe (Alonzo.WitnessPPDataHash StandardCrypto) -> Aeson.Value
-renderWitnessPPDataHash (Just witPPDataHash) =
+renderScriptIntegrityHash :: Maybe (Alonzo.ScriptIntegrityHash StandardCrypto) -> Aeson.Value
+renderScriptIntegrityHash (Just witPPDataHash) =
   Aeson.String . Crypto.hashToTextAsHex $ SafeHash.extractHash witPPDataHash
-renderWitnessPPDataHash Nothing = Aeson.Null
+renderScriptIntegrityHash Nothing = Aeson.Null
 
 renderScriptHash :: ScriptHash StandardCrypto -> Text
 renderScriptHash = Api.serialiseToRawBytesHexText . Api.fromShelleyScriptHash
 
-renderUnredeemableScripts :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto)] -> Aeson.Value
-renderUnredeemableScripts scripts = Aeson.object $ map renderTuple  scripts
+renderMissingRedeemers :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto)] -> Aeson.Value
+renderMissingRedeemers scripts = Aeson.object $ map renderTuple  scripts
  where
   renderTuple :: (Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto) -> Aeson.Pair
   renderTuple (scriptPurpose, sHash) =  renderScriptHash sHash .= renderScriptPurpose scriptPurpose

--- a/plutus-example/cabal.project
+++ b/plutus-example/cabal.project
@@ -25,8 +25,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 8c732560b201b5da8e3bdf175c6eda73a32d64bc
-  --sha256: 0nwy03wyd2ks4qxg47py7lm18karjz6vs7p8knmn3zy72i3n9rfi
+  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
+  --sha256: 0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq
   subdir:
     base-deriving-via
     binary
@@ -48,8 +48,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 30eca73a2f5c13f1fbed9a98a59540ac3d0c8afe
-  --sha256: 02klj4zpcl98p22n2v9nkjxxdf8mmw069mw4ddhlgr931bfigz6w
+  tag: 12a0ef69d64a55e737fbf4e846bd8ed9fb30a956
+  --sha256: 0mx1g18ypdd5m8ijc2cl9m1xmymlqfbwl1r362f92vxrmziacifv
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -106,8 +106,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e9cda57df7ea6969edbc3bfc4e117668277d09c8
-  --sha256: 1a91z6yvlhzlqrf7fy51fmmpm3ssk684h6pjgg022cdlsq56yif2
+  tag: f149c1c1e4e4bb5bab51fa055e9e3a7084ddc30e
+  --sha256: 1szh3xr7qnx56kyxd554yswpddbavb7m7k2mk3dqdn7xbg7s8b8w
   subdir:
     io-sim
     io-classes
@@ -126,8 +126,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 826c2514a40e962c2e4d56ce912803a434cc28fe
-  --sha256: 04jryrgi2wggkf4a994smbcp8j39clshbzfnvfvvk7lq0sm8kssz
+  tag: 2c8161ad142f56b14611cc0f66b0a2803016fe37
+  --sha256: 19sj9f4pxfjcqkdxq46kx7qiv0qw4lf670jy8jyzvkmwyjl5agwm
   subdir:
     plutus-core
     plutus-ledger


### PR DESCRIPTION
Upgrade dependencies including:

* cardano-base
* cardano-ledger-specs
* ouroboros-network

This involved a few renamed variables.

This is the same as https://github.com/input-output-hk/cardano-node/pull/3075 except with an additional fix:

* Delaying the start time for the testnet Shelley chairman tests on Windows (due to longer setup times on that platform)
* Enable testing of `submit-api` in CI
