### PR TITLE
Use renamed version of optparse applicative fork

### DIFF
--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -34,6 +34,6 @@ executable cardano-topology
                       , bytestring
                       , containers
                       , graphviz
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , split
                       , text

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -52,7 +52,7 @@ library
                      , gnuplot
                      , Histogram
                      , iohk-monitoring
-                     , optparse-applicative
+                     , optparse-applicative-fork
                      , optparse-generic
                      , ouroboros-network
                      , process
@@ -94,7 +94,7 @@ executable locli
   build-depends:       base
                      , cardano-prelude
                      , locli
-                     , optparse-applicative
+                     , optparse-applicative-fork
                      , text
                      , text-short
                      , transformers

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -86,7 +86,7 @@ library
                      , ixset-typed
                      , network
                      , network-mux
-                     , optparse-applicative
+                     , optparse-applicative-fork
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
@@ -139,7 +139,7 @@ test-suite tx-generator-test
   build-depends:        base >=4.12 && <5
                       , hedgehog
                       , heredoc
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , tasty
                       , tasty-hedgehog
                       , tasty-hunit

--- a/cabal.project
+++ b/cabal.project
@@ -115,15 +115,8 @@ package cardano-ledger-alonzo-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/optparse-applicative
-  tag: 3876479d01d681ee529d1b26784335cbe0baf7cd
-  --sha256: 00gavws6jvl930rq09gs5rdwmyc4n42avk7p9s7pjv52d205v967
-
--- Using a fork until our patches can be merged upstream
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/criterion
-  tag: fb2e7be532db96255d203f86360230cae37130f3
-  --sha256: 14r9zkfa8zslky3969gaq27gi7yi9rlqv0h1iq7zam9l15z53vhr
+  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
+  --sha256: 1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r
 
 source-repository-package
   type: git

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -125,7 +125,7 @@ library
                       , formatting
                       , iproute
                       , network
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , ouroboros-consensus
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano
@@ -158,7 +158,7 @@ executable cardano-cli
   build-depends:        cardano-cli
                       , cardano-crypto-class
                       , cardano-prelude
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , transformers-except
 
 test-suite cardano-cli-test

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -35,7 +35,9 @@ customRenderHelp cols
   . helpText
   where
     renderElement = if cliHelpTraceEnabled
-      then \(AnnTrace _ name) x -> "<span name=" <> show name <> ">" <> x <> "</span>"
+      then \ann x -> case ann of
+        AnnTrace _ name -> "<span name=" <> show name <> ">" <> x <> "</span>"
+        AnnStyle _ -> x
       else flip const
     wrapper = if cliHelpTraceEnabled
       then id

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -48,7 +48,7 @@ executable cardano-node-chairman
                       , contra-tracer
                       , io-classes
                       , network-mux
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , ouroboros-consensus
                       , ouroboros-network
                       , ouroboros-network-framework

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -129,7 +129,7 @@ library
                       , network
                       , network-mux
                       , nothunks
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , ouroboros-consensus
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano
@@ -167,7 +167,7 @@ executable cardano-node
   build-depends:        cardano-config
                       , cardano-node
                       , cardano-prelude
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , text
 
 test-suite cardano-node-test

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -31,7 +31,7 @@ common http-media                   { build-depends: http-media                 
 common iohk-monitoring              { build-depends: iohk-monitoring                  >= 0.1.10.1                 }
 common mtl                          { build-depends: mtl                              >= 2.2.2                    }
 common network                      { build-depends: network                          >= 3.1.2.1                  }
-common optparse-applicative         { build-depends: optparse-applicative             >= 0.16.1.0                 }
+common optparse-applicative-fork    { build-depends: optparse-applicative-fork        >= 0.16.1.0                 }
 common ouroboros-consensus-cardano  { build-depends: ouroboros-consensus-cardano      >= 0.1.0.0                  }
 common ouroboros-network            { build-depends: ouroboros-network                >= 0.1.0.0                  }
 common prometheus                   { build-depends: prometheus                       >= 2.2.2                    }
@@ -78,7 +78,7 @@ library
                       , iohk-monitoring
                       , mtl
                       , network
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , ouroboros-consensus-cardano
                       , ouroboros-network
                       , prometheus
@@ -111,7 +111,7 @@ library
 executable cardano-submit-api
   import:               base, project-config
                       , cardano-submit-api
-                      , optparse-applicative
+                      , optparse-applicative-fork
   main-is:              Main.hs
   hs-source-dirs:       app
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T -I0"

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -74,7 +74,7 @@ executable cardano-testnet
                       , cardano-testnet
                       , hedgehog
                       , hedgehog-extras
-                      , optparse-applicative
+                      , optparse-applicative-fork
                       , resourcet
                       , stm
                       , text


### PR DESCRIPTION
The rename is necessary because the fork includes some breaking changes unrelated to the fork that causes the latest released version of `criterion` to not build.