### PR TITLE
nix: Fix a component option typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,8 @@ dist/
 *.swp
 .dir-locals.el
 .Rhistory
-result*
+/result*
 /launch-*
-stack.yaml.lock
 
 /.cache
 /db

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -167,7 +167,7 @@ let
         enableLibraryProfiling = true;
         packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;
         packages.tx-generator.components.exes.tx-generator.enableExecutableProfiling = true;
-        packages.locli.components.exes.locli.enableExecutableProfilig = true;
+        packages.locli.components.exes.locli.enableExecutableProfiling = true;
       })
       {
         packages = lib.genAttrs assertedPackages


### PR DESCRIPTION
- Fix a nix evaluation error
- Make the `result` symlinks only be ignored at the repo top-level.
