### PR TITLE
Bump cardano-ledger-specs.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5b184a820853c7ba202efd615b8fadca1acb52c
-  --sha256: 04k5p6qwmfdza65gl5319r1ahdfwjnyqgzpfxdx0x2g5jcbimar4
+  tag: 6aa1cd0a64a464371b94d4ac182e7e2cddc83a36
+  --sha256: 1yv2biqc2q01xn7i7h7d1yn8dzygnqn8mywpjfs1i0pa7gnf5q14
   subdir:
     alonzo/impl
     byron/chain/executable-spec

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -54,6 +54,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo
 import           Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail (..))
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
 import qualified Cardano.Ledger.AuxiliaryData as Core
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.Core as Core
@@ -990,6 +991,36 @@ instance ToJSON (Alonzo.CollectError StandardCrypto) where
           , "error" .= String "NoCostModel"
           , "language" .= toJSON lang
           ]
+
+instance ToJSON Alonzo.TagMismatchDescription where
+  toJSON tmd = case tmd of
+    Alonzo.PassedUnexpectedly ->
+      object
+        [ "kind" .= String "TagMismatchDescription"
+        , "error" .= String "PassedUnexpectedly"
+        ]
+    Alonzo.FailedUnexpectedly forReasons ->
+      object
+        [ "kind" .= String "TagMismatchDescription"
+        , "error" .= String "FailedUnexpectedly"
+        , "reconstruction" .= forReasons
+        ]
+
+instance ToJSON Alonzo.FailureDescription where
+  toJSON f = case f of
+    Alonzo.OnePhaseFailure t ->
+      object
+        [ "kind" .= String "FailureDescription"
+        , "error" .= String "OnePhaseFailure"
+        , "description" .= t
+        ]
+    Alonzo.PlutusFailure t bs ->
+      object
+        [ "kind" .= String "FailureDescription"
+        , "error" .= String "PlutusFailure"
+        , "description" .= t
+        , "reconstructionDetail" .= bs
+        ]
 
 instance ToObject (AlonzoBbodyPredFail (Alonzo.AlonzoEra StandardCrypto)) where
   toObject _ err = mkObject [ "kind" .= String "AlonzoBbodyPredFail"


### PR DESCRIPTION
This commit incorporates the following updates:
- Additional failure information for failed Plutus scripts, sufficient
  to allow local replication of the error.
- A (partial) reversion of a bugfix, which it turns out has occurred on
  the testnet and so must be accounted for.