### PR TITLE
Docker: add cardano-submit-api

### DIFF
--- a/nix/docker/context/bin/entrypoint
+++ b/nix/docker/context/bin/entrypoint
@@ -12,9 +12,13 @@ elif [[ $1 == "cli" ]]; then
 
   exec /usr/local/bin/run-client $@
 
+elif [[ $1 == "submit-api" ]]; then
+
+  exec /usr/local/bin/run-submit-api $@
+
 else
 
-  echo "Nothing to do! Perhaps try [run|cli], or set NETWORK environment variable."
+  echo "Nothing to do! Perhaps try [run|cli|submit-api], or set NETWORK environment variable."
   exit 1
 
 fi

--- a/nix/docker/context/bin/run-submit-api
+++ b/nix/docker/context/bin/run-submit-api
@@ -1,0 +1,6 @@
+#!/bin/env bash
+
+# Shift the first option by one index
+shift
+
+/usr/local/bin/cardano-submit-api $@

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -31,6 +31,7 @@
 # The main contents of the image.
 , cardano-cli
 , cardano-node
+, cardano-submit-api
 , scripts
 
 # Set gitrev to null, to ensure the version below is used
@@ -62,17 +63,18 @@ let
   baseImage = dockerTools.buildImage {
     name = "${repoName}-env";
     contents = [
-      cardano-cli       # Provide cardano-cli capability
-      bashInteractive   # Provide the BASH shell
-      cacert            # X.509 certificates of public CA's
-      coreutils         # Basic utilities expected in GNU OS's
-      curl              # CLI tool for transferring files via URLs
-      glibcLocales      # Locale information for the GNU C Library
-      iana-etc          # IANA protocol and port number assignments
-      iproute           # Utilities for controlling TCP/IP networking
-      iputils           # Useful utilities for Linux networking
-      socat             # Utility for bidirectional data transfer
-      utillinux         # System utilities for Linux
+      cardano-cli        # Provide cardano-cli capability
+      cardano-submit-api # Provide cardano-submit-api support
+      bashInteractive    # Provide the BASH shell
+      cacert             # X.509 certificates of public CA's
+      coreutils          # Basic utilities expected in GNU OS's
+      curl               # CLI tool for transferring files via URLs
+      glibcLocales       # Locale information for the GNU C Library
+      iana-etc           # IANA protocol and port number assignments
+      iproute            # Utilities for controlling TCP/IP networking
+      iputils            # Useful utilities for Linux networking
+      socat              # Utility for bidirectional data transfer
+      utillinux          # System utilities for Linux
     ];
     # set up /tmp (override with TMPDIR variable)
     extraCommands = ''
@@ -132,6 +134,7 @@ in
       cp ${context}/bin/* usr/local/bin
       ln -s ${cardano-node}/bin/cardano-node usr/local/bin/cardano-node
       ln -s ${cardano-cli}/bin/cardano-cli usr/local/bin/cardano-cli
+      ln -s ${cardano-submit-api}/bin/cardano-submit-api usr/local/bin/cardano-submit-api
     '';
     config = {
       EntryPoint = [ "entrypoint" ];


### PR DESCRIPTION
The current `cardano-submit-api` docker images are built from the old `cardano-rest` repository, not from `cardano-node/cardano-submit-api`. The code is out-of-date even though the version matches the cabal project versions in this repository.

This PR adds the `cardano-submit-api` binary to the node image. Currently there is no available dedicated `cardano-submit-api` image that would support alonzo.

Example usage in docker-compose (with hardcoded alonzo-purple testnet):
```
version: "3.5"

services:
  cardano-node:
    image: inputoutput/cardano-node:dev
    volumes:
      - node-alonzo-db:/data
      - node-ipc:/ipc
      - ./node-config:/configs
    ports:
      - 3001:3001
    restart: on-failure
    command: "run --port 3001 --config /configs/alonzo-purple-config.json --database-path /data/db --topology /configs/alonzo-purple-topology.json --socket-path /ipc/node.socket --host-addr 0.0.0.0"
    logging:
      driver: "json-file"
      options:
        compress: "true"
        max-file: "10"
        max-size: "50m"

  cardano-submit-api:
    image: inputoutput/cardano-node:dev
    volumes:
      - node-alonzo-db:/data
      - node-ipc:/ipc
      - ./node-config:/configs
    depends_on: 
      - cardano-node
    ports:
      - 8090:8090
    restart: on-failure
    command: "submit-api --config /configs/submit-api-config.yaml --socket-path /ipc/node.socket --listen-address 0.0.0.0 --port 8090 --testnet-magic 8"
    logging:
      driver: "json-file"
      options:
        compress: "true"
        max-file: "10"
        max-size: "50m"

volumes:
  node-alonzo-db:
  node-ipc:
  node-config:
```

Where node-config contains the `alonzo-purple-*` configs from: https://hydra.iohk.io/build/7366583/download/1/index.html
And the `submit-api-config.yaml` matching `cardano-node/cardano-submit-api/config/tx-submit-mainnet-config.yaml`

I've tested the built image with the build steps from the docker [README](https://github.com/input-output-hk/cardano-node/blob/master/nix/docker/README.md)