### PR TITLE
Enabled `getBlockHeader` for Alonzo Era

### DIFF
--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -249,7 +249,7 @@ getBlockHeader (ShelleyBlock shelleyEra block) = case shelleyEra of
   ShelleyBasedEraShelley -> go
   ShelleyBasedEraAllegra -> go
   ShelleyBasedEraMary -> go
-  ShelleyBasedEraAlonzo -> error "getBlockHeader: Alonzo era not implemented yet"
+  ShelleyBasedEraAlonzo -> go
   where
     go :: Consensus.ShelleyBasedEra (ShelleyLedgerEra era) => BlockHeader
     go = BlockHeader headerFieldSlot (HeaderHash hashSBS) headerFieldBlockNo


### PR DESCRIPTION
This simple fix appears to resolve https://github.com/input-output-hk/cardano-node/issues/3139. I've tested it as follows:
1. `scan-blocks` executable running on `testnet`
2. The `watch-coin` and `watch-address` modes of my chain-walking CLI https://github.com/functionally/mantis.
3. My token-blending application, which also walks the chain to watch coins and addresses: https://github.com/functionally/pigy-genetics

I haven't run any other test suites.