### PR TITLE
Update min utxo calculation cli command

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -232,6 +232,10 @@ module Cardano.Api (
     evaluateTransactionFee,
     estimateTransactionKeyWitnessCount,
 
+    -- ** Minimum required UTxO calculation
+    calculateMinimumUTxO,
+    MinimumUTxOError,
+
     -- ** Script execution units
     evaluateTransactionExecutionUnits,
     ScriptExecutionError(..),

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -91,6 +91,8 @@ module Cardano.Api.Shelley
 
     -- * Protocol parameters
     ProtocolParameters(..),
+    checkProtocolParameters,
+    ProtocolParametersError(..),
 
     -- * Scripts
     toShelleyScript,

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -237,9 +237,10 @@ data TransactionCmd
       TxOutCount
       TxShelleyWitnessCount
       TxByronWitnessCount
-  | TxCalculateMinValue
+  | TxCalculateMinRequiredUTxO
+      AnyCardanoEra
       ProtocolParamsSourceSpec
-      Value
+      TxOutAnyEra
   | TxHashScriptData
       ScriptDataOrFile
   | TxGetTxId InputTxFile
@@ -271,7 +272,7 @@ renderTransactionCmd cmd =
     TxSubmit {} -> "transaction submit"
     TxMintedPolicyId {} -> "transaction policyid"
     TxCalculateMinFee {} -> "transaction calculate-min-fee"
-    TxCalculateMinValue {} -> "transaction calculate-min-value"
+    TxCalculateMinRequiredUTxO {} -> "transaction calculate-min-value"
     TxHashScriptData {} -> "transaction hash-script-data"
     TxGetTxId {} -> "transaction txid"
     TxView {} -> "transaction view"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -13,26 +13,24 @@ module Cardano.CLI.Shelley.Run.Address
 
 import           Cardano.Prelude hiding (putStrLn)
 
-import           System.Console.ANSI
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import qualified System.Console.ANSI as ANSI
-import qualified System.IO as IO
 
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Helpers
 import           Cardano.CLI.Shelley.Key (InputDecodeError, PaymentVerifier (..),
                    StakeVerifier (..), VerificationKeyTextOrFile,
                    VerificationKeyTextOrFileError (..), readVerificationKeyOrFile,
                    readVerificationKeyTextOrFileAnyOf, renderVerificationKeyTextOrFileError)
-import           Cardano.CLI.Shelley.Script
 import           Cardano.CLI.Shelley.Parsers (AddressCmd (..), AddressKeyType (..), OutputFile (..))
 import           Cardano.CLI.Shelley.Run.Address.Info (ShelleyAddressInfoError, runAddressInfo)
+import           Cardano.CLI.Shelley.Script
 import           Cardano.CLI.Types
 
 data ShelleyAddressCmdError
@@ -232,11 +230,6 @@ runAddressBuildScript
   -> Maybe OutputFile
   -> ExceptT ShelleyAddressCmdError IO ()
 runAddressBuildScript scriptFile networkId mOutputFile = do
-  liftIO deprecationWarning
+  liftIO $ deprecationWarning "'address build'"
   runAddressBuild (PaymentVerifierScriptFile scriptFile) Nothing networkId mOutputFile
 
-deprecationWarning :: IO ()
-deprecationWarning = do
-  ANSI.hSetSGR IO.stderr [SetColor Foreground Vivid Yellow]
-  IO.hPutStrLn IO.stderr "WARNING: This CLI command is deprecated.  Please use 'address build' command instead."
-  ANSI.hSetSGR IO.stderr [Reset]


### PR DESCRIPTION
Resolves #3165 

Breaking change: `calculate-min-req-utxo` requires a transaction output (`TxOut era`) instead of a `Value` because to calculate the min required UTxO in the Alonzo era we require a transaction output. It also requires the specification of the era.