### PR TITLE
Remove duplicate scripts when building Alonzo transaction body

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -144,7 +144,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Foldable (toList)
 import           Data.Function (on)
-import           Data.List (intercalate, sortBy)
+import           Data.List (intercalate, nub, sortBy)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -2365,7 +2365,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
     witnesses = collectTxBodyScriptWitnesses txbodycontent
 
     scripts :: [Ledger.Script StandardAlonzo]
-    scripts =
+    scripts = nub
       [ toShelleyScript (scriptWitnessScript scriptwitness)
       | (_, AnyScriptWitness scriptwitness) <- witnesses
       ]


### PR DESCRIPTION
Without this, multiple of the same script can be included in a transaction.