### PR TITLE
trace-forward: flexible buffering mechanism.

### DIFF
--- a/trace-forward/src/Trace/Forward/Configuration.hs
+++ b/trace-forward/src/Trace/Forward/Configuration.hs
@@ -32,9 +32,19 @@ data AcceptorConfiguration lo = AcceptorConfiguration
 -- | Forwarder configuration, parameterized by trace item's type.
 data ForwarderConfiguration lo = ForwarderConfiguration
   { -- | The tracer that will be used by the forwarder in its network layer.
-    forwarderTracer  :: !(Tracer IO (TraceSendRecv (TraceForward lo)))
+    forwarderTracer :: !(Tracer IO (TraceSendRecv (TraceForward lo)))
     -- | The endpoint that will be used to connect to the acceptor.
   , acceptorEndpoint :: !HowToConnect
     -- | An action that returns node's information.
-  , getNodeInfo      :: !(IO NodeInfo)
+  , getNodeInfo :: !(IO NodeInfo)
+    -- | The big size of internal queue for tracing items. We use it in
+    --   the beginning of the session, to avoid queue overflow, because
+    --   initially there is no connection with acceptor yet, and the
+    --   number of tracing items after node's start may be very big.
+  , disconnectedQueueSize :: !Word
+    -- | The small size of internal queue for tracing items. We use it
+    --   after the big queue is empty, which means that acceptor is connected
+    --   and tracing items are already forwarded to it. We switch to small
+    --   queue to reduce memory usage in the node.
+  , connectedQueueSize :: !Word
   }

--- a/trace-forward/src/Trace/Forward/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Forwarder.hs
@@ -8,21 +8,20 @@ module Trace.Forward.Forwarder
   ) where
 
 import qualified Codec.Serialise as CBOR
-import           Control.Concurrent.STM.TBQueue (TBQueue)
 
 import           Ouroboros.Network.IOManager (IOManager)
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy(..))
 
 import           Trace.Forward.Configuration (ForwarderConfiguration (..))
 import           Trace.Forward.Network.Forwarder (connectToAcceptor)
-import           Trace.Forward.Utils (runActionInLoop)
+import           Trace.Forward.Utils
 
 runTraceForwarder
   :: (CBOR.Serialise lo,
       ShowProxy lo)
   => IOManager                 -- ^ 'IOManager' from the external application.
   -> ForwarderConfiguration lo -- ^ Forwarder configuration.
-  -> TBQueue lo                -- ^ The queue from which the forwarder will take 'TraceObject's.
+  -> ForwardSink lo            -- ^ Forward "sink" that will be used to write tracing items.
   -> IO ()
-runTraceForwarder iomgr config@ForwarderConfiguration{acceptorEndpoint} loQueue =
-  runActionInLoop (connectToAcceptor iomgr config loQueue) acceptorEndpoint 1
+runTraceForwarder iomgr config@ForwarderConfiguration{acceptorEndpoint} forwardSink =
+  runActionInLoop (connectToAcceptor iomgr config forwardSink) acceptorEndpoint 1

--- a/trace-forward/src/Trace/Forward/Queue.hs
+++ b/trace-forward/src/Trace/Forward/Queue.hs
@@ -8,46 +8,52 @@ module Trace.Forward.Queue
   ) where
 
 import           Control.Concurrent.STM (STM, atomically, retry)
-import           Control.Concurrent.STM.TBQueue (TBQueue, tryReadTBQueue)
+import           Control.Concurrent.STM.TBQueue
+import           Control.Concurrent.STM.TVar
+import           Control.Monad (unless)
 import qualified Data.List.NonEmpty as NE
 import           Data.Word (Word16)
 
 import           Trace.Forward.Configuration (ForwarderConfiguration (..))
 import qualified Trace.Forward.Protocol.Forwarder as Forwarder
 import           Trace.Forward.Protocol.Type
+import           Trace.Forward.Utils
 
 readItems
   :: ForwarderConfiguration lo -- ^ The forwarder configuration.
-  -> TBQueue lo                -- ^ The queue we will read 'TraceObject's from.
+  -> ForwardSink lo            -- ^ The sink contains the queue we read 'TraceObject's from.
   -> Forwarder.TraceForwarder lo IO ()
-readItems config@ForwarderConfiguration{getNodeInfo} loQueue =
+readItems config@ForwarderConfiguration{getNodeInfo} sink@ForwardSink{forwardQueue, wasUsed} =
   Forwarder.TraceForwarder
     { Forwarder.recvMsgNodeInfoRequest = do
         reply <- getNodeInfo
-        return (reply, readItems config loQueue)
+        return (reply, readItems config sink)
     , Forwarder.recvMsgTraceObjectsRequest = \blocking (NumberOfTraceObjects n) -> do
         replyList <-
           case blocking of
             TokBlocking -> do
-              objs <- atomically $ getNTraceObjects n loQueue >>= \case
+              objs <- atomically $ getNTraceObjects n forwardQueue >>= \case
                 []     -> retry -- No 'TraceObject's yet, just wait...
                 (x:xs) -> return $ x NE.:| xs
+              atomically . modifyTVar' wasUsed . const $ True
               return $ BlockingReply objs
             TokNonBlocking -> do
-              objs <- atomically $ getNTraceObjects n loQueue
+              objs <- atomically $ getNTraceObjects n forwardQueue
+              unless (null objs) $
+                atomically . modifyTVar' wasUsed . const $ True
               return $ NonBlockingReply objs
-        return (replyList, readItems config loQueue)
+        return (replyList, readItems config sink)
     , Forwarder.recvMsgDone = return ()
     }
 
 -- | Returns at most N 'TraceObject's from the queue.
 getNTraceObjects
   :: Word16
-  -> TBQueue lo
+  -> TVar (TBQueue lo)
   -> STM [lo]
 getNTraceObjects 0 _ = return []
 getNTraceObjects n q =
-  tryReadTBQueue q >>= \case
+  readTVar q >>= tryReadTBQueue >>= \case
     Just lo' -> (lo' :) <$> getNTraceObjects (n - 1) q
     Nothing  -> return []
 

--- a/trace-forward/src/Trace/Forward/Utils.hs
+++ b/trace-forward/src/Trace/Forward/Utils.hs
@@ -1,14 +1,23 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Trace.Forward.Utils
-  ( runActionInLoop
+  ( ForwardSink (..)
+  , initForwardSink
+  , writeToSink
+  , runActionInLoop
   ) where
 
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TBQueue
+import           Control.Concurrent.STM.TVar
 import           Control.Exception (SomeAsyncException (..), fromException, tryJust)
+import           Control.Monad.Extra (whenM)
 import           Control.Tracer (showTracing, stdoutTracer, traceWith)
+import           System.IO
 import           System.Time.Extra (sleep)
 
-import           Trace.Forward.Configuration (HowToConnect)
+import           Trace.Forward.Configuration
 
 -- | Run monadic action in a loop. If there's an exception, it will re-run
 --   the action again, after pause that grows.
@@ -36,3 +45,65 @@ runActionInLoop action endpoint prevDelay =
     if prevDelay < 60
       then prevDelay * 2
       else 60 -- After we reached 60+ secs delay, repeat an attempt every minute.
+
+data ForwardSink lo = ForwardSink
+  { forwardQueue     :: !(TVar (TBQueue lo))
+  , disconnectedSize :: !Word
+  , connectedSize    :: !Word
+  , wasUsed          :: !(TVar Bool)
+  }
+
+initForwardSink
+  :: ForwarderConfiguration lo
+  -> IO (ForwardSink lo)
+initForwardSink ForwarderConfiguration{disconnectedQueueSize, connectedQueueSize} = do
+  -- Initially we always create a big queue, because during node's start
+  -- the number of tracing items may be very big.
+  (queue, used) <-
+    atomically $ (,) <$> (newTVar =<< newTBQueue (fromIntegral disconnectedQueueSize))
+                     <*> newTVar False
+  return $ ForwardSink
+    { forwardQueue     = queue
+    , disconnectedSize = disconnectedQueueSize
+    , connectedSize    = connectedQueueSize
+    , wasUsed          = used
+    }
+
+-- | There are 4 possible cases when we try to write tracing item:
+--   1. The queue is __still__ empty (no tracing items were writen in it).
+--   2. The queue is __already__ empty (all previously written items were taken from it).
+--   3. The queue is full. In this case flush all tracing items to stdout and continue.
+--   4. The queue isn't empty and isn't full. Just continue writing.
+writeToSink
+  :: Show lo
+  => ForwardSink lo
+  -> lo
+  -> IO ()
+writeToSink ForwardSink{forwardQueue, disconnectedSize, connectedSize, wasUsed} traceObject = do
+  q <- readTVarIO forwardQueue
+  atomically ((,) <$> isFullTBQueue q
+                  <*> isEmptyTBQueue q) >>= \case
+    (True, _)    -> maybeFlushQueueToStdout q
+    (_,    True) -> checkIfSinkWasUsed q
+    (_,    _)    -> return ()
+  atomically $ readTVar forwardQueue >>= flip writeTBQueue traceObject
+ where
+  -- The queue is full, but if it's a small queue, we can switch it
+  -- to a big one and give a chance not to flush items to stdout yet.
+  maybeFlushQueueToStdout q = do
+    qLen <- atomically $ lengthTBQueue q
+    if fromIntegral qLen == connectedSize
+      then atomically $ switchQueue disconnectedSize
+      else atomically (flushTBQueue q) >>= mapM_ print >> hFlush stdout
+
+  checkIfSinkWasUsed q = atomically $
+    whenM (readTVar wasUsed) $ switchToAnotherQueue q
+
+  switchToAnotherQueue q = do
+    qLen <- lengthTBQueue q
+    if fromIntegral qLen == disconnectedSize
+      then switchQueue connectedSize
+      else switchQueue disconnectedSize
+
+  switchQueue size =
+    newTBQueue (fromIntegral size) >>= modifyTVar' forwardQueue . const

--- a/trace-forward/test/Test/Trace/Forward/Demo/Configs.hs
+++ b/trace-forward/test/Test/Trace/Forward/Demo/Configs.hs
@@ -15,19 +15,25 @@ mkAcceptorConfig
   :: HowToConnect
   -> TVar Bool
   -> AcceptorConfiguration TraceItem
-mkAcceptorConfig ep weAreDone = AcceptorConfiguration
-  { acceptorTracer    = nullTracer
-  , forwarderEndpoint = ep
-  , whatToRequest     = NumberOfTraceObjects 10
-  , shouldWeStop      = weAreDone
-  }
+mkAcceptorConfig ep weAreDone =
+  AcceptorConfiguration
+    { acceptorTracer    = nullTracer
+    , forwarderEndpoint = ep
+    , whatToRequest     = NumberOfTraceObjects 10
+    , shouldWeStop      = weAreDone
+    }
 
 mkForwarderConfig
   :: HowToConnect
   -> IO NodeInfo
+  -> Word
+  -> Word
   -> ForwarderConfiguration TraceItem
-mkForwarderConfig ep getNI = ForwarderConfiguration
-  { forwarderTracer  = nullTracer
-  , acceptorEndpoint = ep
-  , getNodeInfo      = getNI
-  }
+mkForwarderConfig ep getNI disconnectedSize connectedSize =
+  ForwarderConfiguration
+    { forwarderTracer       = nullTracer
+    , acceptorEndpoint      = ep
+    , getNodeInfo           = getNI
+    , disconnectedQueueSize = disconnectedSize
+    , connectedQueueSize    = connectedSize
+    }

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -35,6 +35,7 @@ library
                        Trace.Forward.Configuration
                        Trace.Forward.Forwarder
                        Trace.Forward.Queue
+                       Trace.Forward.Utils
 
                        Trace.Forward.Network.Acceptor
                        Trace.Forward.Network.Forwarder
@@ -44,15 +45,12 @@ library
                        Trace.Forward.Protocol.Forwarder
                        Trace.Forward.Protocol.Type
 
-  other-modules:       Trace.Forward.Utils
-
   build-depends:         async
                        , bytestring
                        , cborg
                        , contra-tracer
                        , extra
                        , io-classes
-                       , network
                        , ouroboros-network-framework
                        , serialise
                        , stm
@@ -81,7 +79,6 @@ test-suite test
                        , trace-forward
                        , QuickCheck
                        , serialise
-                       , stm
                        , tasty
                        , tasty-quickcheck
                        , typed-protocols


### PR DESCRIPTION
This updates the `trace-forward` / `trace-dispatcher` integration:

1. improve the abstraction between the two components
2. we introduce an adaptive buffering mechanism, which:
    - provides sufficient buffering in situations when we don't have a connection to `cardano-tracer` (either initially, or after connection loss)
    - reverts to a smaller buffer (short queue) when the connection is established -- to improve resource efficiency