### PR TITLE
Workbench: `nix-shell -A devops` fixes

### DIFF
--- a/nix/workbench/profiles/adhoc.jq
+++ b/nix/workbench/profiles/adhoc.jq
@@ -25,10 +25,21 @@ def adhoc_profiles:
     , utxo:                  0
     }
   }
-, { name: "default"
+, { name: "default" }
+
+, { name: "devops"
   , genesis:
-    { verbatim:
-      { initialFunds:
+    { slot_duration:         0.2
+    , parameter_k:           10
+    , epoch_length:          1000
+    , active_slots_coeff:    0.1
+    , genesis_future_offset: "10 seconds"
+    , utxo:                  0
+
+    ## For the rare options that don't serve
+    , verbatim:
+      { updateQuorum: 1
+      , initialFunds:
         # genesis-utxo (used for pool owner funds and paying fees for startup scripts)
         { "608634fc2a05c3d7f8dca90321dae19a2172ab3ff146512660721fa15b": 1000000000000000
         # flee three produce crush token where quantum vessel seek include dance reject urge awesome lonely
@@ -38,13 +49,7 @@ def adhoc_profiles:
         , "00b84e9b8980d61ade5167f3e697641acae5e6eec546fcdbc5c03149a02595d4202003415534e919acb2c07132a588827fb8e6b968861b1e5d807b756fe72d6e28": 100000000000000
         , "000b04a2d5dc696f845a7bbe7ead094ac12e8dbbf82eedeabe9cb2fe8c07f1624c2003415534e919acb2c07132a588827fb8e6b968861b1e5d807b756fe72d6e28": 100000000000000
         }
-      , activeSlotsCoeff: 0.1
-      , epochLength: 1000
-      , slotLength: 0.2
-      , securityParam: 10
       }
-      , genesis_future_offset: "10 seconds"
-      , utxo:                  0
     }
   }
 ];

--- a/shell.nix
+++ b/shell.nix
@@ -57,10 +57,9 @@ let
   #  you have to remove all `source-repository-package` entries from cabal.project
   #  after entering nix-shell for cabal to use nix provided dependencies for them.
   mkCluster =
-    { useCabalRun }:
+    { useCabalRun, profileName ? localCluster.profileName }:
     callPackage ./nix/supervisord-cluster
-      { inherit useCabalRun;
-        inherit (localCluster) profileName;
+      { inherit profileName useCabalRun;
         workbench = pkgs.callPackage ./nix/workbench { inherit useCabalRun; };
       };
 
@@ -156,7 +155,7 @@ let
   };
 
   devops =
-    let cluster = mkCluster { useCabalRun = false; };
+    let cluster = mkCluster { useCabalRun = false; profileName = "devops-alzo"; };
     in cardanoNodeProject.shellFor {
     name = "devops-shell";
 


### PR DESCRIPTION
@disassembler has indicated that the workbench changes have broken the devops workflow inside `nix-shell -A devops`.

This, therefore:

- fixes the node PID handling
- introduces the `devops-*` profiles that now explicitly target the devops workflows