### PR TITLE
draft PR for benchmarking 1.30.0-rc3 without the stake distribution calculation pulser

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ab138130d979d273f31a7a383c9ab81906e0727c
-  --sha256: 1pqdm1v6sjf19z3cy4jsyj81wizwafa1lprafnwn5plqd9qimz55
+  tag: be820bd7606e529ccc054803e1408fc71b03d2b4
+  --sha256: 1f7pfds5smg7mcr713gvfprgn69bmvgxsrjyy1hfhr0gr0hckhvx
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -215,8 +215,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e74388a28e8775ed2e85067f0413792071686714
-  --sha256: 1msp9abhnp7pxhj79bfa61ps0g5ram9r7knv3nw6v8gla404zl3r
+  tag: ddfbea14eca45d5ee9efc64c6c9903e82b0eaf4c
+  --sha256: 0zbjzxpd7drx3hzlijr5whq2jibls2hkdspb6d3ccgfxi9jd10pp
   subdir:
     io-sim
     io-classes

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -243,11 +243,7 @@ instance ToJSON Shelley.Likelihood where
   toJSON (Shelley.Likelihood llhd) =
     toJSON $ fmap (\(Shelley.LogWeight f) -> exp $ realToFrac f :: Double) llhd
 
-instance Consensus.ShelleyBasedEra era => ToJSON (ShelleyEpoch.PulsingStakeDistr era m) where
-  toJSON (ShelleyEpoch.StillPulsing _) = Aeson.Null
-  toJSON (ShelleyEpoch.Completed ru) = toJSON ru
-
-instance Consensus.ShelleyBasedEra era => ToJSON (Shelley.SnapShots era) where
+instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShots crypto) where
   toJSON ss = object [ "pstakeMark" .= Shelley._pstakeMark ss
                      , "pstakeSet" .= Shelley._pstakeSet ss
                      , "pstakeGo" .= Shelley._pstakeGo ss

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -490,7 +489,6 @@ writeLedgerState mOutFile qState@(SerialisedDebugLedgerState serLedgerState) =
 
 writeStakeSnapshot :: forall era ledgerera. ()
   => ShelleyLedgerEra era ~ ledgerera
-  => Era.Era ledgerera
   => Era.Crypto ledgerera ~ StandardCrypto
   => FromCBOR (DebugLedgerState era)
   => PoolId
@@ -506,7 +504,7 @@ writeStakeSnapshot (StakePoolKeyHash hk) qState =
       let (DebugLedgerState snapshot) = ledgerState
 
       -- The three stake snapshots, obtained from the ledger state
-      let (SnapShots (runToCompletion @ledgerera -> markS) setS goS _) = esSnapshots $ nesEs snapshot
+      let (SnapShots markS setS goS _) = esSnapshots $ nesEs snapshot
 
       -- Calculate the three pool and active stake values for the given pool
       liftIO . LBS.putStrLn $ encodePretty $ Stakes


### PR DESCRIPTION
draft PR so we can benchmark `1.30.0-rc3` without the stake distribution calculation pulser.