### PR TITLE
Update dependencies

### DIFF
--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -126,7 +126,6 @@ instance FromJSON BlockNo where
 instance ToJSON BlockNo where
   toJSON (BlockNo x) = toJSON x
 
-deriving anyclass instance NFData BlockNo
 deriving instance NFData a => NFData (Resources a)
 
 --

--- a/cabal.project
+++ b/cabal.project
@@ -131,8 +131,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 46502694f6a9f0498f822068008b232b3837a9e9
-  --sha256: 04bvsvghkrjhfjb3phh0s5yfb37fishglrrlcwbvcv48y2in1dcz
+  tag: 592aa61d657ad5935a33bace1243abce3728b643
+  --sha256: 1bgq3a2wfdz24jqfwylcc6jjg5aji8dpy5gjkhpnmkkvgcr2rkyb
   subdir:
     base-deriving-via
     binary
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ab138130d979d273f31a7a383c9ab81906e0727c
-  --sha256: 1pqdm1v6sjf19z3cy4jsyj81wizwafa1lprafnwn5plqd9qimz55
+  tag: 4391341f84a8d0b63d9e56799f7eeec4ab91c5c5
+  --sha256: 1j50dfjfn5k5yw5jdj5adwdc8flqpy02swiz7k5xk804dwkj941x
   subdir:
     alonzo/impl
     byron/chain/executable-spec
@@ -215,8 +215,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e74388a28e8775ed2e85067f0413792071686714
-  --sha256: 1msp9abhnp7pxhj79bfa61ps0g5ram9r7knv3nw6v8gla404zl3r
+  tag: 5d37a927046bc7da2887830d8e35cf604622ce09
+  --sha256: 1620zcnivgm1wp1kq3vqc44g77lv7dalzgywc96qsblf1sv9fw3p
   subdir:
     io-sim
     io-classes

--- a/cabal.project
+++ b/cabal.project
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4391341f84a8d0b63d9e56799f7eeec4ab91c5c5
-  --sha256: 1j50dfjfn5k5yw5jdj5adwdc8flqpy02swiz7k5xk804dwkj941x
+  tag: ec51e4fb1b17461ab612cf427b79f1742942e8cb
+  --sha256: 05bwy7x1asyfshqsfsyv2c70qwrxp4680xlvhwdm1hz9bi0lpq41
   subdir:
     alonzo/impl
     byron/chain/executable-spec

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -173,7 +173,7 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.DState crypto) where
                          , "irwd" .= Shelley._irwd dState
                          ]
 
-instance ToJSON (ShelleyLedger.FutureGenDeleg crypto) where
+instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.FutureGenDeleg crypto) where
   toJSON fGenDeleg =
     object [ "fGenDelegSlot" .= ShelleyLedger.fGenDelegSlot fGenDeleg
            , "fGenDelegGenKeyHash" .= ShelleyLedger.fGenDelegGenKeyHash fGenDeleg
@@ -182,16 +182,20 @@ instance ToJSON (ShelleyLedger.FutureGenDeleg crypto) where
 instance Crypto.Crypto crypto => ToJSON (Shelley.GenDelegs crypto) where
   toJSON (Shelley.GenDelegs delegs) = toJSON delegs
 
-instance ToJSON (Shelley.InstantaneousRewards crypto) where
+instance Crypto.Crypto crypto => ToJSON (Shelley.InstantaneousRewards crypto) where
   toJSON iRwds = object [ "iRReserves" .= Shelley.iRReserves iRwds
                         , "iRTreasury" .= Shelley.iRTreasury iRwds
                         ]
 
-instance ToJSON (Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto)) where
+instance
+  Crypto.Crypto crypto =>
+  ToJSON (Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto))
+  where
   toJSON (MkBiMap ptsStakeM stakePtrSetM) =
     object [ "stakedCreds" .= Map.toList ptsStakeM
            , "credPtrR" .= toJSON stakePtrSetM
            ]
+
 instance ToJSON Shelley.Ptr where
   toJSON (Shelley.Ptr slotNo txIndex certIndex) =
     object [ "slot" .= unSlotNo slotNo
@@ -244,11 +248,7 @@ instance ToJSON Shelley.Likelihood where
   toJSON (Shelley.Likelihood llhd) =
     toJSON $ fmap (\(Shelley.LogWeight f) -> exp $ realToFrac f :: Double) llhd
 
-instance Consensus.ShelleyBasedEra era => ToJSON (ShelleyEpoch.PulsingStakeDistr era m) where
-  toJSON (ShelleyEpoch.StillPulsing _) = Aeson.Null
-  toJSON (ShelleyEpoch.Completed ru) = toJSON ru
-
-instance Consensus.ShelleyBasedEra era => ToJSON (Shelley.SnapShots era) where
+instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShots crypto) where
   toJSON ss = object [ "pstakeMark" .= Shelley._pstakeMark ss
                      , "pstakeSet" .= Shelley._pstakeSet ss
                      , "pstakeGo" .= Shelley._pstakeGo ss
@@ -261,7 +261,7 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShot crypto) where
                      , "poolParams" .= Shelley._poolParams ss
                      ]
 
-instance ToJSON (Shelley.Stake crypto) where
+instance Crypto.Crypto crypto => ToJSON (Shelley.Stake crypto) where
   toJSON (Shelley.Stake s) = toJSON s
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.RewardUpdate crypto) where
@@ -282,13 +282,13 @@ instance ToJSON Shelley.DeltaCoin where
 instance Crypto.Crypto crypto => ToJSON (Praos.PoolDistr crypto) where
   toJSON (Praos.PoolDistr m) = toJSON m
 
-instance ToJSON (Praos.IndividualPoolStake crypto) where
+instance Crypto.Crypto crypto => ToJSON (Praos.IndividualPoolStake crypto) where
   toJSON indivPoolStake =
     object [ "individualPoolStake" .= Praos.individualPoolStake indivPoolStake
            , "individualPoolStakeVrf" .= Praos.individualPoolStakeVrf indivPoolStake
            ]
 
-instance ToJSON (Shelley.Reward crypto) where
+instance Crypto.Crypto crypto => ToJSON (Shelley.Reward crypto) where
   toJSON reward =
      object [ "rewardType" .= Shelley.rewardType reward
             , "rewardPool" .= Shelley.rewardPool reward
@@ -299,7 +299,7 @@ instance ToJSON Shelley.RewardType where
   toJSON Shelley.MemberReward = "MemberReward"
   toJSON Shelley.LeaderReward = "LeaderReward"
 
-instance ToJSON (SafeHash.SafeHash c a) where
+instance Crypto.Crypto c => ToJSON (SafeHash.SafeHash c a) where
   toJSON = toJSON . SafeHash.extractHash
 
 -----

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -20,6 +20,7 @@ import           Data.Yaml.Pretty (defConfig, encodePretty, setConfCompare)
 import           Cardano.Api
 import           Cardano.Api.Byron (Lovelace (..))
 import           Cardano.Api.Shelley (Address (ShelleyAddress), StakeAddress (..))
+import           Cardano.Ledger.Crypto (Crypto)
 import qualified Shelley.Spec.Ledger.API as Shelley
 
 import           Cardano.CLI.Helpers (textShow)
@@ -124,7 +125,7 @@ friendlyTxOut (TxOut addr amount mdatum) =
       , "amount" .= friendlyTxOutValue amount
       ]
 
-friendlyStakeReference :: Shelley.StakeReference crypto -> Aeson.Value
+friendlyStakeReference :: Crypto crypto => Shelley.StakeReference crypto -> Aeson.Value
 friendlyStakeReference = \case
   Shelley.StakeRefBase cred -> toJSON cred
   Shelley.StakeRefNull -> Null

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -23,8 +23,6 @@ import qualified Data.Text.Encoding as Text
 
 import           Cardano.Api.Orphans ()
 
-import           Cardano.Crypto.Hash.Class as Crypto
-
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash (..))
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
@@ -32,6 +30,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
 import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Tip (..))
 
 import           Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
+import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import           Cardano.Protocol.TPraos (PoolDistr (..))
 import           Cardano.Protocol.TPraos.BHeader (HashHeader (..))
 
@@ -72,10 +71,10 @@ deriving newtype instance ToJSON BlockNo
 -- Simple newtype wrappers JSON conversion
 --
 
-deriving newtype instance ToJSON (TxId era)
+deriving newtype instance CC.Crypto crypto => ToJSON (TxId crypto)
 
-deriving newtype instance ToJSON (ShelleyHash era)
-deriving newtype instance ToJSON (HashHeader era)
+deriving newtype instance CC.Crypto crypto => ToJSON (ShelleyHash crypto)
+deriving newtype instance CC.Crypto crypto => ToJSON (HashHeader crypto)
 
 deriving newtype instance ToJSON (AuxiliaryDataHash StandardCrypto)
 deriving newtype instance ToJSON Ledger.LogWeight

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -484,7 +483,6 @@ writeLedgerState mOutFile qState@(SerialisedDebugLedgerState serLedgerState) =
 
 writeStakeSnapshot :: forall era ledgerera. ()
   => ShelleyLedgerEra era ~ ledgerera
-  => Era.Era ledgerera
   => Era.Crypto ledgerera ~ StandardCrypto
   => FromCBOR (DebugLedgerState era)
   => PoolId
@@ -500,7 +498,7 @@ writeStakeSnapshot (StakePoolKeyHash hk) qState =
       let (DebugLedgerState snapshot) = ledgerState
 
       -- The three stake snapshots, obtained from the ledger state
-      let (SnapShots (runToCompletion @ledgerera -> markS) setS goS _) = esSnapshots $ nesEs snapshot
+      let (SnapShots markS setS goS _) = esSnapshots $ nesEs snapshot
 
       -- Calculate the three pool and active stake values for the given pool
       liftIO . LBS.putStrLn $ encodePretty $ Stakes

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
@@ -20,9 +20,10 @@ module Cardano.Tracing.OrphanInstances.HardFork () where
 import           Cardano.Prelude hiding (All)
 
 import           Data.Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Short as SBS
 import           Data.SOP.Strict
 
-import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
 
@@ -53,7 +54,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 --
 
 instance Condense (OneEraHash xs) where
-    condense = condense . Crypto.UnsafeHash . getOneEraHash
+    condense = condense . Base16.encode . SBS.fromShort . getOneEraHash
 
 --
 -- instances for Header HardForkBlock


### PR DESCRIPTION
This PR pulls in a number of key changes:

- https://github.com/input-output-hk/cardano-base/pull/232 changes the in-memory hash representation to reduce memory usage.
- https://github.com/input-output-hk/cardano-base/pull/236 fixes a potential concurrency issue in key generation, and adds some potential speed optimisations to core crypto functions.
- https://github.com/input-output-hk/cardano-ledger-specs/pull/2487 adds a new 'PoolReap' event, which can be used to obtain details of refunds for pool deposits.
- https://github.com/input-output-hk/cardano-ledger-specs/pull/2484 reverts the incremental computation of aggregated stake distribution. Whilst this was intended to be a performance gain, it had the opposite effect.