### PR TITLE
Serialize AssetName to JSON as hex string

### DIFF
--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -30,6 +30,7 @@ module Gen.Cardano.Api.Typed
   , genScriptHash
   , genScriptData
 
+  , genAssetName
   , genOperationalCertificate
   , genOperationalCertificateIssueCounter
   , genShelleyWitness
@@ -227,8 +228,8 @@ genAssetName =
   Gen.frequency
     -- mostly from a small number of choices, so we get plenty of repetition
     [ (9, Gen.element ["", "a", "b", "c"])
-    , (1, AssetName <$> Gen.utf8 (Range.singleton  32) Gen.alphaNum)
-    , (1, AssetName <$> Gen.utf8 (Range.constant 1 31) Gen.alphaNum)
+    , (1, AssetName <$> Gen.bytes (Range.singleton  32))
+    , (1, AssetName <$> Gen.bytes (Range.constant 1 31))
     ]
 
 genPolicyId :: Gen PolicyId

--- a/cardano-api/src/Cardano/Api/Utils.hs
+++ b/cardano-api/src/Cardano/Api/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- | Internal utils for the other Api modules
 --
 module Cardano.Api.Utils
@@ -6,6 +8,7 @@ module Cardano.Api.Utils
   , formatParsecError
   , noInlineMaybeToStrictMaybe
   , runParsecParser
+  , note
   ) where
 
 import           Prelude
@@ -42,3 +45,8 @@ runParsecParser parser input =
   case Parsec.parse (parser <* Parsec.eof) "" (Text.unpack input) of
     Right txin -> pure txin
     Left parseError -> fail $ formatParsecError parseError
+
+note :: MonadFail m => String -> Maybe a -> m a
+note msg = \case
+  Nothing -> fail msg
+  Just a -> pure a

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -56,9 +56,9 @@ module Cardano.Api.Value
 
 import           Prelude
 
-import           Data.Aeson hiding (Value)
+import           Data.Aeson (FromJSON, FromJSONKey, ToJSON, object, parseJSON, toJSON, withObject)
 import qualified Data.Aeson as Aeson
-import           Data.Aeson.Types (Parser, toJSONKeyText)
+import           Data.Aeson.Types (Parser, ToJSONKey)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
@@ -74,9 +74,9 @@ import qualified Data.Text.Encoding as Text
 import qualified Cardano.Chain.Common as Byron
 
 import qualified Cardano.Ledger.Coin as Shelley
+import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Shelley
-import           Cardano.Ledger.Crypto (StandardCrypto)
 
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Script
@@ -158,8 +158,10 @@ scriptPolicyId = PolicyId . hashScript
 
 
 newtype AssetName = AssetName ByteString
-    deriving stock (Eq, Ord)
-    deriving newtype (Show)
+  deriving stock (Eq, Ord)
+  deriving newtype (Show)
+  deriving (ToJSON, FromJSON, ToJSONKey, FromJSONKey)
+    via UsingRawBytesHex AssetName
 
 instance IsString AssetName where
     fromString s
@@ -176,18 +178,6 @@ instance SerialiseAsRawBytes AssetName where
     deserialiseFromRawBytes AsAssetName bs
       | BS.length bs <= 32 = Just (AssetName bs)
       | otherwise          = Nothing
-
-instance ToJSON AssetName where
-  toJSON (AssetName an) = Aeson.String $ Text.decodeUtf8 an
-
-instance FromJSON AssetName where
-  parseJSON = withText "AssetName" (return . AssetName . Text.encodeUtf8)
-
-instance ToJSONKey AssetName where
-  toJSONKey = toJSONKeyText (\(AssetName asset) -> Text.decodeUtf8 asset)
-
-instance FromJSONKey AssetName where
-  fromJSONKey = FromJSONKeyText (AssetName . Text.encodeUtf8)
 
 
 data AssetId = AdaAssetId
@@ -366,11 +356,13 @@ instance FromJSON ValueNestedRep where
     where
       parsePid :: (Text, Aeson.Value) -> Parser ValueNestedBundle
       parsePid ("lovelace", q) = ValueNestedBundleAda <$> parseJSON q
-      parsePid (pid, q) =
-        case deserialiseFromRawBytesHex AsScriptHash (Text.encodeUtf8 pid) of
-          Just sHash -> ValueNestedBundle (PolicyId sHash) <$> parseJSON q
-          Nothing -> fail $ "Failure when deserialising PolicyId: "
-                         <> Text.unpack pid
+      parsePid (pid, quantityBundleJson) = do
+        sHash <-
+          note ("Expected hex encoded PolicyId but got: " <> Text.unpack pid) $
+          deserialiseFromRawBytesHex AsScriptHash $ Text.encodeUtf8 pid
+        quantityBundle <- parseJSON quantityBundleJson
+        pure $ ValueNestedBundle (PolicyId sHash) quantityBundle
+
 
 -- ----------------------------------------------------------------------------
 -- Printing and pretty-printing
@@ -406,6 +398,6 @@ renderPolicyId (PolicyId scriptHash) = serialiseToRawBytesHexText scriptHash
 
 renderAssetId :: AssetId -> Text
 renderAssetId AdaAssetId = "lovelace"
-renderAssetId (AssetId polId (AssetName assetName))
-  | BS.null assetName = renderPolicyId polId
-  | otherwise         = renderPolicyId polId <> "." <> Text.decodeUtf8 assetName
+renderAssetId (AssetId polId (AssetName "")) = renderPolicyId polId
+renderAssetId (AssetId polId assetName) =
+  renderPolicyId polId <> "." <> serialiseToRawBytesHexText assetName

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -83,6 +83,7 @@ import           Cardano.Api.Script
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.Utils (note)
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/ValueParser.hs
+++ b/cardano-api/src/Cardano/Api/ValueParser.hs
@@ -21,6 +21,7 @@ import           Text.Parsec.String (Parser)
 import           Text.ParserCombinators.Parsec.Combinator (many1)
 
 import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.Utils (note)
 import           Cardano.Api.Value
 
 -- | Parse a 'Value' from its string representation.
@@ -113,10 +114,10 @@ decimal = do
 
 -- | Asset name parser.
 assetName :: Parser AssetName
-assetName =
-    toAssetName <$> many alphaNum
-  where
-    toAssetName = AssetName . Text.encodeUtf8 . Text.pack
+assetName = do
+  hexText <- many hexDigit
+  note "AssetName deserisalisation failed" $
+    deserialiseFromRawBytesHex AsAssetName $ BSC.pack hexText
 
 -- | Policy ID parser.
 policyId :: Parser PolicyId

--- a/cardano-api/src/Cardano/Api/ValueParser.hs
+++ b/cardano-api/src/Cardano/Api/ValueParser.hs
@@ -5,15 +5,14 @@ module Cardano.Api.ValueParser
 
 import           Prelude
 
+import           Control.Applicative (many, some, (<|>))
+import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Char as Char
 import           Data.Functor (void, ($>))
 import           Data.List (foldl')
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Word (Word64)
-
-import           Control.Applicative (many, some, (<|>))
-
 import           Text.Parsec as Parsec (notFollowedBy, try, (<?>))
 import           Text.Parsec.Char (alphaNum, char, digit, hexDigit, space, spaces, string)
 import           Text.Parsec.Expr (Assoc (..), Operator (..), buildExpressionParser)

--- a/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
@@ -6,7 +6,7 @@ module Test.Cardano.Api.Typed.Value
 
 import           Prelude
 
-import           Data.Aeson
+import           Data.Aeson (eitherDecode, encode)
 import           Data.List (groupBy, sort)
 import qualified Data.Map.Strict as Map
 import           Hedgehog (Property, forAll, property, tripping, (===))
@@ -14,8 +14,10 @@ import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog (testProperty)
 import           Test.Tasty.TH (testGroupGenerator)
 
-import           Cardano.Api.Shelley
-import           Gen.Cardano.Api.Typed
+import           Cardano.Api (ValueNestedBundle (ValueNestedBundle, ValueNestedBundleAda),
+                   ValueNestedRep (..), valueFromNestedRep, valueToNestedRep)
+
+import           Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genValueNestedRep)
 
 prop_roundtrip_Value_JSON :: Property
 prop_roundtrip_Value_JSON =
@@ -66,6 +68,20 @@ canonicalise =
 
     isZeroOrEmpty (ValueNestedBundleAda q) = q == 0
     isZeroOrEmpty (ValueNestedBundle _ as) = Map.null as
+
+
+prop_roundtrip_AssetName_JSON :: Property
+prop_roundtrip_AssetName_JSON =
+  property $ do
+    v <- forAll genAssetName
+    tripping v encode eitherDecode
+
+prop_roundtrip_AssetName_JSONKey :: Property
+prop_roundtrip_AssetName_JSONKey =
+  property $ do
+    v <- forAll genAssetName
+    tripping (Map.singleton v ()) encode eitherDecode
+
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -208,6 +208,7 @@ test-suite cardano-cli-golden
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson             >= 1.5.6.0
+                      , base16-bytestring
                       , bytestring
                       , cardano-api
                       , cardano-cli

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -162,25 +162,21 @@ friendlyFee = \case
 friendlyLovelace :: Lovelace -> Aeson.Value
 friendlyLovelace (Lovelace value) = String $ textShow value <> " Lovelace"
 
+{-
+  current output:
+
+    52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
+      736b79: 142
+
+  TODO:
+
+    policy 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
+      asset 736b79 (sky): 142
+-}
 friendlyMintValue :: TxMintValue ViewTx era -> Aeson.Value
 friendlyMintValue = \case
   TxMintNone -> Null
-  TxMintValue _ v _ ->
-    object
-      [ friendlyAssetId assetId .= quantity
-      | (assetId, quantity) <- valueToList v
-      ]
-
-friendlyAssetId :: AssetId -> Text
-friendlyAssetId = \case
-  AdaAssetId -> "ADA"
-  AssetId policyId (AssetName assetName) ->
-    decodeUtf8 $ serialiseToRawBytesHex policyId <> suffix
-    where
-      suffix =
-        case assetName of
-          "" -> ""
-          _ -> "." <> assetName
+  TxMintValue _ v _ -> toJSON v
 
 friendlyTxOutValue :: TxOutValue era -> Aeson.Value
 friendlyTxOutValue = \case

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
@@ -11,6 +11,8 @@ module Test.Golden.Shelley.Transaction.Build
 import           Cardano.Prelude
 import           Prelude (String)
 
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BSC
 import           Hedgehog (Property)
 import           Test.OptParse
 
@@ -76,7 +78,9 @@ golden_shelleyTransactionBuild_Minting =
                , scriptWit
                ]
 
-    let dummyMA = filter (/= '\n') $ "50 " ++ polid ++ ".ethereum"
+    let dummyMA =
+          filter (/= '\n') $
+          "50 " ++ polid ++ "." ++ BSC.unpack (Base16.encode "ethereum")
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
@@ -134,5 +138,3 @@ golden_shelleyTransactionBuild_TxInScriptWitnessed =
     H.assertFileOccurences 1 "TxBodyMary" txBodyOutFile
 
     H.assertEndsWithSingleNewline txBodyOutFile
-
-

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -127,11 +127,21 @@ golden_view_mary =
         , "--fee", "139"
         , "--invalid-before", "140"
         , "--mint"
-        ,   "42 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
+        ,   "130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
             \ + \
-            \43 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.snow\
+            \132 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.cafe\
             \ + \
-            \44 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.sky"
+            \134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d\
+            \ + \
+            \136 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.dead\
+            \ + \
+            \138\
+              \ d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
+              \.736e6f77\
+            \ + \
+            \142\
+              \ 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528\
+              \.736b79"
         , "--minting-script-file", "test/data/golden/mary/scripts/mint.all"
         , "--minting-script-file", "test/data/golden/mary/scripts/mint.any"
         , "--out-file", transactionBodyFile

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -94,7 +94,9 @@ golden_view_allegra =
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
             \#94"
         , "--tx-out"
-        ,   "addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
+        ,   "addr_test1\
+            \qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7\
+            \9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
             \+99"
         , "--fee", "100"
         , "--invalid-hereafter", "101"
@@ -122,8 +124,27 @@ golden_view_mary =
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891\
             \#135"
         , "--tx-out"
-        ,   "addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
-            \+138"
+        ,   "addr_test1\
+            \qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7\
+            \9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4\
+            \ + \
+            \138\
+            \ + \
+            \130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
+            \ + \
+            \132 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.cafe\
+            \ + \
+            \134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d\
+            \ + \
+            \136 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.dead\
+            \ + \
+            \138\
+              \ d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf\
+              \.736e6f77\
+            \ + \
+            \142\
+              \ 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528\
+              \.736b79"
         , "--fee", "139"
         , "--invalid-before", "140"
         , "--mint"

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -6,19 +6,27 @@ inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135
 metadata: null
 mint:
-  52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
-    736b79: 142
-    cafe: 132
-    dead: 136
-  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf:
-    '': 130
-    736e6f77: 138
-    f00d: 134
+  policy 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
+    asset 736b79 (sky): 142
+    asset cafe: 132
+    asset dead: 136
+  policy d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf:
+    asset 736e6f77 (snow): 138
+    asset f00d: 134
+    default asset: 130
 outputs:
 - address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
   address era: Shelley
   amount:
     lovelace: 138
+    policy 52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
+      asset 736b79 (sky): 142
+      asset cafe: 132
+      asset dead: 136
+    policy d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf:
+      asset 736e6f77 (snow): 138
+      asset f00d: 134
+      default asset: 130
   network: Testnet
   payment credential:
     key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313

--- a/cardano-cli/test/data/golden/mary/transaction-view.out
+++ b/cardano-cli/test/data/golden/mary/transaction-view.out
@@ -6,9 +6,14 @@ inputs:
 - fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135
 metadata: null
 mint:
-  52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528.snow: 43
-  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf: 42
-  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.sky: 44
+  52dc3d43b6d2465e96109ce75ab61abe5e9c1d8a3c9ce6ff8a3af528:
+    736b79: 142
+    cafe: 132
+    dead: 136
+  d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf:
+    '': 130
+    736e6f77: 138
+    f00d: 134
 outputs:
 - address: addr_test1qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r79jmxlyk4eqt6z6hj5g8jd8393msqaw47f4
   address era: Shelley

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -101,6 +101,8 @@ test-suite cardano-testnet-tests
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson
+                      , base16-bytestring
+                      , bytestring
                       , cardano-api
                       , cardano-testnet
                       , containers

--- a/cardano-testnet/test/Spec/Plutus/Direct/ScriptContextEqualityMint.hs
+++ b/cardano-testnet/test/Spec/Plutus/Direct/ScriptContextEqualityMint.hs
@@ -13,16 +13,15 @@ import           Prelude
 import           Cardano.Api
 
 import           Control.Monad
-import           Data.Monoid (Last (..))
-import           Data.String
-import           Hedgehog (Property, (===))
-import           System.Environment (getEnvironment)
-import           System.FilePath ((</>))
-
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Map.Strict as Map
+import           Data.Monoid (Last (..))
+import           Data.String
 import qualified Data.Text as T
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
@@ -30,6 +29,9 @@ import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
+import           System.Environment (getEnvironment)
+import           System.FilePath ((</>))
+
 import qualified Test.Base as H
 import           Test.Process (execCreateScriptContext, execCreateScriptContext')
 import qualified Test.Process as H
@@ -40,6 +42,9 @@ import qualified Testnet.Conf as H
 {- HLINT ignore "Redundant <&>" -}
 {- HLINT ignore "Redundant return" -}
 {- HLINT ignore "Use let" -}
+
+millarCoin :: String
+millarCoin = BSC.unpack $ Base16.encode "MillarCoin"
 
 hprop_plutus_script_context_mint_equality :: Property
 hprop_plutus_script_context_mint_equality = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
@@ -183,8 +188,8 @@ hprop_plutus_script_context_mint_equality = H.integration . H.runFinallies . H.w
     , "--tx-in-collateral", T.unpack $ renderTxIn txinCollateral
     , "--mint-script-file", plutusContextEqualityMintScript
     , "--mint-redeemer-file", scriptDummyRedeemer
-    , "--tx-out", dummyaddress <> "+" <> show @Integer 10000000 <> "+ 5 " <> (policyId <> ".MillarCoin")
-    , "--mint", "5 " <> (policyId <> ".MillarCoin")
+    , "--tx-out", dummyaddress <> "+" <> show @Integer 10000000 <> "+ 5 " <> (policyId <> "." <> millarCoin)
+    , "--mint", "5 " <> (policyId <> "." <> millarCoin)
     , "--protocol-params-file", work </> "pparams.json"
     , "--out-file", work </> "mint-dummy.body"
     ]
@@ -223,8 +228,8 @@ hprop_plutus_script_context_mint_equality = H.integration . H.runFinallies . H.w
     , "--tx-in-collateral", T.unpack $ renderTxIn txinCollateral
     , "--mint-script-file", plutusContextEqualityMintScript
     , "--mint-redeemer-file", scriptContextRedeemer
-    , "--tx-out", dummyaddress <> "+" <> show @Integer 10000000 <> "+ 5 " <> (policyId <> ".MillarCoin")
-    , "--mint", "5 " <> (policyId <> ".MillarCoin")
+    , "--tx-out", dummyaddress <> "+" <> show @Integer 10000000 <> "+ 5 " <> (policyId <> "." <> millarCoin)
+    , "--mint", "5 " <> (policyId <> "." <> millarCoin)
     , "--protocol-params-file", work </> "pparams.json"
     , "--out-file", work </> "mint-final.body"
     ]


### PR DESCRIPTION
Fix (second attempt) of incorrect UTF-8 decoding of non-textual (non-UTF-8) asset names.

I also changed tx-view to test JSON repr.

BEFORE:
```js
{
  "51f056b530aba5969bf996d1be51c7aa3581f6e0d7b9e0911a5c0c1d": {
    "TheDrifter13": 1,
    "GOLDtest": 5,
    "��\"3DUfw��������": 42 // UTF-8 fail, actually
  }
}
```

AFTER:
```js
{
  "51f056b530aba5969bf996d1be51c7aa3581f6e0d7b9e0911a5c0c1d": {
    "546865447269667465723133": 1,
    "474f4c4474657374": 5,
    "00112233445566778899AABBCCDDEEFF": 42
  }
}
```

This is how it already looks like in UI (Cardano Explorer):
> asset1...
> Ticker:
> Name:
> Description:
> Policy ID: 51f056b530aba5969bf996d1be51c7aa3581f6e0d7b9e0911a5c0c1d
> Asset Name: 474f4c4474657374

Future Daedalus:
> Name: GoodCoin
> Asset name: 676f6f64636f696e (ASCII: goodcoin)