### PR TITLE
tx-generator: Add alternative submit modes.

### DIFF
--- a/bench/script/test-large.json
+++ b/bench/script/test-large.json
@@ -16,18 +16,46 @@
         ] },
     { "setLocalSocket": "run/current/node-0/node.socket" },
     { "readSigningKey": "pass-partout", "filePath": "run/current/genesis/utxo-keys/utxo1.skey" },
-    { "importGenesisFund": "pass-partout", "fundKey": "pass-partout" },
-    { "delay": 10 },
-    { "createChange" : 2200000000000, "count" :       10 },
-    { "delay": 10 },
-    { "createChange" :   70000000000, "count" :      300 },
-    { "delay": 10 },
-    { "createChange" :    2200000000, "count" :     9000 },
-    { "delay": 10 },
-    { "createChange" :      70000000, "count" :   270000 },
-    { "delay": 10 },
-    { "createChange" :       2300000, "count" :  8100000 },    
-    { "delay": 10 },
-    { "runBenchmark": "walletBasedBenchmark", "txCount": 1000000, "tps": 100 },
-    { "waitBenchmark": "walletBasedBenchmark" }
+    { "importGenesisFund": "pass-partout", "fundKey": "pass-partout"
+      , "submitMode": {
+            "contents": "/tmp/tx-list.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "createChange" : 2200000000000, "count" :       10
+      , "submitMode": {
+            "contents": "/tmp/tx-split.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "createChange" :   70000000000, "count" :      300
+      , "submitMode": {
+            "contents": "/tmp/tx-split.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "createChange" :    2200000000, "count" :     9000
+      , "submitMode": {
+            "contents": "/tmp/tx-split.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "createChange" :      70000000, "count" :   270000
+      , "submitMode": {
+            "contents": "/tmp/tx-split.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "createChange" :       2300000, "count" :  8100000
+      , "submitMode": {
+            "contents": "/tmp/tx-split.txt",
+            "tag": "DumpToFile"
+        }
+    },
+    { "runBenchmark": "walletBasedBenchmark", "txCount": 1000000, "tps": 100
+      , "submitMode": {
+            "contents": "/tmp/tx-submit.txt",
+            "tag": "DumpToFile"
+        }
+    }
 ]

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
@@ -20,6 +20,7 @@ import           Cardano.Benchmarking.Script.Action
 import           Cardano.Benchmarking.Script.Aeson (parseScriptFile)
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
+import           Cardano.Benchmarking.Script.Types
 
 type Script = [Action]
 

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -1,50 +1,13 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Cardano.Benchmarking.Script.Action
 where
 
-import           Prelude
-import           GHC.Generics
 import           Data.Functor.Identity
 import           Data.Dependent.Sum (DSum(..))
-
-import           Cardano.Benchmarking.OuroborosImports (SigningKeyFile)
-import           Cardano.Api (AnyCardanoEra, Lovelace)
 
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Core
-import           Cardano.Benchmarking.Types (TPSRate, NumberOfTxs)
-
-data Action where
-  Set                :: !SetKeyVal -> Action
---  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
-  StartProtocol      :: !FilePath -> Action
-  Delay              :: !Double -> Action
-  ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
-  SecureGenesisFund  :: !FundName -> !KeyName -> !KeyName -> Action
-  SplitFund          :: [FundName] -> !KeyName -> !FundName -> Action
-  SplitFundToList    :: !FundListName -> !KeyName -> !FundName -> Action
-  PrepareTxList      :: !TxListName -> !KeyName -> !FundListName -> Action
-  AsyncBenchmark     :: !ThreadName -> !TxListName -> !TPSRate -> Action
-  ImportGenesisFund  :: !KeyName -> !KeyName -> Action
-  CreateChange       :: !Lovelace -> !Int -> Action
-  RunBenchmark       :: !ThreadName -> !NumberOfTxs -> !TPSRate -> Action
-  WaitBenchmark      :: !ThreadName -> Action
-  CancelBenchmark    :: !ThreadName -> Action
-  Reserved           :: [String] -> Action
-  WaitForEra         :: !AnyCardanoEra -> Action
-  deriving (Show, Eq)
-
-deriving instance Generic Action
+import           Cardano.Benchmarking.Script.Types
 
 action :: Action -> ActionM ()
 action a = case a of
@@ -57,9 +20,9 @@ action a = case a of
   Delay t -> delay t
   PrepareTxList name key fund -> prepareTxList name key fund
   AsyncBenchmark thread txs tps -> asyncBenchmark thread txs tps
-  ImportGenesisFund genesisKey fundKey -> importGenesisFund genesisKey fundKey
-  CreateChange value count -> createChange value count
-  RunBenchmark thread count tps -> runBenchmark thread count tps
+  ImportGenesisFund submitMode genesisKey fundKey -> importGenesisFund submitMode genesisKey fundKey
+  CreateChange submitMode value count -> createChange submitMode value count
+  RunBenchmark submitMode thread count tps -> runBenchmark submitMode thread count tps
   WaitBenchmark thread -> waitBenchmark thread
   CancelBenchmark thread -> cancelBenchmark thread
   WaitForEra era -> waitForEra era

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -18,6 +18,7 @@ import           Cardano.Benchmarking.Script.Aeson
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Setters
+import           Cardano.Benchmarking.Script.Types
 
 runTestScript :: IO (Either Error (), Env, ())
 runTestScript = withIOManager $ runActionM (forM_ testScript action)
@@ -54,9 +55,9 @@ testScript =
   , AsyncBenchmark threadName txList (TPSRate 10)
   , WaitForEra $ AnyCardanoEra ByronEra
   , CancelBenchmark threadName
-  , ImportGenesisFund passPartout passPartout
-  , CreateChange (quantityToLovelace 10000) 1000
-  , RunBenchmark (ThreadName "walletThread") (NumberOfTxs 1000) (TPSRate 10)
+  , ImportGenesisFund DiscardTX passPartout passPartout
+  , CreateChange LocalSocket (quantityToLovelace 10000) 1000
+  , RunBenchmark (DumpToFile "/tmp/tx-list.txt") (ThreadName "walletThread") (NumberOfTxs 1000) (TPSRate 10)
   , Reserved []
   ]
  where

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Benchmarking.Script.Types
+where
+
+import           Prelude
+import           GHC.Generics
+
+import           Cardano.Benchmarking.OuroborosImports (SigningKeyFile)
+import           Cardano.Api (AnyCardanoEra, Lovelace)
+
+import           Cardano.Benchmarking.Script.Env
+import           Cardano.Benchmarking.Script.Store
+import           Cardano.Benchmarking.Types (TPSRate, NumberOfTxs)
+
+data Action where
+  Set                :: !SetKeyVal -> Action
+--  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
+  StartProtocol      :: !FilePath -> Action
+  Delay              :: !Double -> Action
+  ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
+  SecureGenesisFund  :: !FundName -> !KeyName -> !KeyName -> Action
+  SplitFund          :: [FundName] -> !KeyName -> !FundName -> Action
+  SplitFundToList    :: !FundListName -> !KeyName -> !FundName -> Action
+  PrepareTxList      :: !TxListName -> !KeyName -> !FundListName -> Action
+  AsyncBenchmark     :: !ThreadName -> !TxListName -> !TPSRate -> Action
+  ImportGenesisFund  :: !SubmitMode -> !KeyName -> !KeyName -> Action
+  CreateChange       :: !SubmitMode -> !Lovelace -> !Int -> Action
+  RunBenchmark       :: !SubmitMode -> !ThreadName -> !NumberOfTxs -> !TPSRate -> Action
+  WaitBenchmark      :: !ThreadName -> Action
+  CancelBenchmark    :: !ThreadName -> Action
+  Reserved           :: [String] -> Action
+  WaitForEra         :: !AnyCardanoEra -> Action
+  deriving (Show, Eq)
+deriving instance Generic Action
+
+data SubmitMode where
+  LocalSocket :: SubmitMode
+  NodeToNode  :: SubmitMode
+  DumpToFile  :: !FilePath -> SubmitMode
+  DiscardTX   :: SubmitMode
+  deriving (Show, Eq)
+deriving instance Generic SubmitMode

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -49,6 +49,7 @@ library
                        Cardano.Benchmarking.Script.Example
                        Cardano.Benchmarking.Script.Setters
                        Cardano.Benchmarking.Script.Store
+                       Cardano.Benchmarking.Script.Types
                        Cardano.Benchmarking.Tracer
                        Cardano.Benchmarking.Types
                        Cardano.Benchmarking.Wallet

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -24,7 +24,7 @@ let
       }
       { setLocalSocket    = localNodeSocketPath; }
       { readSigningKey    = "pass-partout"; filePath = sigKey; }
-      { importGenesisFund = "pass-partout"; fundKey  = "pass-partout"; }
+      { importGenesisFund = "pass-partout"; fundKey  = "pass-partout"; submitMode = { tag = "LocalSocket"; }; }
       { delay             = init_cooldown; }
     ]
     ++
@@ -40,7 +40,10 @@ let
     ++
     [
       { runBenchmark      = "walletBasedBenchmark";
-                  txCount = tx_count; tps = tps; }
+        txCount = tx_count;
+        tps = tps;
+        submitMode = { tag = "NodeToNode"; };
+      }
       { waitBenchmark     = "walletBasedBenchmark"; }
     ];
 
@@ -60,7 +63,7 @@ let
   capitalise = x: (pkgs.lib.toUpper (__substring 0 1 x)) + __substring 1 99999 x;
 
   createChangeScript = cfg: value: count:
-    [ { createChange = value; count=count; }
+    [ { createChange = value; count=count; submitMode = { tag = "LocalSocket"; }; }
       { delay = cfg.init_cooldown; }
     ];
 


### PR DESCRIPTION
* This PR adds the following scriptable submit modes to the tx-generator:
  LocalSocket: submit tx via local submit protocol.
  NodeToNode:  submit tx via NodeToNode protocol.
  DumpToFile:  write tx to a file.
  DiscardTX:   generate tx and discard it.