### PR TITLE
Check config workflow

### DIFF
--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -1,0 +1,46 @@
+name: Check mainnet configuration
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v14
+
+    - name: Setup nix cache
+      run: |
+        sudo mkdir -p /etc/nix
+        cat <<EOF | sudo tee /etc/nix/nix.conf
+        substituters = https://cache.nixos.org https://hydra.iohk.io
+        trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+    - uses: actions/checkout@v2
+
+    - name: Refresh cardano-node mainnet configuration
+      run: |
+        SOURCE=$(nix-build $(pwd)/release.nix -A cardano-deployment)
+        TARGET=$(pwd)/configuration/cardano
+
+        copyFile() {
+          echo $1
+          cp ${SOURCE}/$1 ${TARGET}/$1
+        }
+
+        copyFile "mainnet-alonzo-genesis.json"
+        copyFile "mainnet-byron-genesis.json"
+        copyFile "mainnet-config.json"
+        copyFile "mainnet-shelley-genesis.json"
+        copyFile "mainnet-topology.json"
+
+    - name: Check mainnet for mainnet configuration differences
+      run: |
+        git diff --exit-code

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -13,6 +13,7 @@
   "RequiresNetworkMagic": "RequiresNoMagic",
   "ShelleyGenesisFile": "mainnet-shelley-genesis.json",
   "ShelleyGenesisHash": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
+  "TraceAcceptPolicy": true,
   "TraceBlockFetchClient": false,
   "TraceBlockFetchDecisions": false,
   "TraceBlockFetchProtocol": false,


### PR DESCRIPTION
This checks that the mainnet configuration in the repository matches the mainnet configuration reported by our nix build.

An example of a failed check can be found here:  https://github.com/input-output-hk/cardano-node/runs/3651630615?check_suite_focus=true