### PR TITLE
Test to assert mainnet configuration is valid

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -144,7 +144,6 @@ library
                       , transformers
                       , transformers-except
                       , utf8-string
-                      , unordered-containers
                       , vector
                       , yaml
 
@@ -177,13 +176,17 @@ test-suite cardano-cli-test
                       , cardano-node
                       , cardano-prelude
                       , cardano-slotting
+                      , directory
                       , exceptions
+                      , filepath
                       , hedgehog
                       , hedgehog-extras
                       , parsec
                       , text
+                      , transformers
 
-  other-modules:        Test.Cli.FilePermissions
+  other-modules:        Test.Config.Mainnet
+                        Test.Cli.FilePermissions
                         Test.Cli.ITN
                         Test.Cli.MultiAssetParsing
                         Test.Cli.Pioneers.Exercise1

--- a/cardano-cli/test/Test/Config/Mainnet.hs
+++ b/cardano-cli/test/Test/Config/Mainnet.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Config.Mainnet
+  ( tests
+  ) where
+
+import           Cardano.Api (initialLedgerState, renderInitialLedgerStateError)
+import           Control.Monad
+import           Control.Monad.Trans.Except
+import           Data.Bool (Bool(..))
+import           Data.Either (Either(..))
+import           Data.Function
+import           Data.Maybe
+import           Hedgehog (Property)
+import           System.FilePath ((</>))
+import           System.IO (IO)
+
+import qualified Data.Text as T
+import qualified GHC.Stack as GHC
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Process as H
+import qualified System.Directory as IO
+
+hprop_configMainnet :: Property
+hprop_configMainnet = H.propertyOnce $ do
+  projectBase <- H.note =<< H.evalIO . IO.canonicalizePath =<< H.getProjectBase
+  result <- H.evalIO $ runExceptT $ initialLedgerState $ projectBase </> "configuration/cardano/mainnet-config.json"
+  case result of
+    Right (_, _) -> return ()
+    Left e -> H.failWithCustom GHC.callStack Nothing (T.unpack (renderInitialLedgerStateError e))
+
+tests :: IO Bool
+tests =
+  H.checkSequential
+    $ H.Group "Test.Config.Mainnet"
+        [ ("hprop_configMainnet", hprop_configMainnet)
+        ]

--- a/cardano-cli/test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test.hs
@@ -10,6 +10,7 @@ import qualified Test.Cli.Pioneers.Exercise2
 import qualified Test.Cli.Pioneers.Exercise3
 import qualified Test.Cli.Pioneers.Exercise4
 import qualified Test.Cli.Shelley.Run.Query
+import qualified Test.Config.Mainnet
 
 main :: IO ()
 main =
@@ -22,4 +23,5 @@ main =
     , Test.Cli.Pioneers.Exercise3.tests
     , Test.Cli.Pioneers.Exercise4.tests
     , Test.Cli.Shelley.Run.Query.tests
+    , Test.Config.Mainnet.tests
     ]


### PR DESCRIPTION
Ensures that `configuration/cardano/mainnet-config.json` is always valid.