### PR TITLE
Add missing AsType for current Tx eras

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -173,10 +173,12 @@ instance HasTypeProxy era => HasTypeProxy (Tx era) where
     data AsType (Tx era) = AsTx (AsType era)
     proxyToAsType _ = AsTx (proxyToAsType (Proxy :: Proxy era))
 
+{-# DEPRECATED AsByronTx "Use AsTx AsByronEra instead." #-}
 pattern AsByronTx :: AsType (Tx ByronEra)
 pattern AsByronTx   = AsTx AsByronEra
 {-# COMPLETE AsByronTx #-}
 
+{-# DEPRECATED AsShelleyTx "Use AsTx AsShelleyEra instead." #-}
 pattern AsShelleyTx :: AsType (Tx ShelleyEra)
 pattern AsShelleyTx = AsTx AsShelleyEra
 {-# COMPLETE AsShelleyTx #-}

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -55,7 +55,7 @@ golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--out-file", transactionFile
     ]
 
-  let txType = textEnvelopeType AsShelleyTx
+  let txType = textEnvelopeType (AsTx AsShelleyEra)
 
   -- Check the newly created files have not deviated from the
   -- golden files


### PR DESCRIPTION
Motivation: Trying to deserialize a `Tx era` with `deserialiseFromTextEnvelope` requires as parameter of type `AsType`. Currently we only have `AsByronTx` and `AsShelleyTx`. Therefore, this PR extends this to all current eras.