### PR TITLE
Update dependencies.

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -63,7 +63,7 @@ import           Cardano.Benchmarking.Tracer
 import           Cardano.Benchmarking.Wallet
 import qualified Cardano.Benchmarking.FundSet as FundSet
 
-import           Shelley.Spec.Ledger.API (ShelleyGenesis)
+import           Cardano.Ledger.Shelley.API (ShelleyGenesis)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
 
 readSigningKey :: SigningKeyFile -> ExceptT TxGenError IO (SigningKey PaymentKey)

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -17,7 +17,7 @@ import           Cardano.Api.Shelley (fromShelleyLovelace, fromShelleyStakeRefer
 
 import           Cardano.Benchmarking.GeneratorTx.Tx
 
-import           Shelley.Spec.Ledger.API (Addr(..), ShelleyGenesis, sgInitialFunds)
+import           Cardano.Ledger.Shelley.API (Addr(..), ShelleyGenesis, sgInitialFunds)
 import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
 genesisFunds :: forall era. IsShelleyBasedEra era

--- a/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -45,7 +45,7 @@ import           Cardano.Api (NetworkId(..), LocalNodeConnectInfo(..), Consensus
                              , submitTxToNodeLocal)
 import           Cardano.Api.Protocol.Types (BlockType(..), ProtocolInfoArgs(..), protocolInfo)
 
-import           Shelley.Spec.Ledger.Genesis (ShelleyGenesis)
+import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesis)
 
 type CardanoBlock = Consensus.CardanoBlock StandardCrypto
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                      , ouroboros-network-framework
                      , random
                      , serialise
-                     , shelley-spec-ledger
+                     , cardano-ledger-shelley
                      , stm
                      , text
                      , time

--- a/cabal.project
+++ b/cabal.project
@@ -131,8 +131,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 592aa61d657ad5935a33bace1243abce3728b643
-  --sha256: 1bgq3a2wfdz24jqfwylcc6jjg5aji8dpy5gjkhpnmkkvgcr2rkyb
+  tag: 64d7702866225f6d53afab4e2fe935f2f0d5848a
+  --sha256: 0aalxzrgb1pgaz254mddmrcn2zk6g0yip383kc346ma1nn49frh1
   subdir:
     base-deriving-via
     binary
@@ -154,27 +154,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5ddef26dac3638df72453e183a419f8f5193dd33
-  --sha256: 0ryx1irqjggchdd6xz7abbpgnh1p8kwviv4zggmh61ynh12cdvim
+  tag: c6c4be1562e23a3dd48282387c4e48ff918fbab0
+  --sha256: 1csi3ypq9h14hpf7fw40my11gb6gr4dvdiy7bl1nsi913qzbcra8
   subdir:
-    alonzo/impl
-    byron/chain/executable-spec
-    byron/crypto
-    byron/crypto/test
-    byron/ledger/executable-spec
-    byron/ledger/impl
-    byron/ledger/impl/test
-    cardano-ledger-core
-    cardano-protocol-tpraos
-    semantics/executable-spec
-    semantics/small-steps-test
-    shelley/chain-and-ledger/dependencies/non-integer
-    shelley/chain-and-ledger/executable-spec
-    shelley/chain-and-ledger/shelley-spec-ledger-test
-    shelley-ma/impl
-    shelley-ma/shelley-ma-test
---TODO: disabled until it drops its dep on plutus-tx-plugin
---  alonzo/test
+    eras/alonzo/impl
+    eras/alonzo/test-suite
+    eras/byron/chain/executable-spec
+    eras/byron/crypto
+    eras/byron/crypto/test
+    eras/byron/ledger/executable-spec
+    eras/byron/ledger/impl
+    eras/byron/ledger/impl/test
+    eras/shelley/impl
+    eras/shelley/test-suite
+    eras/shelley-ma/impl
+    eras/shelley-ma/test-suite
+    libs/cardano-ledger-core
+    libs/cardano-protocol-tpraos
+    libs/small-steps
+    libs/small-steps-test
+    libs/non-integral
+    eras/shelley/chain-and-ledger/executable-spec
+    eras/shelley/chain-and-ledger/shelley-spec-ledger-test
+    eras/shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
@@ -215,8 +217,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c25d36e62549d5bec9876cb57d1c52ee41bdec3a
-  --sha256: 0nzlsswi0mxajgwm1s6qq4nhjp7whjnfd2y3bc7aym6zhiw2yckg
+  tag: e0ccbb73296027a5e5fd224a78374321974758ce
+  --sha256: 1a6djwb2jkhh4pq6iwr10zxgpiz3n3f2yw54ciwnwqdm59cami38
   subdir:
     io-sim
     io-classes

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -134,7 +134,7 @@ library
                       , plutus-ledger-api
                       , prettyprinter
                       , scientific
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
                       , small-steps
                       , stm
                       , strict-containers
@@ -176,7 +176,7 @@ library gen
                       , containers
                       , hedgehog
                       , plutus-ledger-api
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
                       , tasty
                       , tasty-hedgehog
                       , text
@@ -205,8 +205,8 @@ test-suite cardano-api-test
                       , ouroboros-consensus
                       , ouroboros-consensus-shelley
                       , QuickCheck
-                      , shelley-spec-ledger
-                      , shelley-spec-ledger-test
+                      , cardano-ledger-shelley
+                      , cardano-ledger-shelley-test
                       , tasty
                       , tasty-quickcheck
                       , time

--- a/cardano-api/gen/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Gen/Cardano/Api.hs
@@ -15,7 +15,7 @@ import qualified Data.Map.Strict as Map
 --TODO: why do we have this odd split? We can get rid of the old name "typed"
 import           Gen.Cardano.Api.Typed (genRational)
 
-import           Shelley.Spec.Ledger.Metadata (Metadata (..), Metadatum (..))
+import           Cardano.Ledger.Shelley.Metadata (Metadata (..), Metadatum (..))
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -73,7 +73,7 @@ import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Seed as Crypto
 import qualified Plutus.V1.Ledger.Api as Plutus
-import qualified Shelley.Spec.Ledger.TxBody as Ledger (EraIndependentTxBody)
+import qualified Cardano.Ledger.Shelley.TxBody as Ledger (EraIndependentTxBody)
 
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -67,7 +67,7 @@ import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Protocol.TPraos.BHeader as Praos
-import qualified Shelley.Spec.Ledger.BlockChain as Ledger
+import qualified Cardano.Ledger.Shelley.BlockChain as Ledger
 
 import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -58,8 +58,8 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Shelley
 import qualified Cardano.Ledger.Coin as Shelley (toDeltaCoin)
-import           Shelley.Spec.Ledger.TxBody (MIRPot (..))
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import           Cardano.Ledger.Shelley.TxBody (MIRPot (..))
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 import           Cardano.Api.Address
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -68,11 +68,11 @@ import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Era as Ledger.Era (Crypto)
 import qualified Cardano.Ledger.Keys as Ledger
-import qualified Shelley.Spec.Ledger.API as Ledger (CLI, DCert, TxIn, Wdrl)
-import qualified Shelley.Spec.Ledger.API.Wallet as Ledger (evaluateTransactionBalance,
+import qualified Cardano.Ledger.Shelley.API as Ledger (CLI, DCert, TxIn, Wdrl)
+import qualified Cardano.Ledger.Shelley.API.Wallet as Ledger (evaluateTransactionBalance,
                    evaluateTransactionFee)
 
-import           Shelley.Spec.Ledger.PParams (PParams' (..))
+import           Cardano.Ledger.Shelley.PParams (PParams' (..))
 
 import qualified Cardano.Ledger.Mary.Value as Mary
 

--- a/cardano-api/src/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/src/Cardano/Api/GenesisParameters.hs
@@ -23,7 +23,7 @@ import           Data.Time (NominalDiffTime, UTCTime)
 import           Cardano.Slotting.Slot (EpochSize (..))
 
 import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Shelley.Spec.Ledger.Genesis as Shelley
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
 
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -578,4 +578,3 @@ chainSyncGetCurrentTip tipVar =
         void $ atomically $ tryPutTMVar tipVar tip
         pure $ Net.Sync.SendMsgDone ()
     }
-

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -22,7 +22,7 @@ import Control.Monad.Trans.Cont
 import Data.Either
 import Data.Function
 import Data.Maybe
-import Shelley.Spec.Ledger.Scripts ()
+import Cardano.Ledger.Shelley.Scripts ()
 import System.IO
 
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as Net.Sync

--- a/cardano-api/src/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/src/Cardano/Api/LedgerEvent.hs
@@ -42,12 +42,12 @@ import           Ouroboros.Consensus.Ledger.Basics (AuxLedgerEvent)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                    ShelleyLedgerEvent (ShelleyLedgerEventTICK))
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import           Shelley.Spec.Ledger.API (InstantaneousRewards (InstantaneousRewards))
-import           Shelley.Spec.Ledger.STS.Epoch (EpochEvent (PoolReapEvent))
-import           Shelley.Spec.Ledger.STS.Mir (MirEvent (..))
-import           Shelley.Spec.Ledger.STS.NewEpoch (NewEpochEvent (EpochEvent, MirEvent, SumRewards))
-import           Shelley.Spec.Ledger.STS.PoolReap (PoolreapEvent (RetiredPools))
-import           Shelley.Spec.Ledger.STS.Tick (TickEvent (NewEpochEvent))
+import           Cardano.Ledger.Shelley.API (InstantaneousRewards (InstantaneousRewards))
+import           Cardano.Ledger.Shelley.Rules.Epoch (EpochEvent (PoolReapEvent))
+import           Cardano.Ledger.Shelley.Rules.Mir (MirEvent (..))
+import           Cardano.Ledger.Shelley.Rules.NewEpoch (NewEpochEvent (EpochEvent, MirEvent, SumRewards))
+import           Cardano.Ledger.Shelley.Rules.PoolReap (PoolreapEvent (RetiredPools))
+import           Cardano.Ledger.Shelley.Rules.Tick (TickEvent (NewEpochEvent))
 
 data LedgerEvent
   = -- | The given pool is being registered for the first time on chain.
@@ -110,7 +110,7 @@ data MIRDistributionDetails = MIRDistributionDetails
   }
 
 data PoolReapDetails = PoolReapDetails
-  { epochNo :: EpochNo, 
+  { epochNo :: EpochNo,
     -- | Refunded deposits. The pools referenced are now retired, and the
     --   'StakeCredential' accounts are credited with the deposits.
     refunded :: Map StakeCredential (Map (Hash StakePoolKey) Lovelace),

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -110,8 +110,8 @@ import qualified Ouroboros.Network.Block
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as CS
 import qualified Ouroboros.Network.Protocol.ChainSync.ClientPipelined as CSP
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
-import qualified Shelley.Spec.Ledger.Genesis as Shelley.Spec
-import qualified Shelley.Spec.Ledger.PParams as Shelley.Spec
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley.Spec
+import qualified Cardano.Ledger.Shelley.PParams as Shelley.Spec
 import Data.Maybe (mapMaybe)
 import Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerEvent(WrapLedgerEvent))
 

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -52,12 +52,12 @@ import qualified Cardano.Ledger.SafeHash as SafeHash
 import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Cardano.Protocol.TPraos as Praos
 import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
-import qualified Shelley.Spec.Ledger.API as Shelley
-import qualified Shelley.Spec.Ledger.EpochBoundary as ShelleyEpoch
-import qualified Shelley.Spec.Ledger.LedgerState as ShelleyLedger
-import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
-import qualified Shelley.Spec.Ledger.RewardUpdate as Shelley
-import qualified Shelley.Spec.Ledger.Rewards as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Ledger.Shelley.EpochBoundary as ShelleyEpoch
+import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyLedger
+import           Cardano.Ledger.Shelley.PParams (PParamsUpdate)
+import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
+import qualified Cardano.Ledger.Shelley.Rewards as Shelley
 
 import           Plutus.V1.Ledger.Api (defaultCostModelParams)
 

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -84,12 +84,12 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 
-import qualified Shelley.Spec.Ledger.PParams as Ledger (ProposedPPUpdates (..), ProtVer (..),
+import qualified Cardano.Ledger.Shelley.PParams as Ledger (ProposedPPUpdates (..), ProtVer (..),
                    Update (..))
--- Some of the things from Shelley.Spec.Ledger.PParams are generic across all
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
 -- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
 -- So we import in twice under different names.
-import qualified Shelley.Spec.Ledger.PParams as Shelley (PParams, PParams' (..), PParamsUpdate)
+import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..), PParamsUpdate)
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -88,8 +88,8 @@ import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Ledger
 
-import qualified Shelley.Spec.Ledger.API as Shelley
-import qualified Shelley.Spec.Ledger.LedgerState as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 
 import           Cardano.Api.Address
 import           Cardano.Api.Block
@@ -684,4 +684,3 @@ fromConsensusQueryResultMismatch =
 fromConsensusEraMismatch :: SListI xs
                          => Consensus.MismatchEraInfo xs -> EraMismatch
 fromConsensusEraMismatch = Consensus.mkEraMismatch
-

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -133,7 +133,7 @@ import qualified Cardano.Ledger.Era  as Ledger
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as Timelock
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 import qualified Cardano.Ledger.Keys as Shelley
-import qualified Shelley.Spec.Ledger.Scripts as Shelley
+import qualified Cardano.Ledger.Shelley.Scripts as Shelley
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo

--- a/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
@@ -19,7 +19,7 @@ import           Cardano.Slotting.Slot (EpochSize (..))
 
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..), emptyGenesisStaking)
 
-import           Shelley.Spec.Ledger.PParams as Ledger (PParams' (..), emptyPParams)
+import           Cardano.Ledger.Shelley.PParams as Ledger (PParams' (..), emptyPParams)
 
 
 -- | Some reasonable starting defaults for constructing a 'ShelleyGenesis'.

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -91,9 +91,9 @@ import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.SafeHash as Ledger
 import qualified Cardano.Ledger.Shelley.Constraints as Shelley
-import qualified Shelley.Spec.Ledger.Address.Bootstrap as Shelley
-import qualified Shelley.Spec.Ledger.Tx as Shelley
-import qualified Shelley.Spec.Ledger.TxBody as Ledger (EraIndependentTxBody)
+import qualified Cardano.Ledger.Shelley.Address.Bootstrap as Shelley
+import qualified Cardano.Ledger.Shelley.Tx as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Ledger (EraIndependentTxBody)
 
 import qualified Cardano.Ledger.Alonzo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -181,11 +181,11 @@ import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.SafeHash as SafeHash
 import qualified Cardano.Ledger.Shelley.Constraints as Ledger
 
-import qualified Shelley.Spec.Ledger.Genesis as Shelley
-import qualified Shelley.Spec.Ledger.Metadata as Shelley
-import qualified Shelley.Spec.Ledger.Tx as Shelley
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
-import qualified Shelley.Spec.Ledger.UTxO as Shelley
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
+import qualified Cardano.Ledger.Shelley.Metadata as Shelley
+import qualified Cardano.Ledger.Shelley.Tx as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary

--- a/cardano-api/src/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/src/Cardano/Api/TxMetadata.hs
@@ -70,7 +70,7 @@ import           Control.Monad (guard, when)
 
 import qualified Cardano.Binary as CBOR
 
-import qualified Shelley.Spec.Ledger.Metadata as Shelley
+import qualified Cardano.Ledger.Shelley.Metadata as Shelley
 
 import           Cardano.Api.Eras
 import           Cardano.Api.Error

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -26,9 +26,9 @@ import           Cardano.Ledger.BaseTypes (Network (..))
 import           Cardano.Ledger.Coin (Coin (..))
 import           Cardano.Ledger.Keys (GenDelegPair (..), Hash, KeyHash (..), KeyRole (..),
                    VerKeyVRF)
-import           Shelley.Spec.Ledger.PParams (PParams' (..), emptyPParams)
+import           Cardano.Ledger.Shelley.PParams (PParams' (..), emptyPParams)
 
-import           Test.Shelley.Spec.Ledger.Utils (unsafeBoundRational)
+import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
 
 exampleShelleyGenesis :: ShelleyGenesis StandardShelley
 exampleShelleyGenesis =

--- a/cardano-api/test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/Test/Cardano/Api/Ledger.hs
@@ -12,7 +12,7 @@ import           Gen.Tasty.Hedgehog.Group (fromGroup)
 import           Hedgehog (Property, discover)
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 import           Test.Cardano.Api.Genesis
-import           Test.Shelley.Spec.Ledger.Serialisation.Generators.Genesis (genAddress)
+import           Test.Cardano.Ledger.Shelley.Serialisation.Generators.Genesis (genAddress)
 import           Test.Tasty (TestTree)
 
 import qualified Hedgehog as H

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -135,7 +135,7 @@ library
                       , parsec
                       , plutus-ledger-api
                       , prettyprinter
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
                       , small-steps
                       , split
                       , strict-containers

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -21,7 +21,7 @@ import           Cardano.Api
 import           Cardano.Api.Byron (Lovelace (..))
 import           Cardano.Api.Shelley (Address (ShelleyAddress), StakeAddress (..))
 import           Cardano.Ledger.Crypto (Crypto)
-import qualified Shelley.Spec.Ledger.API as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
 
 import           Cardano.CLI.Helpers (textShow)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -58,7 +58,7 @@ import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeVerifier, Verifi
                    VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
-import           Shelley.Spec.Ledger.TxBody (MIRPot)
+import           Cardano.Ledger.Shelley.TxBody (MIRPot)
 --
 -- Shelley CLI command data types
 --

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -35,12 +35,12 @@ import           Cardano.Protocol.TPraos (PoolDistr (..))
 import           Cardano.Protocol.TPraos.BHeader (HashHeader (..))
 
 import qualified Cardano.Ledger.Credential as Ledger
-import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
-import qualified Shelley.Spec.Ledger.EpochBoundary as Ledger
-import qualified Shelley.Spec.Ledger.Rewards as Ledger
+import qualified Cardano.Ledger.Shelley.API.Protocol as Ledger
+import qualified Cardano.Ledger.Shelley.EpochBoundary as Ledger
+import qualified Cardano.Ledger.Shelley.Rewards as Ledger
 import qualified Cardano.Protocol.TPraos.Rules.Prtcl as Ledger
-import qualified Shelley.Spec.Ledger.STS.Tickn as Ledger
-import           Shelley.Spec.Ledger.TxBody (TxId (..))
+import qualified Cardano.Ledger.Shelley.Rules.Tickn as Ledger
+import           Cardano.Ledger.Shelley.TxBody (TxId (..))
 
 import qualified Cardano.Ledger.Mary.Value as Ledger.Mary
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -18,7 +18,7 @@ import           Data.Aeson (KeyValue, ToJSON (..), (.=))
 import           Data.Function (id, ($), (.))
 import           Data.Maybe
 import           Data.Monoid (mconcat)
-import           Shelley.Spec.Ledger.Scripts ()
+import           Cardano.Ledger.Shelley.Scripts ()
 
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Encoding as JE

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -55,7 +55,7 @@ import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
 
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 {- HLINT ignore "Use <$>" -}
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -65,8 +65,8 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Keys as Ledger
-import qualified Shelley.Spec.Ledger.API as Ledger
-import qualified Shelley.Spec.Ledger.PParams as Shelley
+import qualified Cardano.Ledger.Shelley.API as Ledger
+import qualified Cardano.Ledger.Shelley.PParams as Shelley
 
 import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import           Cardano.Ledger.Era ()

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -18,7 +18,7 @@ import           Cardano.CLI.Shelley.Key (InputDecodeError, VerificationKeyOrHas
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Types
 
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 
 data ShelleyGovernanceCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -52,9 +52,9 @@ import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure (..))
 import           Prelude (String, id)
-import           Shelley.Spec.Ledger.EpochBoundary
-import           Shelley.Spec.Ledger.LedgerState hiding (_delegations)
-import           Shelley.Spec.Ledger.Scripts ()
+import           Cardano.Ledger.Shelley.EpochBoundary
+import           Cardano.Ledger.Shelley.LedgerState hiding (_delegations)
+import           Cardano.Ledger.Shelley.Scripts ()
 import           Text.Printf (printf)
 
 import qualified Cardano.CLI.Shelley.Output as O
@@ -72,7 +72,7 @@ import qualified Data.Text.IO as Text
 import qualified Data.Vector as Vector
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
-import qualified Shelley.Spec.Ledger.API.Protocol as Ledger
+import qualified Cardano.Ledger.Shelley.API.Protocol as Ledger
 import qualified System.IO as IO
 
 {- HLINT ignore "Reduce duplication" -}

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -38,7 +38,7 @@ import qualified Cardano.Binary as CBOR
 
 --TODO: following import needed for orphan Eq Script instance
 import           Cardano.Ledger.ShelleyMA.TxBody ()
-import           Shelley.Spec.Ledger.Scripts ()
+import           Cardano.Ledger.Shelley.Scripts ()
 
 import           Cardano.CLI.Environment (EnvSocketError, readEnvSocketPath, renderEnvSocketError)
 import           Cardano.CLI.Run.Friendly (friendlyTxBodyBS)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -38,7 +38,7 @@ import           Cardano.Api
 
 import qualified Cardano.Ledger.Crypto as Crypto
 
-import           Shelley.Spec.Ledger.TxBody (PoolParams (..))
+import           Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 
 -- | Specify what the CBOR file is
 -- i.e a block, a tx, etc
@@ -208,4 +208,3 @@ newtype TxOutChangeAddress = TxOutChangeAddress AddressAny
 -- | A flag that differentiates between automatically
 -- and manually balancing a tx.
 data BalanceTxExecUnits = AutoBalance | ManualBalance
-

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -81,5 +81,5 @@ executable ledger-state
                        ouroboros-consensus-cardano,
                        ouroboros-consensus-byron,
                        ouroboros-consensus-shelley,
-                       shelley-spec-ledger,
+                       cardano-ledger-shelley,
                        typed-protocols,

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -140,7 +140,7 @@ library
                       , process
                       , safe-exceptions
                       , scientific
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
                       , small-steps
                       , stm
                       , text

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -73,7 +73,7 @@ import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
-import qualified Shelley.Spec.Ledger.API as SL
+import qualified Cardano.Ledger.Shelley.API as SL
 
 import           Cardano.Api.Protocol.Types (BlockType (..), protocolInfo)
 import           Cardano.Config.Git.Rev (gitRev)

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -16,7 +16,7 @@ import qualified Data.Text as Text
 import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Shelley.Spec.Ledger.CompactAddr as Shelley
+import qualified Cardano.Ledger.Shelley.CompactAddr as Shelley
 
 instance FromJSON TracingVerbosity where
   parseJSON (String str) = case str of

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -40,8 +40,8 @@ import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ProtocolParamsShe
                    ProtocolParamsShelleyBased (..), TPraosLeaderCredentials (..))
 import           Ouroboros.Consensus.Shelley.Protocol (TPraosCanBeLeader (..))
 
-import qualified Shelley.Spec.Ledger.Genesis as Shelley
-import           Shelley.Spec.Ledger.PParams (ProtVer (..))
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
+import           Cardano.Ledger.Shelley.PParams (ProtVer (..))
 
 import qualified Cardano.Api as Api (FileError (..))
 import           Cardano.Api.Orphans ()

--- a/cardano-node/src/Cardano/Tracing/ConvertTxId.hs
+++ b/cardano-node/src/Cardano/Tracing/ConvertTxId.hs
@@ -21,7 +21,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (TxId (..))
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 -- | Convert a transaction ID to raw bytes.
 class ConvertTxId blk where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -70,28 +70,28 @@ import           Cardano.Protocol.TPraos.Rules.Overlay
 import           Cardano.Protocol.TPraos.Rules.Updn
 
 -- TODO: this should be exposed via Cardano.Api
-import           Shelley.Spec.Ledger.API hiding (ShelleyBasedEra)
+import           Cardano.Ledger.Shelley.API hiding (ShelleyBasedEra)
 
-import           Shelley.Spec.Ledger.STS.Bbody
-import           Shelley.Spec.Ledger.STS.Chain
-import           Shelley.Spec.Ledger.STS.Deleg
-import           Shelley.Spec.Ledger.STS.Delegs
-import           Shelley.Spec.Ledger.STS.Delpl
-import           Shelley.Spec.Ledger.STS.Epoch
-import           Shelley.Spec.Ledger.STS.Ledger
-import           Shelley.Spec.Ledger.STS.Ledgers
-import           Shelley.Spec.Ledger.STS.Mir
-import           Shelley.Spec.Ledger.STS.NewEpoch
-import           Shelley.Spec.Ledger.STS.Newpp
-import           Shelley.Spec.Ledger.STS.Pool
-import           Shelley.Spec.Ledger.STS.PoolReap
-import           Shelley.Spec.Ledger.STS.Ppup
-import           Shelley.Spec.Ledger.STS.Rupd
-import           Shelley.Spec.Ledger.STS.Snap
-import           Shelley.Spec.Ledger.STS.Tick
-import           Shelley.Spec.Ledger.STS.Upec
-import           Shelley.Spec.Ledger.STS.Utxo
-import           Shelley.Spec.Ledger.STS.Utxow
+import           Cardano.Ledger.Shelley.Rules.Bbody
+import           Cardano.Ledger.Shelley.Rules.Chain
+import           Cardano.Ledger.Shelley.Rules.Deleg
+import           Cardano.Ledger.Shelley.Rules.Delegs
+import           Cardano.Ledger.Shelley.Rules.Delpl
+import           Cardano.Ledger.Shelley.Rules.Epoch
+import           Cardano.Ledger.Shelley.Rules.Ledger
+import           Cardano.Ledger.Shelley.Rules.Ledgers
+import           Cardano.Ledger.Shelley.Rules.Mir
+import           Cardano.Ledger.Shelley.Rules.NewEpoch
+import           Cardano.Ledger.Shelley.Rules.Newpp
+import           Cardano.Ledger.Shelley.Rules.Pool
+import           Cardano.Ledger.Shelley.Rules.PoolReap
+import           Cardano.Ledger.Shelley.Rules.Ppup
+import           Cardano.Ledger.Shelley.Rules.Rupd
+import           Cardano.Ledger.Shelley.Rules.Snap
+import           Cardano.Ledger.Shelley.Rules.Tick
+import           Cardano.Ledger.Shelley.Rules.Upec
+import           Cardano.Ledger.Shelley.Rules.Utxo
+import           Cardano.Ledger.Shelley.Rules.Utxow
 
 {- HLINT ignore "Use :" -}
 

--- a/cardano-node/src/Cardano/Tracing/Queries.hs
+++ b/cardano-node/src/Cardano/Tracing/Queries.hs
@@ -19,8 +19,8 @@ import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
 import qualified Ouroboros.Consensus.Byron.Ledger.Ledger as Byron
 
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
-import qualified Shelley.Spec.Ledger.LedgerState as Shelley
-import qualified Shelley.Spec.Ledger.UTxO as Shelley
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
+import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 
 import qualified Ouroboros.Consensus.Cardano as Cardano
 import qualified Ouroboros.Consensus.Cardano.Block as Cardano

--- a/plutus-example/plutus-example/plutus-example.cabal
+++ b/plutus-example/plutus-example/plutus-example.cabal
@@ -78,7 +78,7 @@ library
                       , plutus-tx
                       , plutus-tx-plugin
                       , serialise
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
                       , strict-containers
                       , transformers
                       , transformers-except
@@ -126,7 +126,7 @@ test-suite plutus-example-test
                       , plutus-example
                       , plutus-ledger
                       , plutus-ledger-api
-                      , shelley-spec-ledger
+                      , cardano-ledger-shelley
 
 
   other-modules:        Test.PlutusExample.Gen

--- a/plutus-example/plutus-example/src/Cardano/PlutusExample/ScriptContextChecker.hs
+++ b/plutus-example/plutus-example/src/Cardano/PlutusExample/ScriptContextChecker.hs
@@ -59,7 +59,7 @@ import qualified PlutusTx.AssocMap as AMap
 import           PlutusTx.IsData.Class
 import           PlutusTx.Prelude hiding (Semigroup (..), unless)
 import qualified PlutusTx.Prelude as P
-import qualified Shelley.Spec.Ledger.TxBody as Shelley
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 -- Description
 -- MyCustomRedeemer mimics the ScriptContext. MyCustomRedeemer is built via reading

--- a/plutus-example/plutus-example/test/Test/PlutusExample/Gen.hs
+++ b/plutus-example/plutus-example/test/Test/PlutusExample/Gen.hs
@@ -16,8 +16,8 @@ import           Cardano.PlutusExample.ScriptContextChecker
 import           Gen.Cardano.Api.Typed
 import qualified Ledger as Plutus
 import qualified Plutus.V1.Ledger.DCert as Plutus
-import qualified Shelley.Spec.Ledger.TxBody as Ledger
-import qualified Shelley.Spec.Ledger.UTxO as Ledger
+import qualified Cardano.Ledger.Shelley.TxBody as Ledger
+import qualified Cardano.Ledger.Shelley.UTxO as Ledger
 
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen


### PR DESCRIPTION
- cardano-ledger-specs has been reorganised for sanity.
  (https://github.com/input-output-hk/cardano-ledger-specs/pull/2483)
  This entails a number of refactorings:
  - The package 'shelley-spec-ledger' is now deprecated in favour of
    'cardano-ledger-shelley'.
  - Shelley.Spec.NonIntegral -> Cardano.Ledger.NonIntegral
  - Shelley.Spec.Ledger -> Cardano.Ledger.Shelley
  - *.STS -> *.Rules
  - Test.Shelley.Spec.Ledger -> Test.Cardano.Ledger.Shelley

- As per https://github.com/input-output-hk/ouroboros-network/pull/3369,
  there is now no 'FilePath' argument to 'localSnocket'.

- Bump base to include a potential memory leak fix.