### PR TITLE
add description submit-api service

### DIFF
--- a/nix/nixos/cardano-submit-api-service.nix
+++ b/nix/nixos/cardano-submit-api-service.nix
@@ -29,6 +29,11 @@ in {
       socketPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
+        description = ''
+          cardano node socket path. If set, the entrypoint
+          takes this value over CARDANO_NODE_SOCKET_PATH env
+          variable.
+        '';
       };
       config = lib.mkOption {
         type = lib.types.nullOr lib.types.attrs;


### PR DESCRIPTION
- This is not immediately obvious.
- Lack of context, one could at first think its submit-api's socket.