### PR TITLE
tx-generator: Select funds with correct ScriptData

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/FundSet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/FundSet.hs
@@ -29,7 +29,8 @@ data FundInEra era = FundInEra {
 
 data Variant
   = PlainOldFund
-  | PlutusScriptFund !FilePath
+  -- maybe better use the script itself instead of the filePath
+  | PlutusScriptFund !FilePath !ScriptData
   -- A collateralFund is just a regular (PlainOldFund) on the chain,
   -- but tagged in the wallet so that it is not selected for spending.
   | CollateralFund
@@ -133,12 +134,6 @@ selectMinValue minValue fs = case coins of
     [] -> Left $ "findSufficientCoin: no single coin with min value >= " ++ show minValue
     (c:_) -> Right [c]
     where coins = toAscList ( Proxy :: Proxy Lovelace) (fs @=PlainOldFund @= IsConfirmed @>= minValue)
-
-selectPlutusFund :: FilePath -> FundSet -> Either String [Fund]
-selectPlutusFund scriptFile fs = case coins of
-    [] -> Left "no Plutus fund found"
-    (c:_) -> Right [c]
-    where coins = toAscList ( Proxy :: Proxy Lovelace) (fs @=PlutusScriptFund scriptFile @= IsConfirmed )
 
 selectCollateral :: FundSet -> Either String [Fund]
 selectCollateral fs = case coins of

--- a/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
@@ -20,15 +20,15 @@ import           Cardano.Benchmarking.Wallet
 mkUtxoScript ::
      NetworkId
   -> SigningKey PaymentKey
-  -> (FilePath, Script PlutusScriptV1, Hash ScriptData)
+  -> (FilePath, Script PlutusScriptV1, ScriptData)
   -> Validity
   -> ToUTxO AlonzoEra
-mkUtxoScript networkId key (scriptFile, script, txOutDatumHash) validity values
+mkUtxoScript networkId key (scriptFile, script, txOutDatum) validity values
   = ( map mkTxOut values
     , newFunds
     )
  where
-  mkTxOut v = TxOut plutusScriptAddr (mkTxOutValueAdaOnly v) (TxOutDatumHash ScriptDataInAlonzoEra txOutDatumHash)
+  mkTxOut v = TxOut plutusScriptAddr (mkTxOutValueAdaOnly v) (TxOutDatumHash ScriptDataInAlonzoEra $ hashScriptData txOutDatum)
 
   plutusScriptAddr = makeShelleyAddressInEra
                        networkId
@@ -43,7 +43,7 @@ mkUtxoScript networkId key (scriptFile, script, txOutDatumHash) validity values
     , _fundVal = mkTxOutValueAdaOnly val
     , _fundSigningKey = key
     , _fundValidity = validity
-    , _fundVariant = PlutusScriptFund scriptFile
+    , _fundVariant = PlutusScriptFund scriptFile txOutDatum
     }
 
 readScript :: FilePath -> IO (Script PlutusScriptV1)

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -425,7 +425,7 @@ runPlutusBenchmark submitMode scriptFile executionUnits scriptData scriptRedeeme
   fundSource <- liftIO (mkBufferedSource walletRef
                    (fromIntegral (unNumberOfTxs txCount) * numInputs)
                    minValuePerInput
-                   (PlutusScriptFund scriptFile) numInputs) >>= \case
+                   (PlutusScriptFund scriptFile scriptData) numInputs) >>= \case
     Right a  -> return a
     Left err -> throwE $ WalletError err
 
@@ -535,7 +535,7 @@ createChangeScriptFunds submitMode scriptFile scriptData value count = do
 --        selector = mkWalletFundSource walletRef $ FundSet.selectMinValue $ sum coins + fee
         inOut :: [Lovelace] -> [Lovelace]
         inOut = Wallet.includeChange fee coins
-        toUTxO = PlutusExample.mkUtxoScript networkId fundKey (scriptFile, script, hashScriptData scriptData) Confirmed
+        toUTxO = PlutusExample.mkUtxoScript networkId fundKey (scriptFile, script, scriptData) Confirmed
         fundToStore = mkWalletFundStore walletRef
 
       tx <- liftIO $ sourceToStoreTransaction (genTx (mkFee fee) TxMetadataNone) fundSource inOut toUTxO fundToStore

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -180,6 +180,9 @@ data WalletStep era
   | NextTx !(WalletScript era) !(Tx era)
   | Error String
 
+-- TODO:
+-- use explicit tx- counter for each walletscript
+-- Do not rely on global walletSeqNum
 benchmarkWalletScript :: forall era .
      IsShelleyBasedEra era
   => WalletRef


### PR DESCRIPTION
This PR fixes the following bug:
In a benchmark run which uses the same smart contract with
different script data, the benchmarks may mix up the
the script addresses with different script data.