### PR TITLE
ghc:  bump to ghc8107

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,7 @@
 # our packages overlay
 final: prev: with final;
   let
-    compiler-nix-name = config.haskellNix.compiler or "ghc8105";
+    compiler-nix-name = config.haskellNix.compiler or "ghc8107";
   in {
   cardanoNodeProject = import ./haskell.nix {
     inherit compiler-nix-name


### PR DESCRIPTION
This at least helps with an ICE we've encountered with 8.10.5:

```error:
    • GHC internal error: ‘gsis’ is not in scope during type checking, but it passed the renamer
      tcl_env of environment: [r7l2 :-> Identifier[renderChainInfoExport::ChainInfo
                                                                          -> [Text], TopLevelLet {} True],
                               r7l3 :-> Identifier[slotStart::ChainInfo
                                                              -> SlotNo -> SlotStart, TopLevelLet],
                               r7l4 :-> Identifier[sinceSlot::UTCTime
                                                              -> SlotStart
                                                              -> NominalDiffTime, TopLevelLet],
                               r7l5 :-> Identifier[afterSlot::NominalDiffTime
                                                              -> SlotStart -> UTCTime, TopLevelLet],
                               r7l6 :-> Identifier[optUTCTime::String
                                                               -> String
                                                               -> Parser UTCTime, TopLevelLet],
                               r7l7 :-> Identifier[optDuration::String
                                                                -> String
                                                                -> NominalDiffTime
                                                                -> Parser
                                                                     NominalDiffTime, TopLevelLet],
                               r7l8 :-> Identifier[optWord::String
                                                            -> String
                                                            -> Word64
                                                            -> Parser Word64, TopLevelLet],
                               r7l9 :-> Identifier[readerFromAttoParser::forall a.
                                                                         Atto.Parser a
                                                                         -> ReadM a, TopLevelLet]]
    • In the pattern: CInfo {..}
      In an equation for ‘renderChainInfoExport’:
          renderChainInfoExport CInfo {..}
            = Data.Text.intercalate ","
                <$>
                  [["Profile", profile_name prof], ["Era", era prof],
                   ["Date", show $ date prof], ....]```