### PR TITLE
CAD-3628: remove NodeInfo from trace-forward.

### DIFF
--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
@@ -48,7 +48,6 @@ import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Forwarder (forwardEKGMetricsResp)
 import qualified Trace.Forward.Configuration as TF
 import           Trace.Forward.Network.Forwarder (forwardTraceObjectsResp)
-import           Trace.Forward.Protocol.Type (NodeInfo (..))
 import           Trace.Forward.Utils
 
 import           Cardano.Logging.DocuGenerator
@@ -60,9 +59,8 @@ import           Cardano.Logging.Utils(uncurry3)
 forwardTracer :: forall m. (MonadIO m)
   => IOManager
   -> TraceConfig
-  -> NodeInfo
   -> m (Trace m FormattedMessage)
-forwardTracer iomgr config nodeInfo = liftIO $ do
+forwardTracer iomgr config = liftIO $ do
   forwardSink <- initForwardSink tfConfig
   store <- EKG.newStore
   EKG.registerGcMetrics store
@@ -99,7 +97,6 @@ forwardTracer iomgr config nodeInfo = liftIO $ do
     TF.ForwarderConfiguration
       { TF.forwarderTracer       = contramap show stdoutTracer
       , TF.acceptorEndpoint      = TF.LocalPipe p
-      , TF.getNodeInfo           = pure nodeInfo
       , TF.disconnectedQueueSize = 200000
       , TF.connectedQueueSize    = 2000
       }

--- a/trace-forward/src/Trace/Forward/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Acceptor.hs
@@ -14,7 +14,6 @@ import           Ouroboros.Network.Util.ShowProxy (ShowProxy(..))
 
 import           Trace.Forward.Network.Acceptor (listenToForwarder)
 import           Trace.Forward.Configuration (AcceptorConfiguration (..))
-import           Trace.Forward.Protocol.Type (NodeInfo)
 import           Trace.Forward.Utils (runActionInLoop)
 
 runTraceAcceptor
@@ -24,7 +23,6 @@ runTraceAcceptor
   => IOManager                -- ^ 'IOManager' from the external application.
   -> AcceptorConfiguration lo -- ^ Acceptor configuration.
   -> ([lo] -> IO ())          -- ^ The handler for 'TraceObject's received from the node.
-  -> (NodeInfo -> IO ())      -- ^ The handler for node's info received from the node.
   -> IO ()
-runTraceAcceptor iomgr config@AcceptorConfiguration{forwarderEndpoint} loHandler niHandler =
-  runActionInLoop (listenToForwarder iomgr config loHandler niHandler) forwarderEndpoint 1
+runTraceAcceptor iomgr config@AcceptorConfiguration{forwarderEndpoint} loHandler =
+  runActionInLoop (listenToForwarder iomgr config loHandler) forwarderEndpoint 1

--- a/trace-forward/src/Trace/Forward/Configuration.hs
+++ b/trace-forward/src/Trace/Forward/Configuration.hs
@@ -35,8 +35,6 @@ data ForwarderConfiguration lo = ForwarderConfiguration
     forwarderTracer :: !(Tracer IO (TraceSendRecv (TraceForward lo)))
     -- | The endpoint that will be used to connect to the acceptor.
   , acceptorEndpoint :: !HowToConnect
-    -- | An action that returns node's information.
-  , getNodeInfo :: !(IO NodeInfo)
     -- | The big size of internal queue for tracing items. We use it in
     --   the beginning of the session, to avoid queue overflow, because
     --   initially there is no connection with acceptor yet, and the

--- a/trace-forward/src/Trace/Forward/Network/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Network/Forwarder.hs
@@ -93,10 +93,9 @@ forwardTraceObjects config sink =
       runPeer
         (forwarderTracer config)
         (Forwarder.codecTraceForward CBOR.encode CBOR.decode
-                                     CBOR.encode CBOR.decode
                                      CBOR.encode CBOR.decode)
         channel
-        (Forwarder.traceForwarderPeer $ readItems config sink)
+        (Forwarder.traceForwarderPeer $ readItems sink)
 
 forwardTraceObjectsResp
   :: (CBOR.Serialise lo,
@@ -110,7 +109,6 @@ forwardTraceObjectsResp config sink =
       runPeer
         (forwarderTracer config)
         (Forwarder.codecTraceForward CBOR.encode CBOR.decode
-                                     CBOR.encode CBOR.decode
                                      CBOR.encode CBOR.decode)
         channel
-        (Forwarder.traceForwarderPeer $ readItems config sink)
+        (Forwarder.traceForwarderPeer $ readItems sink)

--- a/trace-forward/src/Trace/Forward/Protocol/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/Acceptor.hs
@@ -20,10 +20,6 @@ import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..),
 import           Trace.Forward.Protocol.Type
 
 data TraceAcceptor lo m a where
-  SendMsgNodeInfoRequest
-    :: (NodeInfo -> m (TraceAcceptor lo m a))
-    -> TraceAcceptor lo m a
-
   SendMsgTraceObjectsRequest
     :: TokBlockingStyle blocking
     -> NumberOfTraceObjects
@@ -41,15 +37,6 @@ traceAcceptorPeer
   => TraceAcceptor lo m a
   -> Peer (TraceForward lo) 'AsClient 'StIdle m a
 traceAcceptorPeer = \case
-  SendMsgNodeInfoRequest next ->
-    -- Send our message (request for node's info from the forwarder).
-    Yield (ClientAgency TokIdle) MsgNodeInfoRequest $
-      -- We're now into the 'StNodeInfoBusy' state, and now we'll wait for
-      -- a reply from the forwarder.
-      Await (ServerAgency TokNodeInfoBusy) $ \(MsgNodeInfoReply reply) ->
-        Effect $
-          traceAcceptorPeer <$> next reply
-
   SendMsgTraceObjectsRequest TokBlocking request next ->
     -- Send our message (request for new 'TraceObject's from the forwarder).
     Yield (ClientAgency TokIdle) (MsgTraceObjectsRequest TokBlocking request) $

--- a/trace-forward/test/Test/Trace/Forward/Demo/Configs.hs
+++ b/trace-forward/test/Test/Trace/Forward/Demo/Configs.hs
@@ -25,15 +25,13 @@ mkAcceptorConfig ep weAreDone =
 
 mkForwarderConfig
   :: HowToConnect
-  -> IO NodeInfo
   -> Word
   -> Word
   -> ForwarderConfiguration TraceItem
-mkForwarderConfig ep getNI disconnectedSize connectedSize =
+mkForwarderConfig ep disconnectedSize connectedSize =
   ForwarderConfiguration
     { forwarderTracer       = nullTracer
     , acceptorEndpoint      = ep
-    , getNodeInfo           = getNI
     , disconnectedQueueSize = disconnectedSize
     , connectedQueueSize    = connectedSize
     }

--- a/trace-forward/test/Test/Trace/Forward/Protocol/Codec.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/Codec.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Test.Trace.Forward.Protocol.Codec () where
 
-import           Data.Time.Calendar (fromGregorian)
-import           Data.Time.Clock (UTCTime (..))
 import           Test.QuickCheck
 
 import           Network.TypedProtocol.Core
@@ -18,40 +15,16 @@ import           Test.Trace.Forward.Protocol.TraceItem
 instance Arbitrary NumberOfTraceObjects where
   arbitrary = NumberOfTraceObjects <$> arbitrary
 
-ni1, ni2 :: NodeInfo
-ni1 = NodeInfo
-  { niName            = "core-1"
-  , niProtocol        = "Shelley"
-  , niVersion         = "1.28.0"
-  , niCommit          = "cffa06c"
-  , niStartTime       = UTCTime (fromGregorian 2021 7 24) ((22 * 3600) + (15 * 60) +  1)
-  , niSystemStartTime = UTCTime (fromGregorian 2017 9 24) (( 1 * 3600) + (44 * 60) + 51)
-  }
-ni2 = NodeInfo
-  { niName            = "core-2"
-  , niProtocol        = "Shelley"
-  , niVersion         = "1.28.0"
-  , niCommit          = "cffa06c"
-  , niStartTime       = UTCTime (fromGregorian 2021 7 24) ((22 * 3600) + (15 * 60) +  1)
-  , niSystemStartTime = UTCTime (fromGregorian 2017 9 24) (( 1 * 3600) + (44 * 60) + 51)
-  }
-
 instance Arbitrary (AnyMessageAndAgency (TraceForward TraceItem)) where
   arbitrary = oneof
-    [ pure $ AnyMessageAndAgency (ClientAgency TokIdle) MsgNodeInfoRequest
-    , AnyMessageAndAgency (ClientAgency TokIdle) . MsgTraceObjectsRequest TokBlocking <$> arbitrary
+    [ AnyMessageAndAgency (ClientAgency TokIdle) . MsgTraceObjectsRequest TokBlocking <$> arbitrary
     , AnyMessageAndAgency (ClientAgency TokIdle) . MsgTraceObjectsRequest TokNonBlocking <$> arbitrary
-    , AnyMessageAndAgency (ServerAgency TokNodeInfoBusy) . MsgNodeInfoReply <$> oneof [pure ni1, pure ni2]
     , AnyMessageAndAgency (ServerAgency (TokBusy TokBlocking)) . MsgTraceObjectsReply . BlockingReply <$> arbitrary
     , AnyMessageAndAgency (ServerAgency (TokBusy TokNonBlocking)) . MsgTraceObjectsReply . NonBlockingReply <$> arbitrary
     , pure  $ AnyMessageAndAgency (ClientAgency TokIdle) MsgDone
     ]
 
 instance Eq (AnyMessage (TraceForward TraceItem)) where
-  AnyMessage MsgNodeInfoRequest
-    == AnyMessage MsgNodeInfoRequest = True
-  AnyMessage (MsgNodeInfoReply r1)
-    == AnyMessage (MsgNodeInfoReply r2) = r1 == r2
   AnyMessage (MsgTraceObjectsRequest TokBlocking r1)
     == AnyMessage (MsgTraceObjectsRequest TokBlocking r2) = r1 == r2
   AnyMessage (MsgTraceObjectsRequest TokNonBlocking r1)

--- a/trace-forward/test/Test/Trace/Forward/Protocol/Tests.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/Tests.hs
@@ -24,6 +24,5 @@ prop_codec_TraceForward :: AnyMessageAndAgency (TraceForward TraceItem) -> Bool
 prop_codec_TraceForward msg =
   runST $ prop_codecM
           (codecTraceForward CBOR.encode CBOR.decode
-                             CBOR.encode CBOR.decode
                              CBOR.encode CBOR.decode)
           msg

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -54,8 +54,6 @@ library
                        , ouroboros-network-framework
                        , serialise
                        , stm
-                       , text
-                       , time
                        , typed-protocols
                        , typed-protocols-cborg
 


### PR DESCRIPTION
Since the new `datapoint-forward` library (https://github.com/input-output-hk/cardano-node/pull/3303) will be used to forward structured data from the node, `NodeInfo` type should be removed from `trace-forward` library.