### PR TITLE
Expose textEnvelopeToJSON

### DIFF
--- a/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
@@ -21,6 +21,7 @@ module Cardano.Api.SerialiseTextEnvelope
   , writeFileTextEnvelopeWithOwnerPermissions
   , readTextEnvelopeFromFile
   , readTextEnvelopeOfTypeFromFile
+  , textEnvelopeToJSON
 
     -- * Reading one of several key types
   , FromSomeType(..)


### PR DESCRIPTION
Otherwise we're forced to use writeFileTextEnvelope
or duplicate internal functions, without a clean option
to e.g. print to stdout.