### PR TITLE
Disable idle GC in the default nix build

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -404,7 +404,7 @@ in {
 
       rtsArgs = mkOption {
         type = types.listOf types.str;
-        default = [ "-N2" "-A16m" "-qg" "-qb" "--disable-delayed-os-memory-return" ];
+        default = [ "-N2" "-I0" "-A16m" "-qg" "-qb" "--disable-delayed-os-memory-return" ];
         apply = args: if (args != [] || cfg.profilingArgs != []) then
           ["+RTS"] ++ cfg.profilingArgs ++ args ++ ["-RTS"]
           else [];


### PR DESCRIPTION
I guess this is what's causing cardano-node constantly high CPU usage when running in Daedalus.

My suggestion would be to also add "-c" - always compact oldest generation instead of copying collection. Since most heap data is very long-lived, this can cause considerably less memory usage.