### PR TITLE
Suggestion to use the compacting collector in the nix build

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -404,7 +404,7 @@ in {
 
       rtsArgs = mkOption {
         type = types.listOf types.str;
-        default = [ "-N2" "-A16m" "-qg" "-qb" "--disable-delayed-os-memory-return" ];
+        default = [ "-N2" "-A16m" "-c" "-qg" "-qb" "--disable-delayed-os-memory-return" ];
         apply = args: if (args != [] || cfg.profilingArgs != []) then
           ["+RTS"] ++ cfg.profilingArgs ++ args ++ ["-RTS"]
           else [];


### PR DESCRIPTION
Will reduce memory usage, might be bad for block-producing nodes without
enough CPU.