### PR TITLE
Disable reorder-goals

### DIFF
--- a/.github/workflows/cabal.project.local.Windows
+++ b/.github/workflows/cabal.project.local.Windows
@@ -5,4 +5,4 @@ write-ghc-environment-files: always
 
 ignore-project: False
 
-reorder-goals: True
+reorder-goals: False


### PR DESCRIPTION
This speeds up Windows builds `4x`.