### PR TITLE
Delete obsolete function executeLocalStateQueryExprWithChainSync

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -615,7 +615,6 @@ module Cardano.Api (
     -- ** Monadic queries
     LocalStateQueryExpr,
     executeLocalStateQueryExpr,
-    executeLocalStateQueryExprWithChainSync,
     queryExpr,
     determineEraExpr,
 


### PR DESCRIPTION
The function was necessary previously because it was not possible to query for chain tip from local state queries.  This changed with this PR: https://github.com/input-output-hk/cardano-node/pull/3179 which provided `QueryChainBlockNo`
 and `QueryChainPoint`.

This means `executeLocalStateQueryExprWithChainSync` is no longer used nor needed.