### PR TITLE
Better error message for query utxo 2

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -249,7 +249,8 @@ queryEra :: ActionM AnyCardanoEra
 queryEra = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
-  ret <- liftIO $ queryNodeLocalState localNodeConnectInfo (Just $ chainTipToChainPoint chainTip) $ QueryCurrentEra CardanoModeIsMultiEra
+  ret <- liftIO $ executeLocalStateQueryExpr @() localNodeConnectInfo (Just $ chainTipToChainPoint chainTip)
+    $ queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
   case ret of
     Right era -> return era
     Left err -> throwE $ ApiError $ show err
@@ -258,8 +259,8 @@ queryProtocolParameters :: ActionM ProtocolParameters
 queryProtocolParameters = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
-  ret <- liftIO $ queryNodeLocalState localNodeConnectInfo (Just $ chainTipToChainPoint chainTip)
-                    $ QueryInEra AlonzoEraInCardanoMode $ QueryInShelleyBasedEra ShelleyBasedEraAlonzo QueryProtocolParameters
+  ret <- liftIO $ executeLocalStateQueryExpr @() localNodeConnectInfo (Just $ chainTipToChainPoint chainTip)
+    $ queryExpr $ QueryInEra AlonzoEraInCardanoMode $ QueryInShelleyBasedEra ShelleyBasedEraAlonzo QueryProtocolParameters
   case ret of
     Right (Right pp) -> return pp
     Right (Left err) -> throwE $ ApiError $ show err

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -249,7 +249,7 @@ queryEra :: ActionM AnyCardanoEra
 queryEra = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
-  ret <- liftIO $ executeLocalStateQueryExpr @() localNodeConnectInfo (Just $ chainTipToChainPoint chainTip)
+  ret <- liftIO $ executeLocalStateQueryExpr localNodeConnectInfo (Just $ chainTipToChainPoint chainTip) id
     $ queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
   case ret of
     Right era -> return era
@@ -259,7 +259,7 @@ queryProtocolParameters :: ActionM ProtocolParameters
 queryProtocolParameters = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
-  ret <- liftIO $ executeLocalStateQueryExpr @() localNodeConnectInfo (Just $ chainTipToChainPoint chainTip)
+  ret <- liftIO $ executeLocalStateQueryExpr  localNodeConnectInfo (Just $ chainTipToChainPoint chainTip) id
     $ queryExpr $ QueryInEra AlonzoEraInCardanoMode $ QueryInShelleyBasedEra ShelleyBasedEraAlonzo QueryProtocolParameters
   case ret of
     Right (Right pp) -> return pp

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library
                         Cardano.Api.HasTypeProxy
                         Cardano.Api.IPC
                         Cardano.Api.IPC.Monad
+                        Cardano.Api.IPC.NtcVersionOf
                         Cardano.Api.Json
                         Cardano.Api.Key
                         Cardano.Api.KeysByron

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -550,6 +550,8 @@ module Cardano.Api (
     QueryUTxOFilter(..),
     UTxO(..),
     queryNodeLocalState,
+    QueryError(..),
+    MinNodeToClientVersion,
 
     EraHistory(..),
     getProgress,
@@ -616,12 +618,13 @@ module Cardano.Api (
     LocalStateQueryExpr,
     executeLocalStateQueryExpr,
     queryExpr,
+    maybeQueryExpr,
     determineEraExpr,
+    getNtcVersion,
 
     chainPointToSlotNo,
     chainPointToHeaderHash,
     makeChainTip
-
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -51,9 +51,10 @@ import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 
 import           Ouroboros.Consensus.Shelley.Eras as Ledger (StandardAllegra, StandardAlonzo,
                    StandardMary, StandardShelley)
+import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
 
 import           Cardano.Api.HasTypeProxy
-
+import           Cardano.Api.IPC.NtcVersionOf (NtcVersionOf (..))
 
 -- | A type used as a tag to distinguish the Byron era.
 data ByronEra
@@ -190,6 +191,9 @@ data AnyCardanoEra where
      AnyCardanoEra :: IsCardanoEra era  -- Provide class constraint
                    => CardanoEra era    -- and explicit value.
                    -> AnyCardanoEra
+
+instance NtcVersionOf AnyCardanoEra where
+  ntcVersionOf (AnyCardanoEra _) = NodeToClientV_1
 
 deriving instance Show AnyCardanoEra
 

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -1,31 +1,40 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Api.IPC.Monad
   ( LocalStateQueryExpr
   , executeLocalStateQueryExpr
   , queryExpr
   , determineEraExpr
+  , NtcVersionOf (..)
+  , getNtcVersion
+  , maybeQueryExpr
   ) where
 
 import Cardano.Api.Block
 import Cardano.Api.Eras
 import Cardano.Api.IPC
+import Cardano.Api.IPC.NtcVersionOf (NtcVersionOf (..))
 import Cardano.Api.Modes
 import Control.Applicative
 import Control.Concurrent.STM
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Except
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Cont
+import Control.Monad.Trans.Reader
 import Data.Either
 import Data.Function
 import Data.Maybe
+import Data.Ord
 import Cardano.Ledger.Shelley.Scripts ()
 import System.IO
 
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Net.Query
 
 {- HLINT ignore "Use const" -}
 {- HLINT ignore "Use let" -}
@@ -42,15 +51,16 @@ import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Net.Query
 -- In order to make pipelining still possible we can explore the use of Selective Functors
 -- which would allow us to straddle both worlds.
 newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
-  { runLocalStateQueryExpr :: ContT (Net.Query.ClientStAcquired block point query m r) m a
+  { runLocalStateQueryExpr :: ReaderT NodeToClientVersion (ContT (Net.Query.ClientStAcquired block point query m r) m) a
   } deriving (Functor, Applicative, Monad, MonadIO)
 
 -- | Execute a local state query expression.
 executeLocalStateQueryExpr
-  :: LocalNodeConnectInfo mode
+  :: forall e mode a .
+     LocalNodeConnectInfo mode
   -> Maybe ChainPoint
-  -> (NodeToClientVersion -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a)
-  -> IO (Either AcquireFailure a)
+  -> ExceptT (QueryError e) (LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO) a
+  -> IO (Either (QueryError e) a)
 executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
   let waitResult = readTMVar tmvResultLocalState
@@ -60,7 +70,7 @@ executeLocalStateQueryExpr connectInfo mpoint f = do
     (\ntcVersion ->
       LocalNodeClientProtocols
       { localChainSyncClient    = NoLocalChainSyncClient
-      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint tmvResultLocalState (f ntcVersion)
+      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint tmvResultLocalState ntcVersion f
       , localTxSubmissionClient = Nothing
       }
     )
@@ -74,36 +84,56 @@ setupLocalStateQueryExpr ::
      -- Protocols must wait until 'waitDone' returns because premature exit will
      -- cause other incomplete protocols to abort which may lead to deadlock.
   -> Maybe ChainPoint
-  -> TMVar (Either Net.Query.AcquireFailure a)
-  -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
+  -> TMVar (Either (QueryError e) a)
+  -> NodeToClientVersion
+  -> ExceptT (QueryError e) (LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO) a
   -> Net.Query.LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) IO ()
-setupLocalStateQueryExpr waitDone mPointVar' resultVar' f =
+setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring
-    { Net.Query.recvMsgAcquired = runContT (runLocalStateQueryExpr f) $ \result -> do
-        atomically $ putTMVar resultVar' (Right result)
+    { Net.Query.recvMsgAcquired = runContT (runReaderT (runLocalStateQueryExpr (runExceptT f)) ntcVersion) $ \result -> do
+        atomically $ putTMVar resultVar' result
         void $ atomically waitDone -- Wait for all protocols to complete before exiting.
         pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
 
     , Net.Query.recvMsgFailure = \failure -> do
-        atomically $ putTMVar resultVar' (Left failure)
+        atomically $ putTMVar resultVar' (Left (QueryErrorAcquireFailure failure))
         void $ atomically waitDone -- Wait for all protocols to complete before exiting.
         pure $ Net.Query.SendMsgDone ()
     }
 
--- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: QueryInMode mode a -> LocalStateQueryExpr block point (QueryInMode mode) r IO a
-queryExpr q =
-  LocalStateQueryExpr . ContT $ \f -> pure $
-    Net.Query.SendMsgQuery q $
-      Net.Query.ClientStQuerying
-      { Net.Query.recvMsgResult = f
-      }
+-- | Get the node server's Node-to-Client version.
+getNtcVersion :: ExceptT (QueryError e) (LocalStateQueryExpr block point (QueryInMode mode) r IO) NodeToClientVersion
+getNtcVersion =  lift $ LocalStateQueryExpr $ ReaderT pure
 
--- | A monad expresion that determines what era the node is in.
+-- | Lift a query value into a monadic query expression.
+-- Use 'queryExpr' in a do block to construct monadic local state queries.
+queryExpr :: QueryInMode mode a -> ExceptT (QueryError e) (LocalStateQueryExpr block point (QueryInMode mode) r IO) a
+queryExpr q = do
+  let minNtcVersion = ntcVersionOf q
+  ntcVersion <- getNtcVersion
+  if ntcVersion >= minNtcVersion
+    then lift
+      $ LocalStateQueryExpr $ ReaderT $ \_ -> ContT $ \f -> pure $
+        Net.Query.SendMsgQuery q $
+          Net.Query.ClientStQuerying
+          { Net.Query.recvMsgResult = f
+          }
+    else throwE $ QueryErrorUnsupportedVersion minNtcVersion ntcVersion
+
+-- | Lift a query value into a monadic query expression returning Maybe of a result.
+-- This is the same as 'queryExpr' except if the query is not supported by the server, will return Nothing instead
+-- of throwing an error.
+maybeQueryExpr :: QueryInMode mode a -> ExceptT (QueryError e) (LocalStateQueryExpr block point (QueryInMode mode) r IO) (Maybe a)
+maybeQueryExpr q = catchE (Just <$> queryExpr q) $ \e ->
+  case e of
+    QueryErrorUnsupportedVersion _ _ -> return Nothing
+    _ -> throwE e
+
+-- | A monadic expresion that determines what era the node is in.
 determineEraExpr ::
      ConsensusModeParams mode
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO AnyCardanoEra
+  -> ExceptT (QueryError a) (LocalStateQueryExpr block point (QueryInMode mode) r IO) AnyCardanoEra
 determineEraExpr cModeParams =
   case consensusModeOnly cModeParams of
     ByronMode -> return $ AnyCardanoEra ByronEra

--- a/cardano-api/src/Cardano/Api/IPC/NtcVersionOf.hs
+++ b/cardano-api/src/Cardano/Api/IPC/NtcVersionOf.hs
@@ -1,0 +1,10 @@
+module Cardano.Api.IPC.NtcVersionOf
+  ( NtcVersionOf (..)
+  ) where
+
+import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
+
+-- | The query 'a' is a versioned query, which means it requires the Node to support a minimum
+-- Node-to-Client version.
+class NtcVersionOf a where
+  ntcVersionOf :: a -> NodeToClientVersion

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -284,9 +284,7 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
             localNodeSocketPath      = socketPath
           }
 
-  lift $ connectToLocalNode
-    connectInfo
-    (protocols stateIORef errorIORef env ledgerState)
+  lift $ connectToLocalNode connectInfo (protocols stateIORef errorIORef env ledgerState)
 
   lift (readIORef errorIORef) >>= \case
     Just err -> throwE (FoldBlocksApplyBlockError err)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -88,9 +88,16 @@ data ShelleyQueryCmdError
   | ShelleyQueryCmdPoolIdError (Hash StakePoolKey)
   | ShelleyQueryCmdEraMismatch !EraMismatch
   | ShelleyQueryCmdUnsupportedMode !AnyConsensusMode
+  | ShelleyQueryCmdUnsupportedVersion !MinNodeToClientVersion !NodeToClientVersion
   | ShelleyQueryCmdPastHorizon !Qry.PastHorizonException
   | ShelleyQueryCmdSystemStartUnavailable
   deriving Show
+
+renderQueryError :: QueryError ShelleyQueryCmdError -> Text
+renderQueryError (QueryErrorAcquireFailure acquireFail) = Text.pack $ show acquireFail
+renderQueryError (QueryErrorUnsupportedVersion minNtcVersion ntcVersion) =
+  "Minimum NtcVersion of " <> Text.pack (show minNtcVersion) <> " needed, but got " <> Text.pack (show ntcVersion)
+renderQueryError (QueryErrorOf e) = renderShelleyQueryCmdError e
 
 renderShelleyQueryCmdError :: ShelleyQueryCmdError -> Text
 renderShelleyQueryCmdError err =
@@ -111,6 +118,10 @@ renderShelleyQueryCmdError err =
     ShelleyQueryCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
     ShelleyQueryCmdPastHorizon e -> "Past horizon: " <> show e
     ShelleyQueryCmdSystemStartUnavailable -> "System start unavailable"
+    ShelleyQueryCmdUnsupportedVersion minNtcVersion ntcVersion ->
+      "Unsupported feature for the node-to-client protocol version.\n\
+      \This query requires at least " <> show minNtcVersion <> " but the node negotiated " <> show ntcVersion <> ".\n\
+      \Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
 
 runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmd cmd =
@@ -136,6 +147,11 @@ runQueryCmd cmd =
     QueryUTxO' consensusModeParams qFilter networkId mOutFile ->
       runQueryUTxO consensusModeParams qFilter networkId mOutFile
 
+queryErrorToShelleyQueryCmdError :: QueryError ShelleyQueryCmdError -> ShelleyQueryCmdError
+queryErrorToShelleyQueryCmdError (QueryErrorOf e) = e
+queryErrorToShelleyQueryCmdError (QueryErrorAcquireFailure a) = ShelleyQueryCmdAcquireFailure a
+queryErrorToShelleyQueryCmdError (QueryErrorUnsupportedVersion minNtcVersion mtcVersion) = ShelleyQueryCmdUnsupportedVersion minNtcVersion mtcVersion
+
 runQueryProtocolParameters
   :: AnyConsensusModeParams
   -> NetworkId
@@ -146,22 +162,22 @@ runQueryProtocolParameters (AnyConsensusModeParams cModeParams) network mOutFile
                            readEnvSocketPath
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT $ do
-    anyE@(AnyCardanoEra era) <- lift $ determineEraExpr cModeParams
+  result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ do
+    anyE@(AnyCardanoEra era) <- determineEraExpr cModeParams
 
     case cardanoEraStyle era of
-      LegacyByronEra -> left ShelleyQueryCmdByronEra
+      LegacyByronEra -> left (QueryErrorOf ShelleyQueryCmdByronEra)
       ShelleyBasedEra sbe -> do
         let cMode = consensusModeOnly cModeParams
 
         eInMode <- toEraInMode era cMode
-          & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+          & hoistMaybe (QueryErrorOf (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        ppResult <- lift . queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+        ppResult <- queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
-        except ppResult & firstExceptT ShelleyQueryCmdEraMismatch
+        except ppResult & firstExceptT (QueryErrorOf . ShelleyQueryCmdEraMismatch)
 
-  writeProtocolParameters mOutFile =<< except (join (first ShelleyQueryCmdAcquireFailure result))
+  writeProtocolParameters mOutFile =<< except (first queryErrorToShelleyQueryCmdError result)
  where
   writeProtocolParameters
     :: Maybe OutputFile
@@ -220,18 +236,12 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
     CardanoMode -> do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-      eLocalState <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ \ntcVersion -> do
-        era <- queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
+      eLocalState <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ do
+        era <-  queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
         eraHistory <- queryExpr (QueryEraHistory CardanoModeIsMultiEra)
-        mChainBlockNo <- if ntcVersion >= NodeToClientV_10
-          then Just <$> queryExpr QueryChainBlockNo
-          else return Nothing
-        mChainPoint <- if ntcVersion >= NodeToClientV_10
-          then Just <$> queryExpr (QueryChainPoint CardanoMode)
-          else return Nothing
-        mSystemStart <- if ntcVersion >= NodeToClientV_9
-          then Just <$> queryExpr QuerySystemStart
-          else return Nothing
+        mChainBlockNo <- maybeQueryExpr QueryChainBlockNo
+        mChainPoint <- maybeQueryExpr (QueryChainPoint CardanoMode)
+        mSystemStart <- maybeQueryExpr QuerySystemStart
 
         return O.QueryTipLocalState
           { O.era = era
@@ -240,8 +250,8 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
           , O.mChainTip = makeChainTip <$> mChainBlockNo <*> mChainPoint
           }
 
-      mLocalState <- hushM (first ShelleyQueryCmdAcquireFailure eLocalState) $ \e ->
-        liftIO . T.hPutStrLn IO.stderr $ "Warning: Local state unavailable: " <> renderShelleyQueryCmdError e
+      mLocalState <- hushM eLocalState $ \e ->
+        liftIO . T.hPutStrLn IO.stderr $ "Warning: Local state unavailable: " <> renderQueryError e
 
       chainTip <- case mLocalState >>= O.mChainTip of
         Just chainTip -> return chainTip
@@ -297,7 +307,6 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
 --
-
 runQueryUTxO
   :: AnyConsensusModeParams
   -> QueryUTxOFilter
@@ -706,23 +715,23 @@ runQueryStakePools (AnyConsensusModeParams cModeParams)
 
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network sockPath
 
-  result <- ExceptT . fmap (join . first ShelleyQueryCmdAcquireFailure) $
-    executeLocalStateQueryExpr localNodeConnInfo Nothing $ \_ntcVersion -> runExceptT @ShelleyQueryCmdError $ do
+  result <- ExceptT . fmap (join . first queryErrorToShelleyQueryCmdError) $
+    executeLocalStateQueryExpr localNodeConnInfo Nothing $ do
       anyE@(AnyCardanoEra era) <- case consensusModeOnly cModeParams of
         ByronMode -> return $ AnyCardanoEra ByronEra
         ShelleyMode -> return $ AnyCardanoEra ShelleyEra
-        CardanoMode -> lift . queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
+        CardanoMode -> queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
 
       let cMode = consensusModeOnly cModeParams
 
       case toEraInMode era cMode of
         Just eInMode -> do
-          sbe <- getSbe $ cardanoEraStyle era
+          sbe <- getSbeInQuery $ cardanoEraStyle era
 
-          firstExceptT ShelleyQueryCmdEraMismatch . ExceptT $
+          fmap (first ShelleyQueryCmdEraMismatch) $
             queryExpr . QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
 
-        Nothing -> left $ ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE
+        Nothing -> left $ QueryErrorOf $ ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE
 
   writeStakePools mOutFile result
 
@@ -757,11 +766,7 @@ runQueryStakeDistribution (AnyConsensusModeParams cModeParams)
       let query = QueryInEra eInMode
                     . QueryInShelleyBasedEra sbe
                     $ QueryStakeDistribution
-      result <- executeQuery
-                  era
-                  cModeParams
-                  localNodeConnInfo
-                  query
+      result <- executeQuery era cModeParams localNodeConnInfo query
       writeStakeDistribution mOutFile result
     Nothing -> left $ ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE
 
@@ -846,10 +851,12 @@ determineEra cModeParams localNodeConnInfo =
     ByronMode -> return $ AnyCardanoEra ByronEra
     ShelleyMode -> return $ AnyCardanoEra ShelleyEra
     CardanoMode -> do
-      eraQ <- liftIO . queryNodeLocalState localNodeConnInfo Nothing
-                     $ QueryCurrentEra CardanoModeIsMultiEra
+      eraQ <- liftIO . executeLocalStateQueryExpr localNodeConnInfo Nothing
+        $ queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
       case eraQ of
-        Left acqFail -> left $ ShelleyQueryCmdAcquireFailure acqFail
+        Left (QueryErrorAcquireFailure acqFail) -> left $ ShelleyQueryCmdAcquireFailure acqFail
+        Left (QueryErrorUnsupportedVersion minNtcVersion ntcVersion) -> left $ ShelleyQueryCmdUnsupportedVersion minNtcVersion ntcVersion
+        Left (QueryErrorOf e) -> left e
         Right anyCarEra -> return anyCarEra
 
 executeQuery
@@ -864,19 +871,27 @@ executeQuery era cModeP localNodeConnInfo q = do
     ByronEraInByronMode -> left ShelleyQueryCmdByronEra
     _ -> liftIO execQuery >>= queryResult
  where
-   execQuery :: IO (Either AcquireFailure (Either EraMismatch result))
-   execQuery = queryNodeLocalState localNodeConnInfo Nothing q
+   execQuery :: IO (Either (QueryError ShelleyQueryCmdError) (Either EraMismatch result))
+   execQuery = executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr q
 
 getSbe :: Monad m => CardanoEraStyle era -> ExceptT ShelleyQueryCmdError m (ShelleyBasedEra era)
 getSbe LegacyByronEra = left ShelleyQueryCmdByronEra
 getSbe (ShelleyBasedEra sbe) = return sbe
 
+
+getSbeInQuery :: Monad m => CardanoEraStyle era -> ExceptT (QueryError ShelleyQueryCmdError) m (ShelleyBasedEra era)
+getSbeInQuery LegacyByronEra = left (QueryErrorOf ShelleyQueryCmdByronEra)
+getSbeInQuery (ShelleyBasedEra sbe) = return sbe
+
 queryResult
-  :: Either AcquireFailure (Either EraMismatch a)
+  :: Either (QueryError ShelleyQueryCmdError) (Either EraMismatch a)
   -> ExceptT ShelleyQueryCmdError IO a
 queryResult eAcq =
   case eAcq of
-    Left acqFailure -> left $ ShelleyQueryCmdAcquireFailure acqFailure
+    Left queryError -> case queryError of
+      QueryErrorAcquireFailure acquireFailure -> left $ ShelleyQueryCmdAcquireFailure acquireFailure
+      QueryErrorUnsupportedVersion minNtcVersion ntcVersion -> left (ShelleyQueryCmdUnsupportedVersion minNtcVersion ntcVersion)
+      QueryErrorOf e -> left e
     Right eResult ->
       case eResult of
         Left err -> left . ShelleyQueryCmdLocalStateQueryError $ EraMismatchError err

--- a/plutus-example/plutus-example/src/Cardano/PlutusExample/ScriptContextChecker.hs
+++ b/plutus-example/plutus-example/src/Cardano/PlutusExample/ScriptContextChecker.hs
@@ -333,12 +333,12 @@ readCustomRedeemerFromTx fp (AnyConsensusModeParams cModeParams) network = do
                    (ConsensusModeMismatch (AnyConsensusMode CardanoMode) (AnyCardanoEra cEra))
                    $ toEraInMode cEra CardanoMode
 
-      eResult <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ do
-        (EraHistory _ interpreter) <- queryExpr $ QueryEraHistory CardanoModeIsMultiEra
-        mSystemStart <- maybeQueryExpr QuerySystemStart
+      eResult <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+        (EraHistory _ interpreter) <- ExceptT $ queryExpr $ QueryEraHistory CardanoModeIsMultiEra
+        mSystemStart <- ExceptT $ maybeQueryExpr QuerySystemStart
         let eInfo = hoistEpochInfo (first TransactionValidityIntervalError . runExcept)
                       $ Consensus.interpreterToEpochInfo interpreter
-        ppResult <- queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+        ppResult <- ExceptT $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
         return (eInfo, mSystemStart, ppResult)
 
       (eInfo, mSystemStart, ePParams) <- firstExceptT queryErrorToScriptContextError $ hoistEither eResult


### PR DESCRIPTION
This PR adds better messages for `query utxo`.  It replaces an earlier PR https://github.com/input-output-hk/cardano-node/pull/2957.

This PR improves on the earlier version by making it so that the monadic expressions no longer need to know what version each query requires.  If the node that is connected to does not support the query being made, then the query expression throws `QueryErrorUnsupportedVersion` which can be handled in a convenient top-level location.