### PR TITLE
tx-generator: derive Plutus budged automatically

### DIFF
--- a/bench/script/test-plutus-to-file.json
+++ b/bench/script/test-plutus-to-file.json
@@ -45,7 +45,7 @@
       , "spendMode": {
 	  "SpendScript": [
 	      "bench/script/sum1ToN.plutus",
-	      { "memory": 700000000, "steps": 700000000 },
+              { "PreExecuteScript" : [] },
 	      3,
 	      6
 	  ]

--- a/bench/script/test-plutus.json
+++ b/bench/script/test-plutus.json
@@ -40,12 +40,12 @@
       , "submitMode": { "LocalSocket": [] }
       , "payMode": { "PayToScript": [ "bench/script/sum1ToN.plutus", 3] }
     },
-    { "runBenchmark": "spendPlutus", "txCount": 500, "tps": 10
+    { "runBenchmark": "spendPlutus", "txCount": 10, "tps": 10
       , "submitMode": { "NodeToNode": [] }
       , "spendMode": {
 	  "SpendScript": [
 	      "bench/script/sum1ToN.plutus",
-	      { "memory": 700000000, "steps": 700000000 },
+              { "StaticScriptBudget": { "memory": 700000000, "steps": 700000000 } },
               3,
 	      6
 	  ]

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -61,7 +61,7 @@ import           Cardano.Benchmarking.GeneratorTx.SubmissionClient
 import           Cardano.Benchmarking.GeneratorTx.Tx
 import           Cardano.Benchmarking.Tracer
 import           Cardano.Benchmarking.Types
-import           Cardano.Benchmarking.Wallet
+import           Cardano.Benchmarking.Wallet (WalletScript)
 
 import           Cardano.Ledger.Shelley.API (ShelleyGenesis)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))

--- a/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
@@ -4,6 +4,7 @@
 module Cardano.Benchmarking.PlutusExample
 where
 import           Prelude
+import qualified Data.Map as Map
 
 import           Control.Monad.Trans.Except
 import qualified Data.ByteString.Char8 as BSC
@@ -11,11 +12,13 @@ import qualified Data.ByteString.Char8 as BSC
 import           Cardano.CLI.Shelley.Script (readFileScriptInAnyLang)
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (ProtocolParameters)
-
+import           Cardano.Api.Shelley (ProtocolParameters, PlutusScript(..), fromAlonzoExUnits, protocolParamCostModels, toPlutusData)
+import           Cardano.Ledger.Alonzo.TxInfo (exBudgetToExUnits)
 import           Cardano.Benchmarking.FundSet
-import           Cardano.Benchmarking.GeneratorTx.Tx as Tx (mkTxOutValueAdaOnly)
 import           Cardano.Benchmarking.Wallet
+
+import qualified Plutus.V1.Ledger.Api as Plutus
+import           Plutus.V1.Ledger.Contexts (ScriptContext(..), ScriptPurpose(..), TxInfo(..), TxOutRef(..))
 
 mkUtxoScript ::
      NetworkId
@@ -93,3 +96,42 @@ genTxPlutusSpend protocolParameters collateral scriptWitness fee metadata inFund
     , txMintValue = TxMintNone
     , txScriptValidity = TxScriptValidityNone
     }
+
+preExecuteScript ::
+     ProtocolParameters
+  -> Script PlutusScriptV1
+  -> ScriptData
+  -> ScriptData
+  -> Either String ExecutionUnits
+preExecuteScript protocolParameters (PlutusScript _ (PlutusScriptSerialised script)) datum redeemer = do
+  costModel <- case Map.lookup (AnyPlutusScriptVersion PlutusScriptV1) (protocolParamCostModels protocolParameters) of
+    Just (CostModel x) -> Right x
+    Nothing -> Left "costModel unavailable"
+  let (_logout, res) = Plutus.evaluateScriptCounting Plutus.Verbose costModel script
+                              [ toPlutusData datum
+                              , toPlutusData redeemer
+                              , Plutus.toData dummyContext ]
+  case res of
+     Left err -> Left $ show err
+     Right exBudget -> case exBudgetToExUnits exBudget of
+       Just x -> Right $ fromAlonzoExUnits x
+       Nothing -> Left "exBudgetToExUnits exBudget == Nothing"
+  where
+    dummyContext :: ScriptContext
+    dummyContext = ScriptContext dummyTxInfo (Spending dummyOutRef)
+
+    dummyOutRef :: TxOutRef
+    dummyOutRef = TxOutRef (Plutus.TxId "") 0
+    dummyTxInfo :: TxInfo
+    dummyTxInfo = TxInfo
+      { txInfoInputs = []
+      , txInfoOutputs = []
+      , txInfoFee = mempty
+      , txInfoMint = mempty
+      , txInfoDCert = []
+      , txInfoWdrl = []
+      , txInfoValidRange = Plutus.always
+      , txInfoSignatories = []
+      , txInfoData = []
+      , txInfoId = Plutus.TxId ""
+      }

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -85,6 +85,12 @@ instance ToJSON SpendMode where
 instance FromJSON SpendMode where
   parseJSON = genericParseJSON jsonOptionsUnTaggedSum
 
+instance ToJSON ScriptBudget where
+  toJSON     = genericToJSON jsonOptionsUnTaggedSum
+  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
+instance FromJSON ScriptBudget where
+  parseJSON = genericParseJSON jsonOptionsUnTaggedSum
+
 instance ToJSON (DSum Tag Identity) where
   toEncoding = error "DSum Tag Identity"
   toJSON = error "DSum Tag Identity"

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -63,7 +63,7 @@ testScript =
   , Reserved []
   ]
  where
-  scriptDef = SpendScript "filePath" (ExecutionUnits 70000000 70000000) (ScriptDataNumber 3) (ScriptDataNumber 6)
+  scriptDef = SpendScript "filePath" (StaticScriptBudget $ ExecutionUnits 70000000 70000000) (ScriptDataNumber 3) (ScriptDataNumber 6)
   passPartout = KeyName "pass-partout"
   genFund = FundName "genFund"
   outputFunds = map FundName ["fund1", "fund2", "fund3", "fund4"]

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -59,6 +59,14 @@ deriving instance Generic PayMode
 
 data SpendMode where
   SpendOutput :: SpendMode
-  SpendScript :: !String -> !ExecutionUnits -> !ScriptData -> !ScriptRedeemer -> SpendMode
+  SpendScript :: !String -> ScriptBudget -> !ScriptData -> !ScriptRedeemer -> SpendMode
   deriving (Show, Eq)
 deriving instance Generic SpendMode
+
+data ScriptBudget where
+  StaticScriptBudget :: !ExecutionUnits -> ScriptBudget
+  PreExecuteScript   :: ScriptBudget
+  CheckScriptBudget  :: !ExecutionUnits -> ScriptBudget
+  deriving (Show, Eq)
+deriving instance Generic ScriptBudget
+

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -69,6 +69,7 @@ library
                      , cardano-cli
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
+                     , cardano-ledger-alonzo
                      , cardano-ledger-byron
                      , cardano-node
                      , cardano-prelude
@@ -95,6 +96,7 @@ library
                      , ouroboros-consensus-shelley
                      , ouroboros-network
                      , ouroboros-network-framework
+                     , plutus-ledger-api
                      , random
                      , serialise
                      , cardano-ledger-shelley


### PR DESCRIPTION
This PR adds a plutusAutoCosts mode to the tx-generator.
This mode determines the Plutus script budget by pre-execution of the script,
such that it in no longer necessary to provide values
for the Plutus execution units in definition of benchmark run.

Also:

* Add Plutus loop example.
* Log addresses in splitting phase (useful for debugging).