### PR TITLE
Integration with peer2peer networking

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -235,8 +235,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6568bfe289e9610c2792c2194219f8cc8d64a8af
-  --sha256: 0mi1qbw7xlcidja7yvafjl7x7sbxvgy2gkz9x38j8lz10dbi51sz
+  tag: d613de3d872ec8b4a5da0c98afb443f322dc4dab
+  --sha256: 0lfbipfdrzay8v1pcazx0qgkda3d1j0505yig9jrml9j7991rmhl
   subdir:
     io-sim
     io-classes
@@ -272,8 +272,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ekg-forward
-  tag: d9e8fd302fa6ba41c07183d371e6777286d37bc2
-  --sha256: 0s8cblhq3i528jj7r7yd4v82nqzafj8vrgf0y80l7saxc3a5f2lk
+  tag: 2adc8b698443bb10154304b24f6c1d6913bb65b9
+  --sha256: 0cyixq3jmq43zs1yzrycqw1klyjy0zxf1vifknnr1k9d6sc3zf6b
 
 source-repository-package
   type: git

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -75,7 +75,7 @@ chairmanOver timeoutSeconds requiredProgress H.Conf {..} allNodes = do
         )
       )
 
-    chairmanResult <- H.waitSecondsForProcess (timeoutSeconds + 10) hProcess
+    chairmanResult <- H.waitSecondsForProcess (timeoutSeconds + 60) hProcess
 
     case chairmanResult of
       Right ExitSuccess -> return ()

--- a/cardano-node-chairman/testnet/Testnet/Commands/Byron.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands/Byron.hs
@@ -4,6 +4,7 @@ module Testnet.Commands.Byron
   , runByronOptions
   ) where
 
+import           Data.Bool
 import           Data.Eq
 import           Data.Function
 import           Data.Int
@@ -70,6 +71,7 @@ optsTestnet = TestnetOptions
       <>  OA.showDefault
       <>  OA.value (totalBalance defaultTestnetOptions)
       )
+  <*> pure False
 
 runByronOptions :: ByronOptions -> IO ()
 runByronOptions opts = runTestnet (maybeTestnetMagic opts) (Testnet.Byron.testnet (testnetOptions opts))

--- a/cardano-node-chairman/testnet/Testnet/Commands/Shelley.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands/Shelley.hs
@@ -5,6 +5,7 @@ module Testnet.Commands.Shelley
   ) where
 
 
+import           Data.Bool
 import           Data.Eq
 import           Data.Function
 import           Data.Int
@@ -74,6 +75,7 @@ optsTestnet = TestnetOptions
       <>  OA.showDefault
       <>  OA.value (maxLovelaceSupply defaultTestnetOptions)
       )
+  <*> pure False
 
 optsShelley :: Parser ShelleyOptions
 optsShelley = ShelleyOptions

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -62,6 +62,7 @@ library
   exposed-modules:     Cardano.Node.Configuration.Logging
                        Cardano.Node.Configuration.POM
                        Cardano.Node.Configuration.Topology
+                       Cardano.Node.Configuration.TopologyP2P
                        Cardano.Node.Handlers.Shutdown
                        Cardano.Node.Handlers.TopLevel
                        Cardano.Node.Orphans

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -7,6 +9,8 @@
 
 module Cardano.Node.Configuration.POM
   ( NodeConfiguration (..)
+  , NetworkP2PMode (..)
+  , SomeNetworkP2PMode (..)
   , PartialNodeConfiguration(..)
   , defaultPartialNodeConfiguration
   , lastOption
@@ -19,9 +23,12 @@ where
 
 import           Cardano.Prelude
 import           Prelude (String)
+import qualified GHC.Show as Show
 
 import           Control.Monad (fail)
 import           Data.Aeson
+import qualified Data.Aeson.Types as Aeson
+import           Data.Time.Clock (DiffTime)
 import           Data.Yaml (decodeFileThrow)
 import           Generic.Data (gmappend)
 import           Generic.Data.Orphans ()
@@ -38,8 +45,29 @@ import           Ouroboros.Consensus.Mempool.API (MempoolCapacityBytesOverride (
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
 import           Ouroboros.Network.Block (MaxSlotNo (..))
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import qualified Ouroboros.Consensus.Node as Consensus ( NetworkP2PMode (..) )
 
-import qualified Data.Aeson.Types as Aeson
+data NetworkP2PMode = EnabledP2PMode | DisabledP2PMode
+  deriving (Eq, Show, Generic)
+
+data SomeNetworkP2PMode where
+    SomeNetworkP2PMode :: forall p2p.
+                          Consensus.NetworkP2PMode p2p
+                       -> SomeNetworkP2PMode
+
+instance Eq SomeNetworkP2PMode where
+    (==) (SomeNetworkP2PMode Consensus.EnabledP2PMode)
+         (SomeNetworkP2PMode Consensus.EnabledP2PMode)
+       = True
+    (==) (SomeNetworkP2PMode Consensus.DisabledP2PMode)
+         (SomeNetworkP2PMode Consensus.DisabledP2PMode)
+       = True
+    (==) _ _
+       = False
+
+instance Show SomeNetworkP2PMode where
+    show (SomeNetworkP2PMode mode@Consensus.EnabledP2PMode)  = show mode
+    show (SomeNetworkP2PMode mode@Consensus.DisabledP2PMode) = show mode
 
 data NodeConfiguration
   = NodeConfiguration
@@ -89,6 +117,24 @@ data NodeConfiguration
        , ncTraceConfig    :: !TraceOptions
 
        , ncMaybeMempoolCapacityOverride :: !(Maybe MempoolCapacityBytesOverride)
+
+         -- | Protocol idleness timeout, see
+         -- 'Ouroboros.Network.Diffusion.daProtocolIdleTimeout'.
+         --
+       , ncProtocolIdleTimeout   :: DiffTime
+         -- | Wait time timeout, see
+         -- 'Ouroboros.Netowrk.Diffusion.daTimeWaitTimeout'.
+         --
+       , ncTimeWaitTimeout       :: DiffTime
+
+         -- P2P governor targets
+       , ncTargetNumberOfRootPeers        :: Int
+       , ncTargetNumberOfKnownPeers       :: Int
+       , ncTargetNumberOfEstablishedPeers :: Int
+       , ncTargetNumberOfActivePeers      :: Int
+
+         -- Enable experimental P2P mode
+       , ncEnableP2P :: SomeNetworkP2PMode
        } deriving (Eq, Show)
 
 
@@ -128,6 +174,19 @@ data PartialNodeConfiguration
 
          -- Configuration for testing purposes
        , pncMaybeMempoolCapacityOverride :: !(Last MempoolCapacityBytesOverride)
+
+         -- Network timeouts
+       , pncProtocolIdleTimeout   :: !(Last DiffTime)
+       , pncTimeWaitTimeout       :: !(Last DiffTime)
+
+         -- P2P governor targets
+       , pncTargetNumberOfRootPeers        :: !(Last Int)
+       , pncTargetNumberOfKnownPeers       :: !(Last Int)
+       , pncTargetNumberOfEstablishedPeers :: !(Last Int)
+       , pncTargetNumberOfActivePeers      :: !(Last Int)
+
+         -- Enable experimental P2P mode
+       , pncEnableP2P :: !(Last NetworkP2PMode)
        } deriving (Eq, Generic, Show)
 
 instance AdjustFilePaths PartialNodeConfiguration where
@@ -178,6 +237,24 @@ instance FromJSON PartialNodeConfiguration where
                                                                <*> parseHardForkProtocol v)
       pncMaybeMempoolCapacityOverride <- Last <$> parseMempoolCapacityBytesOverride v
 
+      -- Network timeouts
+      pncProtocolIdleTimeout   <- Last <$> v .:? "ProtocolIdleTimeout"
+      pncTimeWaitTimeout       <- Last <$> v .:? "TimeWaitTimeout"
+
+      -- P2P Governor parameters, with conservative defaults.
+      pncTargetNumberOfRootPeers        <- Last <$> v .:? "TargetNumberOfRootPeers"
+      pncTargetNumberOfKnownPeers       <- Last <$> v .:? "TargetNumberOfKnownPeers"
+      pncTargetNumberOfEstablishedPeers <- Last <$> v .:? "TargetNumberOfEstablishedPeers"
+      pncTargetNumberOfActivePeers      <- Last <$> v .:? "TargetNumberOfActivePeers"
+
+      -- Enable P2P switch
+      p2pSwitch <- v .:? "EnableP2P" .!= Just False
+      let pncEnableP2P =
+            case p2pSwitch of
+              Nothing    -> mempty
+              Just False -> Last $ Just DisabledP2PMode
+              Just True  -> Last $ Just EnabledP2PMode
+
       pure PartialNodeConfiguration {
              pncProtocolConfig
            , pncSocketPath
@@ -200,6 +277,13 @@ instance FromJSON PartialNodeConfiguration where
            , pncShutdownIPC = mempty
            , pncShutdownOnSlotSynced = mempty
            , pncMaybeMempoolCapacityOverride
+           , pncProtocolIdleTimeout
+           , pncTimeWaitTimeout
+           , pncTargetNumberOfRootPeers
+           , pncTargetNumberOfKnownPeers
+           , pncTargetNumberOfEstablishedPeers
+           , pncTargetNumberOfActivePeers
+           , pncEnableP2P
            }
     where
       parseMempoolCapacityBytesOverride v = parseNoOverride <|> parseOverride
@@ -334,6 +418,13 @@ defaultPartialNodeConfiguration =
     , pncLogMetrics = mempty
     , pncTraceConfig = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncProtocolIdleTimeout   = Last (Just 5)
+    , pncTimeWaitTimeout       = Last (Just 60)
+    , pncTargetNumberOfRootPeers        = Last (Just 100)
+    , pncTargetNumberOfKnownPeers       = Last (Just 100)
+    , pncTargetNumberOfEstablishedPeers = Last (Just 50)
+    , pncTargetNumberOfActivePeers      = Last (Just 20)
+    , pncEnableP2P                      = Last (Just DisabledP2PMode)
     }
 
 lastOption :: Parser a -> Parser (Last a)
@@ -357,6 +448,28 @@ makeNodeConfiguration pnc = do
   traceConfig <- lastToEither "Missing TraceConfig" $ pncTraceConfig pnc
   diffusionMode <- lastToEither "Missing DiffusionMode" $ pncDiffusionMode pnc
   snapshotInterval <- lastToEither "Missing SnapshotInterval" $ pncSnapshotInterval pnc
+
+  ncTargetNumberOfRootPeers <-
+    lastToEither "Missing TargetNumberOfRootPeers"
+    $ pncTargetNumberOfRootPeers pnc
+  ncTargetNumberOfKnownPeers <-
+    lastToEither "Missing TargetNumberOfKnownPeers"
+    $ pncTargetNumberOfKnownPeers pnc
+  ncTargetNumberOfEstablishedPeers <-
+    lastToEither "Missing TargetNumberOfEstablishedPeers"
+    $ pncTargetNumberOfEstablishedPeers pnc
+  ncTargetNumberOfActivePeers <-
+    lastToEither "Missing TargetNumberOfActivePeers"
+    $ pncTargetNumberOfActivePeers pnc
+  ncProtocolIdleTimeout <-
+    lastToEither "Missing ProtocolIdleTimeout"
+    $ pncProtocolIdleTimeout pnc
+  ncTimeWaitTimeout <-
+    lastToEither "Missing TimeWaitTimeout"
+    $ pncTimeWaitTimeout pnc
+  enableP2P <-
+    lastToEither "Missing EnableP2P"
+    $ pncEnableP2P pnc
 
   testEnableDevelopmentNetworkProtocols <-
     lastToEither "Missing TestEnableDevelopmentNetworkProtocols" $
@@ -384,6 +497,15 @@ makeNodeConfiguration pnc = do
              , ncTraceConfig = if loggingSwitch then traceConfig
                                                 else TracingOff
              , ncMaybeMempoolCapacityOverride = getLast $ pncMaybeMempoolCapacityOverride pnc
+             , ncProtocolIdleTimeout
+             , ncTimeWaitTimeout
+             , ncTargetNumberOfRootPeers
+             , ncTargetNumberOfKnownPeers
+             , ncTargetNumberOfEstablishedPeers
+             , ncTargetNumberOfActivePeers
+             , ncEnableP2P = case enableP2P of
+                 EnabledP2PMode  -> SomeNetworkP2PMode Consensus.EnabledP2PMode
+                 DisabledP2PMode -> SomeNetworkP2PMode Consensus.DisabledP2PMode
              }
 
 ncProtocol :: NodeConfiguration -> Protocol

--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -141,4 +141,8 @@ readTopologyFile nc = do
                         ++ displayException e
   handlerJSON :: String -> Text
   handlerJSON err = "Is your topology file formatted correctly? \
-                    \The port and valency fields should be numerical. " <> Text.pack err
+                    \Expecting Non-P2P Topology file format. \
+                    \The port and valency fields should be numerical. \
+                    \If you specified the correct topology file \
+                    \make sure that you correctly setup EnableP2P \
+                    \configuration flag. " <> Text.pack err

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Node.Configuration.TopologyP2P
+  ( TopologyError(..)
+  , NetworkTopology(..)
+  , PublicRootPeers(..)
+  , LocalRootPeersGroup(..)
+  , LocalRootPeersGroups(..)
+  , RootConfig(..)
+  , NodeHostIPAddress(..)
+  , NodeHostIPv4Address(..)
+  , NodeHostIPv6Address(..)
+  , NodeSetup(..)
+  , PeerAdvertise(..)
+  , UseLedger(..)
+  , nodeAddressToSockAddr
+  , readTopologyFile
+  , readTopologyFileOrError
+  , rootConfigToRelayAccessPoint
+  )
+where
+
+import           Cardano.Prelude hiding (ap)
+import           Prelude (String)
+
+import qualified Control.Exception as Exception
+import           Data.Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as Text
+
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+import           Cardano.Slotting.Slot (SlotNo (..))
+
+import           Cardano.Node.Types
+import           Cardano.Node.Configuration.Topology (TopologyError (..))
+
+import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+
+
+-- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
+-- 'ToJSON' instances.
+--
+-- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
+-- chain root peers.
+--
+newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
+
+instance FromJSON UseLedger where
+  parseJSON (Data.Aeson.Number n) =
+    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
+              else return $ UseLedger   DontUseLedger
+  parseJSON _ = mzero
+
+instance ToJSON UseLedger where
+  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
+  toJSON (UseLedger DontUseLedger)               = Number (-1)
+
+data NodeSetup = NodeSetup
+  { nodeId          :: !Word64
+  , nodeIPv4Address :: !(Maybe NodeIPv4Address)
+  , nodeIPv6Address :: !(Maybe NodeIPv6Address)
+  , producers       :: ![RootConfig]
+  , useLedger       :: !UseLedger
+  } deriving (Eq, Show)
+
+instance FromJSON NodeSetup where
+  parseJSON = withObject "NodeSetup" $ \o ->
+                NodeSetup
+                  <$> o .:  "nodeId"
+                  <*> o .:  "nodeIPv4Address"
+                  <*> o .:  "nodeIPv6Address"
+                  <*> o .:  "producers"
+                  <*> o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger
+
+instance ToJSON NodeSetup where
+  toJSON ns =
+    object
+      [ "nodeId"             .= nodeId ns
+      , "nodeIPv4Address"    .= nodeIPv4Address ns
+      , "nodeIPv6Address"    .= nodeIPv6Address ns
+      , "producers"          .= producers ns
+      , "useLedgerAfterSlot" .= useLedger ns
+      ]
+
+
+-- | Each root peer consists of a list of access points and a shared
+-- 'PeerAdvertise' field.
+--
+data RootConfig = RootConfig
+  { rootAccessPoints :: [RelayAccessPoint]
+    -- ^ a list of relay access points, each of which is either an ip address
+    -- or domain name and a port number.
+  , rootAdvertise    :: PeerAdvertise
+    -- ^ 'advertise' configures whether the root should be advertised through
+    -- gossip.
+  } deriving (Eq, Show)
+
+instance FromJSON RootConfig where
+  parseJSON = withObject "RootConfig" $ \o ->
+                RootConfig
+                  <$> o .:  "accessPoints"
+                  <*> o .:? "advertise" .!= DoNotAdvertisePeer
+
+instance ToJSON RootConfig where
+  toJSON ra =
+    object
+      [ "accessPoints" .= rootAccessPoints ra
+      , "advertise"    .= rootAdvertise ra
+      ]
+
+-- | Transforms a 'RootConfig' into a pair of 'RelayAccessPoint' and its
+-- corresponding 'PeerAdvertise' value.
+--
+rootConfigToRelayAccessPoint
+  :: RootConfig
+  -> [(RelayAccessPoint, PeerAdvertise)]
+rootConfigToRelayAccessPoint RootConfig { rootAccessPoints, rootAdvertise } =
+    [ (ap, rootAdvertise) | ap <- rootAccessPoints ]
+
+
+-- | A local root peers group.  Local roots are treated by the outbound
+-- governor in a special way.  The node will make sure that a node has the
+-- requested number ('valency') of connections to the local root peer group.
+--
+data LocalRootPeersGroup = LocalRootPeersGroup
+  { localRoots :: RootConfig
+  , valency    :: Int
+  } deriving (Eq, Show)
+
+instance FromJSON LocalRootPeersGroup where
+  parseJSON = withObject "LocalRootPeersGroup" $ \o ->
+                LocalRootPeersGroup
+                  <$> o .: "localRoots"
+                  <*> o .: "valency"
+
+instance ToJSON LocalRootPeersGroup where
+  toJSON lrpg =
+    object
+      [ "localRoots" .= localRoots lrpg
+      , "valency"    .= valency lrpg
+      ]
+
+newtype LocalRootPeersGroups = LocalRootPeersGroups
+  { groups :: [LocalRootPeersGroup]
+  } deriving (Eq, Show)
+
+instance FromJSON LocalRootPeersGroups where
+  parseJSON = withObject "LocalRootPeersGroups" $ \o ->
+                LocalRootPeersGroups
+                  <$> o .: "groups"
+
+instance ToJSON LocalRootPeersGroups where
+  toJSON lrpg =
+    object
+      [ "groups" .= groups lrpg
+      ]
+
+newtype PublicRootPeers = PublicRootPeers
+  { publicRoots :: RootConfig
+  } deriving (Eq, Show)
+
+instance FromJSON PublicRootPeers where
+  parseJSON = withObject "PublicRootPeers" $ \o ->
+                PublicRootPeers
+                  <$> o .: "publicRoots"
+
+instance ToJSON PublicRootPeers where
+  toJSON prp =
+    object
+      [ "publicRoots" .= publicRoots prp
+      ]
+
+data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers] !UseLedger
+  deriving (Eq, Show)
+
+instance FromJSON NetworkTopology where
+  parseJSON = withObject "NetworkTopology" $ \o ->
+                RealNodeTopology <$> (o .: "LocalRoots"                                     )
+                                 <*> (o .: "PublicRoots"                                    )
+                                 <*> (o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger)
+
+instance ToJSON NetworkTopology where
+  toJSON top =
+    case top of
+      RealNodeTopology lrpg prp ul -> object [ "LocalRoots"         .= lrpg
+                                             , "PublicRoots"        .= prp
+                                             , "useLedgerAfterSlot" .= ul
+                                             ]
+
+-- | Read the `NetworkTopology` configuration from the specified file.
+--
+readTopologyFile :: NodeConfiguration -> IO (Either Text NetworkTopology)
+readTopologyFile nc = do
+  eBs <- Exception.try $ BS.readFile (unTopology $ ncTopologyFile nc)
+
+  case eBs of
+    Left e -> return . Left $ handler e
+    Right bs -> return . first handlerJSON . eitherDecode $ LBS.fromStrict bs
+
+ where
+  handler :: IOException -> Text
+  handler e = Text.pack $ "Cardano.Node.Configuration.Topology.readTopologyFile: "
+                        ++ displayException e
+  handlerJSON :: String -> Text
+  handlerJSON err = "Is your topology file formatted correctly? \
+                    \Expecting P2P Topology file format. \
+                    \The port and valency fields should be numerical. \
+                    \If you specified the correct topology file \
+                    \make sure that you correctly setup EnableP2P \
+                    \configuration flag. " <> Text.pack err
+
+readTopologyFileOrError :: NodeConfiguration -> IO NetworkTopology
+readTopologyFileOrError nc =
+      readTopologyFile nc
+  >>= either (\err -> panic $ "Cardano.Node.Run.handleSimpleNodeP2P.readTopologyFile: "
+                           <> err)
+             pure

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -95,6 +95,13 @@ nodeRunParser = do
            , pncLogMetrics = mempty
            , pncTraceConfig = mempty
            , pncMaybeMempoolCapacityOverride = maybeMempoolCapacityOverride
+           , pncProtocolIdleTimeout = mempty
+           , pncTimeWaitTimeout = mempty
+           , pncTargetNumberOfRootPeers = mempty
+           , pncTargetNumberOfKnownPeers = mempty
+           , pncTargetNumberOfEstablishedPeers = mempty
+           , pncTargetNumberOfActivePeers = mempty
+           , pncEnableP2P = mempty
            }
 
 parseSocketPath :: Text -> Parser SocketPath

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -10,6 +10,11 @@ module Cardano.Tracing.Config
   , TraceSelection (..)
   , traceConfigParser
   , OnOff (..)
+
+  -- * Trace symbols
+  , TraceConnectionManagerCounters
+  , TracePeerSelectionCounters
+  , TraceInboundGovernorCounters
   ) where
 
 import           Cardano.Prelude
@@ -40,6 +45,10 @@ type TraceChainSyncClient = ("TraceChainSyncClient" :: Symbol)
 type TraceChainSyncBlockServer = ("TraceChainSyncBlockServer" :: Symbol)
 type TraceChainSyncHeaderServer = ("TraceChainSyncHeaderServer" :: Symbol)
 type TraceChainSyncProtocol = ("TraceChainSyncProtocol" :: Symbol)
+type TraceConnectionManager = ("TraceConnectionManager" :: Symbol)
+type TraceConnectionManagerCounters = ("TraceConnectionManagerCounters" :: Symbol)
+type DebugPeerSelectionInitiator = ("DebugPeerSelectionInitiator" :: Symbol)
+type DebugPeerSelectionInitiatorResponder = ("DebugPeerSelectionInitiatorResponder" :: Symbol)
 type TraceDiffusionInitialization = ("TraceDiffusionInitialization" :: Symbol)
 type TraceDnsResolver = ("TraceDnsResolver" :: Symbol)
 type TraceDnsSubscription = ("TraceDnsSubscription" :: Symbol)
@@ -49,15 +58,27 @@ type TraceForgeStateInfo = ("TraceForgeStateInfo" :: Symbol)
 type TraceHandshake = ("TraceHandshake" :: Symbol)
 type TraceIpSubscription = ("TraceIpSubscription" :: Symbol)
 type TraceKeepAliveClient = ("TraceKeepAliveClient" :: Symbol)
+type TraceLedgerPeers = ("TraceLedgerPeers" :: Symbol)
 type TraceLocalChainSyncProtocol = ("TraceLocalChainSyncProtocol" :: Symbol)
+type TraceLocalConnectionManager = ("TraceLocalConnectionManager" :: Symbol)
 type TraceLocalErrorPolicy = ("TraceLocalErrorPolicy" :: Symbol)
 type TraceLocalHandshake = ("TraceLocalHandshake" :: Symbol)
+type TraceLocalInboundGovernor = ("TraceLocalInboundGovernor" :: Symbol)
+type TraceLocalRootPeers = ("TraceLocalRootPeers" :: Symbol)
+type TraceLocalServer = ("TraceLocalServer" :: Symbol)
+type TraceLocalStateQueryProtocol = ("TraceLocalStateQueryProtocol" :: Symbol)
 type TraceLocalTxSubmissionProtocol = ("TraceLocalTxSubmissionProtocol" :: Symbol)
 type TraceLocalTxSubmissionServer = ("TraceLocalTxSubmissionServer" :: Symbol)
-type TraceLocalStateQueryProtocol = ("TraceLocalStateQueryProtocol" :: Symbol)
 type TraceMempool = ("TraceMempool" :: Symbol)
 type TraceMux = ("TraceMux" :: Symbol)
 type TraceLocalMux = ("TraceLocalMux" :: Symbol)
+type TracePeerSelection = ("TracePeerSelection" :: Symbol)
+type TracePeerSelectionCounters = ("TracePeerSelectionCounters" :: Symbol)
+type TracePeerSelectionActions = ("TracePeerSelectionActions" :: Symbol)
+type TracePublicRootPeers = ("TracePublicRootPeers" :: Symbol)
+type TraceServer = ("TraceServer" :: Symbol)
+type TraceInboundGovernor = ("TraceInboundGovernor" :: Symbol)
+type TraceInboundGovernorCounters = ("TraceInboundGovernorCounters" :: Symbol)
 type TraceTxInbound = ("TraceTxInbound" :: Symbol)
 type TraceTxOutbound = ("TraceTxOutbound" :: Symbol)
 type TraceTxSubmissionProtocol = ("TraceTxSubmissionProtocol" :: Symbol)
@@ -89,6 +110,10 @@ data TraceSelection
   , traceChainSyncClient :: OnOff TraceChainSyncClient
   , traceChainSyncHeaderServer :: OnOff TraceChainSyncHeaderServer
   , traceChainSyncProtocol :: OnOff TraceChainSyncProtocol
+  , traceConnectionManager :: OnOff TraceConnectionManager
+  , traceConnectionManagerCounters :: OnOff TraceConnectionManagerCounters
+  , traceDebugPeerSelectionInitiatorTracer :: OnOff DebugPeerSelectionInitiator
+  , traceDebugPeerSelectionInitiatorResponderTracer :: OnOff DebugPeerSelectionInitiatorResponder
   , traceDiffusionInitialization :: OnOff TraceDiffusionInitialization
   , traceDnsResolver :: OnOff TraceDnsResolver
   , traceDnsSubscription :: OnOff TraceDnsSubscription
@@ -96,17 +121,29 @@ data TraceSelection
   , traceForge :: OnOff TraceForge
   , traceForgeStateInfo :: OnOff TraceForgeStateInfo
   , traceHandshake :: OnOff TraceHandshake
+  , traceInboundGovernor :: OnOff TraceInboundGovernor
+  , traceInboundGovernorCounters :: OnOff TraceInboundGovernorCounters
   , traceIpSubscription :: OnOff TraceIpSubscription
   , traceKeepAliveClient :: OnOff TraceKeepAliveClient
+  , traceLedgerPeers :: OnOff TraceLedgerPeers
   , traceLocalChainSyncProtocol :: OnOff TraceLocalChainSyncProtocol
+  , traceLocalConnectionManager :: OnOff TraceLocalConnectionManager
   , traceLocalErrorPolicy :: OnOff TraceLocalErrorPolicy
   , traceLocalHandshake :: OnOff TraceLocalHandshake
+  , traceLocalInboundGovernor :: OnOff TraceLocalInboundGovernor
+  , traceLocalRootPeers :: OnOff TraceLocalRootPeers
+  , traceLocalServer :: OnOff TraceLocalServer
   , traceLocalStateQueryProtocol :: OnOff TraceLocalStateQueryProtocol
   , traceLocalTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
   , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
   , traceMempool :: OnOff TraceMempool
   , traceMux :: OnOff TraceMux
   , traceLocalMux :: OnOff TraceLocalMux
+  , tracePeerSelection :: OnOff TracePeerSelection
+  , tracePeerSelectionCounters :: OnOff TracePeerSelectionCounters
+  , tracePeerSelectionActions :: OnOff TracePeerSelectionActions
+  , tracePublicRootPeers :: OnOff TracePublicRootPeers
+  , traceServer :: OnOff TraceServer
   , traceTxInbound :: OnOff TraceTxInbound
   , traceTxOutbound :: OnOff TraceTxOutbound
   , traceTxSubmissionProtocol :: OnOff TraceTxSubmissionProtocol
@@ -116,6 +153,7 @@ data TraceSelection
 
 traceConfigParser :: Object -> Parser TraceOptions
 traceConfigParser v =
+  -- TODO: By using 'TypeApplication' we can cut half of the lines below!
   let acceptPolicy :: OnOff TraceAcceptPolicy
       acceptPolicy = OnOff False
       blockFetchClient :: OnOff TraceBlockFetchClient
@@ -140,6 +178,14 @@ traceConfigParser v =
       chainSyncHeaderServer = OnOff False
       chainSyncProtocol :: OnOff TraceChainSyncProtocol
       chainSyncProtocol = OnOff False
+      connectionManager :: OnOff TraceConnectionManager
+      connectionManager = OnOff False
+      connectionManagerCounters :: OnOff TraceConnectionManagerCounters
+      connectionManagerCounters = OnOff True
+      debugPeerSelectionInitiator :: OnOff DebugPeerSelectionInitiator
+      debugPeerSelectionInitiator = OnOff False
+      debugPeerSelectionInitiatorResponder :: OnOff DebugPeerSelectionInitiatorResponder
+      debugPeerSelectionInitiatorResponder = OnOff False
       diffusionInitialization :: OnOff TraceDiffusionInitialization
       diffusionInitialization = OnOff False
       dnsResolver :: OnOff TraceDnsResolver
@@ -154,16 +200,30 @@ traceConfigParser v =
       forgeStateInfo = OnOff True
       handshake :: OnOff TraceHandshake
       handshake = OnOff False
+      inboundGovernor :: OnOff TraceInboundGovernor
+      inboundGovernor = OnOff False
+      inboundGovernorCounters :: OnOff TraceInboundGovernorCounters
+      inboundGovernorCounters = OnOff True
       ipSubscription :: OnOff TraceIpSubscription
       ipSubscription = OnOff True
-      keepAliveClient :: OnOff TraceKeepAliveClient
-      keepAliveClient = OnOff False
-      localChainSyncProtocol :: OnOff TraceLocalChainSyncProtocol
-      localChainSyncProtocol = OnOff False
       localErrorPolicy :: OnOff TraceLocalErrorPolicy
       localErrorPolicy = OnOff True
+      keepAliveClient :: OnOff TraceKeepAliveClient
+      keepAliveClient = OnOff False
+      ledgerPeers :: OnOff TraceLedgerPeers
+      ledgerPeers = OnOff False
+      localChainSyncProtocol :: OnOff TraceLocalChainSyncProtocol
+      localChainSyncProtocol = OnOff False
+      localConnectionManager :: OnOff TraceLocalConnectionManager
+      localConnectionManager = OnOff False
       localHandshake :: OnOff TraceLocalHandshake
       localHandshake = OnOff False
+      localInboundGovernor :: OnOff TraceLocalInboundGovernor
+      localInboundGovernor = OnOff False
+      localRootPeers :: OnOff TraceLocalRootPeers
+      localRootPeers = OnOff False
+      localServer :: OnOff TraceLocalServer
+      localServer = OnOff False
       localStateQueryProtocol :: OnOff TraceLocalStateQueryProtocol
       localStateQueryProtocol = OnOff False
       localTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
@@ -176,6 +236,16 @@ traceConfigParser v =
       mux = OnOff True
       localMux :: OnOff TraceLocalMux
       localMux = OnOff False
+      peerSelection :: OnOff TracePeerSelection
+      peerSelection = OnOff False
+      peerSelectionCounters :: OnOff TracePeerSelectionCounters
+      peerSelectionCounters = OnOff True
+      peerSelectionActions :: OnOff TracePeerSelectionActions
+      peerSelectionActions = OnOff False
+      publicRootPeers :: OnOff TracePublicRootPeers
+      publicRootPeers = OnOff False
+      server :: OnOff TraceServer
+      server = OnOff False
       txInbound :: OnOff TraceTxInbound
       txInbound = OnOff False
       txOutbound :: OnOff TraceTxOutbound
@@ -200,6 +270,12 @@ traceConfigParser v =
     <*> v .:? getName chainSyncClient .!= chainSyncClient
     <*> v .:? getName chainSyncHeaderServer .!= chainSyncHeaderServer
     <*> v .:? getName chainSyncProtocol .!= chainSyncProtocol
+    <*> v .:? getName connectionManager .!= connectionManager
+    <*> v .:? getName connectionManagerCounters .!= connectionManagerCounters
+    <*> v .:? getName debugPeerSelectionInitiator
+                       .!= debugPeerSelectionInitiator
+    <*> v .:? getName debugPeerSelectionInitiatorResponder
+                       .!= debugPeerSelectionInitiatorResponder
     <*> v .:? getName diffusionInitialization .!= diffusionInitialization
     <*> v .:? getName dnsResolver .!= dnsResolver
     <*> v .:? getName dnsSubscription .!= dnsSubscription
@@ -207,17 +283,29 @@ traceConfigParser v =
     <*> v .:? getName forge .!= forge
     <*> v .:? getName forgeStateInfo .!= forgeStateInfo
     <*> v .:? getName handshake .!= handshake
+    <*> v .:? getName inboundGovernor .!= inboundGovernor
+    <*> v .:? getName inboundGovernorCounters .!= inboundGovernorCounters
     <*> v .:? getName ipSubscription .!= ipSubscription
     <*> v .:? getName keepAliveClient .!= keepAliveClient
+    <*> v .:? getName ledgerPeers .!= ledgerPeers
     <*> v .:? getName localChainSyncProtocol .!= localChainSyncProtocol
+    <*> v .:? getName localConnectionManager .!= localConnectionManager
     <*> v .:? getName localErrorPolicy .!= localErrorPolicy
     <*> v .:? getName localHandshake .!= localHandshake
+    <*> v .:? getName localInboundGovernor .!= localInboundGovernor
+    <*> v .:? getName localRootPeers .!= localRootPeers
+    <*> v .:? getName localServer .!= localServer
     <*> v .:? getName localStateQueryProtocol .!= localStateQueryProtocol
     <*> v .:? getName localTxSubmissionProtocol .!= localTxSubmissionProtocol
     <*> v .:? getName localTxSubmissionServer .!= localTxSubmissionServer
     <*> v .:? getName mempool .!= mempool
     <*> v .:? getName mux .!= mux
     <*> v .:? getName localMux .!= localMux
+    <*> v .:? getName peerSelection .!= peerSelection
+    <*> v .:? getName peerSelectionCounters .!= peerSelectionCounters
+    <*> v .:? getName peerSelectionActions .!= peerSelectionActions
+    <*> v .:? getName publicRootPeers .!= publicRootPeers
+    <*> v .:? getName server .!= server
     <*> v .:? getName txInbound .!= txInbound
     <*> v .:? getName txOutbound .!= txOutbound
     <*> v .:? getName txSubmissionProtocol .!= txSubmissionProtocol

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -131,6 +131,7 @@ data TraceSelection
   , traceLocalErrorPolicy :: OnOff TraceLocalErrorPolicy
   , traceLocalHandshake :: OnOff TraceLocalHandshake
   , traceLocalInboundGovernor :: OnOff TraceLocalInboundGovernor
+  , traceLocalMux :: OnOff TraceLocalMux
   , traceLocalRootPeers :: OnOff TraceLocalRootPeers
   , traceLocalServer :: OnOff TraceLocalServer
   , traceLocalStateQueryProtocol :: OnOff TraceLocalStateQueryProtocol
@@ -138,7 +139,6 @@ data TraceSelection
   , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
   , traceMempool :: OnOff TraceMempool
   , traceMux :: OnOff TraceMux
-  , traceLocalMux :: OnOff TraceLocalMux
   , tracePeerSelection :: OnOff TracePeerSelection
   , tracePeerSelectionCounters :: OnOff TracePeerSelectionCounters
   , tracePeerSelectionActions :: OnOff TracePeerSelectionActions
@@ -206,8 +206,6 @@ traceConfigParser v =
       inboundGovernorCounters = OnOff True
       ipSubscription :: OnOff TraceIpSubscription
       ipSubscription = OnOff True
-      localErrorPolicy :: OnOff TraceLocalErrorPolicy
-      localErrorPolicy = OnOff True
       keepAliveClient :: OnOff TraceKeepAliveClient
       keepAliveClient = OnOff False
       ledgerPeers :: OnOff TraceLedgerPeers
@@ -216,10 +214,14 @@ traceConfigParser v =
       localChainSyncProtocol = OnOff False
       localConnectionManager :: OnOff TraceLocalConnectionManager
       localConnectionManager = OnOff False
+      localErrorPolicy :: OnOff TraceLocalErrorPolicy
+      localErrorPolicy = OnOff True
       localHandshake :: OnOff TraceLocalHandshake
       localHandshake = OnOff False
       localInboundGovernor :: OnOff TraceLocalInboundGovernor
       localInboundGovernor = OnOff False
+      localMux :: OnOff TraceLocalMux
+      localMux = OnOff False
       localRootPeers :: OnOff TraceLocalRootPeers
       localRootPeers = OnOff False
       localServer :: OnOff TraceLocalServer
@@ -234,8 +236,6 @@ traceConfigParser v =
       mempool = OnOff True
       mux :: OnOff TraceMux
       mux = OnOff True
-      localMux :: OnOff TraceLocalMux
-      localMux = OnOff False
       peerSelection :: OnOff TracePeerSelection
       peerSelection = OnOff False
       peerSelectionCounters :: OnOff TracePeerSelectionCounters
@@ -293,6 +293,7 @@ traceConfigParser v =
     <*> v .:? getName localErrorPolicy .!= localErrorPolicy
     <*> v .:? getName localHandshake .!= localHandshake
     <*> v .:? getName localInboundGovernor .!= localInboundGovernor
+    <*> v .:? getName localMux .!= localMux
     <*> v .:? getName localRootPeers .!= localRootPeers
     <*> v .:? getName localServer .!= localServer
     <*> v .:? getName localStateQueryProtocol .!= localStateQueryProtocol
@@ -300,7 +301,6 @@ traceConfigParser v =
     <*> v .:? getName localTxSubmissionServer .!= localTxSubmissionServer
     <*> v .:? getName mempool .!= mempool
     <*> v .:? getName mux .!= mux
-    <*> v .:? getName localMux .!= localMux
     <*> v .:? getName peerSelection .!= peerSelection
     <*> v .:? getName peerSelectionCounters .!= peerSelectionCounters
     <*> v .:? getName peerSelectionActions .!= peerSelectionActions

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1013,8 +1013,9 @@ instance (ConvertRawHash blk, LedgerSupportsProtocol blk)
                , "exception" .= String (pack $ show exc) ]
     TraceFoundIntersection _ _ _ ->
       mkObject [ "kind" .= String "ChainSyncClientEvent.TraceFoundIntersection" ]
-    TraceTermination _ ->
-      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceTermination" ]
+    TraceTermination reason ->
+      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceTermination"
+               , "reason" .= String (pack $ show reason) ]
 
 instance ConvertRawHash blk
       => ToObject (TraceChainSyncServerEvent blk) where

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -28,7 +28,7 @@ import           Cardano.BM.Trace (traceNamedObject)
 import           Cardano.BM.Tracing
 
 import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Consensus.Node (remoteAddress)
+import           Ouroboros.Network.ConnectionId (remoteAddress)
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as Net

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -18,11 +18,17 @@ module Test.Cardano.Node.Gen
 
 import           Cardano.Prelude
 
-import           Cardano.Node.Configuration.Topology (NetworkTopology (..), NodeSetup (..),
-                     RemoteAddress (..))
+import           Cardano.Node.Configuration.TopologyP2P (NetworkTopology (..), PublicRootPeers (..),
+                   LocalRootPeersGroups (..), LocalRootPeersGroup (..), RootConfig (..),
+                   NodeSetup (..), PeerAdvertise (..), UseLedger (..))
 import           Cardano.Node.Types (NodeAddress' (..), NodeHostIPAddress (..),
                    NodeHostIPv4Address (..), NodeHostIPv6Address (..),
                    NodeIPAddress, NodeIPv4Address, NodeIPv6Address)
+import           Cardano.Slotting.Slot (SlotNo (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (
+                   DomainAccessPoint (..), RelayAccessPoint (..))
+
 
 import qualified Data.IP as IP
 
@@ -35,8 +41,9 @@ import qualified Hedgehog.Range as Range
 genNetworkTopology :: Gen NetworkTopology
 genNetworkTopology =
   Gen.choice
-    [ MockNodeTopology <$> Gen.list (Range.linear 0 10) genNodeSetup
-    , RealNodeTopology <$> Gen.list (Range.linear 0 10) genRemoteAddress
+    [ RealNodeTopology <$> genLocalRootPeersGroups
+                       <*> Gen.list (Range.linear 0 10) genPublicRootPeers
+                       <*> genUseLedger
     ]
 
 genNodeAddress' :: Gen addr -> Gen (NodeAddress' addr)
@@ -83,12 +90,51 @@ genNodeSetup =
     <$> Gen.word64 (Range.linear 0 10000)
     <*> Gen.maybe (genNodeAddress' genNodeHostIPv4Address)
     <*> Gen.maybe (genNodeAddress' genNodeHostIPv6Address)
-    <*> Gen.list (Range.linear 0 6) genRemoteAddress
+    <*> Gen.list (Range.linear 0 6) genRootConfig
+    <*> genUseLedger
 
-genRemoteAddress :: Gen RemoteAddress
-genRemoteAddress =
-  RemoteAddress
+genDomainAddress :: Gen DomainAccessPoint
+genDomainAddress =
+  DomainAccessPoint
     <$> Gen.element cooking
-    <*> fmap fromIntegral (Gen.word16 $ Range.linear 100 20000)
-    <*> Gen.int (Range.linear 0 100)
+    <*> (fromIntegral <$> Gen.int (Range.linear 1000 9000))
 
+genRelayAddress :: Gen RelayAccessPoint
+genRelayAddress = do
+  isDomain <- Gen.bool
+  if isDomain
+    then RelayDomainAccessPoint <$> genDomainAddress
+    else RelayAccessAddress
+          <$> Gen.choice
+                [ IP.IPv4 . unNodeHostIPv4Address <$> genNodeHostIPv4Address
+                , IP.IPv6 . unNodeHostIPv6Address <$> genNodeHostIPv6Address
+                ]
+          <*> (fromIntegral <$> Gen.int (Range.linear 1000 9000))
+
+genRootConfig :: Gen RootConfig
+genRootConfig = do
+  RootConfig
+    <$> Gen.list (Range.linear 0 6) genRelayAddress
+    <*> Gen.element [DoAdvertisePeer, DoNotAdvertisePeer]
+
+genLocalRootPeersGroup :: Gen LocalRootPeersGroup
+genLocalRootPeersGroup = do
+    ra <- genRootConfig
+    val <- Gen.int (Range.linear 0 (length (rootAccessPoints ra)))
+    return (LocalRootPeersGroup ra val)
+
+genLocalRootPeersGroups :: Gen LocalRootPeersGroups
+genLocalRootPeersGroups =
+  LocalRootPeersGroups
+    <$> Gen.list (Range.linear 0 6) genLocalRootPeersGroup
+
+genPublicRootPeers :: Gen PublicRootPeers
+genPublicRootPeers =
+  PublicRootPeers
+    <$> genRootConfig
+
+genUseLedger :: Gen UseLedger
+genUseLedger = do
+    slot <- Gen.integral (Range.linear (-1) 10) :: Gen Integer
+    if slot >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ fromIntegral slot
+                 else return $ UseLedger   DontUseLedger

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -15,6 +15,7 @@ import           Cardano.Tracing.Config (TraceOptions (..))
 import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo (..))
 import           Ouroboros.Network.NodeToNode (DiffusionMode (InitiatorAndResponderDiffusionMode))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import qualified Ouroboros.Consensus.Node as Consensus ( NetworkP2PMode (..) )
 
 import           Hedgehog (Property, discover, withTests, (===))
 import qualified Hedgehog
@@ -66,6 +67,13 @@ testPartialYamlConfig =
     , pncShutdownIPC = mempty
     , pncShutdownOnSlotSynced = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncProtocolIdleTimeout = mempty
+    , pncTimeWaitTimeout = mempty
+    , pncTargetNumberOfRootPeers = mempty
+    , pncTargetNumberOfKnownPeers = mempty
+    , pncTargetNumberOfEstablishedPeers = mempty
+    , pncTargetNumberOfActivePeers = mempty
+    , pncEnableP2P = Last (Just DisabledP2PMode)
     }
 
 -- | Example partial configuration theoretically created
@@ -94,6 +102,13 @@ testPartialCliConfig =
     , pncLogMetrics = mempty
     , pncTraceConfig = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncProtocolIdleTimeout = mempty
+    , pncTimeWaitTimeout = mempty
+    , pncTargetNumberOfRootPeers = mempty
+    , pncTargetNumberOfKnownPeers = mempty
+    , pncTargetNumberOfEstablishedPeers = mempty
+    , pncTargetNumberOfActivePeers = mempty
+    , pncEnableP2P = Last (Just DisabledP2PMode)
     }
 
 -- | Expected final NodeConfiguration
@@ -123,6 +138,13 @@ expectedConfig =
     , ncLogMetrics = True
     , ncTraceConfig = TracingOff
     , ncMaybeMempoolCapacityOverride = Nothing
+    , ncProtocolIdleTimeout = 5
+    , ncTimeWaitTimeout = 60
+    , ncTargetNumberOfRootPeers = 100
+    , ncTargetNumberOfKnownPeers = 100
+    , ncTargetNumberOfEstablishedPeers = 50
+    , ncTargetNumberOfActivePeers = 20
+    , ncEnableP2P = SomeNetworkP2PMode Consensus.DisabledP2PMode
     }
 
 -- -----------------------------------------------------------------------------

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -36,6 +36,7 @@ library
   build-depends:        aeson
                       , base16-bytestring
                       , bytestring
+                      , cardano-node
                       , containers
                       , directory
                       , exceptions
@@ -44,6 +45,7 @@ library
                       , hedgehog-extras
                       , http-client
                       , http-types
+                      , ouroboros-network
                       , process
                       , random
                       , resourcet

--- a/cardano-testnet/src/Testnet/Byron.hs
+++ b/cardano-testnet/src/Testnet/Byron.hs
@@ -13,6 +13,8 @@ module Testnet.Byron
 
 import           Control.Monad
 import           Data.Aeson (Value, (.=))
+import           Data.Bool (Bool(..))
+import           Data.ByteString.Lazy (ByteString)
 import           Data.Eq
 import           Data.Function
 import           Data.Functor
@@ -22,11 +24,17 @@ import           Data.Ord
 import           Data.Semigroup
 import           Data.String
 import           GHC.Num
+import           GHC.Real
 import           Hedgehog.Extras.Stock.Aeson (rewriteObject)
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           Hedgehog.Extras.Stock.Time
 import           System.FilePath.Posix ((</>))
 import           Text.Show
+
+import qualified Cardano.Node.Configuration.Topology    as NonP2P
+import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
@@ -60,6 +68,7 @@ data TestnetOptions = TestnetOptions
   , securityParam :: Int
   , nPoorAddresses :: Int
   , totalBalance :: Int
+  , enableP2P :: Bool
   } deriving (Eq, Show)
 
 defaultTestnetOptions :: TestnetOptions
@@ -69,6 +78,7 @@ defaultTestnetOptions = TestnetOptions
   , securityParam = 10
   , nPoorAddresses = 128
   , totalBalance = 8000000000000000
+  , enableP2P = False
   }
 
 replaceNodeLog :: Int -> String -> String
@@ -76,14 +86,54 @@ replaceNodeLog n s = T.unpack (T.replace "logs/node-0.log" replacement (T.pack s
   where replacement = T.pack ("logs/node-" <> show @Int n <> ".log")
 
 -- | Rewrite a line in the configuration file
-rewriteConfiguration :: Int -> String -> String
-rewriteConfiguration _ "TraceBlockchainTime: False" = "TraceBlockchainTime: True"
-rewriteConfiguration n s | "logs/node-0.log" `L.isInfixOf` s = replaceNodeLog n s
-rewriteConfiguration _ s = s
+rewriteConfiguration :: Bool -> Int -> String -> String
+rewriteConfiguration _ _ "TraceBlockchainTime: False"          = "TraceBlockchainTime: True"
+rewriteConfiguration _ n s | "logs/node-0.log" `L.isInfixOf` s = replaceNodeLog n s
+rewriteConfiguration True _ "EnableP2P: False"                 = "EnableP2P: True"
+rewriteConfiguration False _ "EnableP2P: True"                 = "EnableP2P: False"
+rewriteConfiguration _ _ s                                     = s
 
 rewriteParams :: TestnetOptions -> Value -> Value
 rewriteParams testnetOptions = rewriteObject
   $ HM.insert "slotDuration" (J.toJSON @String (show @Int (slotDuration testnetOptions)))
+
+mkTopologyConfig :: Int -> Int -> [Int]
+                 -> Bool -- ^ if true use p2p topology configuration
+                 -> ByteString
+mkTopologyConfig i numBftNodes allPorts False = J.encode topologyNonP2P
+  where
+    topologyNonP2P :: NonP2P.NetworkTopology
+    topologyNonP2P =
+      NonP2P.RealNodeTopology
+        $ flip fmap ([0 .. numBftNodes - 1] L.\\ [i])
+        $ \j -> NonP2P.RemoteAddress "127.0.0.1"
+                                    (fromIntegral $ allPorts L.!! j)
+                                    1
+mkTopologyConfig i numBftNodes allPorts True = J.encode topologyP2P
+  where
+    rootConfig :: P2P.RootConfig
+    rootConfig =
+      P2P.RootConfig
+        (flip fmap ([0 .. numBftNodes - 1] L.\\ [i])
+        $ \j -> RelayAccessAddress "127.0.0.1"
+                            (fromIntegral $ allPorts L.!! j)
+        )
+        P2P.DoNotAdvertisePeer
+
+    localRootPeerGroups :: P2P.LocalRootPeersGroups
+    localRootPeerGroups =
+      P2P.LocalRootPeersGroups
+        [ P2P.LocalRootPeersGroup rootConfig
+                                  (numBftNodes - 1)
+        ]
+
+    topologyP2P :: P2P.NetworkTopology
+    topologyP2P =
+      P2P.RealNodeTopology
+        localRootPeerGroups
+        []
+        (P2P.UseLedger DontUseLedger)
+
 
 testnet :: TestnetOptions -> H.Conf -> H.Integration [String]
 testnet testnetOptions H.Conf {..} = do
@@ -128,7 +178,7 @@ testnet testnetOptions H.Conf {..} = do
 
   H.createDirectoryIfMissing logDir
 
-  -- Launch cluster of three nodes
+  -- Launch cluster of three nodes in P2P Mode
   forM_ nodeIndexes $ \i -> do
     si <- H.noteShow $ show @Int i
     dbDir <- H.noteShow $ tempAbsPath </> "db/node-" <> si
@@ -144,20 +194,10 @@ testnet testnetOptions H.Conf {..} = do
     H.createDirectoryIfMissing dbDir
     H.createDirectoryIfMissing $ tempBaseAbsPath </> "" <> socketDir
 
-    otherPorts <- H.noteShow $ L.dropNth i allPorts
+    H.lbsWriteFile (tempAbsPath </> "topology-node-" <> si <> ".json") $
+      mkTopologyConfig i (numBftNodes testnetOptions) allPorts (enableP2P testnetOptions)
 
-    H.lbsWriteFile (tempAbsPath </> "topology-node-" <> si <> ".json") $ J.encode $
-      J.object
-      [ ( "Producers"
-        , J.toJSON $ flip fmap [0 .. numBftNodes testnetOptions - 2] $ \j -> J.object
-          [ ("addr", "127.0.0.1")
-          , ("valency", J.toJSON @Int 1)
-          , ("port", J.toJSON (otherPorts L.!! j))
-          ]
-        )
-      ]
-
-    H.writeFile (tempAbsPath </> "config-" <> si <> ".yaml") . L.unlines . fmap (rewriteConfiguration i) . L.lines =<<
+    H.writeFile (tempAbsPath </> "config-" <> si <> ".yaml") . L.unlines . fmap (rewriteConfiguration (enableP2P testnetOptions) i) . L.lines =<<
       H.readFile (baseConfig </> "config-0.yaml")
 
     hNodeStdout <- H.openFile nodeStdoutFile IO.WriteMode

--- a/cardano-testnet/testnet/Testnet/Commands/Byron.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Byron.hs
@@ -70,6 +70,13 @@ optsTestnet = TestnetOptions
       <>  OA.showDefault
       <>  OA.value (totalBalance defaultTestnetOptions)
       )
+  <*> OA.option auto
+      (   OA.long "enable-p2p"
+      <>  OA.help "Enable P2P"
+      <>  OA.metavar "BOOL"
+      <>  OA.showDefault
+      <>  OA.value (enableP2P defaultTestnetOptions)
+      )
 
 runByronOptions :: ByronOptions -> IO ()
 runByronOptions opts = runTestnet (maybeTestnetMagic opts) (Testnet.Byron.testnet (testnetOptions opts))

--- a/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
@@ -70,6 +70,13 @@ optsTestnet = TestnetOptions
       <>  OA.showDefault
       <>  OA.value (activeSlotsCoeff defaultTestnetOptions)
       )
+  <*> OA.option auto
+      (   OA.long "enable-p2p"
+      <>  OA.help "Enable P2P"
+      <>  OA.metavar "BOOL"
+      <>  OA.showDefault
+      <>  OA.value (enableP2P defaultTestnetOptions)
+      )
 
 optsCardano :: Parser CardanoOptions
 optsCardano = CardanoOptions

--- a/cardano-testnet/testnet/Testnet/Commands/Shelley.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Shelley.hs
@@ -74,6 +74,13 @@ optsTestnet = TestnetOptions
       <>  OA.showDefault
       <>  OA.value (maxLovelaceSupply defaultTestnetOptions)
       )
+  <*> OA.option auto
+      (   OA.long "enable-p2p"
+      <>  OA.help "Enable P2P"
+      <>  OA.metavar "BOOL"
+      <>  OA.showDefault
+      <>  OA.value (enableP2P defaultTestnetOptions)
+      )
 
 optsShelley :: Parser ShelleyOptions
 optsShelley = ShelleyOptions

--- a/configuration/cardano/mainnet-p2p-toplogy.json
+++ b/configuration/cardano/mainnet-p2p-toplogy.json
@@ -1,0 +1,18 @@
+{
+  "LocalRoots": {
+    "groups": []
+  },
+  "PublicRoots": [
+    {
+      "publicRoots": {
+        "accessPoints": [
+          {
+            "address": "relays-new.cardano-mainnet.iohk.io",
+            "port": 3001
+          }
+        ],
+        "advertise": false
+      }
+    }
+  ]
+}

--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -49,6 +49,9 @@ LastKnownBlockVersion-Alt: 0
 ApplicationName: cardano-sl
 ApplicationVersion: 1
 
+##### Enable P2P Mode #####
+EnableP2P: False
+TestEnableDevelopmentNetworkProtocols: True
 
 ##### Logging configuration #####
 
@@ -209,6 +212,10 @@ TraceHandshake: True
 
 # Trace IP Subscription messages.
 TraceIpSubscription: True
+
+# Trace Connection Manager messages.
+# P2P Only
+TraceConnectionManager: True
 
 # Trace local ChainSync protocol messages.
 TraceLocalChainSyncProtocol: False

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -67,6 +67,8 @@ TurnOnLogMetrics: True
 SocketPath:
 
 
+#####    P2P Mode    #####
+EnableP2P: False
 
 #####    Update Parameters    #####
 

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -65,6 +65,8 @@ TurnOnLogging: True
 TurnOnLogMetrics: True
 SocketPath:
 
+#####    P2P Mode    #####
+EnableP2P: True
 
 
 #####    Update Parameters    #####

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -66,6 +66,8 @@ TurnOnLogging: True
 TurnOnLogMetrics: True
 SocketPath:
 
+#####    P2P Mode    #####
+EnableP2P: True
 
 
 #####    Update Parameters    #####

--- a/configuration/chairman/shelley-only/configuration.yaml
+++ b/configuration/chairman/shelley-only/configuration.yaml
@@ -45,6 +45,8 @@ LastKnownBlockVersion-Alt: 0
 ApplicationName: cardano-sl
 ApplicationVersion: 1
 
+##### Enable P2P Mode #####
+EnableP2P: False
 
 ##### Logging configuration #####
 

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -200,6 +200,34 @@ TraceHandshake: False
 # Trace IP Subscription messages.
 TraceIpSubscription: True
 
+# Trace local root peers
+TraceLocalRootPeers: True
+
+# Trace public root peers
+TracePublicRootPeers: True 
+
+# Trace peer selection
+TracePeerSelection: True
+
+# Debug peer selection
+TraceDebugPeerSelection: False
+
+# Trace peer selection actions (demotion / protmotion between cold / warm and
+# hot peers).
+TracePeerSelectionActions: True
+
+# Trace connection manager
+TraceConnectionManager: True
+
+# Trace server
+TraceServer: True
+
+# Trace local connection manager
+TraceLocalConnectionManager: False
+
+# Trace local server
+TraceLocalServer: False
+
 # Trace local ChainSync protocol messages.
 TraceLocalChainSyncProtocol: False
 

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -13,7 +13,14 @@ let
     let baseConfig = recursiveUpdate (cfg.nodeConfig
       // (mapAttrs' (era: epoch:
         nameValuePair "Test${era}HardForkAtEpoch" epoch
-      ) cfg.forceHardForks)) cfg.extraNodeConfig;
+      ) cfg.forceHardForks)
+      // (optionalAttrs cfg.useNewTopology {
+        EnableP2P = true;
+        TargetNumberOfRootPeers = cfg.targetNumberOfRootPeers;
+        TargetNumberOfKnownPeers = cfg.targetNumberOfKnownPeers;
+        TargetNumberOfEstablishedPeers = cfg.targetNumberOfEstablishedPeers;
+        TargetNumberOfActivePeers = cfg.targetNumberOfActivePeers;
+      })) cfg.extraNodeConfig;
     in i: let
     instanceConfig = recursiveUpdate (baseConfig
       // (optionalAttrs (baseConfig ? hasEKG) {
@@ -24,9 +31,34 @@ let
       })) (cfg.extraNodeInstanceConfig i);
     nodeConfigFile = if (cfg.nodeConfigFile != null) then cfg.nodeConfigFile
       else toFile "config-${toString cfg.nodeId}-${toString i}.json" (toJSON instanceConfig);
-    topology = if cfg.topology != null then cfg.topology else toFile "topology.yaml" (toJSON {
-      Producers = cfg.producers ++ (cfg.instanceProducers i);
-    });
+    newTopology = {
+      LocalRoots = {
+        groups = map (g: {
+          localRoots = {
+            inherit (g) addrs;
+            advertise = g.advertise or false;
+          };
+          valency = g.valency or (length g.addrs);
+        }) (cfg.producers ++ (cfg.instanceProducers i));
+      };
+      PublicRoots = map (g: {
+        publicRoots = {
+          inherit (g) addrs;
+          advertise = g.advertise or false;
+        };
+      }) (cfg.publicProducers ++ (cfg.instancePublicProducers i));
+    } // optionalAttrs (cfg.usePeersFromLedgerAfterSlot != null) {
+      useLedgerAfterSlot = cfg.usePeersFromLedgerAfterSlot;
+    };
+    oldTopology = {
+      Producers = concatMap (g: map (a: a // { valency = a.valency or 1; }) g.addrs) (
+        cfg.producers ++ (cfg.instanceProducers i) ++ cfg.publicProducers ++ (cfg.instancePublicProducers i)
+      );
+    };
+    topology = if cfg.topology != null then cfg.topology else toFile "topology.yaml" (toJSON (
+      if (cfg.useNewTopology) then newTopology
+      else oldTopology
+    ));
     consensusParams = {
       RealPBFT = [
         "${lib.optionalString (cfg.signingKey != null)
@@ -331,21 +363,62 @@ in {
         '';
       };
 
-      producers = mkOption {
+      publicProducers = mkOption {
+        type = types.listOf types.attrs;
         default = [{
-          addr = envConfig.relaysNew;
-          port = envConfig.edgePort;
+          addrs = [{
+            addr = envConfig.relaysNew;
+            port = envConfig.edgePort;
+          }];
+          advertise = false;
+        }];
+        description = ''Routes to public peers. Only used if slot < usePeersFromLedgerAfterSlot'';
+      };
+
+      instancePublicProducers = mkOption {
+        # type = types.functionTo (types.listOf types.attrs);
+        default = _: [];
+        description = ''Routes to public peers. Only used if slot < usePeersFromLedgerAfterSlot and specific to a given instance (when multiple instances are used).'';
+      };
+
+      producers = mkOption {
+        type = types.listOf types.attrs;
+        default = [];
+        example = [{
+          addrs = [{
+            addr = "127.0.0.1";
+            port = 3001;
+          }];
+          advertise = false;
           valency = 1;
         }];
-        type = types.listOf types.attrs;
-        description = ''Static routes to peers.'';
+        description = ''Static routes to local peers.'';
       };
 
       instanceProducers = mkOption {
         type = types.functionTo (types.listOf types.attrs);
         default = _: [];
         description = ''
-          Static routes to peers, specific to a given instance (when multiple instances are used).
+          Static routes to local peers, specific to a given instance (when multiple instances are used).
+        '';
+      };
+
+      useNewTopology = mkOption {
+        type = types.bool;
+        default = cfg.nodeConfig.EnableP2P or false;
+        description = ''
+          Use new, p2p/ledger peers compatible topology.
+        '';
+      };
+
+      usePeersFromLedgerAfterSlot = mkOption {
+        type = types.nullOr types.int;
+        default = if cfg.kesKey != null then null
+          else envConfig.usePeersFromLedgerAfterSlot or null;
+        description = ''
+          If set, bootstraps from public roots until it reaches given slot,
+          then it switches to using the ledger as a source of peers. It maintains a connection to its local roots.
+          Default to null for block producers.
         '';
       };
 
@@ -363,6 +436,38 @@ in {
         };
         default = envConfig.nodeConfig;
         description = ''Internal representation of the config.'';
+      };
+
+      targetNumberOfRootPeers = mkOption {
+        type = types.int;
+        default = cfg.nodeConfig.TargetNumberOfRootPeers or 60;
+        description = "Limits the maximum number of root peers the node will know about";
+      };
+
+      targetNumberOfKnownPeers = mkOption {
+        type = types.int;
+        default = cfg.nodeConfig.TargetNumberOfKnownPeers or cfg.targetNumberOfRootPeers;
+        description = ''
+          Target number for known peers (root peers + peers known through gossip).
+          Default to targetNumberOfRootPeers.
+        '';
+      };
+
+      targetNumberOfEstablishedPeers = mkOption {
+        type = types.int;
+        default = cfg.nodeConfig.TargetNumberOfEstablishedPeers
+          or (2 * cfg.targetNumberOfKnownPeers / 3);
+        description = ''Number of peers the node will be connected to, but not necessarily following their chain.
+          Default to 2/3 of targetNumberOfKnownPeers.
+        '';
+      };
+
+      targetNumberOfActivePeers = mkOption {
+        type = types.int;
+        default = cfg.nodeConfig.TargetNumberOfActivePeers or (cfg.targetNumberOfEstablishedPeers / 2);
+        description = ''Number of peers your node is actively downloading headers and blocks from.
+          Default to half of targetNumberOfEstablishedPeers.
+        '';
       };
 
       extraNodeConfig = mkOption {

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -136,7 +136,7 @@ in {
       };
 
       profiling = mkOption {
-        type = types.enum ["none" "time" "space" "space-cost" "space-module" "space-closure" "space-type" "space-retainer" "space-bio"];
+        type = types.enum ["none" "time" "space" "space-cost" "space-module" "space-closure" "space-type" "space-retainer" "space-bio" "space-heap"];
         default = "none";
       };
 
@@ -528,6 +528,7 @@ in {
             else if cfg.profiling == "space-type" then ["-hy"] ++ commonProfilingArgs
             else if cfg.profiling == "space-retainer" then ["-hr"] ++ commonProfilingArgs
             else if cfg.profiling == "space-bio" then ["-hb"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-heap" then ["-hT"] ++ commonProfilingArgs
             else [];
         description = ''RTS profiling options'';
       };

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -136,7 +136,7 @@ in {
       };
 
       profiling = mkOption {
-        type = types.enum ["none" "time" "space" "space-module" "space-closure" "space-type" "space-retainer" "space-bio"];
+        type = types.enum ["none" "time" "space" "space-cost" "space-module" "space-closure" "space-type" "space-retainer" "space-bio"];
         default = "none";
       };
 
@@ -522,6 +522,7 @@ in {
           ++ lib.optional (cfg.eventlog) "-l";
           in if cfg.profiling == "time" then ["-P"] ++ commonProfilingArgs
             else if cfg.profiling == "space" then ["-h"] ++ commonProfilingArgs
+            else if cfg.profiling == "space-cost" then ["-hc"] ++ commonProfilingArgs
             else if cfg.profiling == "space-module" then ["-hm"] ++ commonProfilingArgs
             else if cfg.profiling == "space-closure" then ["-hd"] ++ commonProfilingArgs
             else if cfg.profiling == "space-type" then ["-hy"] ++ commonProfilingArgs


### PR DESCRIPTION
This PR integrates with peer2peer networking and allows to run a node in either mode:

* non-p2p: the only officially supported version
* p2p: unverified and unsupported p2p mode

This also includes:

* a new topology file format for p2p nodes
* a mechanism to reload topology file on SIGHUP signal

- network trace instances: use ToJSON or ToObject instances
- network trace instances: peer selection traces
- network trace instances: ToJSON instances
- consensus trace instances: trace termination reason
- P2P / NonP2P cardano-node
- Update p2p topology configuration via the SIGHUP signal
- Removed MonoLocalBinds extension
- topology file: improved parsing error message
- Improve NetworkTopology generator
- byron-mainnet configuration: added p2p trace options
- p2p topology file for cardano mainnet
- Document the p2p topology file
- Updated cardano-node-chairman
- Updated trace-dispatcher and trace-forward libraries
- Updated tx-generator
- Updated cardano-testnet package
- Code cleanup in Tracing.Config
- nixos service: add p2p topology support.
- nixos-service: Add space-cost profiling support
- nixos-service: Add space-heap profiling support
