### PR TITLE
Expose events api via foldBlocks, chainSyncClientWithLedgerState, and chainSyncClientPipelinedWithLedgerState

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -496,6 +496,12 @@ module Cardano.Api (
     applyBlock,
     ValidationMode(..),
 
+    -- *** Ledger Events
+    LedgerEvent(..),
+    MIRDistributionDetails(..),
+    PoolReapDetails(..),
+    toLedgerEvent,
+
     -- *** Traversing the block chain
     foldBlocks,
     chainSyncClientWithLedgerState,
@@ -639,6 +645,7 @@ import           Cardano.Api.Key
 import           Cardano.Api.KeysByron
 import           Cardano.Api.KeysPraos
 import           Cardano.Api.KeysShelley
+import           Cardano.Api.LedgerEvent
 import           Cardano.Api.LedgerState
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId

--- a/cardano-api/src/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/src/Cardano/Api/LedgerEvent.hs
@@ -105,21 +105,21 @@ instance All ConvertLedgerEvent xs => ConvertLedgerEvent (HardForkBlock xs) wher
 --   are inverse; a transfer of 100 ADA in either direction will result in a net
 --   movement of 0, but we include both directions for assistance in debugging.
 data MIRDistributionDetails = MIRDistributionDetails
-  { reservePayouts :: Map StakeCredential Lovelace,
-    treasuryPayouts :: Map StakeCredential Lovelace,
-    reservesToTreasury :: Lovelace,
-    treasuryToReserves :: Lovelace
+  { mirddReservePayouts :: Map StakeCredential Lovelace,
+    mirddTreasuryPayouts :: Map StakeCredential Lovelace,
+    mirddReservesToTreasury :: Lovelace,
+    mirddTreasuryToReserves :: Lovelace
   }
 
 data PoolReapDetails = PoolReapDetails
-  { epochNo :: EpochNo,
+  { prdEpochNo :: EpochNo,
     -- | Refunded deposits. The pools referenced are now retired, and the
     --   'StakeCredential' accounts are credited with the deposits.
-    refunded :: Map StakeCredential (Map (Hash StakePoolKey) Lovelace),
+    prdRefunded :: Map StakeCredential (Map (Hash StakePoolKey) Lovelace),
     -- | Unclaimed deposits. The 'StakeCredential' referenced in this map is not
     -- actively registered at the time of the pool reaping, and as such the
     -- funds are returned to the treasury.
-    unclaimed :: Map StakeCredential (Map (Hash StakePoolKey) Lovelace)
+    prdUnclaimed :: Map StakeCredential (Map (Hash StakePoolKey) Lovelace)
   }
 
 --------------------------------------------------------------------------------

--- a/cardano-client-demo/LedgerState.hs
+++ b/cardano-client-demo/LedgerState.hs
@@ -38,6 +38,7 @@ main = do
     (0 :: Int) -- We just use a count of the blocks as the current state
     (\_env
       !ledgerState
+      _
       (BlockInMode (Block (BlockHeader _slotNo _blockHeaderHash (BlockNo blockNoI)) _transactions) _era)
       blockCount -> do
         case ledgerState of

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -236,6 +236,7 @@ main = do
          startingState
          (\_env
            !ledgerState
+           _
            (BlockInMode
              (Block (BlockHeader slotNo _blockHeaderHash (BlockNo _blockNoI)) transactions)
              _era)


### PR DESCRIPTION
This simply exposes the `[LedgerEvent]` that comes with applying blocks. This should be useful for db-sync in the future.