### PR TITLE
Accept keyhashes for required signers

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -178,7 +178,7 @@ module Cardano.Api (
     txOutValueToLovelace,
     txOutValueToValue,
     TxOutDatum(..),
-    parseHashScriptData,
+    parseHash,
 
     -- ** Other transaction body types
     TxInsCollateral(..),

--- a/cardano-api/src/Cardano/Api/KeysShelley.hs
+++ b/cardano-api/src/Cardano/Api/KeysShelley.hs
@@ -52,8 +52,8 @@ import qualified Cardano.Ledger.Keys as Shelley
 
 import           Cardano.Ledger.Crypto (StandardCrypto)
 
-import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Hash
 import           Cardano.Api.Key
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -90,8 +90,8 @@ import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.SafeHash as Ledger
-import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Cardano.Ledger.Shelley.Address.Bootstrap as Shelley
+import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Cardano.Ledger.Shelley.Tx as Shelley
 import qualified Cardano.Ledger.Shelley.TxBody as Ledger (EraIndependentTxBody)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -167,7 +167,7 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-      [WitnessSigningData]
+      [RequiredSigner]
       -- ^ Required signers
       [TxOutAnyEra]
       (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
@@ -199,7 +199,7 @@ data TransactionCmd
       -- ^ Override the required number of tx witnesses
       [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
       -- ^ Required signers
-      [WitnessSigningData]
+      [RequiredSigner]
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -25,6 +25,7 @@ module Cardano.CLI.Types
   , VerificationKeyFile (..)
   , Stakes (..)
   , Params (..)
+  , RequiredSigner (..)
   ) where
 
 import           Cardano.Prelude
@@ -215,3 +216,9 @@ newtype TxOutChangeAddress = TxOutChangeAddress AddressAny
 -- | A flag that differentiates between automatically
 -- and manually balancing a tx.
 data BalanceTxExecUnits = AutoBalance | ManualBalance
+
+-- | Plutus script required signers
+data RequiredSigner
+ = RequiredSignerSkeyFile SigningKeyFile
+ | RequiredSignerHash (Hash PaymentKey)
+ deriving Show


### PR DESCRIPTION
Required signers can now be specified via the `--required-signer-hash` cli option
Resolves: #3338