### PR TITLE
[cardano-api] Add a FromJSONKey instance for TxIn

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -399,7 +399,10 @@ instance ToJSONKey TxIn where
   toJSONKey = toJSONKeyText renderTxIn
 
 instance FromJSON TxIn where
-  parseJSON = withText "TxIn" $ \txinStr -> runParsecParser parseTxIn txinStr
+  parseJSON = withText "TxIn" $ runParsecParser parseTxIn
+
+instance FromJSONKey TxIn where
+  fromJSONKey = Aeson.FromJSONKeyTextParser $ runParsecParser parseTxIn
 
 parseTxId :: Parsec.Parser TxId
 parseTxId = do


### PR DESCRIPTION
Was trying to build, but `cabal` fails (like on `master`) with:
```
λ cabal build cardano-api
/nix/store/qbv8c3ilaawqm36cbxflvv6gny00nzjj-cabal-install-exe-cabal-3.6.0.0/bin/cabal --project-file=/home/ch1bo/code/iog/cardano-haskell/cardano-node/.nix-shell-cabal.project build cardano-api
Warning: No remote package servers have been specified. Usually you would have
one specified in the config file.
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: cardano-api-1.31.0 (user goal)
[__1] unknown package: compact-map (dependency of cardano-api)
[__1] fail (backjumping, conflict set: cardano-api, compact-map)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: cardano-api, compact-map
```