### PR TITLE
Tune the default RTS params

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -162,9 +162,9 @@ executable cardano-node
                         -rtsopts
 
   if arch(arm)
-    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
+    ghc-options:        "-with-rtsopts=-T -I0 -C0 -A16m -n1m -N1 --disable-delayed-os-memory-return"
   else
-    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
+    ghc-options:        "-with-rtsopts=-T -I0 -C0 -A32m -n1m -AL512m -N2 --disable-delayed-os-memory-return"
 
   other-modules:        Paths_cardano_node
 


### PR DESCRIPTION
- **-C0** - context-switch as often as possible, I think this will fix prop delays that are currently experienced. Default is wait 20ms before trying a switch.
- -**A32m** - 32m allocation region per core, the node really generates a lot of data
- **-n1m** - 1m nursery size blocks, make sure allocation areas are filled better before GC
- **-AL512m** - 512MB limit for large object allocation before forcing a GC. Default is the value of **-A**.

Usually a lot of large object allocation happens during snapshot creation and it will hit a lot of times since the mainnet ledger snapshot is around ~1GB. The regular Gen0 collects will make sure large blocks get promoted to Gen 1 anyway.

All in all I think these are safe & useful modifications to the default behavior of cardano-node and will increase performance of the entire network a lot.

Yes, actual useful time spent on computing stuff will decline due to -C0, but really. Most nodes are idling pretty much all of the time except for when starting up / making snapshots. So this small dent on throughput really will not impact real world performance, it will just make the cardano-node handle threads that want to do stuff faster.

I played around with RTS parameters **a lot** and the propagation delays to my nodes dropped significantly. Not entirely due to these parameters, I also connected to more nodes in the network. But that was not the only factor.

![image](https://user-images.githubusercontent.com/2385844/143920964-48d5264d-1962-4a56-84b2-ed1c8015a5cb.png)



