### PR TITLE
scripts: simple transaction example in alonzo era

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@
 The `scripts` directory consists of the following directories:
 - [benchmarking](#benchmarking)
 - [buildkite](#buildkite)
-- [byron-shelley-allegra-mary](#byron-shelley-allegra-mary)
+- [byron-to-shelley](#byron-to-shelley)
 - [lite](#lite)
 - [shelley-from-scratch](#shelley-from-scratch)
 - [byron-to-alonzo](#byron-to-alonzo)
@@ -12,31 +12,50 @@ The `scripts` directory consists of the following directories:
 #### buildkite
 Contains scripts relevant to IOHK's CI.
 
-#### byron-shelley-allegra-mary
-Contains a script that sets up a cluster beginning in the Byron era and can transition to the Shelley era. You can also start a cluster in the Shelley, Allegra or Mary era by supplying an argument to `mk-files.sh`.
+### Clusters
+
+Generally clusters sub-folders contain a `mkfiles.sh` script which creates a top level
+`examples` subdirectory with keys and configuration to start a cluster. The script prints
+to stdout instructions for starting nodes, transitioning protocols and general use. There are
+also some scripts with examples of various kinds of transactions.
+
+#### byron-to-shelley
+
+Contains a script that sets up a config files and keys needed to start a cluster. The cluster starts in the Byron era and can transition to the Shelley era.
+
+You can also start a cluster in the Shelley, Allegra or Mary era by supplying an argument to `mk-files.sh`.
 E.g
 ```bash
 ./scripts/byron-to-mary/mk-files.sh shelley # Starts nodes in Shelley era
 ./scripts/byron-to-mary/mk-files.sh allegra # Starts nodes in Allegra era
 ./scripts/byron-to-mary/mk-files.sh mary    # Starts nodes in Mary era
 ```
+
 #### lite
-Contains scripts that can start various clusters and intended to be as simple as possible. Note that using the shelley only era testnet clusters breaks compatibility with some cli commands.
+Contains scripts that can start various clusters and intended to be as simple as possible.
+This does not follow the pattern of using a `mkfiles.sh` script as described above.
+Note that using the shelley only era testnet clusters breaks compatibility with some cli commands.
 
 #### shelley-from-scratch
-Contains a script that creates all the necessary keys etc to create a shelley cluster from scratch.
+Contains a `mkfiles.sh` script that creates all the necessary keys etc to create a shelley cluster from scratch.
 
 #### byron-to-alonzo
-Contains a script that creates all the necessary keys and configuration files to create an alonzo cluster from scratch.
-This script is similar to [byron-shelley-allegra-mary](#byron-shelley-allegra-mary) script: It can either be used to start cluster in Byron and then gradually transition to Alonzo, or can jumpstart straight into selected era, eg.:
+
+Contains a `mkfiles.sh` script that creates all the necessary keys and configuration files to create an alonzo cluster from scratch.
+
+It can either be used to start cluster in Byron and then gradually transition to Alonzo, or can jumpstart straight into selected era, eg.:
 ```
 ./scripts/byron-to-alonzo/mkfiles.sh alonzo
 ```
 will start the cluster in Alonzo era from epoch 0.
 
+The folder also contains examples of using transactions, namely a very simple example
+in `simple-tx.sh` and examples of minting and burning ada in `mint.sh` and `burn.sh`.
+
 #### plutus
 
-Contains scripts to test submission of transactions containing (simple) Plutus scripts. Obviously, only works against a test cluster running in Alonzo era.
+Contains scripts to test submission of transactions containing (simple) Plutus scripts. Obviously, only works against a test cluster running in Alonzo era. Note: this does not follow the
+pattern of using a `mkfiles.sh` script as described above.
 
 Example:
 ```

--- a/scripts/byron-to-alonzo/simple-tx.sh
+++ b/scripts/byron-to-alonzo/simple-tx.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# This script creates, signs, and submits a simple transaction in the Alonzo era.
+# We simply generate a new user and send him some money.
+# To use:
+#   start an alonzo cluster and wait until, say, you can query the tip of node-bft1
+#   then run as ./scripts/byron-to-alonzo/simple-tx.sh
+
+ROOT=example
+TESTNET=42
+WORK=simple-tx-files
+CLI=cardano-cli
+pushd ${ROOT}
+mkdir ${WORK}
+export CARDANO_NODE_SOCKET_PATH=node-bft1/node.sock
+
+# 1. Build a new user
+#########################################################################################
+
+pushd ${WORK}
+$CLI address key-gen --normal-key \
+  --verification-key-file user.vkey \
+  --signing-key-file user.skey
+$CLI address build --payment-verification-key-file user.vkey --testnet-magic $TESTNET \
+  --out-file user.addr
+popd
+
+# 2. Build a transaction body
+#########################################################################################
+
+# The single utxo input
+UTXO_SKEY=shelley/utxo-keys/utxo1.skey
+UTXO_VKEY=shelley/utxo-keys/utxo1.vkey
+$CLI address build --payment-verification-key-file ${UTXO_VKEY} \
+  --testnet-magic $TESTNET \
+  --out-file shelley/utxo-keys/utxo1.addr
+UTXO_ADDR=$(cat shelley/utxo-keys/utxo1.addr)
+$CLI query utxo --address ${UTXO_ADDR} --cardano-mode --testnet-magic $TESTNET \
+  --out-file $WORK/txin.json
+TXIN=$(jq -r 'keys[0]' $WORK/txin.json)
+
+# The first output of 10 ada
+USER_ADDR=$(cat $WORK/user.addr)
+TXOUT="${USER_ADDR}+10000000"
+
+# Protocol parameters
+$CLI query protocol-parameters --cardano-mode --testnet-magic \
+  $TESTNET --out-file $WORK/pparams.json
+
+# The tx body itself
+$CLI transaction build --alonzo-era --cardano-mode --testnet-magic $TESTNET \
+  --change-address ${UTXO_ADDR} \
+  --tx-in $TXIN \
+  --tx-out $TXOUT \
+  --protocol-params-file $WORK/pparams.json \
+  --out-file $WORK/example-tx.body
+
+# 3. Sign the transaction body
+#########################################################################################
+
+$CLI transaction sign --tx-body-file $WORK/example-tx.body \
+  --testnet-magic $TESTNET \
+  --signing-key-file ${UTXO_SKEY} \
+  --out-file $WORK/example-tx.tx
+
+# 4. Submit the signed transaction
+#########################################################################################
+
+$CLI transaction submit --tx-file $WORK/example-tx.tx --testnet-magic $TESTNET
+
+# 4. Query the new utxo of the new user
+#########################################################################################
+
+sleep 4
+$CLI query utxo --address ${USER_ADDR} --cardano-mode --testnet-magic $TESTNET
+
+popd


### PR DESCRIPTION
This MR improves the docs of `/scripts` and adds a script for making a simple transaction in the Alonzo era.

This should also help with https://github.com/input-output-hk/cardano-node/issues/721 by providing an easy example to check the rendering of txids in the node log files.