### PR TITLE
cardano-cli: Add option `--stake-address` to several subcommands

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -98,6 +98,7 @@ module Cardano.Api (
     StakeAddress,
     StakeCredential,
     makeStakeAddress,
+    stakeAddressCredential,
     StakeKey,
     StakeExtendedKey,
 

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -719,6 +719,7 @@ fromShelleyStakeReference (Shelley.StakeRefPtr ptr) =
 fromShelleyStakeReference Shelley.StakeRefNull =
   NoStakeAddress
 
--- | Get credential from a stake address. This drops the network information.
+-- | Get a stake credential from a stake address.
+-- This drops the network information.
 stakeAddressCredential :: StakeAddress -> StakeCredential
 stakeAddressCredential (StakeAddress _ scred) = fromShelleyStakeCredential scred

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -47,6 +47,7 @@ module Cardano.Api.Address (
     StakeAddress(..),
     StakeCredential(..),
     makeStakeAddress,
+    stakeAddressCredential,
     StakeKey,
     StakeExtendedKey,
 
@@ -718,3 +719,6 @@ fromShelleyStakeReference (Shelley.StakeRefPtr ptr) =
 fromShelleyStakeReference Shelley.StakeRefNull =
   NoStakeAddress
 
+-- | Get credential from a stake address. This drops the network information.
+stakeAddressCredential :: StakeAddress -> StakeCredential
+stakeAddressCredential (StakeAddress _ scred) = fromShelleyStakeCredential scred

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -14,6 +14,13 @@
 
 - Add `slotInEpoch` and `slotsToEpochEnd` to output of `query tip` command ([PR 4912](https://github.com/input-output-hk/cardano-node/pull/4912))
 
+- Add `--stake-address` option to the following CLI commands ([PR 3404](https://github.com/input-output-hk/cardano-node/pull/3404)):
+  - address build
+  - stake-address build
+  - stake-address registration-certificate
+  - stake-address delegation-certificate
+  - stake-address deregistration-certificate
+
 ### Bugs
 
 - Allow reading signing keys from a pipe ([PR 4342](https://github.com/input-output-hk/cardano-node/pull/4342))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -102,6 +102,7 @@ data PaymentVerifier
 data StakeVerifier
   = StakeVerifierKey (VerificationKeyOrFile StakeKey)
   | StakeVerifierScriptFile ScriptFile
+  | StakeVerifierAddress StakeAddress
   deriving (Eq, Show)
 
 -- | Either an unvalidated text representation of a verification key or a path

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -178,6 +178,7 @@ pStakeVerifier =
     <|> StakeVerifierScriptFile <$>
           pScriptFor "stake-script-file" Nothing
                      "Filepath of the staking script."
+    <|> StakeVerifierAddress <$> pStakeAddress
 
 pPaymentVerificationKeyTextOrFile :: Parser VerificationKeyTextOrFile
 pPaymentVerificationKeyTextOrFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -173,6 +173,9 @@ makeStakeAddressRef stakeVerifier = case stakeVerifier of
         let stakeCred = StakeCredentialByScript (hashScript script)
         return (StakeAddressByValue stakeCred)
 
+      StakeVerifierAddress stakeAddr ->
+        pure $ StakeAddressByValue $ stakeAddressCredential stakeAddr
+
 buildShelleyAddress
   :: VerificationKey PaymentKey
   -> Maybe StakeVerifier

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -87,7 +87,7 @@ runGovernanceMIRCertificatePayStakeAddrs mirPot sAddrs rwdAmts (OutputFile oFp) 
       left $ ShelleyGovernanceCmdMIRCertificateKeyRewardMistmach
                oFp (length sAddrs) (length rwdAmts)
 
-    let sCreds  = map stakeAddrToStakeCredential sAddrs
+    let sCreds  = map stakeAddressCredential sAddrs
         mirCert = makeMIRCertificate mirPot (StakeAddressesMIR $ zip sCreds rwdAmts)
 
     firstExceptT ShelleyGovernanceCmdTextEnvWriteError
@@ -96,11 +96,6 @@ runGovernanceMIRCertificatePayStakeAddrs mirPot sAddrs rwdAmts (OutputFile oFp) 
   where
     mirCertDesc :: TextEnvelopeDescr
     mirCertDesc = "Move Instantaneous Rewards Certificate"
-
-    --TODO: expose a pattern for StakeAddress that give us the StakeCredential
-    stakeAddrToStakeCredential :: StakeAddress -> StakeCredential
-    stakeAddrToStakeCredential (StakeAddress _ scred) =
-      fromShelleyStakeCredential scred
 
 runGovernanceMIRCertificateTransfer
   :: Lovelace


### PR DESCRIPTION
Fix #2723