### PR TITLE
add protocol version to stake cred tool

### DIFF
--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -98,6 +98,7 @@ executable stake-credential-history
                        binary,
                        bech32,
                        bytestring,
+                       cardano-ledger-alonzo,
                        cardano-api,
                        cardano-ledger-core,
                        cardano-ledger-shelley,


### PR DESCRIPTION
It is going to be helpful for the stake credential history tool to be aware of intra-era hard forks. For this reason, I added an event to the tool to record when the protocol version changes.