### PR TITLE
tx-generator: Use generic JSON instances

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
@@ -3,7 +3,8 @@
 module Cardano.Benchmarking.Script
   ( Script
   , runScript
-  , parseScriptFile
+  , parseScriptFileAeson
+  , parseScriptFileLegacy  
   )
 where
 
@@ -17,7 +18,8 @@ import           Ouroboros.Network.NodeToClient (IOManager)
 import           Cardano.Node.Configuration.Logging (shutdownLoggingLayer)
 
 import           Cardano.Benchmarking.Script.Action
-import           Cardano.Benchmarking.Script.Aeson (parseScriptFile)
+import           Cardano.Benchmarking.Script.Aeson (parseScriptFileAeson)
+import           Cardano.Benchmarking.Script.AesonLegacy (parseScriptFileLegacy)
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Types

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns #-}
 module Cardano.Benchmarking.Script.Aeson
 where
 
@@ -13,7 +12,6 @@ import           Data.Functor.Identity
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Dependent.Sum
-import qualified Data.HashMap.Strict as HashMap (toList, lookup)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS (lines)
@@ -25,11 +23,9 @@ import qualified Data.Attoparsec.ByteString as Atto
 import           Cardano.Api (AnyCardanoEra(..), CardanoEra(..), ScriptData, ScriptDataJsonSchema(..), scriptDataFromJson, scriptDataToJson)
 import           Cardano.CLI.Types (SigningKeyFile(..))
 
-import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Setters
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Types
-import           Cardano.Benchmarking.Types (NumberOfTxs(..), TPSRate(..))
 
 testJSONRoundTrip :: [Action] -> Maybe String
 testJSONRoundTrip l = case fromJSON $ toJSON l of
@@ -101,136 +97,14 @@ instance ToJSON Sum where
   toEncoding = genericToEncoding defaultOptions
 instance FromJSON Sum
 
-actionToJSON :: Action -> Value
-actionToJSON a = case a of
-  Set keyVal -> keyValToJSONCompact keyVal -- Remove the inner/ nested Object and add "set" -prefix.
-  StartProtocol filePath -> singleton "startProtocol" filePath
-  ReadSigningKey (KeyName name) (SigningKeyFile filePath)
-    -> object ["readSigningKey" .= name, "filePath" .= filePath]
-  SecureGenesisFund (FundName fundName) (KeyName fundKey) (KeyName genesisKey)
-    -> object ["secureGenesisFund" .= fundName, "fundKey" .= fundKey, "genesisKey" .= genesisKey ]
-  SplitFund newFunds (KeyName newKey) (FundName sourceFund)
-    -> object ["splitFund" .= names, "newKey" .= newKey, "sourceFund" .= sourceFund]
-    where names = [n | FundName n <- newFunds]
-  SplitFundToList (FundListName fundList) (KeyName destKey) (FundName sourceFund)
-    -> object ["splitFundToList" .= fundList, "newKey" .= destKey, "sourceFund" .= sourceFund ]
-  Delay t -> object ["delay" .= t ]
-  PrepareTxList (TxListName name) (KeyName key) (FundListName fund)
-    -> object ["prepareTxList" .= name, "newKey" .= key, "fundList" .= fund ]
-  AsyncBenchmark (ThreadName t) (TxListName txs) (TPSRate tps) 
-    -> object ["asyncBenchmark" .= t, "txList" .= txs, "tps" .= tps]
-  ImportGenesisFund submitMode (KeyName genesisKey) (KeyName fundKey)
-    -> object ["importGenesisFund" .= genesisKey, "submitMode" .= submitMode, "fundKey" .= fundKey ]
-  CreateChange submitMode payMode value count
-    -> object ["createChange" .= value, "payMode" .= payMode, "submitMode" .= submitMode, "count" .= count ]
-  RunBenchmark submitMode spendMode (ThreadName t) (NumberOfTxs txCount) (TPSRate tps)
-    -> object ["runBenchmark" .= t, "submitMode" .= submitMode, "spendMode" .= spendMode, "txCount" .= txCount, "tps" .= tps]
-  WaitBenchmark (ThreadName t) ->  singleton "waitBenchmark" t
-  CancelBenchmark (ThreadName t) ->  singleton "cancelBenchmark" t
-  WaitForEra era -> singleton "waitForEra" era
-  Reserved l -> singleton "reserved" l
- where
-  singleton k v = object [ k .= v ]
+instance ToJSON Action where
+  toJSON     = genericToJSON jsonOptionsUnTaggedSum
+  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
+instance FromJSON Action where
+  parseJSON = genericParseJSON jsonOptionsUnTaggedSum
 
-keyValToJSONCompact :: SetKeyVal -> Value
-keyValToJSONCompact keyVal = case parseEither (withObject "internal Error" parseSum) v of
-  Right c  -> c
-  Left err -> error err
- where
-  v = toJSON $ runIdentity $ taggedToSum keyVal
-  parseSum obj = do
-    key <- obj .: "tag"
-    (val :: Value)  <- obj .: "contents"
-    return $ object [("set" <> Text.tail key) .= val]
-
-instance ToJSON Action where toJSON = actionToJSON
-instance FromJSON Action where parseJSON = jsonToAction
-
-jsonToAction :: Value -> Parser Action
-jsonToAction = withObject "Error: Action is not a JSON object." objectToAction
-
-objectToAction :: Object -> Parser Action
-objectToAction obj = case obj of
-  (HashMap.lookup "startProtocol"     -> Just v)
-    -> (withText "Error parsing startProtocol" $ \t -> return $ StartProtocol $ Text.unpack t) v
-  (HashMap.lookup "readSigningKey"    -> Just v) -> parseReadSigningKey v
-  (HashMap.lookup "secureGenesisFund" -> Just v) -> parseSecureGenesisFund v
-  (HashMap.lookup "splitFund"         -> Just v) -> parseSplitFund v
-  (HashMap.lookup "splitFundToList"   -> Just v) -> parseSplitFundToList v
-  (HashMap.lookup "delay"             -> Just v) -> Delay <$> parseJSON v
-  (HashMap.lookup "prepareTxList"     -> Just v) -> parsePrepareTxList v
-  (HashMap.lookup "asyncBenchmark"    -> Just v) -> parseAsyncBenchmark v
-  (HashMap.lookup "importGenesisFund" -> Just v) -> parseImportGenesisFund v
-  (HashMap.lookup "createChange"      -> Just v) -> parseCreateChange v
-  (HashMap.lookup "runBenchmark"      -> Just v) -> parseRunBenchmark v
-  (HashMap.lookup "waitBenchmark"     -> Just v) -> WaitBenchmark <$> parseThreadName v
-  (HashMap.lookup "cancelBenchmark"   -> Just v) -> CancelBenchmark <$> parseThreadName v
-  (HashMap.lookup "waitForEra"        -> Just v) -> WaitForEra <$> parseJSON v
-  (HashMap.lookup "reserved"          -> Just v) -> Reserved <$> parseJSON v
-  (HashMap.toList -> [(k, v)]                  ) -> parseSetter k v
-  _ -> parseFail "Error: cannot parse action Object."
- where
-  parseSetter k v = case k of
-    (Text.stripPrefix "set" -> Just tag) -> do
-        s <- parseJSON $ object [ "tag" .= ("S" <> tag), "contents" .= v]
-        return $ Set $ sumToTaggged s
-    _ -> parseFail $ "Error: cannot parse action Object with key " <> Text.unpack k
-
-  parseKey f = KeyName <$> parseField obj f
-  parseFund f = FundName <$> parseField obj f
-  parseThreadName
-    = withText "Error parsing ThreadName" $ \t -> return $ ThreadName $ Text.unpack t
-
-  parseReadSigningKey v = ReadSigningKey
-    <$> ( KeyName <$> parseJSON v )
-    <*> ( SigningKeyFile <$> parseField obj "filePath" )
-
-  parseSecureGenesisFund v = SecureGenesisFund
-    <$> ( FundName <$> parseJSON v )
-    <*> parseKey "fundKey"
-    <*> parseKey "genesisKey"
-
-  parseSplitFund v  = do
-    l <- parseJSON v
-    k <- parseKey "newKey"
-    f <- parseFund "sourceFund"
-    return $ SplitFund (map FundName l) k f
-
-  parseSplitFundToList v = SplitFundToList
-    <$> ( FundListName <$> parseJSON v )
-    <*> parseKey "newKey"
-    <*> parseFund "sourceFund"
-
-  parsePrepareTxList v = PrepareTxList
-    <$> ( TxListName <$> parseJSON v )
-    <*> parseKey "newKey"
-    <*> ( FundListName <$>parseField obj "fundList" )
-
-  parseAsyncBenchmark v = AsyncBenchmark
-    <$> ( ThreadName <$> parseJSON v )
-    <*> ( TxListName <$> parseField obj "txList" )
-    <*> ( TPSRate <$> parseField obj "tps" )   
-
-  parseRunBenchmark v = RunBenchmark
-    <$> parseField obj "submitMode"
-    <*> parseField obj "spendMode"
-    <*> ( ThreadName <$> parseJSON v )
-    <*> ( NumberOfTxs <$> parseField obj "txCount" )
-    <*> ( TPSRate <$> parseField obj "tps" )
-
-  parseImportGenesisFund v = ImportGenesisFund
-    <$> parseField obj "submitMode"
-    <*> ( KeyName <$> parseJSON v )
-    <*> parseKey "fundKey"
-
-  parseCreateChange v = CreateChange
-    <$> parseField obj "submitMode"
-    <*> parseField obj "payMode"
-    <*> parseJSON v
-    <*> parseField obj "count"
-
-parseScriptFile :: FilePath -> IO [Action]
-parseScriptFile filePath = do
+scanScriptFile :: FilePath -> IO Value
+scanScriptFile filePath = do
   input <- BS.readFile filePath
   case Atto.parse Data.Aeson.json input of
     Atto.Fail rest _context msg -> die errorMsg
@@ -253,6 +127,28 @@ parseScriptFile filePath = do
 --          , "file :" , filePath , "\n"
 --          , "leftover data"
 --          ]
-    Atto.Done _ value -> case fromJSON value of
-      Error err -> die err
-      Success script -> return script
+    Atto.Done _ value -> return value
+
+parseScriptFile :: (Value -> Result [Action]) -> FilePath -> IO [Action]
+parseScriptFile parser filePath = do
+  value <- scanScriptFile filePath
+  case parser value of
+    Error err -> die err
+    Success script -> return script
+
+parseScriptFileAeson :: FilePath -> IO [Action]
+parseScriptFileAeson = parseScriptFile fromJSON
+
+instance ToJSON KeyName         where toJSON (KeyName a) = toJSON a
+instance ToJSON FundName        where toJSON (FundName a) = toJSON a
+instance ToJSON FundListName    where toJSON (FundListName a) = toJSON a
+instance ToJSON TxListName      where toJSON (TxListName a) = toJSON a
+instance ToJSON ThreadName      where toJSON (ThreadName a) = toJSON a
+instance ToJSON SigningKeyFile  where toJSON (SigningKeyFile a) = toJSON a
+
+instance FromJSON KeyName         where parseJSON a = KeyName <$> parseJSON a
+instance FromJSON FundName        where parseJSON a = FundName <$> parseJSON a
+instance FromJSON FundListName    where parseJSON a = FundListName <$> parseJSON a
+instance FromJSON TxListName      where parseJSON a = TxListName <$> parseJSON a
+instance FromJSON ThreadName      where parseJSON a = ThreadName <$> parseJSON a
+instance FromJSON SigningKeyFile  where parseJSON a = SigningKeyFile <$> parseJSON a

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/AesonLegacy.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/AesonLegacy.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
+module Cardano.Benchmarking.Script.AesonLegacy
+(
+  parseScriptFileLegacy
+, actionToJSON
+, jsonToAction
+)
+where
+
+import           Prelude
+import           Data.Functor.Identity
+import qualified Data.Text as Text
+import qualified Data.HashMap.Strict as HashMap (toList, lookup)
+import           Data.Aeson
+import           Data.Aeson.Types
+
+import           Cardano.CLI.Types (SigningKeyFile(..))
+
+import           Cardano.Benchmarking.Script.Aeson (parseScriptFile)
+import           Cardano.Benchmarking.Script.Env
+import           Cardano.Benchmarking.Script.Setters
+import           Cardano.Benchmarking.Script.Store
+import           Cardano.Benchmarking.Script.Types
+import           Cardano.Benchmarking.Types (NumberOfTxs(..), TPSRate(..))
+
+parseScriptFileLegacy :: FilePath -> IO [Action]
+parseScriptFileLegacy = parseScriptFile (parse $ listParser jsonToAction)
+
+actionToJSON :: Action -> Value
+actionToJSON a = case a of
+  Set keyVal -> keyValToJSONCompact keyVal -- Remove the inner/ nested Object and add "set" -prefix.
+  StartProtocol filePath -> singleton "startProtocol" filePath
+  ReadSigningKey (KeyName name) (SigningKeyFile filePath)
+    -> object ["readSigningKey" .= name, "filePath" .= filePath]
+  SecureGenesisFund (FundName fundName) (KeyName fundKey) (KeyName genesisKey)
+    -> object ["secureGenesisFund" .= fundName, "fundKey" .= fundKey, "genesisKey" .= genesisKey ]
+  SplitFund newFunds (KeyName newKey) (FundName sourceFund)
+    -> object ["splitFund" .= names, "newKey" .= newKey, "sourceFund" .= sourceFund]
+    where names = [n | FundName n <- newFunds]
+  SplitFundToList (FundListName fundList) (KeyName destKey) (FundName sourceFund)
+    -> object ["splitFundToList" .= fundList, "newKey" .= destKey, "sourceFund" .= sourceFund ]
+  Delay t -> object ["delay" .= t ]
+  PrepareTxList (TxListName name) (KeyName key) (FundListName fund)
+    -> object ["prepareTxList" .= name, "newKey" .= key, "fundList" .= fund ]
+  AsyncBenchmark (ThreadName t) (TxListName txs) (TPSRate tps) 
+    -> object ["asyncBenchmark" .= t, "txList" .= txs, "tps" .= tps]
+  ImportGenesisFund submitMode (KeyName genesisKey) (KeyName fundKey)
+    -> object ["importGenesisFund" .= genesisKey, "submitMode" .= submitMode, "fundKey" .= fundKey ]
+  CreateChange submitMode payMode value count
+    -> object ["createChange" .= value, "payMode" .= payMode, "submitMode" .= submitMode, "count" .= count ]
+  RunBenchmark submitMode spendMode (ThreadName t) (NumberOfTxs txCount) (TPSRate tps)
+    -> object ["runBenchmark" .= t, "submitMode" .= submitMode, "spendMode" .= spendMode, "txCount" .= txCount, "tps" .= tps]
+  WaitBenchmark (ThreadName t) ->  singleton "waitBenchmark" t
+  CancelBenchmark (ThreadName t) ->  singleton "cancelBenchmark" t
+  WaitForEra era -> singleton "waitForEra" era
+  Reserved l -> singleton "reserved" l
+ where
+  singleton k v = object [ k .= v ]
+
+keyValToJSONCompact :: SetKeyVal -> Value
+keyValToJSONCompact keyVal = case parseEither (withObject "internal Error" parseSum) v of
+  Right c  -> c
+  Left err -> error err
+ where
+  v = toJSON $ runIdentity $ taggedToSum keyVal
+  parseSum obj = do
+    key <- obj .: "tag"
+    (val :: Value)  <- obj .: "contents"
+    return $ object [("set" <> Text.tail key) .= val]
+
+jsonToAction :: Value -> Parser Action
+jsonToAction = withObject "Error: Action is not a JSON object." objectToAction
+
+objectToAction :: Object -> Parser Action
+objectToAction obj = case obj of
+  (HashMap.lookup "startProtocol"     -> Just v)
+    -> (withText "Error parsing startProtocol" $ \t -> return $ StartProtocol $ Text.unpack t) v
+  (HashMap.lookup "readSigningKey"    -> Just v) -> parseReadSigningKey v
+  (HashMap.lookup "secureGenesisFund" -> Just v) -> parseSecureGenesisFund v
+  (HashMap.lookup "splitFund"         -> Just v) -> parseSplitFund v
+  (HashMap.lookup "splitFundToList"   -> Just v) -> parseSplitFundToList v
+  (HashMap.lookup "delay"             -> Just v) -> Delay <$> parseJSON v
+  (HashMap.lookup "prepareTxList"     -> Just v) -> parsePrepareTxList v
+  (HashMap.lookup "asyncBenchmark"    -> Just v) -> parseAsyncBenchmark v
+  (HashMap.lookup "importGenesisFund" -> Just v) -> parseImportGenesisFund v
+  (HashMap.lookup "createChange"      -> Just v) -> parseCreateChange v
+  (HashMap.lookup "runBenchmark"      -> Just v) -> parseRunBenchmark v
+  (HashMap.lookup "waitBenchmark"     -> Just v) -> WaitBenchmark <$> parseThreadName v
+  (HashMap.lookup "cancelBenchmark"   -> Just v) -> CancelBenchmark <$> parseThreadName v
+  (HashMap.lookup "waitForEra"        -> Just v) -> WaitForEra <$> parseJSON v
+  (HashMap.lookup "reserved"          -> Just v) -> Reserved <$> parseJSON v
+  (HashMap.toList -> [(k, v)]                  ) -> parseSetter k v
+  _ -> parseFail "Error: cannot parse action Object."
+ where
+  parseSetter k v = case k of
+    (Text.stripPrefix "set" -> Just tag) -> do
+        s <- parseJSON $ object [ "tag" .= ("S" <> tag), "contents" .= v]
+        return $ Set $ sumToTaggged s
+    _ -> parseFail $ "Error: cannot parse action Object with key " <> Text.unpack k
+
+  parseKey f = KeyName <$> parseField obj f
+  parseFund f = FundName <$> parseField obj f
+  parseThreadName
+    = withText "Error parsing ThreadName" $ \t -> return $ ThreadName $ Text.unpack t
+
+  parseReadSigningKey v = ReadSigningKey
+    <$> ( KeyName <$> parseJSON v )
+    <*> ( SigningKeyFile <$> parseField obj "filePath" )
+
+  parseSecureGenesisFund v = SecureGenesisFund
+    <$> ( FundName <$> parseJSON v )
+    <*> parseKey "fundKey"
+    <*> parseKey "genesisKey"
+
+  parseSplitFund v  = do
+    l <- parseJSON v
+    k <- parseKey "newKey"
+    f <- parseFund "sourceFund"
+    return $ SplitFund (map FundName l) k f
+
+  parseSplitFundToList v = SplitFundToList
+    <$> ( FundListName <$> parseJSON v )
+    <*> parseKey "newKey"
+    <*> parseFund "sourceFund"
+
+  parsePrepareTxList v = PrepareTxList
+    <$> ( TxListName <$> parseJSON v )
+    <*> parseKey "newKey"
+    <*> ( FundListName <$>parseField obj "fundList" )
+
+  parseAsyncBenchmark v = AsyncBenchmark
+    <$> ( ThreadName <$> parseJSON v )
+    <*> ( TxListName <$> parseField obj "txList" )
+    <*> ( TPSRate <$> parseField obj "tps" )   
+
+  parseRunBenchmark v = RunBenchmark
+    <$> parseField obj "submitMode"
+    <*> parseField obj "spendMode"
+    <*> ( ThreadName <$> parseJSON v )
+    <*> ( NumberOfTxs <$> parseField obj "txCount" )
+    <*> ( TPSRate <$> parseField obj "tps" )
+
+  parseImportGenesisFund v = ImportGenesisFund
+    <$> parseField obj "submitMode"
+    <*> ( KeyName <$> parseJSON v )
+    <*> parseKey "fundKey"
+
+  parseCreateChange v = CreateChange
+    <$> parseField obj "submitMode"
+    <*> parseField obj "payMode"
+    <*> parseJSON v
+    <*> parseField obj "count"

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,5 +1,5 @@
 name:                  tx-generator
-version:               1.30
+version:               1.32
 description:           The transaction generator for cardano node
 author:                IOHK
 maintainer:            operations@iohk.io
@@ -44,6 +44,7 @@ library
                        Cardano.Benchmarking.Script
                        Cardano.Benchmarking.Script.Action
                        Cardano.Benchmarking.Script.Aeson
+                       Cardano.Benchmarking.Script.AesonLegacy                       
                        Cardano.Benchmarking.Script.Core
                        Cardano.Benchmarking.Script.Env
                        Cardano.Benchmarking.Script.Example

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -214,7 +214,7 @@ in pkgs.commonLib.defServiceModule
                   if runScriptFile != null then runScriptFile
                   else "${pkgs.writeText "generator-config-run-script.json"
                                          (decideRunScript cfg)}";
-            in ["json" jsonFile]
+            in ["legacy-json" jsonFile]
           else
           (["cliArguments"
 


### PR DESCRIPTION
This PR adds new generic JSON instances for the tx-generator script language.
The old manual instances are still available in the CLI with the `legacy-json` command,
and the tx-generator-service still uses the legacy format.