### PR TITLE
Add a normal dev shell in shell.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,8 @@ let
 
     devopsShell = shell.devops;
 
+    devShell = shell.dev;
+
     nixosTests = recRecurseIntoAttrs nixosTests;
 
     # so that eval time gc roots are cached (nix-tools stuff)

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
 
         inherit (pkgs.commonLib) eachEnv environments;
 
-        devShell = import ./shell.nix { inherit pkgs; };
+        devShell = (import ./shell.nix { inherit pkgs; }).dev;
 
         flake = pkgs.cardanoNodeProject.flake {
           crossPlatforms = p: with p; [

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -77,6 +77,16 @@ final: prev: with final;
     inherit (cardanoNodeProject) index-state;
   };
 
+  ghcid = haskell-nix.tool compiler-nix-name "ghcid" {
+    version = "0.8.7";
+    inherit (cardanoNodeProject) index-state;
+  };
+
+  haskell-language-server = haskell-nix.tool compiler-nix-name "haskell-language-server" {
+    version = "latest";
+    inherit (cardanoNodeProject) index-state;
+  };
+
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit compiler-nix-name;
     inherit (cardanoNodeProject) index-state;

--- a/release.nix
+++ b/release.nix
@@ -200,6 +200,7 @@ let
       (collectJobs jobs.linux.native.exes)
       (collectJobs jobs.linux.native.shell)
       (collectJobs jobs.linux.native.devopsShell)
+      (collectJobs jobs.linux.native.devShell)
       [ jobs.cardano-node-linux ]
     ]))
     # macOS builds:

--- a/shell.nix
+++ b/shell.nix
@@ -70,7 +70,7 @@ let
   shell =
     let cluster = mkCluster { useCabalRun = true; };
     in cardanoNodeProject.shellFor {
-    name = "cabal-dev-shell";
+    name = "cluster-shell";
 
     inherit withHoogle;
 
@@ -218,6 +218,30 @@ let
     '';
   };
 
+  dev = cardanoNodeProject.shellFor {
+    name = "cabal-dev-shell";
+
+    packages = ps: lib.attrValues (haskell-nix.haskellLib.selectProjectPackages ps);
+
+    # These programs will be available inside the nix-shell.
+    nativeBuildInputs = [
+      nix-prefetch-git
+      pkg-config
+      hlint
+      ghcid
+      haskell-language-server
+      cabalWrapped
+      # we also add cabal (even if cabalWrapped will be used by default) for shell completion:
+      cabal
+    ];
+
+    # Prevents cabal from choosing alternate plans, so that
+    # *all* dependencies are provided by Nix.
+    exactDeps = true;
+
+    inherit withHoogle;
+  };
+
 in
 
- shell // { inherit devops; }
+ shell // { inherit devops; inherit dev;}


### PR DESCRIPTION
This adds a normal nix-shell, which can be used by developers wanting to work on cardano-node. The current nix-shell _itself_ tries to build cardano-node, which is rather annoying, since it prevents using cabal/hls to iterate on node changes, especially when bumping dependencies.

Honestly this should be the default shell and the other shell should be renamed (e.g. "workbench" or similar), but in the short-term we at least make this possible.

One can enter this shell using `nix-shell -A dev`