### PR TITLE
tx-generator: towards stand-alone mode

### DIFF
--- a/bench/script/test-stand-alone.json
+++ b/bench/script/test-stand-alone.json
@@ -1,0 +1,54 @@
+[
+    { "SetProtocolParameters": { "UseLocalProtocolFile": "/tmp/t2.json" } },    
+    { "Set": { "SNumberOfInputsPerTx": 2 } },
+    { "Set": { "SNumberOfOutputsPerTx": 2 } },
+    { "Set": { "STxAdditionalSize": 39 } },
+    { "Set": { "SFee": 212345 } },
+    { "Set": { "SMinValuePerUTxO": 1000000 } },
+    { "Set": { "STTL": 1000000 } },
+    { "Set": { "SEra": "Allegra" } },
+    { "Set": { "SNetworkId": "Mainnet" } },    
+    { "ReadSigningKey": [ "pass-partout", "run/current/genesis/utxo-keys/utxo1.skey" ] },
+    { "CreateChange": [
+            { "DumpToFile": "/tmp/script-txs.txt" },
+            { "PayToAddr": [] },
+            149200212345,
+            1
+        ] },
+    { "CreateChange": [
+            { "DumpToFile": "/tmp/script-txs.txt" },
+            { "PayToCollateral": [] },
+            149200000000,
+            1
+        ] },
+    { "CreateChange": [
+            { "DumpToFile": "/tmp/split-txs.txt" },
+            { "PayToAddr": [] },
+            2200000000000,
+            10
+        ] },
+    { "CreateChange": [
+            { "DumpToFile": "/tmp/split-txs.txt" },
+            { "PayToAddr": [] },
+            70000000000,
+            300
+        ] },
+    { "CreateChange": [
+            { "DumpToFile": "/tmp/script-txs.txt" },
+            { "PayToScript": [ "bench/script/sum1ToN.plutus", 3 ] },
+            2300000000,
+            9000
+        ] },
+    { "RunBenchmark": [
+            { "DumpToFile": "/tmp/submit-txs.txt" },
+            { "SpendScript": [
+                    "bench/script/sum1ToN.plutus",
+                    { "PreExecuteScript": [] },
+                    3,
+                    6
+                ] },
+            "walletBasedBenchmark",
+            4000,
+            10
+        ] }
+]

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
@@ -107,7 +107,7 @@ runBenchmarkScriptWith ::
 runBenchmarkScriptWith iocp logConfigFile socketFile script = do
   (loggingLayer, ptcl) <- startProtocol logConfigFile
   let tracers :: BenchTracers
-      tracers = createTracers loggingLayer
+      tracers = createLoggingLayerTracers loggingLayer
       dslSet :: MonoDSLs
       dslSet = mangleLocalProtocolDefinition ptcl iocp socketFile tracers
   res <- firstExceptT BenchmarkRunnerError $ script (tracers, dslSet)

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -12,6 +12,7 @@ import           Cardano.Benchmarking.Script.Types
 action :: Action -> ActionM ()
 action a = case a of
   Set (key :=> (Identity val)) -> set (User key) val
+  SetProtocolParameters p -> setProtocolParameters p
   StartProtocol filePath -> startProtocol filePath
   ReadSigningKey name filePath -> readSigningKey name filePath
   SecureGenesisFund fundName fundKey genesisKey -> secureGenesisFund fundName fundKey genesisKey

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/AesonLegacy.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/AesonLegacy.hs
@@ -56,6 +56,7 @@ actionToJSON a = case a of
   CancelBenchmark (ThreadName t) ->  singleton "cancelBenchmark" t
   WaitForEra era -> singleton "waitForEra" era
   Reserved l -> singleton "reserved" l
+  other -> error $ "Action not supported in legacy JSON mode : " ++ show other
  where
   singleton k v = object [ k .= v ]
 

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -50,7 +50,7 @@ runActionMEnv env action iom = RWS.runRWST (runExceptT action) iom env
 type SetKeyVal = DSum Setters.Tag Identity
 
 data Error where
-  LookupError :: !(Store v)    -> Error
+  LookupError :: !(Store v)  -> Error
   TxGenError  :: !TxGenError -> Error
   CliError    :: !CliError   -> Error
   ApiError    :: !String     -> Error

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -19,7 +19,7 @@ import           Data.GADT.Compare.TH (deriveGCompare, deriveGEq)
 import           Data.GADT.Show.TH (deriveGShow)
 import           Data.List.NonEmpty
 
-import           Cardano.Api (Lovelace, SlotNo, AnyCardanoEra(..))
+import           Cardano.Api (AnyCardanoEra(..), SlotNo, Lovelace, NetworkId)
 
 import           Cardano.Benchmarking.Types
 
@@ -35,6 +35,7 @@ data Tag v where
   TLocalSocket          :: Tag String
   TEra                  :: Tag AnyCardanoEra
   TTargets              :: Tag (NonEmpty NodeIPv4Address)
+  TNetworkId            :: Tag NetworkId
 
 deriveGEq ''Tag
 deriveGCompare ''Tag
@@ -55,6 +56,7 @@ data Sum where
   SLocalSocket          :: !String               -> Sum
   SEra                  :: !AnyCardanoEra        -> Sum
   STargets              :: !(NonEmpty NodeIPv4Address) -> Sum
+  SNetworkId            :: !NetworkId            -> Sum
   deriving (Eq, Show, Generic)
 
 taggedToSum :: Applicative f => DSum Tag f -> f Sum
@@ -69,6 +71,7 @@ taggedToSum x = case x of
   (TLocalSocket          :=> v) -> SLocalSocket          <$> v
   (TEra                  :=> v) -> SEra                  <$> v
   (TTargets              :=> v) -> STargets              <$> v
+  (TNetworkId            :=> v) -> SNetworkId            <$> v
 
 sumToTagged :: Applicative f => Sum -> DSum Tag f
 sumToTagged x = case x of
@@ -82,3 +85,4 @@ sumToTagged x = case x of
   SLocalSocket          v -> TLocalSocket          ==> v
   SEra                  v -> TEra                  ==> v
   STargets              v -> TTargets              ==> v
+  SNetworkId            v -> TNetworkId            ==> v

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Store.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Store.hs
@@ -19,12 +19,13 @@ import           Data.GADT.Compare.TH (deriveGCompare, deriveGEq)
 import           Data.GADT.Show.TH (deriveGShow)
 
 import           Cardano.Api as Cardano (InAnyCardanoEra(..), Tx)
+import           Cardano.Api.Shelley as Cardano (ProtocolParameters)
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol)
 
 import           Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.OuroborosImports as Cardano
                     ( LoggingLayer, ShelleyGenesis, StandardShelley
-                    , NetworkId, SigningKey, PaymentKey)
+                    , SigningKey, PaymentKey)
 
 import           Cardano.Benchmarking.GeneratorTx as Core (AsyncBenchmarkControl)
 import qualified Cardano.Benchmarking.GeneratorTx.Tx as Core (Fund)
@@ -39,9 +40,9 @@ data Store v where
   LoggingLayer :: Store LoggingLayer
   Protocol     :: Store SomeConsensusProtocol
   BenchTracers :: Store Core.BenchTracers
-  NetworkId    :: Store Cardano.NetworkId -- could be in Setters (just need JSON instance)
   Genesis      :: Store (ShelleyGenesis StandardShelley)
   Named        :: Name x -> Store x
+  ProtocolParameterMode :: Store ProtocolParameterMode
 
 data Name x where
   KeyName      :: !String -> Name (SigningKey PaymentKey)
@@ -57,6 +58,10 @@ type TxListName   = Name (InAnyCardanoEra TxList)
 type ThreadName   = Name AsyncBenchmarkControl
 
 newtype TxList era = TxList [Tx era]
+
+data ProtocolParameterMode where
+  ProtocolParameterQuery :: ProtocolParameterMode
+  ProtocolParameterLocal :: ProtocolParameters -> ProtocolParameterMode
 
 -- Remember when debugging at 4:00AM :
 -- TH-Haskell is imperative: It breaks up Main into smaller binding groups!

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -39,8 +39,15 @@ data Action where
   CancelBenchmark    :: !ThreadName -> Action
   Reserved           :: [String] -> Action
   WaitForEra         :: !AnyCardanoEra -> Action
+  SetProtocolParameters :: ProtocolParametersSource -> Action
   deriving (Show, Eq)
 deriving instance Generic Action
+
+data ProtocolParametersSource where
+  QueryLocalNode :: ProtocolParametersSource
+  UseLocalProtocolFile :: !FilePath -> ProtocolParametersSource
+  deriving (Show, Eq)
+deriving instance Generic ProtocolParametersSource
 
 data SubmitMode where
   LocalSocket :: SubmitMode
@@ -70,4 +77,3 @@ data ScriptBudget where
   CheckScriptBudget  :: !ExecutionUnits -> ScriptBudget
   deriving (Show, Eq)
 deriving instance Generic ScriptBudget
-

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -21,17 +21,13 @@ type TxGenerator era = [Fund] -> [TxOut CtxTx era] -> Either String (Tx era, TxI
 type ToUTxO era = [Lovelace] -> ([TxOut CtxTx era], TxId -> [Fund])
 
 data Wallet = Wallet {
-    walletNetworkId :: !NetworkId
-  , walletKey :: !(SigningKey PaymentKey)
-  , walletSeqNumber :: !SeqNumber
+    walletSeqNumber :: !SeqNumber
   , walletFunds :: !FundSet
   }
 
-initWallet :: NetworkId -> SigningKey PaymentKey -> IO (MVar Wallet)
-initWallet network key = newMVar $ Wallet {
-    walletNetworkId = network
-  , walletKey = key
-  , walletSeqNumber = SeqNumber 1
+initWallet :: IO (MVar Wallet)
+initWallet = newMVar $ Wallet {
+    walletSeqNumber = SeqNumber 1
   , walletFunds = emptyFunds
   }
 


### PR DESCRIPTION
In stand-alone mode, the transaction generator can generate lists of transactions
and dump them to files, without a connection to a local or remote node.
This supports new use cases of the transaction generator outside of
benchmarking and makes it easier to test and debug the transaction generator.
This PR add the script action 
`{ "SetProtocolParameters": { "UseLocalProtocolFile": "/tmp/t2.json" } }`
that reads the protocol parameters from a file (instead of querying a node).
And some other changes.