### PR TITLE
tx-generator: make the used key/address explicit

### DIFF
--- a/bench/script/test-full-auto.ljson
+++ b/bench/script/test-full-auto.ljson
@@ -18,23 +18,23 @@
     { "readSigningKey": "pass-partout", "filePath": "run/current/genesis/utxo-keys/utxo1.skey" },
     { "importGenesisFund": "pass-partout", "fundKey": "pass-partout"
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200212345, "count" :     1
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200000000, "count" :     1
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToCollateral": [] }
+      , "payMode": { "PayToCollateral": "pass-partout" }
     },
     { "createChange" : 2200000000000, "count" :       10
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   70000000000, "count" :      300
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :    2300000000, "count" :     1000
       , "submitMode": { "LocalSocket": [] }

--- a/bench/script/test-large.ljson
+++ b/bench/script/test-large.ljson
@@ -18,27 +18,27 @@
     { "readSigningKey": "pass-partout", "filePath": "run/current/genesis/utxo-keys/utxo1.skey" },
     { "importGenesisFund": "pass-partout", "fundKey": "pass-partout"
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" : 2200000000000, "count" :       10
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   70000000000, "count" :      300
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :    2200000000, "count" :     9000
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :      70000000, "count" :   270000
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :       2300000, "count" :  8100000
       , "submitMode": { "DumpToFile": "/tmp/tx-list.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "runBenchmark": "walletBasedBenchmark", "txCount": 1000000, "tps": 100
       , "submitMode": { "DumpToFile": "/tmp/submit-list.txt" }

--- a/bench/script/test-plutus-to-file.json
+++ b/bench/script/test-plutus-to-file.json
@@ -22,25 +22,25 @@
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/script-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             149200212345,
             1
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/script-txs.txt" },
-            { "PayToCollateral": [] },
+            { "PayToCollateral": "pass-partout" },
             149200000000,
             1
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/split-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             2200000000000,
             10
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/split-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             70000000000,
             300
         ] },

--- a/bench/script/test-plutus-to-file.ljson
+++ b/bench/script/test-plutus-to-file.ljson
@@ -18,23 +18,23 @@
     { "readSigningKey": "pass-partout", "filePath": "run/current/genesis/utxo-keys/utxo1.skey" },
     { "importGenesisFund": "pass-partout", "fundKey": "pass-partout"
       , "submitMode": { "DumpToFile": "/tmp/split-txs.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200212345, "count" :     1
       , "submitMode": { "DumpToFile": "/tmp/script-txs.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200000000, "count" :     1
       , "submitMode": { "DumpToFile": "/tmp/script-txs.txt" }
-      , "payMode": { "PayToCollateral": [] }
+      , "payMode": { "PayToCollateral": "pass-partout" }
     },
     { "createChange" : 2200000000000, "count" :       10
       , "submitMode": { "DumpToFile": "/tmp/split-txs.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   70000000000, "count" :      300
       , "submitMode": { "DumpToFile": "/tmp/split-txs.txt" }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :    2300000000, "count" :     9000
       , "submitMode": { "DumpToFile": "/tmp/script-txs.txt" }

--- a/bench/script/test-plutus.ljson
+++ b/bench/script/test-plutus.ljson
@@ -18,23 +18,23 @@
     { "readSigningKey": "pass-partout", "filePath": "run/current/genesis/utxo-keys/utxo1.skey" },
     { "importGenesisFund": "pass-partout", "fundKey": "pass-partout"
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200212345, "count" :     1
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   149200000000, "count" :     1
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToCollateral": [] }
+      , "payMode": { "PayToCollateral": "pass-partout" }
     },
     { "createChange" : 2200000000000, "count" :       10
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :   70000000000, "count" :      300
       , "submitMode": { "LocalSocket": [] }
-      , "payMode": { "PayToAddr": [] }
+      , "payMode": { "PayToAddr": "pass-partout" }
     },
     { "createChange" :    2300000000, "count" :     1000
       , "submitMode": { "LocalSocket": [] }

--- a/bench/script/test-stand-alone.json
+++ b/bench/script/test-stand-alone.json
@@ -11,25 +11,25 @@
     { "ReadSigningKey": [ "pass-partout", "run/current/genesis/utxo-keys/utxo1.skey" ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/script-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             149200212345,
             1
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/script-txs.txt" },
-            { "PayToCollateral": [] },
+            { "PayToCollateral": "pass-partout" },
             149200000000,
             1
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/split-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             2200000000000,
             10
         ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/split-txs.txt" },
-            { "PayToAddr": [] },
+            { "PayToAddr": "pass-partout" },
             70000000000,
             300
         ] },

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -57,7 +57,7 @@ testScript =
   , WaitForEra $ AnyCardanoEra ByronEra
   , CancelBenchmark threadName
   , ImportGenesisFund DiscardTX passPartout passPartout
-  , CreateChange LocalSocket PayToAddr (quantityToLovelace 10000) 1000
+  , CreateChange LocalSocket (PayToAddr passPartout) (quantityToLovelace 10000) 1000
   , RunBenchmark (DumpToFile "/tmp/tx-list.txt") SpendOutput (ThreadName "walletThread") (NumberOfTxs 1000) (TPSRate 10)
   , RunBenchmark (DumpToFile "/tmp/tx-list.txt") scriptDef (ThreadName "walletThread") (NumberOfTxs 1000) (TPSRate 10)  
   , Reserved []

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -58,8 +58,8 @@ data SubmitMode where
 deriving instance Generic SubmitMode
 
 data PayMode where
-  PayToAddr :: PayMode
-  PayToCollateral :: PayMode  
+  PayToAddr :: !KeyName -> PayMode
+  PayToCollateral :: !KeyName  -> PayMode
   PayToScript :: !FilePath -> !ScriptData -> PayMode
   deriving (Show, Eq)
 deriving instance Generic PayMode

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -51,10 +51,10 @@ let
           # Therefor this first creates a matching regular output
           # and turns that into a collateral right in the next step.
           { createChange = safeCollateral + tx_fee; count = 1;
-            submitMode.LocalSocket = []; payMode.PayToAddr = [];
+            submitMode.LocalSocket = []; payMode.PayToAddr = "pass-partout";
           }
           { createChange = safeCollateral; count = 1;
-            submitMode.LocalSocket = []; payMode.PayToCollateral = [];
+            submitMode.LocalSocket = []; payMode.PayToCollateral = "pass-partout";
           }
           ]
           ++ createChangePlutus cfg minValuePerInput (tx_count * inputs_per_tx)
@@ -109,7 +109,7 @@ let
     [ { createChange = value;
         count = count;
         submitMode.LocalSocket = [];
-        payMode.PayToAddr = [];
+        payMode.PayToAddr = "pass-partout";
       }
       { delay = cfg.init_cooldown; }
     ];


### PR DESCRIPTION
This removes the special role of the key named `pass-partout`.
Now the name of the key must be specified explicitly.