### PR TITLE
tx-generator: add literate keys and manual funds.

### DIFF
--- a/bench/script/test-stand-alone.json
+++ b/bench/script/test-stand-alone.json
@@ -7,8 +7,19 @@
     { "Set": { "SMinValuePerUTxO": 1000000 } },
     { "Set": { "STTL": 1000000 } },
     { "Set": { "SEra": "Allegra" } },
-    { "Set": { "SNetworkId": "Mainnet" } },    
-    { "ReadSigningKey": [ "pass-partout", "run/current/genesis/utxo-keys/utxo1.skey" ] },
+    { "Set": { "SNetworkId": { "Testnet": 42 } } },
+    { "DefineSigningKey":
+      [ "pass-partout"
+      , {
+          "type": "GenesisUTxOSigningKey_ed25519",
+          "description": "Genesis Initial UTxO Signing Key",
+          "cborHex": "58200b6c317eb6c9762898fa41ca9d683003f86899ab0f2f6dbaf244e415b62826a2"
+      } ] },
+    { "AddFund":
+      [ "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162#0"
+      , 90000000000000
+      , "pass-partout"
+      ] },
     { "CreateChange": [
             { "DumpToFile": "/tmp/script-txs.txt" },
             { "PayToAddr": "pass-partout" },

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -15,6 +15,8 @@ action a = case a of
   SetProtocolParameters p -> setProtocolParameters p
   StartProtocol filePath -> startProtocol filePath
   ReadSigningKey name filePath -> readSigningKey name filePath
+  DefineSigningKey name descr -> defineSigningKey name descr
+  AddFund txIn lovelace keyName -> addFund txIn lovelace keyName
   SecureGenesisFund fundName fundKey genesisKey -> secureGenesisFund fundName fundKey genesisKey
   SplitFund newFunds newKey sourceFund -> splitFund  newFunds newKey sourceFund
   SplitFundToList fundList destKey sourceFund -> splitFundToList fundList destKey sourceFund

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -15,7 +15,7 @@ import           Prelude
 import           GHC.Generics
 
 import           Cardano.Benchmarking.OuroborosImports (SigningKeyFile)
-import           Cardano.Api (AnyCardanoEra, ExecutionUnits, Lovelace, ScriptData, ScriptRedeemer)
+import           Cardano.Api (AnyCardanoEra, ExecutionUnits, Lovelace, ScriptData, ScriptRedeemer, TextEnvelope, TxIn)
 
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
@@ -27,6 +27,8 @@ data Action where
   StartProtocol      :: !FilePath -> Action
   Delay              :: !Double -> Action
   ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
+  DefineSigningKey   :: !KeyName -> !TextEnvelope -> Action
+  AddFund            :: !TxIn -> !Lovelace -> !KeyName -> Action
   SecureGenesisFund  :: !FundName -> !KeyName -> !KeyName -> Action
   SplitFund          :: [FundName] -> !KeyName -> !FundName -> Action
   SplitFundToList    :: !FundListName -> !KeyName -> !FundName -> Action


### PR DESCRIPTION
This PR adds support for literate keys in benchmarking scripts
and manual definition of funds.