### PR TITLE
Improve GenTx ToObject and ToJSON instances for logs

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -16,6 +16,7 @@ import           Data.Aeson (Value (..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
+import           Cardano.Tracing.Render (renderTxId)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
 
@@ -114,17 +115,11 @@ instance ToObject UpdateState where
           ]
 
 instance ToObject (GenTx ByronBlock) where
-  toObject verb tx =
-    mkObject $
-        [ "txid" .= txId tx ]
-     ++ [ "tx"   .= condense tx | verb == MaximalVerbosity ]
+  toObject _ tx = mkObject [ "txid" .= Text.take 8 (renderTxId (txId tx)) ]
 
 
 instance ToJSON (TxId (GenTx ByronBlock)) where
-  toJSON (ByronTxId             i) = toJSON (condense i)
-  toJSON (ByronDlgId            i) = toJSON (condense i)
-  toJSON (ByronUpdateProposalId i) = toJSON (condense i)
-  toJSON (ByronUpdateVoteId     i) = toJSON (condense i)
+  toJSON = String . Text.take 8 . renderTxId
 
 
 instance ToObject ChainValidationError where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -32,6 +32,7 @@ import qualified Cardano.Api.Shelley as Api
 import           Cardano.Ledger.Crypto (StandardCrypto)
 
 import           Cardano.Slotting.Block (BlockNo (..))
+import           Cardano.Tracing.Render (renderTxId)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
 
@@ -103,13 +104,10 @@ import           Cardano.Ledger.Shelley.Rules.Utxow
 -- NOTE: this list is sorted in roughly topological order.
 
 instance ShelleyBasedEra era => ToObject (GenTx (ShelleyBlock era)) where
-  toObject verb tx =
-    mkObject $
-        [ "txid" .= txId tx ]
-     ++ [ "tx"   .= condense tx | verb == MaximalVerbosity ]
+  toObject _ tx = mkObject [ "txid" .= Text.take 8 (renderTxId (txId tx)) ]
 
 instance ToJSON (SupportsMempool.TxId (GenTx (ShelleyBlock era))) where
-  toJSON i = toJSON (condense i)
+  toJSON = String . Text.take 8 . renderTxId
 
 instance ShelleyBasedEra era => ToObject (Header (ShelleyBlock era)) where
   toObject _verb b = mkObject


### PR DESCRIPTION
# Description

This PR works on https://github.com/input-output-hk/cardano-node/issues/721 towards rendering transactions ids in logs nicely.

The culprit was the reused `Condense` instances from the consensus repo. 

As far as I understand, the tracers that write to the log file (or elsewhere) rely on

```haskell
type TraceConstraints blk =
    ( ConvertTxId blk
    , HasTxs blk
    , HasTxId (GenTx blk)
    , LedgerQueries blk
    , ToJSON   (TxId (GenTx blk))
    , ToJSON   (TxOut (AlonzoEra StandardCrypto))
    , ToJSON   (PParamsUpdate (AlonzoEra StandardCrypto))
    , ToObject (ApplyTxErr blk)
    , ToObject (GenTx blk)
    , ToObject (Header blk)
    , ToObject (LedgerError blk)
    , ToObject (LedgerEvent blk)
    , ToObject (OtherHeaderEnvelopeError blk)
    , ToObject (ValidationErr (BlockProtocol blk))
    , ToObject (CannotForge blk)
    , ToObject (ForgeStateUpdateError blk)
    , ToObject (UtxoPredicateFailure (AlonzoEra StandardCrypto))
    , ToObject (AlonzoBbodyPredFail (AlonzoEra StandardCrypto))
    , ToObject (AlonzoPredFail (AlonzoEra StandardCrypto))
    , Show blk
    , Show (Header blk)
    )
```

Currently, these don't mention `Condense` and it seems the only use is in `Cardano.Tracing.OrphanInstances.{Consensus, Shelley, Byron, HardFork}`, specifically with the `ToObject (GenTx blk)` and ` ToJSON   (TxId (GenTx blk))` instances in the `Shelley` and `Byron` modules so I just touched those.

## Testing

I tested this as follows: (relying on `simple-tx.sh` from https://github.com/input-output-hk/cardano-node/pull/3400)

```bash
$ ./scripts/byron-to-alonzo/mkfiles.sh alonzo
$ ./example/run/all.sh
$ ./scripts/byron-to-alonzo-simple-tx.sh
$ grep "txid" example/node-bft1/node.log
[haldane:cardano.node.Mempool:Info:143] [2021-12-08 21:54:40.57 UTC] fromList [("mempoolSize",Object (fromList [("bytes",Number 239.0),("numTxs",Number 1.0)])),("tx",Object (fromList [("txid",String "ba5e446c")])),("kind",String "TraceMempoolAddedTx")]
[haldane:cardano.node.Mempool:Info:31] [2021-12-08 21:54:41.14 UTC] fromList [("txs",Array [Object (fromList [("txid",String "ba5e446c")])]),("mempoolSize",Object (fromList [("bytes",Number 0.0),("numTxs",Number 0.0)])),("kind",String "TraceMempoolRemoveTxs")]
```

## Notes

- I tried earlier to convert `GenTx blk` into a `Cardano.API.Tx.Tx era` and then render that as `JSON`. This has some issues since not all branches of `GenTx ByronBlock` can be converted to `Tx ByronEra` (like a delegation certificate).
- There are several other uses of `Condense` also to be removed

