### PR TITLE
tx-generator: set default: query local node for protocol parameters

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
@@ -21,7 +21,7 @@ import           Cardano.Benchmarking.Tracer (createDebugTracers)
 import           Cardano.Benchmarking.Script.Action
 import           Cardano.Benchmarking.Script.Aeson (parseScriptFileAeson)
 import           Cardano.Benchmarking.Script.AesonLegacy (parseScriptFileLegacy)
-import           Cardano.Benchmarking.Script.Core (initGlobalWallet)
+import           Cardano.Benchmarking.Script.Core (initGlobalWallet, setProtocolParameters)
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Types
@@ -41,8 +41,9 @@ runScript script iom = runActionM execScript iom >>= \case
  where
   cleanup s a = void $ runActionMEnv s a iom
   execScript = do
-    initGlobalWallet    
     set BenchTracers createDebugTracers
+    initGlobalWallet
+    setProtocolParameters QueryLocalNode
     forM_ script action
 
 shutDownLogging :: ActionM ()


### PR DESCRIPTION
Initialize the tx-generator with a default mode for the protocol parameters.
The default is to query the local node for the protocol parameters.