### PR TITLE
tx-generator: bug fix: breakup large STM transactions.

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -88,12 +88,13 @@ createLoggingLayerTracers loggingLayer
 initTracers :: Trace IO Text -> Trace IO Text -> BenchTracers
 initTracers baseTrace tr =
   BenchTracers
-    baseTrace
-    benchTracer
-    connectTracer
-    submitTracer
-    lowLevelSubmitTracer
-    n2nSubmitTracer
+    { btBase_        = baseTrace
+    , btTxSubmit_    = benchTracer
+    , btConnect_     = connectTracer
+    , btSubmission2_ = submitTracer
+    , btLowLevel_    = lowLevelSubmitTracer
+    , btN2N_         = n2nSubmitTracer
+    }
  where
   tr' :: Trace IO Text
   tr' = appendName "generate-txs" tr

--- a/bench/tx-generator/src/Cardano/Benchmarking/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Types.hs
@@ -116,7 +116,7 @@ newtype Acked tx = Acked [tx]
 newtype Ack = Ack Int deriving newtype (Enum, Eq, Integral, Num, Ord, Real)
 
 -- | Peer requested this many txids to add to the outstanding window.
-newtype Req = Req Int deriving newtype (Enum, Eq, Integral, Num, Ord, Real)
+newtype Req = Req Int deriving newtype (Enum, Eq, Integral, Num, Ord, Real, Show)
 
 -- | This many Txs sent to peer.
 newtype Sent = Sent Int deriving newtype (Enum, Eq, Integral, Num, Ord, Real, Show)


### PR DESCRIPTION
This fixed a bug in the tx-generator that affects proper shutdown of
the Node2Node submission clients.
The tx-generator uses an internal TX queue of size 32
and the code for shutting the submission clients down
had tried to write n times Nothing to that queue (n== number of nodes) in one atomic transaction.
TODO: TX-queue is not really needed in the new design and is to be removed altogether.