### PR TITLE
Implement kes-period-info command 

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -589,6 +589,9 @@ module Cardano.Api (
     OperationalCertificate,
     OperationalCertificateIssueCounter,
     OperationalCertIssueError,
+    getHotKey,
+    getKesPeriod,
+    getOpCertCount,
     issueOperationalCertificate,
 
     -- * Genesis file

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -77,6 +77,7 @@ import qualified Cardano.Protocol.TPraos.BHeader as TPraos
 import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
+import           Cardano.Api.KeysShelley
 import           Cardano.Api.Modes
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseUsing

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -86,7 +86,6 @@ import           Cardano.Api.IPC (ConsensusModeParams (..),
                    LocalNodeClientProtocols (..), LocalNodeClientProtocolsInMode,
                    LocalNodeConnectInfo (..), connectToLocalNode)
 import           Cardano.Api.KeysPraos
-import           Cardano.Api.KeysShelley
 import           Cardano.Api.LedgerEvent (LedgerEvent, toLedgerEvent)
 import           Cardano.Api.Modes (CardanoMode, EpochSlots (..))
 import           Cardano.Api.NetworkId (NetworkId (..), NetworkMagic (NetworkMagic))

--- a/cardano-api/src/Cardano/Api/OperationalCertificate.hs
+++ b/cardano-api/src/Cardano/Api/OperationalCertificate.hs
@@ -9,6 +9,9 @@ module Cardano.Api.OperationalCertificate (
     OperationalCertificateIssueCounter(..),
     Shelley.KESPeriod(..),
     OperationalCertIssueError(..),
+    getHotKey,
+    getKesPeriod,
+    getOpCertCount,
     issueOperationalCertificate,
 
     -- * Data family instances
@@ -51,8 +54,9 @@ data OperationalCertificate =
 
 data OperationalCertificateIssueCounter =
      OperationalCertificateIssueCounter
-       !Word64
-       !(VerificationKey StakePoolKey) -- For consistency checking
+       { opCertIssueCount :: !Word64
+       , opCertIssueColdKey :: !(VerificationKey StakePoolKey) -- For consistency checking
+       }
   deriving (Eq, Show)
   deriving anyclass SerialiseAsCBOR
 
@@ -152,3 +156,12 @@ issueOperationalCertificate (KesVerificationKey kesVKey)
                     ShelleyNormalSigningKey poolSKey
                   Right (GenesisDelegateExtendedSigningKey delegSKey) ->
                     ShelleyExtendedSigningKey delegSKey
+
+getHotKey :: OperationalCertificate -> VerificationKey KesKey
+getHotKey (OperationalCertificate cert _) = KesVerificationKey $ Shelley.ocertVkHot cert
+
+getKesPeriod :: OperationalCertificate -> Word
+getKesPeriod (OperationalCertificate cert _) = Shelley.unKESPeriod $ Shelley.ocertKESPeriod cert
+
+getOpCertCount :: OperationalCertificate -> Word64
+getOpCertCount (OperationalCertificate cert _) = Shelley.ocertN cert

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -125,7 +125,7 @@ module Cardano.Api.Shelley
 
     -- ** Operational certificates
     OperationalCertificate(OperationalCertificate),
-    OperationalCertificateIssueCounter(OperationalCertificateIssueCounter),
+    OperationalCertificateIssueCounter(..),
     OperationalCertIssueError(..),
 
     -- * Stake Pool

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -357,6 +357,14 @@ data QueryCmd =
   | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryStakeSnapshot' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
   | QueryPoolParams' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+  | QueryKesPeriodInfo
+      AnyConsensusModeParams
+      NetworkId
+      FilePath
+      -- ^ Node operational certificate
+      OpCertCounterFile
+      -- ^ Node operational certificate counter
+      (Maybe OutputFile)
   deriving Show
 
 renderQueryCmd :: QueryCmd -> Text
@@ -373,6 +381,7 @@ renderQueryCmd cmd =
     QueryProtocolState' {} -> "query protocol-state"
     QueryStakeSnapshot' {} -> "query stake-snapshot"
     QueryPoolParams' {} -> "query pool-params"
+    QueryKesPeriodInfo {} -> "query kes-period-info"
 
 data GovernanceCmd
   = GovernanceMIRPayStakeAddressesCertificate

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -1,21 +1,66 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.CLI.Shelley.Output
-  ( QueryTipLocalState(..)
+  ( QueryKesPeriodInfoOutput (..)
+  , QueryTipLocalState(..)
   , QueryTipLocalStateOutput(..)
   ) where
 
 import           Cardano.Api
 import           Prelude
 
-import           Data.Aeson (FromJSON (..), KeyValue, ToJSON (..), object, pairs, withObject, (.:?),
-                   (.=))
 import           Data.Text (Text)
+import           Data.Time.Clock (UTCTime)
+import           Data.Word
 
 import           Cardano.CLI.Shelley.Orphans ()
 import           Cardano.Ledger.Shelley.Scripts ()
 import           Cardano.Slotting.Time (SystemStart (..))
+
+data QueryKesPeriodInfoOutput =
+  QueryKesPeriodInfoOutput
+    { qKesInfoCurrentKESPeriod :: Word64
+    -- ^ Current KES period.
+    , qKesInfoStartKesInterval :: Word64
+    -- ^ Beginning of the Kes validity interval.
+    , qKesInfoStartEndInterval :: Word64
+    -- ^ End of the Kes validity interval.
+    , qKesInfoRemainingSlotsInPeriod :: Word64
+    -- ^ Remaining slots in current KESPeriod.
+    , qKesInfoKesKeyExpiry :: UTCTime
+    -- ^ Date of KES key expiry.
+    , qKesInfoNodeStateOperationalCertNo :: Word64
+    -- ^ The lastest operational certificate number in the node's state
+    -- i.e how many times a new KES key has been generated.
+    , qKesInfoOnDiskOperationalCertNo :: Word64
+    -- ^ The on disk operational certificate number.
+    , qKesInfoMaxKesKeyEvolutions :: Word64
+    -- ^ The maximum number of KES key evolutions permitted per KESPeriod.
+    , qKesInfoSlotsPerKesPeriod :: Word64
+    }
+
+instance ToJSON QueryKesPeriodInfoOutput where
+  toJSON QueryKesPeriodInfoOutput { qKesInfoCurrentKESPeriod
+                                  , qKesInfoStartKesInterval
+                                  , qKesInfoStartEndInterval
+                                  , qKesInfoRemainingSlotsInPeriod
+                                  , qKesInfoKesKeyExpiry
+                                  , qKesInfoNodeStateOperationalCertNo
+                                  , qKesInfoOnDiskOperationalCertNo
+                                  , qKesInfoMaxKesKeyEvolutions
+                                  , qKesInfoSlotsPerKesPeriod} =
+    object [ "qKesCurrentKesPeriod" .= qKesInfoCurrentKESPeriod
+           , "qKesStartKesInterval" .= qKesInfoStartKesInterval
+           , "qKesEndKesInterval" .= qKesInfoStartEndInterval
+           , "qKesRemainingSlotsInKesPeriod" .= qKesInfoRemainingSlotsInPeriod
+           , "qKesOnDiskOperationalCertificateNumber" .= qKesInfoOnDiskOperationalCertNo
+           , "qKesNodeStateOperationalCertificateNumber" .= qKesInfoNodeStateOperationalCertNo
+           , "qKesMaxKESEvolutions" .= qKesInfoMaxKesKeyEvolutions
+           , "qKesSlotsPerKesPeriod" .= qKesInfoSlotsPerKesPeriod
+           , "qKesKesKeyExpiry" .= qKesInfoKesKeyExpiry
+           ]
 
 data QueryTipLocalState mode = QueryTipLocalState
   { era :: AnyCardanoEra

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Shelley.Output
 import           Cardano.Api
 import           Prelude
 
+import           Data.Aeson
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
 import           Data.Word

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -901,7 +901,9 @@ pQueryCmd =
     , subParser "pool-params"
         (Opt.info pQueryPoolParams $ Opt.progDesc "Dump the pool parameters (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)")
     , subParser "leadership-schedule"
-        (Opt.info pLeadershipSchedule $ Opt.progDesc "Get the slots the node is the slot leader of (advanced command)")
+        (Opt.info pLeadershipSchedule $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)")
+    , subParser "kes-period-info"
+        (Opt.info pKesPeriodInfo $ Opt.progDesc "Get information about the current KES period and your node's operational certificate.")
     ]
   where
     pQueryProtocolParameters :: Parser QueryCmd
@@ -979,6 +981,14 @@ pQueryCmd =
       <*> pStakePoolVerificationKeyOrHashOrFile
       <*> pVrfSigningKeyFile
       <*> pWhichLeadershipSchedule
+
+    pKesPeriodInfo :: Parser QueryCmd
+    pKesPeriodInfo = QueryKesPeriodInfo
+      <$> pConsensusModeParams
+      <*> pNetworkId
+      <*> pOperationalCertificateFile
+      <*> pOperatorCertIssueCounterFile
+      <*> pMaybeOutputFile
 
 pGovernanceCmd :: Parser GovernanceCmd
 pGovernanceCmd =
@@ -1588,6 +1598,14 @@ pOperatorCertIssueCounterFile =
         )
     )
 
+pOperationalCertificateFile :: Parser FilePath
+pOperationalCertificateFile =
+  Opt.strOption
+    (  Opt.long "op-cert-file"
+    <> Opt.metavar "FILE"
+    <> Opt.help "Filepath of the node's operational certificate."
+    <> Opt.completer (Opt.bashCompleter "file")
+    )
 
 pOutputFormat :: Parser OutputFormat
 pOutputFormat =

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -27,7 +27,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
                    newExceptT)
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -48,7 +48,6 @@ import qualified Cardano.Api as Api (FileError (..))
 import           Cardano.Api.Orphans ()
 import qualified Cardano.Api.Protocol.Types as Protocol
 import           Cardano.Api.Shelley hiding (FileError)
-
 
 import           Cardano.Node.Types
 
@@ -138,9 +137,9 @@ validateGenesis genesis =
     firstExceptT GenesisValidationErrors . hoistEither $
       Shelley.validateGenesis genesis
 
-readLeaderCredentials :: Maybe ProtocolFilepaths
-                      -> ExceptT PraosLeaderCredentialsError IO
-                                 [TPraosLeaderCredentials StandardCrypto]
+readLeaderCredentials
+  :: Maybe ProtocolFilepaths
+  -> ExceptT PraosLeaderCredentialsError IO [TPraosLeaderCredentials StandardCrypto]
 readLeaderCredentials Nothing = return []
 readLeaderCredentials (Just pfp) =
   -- The set of credentials is a sum total of what comes from the CLI,
@@ -161,23 +160,43 @@ readLeaderCredentialsSingleton
      } = pure []
 -- Or to supply all of the files
 readLeaderCredentialsSingleton
-   ProtocolFilepaths
-     { shelleyCertFile      = Just certFile,
-       shelleyVRFFile       = Just vrfFile,
-       shelleyKESFile       = Just kesFile
-     } =
-     fmap (:[]) $
-     mkPraosLeaderCredentials
-       <$> firstExceptT FileError (newExceptT $ readFileTextEnvelope AsOperationalCertificate certFile)
-       <*> firstExceptT FileError (newExceptT $ readFileTextEnvelope (AsSigningKey AsVrfKey) vrfFile)
-       <*> firstExceptT FileError (newExceptT $ readFileTextEnvelope (AsSigningKey AsKesKey) kesFile)
+  ProtocolFilepaths { shelleyCertFile = Just opCertFile,
+                      shelleyVRFFile = Just vrfFile,
+                      shelleyKESFile = Just kesFile
+                    } = do
+    vrfSKey <-
+      firstExceptT FileError (newExceptT $ readFileTextEnvelope (AsSigningKey AsVrfKey) vrfFile)
+
+    (opCert, kesSKey) <- opCertKesKeyCheck kesFile opCertFile
+
+    return [mkPraosLeaderCredentials opCert vrfSKey kesSKey]
+
 -- But not OK to supply some of the files without the others.
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyCertFile = Nothing} =
-     throwError OCertNotSpecified
+     left OCertNotSpecified
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyVRFFile = Nothing} =
-     throwError VRFKeyNotSpecified
+     left VRFKeyNotSpecified
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyKESFile = Nothing} =
-     throwError KESKeyNotSpecified
+     left KESKeyNotSpecified
+
+opCertKesKeyCheck
+  :: FilePath
+  -- ^ KES key
+  -> FilePath
+  -- ^ Operational certificate
+  -> ExceptT PraosLeaderCredentialsError IO (OperationalCertificate, SigningKey KesKey)
+opCertKesKeyCheck kesFile certFile = do
+  opCert <-
+    firstExceptT FileError (newExceptT $ readFileTextEnvelope AsOperationalCertificate certFile)
+  kesSKey <-
+    firstExceptT FileError (newExceptT $ readFileTextEnvelope (AsSigningKey AsKesKey) kesFile)
+  let opCertSpecifiedKesKeyhash = verificationKeyHash $ getHotKey opCert
+      suppliedKesKeyHash = verificationKeyHash $ getVerificationKey kesSKey
+  -- Specified KES key in operational certificate should match the one
+  -- supplied to the node.
+  if suppliedKesKeyHash /= opCertSpecifiedKesKeyhash
+  then left $ MismatchedKesKey kesFile certFile
+  else return (opCert, kesSKey)
 
 data ShelleyCredentials
   = ShelleyCredentials
@@ -186,26 +205,25 @@ data ShelleyCredentials
     , scKes  :: (TextEnvelope, FilePath)
     }
 
-readLeaderCredentialsBulk ::
-     ProtocolFilepaths
-  -> ExceptT PraosLeaderCredentialsError IO
-             [TPraosLeaderCredentials StandardCrypto]
+readLeaderCredentialsBulk
+  :: ProtocolFilepaths
+  -> ExceptT PraosLeaderCredentialsError IO [TPraosLeaderCredentials StandardCrypto]
 readLeaderCredentialsBulk ProtocolFilepaths { shelleyBulkCredsFile = mfp } =
   mapM parseShelleyCredentials =<< readBulkFile mfp
  where
-   parseShelleyCredentials ::
-        ShelleyCredentials
-     -> ExceptT PraosLeaderCredentialsError IO
-                (TPraosLeaderCredentials StandardCrypto)
+   parseShelleyCredentials
+     :: ShelleyCredentials
+     -> ExceptT PraosLeaderCredentialsError IO (TPraosLeaderCredentials StandardCrypto)
    parseShelleyCredentials ShelleyCredentials { scCert, scVrf, scKes } = do
+     _ <- opCertKesKeyCheck (snd scKes) (snd scCert)
      mkPraosLeaderCredentials
        <$> parseEnvelope AsOperationalCertificate scCert
        <*> parseEnvelope (AsSigningKey AsVrfKey) scVrf
        <*> parseEnvelope (AsSigningKey AsKesKey) scKes
 
-   readBulkFile :: Maybe FilePath
-                -> ExceptT PraosLeaderCredentialsError IO
-                           [ShelleyCredentials]
+   readBulkFile
+     :: Maybe FilePath
+     -> ExceptT PraosLeaderCredentialsError IO [ShelleyCredentials]
    readBulkFile Nothing = pure []
    readBulkFile (Just fp) = do
      content <- handleIOExceptT (CredentialsReadError fp) $
@@ -306,6 +324,11 @@ data PraosLeaderCredentialsError =
      | OCertNotSpecified
      | VRFKeyNotSpecified
      | KESKeyNotSpecified
+     | MismatchedKesKey
+         FilePath
+         -- KES signing key
+         FilePath
+         -- Operational certificate
   deriving Show
 
 instance Error PraosLeaderCredentialsError where
@@ -318,7 +341,9 @@ instance Error PraosLeaderCredentialsError where
      <> toS fp <> " Error: " <> show err
 
   displayError (FileError fileErr) = displayError fileErr
-
+  displayError (MismatchedKesKey kesFp certFp) =
+       "The KES key provided at: " <> show kesFp
+    <> " does not match the KES key specified in the operational certificate at: " <> show certFp
   displayError OCertNotSpecified  = missingFlagMessage "shelley-operational-certificate"
   displayError VRFKeyNotSpecified = missingFlagMessage "shelley-vrf-key"
   displayError KESKeyNotSpecified = missingFlagMessage "shelley-kes-key"


### PR DESCRIPTION
Resolves: #2551, #3257, #2558, #3556

Implement `kes-period-info` cli command that checks your operational certificate and certificate issue counter file are correct:
```
> cardano-cli query kes-period-info --testnet-magic 42  \
    --op-cert-file example/node-pool1/shelley/node.cert \
    --operational-certificate-issue-counter-file example/node-pool1/shelley/operator.counter
✓ Operational certificate's counter agrees with the counter in the node's state
✓ Counters in the issue counter and operational certificate are equal
✓ Operational certificate's kes period is correct
{
    "maxKESEvolutions": 60,
    "latestOperationalCertificateNumber": 0,
    "remainingSlotsInKesPeriod": 36343,
    "slotsPerKesPeriod": 129600,
    "currentKesPeriod": 0
}
```
It checks:
- The counters in the operational certificate and operational certificate issue counter file are the same.
- The counters match what is in the node's protocol state 
- The KES period in the operational certificate is correct (based on the current slot).