### PR TITLE
Expect hexadecimal asset name - ValueParser Message

### DIFF
--- a/cardano-api/src/Cardano/Api/ValueParser.hs
+++ b/cardano-api/src/Cardano/Api/ValueParser.hs
@@ -156,7 +156,7 @@ assetId =
     fullAssetId :: PolicyId -> Parser AssetId
     fullAssetId polId = do
       _ <- period
-      aName <- assetName <?> "alphanumeric asset name"
+      aName <- assetName <?> "hexadecimal asset name"
       pure (AssetId polId aName)
 
     -- Parse a multi-asset ID that specifies a policy ID, but no asset name.


### PR DESCRIPTION
This is a left over, changed to "hexadecimal asset name" as expected. Was "alphanumeric asset name" before.