### PR TITLE
Guard against overflows in Shelley TxIns

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -157,7 +157,7 @@ module Cardano.Api.TxBody (
   ) where
 
 import           Control.Applicative (some)
-import           Control.Monad (guard)
+import           Control.Monad (guard, unless)
 import           Data.Aeson (object, withObject, (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -2245,19 +2245,23 @@ validateTxBodyContent era txBodContent@TxBodyContent {
   in case era of
        ShelleyBasedEraShelley -> do
          validateTxIns txIns
+         guardShelleyTxInsOverflow (map fst txIns)
          validateTxOuts era txOuts
          validateMetadata txMetadata
        ShelleyBasedEraAllegra -> do
          validateTxIns txIns
+         guardShelleyTxInsOverflow (map fst txIns)
          validateTxOuts era txOuts
          validateMetadata txMetadata
        ShelleyBasedEraMary -> do
          validateTxIns txIns
+         guardShelleyTxInsOverflow (map fst txIns)
          validateTxOuts era txOuts
          validateMetadata txMetadata
          validateMintValue txMintValue
        ShelleyBasedEraAlonzo -> do
          validateTxIns txIns
+         guardShelleyTxInsOverflow (map fst txIns)
          validateTxOuts era txOuts
          validateMetadata txMetadata
          validateMintValue txMintValue
@@ -2265,6 +2269,7 @@ validateTxBodyContent era txBodContent@TxBodyContent {
          validateProtocolParameters txProtocolParams languages
        ShelleyBasedEraBabbage -> do
          validateTxIns txIns
+         guardShelleyTxInsOverflow (map fst txIns)
          validateTxOuts era txOuts
          validateMetadata txMetadata
          validateMintValue txMintValue
@@ -2299,9 +2304,10 @@ validateTxInsCollateral
   :: TxInsCollateral era -> Set Alonzo.Language -> Either TxBodyError ()
 validateTxInsCollateral txInsCollateral languages =
   case txInsCollateral of
-    TxInsCollateralNone | not (Set.null languages)
-      -> Left TxBodyEmptyTxInsCollateral
-    _ -> return ()
+    TxInsCollateralNone ->
+      unless (Set.null languages) (Left TxBodyEmptyTxInsCollateral)
+    TxInsCollateral _ collateralTxIns ->
+      guardShelleyTxInsOverflow collateralTxIns
 
 validateTxOuts :: ShelleyBasedEra era -> [TxOut CtxTx era] -> Either TxBodyError ()
 validateTxOuts era txOuts =
@@ -3240,6 +3246,11 @@ getLedgerEraConstraint ShelleyBasedEraAllegra f = f
 getLedgerEraConstraint ShelleyBasedEraMary f = f
 getLedgerEraConstraint ShelleyBasedEraAlonzo f = f
 getLedgerEraConstraint ShelleyBasedEraBabbage f = f
+
+guardShelleyTxInsOverflow :: [TxIn] -> Either TxBodyError ()
+guardShelleyTxInsOverflow txIns = do
+    for_ txIns $ \txin@(TxIn _ (TxIx txix)) ->
+      guard (txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
 
 makeShelleyTransactionBody
   :: ShelleyBasedEra era


### PR DESCRIPTION
- makeByronTransactionBody guards against overflows in the transaction indices,
but makeShelleyTransactionBody does not.
- I lost some time debugging this here: https://github.com/input-output-hk/cardano-wallet/pull/3071
- Add appropriate guards to makeShelleyTransactionBody.

Now, I have no idea if the `maxShelleyTxInIx` value here is correct, so help would be appreciated!