### PR TITLE
Update leadership-schedule command to calculate following epoch's schedule

### DIFF
--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -39,6 +39,7 @@ module Cardano.Api.ProtocolParameters (
     makeShelleyUpdateProposal,
 
     -- * Internal conversion functions
+    toLedgerNonce,
     toLedgerUpdate,
     fromLedgerUpdate,
     toLedgerProposedPPUpdates,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -190,6 +190,7 @@ module Cardano.Api.Shelley
     -- ** Various calculations
     LeadershipError(..),
     currentEpochEligibleLeadershipSlots,
+    nextEpochEligibleLeadershipSlots,
     -- ** Conversions
     shelleyPayAddrToPlutusPubKHash,
     --TODO: arrange not to export these

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1484,13 +1484,20 @@ pVrfSigningKeyFile =
       )
 
 pWhichLeadershipSchedule :: Parser EpochLeadershipSchedule
-pWhichLeadershipSchedule = pCurrent
+pWhichLeadershipSchedule = pCurrent <|> pNext
  where
    pCurrent :: Parser EpochLeadershipSchedule
    pCurrent =
      Opt.flag' CurrentEpoch
        (  Opt.long "current"
        <> Opt.help "Get the leadership schedule for the current epoch."
+       )
+
+   pNext :: Parser EpochLeadershipSchedule
+   pNext =
+     Opt.flag' NextEpoch
+       (  Opt.long "next"
+       <> Opt.help "Get the leadership schedule for the following epoch."
        )
 
 pSomeWitnessSigningData :: Parser [WitnessSigningData]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -902,23 +902,34 @@ runQueryLeadershipSchedule (AnyConsensusModeParams cModeParams) network
           & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
       let pparamsQuery = QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
-          serDebugLedgerStateQuery = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryDebugLedgerState
           ptclStateQuery = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryProtocolState
           eraHistoryQuery = QueryEraHistory CardanoModeIsMultiEra
 
       pparams <- executeQuery era cModeParams localNodeConnInfo pparamsQuery
-      serDebugLedState <- executeQuery era cModeParams localNodeConnInfo serDebugLedgerStateQuery
       ptclState <- executeQuery era cModeParams localNodeConnInfo ptclStateQuery
       eraHistory <- firstExceptT ShelleyQueryCmdAcquireFailure . newExceptT $ queryNodeLocalState localNodeConnInfo Nothing eraHistoryQuery
       let eInfo = toEpochInfo eraHistory
 
       schedule :: Set SlotNo
         <- case whichSchedule of
-             CurrentEpoch ->
+             CurrentEpoch -> do
+               let currentEpochStateQuery = QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
+                   currentEpochQuery = QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryEpoch
+               serCurrentEpochState <- executeQuery era cModeParams localNodeConnInfo currentEpochStateQuery
+               curentEpoch <- executeQuery era cModeParams localNodeConnInfo currentEpochQuery
+
                firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
                  $ eligibleLeaderSlotsConstaints sbe
-                 $ currentEpochEligibleLeadershipSlots sbe shelleyGenesis eInfo
-                                           pparams serDebugLedState ptclState poolid vrkSkey
+                 $ currentEpochEligibleLeadershipSlots
+                     sbe
+                     shelleyGenesis
+                     eInfo
+                     pparams
+                     ptclState
+                     poolid
+                     vrkSkey
+                     serCurrentEpochState
+                     curentEpoch
 
              NextEpoch -> do
                let currentEpochStateQuery = QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
@@ -932,7 +943,7 @@ runQueryLeadershipSchedule (AnyConsensusModeParams cModeParams) network
                  $ eligibleLeaderSlotsConstaints sbe
                  $ nextEpochEligibleLeadershipSlots sbe shelleyGenesis
                      serCurrentEpochState ptclState poolid vrkSkey pparams
-                     (tip, curentEpoch)
+                     eInfo (tip, curentEpoch)
 
       liftIO $ printLeadershipSchedule schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
     mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -239,5 +239,6 @@ data RequiredSigner
 -- TODO: Implement Previous and Next epochs
 data EpochLeadershipSchedule
   = CurrentEpoch
+  | NextEpoch
   deriving Show
 


### PR DESCRIPTION
`cardano-cli query leadership-schedule ...` now accepts the flag `--next` that allows the leadership schedule calculation for the following epoch. 

Resolves #3546