### PR TITLE
trace-forward: new API for acceptor's part.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -279,8 +279,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ekg-forward
-  tag: 2adc8b698443bb10154304b24f6c1d6913bb65b9
-  --sha256: 0cyixq3jmq43zs1yzrycqw1klyjy0zxf1vifknnr1k9d6sc3zf6b
+  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
+  --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
 
 source-repository-package
   type: git

--- a/trace-forward/src/Trace/Forward/Run/DataPoint/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Run/DataPoint/Acceptor.hs
@@ -8,6 +8,8 @@ module Trace.Forward.Run.DataPoint.Acceptor
   ) where
 
 import qualified Codec.Serialise as CBOR
+import           Control.Exception (finally)
+import           Control.Monad (unless)
 import           Control.Monad.Extra (ifM)
 import           Control.Monad.STM (atomically, check)
 import           Control.Concurrent.STM.TVar (modifyTVar', readTVar, readTVarIO)
@@ -21,46 +23,52 @@ import qualified Trace.Forward.Protocol.DataPoint.Acceptor as Acceptor
 import qualified Trace.Forward.Protocol.DataPoint.Codec as Acceptor
 import           Trace.Forward.Protocol.DataPoint.Type (DataPointName)
 import           Trace.Forward.Configuration.DataPoint (AcceptorConfiguration (..))
-import           Trace.Forward.Utils.DataPoint (DataPointAsker (..))
+import           Trace.Forward.Utils.DataPoint (DataPointRequestor (..))
 
 acceptDataPointsInit
   :: AcceptorConfiguration
-  -> DataPointAsker
+  -> IO DataPointRequestor
+  -> IO ()
   -> RunMiniProtocol 'InitiatorMode LBS.ByteString IO () Void
-acceptDataPointsInit config dpAsker =
-  InitiatorProtocolOnly $ runPeerWithAsker config dpAsker
+acceptDataPointsInit config mkDPRequestor peerErrorHandler =
+  InitiatorProtocolOnly $ runPeerWithRequestor config mkDPRequestor peerErrorHandler
 
 acceptDataPointsResp
   :: AcceptorConfiguration
-  -> DataPointAsker
+  -> IO DataPointRequestor
+  -> IO ()
   -> RunMiniProtocol 'ResponderMode LBS.ByteString IO Void ()
-acceptDataPointsResp config dpAsker =
-  ResponderProtocolOnly $ runPeerWithAsker config dpAsker
+acceptDataPointsResp config mkDPRequestor peerErrorHandler =
+  ResponderProtocolOnly $ runPeerWithRequestor config mkDPRequestor peerErrorHandler
 
-runPeerWithAsker
+runPeerWithRequestor
   :: AcceptorConfiguration
-  -> DataPointAsker
+  -> IO DataPointRequestor
+  -> IO ()
   -> MuxPeer LBS.ByteString IO ()
-runPeerWithAsker config dpAsker = 
-  MuxPeerRaw $ \channel ->
-      runPeer
-        (acceptorTracer config)
-        (Acceptor.codecDataPointForward CBOR.encode CBOR.decode
-                                        CBOR.encode CBOR.decode)
-        channel
-        (Acceptor.dataPointAcceptorPeer $ acceptorActions config dpAsker [])
+runPeerWithRequestor config mkDPRequestor peerErrorHandler = 
+  MuxPeerRaw $ \channel -> do
+    dpRequestor <- mkDPRequestor
+    runPeer
+      (acceptorTracer config)
+      (Acceptor.codecDataPointForward CBOR.encode CBOR.decode
+                                      CBOR.encode CBOR.decode)
+      channel
+      (Acceptor.dataPointAcceptorPeer $ acceptorActions config dpRequestor [])
+    `finally` peerErrorHandler
 
 acceptorActions
   :: AcceptorConfiguration
-  -> DataPointAsker
+  -> DataPointRequestor
   -> [DataPointName]
   -> Acceptor.DataPointAcceptor IO ()
 acceptorActions config@AcceptorConfiguration{shouldWeStop}
-                dpAsker@DataPointAsker{askDataPoints, dataPointsNames, dataPointsReply}
+                dpRequestor@DataPointRequestor{askDataPoints, dataPointsNames, dataPointsReply}
                 dpNames =
   Acceptor.SendMsgDataPointsRequest dpNames $ \replyWithDataPoints -> do
-    -- Ok, reply with 'DataPoint's is already here, update the asker.
-    atomically $ do
+    -- Ok, reply with 'DataPoint's is already here, update the requestor.
+    unless (null replyWithDataPoints) $ atomically $ do
+      -- Store the reply for acceptor's external context.
       putTMVar dataPointsReply replyWithDataPoints
       -- To prevent new automatic request.
       modifyTVar' askDataPoints $ const False
@@ -72,4 +80,4 @@ acceptorActions config@AcceptorConfiguration{shouldWeStop}
         -- Ok, external context asked for 'DataPoint's, take their names.
         dpNames' <- readTVarIO dataPointsNames
         -- Ask.
-        return $ acceptorActions config dpAsker dpNames'
+        return $ acceptorActions config dpRequestor dpNames'


### PR DESCRIPTION
This PR changes API of the acceptor's part only, it doesn't touch the forwarder's part (used by `trace-dispatcher`):

1. `IO`-action returning `DataPointAsker` is provided. It allows avoiding `unsafePerformIO` in the acceptor application.
2. Peer error handlers were added. It allows the acceptor application to know if the connection with the node was dropped.

Additionally:

1. `ekg-forward` dependency is updated.
2. `DataPoint` protocol is fixed: now there is a check if the reply with `DataPoint`s is empty.

**Please note that `cardano-tracer` service, the next part of the new tracing infrastructure, depends on this PR. After it will be merged, the PR for `cardano-tracer` will be opened.**