### PR TITLE
cardano-tracer: logging/monitoring service for node

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,7 @@ README.*                                                      @docs-access
 
 bench/tx-generator                                            @deepfire @MarcFontaine
 bench                                                         @deepfire @denisshevchenko @jutaro @MarcFontaine
+cardano-tracer                                                @deepfire @denisshevchenko
 nix/workbench                                                 @deepfire @denisshevchenko @jutaro @MarcFontaine
 nix/supervisord-cluster                                       @deepfire @denisshevchenko @jutaro @MarcFontaine
 trace-dispatcher                                              @deepfire @denisshevchenko @jutaro

--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,7 @@ packages:
     cardano-node-chairman
     cardano-submit-api
     cardano-testnet
+    cardano-tracer
     bench/cardano-topology
     bench/locli
     bench/tx-generator
@@ -40,6 +41,9 @@ package trace-dispatcher
   ghc-options: -Werror
 
 package trace-resources
+  ghc-options: -Werror
+
+package cardano-tracer
   ghc-options: -Werror
 
 package plutus-examples
@@ -87,6 +91,9 @@ package trace-dispatcher
   tests: True
 
 package trace-forward
+  tests: True
+
+package cardano-tracer
   tests: True
 
 package trace-resources
@@ -286,6 +293,12 @@ source-repository-package
   location: https://github.com/input-output-hk/ekg-forward
   tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
   --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
+
+source-repository-package
+  type: git
+  location: https://github.com/HeinrichApfelmus/threepenny-gui
+  tag: e3bb8283fc7d2e8aa374eea29426002e8dcd67a8
+  --sha256: 0nf836b552asgpwn2gxwl7yd7ssdhb1wkvdqz6s4dpzqnlpyivx9
 
 -- Drops an instance breaking our code. Should be released to Hackage eventually.
 source-repository-package

--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ChangeLog
+
+## 0.1.0
+
+Initial version.

--- a/cardano-tracer/CODEOWNERS
+++ b/cardano-tracer/CODEOWNERS
@@ -1,0 +1,3 @@
+# General reviewers per PR
+#                       Denis            Serge
+*                       @denisshevchenko @deepfire

--- a/cardano-tracer/LICENSE
+++ b/cardano-tracer/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-tracer/NOTICE
+++ b/cardano-tracer/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2022 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/cardano-tracer/README.md
+++ b/cardano-tracer/README.md
@@ -1,0 +1,9 @@
+# Cardano Tracer
+
+`cardano-tracer` is a service for logging and monitoring over Cardano nodes. After it is connected to the node, it periodically asks the node for different information, receives it, and handles it.
+
+For more details please [read the documentation](https://github.com/input-output-hk/cardano-node/blob/master/cardano-tracer/docs/cardano-tracer.md).
+
+## Developers
+
+Benchmarking team is responsible for this service. The primary developer is [@denisshevchenko](https://github.com/denisshevchenko).

--- a/cardano-tracer/app/cardano-tracer.hs
+++ b/cardano-tracer/app/cardano-tracer.hs
@@ -1,0 +1,20 @@
+import           Data.Version (showVersion)
+import           Options.Applicative
+
+import           Cardano.Tracer.CLI (TracerParams, parseTracerParams)
+import           Cardano.Tracer.Run (runCardanoTracer)
+import           Paths_cardano_tracer (version)
+
+main :: IO ()
+main =
+  runCardanoTracer =<< customExecParser (prefs showHelpOnEmpty) tracerInfo
+ where
+  tracerInfo :: ParserInfo TracerParams
+  tracerInfo = info
+    (parseTracerParams <**> helper <**> versionOption)
+    (fullDesc <> header "cardano-tracer - the logging and monitoring service for Cardano nodes.")
+  versionOption = infoOption
+    (showVersion version)
+    (long "version" <>
+     short 'v' <>
+     help "Show version")

--- a/cardano-tracer/bench/cardano-tracer-bench.hs
+++ b/cardano-tracer/bench/cardano-tracer-bench.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Control.Concurrent.Extra (newLock)
+import           Criterion.Main
+import qualified Data.List.NonEmpty as NE
+import           Data.Time.Clock (getCurrentTime)
+import           System.FilePath ((</>))
+import           System.Directory (getTemporaryDirectory, removePathForcibly)
+
+import           Cardano.Logging hiding (LocalSocket)
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.Types (NodeId (..))
+
+main :: IO ()
+main = do
+  tmpDir <- getTemporaryDirectory
+  let root = tmpDir </> "cardano-tracer-bench"
+      c1 = mkConfig root ForHuman
+      c2 = mkConfig root ForMachine
+  lock <- newLock
+
+  to10   <- generate 10
+  to100  <- generate 100
+  to1000 <- generate 1000
+
+  removePathForcibly root
+
+  defaultMain
+    [ bgroup "cardano-tracer"
+      [ -- 10 'TraceObject's per request.
+        bench "Handle TraceObjects LOG,  10"   $ whnfIO $ traceObjectsHandler c1 nId lock to10
+      , bench "Handle TraceObjects JSON, 10"   $ whnfIO $ traceObjectsHandler c2 nId lock to10
+        -- 100 'TraceObject's per request.
+      , bench "Handle TraceObjects LOG,  100"  $ whnfIO $ traceObjectsHandler c1 nId lock to100
+      , bench "Handle TraceObjects JSON, 100"  $ whnfIO $ traceObjectsHandler c2 nId lock to100
+        -- 1000 'TraceObject's per request.
+      , bench "Handle TraceObjects LOG,  1000" $ whnfIO $ traceObjectsHandler c1 nId lock to1000
+      , bench "Handle TraceObjects JSON, 1000" $ whnfIO $ traceObjectsHandler c2 nId lock to1000
+      ]
+    ]
+ where
+  nId = NodeId "run-user-1000-cardano-tracer-demo.sock@0"
+
+  mkConfig root format = TracerConfig
+    { networkMagic   = 764824073
+    , network        = AcceptAt (LocalSocket "")
+    , loRequestNum   = Nothing
+    , ekgRequestFreq = Nothing
+    , hasEKG         = Nothing
+    , hasPrometheus  = Nothing
+    , logging        = NE.fromList [LoggingParams root FileMode format]
+    , rotation       = Nothing
+    , verbosity      = Nothing
+    }
+
+  generate num = replicate num . mkTraceObject <$> getCurrentTime
+
+  mkTraceObject now = TraceObject
+    { toHuman     = Just "Human Message About Some Important Information From The Cardano Node"
+    , toMachine   = Just "{\"msg\": \"forMachine Important Message\"}"
+    , toNamespace = ["name", "space", "for", "bench"]
+    , toSeverity  = Info
+    , toDetails   = DNormal
+    , toTimestamp = now
+    , toHostname  = "nixos"
+    , toThreadId  = "1"
+    }

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -148,7 +148,7 @@ test-suite cardano-tracer-test
   other-modules:       Cardano.Tracer.Test.Forwarder
                        Cardano.Tracer.Test.DataPoint.Tests
                        Cardano.Tracer.Test.Logs.Tests
-                       Cardano.Tracer.Test.Network.Tests
+                       Cardano.Tracer.Test.Restart.Tests
                        Cardano.Tracer.Test.Queue.Tests
                        Cardano.Tracer.Test.Utils
 

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -1,0 +1,200 @@
+cabal-version:         2.4
+name:                  cardano-tracer
+version:               0.1.0
+synopsis:              A service for logging and monitoring over Cardano nodes.
+description:           See README for more info
+license:               Apache-2.0
+license-file:          LICENSE
+copyright:             2022 Input Output (Hong Kong) Ltd.
+author:                IOHK
+maintainer:            operations@iohk.io
+build-type:            Simple
+extra-doc-files:       README.md
+                       CHANGELOG.md
+
+common base            { build-depends: base >= 4.14 && < 4.15 }
+
+common project-config
+  default-language:    Haskell2010
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-record-updates
+                       -Wincomplete-uni-patterns
+                       -Wno-unticked-promoted-constructors
+                       -Wno-orphans
+                       -Wpartial-fields
+                       -Wredundant-constraints
+                       -Wunused-packages
+
+library
+  import:              base, project-config
+  hs-source-dirs:      src
+
+  exposed-modules:     Cardano.Tracer.Acceptors.Client
+                       Cardano.Tracer.Acceptors.Run
+                       Cardano.Tracer.Acceptors.Server
+                       Cardano.Tracer.Acceptors.Utils
+
+                       Cardano.Tracer.Handlers.Logs.File
+                       Cardano.Tracer.Handlers.Logs.Journal
+                       Cardano.Tracer.Handlers.Logs.Rotator
+                       Cardano.Tracer.Handlers.Logs.TraceObjects
+                       Cardano.Tracer.Handlers.Logs.Utils
+
+                       Cardano.Tracer.Handlers.Metrics.Monitoring
+                       Cardano.Tracer.Handlers.Metrics.Prometheus
+                       Cardano.Tracer.Handlers.Metrics.Servers
+
+                       Cardano.Tracer.CLI
+                       Cardano.Tracer.Configuration
+                       Cardano.Tracer.Run
+                       Cardano.Tracer.Types
+                       Cardano.Tracer.Utils
+
+  other-modules:       Paths_cardano_tracer
+
+  build-depends:         aeson
+                       , async
+                       , async-extras
+                       , blaze-html
+                       , blaze-markup
+                       , bytestring
+                       , cborg
+                       , containers
+                       , contra-tracer
+                       , directory
+                       , ekg
+                       , ekg-core
+                       , ekg-forward
+                       , extra
+                       , filepath
+                       , optparse-applicative
+                       , ouroboros-network
+                       , ouroboros-network-framework
+                       , snap-blaze
+                       , snap-core
+                       , snap-server
+                       , stm
+                       , text
+                       , threepenny-gui
+                       , time
+                       , trace-dispatcher
+                       , trace-forward
+                       , unordered-containers
+                       , yaml
+
+  if os(linux)
+    build-depends:     libsystemd-journal
+
+executable cardano-tracer
+  import:              base, project-config
+
+  hs-source-dirs:      app
+
+  main-is:             cardano-tracer.hs
+
+  other-modules:       Paths_cardano_tracer
+
+  build-depends:         cardano-tracer
+                       , optparse-applicative
+
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+library demo-forwarder-lib
+  import:              base, project-config
+
+  hs-source-dirs:      test
+
+  exposed-modules:     Cardano.Tracer.Test.Forwarder
+
+  build-depends:         aeson
+                       , async
+                       , bytestring
+                       , cborg
+                       , cardano-tracer
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , ouroboros-network
+                       , ouroboros-network-framework
+                       , time
+                       , trace-dispatcher
+                       , trace-forward
+
+executable demo-forwarder
+  import:              base, project-config
+
+  hs-source-dirs:      demo/ssh
+
+  main-is:             forwarder.hs
+
+  build-depends:       demo-forwarder-lib
+
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+test-suite cardano-tracer-test
+  import:              base, project-config
+  type:                exitcode-stdio-1.0
+
+  hs-source-dirs:      test
+
+  main-is:             cardano-tracer-test.hs
+
+  other-modules:       Cardano.Tracer.Test.Forwarder
+                       Cardano.Tracer.Test.DataPoint.Tests
+                       Cardano.Tracer.Test.Logs.Tests
+                       Cardano.Tracer.Test.Network.Tests
+                       Cardano.Tracer.Test.Queue.Tests
+                       Cardano.Tracer.Test.Utils
+
+  build-depends:         aeson
+                       , async
+                       , bytestring
+                       , cardano-tracer
+                       , cborg
+                       , containers
+                       , contra-tracer
+                       , directory
+                       , ekg-core
+                       , ekg-forward
+                       , extra
+                       , filepath
+                       , ouroboros-network
+                       , ouroboros-network-framework
+                       , QuickCheck
+                       , stm
+                       , tasty
+                       , tasty-quickcheck
+                       , text
+                       , time
+                       , trace-dispatcher
+                       , trace-forward
+
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-N
+
+benchmark cardano-tracer-bench
+  import:              base, project-config
+  type:                exitcode-stdio-1.0
+
+  hs-source-dirs:      bench
+
+  main-is:             cardano-tracer-bench.hs
+
+  build-depends:         cardano-tracer
+                       , criterion
+                       , directory
+                       , extra
+                       , filepath
+                       , time
+                       , trace-dispatcher
+
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-N

--- a/cardano-tracer/configuration/complete-example.json
+++ b/cardano-tracer/configuration/complete-example.json
@@ -1,0 +1,42 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "AcceptAt",
+    "contents": "/tmp/forwarder.sock"
+  },
+  "loRequestNum": 100,
+  "ekgRequestFreq": 2,
+  "hasEKG": [
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3100
+    },
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3101
+    }
+  ],
+  "hasPrometheus": {
+    "epHost": "127.0.0.1",
+    "epPort": 3000
+  },
+  "logging": [
+    {
+      "logRoot": "/tmp/cardano-tracer-h-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForHuman"
+    },
+    {
+      "logRoot": "/tmp/cardano-tracer-m-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ],
+  "rotation": {
+    "rpFrequencySecs": 15,
+    "rpKeepFilesNum": 1,
+    "rpLogLimitBytes": 50000,
+    "rpMaxAgeHours": 1
+  },
+  "verbosity": "ErrorsOnly"
+}

--- a/cardano-tracer/configuration/complete-example.yaml
+++ b/cardano-tracer/configuration/complete-example.yaml
@@ -1,0 +1,28 @@
+---
+networkMagic: 764824073
+network:
+  tag: AcceptAt
+  contents: "/tmp/forwarder.sock"
+loRequestNum: 100
+ekgRequestFreq: 2
+hasEKG:
+- epHost: 127.0.0.1
+  epPort: 3100
+- epHost: 127.0.0.1
+  epPort: 3101
+hasPrometheus:
+  epHost: 127.0.0.1
+  epPort: 3000
+logging:
+- logRoot: "/tmp/cardano-tracer-h-logs"
+  logMode: FileMode
+  logFormat: ForHuman
+- logRoot: "/tmp/cardano-tracer-m-logs"
+  logMode: FileMode
+  logFormat: ForMachine
+rotation:
+  rpFrequencySecs: 15
+  rpKeepFilesNum: 1
+  rpLogLimitBytes: 50000
+  rpMaxAgeHours: 1
+verbosity: ErrorsOnly

--- a/cardano-tracer/configuration/minimal-example.json
+++ b/cardano-tracer/configuration/minimal-example.json
@@ -1,0 +1,14 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "ConnectTo",
+    "contents": ["/tmp/forwarder.sock"]
+  },
+  "logging": [
+    {
+      "logRoot": "/tmp/cardano-tracer-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}

--- a/cardano-tracer/configuration/minimal-example.yaml
+++ b/cardano-tracer/configuration/minimal-example.yaml
@@ -1,0 +1,10 @@
+---
+networkMagic: 764824073
+network:
+  tag: ConnectTo
+  contents:
+  - "/tmp/forwarder.sock"
+logging:
+- logRoot: "/tmp/cardano-tracer-logs"
+  logMode: FileMode
+  logFormat: ForMachine

--- a/cardano-tracer/demo/multi/README.md
+++ b/cardano-tracer/demo/multi/README.md
@@ -1,0 +1,33 @@
+# Multi Forwarders Demo
+
+Run `./run.sh PASS FMODE`, where `FMODE` is forwarders' mode: `Responder` or `Initiator`.
+
+As a result, 3 `demo-forwarder`s and one `cardano-tracer` will be launched. It imitates the real-world situation when `N` nodes work with one `cardano-tracer`.
+
+Please note that if you run the script with `Responder` mode, `demo-forwarder`s work as a servers, and `cardano-tracer` works as a client:
+
+```
++------------------+
+| demo-forwarder 1 |  <====connect
++------------------+              \
++------------------+               \  +----------------+
+| demo-forwarder 2 |  <====connect====| cardano-tracer |
++------------------+               /  +----------------+
++------------------+              /
+| demo-forwarder 3 |  <====connect
++------------------+
+```
+
+Otherwise, with `Initiator` mode, we have an opposite scenario:
+
+```
++------------------+
+| demo-forwarder 1 |====connect==
++------------------+              \
++------------------+               \   +----------------+
+| demo-forwarder 2 |====connect=====>  | cardano-tracer |
++------------------+               /   +----------------+
++------------------+              /
+| demo-forwarder 3 |====connect==
++------------------+
+```

--- a/cardano-tracer/demo/multi/active-tracer-config.json
+++ b/cardano-tracer/demo/multi/active-tracer-config.json
@@ -1,0 +1,38 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "ConnectTo",
+    "contents": [
+      "/run/user/1000/cardano-tracer-demo-1.sock",
+      "/run/user/1000/cardano-tracer-demo-2.sock",
+      "/run/user/1000/cardano-tracer-demo-3.sock"
+    ]
+  },
+  "hasEKG": [
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3100
+    },
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3101
+    }
+  ],
+  "hasPrometheus": {
+    "epHost": "127.0.0.1",
+    "epPort": 3000
+  },
+  "logging": [
+    {
+      "logRoot": "/run/user/1000/cardano-tracer-demo-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ],
+  "rotation": {
+    "rpFrequencySecs": 15,
+    "rpKeepFilesNum": 5,
+    "rpLogLimitBytes": 5000,
+    "rpMaxAgeHours": 1
+  }
+}

--- a/cardano-tracer/demo/multi/forwarder.hs
+++ b/cardano-tracer/demo/multi/forwarder.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE LambdaCase #-}
+
+import System.Environment (getArgs)
+
+import Cardano.Tracer.Test.Forwarder
+
+main :: IO ()
+main = getArgs >>= \case
+  [localSock, "Initiator"] -> launchForwardersSimple Initiator localSock 1000 2000
+  [localSock, "Responder"] -> launchForwardersSimple Responder localSock 1000 2000
+  _ -> putStrLn "Usage: ./demo-forwarder Initiator|Responder /path/to/local/sock"

--- a/cardano-tracer/demo/multi/passive-tracer-config.json
+++ b/cardano-tracer/demo/multi/passive-tracer-config.json
@@ -1,0 +1,34 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "AcceptAt",
+    "contents": "/run/user/1000/cardano-tracer-demo-1.sock"
+  },
+  "hasEKG": [
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3100
+    },
+    {
+      "epHost": "127.0.0.1",
+      "epPort": 3101
+    }
+  ],
+  "hasPrometheus": {
+    "epHost": "127.0.0.1",
+    "epPort": 3000
+  },
+  "logging": [
+    {
+      "logRoot": "/run/user/1000/cardano-tracer-demo-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ],
+  "rotation": {
+    "rpFrequencySecs": 15,
+    "rpKeepFilesNum": 5,
+    "rpLogLimitBytes": 5000,
+    "rpMaxAgeHours": 1
+  }
+}

--- a/cardano-tracer/demo/multi/run.sh
+++ b/cardano-tracer/demo/multi/run.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+  echo "Usage: ./run.sh FMODE, where FMODE is forwarders' mode, Responder or Initiator."
+  exit 1
+fi
+
+rm -rf cardano-tracer demo-forwarder
+
+cabal build cardano-tracer && cabal install cardano-tracer --installdir=./ --overwrite-policy=always
+
+readonly FORWARDER_MODE=$1
+readonly DELAY_IN_SECS=$2
+
+readonly TMP_DIR=/run/user/1000
+readonly TRACER_LOG_ROOT=${TMP_DIR}/cardano-tracer-demo-logs
+
+readonly SOCK_1=${TMP_DIR}/cardano-tracer-demo-1.sock
+readonly SOCK_2=${TMP_DIR}/cardano-tracer-demo-2.sock
+readonly SOCK_3=${TMP_DIR}/cardano-tracer-demo-3.sock
+
+rm -rf ${TRACER_LOG_ROOT} ${SOCK_1} ${SOCK_2} ${SOCK_3}
+mkdir ${TRACER_LOG_ROOT}
+
+echo "Run 3 demo-forwarders..."
+if [ "$FORWARDER_MODE" == "Responder" ]
+then
+  # Run demo-forwarders in Responder mode, so they will accept connections from the tracer via 3 sockets.
+  FORWARDER_1_PID=$(nohup ./demo-forwarder ${SOCK_1} ${FORWARDER_MODE} &>/dev/null & echo $!)
+  FORWARDER_2_PID=$(nohup ./demo-forwarder ${SOCK_2} ${FORWARDER_MODE} &>/dev/null & echo $!)
+  FORWARDER_3_PID=$(nohup ./demo-forwarder ${SOCK_3} ${FORWARDER_MODE} &>/dev/null & echo $!)
+else
+  # Run demo-forwarders in Initiator mode, so they will connect to the tracer via the same socket.
+  FORWARDER_1_PID=$(nohup ./demo-forwarder ${SOCK_1} ${FORWARDER_MODE} &>/dev/null & echo $!)
+  FORWARDER_2_PID=$(nohup ./demo-forwarder ${SOCK_1} ${FORWARDER_MODE} &>/dev/null & echo $!)
+  FORWARDER_3_PID=$(nohup ./demo-forwarder ${SOCK_1} ${FORWARDER_MODE} &>/dev/null & echo $!)
+fi
+
+echo "Run cardano-tracer..."
+if [ "$FORWARDER_MODE" == "Responder" ]
+then
+  TRACER_CONFIG=active-tracer-config.json
+else
+  TRACER_CONFIG=passive-tracer-config.json
+fi
+./cardano-tracer --config ${TRACER_CONFIG} +RTS -M8m -RTS

--- a/cardano-tracer/demo/ssh/README.md
+++ b/cardano-tracer/demo/ssh/README.md
@@ -1,0 +1,35 @@
+# SSH Local Forwarding Demo
+
+Run `./run.sh PASS FMODE`, where `PASS` is your ssh password for `localhost`, and `FMODE` is forwarder's mode: `Responder` or `Initiator`.
+
+As a result, `demo-forwarder` and `cardano-tracer` will be launched on _different_ local sockets, so direct connection between them is impossible:
+
+```
++----------------+                    +----------------+
+| demo-forwarder |-> sock1    sock2 <-| cardano-tracer |
++----------------+                    +----------------+
+```
+
+That's why we initiate ssh local forwarding which connects these local sockets, so `demo-forwarder` can work with `cardano-tracer`:
+
+```
++----------------+                                        +----------------+
+| demo-forwarder |-> sock1 <---SSH forwarding---> sock2 <-| cardano-tracer |
++----------------+                                        +----------------+
+```
+
+Please note that if you run the script with `Responder` mode, `demo-forwarder` works as a server, and `cardano-tracer` works as a client:
+
+```
++----------------+                  +----------------+
+| demo-forwarder |  <====connect====| cardano-tracer |
++----------------+                  +----------------+
+```
+
+otherwise, with `Initiator` mode, we have an opposite scenario:
+
+```
++----------------+                  +----------------+
+| demo-forwarder |====connect====>  | cardano-tracer |
++----------------+                  +----------------+
+```

--- a/cardano-tracer/demo/ssh/active-tracer-config.json
+++ b/cardano-tracer/demo/ssh/active-tracer-config.json
@@ -1,0 +1,14 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "ConnectTo",
+    "contents": [ "/run/user/1000/cardano-tracer-demo.sock" ]
+  },
+  "logging": [
+    {
+      "logRoot": "/run/user/1000/cardano-tracer-demo-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}

--- a/cardano-tracer/demo/ssh/forwarder.hs
+++ b/cardano-tracer/demo/ssh/forwarder.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE LambdaCase #-}
+
+import System.Environment (getArgs)
+
+import Cardano.Tracer.Test.Forwarder
+
+main :: IO ()
+main = getArgs >>= \case
+  [localSock, "Initiator"] -> launchForwardersSimple Initiator localSock 1000 2000
+  [localSock, "Responder"] -> launchForwardersSimple Responder localSock 1000 2000
+  _ -> putStrLn "Usage: ./demo-forwarder Initiator|Responder /path/to/local/sock"

--- a/cardano-tracer/demo/ssh/passive-tracer-config.json
+++ b/cardano-tracer/demo/ssh/passive-tracer-config.json
@@ -1,0 +1,14 @@
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "AcceptAt",
+    "contents": "/run/user/1000/cardano-tracer-demo.sock"
+  },
+  "logging": [
+    {
+      "logRoot": "/run/user/1000/cardano-tracer-demo-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}

--- a/cardano-tracer/demo/ssh/run.sh
+++ b/cardano-tracer/demo/ssh/run.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+  echo "Usage: ./run.sh PASS FMODE, where PASS is your ssh password and FMODE is forwarder's mode, Responder or Initiator."
+  exit 1
+fi
+
+cabal build cardano-tracer && cabal install cardano-tracer --installdir=./ --overwrite-policy=always
+
+readonly SSH_PASS=$1
+readonly FORWARDER_MODE=$2
+
+readonly TMP_DIR=/run/user/1000
+readonly TRACER_SOCK=${TMP_DIR}/cardano-tracer-demo.sock
+readonly TRACER_LOG_ROOT=${TMP_DIR}/cardano-tracer-demo-logs
+readonly FORWARDER_SOCK=${TMP_DIR}/demo-forwarder.sock
+
+rm -rf ${TRACER_LOG_ROOT} ${TRACER_SOCK} ${FORWARDER_SOCK}
+mkdir ${TRACER_LOG_ROOT}
+
+# Please note that TRACER_SOCK and FORWARDER_SOCK are different,
+# so direct connection between parts is impossible. It can be established
+# only via SSH local forwarding.
+
+echo "Enable SSH local forwarding..."
+if [ "$FORWARDER_MODE" == "Responder" ]
+then
+  SSHPASS_PID=$(nohup sshpass -p ${SSH_PASS} ssh -nNT -L ${TRACER_SOCK}:${FORWARDER_SOCK} -o "ExitOnForwardFailure yes" -- localhost &>/dev/null & echo $!)
+else
+  SSHPASS_PID=$(nohup sshpass -p ${SSH_PASS} ssh -nNT -L ${FORWARDER_SOCK}:${TRACER_SOCK} -o "ExitOnForwardFailure yes" -- localhost &>/dev/null & echo $!)
+fi
+sleep 1
+
+echo "Run demo-forwarder..."
+FORWARDER_PID=$(nohup ./demo-forwarder ${FORWARDER_SOCK} ${FORWARDER_MODE} &>/dev/null & echo $!)
+
+echo "Run cardano-tracer..."
+if [ "$FORWARDER_MODE" == "Responder" ]
+then
+  TRACER_CONFIG=active-tracer-config.json
+else
+  TRACER_CONFIG=passive-tracer-config.json
+fi
+TRACER_PID=$(nohup ./cardano-tracer --config ${TRACER_CONFIG} &>/dev/null & echo $!)
+
+echo "Wait..."
+sleep 10
+
+echo "Stop both sides and SSH forwarding..."
+kill ${FORWARDER_PID}
+kill ${TRACER_PID}
+kill ${SSHPASS_PID}
+SSH_PID=$(ps aux | grep 'ssh' | grep 'demo-forwarder.sock' | awk '{print $2}')
+kill ${SSH_PID}
+rm -rf cardano-tracer
+rm -rf demo-forwarder
+
+# If the log root dir isn't empty, it means that there was forwarding of TraceObjects
+# from demo-forwarder to cardano-tracer. It proves that SSH local forwarder works.
+echo "Check the content of log root dir..."
+ls ${TRACER_LOG_ROOT}

--- a/cardano-tracer/docs/cardano-tracer.md
+++ b/cardano-tracer/docs/cardano-tracer.md
@@ -1,0 +1,403 @@
+# Cardano Tracer
+
+`cardano-tracer` is a service for logging and monitoring over Cardano nodes. After it is connected to the node, it periodically asks the node for different information, receives it, and handles it.
+
+# Contents
+
+1. [Introduction](#Introduction)
+   1. [Motivation](#Motivation)
+   3. [Overview](#Overview)
+2. [Build and run](#Build-and-run)
+3. [Configuration](#Configuration)
+   1. [Distributed Scenario](#Distributed-scenario)
+   2. [Local Scenario](#Local-scenario)
+   3. [Network Magic](#Network-magic)
+   4. [Requests](#Requests)
+   5. [Logging](#Logging)
+   6. [Logs Rotation](#Logs-rotation)
+   7. [Prometheus](#Prometheus)
+   8. [EKG Monitoring](#EKG-monitoring)
+   9. [Verbosity](#Verbosity)
+
+# Introduction
+
+## Motivation
+
+Previously, the node handled all the logging by itself. Moreover, it provided monitoring tools as well: two web-servers, for Prometheus and for EKG monitoring page. `cardano-tracer` is a result of _moving_ all the logging/monitoring-related stuff from the node to a separate service. As a result, the node became smaller, faster, and simpler.
+
+## Overview
+
+You can think of Cardano node as a **producer** of logging/monitoring information, and `cardano-tracer` as a **consumer** of this information. After the network connection between them is established, `cardano-tracer` periodically asks for such an information, and the node replies with it.
+
+There are 3 kinds of such an information:
+
+1. Trace object, which contains different logging data. `cardano-tracer` constantly asks for new trace objects each `N` seconds, receives them and stores them in the log files and/or in Linux `systemd`'s journal.
+2. EKG metric, which contains some system metric. Please [read EKG documentation](https://hackage.haskell.org/package/ekg-core) for more info. `cardano-tracer` constantly asks for new EKG metrics each `N` seconds, receives them and displays them using monitoring tools.
+3. Data points, which contains arbitrary information about the node. Please note that `cardano-tracer` asks for new data points only by _explicit_ request when it needs it, there is no constant asking.
+
+Please note that `cardano-tracer` can work as an aggregator as well: _one_ `cardano-tracer` process can receive the information from _multiple_ nodes.
+
+# Build and run
+
+Please make sure you have [Nix installed](https://nixos.org/guides/install-nix.html).
+
+First of all, go to Nix shell using the following command (from the root of `cardano-node` repository):
+
+```
+nix-shell
+```
+
+Now build and install `cardano-tracer` using the following command:
+
+```
+cabal build cardano-tracer && cabal install cardano-tracer --installdir=PATH_TO_DIR --overwrite-policy=always
+```
+
+where `PATH_TO_DIR` is a path to a directory where `cardano-tracer` will be copied after building.
+
+Then you can go to `PATH_TO_DIR` and run `cardano-tracer` using the following command:
+
+```
+./cardano-tracer --config PATH_TO_CONFIG
+```
+
+where `PATH_TO_CONFIG` is a path to your configuration file, please see below an explanation about it. You can find an example of the configuration file in `configuration` subdirectory.
+
+# Configuration
+
+The way how to configure `cardano-tracer` depends on your requirements. There are two basic scenarios:
+
+1. **Distributed** scenario, when `cardano-tracer` is working on one machine, and your nodes are working on another machine(s).
+2. **Local** scenario, when `cardano-tracer` and your nodes are working on the same machine.
+
+Distributed scenario is for real-life case: for example, you have `N` nodes working on `N` different AWS-instances, and you want to collect all the logging/monitoring information from these nodes using one `cardano-tracer` process working on your machine.
+
+Local scenario is for testing case: for example, you want to try your new infrastructure from scratch, so you run `N` nodes and one `cardano-tracer` process on your machine.
+
+**IMPORTANT NOTICE**: Please note that `cardano-tracer` **does not** support connection via IP-address and port, to avoid unauthorized connections. The **only** way to establish connection with the node is a local socket (Unix sockets or Windows named pipes).
+
+## Distributed Scenario
+
+This is an example with 3 nodes and one `cardano-tracer`:
+
+```
+machine A            machine B            machine C
++-----------------+  +-----------------+  +-----------------+
+| node 1          |  | node 2          |  | node 3          |
++-----------------+  +-----------------+  +-----------------+
+                ^             ^             ^
+                 \            |            /
+                  \           |           /
+                   v          v          v
+                   +---------------------+
+                   | cardano-tracer      |
+                   +---------------------+
+                   machine D
+```
+
+The minimalistic configuration file for `cardano-tracer` would be:
+
+```
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "AcceptAt",
+    "contents": "/tmp/cardano-tracer.sock"
+  },
+  "logging": [
+    {
+      "logRoot": "/tmp/cardano-tracer-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}
+```
+
+The `network` field specifies the way how `cardano-tracer` will be connected to your nodes. Here you see `AcceptAt` tag, which means that `cardano-tracer` works as a server: it _accepts_ network connections by listening the local socket `/tmp/cardano-tracer.sock`. Your nodes work as clients: they _initiate_ network connections using their local sockets. It can be shown like this:
+
+```
+machine A            machine B            machine C
++-----------------+  +-----------------+  +-----------------+
+| node 1          |  | node 2          |  | node 3          |
+|      \          |  |      \          |  |      \          |
+|       v         |  |       v         |  |       v         |
+|    local socket |  |    local socket |  |    local socket |
++-----------------+  +-----------------+  +-----------------+
+
+
+
+
+
+                   +---------------------+
+                   | local socket        |
+                   |      ^              |
+                   |       \             |
+                   |      cardano-tracer |
+                   +---------------------+
+                   machine D
+```
+
+To establish the real network connections between your machines, you need SSH forwarding:
+
+```
+machine A            machine B            machine C
++-----------------+  +-----------------+  +-----------------+
+| node 1          |  | node 2          |  | node 3          |
+|      \          |  |      \          |  |      \          |
+|       v         |  |       v         |  |       v         |
+|    local socket |  |    local socket |  |    local socket |
++-----------------+  +-----------------+  +-----------------+
+                ^             ^             ^
+                 \            |            /
+                 SSH         SSH          SSH
+                   \          |          /
+                    v         v         v
+                   +---------------------+
+                   | local socket        |
+                   |      ^              |
+                   |       \             |
+                   |      cardano-tracer |
+                   +---------------------+
+                   machine D
+```
+
+The idea of SSH forwarding is simple: we do connect not the processes directly, but their network endpoints instead. You can think of it as a network channel from the local socket on one machine to the local socket on another machine:
+
+```
+machine A                                      machine D
++----------------------------+                 +------------------------------------+
+| node 1 ---> local socket <-|---SSH channel---|-> local socket <--- cardano-tracer |
++----------------------------+                 +------------------------------------+
+```
+
+So neither your nodes nor `cardano-tracer` know anything about SSH, they only know about their local sockets. But because of SSH forwarding mechanism they work together from different machines. And since you already have your SSH credentials, the connection between your nodes and `cardano-tracer` will be secure.
+
+So, to connect `cardano-node` working on machine `A` with `cardano-tracer` working on machine `D`, run this command on machine `A`:
+
+```
+ssh -nNT -L /tmp/cardano-tracer.sock:/tmp/cardano-node.sock -o "ExitOnForwardFailure yes" john@109.75.33.121
+```
+
+where:
+
+- `/tmp/cardano-tracer.sock` is a path to the local socket on machine `A`,
+- `/tmp/cardano-node.sock` is a path to the local socket on machine `D`,
+- `john` is a user you use to login on machine `D`,
+- `109.75.33.121` is an IP-adress of machine `D`.
+
+Run the same command on machines `B` and `C` to connect corresponding nodes with the same `cardano-tracer` working on machine `D`.
+
+## Local Scenario
+
+As was mentioned above, local scenario is for testing, when your nodes and `cardano-tracer` are working on the same machine. In this case all these processes can see the same local sockets directly, so we don't need `ssh`. The configuration file for 3 local nodes would look like this:
+
+```
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "AcceptAt",
+    "contents": "/tmp/cardano-tracer.sock"
+  },
+  "logging": [
+    {
+      "logRoot": "/tmp/cardano-tracer-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}
+```
+
+As you see, it is the same configuration file: the `cardano-tracer` works as a server: it _accepts_ network connections by listening the local socket `/tmp/cardano-tracer.sock`. Your local nodes work as clients: they _initiate_ network connections using the _same_ local socket `/tmp/cardano-tracer.sock`.
+
+There is another way to connect `cardano-tracer` to your nodes: the `cardano-tracer` can work as _initiator_, this is an example of configuration file:
+
+```
+{
+  "networkMagic": 764824073,
+  "network": {
+    "tag": "ConnectTo",
+    "contents": [
+      "/tmp/cardano-node-1.sock"
+      "/tmp/cardano-node-2.sock"
+      "/tmp/cardano-node-3.sock"
+    ]
+  },
+  "logging": [
+    {
+      "logRoot": "/tmp/cardano-tracer-logs",
+      "logMode": "FileMode",
+      "logFormat": "ForMachine"
+    }
+  ]
+}
+```
+
+As you see, the tag in `network` field is `ConnectTo` now, which means that `cardano-tracer` works as a client: it _establishes_ network connections with your local nodes via the local sockets `/tmp/cardano-node-*.sock`. In this case each socket is used by a particular node.
+
+Please use `ConnectTo`-based scenario only if you really need it. Otherwise, it is **highly recommended** to use `AcceptAt`-based scenario.
+
+## Network Magic
+
+The field `networkMagic` specifies the value of network magic. It is an integer constant from the genesis file, the node uses this value for the network handshake with peers. Since `cardano-tracer` should be connected to the node, it needs that network magic.
+
+The value from the example above, `764824073`, is taken from the Shelley genesis file for Mainnet. Please take this value from the genesis file your nodes are launched with.
+
+## Requests
+
+The optional field `loRequestNum` specifies the number of log items that will be requested from the node. For example, if `loRequestNum` is `10`, `cardano-tracer` will constantly ask 10 log items in one request. This value is useful for reducing the network traffic: it is possible to ask 50 log items in one request or ask them in 50 requests one at a time. Please note that if `loRequestNum` is bigger than the real number of log items in the node, all these items will be returned immediately. For example, if `cardano-tracer` asks 50 log items but the node has only 40 log items _in this moment of time_, these 40 items will be returned, there is no waiting for additional 10 items.
+
+The optional field `ekgRequestFreq` specifies the period of how often EKG metrics will be requested, in seconds. For example, if `ekgRequestFreq` is `1`, `cardano-tracer` will ask for new EKG metrics every second. Please note that there is no limit as `loRequestNum`, so every request returns _all_ the metrics the node has _in this moment of time_.
+
+There are default values for `loRequestNum` and `ekgRequestFreq`, so if you are not sure - please remove these fields from your configuration file to use default values.
+
+## Logging
+
+Logging is one of the most important features of `cardano-tracer`. The field `logging` describes logging parameters:
+
+```
+"logging": [
+  {
+    "logRoot": "/tmp/cardano-tracer-logs",
+    "logMode": "FileMode",
+    "logFormat": "ForMachine"
+  }
+]
+```
+
+The field `logRoot` specifies the path to the root directory. This directory will contain all the subdirectories with the log files inside. Please remember that each subdirectory corresponds to the particular node. If the root directory does not exist, it will be created.
+
+This is an example of log structure:
+
+```
+/rootDir
+   /subdirForNode0
+      node-2021-11-25T10-06-52.json
+      node.json -> /rootDir/subdirForNode0/node-2021-11-25T10-06-52.json
+```
+
+In this example, `subdirForNode0` is a subdirectory containing log files with items received from the node `0`. And `node-2021-11-25T10-06-52.json` is the _current_ log: it means that currently `cardano-tracer` is writing items in this log file, via symbolic link `node.json`.
+
+The field `logMode` specifies logging mode. There are two possible modes: `FileMode` and `JournalMode`. `FileMode` is for storing logs to the files, `JournalMode` is for storing them in `systemd`'s journal. Please note that if you choose `JournalMode`, the field `logRoot` will be ignored.
+
+The field `logFormat` specifies the format of logs. There are two possible modes: `ForMachine` and `ForHuman`. `ForMachine` is for JSON format, `ForHuman` is for human-friendly text format.
+
+Please note that `logging` field accepts the list, so you can specify more than one logging section. For example, for both log formats:
+
+```
+"logging": [
+  {
+    "logRoot": "/tmp/cardano-tracer-logs-json",
+    "logMode": "FileMode",
+    "logFormat": "ForMachine"
+  },
+  {
+    "logRoot": "/tmp/cardano-tracer-logs-text",
+    "logMode": "FileMode",
+    "logFormat": "ForHuman"
+  }
+]
+```
+
+In this case log items will be written in JSON format (in `.json`-files) as well as in text format (in `.log`-files).
+
+## Logs Rotation
+
+An optional field `rotation` describes parameters for log rotation. Please note that if you skip this field, all the log items will be stored in one single file, and usually it's not what you want. These are rotation parameters:
+
+```
+"rotation": {
+  "rpFrequencySecs": 30,
+  "rpKeepFilesNum": 3,
+  "rpLogLimitBytes": 50000,
+  "rpMaxAgeHours": 1
+}
+```
+
+The field `rpFrequencySecs` specifies rotation period, in seconds. In this example, `rpFrequencySecs` is `30`, which means that rotation check will be performed every 30 seconds.
+
+The field `rpLogLimitBytes` specifies the maximum size of the log file, in bytes. In this example, `rpLogLimitBytes` is `50000`, which means that once the size of the current log file is 50 KB, the new log file will be created.
+
+The field `rpKeepFilesNum` specifies the number of the log files that will be kept. In this example, `rpKeepFilesNum` is `3`, which means that 3 _last_ log files will always be kept.
+
+The field `rpMaxAgeHours` specifies the lifetime of the log file, in hours. In this example, `rpMaxAgeHours` is `1`, which means that each log file will be kept for 1 hour only. After that, the log file is treated as outdated and will be deleted. Please note that N _last_ log files (specified by `rpKeepFilesNum`) will be kept even if they are outdated.
+
+## Prometheus
+
+The optional field `hasPrometheus` specifies the host and port of the web page with metrics. For example:
+
+```
+"hasPrometheus": {
+  "epHost": "127.0.0.1",
+  "epPort": 3000
+}
+```
+
+Here the web page is available at `http://127.0.0.1:3000`. Please note that if you skip this field, the web page will not be available.
+
+After you open `http://127.0.0.1:3000` in your browser, you will see the list of identifiers of connected nodes (or the warning message, if there are no connected nodes yet), for example:
+
+```
+* tmp-cardano-tracer.sock@0
+* tmp-cardano-tracer.sock@1
+* tmp-cardano-tracer.sock@2
+```
+
+Each identifier is a hyperlink to the page where you will see the **current** list of metrics received from the corresponding node, in such a format:
+
+```
+rts_gc_par_tot_bytes_copied 0
+rts_gc_num_gcs 2
+rts_gc_max_bytes_slop 15880
+rts_gc_num_bytes_usage_samples 1
+rts_gc_wall_ms 4005
+...
+rts_gc_par_max_bytes_copied 0
+rts_gc_mutator_cpu_ms 57
+rts_gc_mutator_wall_ms 4004
+rts_gc_gc_cpu_ms 1
+rts_gc_cumulative_bytes_used 184824
+```
+
+## EKG Monitoring
+
+The optional field `hasEKG` specifies the hosts and ports of two web pages:
+
+1. the list of identifiers of connected nodes,
+2. EKG monitoring page.
+
+For example:
+
+```
+"hasEKG": [
+  {
+    "epHost": "127.0.0.1",
+    "epPort": 3100
+  },
+  {
+    "epHost": "127.0.0.1",
+    "epPort": 3101
+  }
+]
+```
+
+The page with the list of identifiers of connected nodes will be available at `http://127.0.0.1:3100`, for example:
+
+```
+* tmp-cardano-tracer.sock@0
+* tmp-cardano-tracer.sock@1
+* tmp-cardano-tracer.sock@2
+```
+
+Each identifier is a hyperlink, after clicking to it you will be redirected to `http://127.0.0.1:3101` where you will see EKG monitoring page for corresponding node.
+
+## Verbosity
+
+The optional field `verbosity` specifies the verbosity level for the `cardano-tracer` itself. There are 3 levels:
+
+1. `Minimum` - `cardano-tracer` will work as silently as possible.
+2. `ErrorsOnly` - messages about problems will be shown in standard output.
+3. `Maximum` - all the messages will be shown in standard output. **Caution**: the number of messages can be huge.
+
+Please note that if you skip this field, `ErrorsOnly` verbosity will be used by default.

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Tracer.Acceptors.Client
+  ( runAcceptorsClient
+  ) where
+
+import           Codec.CBOR.Term (Term)
+import           Control.Concurrent.Extra (Lock)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Void (Void)
+import           Data.Word (Word32)
+
+import           Cardano.Logging (TraceObject)
+import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
+                   forwardingCodecCBORTerm, forwardingVersionCodec)
+import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
+                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
+                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
+import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
+import           Ouroboros.Network.IOManager (withIOManager)
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
+                   localAddressFromPath, localSnocket)
+import           Ouroboros.Network.Socket (ConnectionId (..), connectToNode,
+                   nullNetworkConnectTracers)
+import           Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
+                   codecHandshake, noTimeLimitsHandshake)
+import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
+import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
+                   simpleSingletonVersions)
+import qualified System.Metrics.Configuration as EKGF
+import           System.Metrics.Network.Acceptor (acceptEKGMetricsInit)
+
+import qualified Trace.Forward.Configuration.DataPoint as DPF
+import qualified Trace.Forward.Configuration.TraceObject as TF
+import           Trace.Forward.Run.DataPoint.Acceptor (acceptDataPointsInit)
+import           Trace.Forward.Run.TraceObject.Acceptor (acceptTraceObjectsInit)
+
+import           Cardano.Tracer.Acceptors.Utils (prepareDataPointRequestor,
+                   prepareMetricsStores, removeDisconnectedNode)
+import qualified Cardano.Tracer.Configuration as TC
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes, DataPointRequestors)
+import           Cardano.Tracer.Utils (connIdToNodeId)
+
+runAcceptorsClient
+  :: TC.TracerConfig
+  -> FilePath
+  -> ( EKGF.AcceptorConfiguration
+     , TF.AcceptorConfiguration TraceObject
+     , DPF.AcceptorConfiguration
+     )
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> DataPointRequestors
+  -> Lock
+  -> IO ()
+runAcceptorsClient config p (ekgConfig, tfConfig, dpfConfig)
+                   connectedNodes acceptedMetrics dpRequestors currentLogLock = withIOManager $ \iocp ->
+  doConnectToForwarder
+    (localSnocket iocp)
+    (localAddressFromPath p)
+    (TC.networkMagic config)
+    noTimeLimitsHandshake $
+    -- Please note that we always run all the supported protocols,
+    -- there is no mechanism to disable some of them.
+    appInitiator
+      [ (runEKGAcceptorInit ekgConfig connectedNodes acceptedMetrics errorHandler, 1)
+      , (runTraceObjectsAcceptorInit config tfConfig currentLogLock  errorHandler, 2)
+      , (runDataPointsAcceptorInit dpfConfig connectedNodes dpRequestors errorHandler, 3)
+      ]
+ where
+  appInitiator protocolsWithNums =
+    OuroborosApplication $ \connectionId _shouldStopSTM ->
+      [ MiniProtocol
+         { miniProtocolNum    = MiniProtocolNum num
+         , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
+         , miniProtocolRun    = protocol connectionId
+         }
+      | (protocol, num) <- protocolsWithNums
+      ]
+  errorHandler = removeDisconnectedNode connectedNodes acceptedMetrics dpRequestors
+
+doConnectToForwarder
+  :: Snocket IO LocalSocket LocalAddress
+  -> LocalAddress
+  -> Word32
+  -> ProtocolTimeLimits (Handshake ForwardingVersion Term)
+  -> OuroborosApplication 'InitiatorMode LocalAddress LBS.ByteString IO () Void
+  -> IO ()
+doConnectToForwarder snocket address netMagic timeLimits app =
+  connectToNode
+    snocket
+    (codecHandshake forwardingVersionCodec)
+    timeLimits
+    (cborTermVersionDataCodec forwardingCodecCBORTerm)
+    nullNetworkConnectTracers
+    acceptableVersion
+    (simpleSingletonVersions
+       ForwardingV_1
+       (ForwardingVersionData $ NetworkMagic netMagic)
+       app
+    )
+    Nothing
+    address
+
+runEKGAcceptorInit
+  :: EKGF.AcceptorConfiguration
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'InitiatorMode LBS.ByteString IO () Void
+runEKGAcceptorInit ekgConfig connectedNodes acceptedMetrics errorHandler connId =
+  acceptEKGMetricsInit
+    ekgConfig
+    (prepareMetricsStores connectedNodes acceptedMetrics connId)
+    (errorHandler connId)
+
+runTraceObjectsAcceptorInit
+  :: TC.TracerConfig
+  -> TF.AcceptorConfiguration TraceObject
+  -> Lock
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'InitiatorMode LBS.ByteString IO () Void
+runTraceObjectsAcceptorInit config tfConfig currentLogLock errorHandler connId =
+  acceptTraceObjectsInit
+    tfConfig
+    (traceObjectsHandler config (connIdToNodeId connId) currentLogLock)
+    (errorHandler connId)
+
+runDataPointsAcceptorInit
+  :: DPF.AcceptorConfiguration
+  -> ConnectedNodes
+  -> DataPointRequestors
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'InitiatorMode LBS.ByteString IO () Void
+runDataPointsAcceptorInit dpfConfig connectedNodes dpRequestors errorHandler connId =
+  acceptDataPointsInit
+    dpfConfig
+    (prepareDataPointRequestor connectedNodes dpRequestors connId)
+    (errorHandler connId)

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
@@ -56,19 +56,20 @@ runAcceptorsClient
   -> Lock
   -> IO ()
 runAcceptorsClient config p (ekgConfig, tfConfig, dpfConfig)
-                   connectedNodes acceptedMetrics dpRequestors currentLogLock = withIOManager $ \iocp ->
-  doConnectToForwarder
-    (localSnocket iocp)
-    (localAddressFromPath p)
-    (TC.networkMagic config)
-    noTimeLimitsHandshake $
-    -- Please note that we always run all the supported protocols,
-    -- there is no mechanism to disable some of them.
-    appInitiator
-      [ (runEKGAcceptorInit ekgConfig connectedNodes acceptedMetrics errorHandler, 1)
-      , (runTraceObjectsAcceptorInit config tfConfig currentLogLock  errorHandler, 2)
-      , (runDataPointsAcceptorInit dpfConfig connectedNodes dpRequestors errorHandler, 3)
-      ]
+                   connectedNodes acceptedMetrics dpRequestors currentLogLock =
+  withIOManager $ \iocp ->
+    doConnectToForwarder
+      (localSnocket iocp)
+      (localAddressFromPath p)
+      (TC.networkMagic config)
+      noTimeLimitsHandshake $
+      -- Please note that we always run all the supported protocols,
+      -- there is no mechanism to disable some of them.
+      appInitiator
+        [ (runEKGAcceptorInit ekgConfig connectedNodes acceptedMetrics errorHandler, 1)
+        , (runTraceObjectsAcceptorInit config tfConfig currentLogLock  errorHandler, 2)
+        , (runDataPointsAcceptorInit dpfConfig connectedNodes dpRequestors errorHandler, 3)
+        ]
  where
   appInitiator protocolsWithNums =
     OuroborosApplication $ \connectionId _shouldStopSTM ->

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Run.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PackageImports #-}
+
+module Cardano.Tracer.Acceptors.Run
+  ( runAcceptors
+  ) where
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Concurrent.Extra (Lock)
+import           "contra-tracer" Control.Tracer (Tracer, contramap, nullTracer,
+                   stdoutTracer)
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (fromMaybe)
+import           Data.Time.Clock (secondsToNominalDiffTime)
+
+import qualified System.Metrics.Configuration as EKGF
+import qualified System.Metrics.ReqResp as EKGF
+
+import qualified Trace.Forward.Configuration.DataPoint as DPF
+import qualified Trace.Forward.Configuration.TraceObject as TOF
+import qualified Trace.Forward.Protocol.TraceObject.Type as TOF
+
+import           Cardano.Tracer.Acceptors.Client (runAcceptorsClient)
+import           Cardano.Tracer.Acceptors.Server (runAcceptorsServer)
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes,
+                   DataPointRequestors, ProtocolsBrake)
+import           Cardano.Tracer.Utils (runInLoop)
+
+-- | Run acceptors for all supported protocols.
+--
+--   There are two "network modes" for acceptors:
+--   1. Server mode, when the tracer accepts connections from any number of nodes.
+--   2. Client mode, when the tracer initiates connections to specified number of nodes.
+runAcceptors
+  :: TracerConfig
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> DataPointRequestors
+  -> ProtocolsBrake
+  -> Lock
+  -> IO ()
+runAcceptors c@TracerConfig{network, ekgRequestFreq, loRequestNum, verbosity}
+             connectedNodes acceptedMetrics dpRequestors stopIt currentLogLock =
+  case network of
+    AcceptAt (LocalSocket p) ->
+      -- Run one server that accepts connections from the nodes.
+      runInLoop
+        (runAcceptorsServer c p (acceptorsConfigs p) connectedNodes
+                            acceptedMetrics dpRequestors currentLogLock)
+        verbosity p 1
+    ConnectTo localSocks ->
+      -- Run N clients that initiate connections to the nodes.
+      forConcurrently_ (NE.nub localSocks) $ \(LocalSocket p) ->
+        runInLoop
+          (runAcceptorsClient c p (acceptorsConfigs p) connectedNodes
+                              acceptedMetrics dpRequestors currentLogLock)
+          verbosity p 1
+ where
+  acceptorsConfigs p =
+    ( EKGF.AcceptorConfiguration
+        { EKGF.acceptorTracer    = mkVerbosity verbosity
+        , EKGF.forwarderEndpoint = EKGF.LocalPipe p
+        , EKGF.requestFrequency  = secondsToNominalDiffTime $ fromMaybe 1.0 ekgRequestFreq
+        , EKGF.whatToRequest     = EKGF.GetAllMetrics
+        , EKGF.shouldWeStop      = stopIt
+        }
+    , TOF.AcceptorConfiguration
+        { TOF.acceptorTracer    = mkVerbosity verbosity
+        , TOF.forwarderEndpoint = p
+        , TOF.whatToRequest     = TOF.NumberOfTraceObjects $ fromMaybe 100 loRequestNum
+        , TOF.shouldWeStop      = stopIt
+        }
+    , DPF.AcceptorConfiguration
+        { DPF.acceptorTracer    = mkVerbosity verbosity
+        , DPF.forwarderEndpoint = p
+        , DPF.shouldWeStop      = stopIt
+        }
+    )
+
+  mkVerbosity :: Show a => Maybe Verbosity -> Tracer IO a
+  mkVerbosity (Just Maximum) = contramap show stdoutTracer
+  mkVerbosity _              = nullTracer

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Tracer.Acceptors.Server
+  ( runAcceptorsServer
+  ) where
+
+import           Codec.CBOR.Term (Term)
+import           Control.Concurrent.Async (race_, wait)
+import           Control.Concurrent.Extra (Lock)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Void (Void)
+import           Data.Word (Word32)
+
+import           Cardano.Logging (TraceObject)
+import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
+                   forwardingCodecCBORTerm, forwardingVersionCodec)
+import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
+                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
+                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
+import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
+import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
+import           Ouroboros.Network.IOManager (withIOManager)
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
+                   localAddressFromPath, localSnocket)
+import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..), ConnectionId (..),
+                   SomeResponderApplication (..), cleanNetworkMutableState,
+                   newNetworkMutableState, nullNetworkServerTracers, withServerNode)
+import           Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
+                   codecHandshake, noTimeLimitsHandshake)
+import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
+import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
+                   simpleSingletonVersions)
+import qualified System.Metrics.Configuration as EKGF
+import           System.Metrics.Network.Acceptor (acceptEKGMetricsResp)
+
+import qualified Trace.Forward.Configuration.DataPoint as DPF
+import qualified Trace.Forward.Configuration.TraceObject as TF
+import           Trace.Forward.Run.DataPoint.Acceptor (acceptDataPointsResp)
+import           Trace.Forward.Run.TraceObject.Acceptor (acceptTraceObjectsResp)
+
+import           Cardano.Tracer.Acceptors.Utils (prepareDataPointRequestor,
+                   prepareMetricsStores, removeDisconnectedNode)
+import qualified Cardano.Tracer.Configuration as TC
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes, DataPointRequestors)
+import           Cardano.Tracer.Utils (connIdToNodeId)
+
+runAcceptorsServer
+  :: TC.TracerConfig
+  -> FilePath
+  -> ( EKGF.AcceptorConfiguration
+     , TF.AcceptorConfiguration TraceObject
+     , DPF.AcceptorConfiguration
+     )
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> DataPointRequestors
+  -> Lock
+  -> IO ()
+runAcceptorsServer config p (ekgConfig, tfConfig, dpfConfig)
+                   connectedNodes acceptedMetrics dpRequestors currentLogLock = withIOManager $ \iocp ->
+  doListenToForwarder
+    (localSnocket iocp)
+    (localAddressFromPath p)
+    (TC.networkMagic config)
+    noTimeLimitsHandshake $
+    -- Please note that we always run all the supported protocols,
+    -- there is no mechanism to disable some of them.
+    appResponder
+      [ (runEKGAcceptor ekgConfig connectedNodes acceptedMetrics errorHandler, 1)
+      , (runTraceObjectsAcceptor config tfConfig currentLogLock  errorHandler, 2)
+      , (runDataPointsAcceptor dpfConfig connectedNodes dpRequestors errorHandler, 3)
+      ]
+ where
+  appResponder protocolsWithNums =
+    OuroborosApplication $ \connectionId _shouldStopSTM ->
+      [ MiniProtocol
+         { miniProtocolNum    = MiniProtocolNum num
+         , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
+         , miniProtocolRun    = protocol connectionId
+         }
+      | (protocol, num) <- protocolsWithNums
+      ]
+  errorHandler = removeDisconnectedNode connectedNodes acceptedMetrics dpRequestors
+
+doListenToForwarder
+  :: Snocket IO LocalSocket LocalAddress
+  -> LocalAddress
+  -> Word32
+  -> ProtocolTimeLimits (Handshake ForwardingVersion Term)
+  -> OuroborosApplication 'ResponderMode LocalAddress LBS.ByteString IO Void ()
+  -> IO ()
+doListenToForwarder snocket address netMagic timeLimits app = do
+  networkState <- newNetworkMutableState
+  race_ (cleanNetworkMutableState networkState)
+        $ withServerNode
+            snocket
+            nullNetworkServerTracers
+            networkState
+            (AcceptedConnectionsLimit maxBound maxBound 0)
+            address
+            (codecHandshake forwardingVersionCodec)
+            timeLimits
+            (cborTermVersionDataCodec forwardingCodecCBORTerm)
+            acceptableVersion
+            (simpleSingletonVersions
+              ForwardingV_1
+              (ForwardingVersionData $ NetworkMagic netMagic)
+              (SomeResponderApplication app)
+            )
+            nullErrorPolicies
+            $ \_ serverAsync -> wait serverAsync -- Block until async exception.
+
+runEKGAcceptor
+  :: EKGF.AcceptorConfiguration
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'ResponderMode LBS.ByteString IO Void ()
+runEKGAcceptor ekgConfig connectedNodes acceptedMetrics errorHandler connId =
+  acceptEKGMetricsResp
+    ekgConfig
+    (prepareMetricsStores connectedNodes acceptedMetrics connId)
+    (errorHandler connId)
+
+runTraceObjectsAcceptor
+  :: TC.TracerConfig
+  -> TF.AcceptorConfiguration TraceObject
+  -> Lock
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'ResponderMode LBS.ByteString IO Void ()
+runTraceObjectsAcceptor config tfConfig currentLogLock errorHandler connId =
+  acceptTraceObjectsResp
+    tfConfig
+    (traceObjectsHandler config (connIdToNodeId connId) currentLogLock)
+    (errorHandler connId)
+
+runDataPointsAcceptor
+  :: DPF.AcceptorConfiguration
+  -> ConnectedNodes
+  -> DataPointRequestors
+  -> (ConnectionId LocalAddress -> IO ())
+  -> ConnectionId LocalAddress
+  -> RunMiniProtocol 'ResponderMode LBS.ByteString IO Void ()
+runDataPointsAcceptor dpfConfig connectedNodes dpRequestors errorHandler connId =
+  acceptDataPointsResp
+    dpfConfig
+    (prepareDataPointRequestor connectedNodes dpRequestors connId)
+    (errorHandler connId)

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Utils.hs
@@ -1,0 +1,67 @@
+module Cardano.Tracer.Acceptors.Utils
+  ( prepareDataPointRequestor
+  , prepareMetricsStores
+  , removeDisconnectedNode
+  ) where
+
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (TVar, newTVarIO, modifyTVar')
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified System.Metrics as EKG
+
+import           Ouroboros.Network.Snocket (LocalAddress)
+import           Ouroboros.Network.Socket (ConnectionId (..))
+import           System.Metrics.Store.Acceptor (MetricsLocalStore, emptyMetricsLocalStore)
+import           Trace.Forward.Utils.DataPoint (DataPointRequestor, initDataPointRequestor)
+
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes, DataPointRequestors)
+import           Cardano.Tracer.Utils (connIdToNodeId)
+
+prepareDataPointRequestor
+  :: ConnectedNodes
+  -> DataPointRequestors
+  -> ConnectionId LocalAddress
+  -> IO DataPointRequestor
+prepareDataPointRequestor connectedNodes dpRequestors connId = do
+  addConnectedNode connectedNodes connId
+  dpRequestor <- initDataPointRequestor
+  atomically $
+    modifyTVar' dpRequestors $ M.insert (connIdToNodeId connId) dpRequestor
+  return dpRequestor
+
+prepareMetricsStores
+  :: ConnectedNodes
+  -> AcceptedMetrics
+  -> ConnectionId LocalAddress
+  -> IO (EKG.Store, TVar MetricsLocalStore)
+prepareMetricsStores connectedNodes acceptedMetrics connId = do
+  addConnectedNode connectedNodes connId
+  storesForNewNode <- (,) <$> EKG.newStore
+                          <*> newTVarIO emptyMetricsLocalStore
+  atomically $
+    modifyTVar' acceptedMetrics $ M.insert (connIdToNodeId connId) storesForNewNode
+  return storesForNewNode
+
+addConnectedNode
+  :: ConnectedNodes
+  -> ConnectionId LocalAddress
+  -> IO ()
+addConnectedNode connectedNodes connId = atomically $
+  modifyTVar' connectedNodes $ S.insert (connIdToNodeId connId)
+
+-- | This handler is called when 'runPeer' function throws an exception,
+--   which means that there is a problem with network connection.
+removeDisconnectedNode
+  :: ConnectedNodes
+  -> AcceptedMetrics
+  -> DataPointRequestors
+  -> ConnectionId LocalAddress
+  -> IO ()
+removeDisconnectedNode connectedNodes acceptedMetrics dpRequestors connId = atomically $ do
+  -- Remove all the stuff related to disconnected node.
+  modifyTVar' connectedNodes  $ S.delete nodeId
+  modifyTVar' acceptedMetrics $ M.delete nodeId
+  modifyTVar' dpRequestors    $ M.delete nodeId
+ where
+  nodeId = connIdToNodeId connId

--- a/cardano-tracer/src/Cardano/Tracer/CLI.hs
+++ b/cardano-tracer/src/Cardano/Tracer/CLI.hs
@@ -1,0 +1,22 @@
+module Cardano.Tracer.CLI
+  ( TracerParams (..)
+  , parseTracerParams
+  ) where
+
+import           Options.Applicative
+
+-- | CLI parameters required for the tracer.
+newtype TracerParams = TracerParams
+  { tracerConfig :: FilePath
+  }
+
+-- | Parse CLI parameters for the tracer.
+parseTracerParams :: Parser TracerParams
+parseTracerParams = TracerParams <$>
+  strOption
+    (    long "config"
+      <> short 'c'
+      <> metavar "FILEPATH"
+      <> help "Configuration file for cardano-tracer"
+      <> completer (bashCompleter "file")
+    )

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tracer.Configuration
+  ( Address (..)
+  , Endpoint (..)
+  , LogFormat (..)
+  , LogMode (..)
+  , LoggingParams (..)
+  , Network (..)
+  , RotationParams (..)
+  , TracerConfig (..)
+  , Verbosity (..)
+  , readTracerConfig
+  ) where
+
+import           Data.Aeson (FromJSON)
+import           Data.Fixed (Pico)
+import           Data.List (intercalate)
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.List.Extra (notNull)
+import           Data.Maybe (catMaybes)
+import           Data.Word (Word16, Word32, Word64)
+import           Data.Yaml (decodeFileEither)
+import           GHC.Generics (Generic)
+import           System.Exit (die)
+
+-- | Only local socket is supported, to avoid unauthorized connections.
+newtype Address = LocalSocket FilePath
+  deriving (Eq, Generic, FromJSON, Show)
+
+-- | Endpoint for internal services.
+data Endpoint = Endpoint
+  { epHost :: !String
+  , epPort :: !Word16
+  } deriving (Eq, Generic, FromJSON, Show)
+
+-- | Parameters of rotation mechanism for logs.
+data RotationParams = RotationParams
+  { rpFrequencySecs :: !Word32  -- ^ Rotation period, in seconds.
+  , rpLogLimitBytes :: !Word64  -- ^ Max size of log file in bytes.
+  , rpMaxAgeHours   :: !Word16  -- ^ Max age of log file in hours.
+  , rpKeepFilesNum  :: !Word32  -- ^ Number of log files to keep in any case.
+  } deriving (Eq, Generic, FromJSON, Show)
+
+-- | Logging mode.
+data LogMode
+  = FileMode    -- ^ Store items in log file.
+  | JournalMode -- ^ Store items in Linux journal service.
+  deriving (Eq, Generic, FromJSON, Show)
+
+-- | Format of log files.
+data LogFormat
+  = ForHuman   -- ^ For human (text)
+  | ForMachine -- ^ For machine (JSON)
+  deriving (Eq, Generic, FromJSON, Show)
+
+-- | Logging parameters.
+data LoggingParams = LoggingParams
+  { logRoot   :: !FilePath  -- ^ Root directory where all subdirs with logs are created.
+  , logMode   :: !LogMode   -- ^ Log mode.
+  , logFormat :: !LogFormat -- ^ Log format.
+  } deriving (Eq, Generic, FromJSON, Show)
+
+-- | Connection mode.
+data Network
+  = AcceptAt  !Address            -- ^ Server mode: accepts connections.
+  | ConnectTo !(NonEmpty Address) -- ^ Client mode: initiates connections.
+  deriving (Eq, Generic, FromJSON, Show)
+
+-- | Tracer's verbosity.
+data Verbosity
+  = Minimum    -- ^ Display minimum of messages.
+  | ErrorsOnly -- ^ Display errors only.
+  | Maximum    -- ^ Display all the messages (protocols tracing, errors).
+  deriving (Eq, Generic, FromJSON, Show)
+
+-- | Tracer configuration.
+data TracerConfig = TracerConfig
+  { networkMagic   :: !Word32                       -- ^ Network magic from genesis the node is launched with.
+  , network        :: !Network                      -- ^ How cardano-tracer will be connected to node(s).
+  , loRequestNum   :: !(Maybe Word16)               -- ^ How many 'TraceObject's will be asked in each request.
+  , ekgRequestFreq :: !(Maybe Pico)                 -- ^ How often to request for EKG-metrics, in seconds.
+  , hasEKG         :: !(Maybe (Endpoint, Endpoint)) -- ^ Endpoint for EKG web-page (list of nodes, monitoring).
+  , hasPrometheus  :: !(Maybe Endpoint)             -- ^ Endpoint for Promeheus web-page.
+  , logging        :: !(NonEmpty LoggingParams)     -- ^ Logging parameters.
+  , rotation       :: !(Maybe RotationParams)       -- ^ Rotation parameters.
+  , verbosity      :: !(Maybe Verbosity)            -- ^ Verbosity of the tracer itself.
+  } deriving (Eq, Generic, FromJSON, Show)
+
+-- | Read the tracer's configuration file.
+readTracerConfig :: FilePath -> IO TracerConfig
+readTracerConfig pathToConfig =
+  decodeFileEither pathToConfig >>= \case
+    Left e -> die $ "Invalid tracer's configuration: " <> show e
+    Right (config :: TracerConfig) ->
+      case checkMeaninglessValues config of
+        Left problems -> die $ "Tracer's configuration is meaningless: " <> problems
+        Right _ -> return config
+
+checkMeaninglessValues :: TracerConfig -> Either String ()
+checkMeaninglessValues TracerConfig{network, hasEKG, hasPrometheus, logging} =
+  if null problems
+    then Right ()
+    else Left $ intercalate ", " problems
+ where
+  problems = catMaybes
+    [ case network of
+        AcceptAt addr -> check "AcceptAt is empty" $ nullAddress addr
+        ConnectTo addrs -> check "ConnectTo are empty" $ null . NE.filter (not . nullAddress) $ addrs
+    , check "empty logRoot(s)" $ notNull . NE.filter invalidFileMode $ logging
+    , (check "no host(s) in hasEKG" . nullEndpoints) =<< hasEKG
+    , (check "no host in hasPrometheus" . nullEndpoint) =<< hasPrometheus
+    ]
+
+  check msg cond = if cond then Just msg else Nothing
+
+  nullAddress (LocalSocket p) = null p
+
+  nullEndpoint (Endpoint h _) = null h
+
+  nullEndpoints (ep1, ep2) = nullEndpoint ep1 || nullEndpoint ep2
+
+  invalidFileMode (LoggingParams root FileMode    _) = null root
+  invalidFileMode (LoggingParams _    JournalMode _) = False

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
@@ -12,7 +12,7 @@ module Cardano.Tracer.Handlers.Logs.File
 
 import           Control.Concurrent.Extra (Lock, withLock)
 import           Control.Monad (unless)
-import           Control.Monad.Extra (ifM, unlessM)
+import           Control.Monad.Extra (ifM)
 import           Data.Aeson (ToJSON, (.=), object, toJSON)
 import           Data.Aeson.Text (encodeToLazyText)
 import qualified Data.ByteString as BS
@@ -25,14 +25,14 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import           Data.Time.Clock (UTCTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
-import           System.Directory (doesFileExist, createDirectoryIfMissing, removeFile)
+import           System.Directory
+import           System.Directory.Extra (listFiles)
 import           System.FilePath ((</>))
 
 import           Cardano.Logging (Namespace, TraceObject (..))
 
 import           Cardano.Tracer.Configuration (LogFormat (..))
-import           Cardano.Tracer.Handlers.Logs.Utils (createLogAndSymLink,
-                   doesSymLinkValid, symLinkName)
+import           Cardano.Tracer.Handlers.Logs.Utils (createLogAndSymLink, isItLog)
 import           Cardano.Tracer.Types (NodeId (..))
 
 -- | Append the list of 'TraceObject's to the latest log via symbolic link.
@@ -51,7 +51,7 @@ writeTraceObjectsToFile
 writeTraceObjectsToFile nodeId currentLogLock rootDir ForHuman traceObjects = do
   let itemsToWrite = mapMaybe traceObjectToText traceObjects
   unless (null itemsToWrite) $ do
-    pathToCurrentLog <- prepareLogsStructure nodeId rootDir ForHuman
+    pathToCurrentLog <- getPathToCurrentlog nodeId rootDir ForHuman
     let preparedLine = TE.encodeUtf8 $ T.concat itemsToWrite
     withLock currentLogLock $
       BS.appendFile pathToCurrentLog preparedLine
@@ -59,12 +59,12 @@ writeTraceObjectsToFile nodeId currentLogLock rootDir ForHuman traceObjects = do
 writeTraceObjectsToFile nodeId currentLogLock rootDir ForMachine traceObjects = do
   let itemsToWrite = mapMaybe traceObjectToJSON traceObjects
   unless (null itemsToWrite) $ do
-    pathToCurrentLog <- prepareLogsStructure nodeId rootDir ForMachine
+    pathToCurrentLog <- getPathToCurrentlog nodeId rootDir ForMachine
     let preparedLine = TLE.encodeUtf8 $ TL.concat itemsToWrite
     withLock currentLogLock $
       LBS.appendFile pathToCurrentLog preparedLine
 
--- | Prepare the structure for the log files:
+-- | Returns the path to the current log. Prepares the structure for the log files if needed:
 --
 --   /rootDir
 --     /subDirForNode1
@@ -75,25 +75,29 @@ writeTraceObjectsToFile nodeId currentLogLock rootDir ForMachine traceObjects = 
 --     /subDirForNodeN
 --       logs from node N
 --
-prepareLogsStructure
+getPathToCurrentlog
   :: NodeId
   -> FilePath
   -> LogFormat
   -> IO FilePath
-prepareLogsStructure (NodeId anId) rootDir format = do
-  ifM (doesFileExist pathToCurrentLog)
-    (unlessM (doesSymLinkValid pathToCurrentLog) $ do
-      removeFile pathToCurrentLog
-      createLogAndSymLink subDirForLogs format)
-    $ do
-      -- The root directory (as a parent for subDirForLogs) will be created as well if needed.
-      createDirectoryIfMissing True subDirForLogs
-      createLogAndSymLink subDirForLogs format
-  return pathToCurrentLog
+getPathToCurrentlog (NodeId anId) rootDir format =
+  ifM (doesDirectoryExist subDirForLogs)
+    getPathToCurrentLogIfExists
+    prepareLogsStructure
  where
   subDirForLogs = rootDir </> T.unpack anId
-  -- This is a symlink to the current log file, please see rotation parameters.
-  pathToCurrentLog = subDirForLogs </> symLinkName format
+
+  getPathToCurrentLogIfExists = do
+    logsWeNeed <- filter (isItLog format) <$> listFiles subDirForLogs
+    if null logsWeNeed
+      then createLogAndSymLink subDirForLogs format
+      -- We can sort the logs by timestamp, the biggest one is the latest one.
+      else return $ subDirForLogs </> maximum logsWeNeed
+
+  prepareLogsStructure = do
+    -- The root directory (as a parent for subDirForLogs) will be created as well if needed.
+    createDirectoryIfMissing True subDirForLogs
+    createLogAndSymLink subDirForLogs format
 
 nl :: T.Text
 #ifdef UNIX

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
+
+module Cardano.Tracer.Handlers.Logs.File
+  ( writeTraceObjectsToFile
+  ) where
+
+import           Control.Concurrent.Extra (Lock, withLock)
+import           Control.Monad (unless)
+import           Control.Monad.Extra (ifM, unlessM)
+import           Data.Aeson (ToJSON, (.=), object, toJSON)
+import           Data.Aeson.Text (encodeToLazyText)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Char (isDigit)
+import           Data.Maybe (mapMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+import           Data.Time.Clock (UTCTime)
+import           Data.Time.Format (defaultTimeLocale, formatTime)
+import           System.Directory (doesFileExist, createDirectoryIfMissing, removeFile)
+import           System.FilePath ((</>))
+
+import           Cardano.Logging (Namespace, TraceObject (..))
+
+import           Cardano.Tracer.Configuration (LogFormat (..))
+import           Cardano.Tracer.Handlers.Logs.Utils (createLogAndSymLink,
+                   doesSymLinkValid, symLinkName)
+import           Cardano.Tracer.Types (NodeId (..))
+
+-- | Append the list of 'TraceObject's to the latest log via symbolic link.
+--
+-- It is technically possible that, during writing in the current log,
+-- the rotator's thread will check if the current log is full and, if so,
+-- the symbolic link will be switched to the new log file and writing can
+-- be interrupted. To prevent it, we use 'Lock'.
+writeTraceObjectsToFile
+  :: NodeId
+  -> Lock
+  -> FilePath
+  -> LogFormat
+  -> [TraceObject]
+  -> IO ()
+writeTraceObjectsToFile nodeId currentLogLock rootDir ForHuman traceObjects = do
+  let itemsToWrite = mapMaybe traceObjectToText traceObjects
+  unless (null itemsToWrite) $ do
+    pathToCurrentLog <- prepareLogsStructure nodeId rootDir ForHuman
+    let preparedLine = TE.encodeUtf8 $ T.concat itemsToWrite
+    withLock currentLogLock $
+      BS.appendFile pathToCurrentLog preparedLine
+
+writeTraceObjectsToFile nodeId currentLogLock rootDir ForMachine traceObjects = do
+  let itemsToWrite = mapMaybe traceObjectToJSON traceObjects
+  unless (null itemsToWrite) $ do
+    pathToCurrentLog <- prepareLogsStructure nodeId rootDir ForMachine
+    let preparedLine = TLE.encodeUtf8 $ TL.concat itemsToWrite
+    withLock currentLogLock $
+      LBS.appendFile pathToCurrentLog preparedLine
+
+-- | Prepare the structure for the log files:
+--
+--   /rootDir
+--     /subDirForNode1
+--       logs from node 1
+--     /subDirForNode2
+--       logs from node 2
+--     ...
+--     /subDirForNodeN
+--       logs from node N
+--
+prepareLogsStructure
+  :: NodeId
+  -> FilePath
+  -> LogFormat
+  -> IO FilePath
+prepareLogsStructure (NodeId anId) rootDir format = do
+  ifM (doesFileExist pathToCurrentLog)
+    (unlessM (doesSymLinkValid pathToCurrentLog) $ do
+      removeFile pathToCurrentLog
+      createLogAndSymLink subDirForLogs format)
+    $ do
+      -- The root directory (as a parent for subDirForLogs) will be created as well if needed.
+      createDirectoryIfMissing True subDirForLogs
+      createLogAndSymLink subDirForLogs format
+  return pathToCurrentLog
+ where
+  subDirForLogs = rootDir </> T.unpack anId
+  -- This is a symlink to the current log file, please see rotation parameters.
+  pathToCurrentLog = subDirForLogs </> symLinkName format
+
+nl :: T.Text
+#ifdef UNIX
+nl = "\n"
+#else
+nl = "\r\n"
+#endif
+
+traceObjectToText :: TraceObject -> Maybe T.Text
+traceObjectToText TraceObject{toHuman, toHostname, toNamespace, toSeverity, toThreadId, toTimestamp} =
+  case toHuman of
+    Nothing -> Nothing
+    Just msgForHuman -> Just $
+      "[" <> host <> ":" <> name <> ":" <> sev <> ":" <> thId <> "] [" <> time <> "] "
+      <> msgForHuman <> nl
+ where
+  host = T.pack toHostname
+  name = mkName toNamespace
+  sev  = T.pack $ show toSeverity
+  thId = T.filter isDigit toThreadId
+  time = T.pack $ formatTime defaultTimeLocale "%F %T%2Q %Z" toTimestamp
+
+mkName :: Namespace -> T.Text
+mkName []    = "noname"
+mkName names = T.intercalate "." names
+
+-- | The type for converting 'TraceObject' to JSON.
+data TraceObjectForJSON = TraceObjectForJSON
+  { jAt   :: !UTCTime
+  , jNS   :: !T.Text
+  , jData :: !T.Text
+  , jHost :: !T.Text
+  , jSev  :: !T.Text
+  , jTId  :: !T.Text
+  }
+
+instance ToJSON TraceObjectForJSON where
+  toJSON toJ = object
+    [ "at"     .= formatTime defaultTimeLocale "%FT%T%2Q%Z" (jAt toJ)
+    , "ns"     .= jNS toJ
+    , "data"   .= jData toJ
+    , "host"   .= jHost toJ
+    , "sev"    .= jSev toJ
+    , "thread" .= jTId toJ
+    ]
+
+traceObjectToJSON :: TraceObject -> Maybe TL.Text
+traceObjectToJSON TraceObject{toMachine, toTimestamp, toNamespace, toHostname, toSeverity, toThreadId} =
+  case toMachine of
+    Nothing -> Nothing
+    Just msgForMachine -> Just . TL.append (TL.fromStrict nl) . encodeToLazyText $
+      TraceObjectForJSON
+        { jAt   = toTimestamp
+        , jNS   = mkName toNamespace
+        , jData = msgForMachine
+        , jHost = T.pack toHostname
+        , jSev  = T.pack $ show toSeverity
+        , jTId  = T.filter isDigit toThreadId
+        }

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+#if defined(linux_HOST_OS)
+#define LINUX
+#endif
+
+module Cardano.Tracer.Handlers.Logs.Journal
+  ( writeTraceObjectsToJournal
+  ) where
+
+#ifdef LINUX
+import           Data.Char (isDigit)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import           Data.Text.Encoding (encodeUtf8)
+import           Data.Time.Format (defaultTimeLocale, formatTime)
+import           Systemd.Journal (Priority (..), message, mkJournalField, priority,
+                   sendJournalFields, syslogIdentifier)
+
+import           Cardano.Logging (TraceObject (..))
+import qualified Cardano.Logging as L
+
+import           Cardano.Tracer.Types (NodeId (..))
+#else
+import           Cardano.Logging (TraceObject)
+
+import           Cardano.Tracer.Types (NodeId)
+#endif
+
+#ifdef LINUX
+-- | Store 'TraceObject's in Linux systemd's journal service.
+writeTraceObjectsToJournal :: NodeId -> [TraceObject] -> IO ()
+writeTraceObjectsToJournal (NodeId anId) = mapM_ (sendJournalFields . mkJournalFields)
+ where
+  mkJournalFields trOb@TraceObject{toHuman, toMachine} =
+    case (toHuman, toMachine) of
+      (Just msgForHuman, Nothing)            -> mkJournalFields' trOb msgForHuman
+      (Nothing,          Just msgForMachine) -> mkJournalFields' trOb msgForMachine
+      (Just _,           Just msgForMachine) -> mkJournalFields' trOb msgForMachine
+      (Nothing,          Nothing)            -> HM.empty
+
+  mkJournalFields' TraceObject{toSeverity, toNamespace, toThreadId, toTimestamp} msg =
+       syslogIdentifier anId
+    <> message msg
+    <> priority (mkPriority toSeverity)
+    <> HM.fromList
+         [ (namespace, encodeUtf8 $ mkName toNamespace)
+         , (thread,    encodeUtf8 $ T.filter isDigit toThreadId)
+         , (time,      encodeUtf8 $ formatAsIso8601 toTimestamp)
+         ]
+
+  mkName [] = "noname"
+  mkName names = T.intercalate "." names
+
+  namespace = mkJournalField "namespace"
+  thread    = mkJournalField "thread"
+  time      = mkJournalField "time"
+
+  formatAsIso8601 = T.pack . formatTime defaultTimeLocale "%F %T%12QZ"
+
+  mkPriority L.Debug     = Debug
+  mkPriority L.Info      = Info
+  mkPriority L.Notice    = Notice
+  mkPriority L.Warning   = Warning
+  mkPriority L.Error     = Error
+  mkPriority L.Critical  = Critical
+  mkPriority L.Alert     = Alert
+  mkPriority L.Emergency = Emergency
+#else
+-- It works on Linux only.
+writeTraceObjectsToJournal :: NodeId -> [TraceObject] -> IO ()
+writeTraceObjectsToJournal _ _ = return ()
+#endif

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 #if defined(linux_HOST_OS)
 #define LINUX
+#endif
+
+#ifdef LINUX
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 #endif
 
 module Cardano.Tracer.Handlers.Logs.Journal

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
@@ -53,7 +53,7 @@ launchRotator loggingParamsForFiles
 -- | All the logs with 'TraceObject's received from particular node
 --   will be stored in a separate subdirectory in the root directory.
 --
---   Each subdirectory contains a symbolic link, we use it to write
+--   Each subdirectory contains a symbolic link, we can use it to write
 --   log items to the latest log file. When we create the new log file,
 --   this symbolic link is switched to it.
 checkRootDir

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Tracer.Handlers.Logs.Rotator
+  ( runLogsRotator
+  ) where
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Concurrent.Extra (Lock)
+import           Control.Monad (forM_, forever, unless, when)
+import           Control.Monad.Extra (whenJust, whenM)
+import           Data.List (nub, sort)
+import           Data.List.Extra (dropEnd)
+import qualified Data.List.NonEmpty as NE
+import           Data.Time (diffUTCTime, getCurrentTime)
+import           Data.Word (Word16, Word32, Word64)
+import           System.Directory (doesDirectoryExist, getFileSize, removeFile)
+import           System.Directory.Extra (listDirectories, listFiles)
+import           System.FilePath ((</>), takeDirectory)
+import           System.Time.Extra (sleep)
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.Utils (createLogAndUpdateSymLink,
+                   getTimeStampFromLog, isItLog)
+import           Cardano.Tracer.Utils (showProblemIfAny)
+
+-- | Runs rotation mechanism for the log files.
+runLogsRotator
+  :: TracerConfig
+  -> Lock
+  -> IO ()
+runLogsRotator TracerConfig{rotation, logging, verbosity} currentLogLock =
+  whenJust rotation $ \rotParams ->
+    launchRotator loggingParamsForFiles rotParams verbosity currentLogLock
+ where
+  loggingParamsForFiles = nub . NE.filter filesOnly $ logging
+  filesOnly LoggingParams{logMode} = logMode == FileMode
+
+launchRotator
+  :: [LoggingParams]
+  -> RotationParams
+  -> Maybe Verbosity
+  -> Lock
+  -> IO ()
+launchRotator [] _ _ _ = return ()
+launchRotator loggingParamsForFiles
+              rotParams@RotationParams{rpFrequencySecs} verb currentLogLock = forever $ do
+  showProblemIfAny verb $
+    forM_ loggingParamsForFiles $ checkRootDir currentLogLock rotParams
+  sleep $ fromIntegral rpFrequencySecs
+
+-- | All the logs with 'TraceObject's received from particular node
+--   will be stored in a separate subdirectory in the root directory.
+--
+--   Each subdirectory contains a symbolic link, we use it to write
+--   log items to the latest log file. When we create the new log file,
+--   this symbolic link is switched to it.
+checkRootDir
+  :: Lock
+  -> RotationParams
+  -> LoggingParams
+  -> IO ()
+checkRootDir currentLogLock rotParams LoggingParams{logRoot, logFormat} =
+  whenM (doesDirectoryExist logRoot) $
+    listDirectories logRoot >>= \case
+      [] ->
+        -- There are no nodes' subdirs yet (or they were deleted),
+        -- so no rotation can be performed for now.
+        return ()
+      logsSubDirs -> do
+        let fullPathsToSubDirs = map (logRoot </>) logsSubDirs
+        forConcurrently_ fullPathsToSubDirs $
+          checkLogs currentLogLock rotParams logFormat
+
+-- | We check the log files:
+--   1. If there are too big log files.
+--   2. If there are too old log files.
+checkLogs
+  :: Lock
+  -> RotationParams
+  -> LogFormat
+  -> FilePath
+  -> IO ()
+checkLogs currentLogLock
+          RotationParams{rpLogLimitBytes, rpMaxAgeHours, rpKeepFilesNum} format subDirForLogs = do
+  logs <- map (subDirForLogs </>) . filter (isItLog format) <$> listFiles subDirForLogs
+  unless (null logs) $ do
+    -- Since logs' names contain timestamps, we can sort them: the maximum one is the latest log,
+    -- and this is the current log (i.e. the log we're writing 'TraceObject's in).
+    let fromOldestToNewest = sort logs
+        -- Usage of partial function 'last' is safe here (we already checked the list isn't empty).
+        currentLog = last fromOldestToNewest
+        -- Only previous logs should be checked if they are outdated.
+        allOtherLogs = dropEnd 1 fromOldestToNewest
+    checkIfCurrentLogIsFull currentLogLock currentLog format rpLogLimitBytes
+    checkIfThereAreOldLogs allOtherLogs rpMaxAgeHours rpKeepFilesNum
+
+-- | If the current log file is full (it's size is too big), the new log will be created.
+checkIfCurrentLogIsFull
+  :: Lock
+  -> FilePath
+  -> LogFormat
+  -> Word64
+  -> IO ()
+checkIfCurrentLogIsFull currentLogLock pathToCurrentLog format maxSizeInBytes =
+  whenM logIsFull $
+    createLogAndUpdateSymLink currentLogLock (takeDirectory pathToCurrentLog) format
+ where
+  logIsFull = do
+    size <- getFileSize pathToCurrentLog
+    return $ fromIntegral size >= maxSizeInBytes
+
+-- | If there are too old log files - they will be removed.
+--   Please note that some number of log files can be kept in any case.
+checkIfThereAreOldLogs
+  :: [FilePath]
+  -> Word16
+  -> Word32
+  -> IO ()
+checkIfThereAreOldLogs [] _ _ = return ()
+checkIfThereAreOldLogs fromOldestToNewest maxAgeInHours keepFilesNum = do
+  -- N ('keepFilesNum') newest files have to be kept in any case.
+  let logsWeHaveToCheck = dropEnd (fromIntegral keepFilesNum) fromOldestToNewest
+  unless (null logsWeHaveToCheck) $
+    checkOldLogs logsWeHaveToCheck =<< getCurrentTime
+ where
+  checkOldLogs [] _ = return ()
+  checkOldLogs (oldestLog:otherLogs) now' =
+    case getTimeStampFromLog oldestLog of
+      Just ts -> do
+        let oldestLogAge = toSeconds $ now' `diffUTCTime` ts
+        when (oldestLogAge >= maxAgeInSecs) $ do
+          removeFile oldestLog
+          checkOldLogs otherLogs now'
+        -- If 'oldestLog' isn't outdated (yet), other logs aren't
+        -- outdated too (because they are newer), so we shouldn't check them.
+      Nothing ->
+        -- Something is wrong with log's name, continue.
+        checkOldLogs otherLogs now'
+
+  maxAgeInSecs = fromIntegral maxAgeInHours * 3600
+  toSeconds age = fromEnum age `div` 1000000000000

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/TraceObjects.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/TraceObjects.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Tracer.Handlers.Logs.TraceObjects
+  ( traceObjectsHandler
+  ) where
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Concurrent.Extra (Lock)
+import qualified Data.List.NonEmpty as NE
+
+import           Cardano.Logging (TraceObject)
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.File (writeTraceObjectsToFile)
+import           Cardano.Tracer.Handlers.Logs.Journal (writeTraceObjectsToJournal)
+import           Cardano.Tracer.Types (NodeId)
+import           Cardano.Tracer.Utils (showProblemIfAny)
+
+-- | This handler is called periodically by 'TraceObjectForward' protocol
+--   from 'trace-forward' library.
+traceObjectsHandler
+  :: TracerConfig  -- ^ Tracer configuration.
+  -> NodeId        -- ^ An id of the node 'TraceObject's were received from.
+  -> Lock          -- ^ The lock we use for single-threaded access to the current log.
+  -> [TraceObject] -- ^ The list of received 'TraceObject's (may be empty).
+  -> IO ()
+traceObjectsHandler _ _ _ [] = return ()
+traceObjectsHandler TracerConfig{logging, verbosity} nodeId currentLogLock traceObjects =
+  forConcurrently_ (NE.nub logging) $ \LoggingParams{logMode, logRoot, logFormat} ->
+    showProblemIfAny verbosity $
+      case logMode of
+        FileMode    -> writeTraceObjectsToFile nodeId currentLogLock logRoot logFormat traceObjects
+        JournalMode -> writeTraceObjectsToJournal nodeId traceObjects

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
@@ -62,9 +62,12 @@ isItLog format pathToLog = hasProperPrefix && hasTimestamp && hasProperExt
   maybeTimestamp = T.drop (length logPrefix) . T.pack . takeBaseName $ fileName
 
 -- | Create a new log file and a symlink to it, from scratch.
-createLogAndSymLink :: FilePath -> LogFormat -> IO ()
-createLogAndSymLink subDirForLogs format =
-  createEmptyLog subDirForLogs format >>= flip createFileLink symLink
+createLogAndSymLink :: FilePath -> LogFormat -> IO FilePath
+createLogAndSymLink subDirForLogs format = do
+  pathToNewLog <- createEmptyLog subDirForLogs format
+  whenM (doesFileExist symLink) $ removeFile symLink
+  createFileLink pathToNewLog symLink
+  return pathToNewLog
  where
   symLink = subDirForLogs </> symLinkName format
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Tracer.Handlers.Logs.Utils
+  ( createLogAndSymLink
+  , createLogAndUpdateSymLink
+  , doesSymLinkValid
+  , getTimeStampFromLog
+  , isItLog
+  , isItSymLink
+  , symLinkName
+  ) where
+
+import           Control.Monad.Extra (whenM)
+import           Control.Concurrent.Extra (Lock, withLock)
+import qualified Data.ByteString as BS
+import           Data.Maybe (isJust)
+import           Data.Time (UTCTime, getCurrentTime)
+import           Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
+import qualified Data.Text as T
+import           System.Directory (createFileLink, doesFileExist, getSymbolicLinkTarget,
+                   pathIsSymbolicLink, renamePath, removeFile)
+import           System.FilePath ((<.>), (</>), takeBaseName, takeExtension,
+                   takeFileName)
+
+import           Cardano.Tracer.Configuration (LogFormat (..))
+
+logPrefix :: String
+logPrefix = "node-"
+
+logExtension :: LogFormat -> String
+logExtension ForHuman   = ".log"
+logExtension ForMachine = ".json"
+
+symLinkName :: LogFormat -> FilePath
+symLinkName format = "node" <.> logExtension format
+
+symLinkNameTmp :: LogFormat -> FilePath
+symLinkNameTmp format = symLinkName format <.> "tmp"
+
+isItSymLink :: LogFormat -> FilePath -> IO Bool
+isItSymLink format fileName =
+  if takeFileName fileName == symLinkName format
+    then pathIsSymbolicLink fileName
+    else return False
+
+doesSymLinkValid :: FilePath -> IO Bool
+doesSymLinkValid pathToSymLink =
+  doesFileExist =<< getSymbolicLinkTarget pathToSymLink
+
+-- | An example of the valid log name: 'node-2021-11-29T09-55-04.json'.
+isItLog :: LogFormat -> FilePath -> Bool
+isItLog format pathToLog = hasProperPrefix && hasTimestamp && hasProperExt
+ where
+  fileName = takeFileName pathToLog
+  hasProperPrefix = T.pack logPrefix `T.isPrefixOf` T.pack fileName
+  hasTimestamp = isJust timeStamp
+  hasProperExt = takeExtension fileName == logExtension format
+
+  timeStamp :: Maybe UTCTime
+  timeStamp = parseTimeM True defaultTimeLocale timeStampFormat $ T.unpack maybeTimestamp
+
+  maybeTimestamp = T.drop (length logPrefix) . T.pack . takeBaseName $ fileName
+
+-- | Create a new log file and a symlink to it, from scratch.
+createLogAndSymLink :: FilePath -> LogFormat -> IO ()
+createLogAndSymLink subDirForLogs format =
+  createEmptyLog subDirForLogs format >>= flip createFileLink symLink
+ where
+  symLink = subDirForLogs </> symLinkName format
+
+-- | Create a new log file and move existing symlink
+--   from the old log file to the new one.
+--
+-- It is technically possible that, during checking if the current log is full,
+-- another thread is writing in the current log (via its symbolic link). If so,
+-- we cannot switch to the new log file to avoid writing interruption. That's why
+-- we use 'Lock'.
+createLogAndUpdateSymLink
+  :: Lock
+  -> FilePath
+  -> LogFormat
+  -> IO ()
+createLogAndUpdateSymLink currentLogLock subDirForLogs format = do
+  newLog <- createEmptyLog subDirForLogs format
+  whenM (doesFileExist tmpSymLink) $ removeFile tmpSymLink
+  createFileLink newLog tmpSymLink
+  withLock currentLogLock $
+    renamePath tmpSymLink realSymLink -- Atomic operation (uses POSIX.rename function).
+ where
+  tmpSymLink  = subDirForLogs </> symLinkNameTmp format
+  realSymLink = subDirForLogs </> symLinkName format
+
+-- | Create an empty log file (with the current timestamp in the name).
+createEmptyLog :: FilePath -> LogFormat -> IO FilePath
+createEmptyLog subDirForLogs format = do
+  ts <- formatTime defaultTimeLocale timeStampFormat <$> getCurrentTime
+  let logName = logPrefix <> ts <.> logExtension format
+      pathToLog = subDirForLogs </> logName
+  BS.writeFile pathToLog BS.empty
+  return pathToLog
+
+getTimeStampFromLog :: FilePath -> Maybe UTCTime
+getTimeStampFromLog pathToLog =
+  parseTimeM True defaultTimeLocale timeStampFormat timeStamp
+ where
+  timeStamp = drop (length logPrefix) . takeBaseName . takeFileName $ pathToLog
+
+timeStampFormat :: String
+timeStampFormat = "%Y-%m-%dT%H-%M-%S"

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tracer.Handlers.Metrics.Monitoring
+  ( runMonitoringServer
+  ) where
+
+import           Control.Concurrent (ThreadId)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, putTMVar,
+                   tryReadTMVar)
+import           Control.Monad (forM, void)
+import           Control.Monad.Extra (whenJust)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import           Data.Text.Encoding (encodeUtf8)
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core (UI, Element, liftIO, set, (#), (#+))
+import           System.Remote.Monitoring (forkServerWith, serverThreadId)
+
+import           Cardano.Tracer.Configuration (Endpoint (..))
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes, NodeId (..))
+
+-- | 'ekg' package allows to run only one EKG server, to display only one web page
+--   for particular EKG.Store. Since 'cardano-tracer' can be connected to any number
+--   of nodes, we display their list on the first web page (the first 'Endpoint')
+--   as a list of hrefs. After clicking on the particular href, the user will be
+--   redirected to the monitoring web page (the second 'Endpoint') built by 'ekg' package.
+--   This page will display the metrics received from that node.
+--
+--   If the user returns to the first web page and clicks to another node's href,
+--   the EKG server will be restarted and the monitoring page will display the metrics
+--   received from that node.
+runMonitoringServer
+  :: (Endpoint, Endpoint) -- ^ (web page with list of connected nodes, EKG web page).
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> IO ()
+runMonitoringServer (Endpoint listHost listPort, monitorEP) connectedNodes acceptedMetrics =
+  UI.startGUI config $ \window -> do
+    void $ return window # set UI.title "EKG Monitoring Nodes"
+    void $ mkPageBody window connectedNodes monitorEP acceptedMetrics
+ where
+  config = UI.defaultConfig
+    { UI.jsPort = Just . fromIntegral $ listPort
+    , UI.jsAddr = Just . encodeUtf8 . T.pack $ listHost
+    }
+
+-- | We have to keep an id of the node as well as thread id of currently launched EKG server.
+type CurrentEKGServer = TMVar (NodeId, ThreadId)
+
+-- | The first web page contains only the list of hrefs
+--   corresponding to currently connected nodes.
+mkPageBody
+  :: UI.Window
+  -> ConnectedNodes
+  -> Endpoint
+  -> AcceptedMetrics
+  -> UI Element
+mkPageBody window connectedNodes mEP@(Endpoint monitorHost monitorPort) acceptedMetrics = do
+  nodes <- liftIO $ S.toList <$> readTVarIO connectedNodes
+  nodesHrefs <-
+    if null nodes
+      then UI.string "There are no connected nodes yet"
+      else do
+        currentServer :: CurrentEKGServer <- liftIO newEmptyTMVarIO
+        nodesLinks <-
+          forM nodes $ \nodeId@(NodeId anId) -> do
+            nodeLink <-
+              UI.li #+
+                [ UI.anchor # set UI.href ("http://" <> monitorHost <> ":" <> show monitorPort)
+                            # set UI.target "_blank"
+                            # set UI.title__ "Open EKG monitor page for this node"
+                            # set UI.text (T.unpack anId)
+                ]
+            void $ UI.on UI.click nodeLink $ const $
+              restartEKGServer nodeId acceptedMetrics mEP currentServer
+            return $ UI.element nodeLink
+        UI.ul #+ nodesLinks
+  UI.getBody window #+ [ UI.element nodesHrefs ]
+
+-- | After clicking on the node's href, the user will be redirected to the monitoring page
+--   which is rendered by 'ekg' package. But before, we have to check if EKG server is
+--   already launched, and if so, restart the server if needed.
+restartEKGServer
+  :: NodeId
+  -> AcceptedMetrics
+  -> Endpoint
+  -> CurrentEKGServer
+  -> UI ()
+restartEKGServer newNodeId acceptedMetrics
+                 (Endpoint monitorHost monitorPort) currentServer = liftIO $ do
+  metrics <- readTVarIO acceptedMetrics
+  whenJust (metrics M.!? newNodeId) $ \(storeForSelectedNode, _) ->
+    atomically (tryReadTMVar currentServer) >>= \case
+      Just (_curNodeId, _sThread) ->
+        -- TODO: Currently we cannot restart EKG server,
+        -- please see https://github.com/tibbe/ekg/issues/87
+        return ()
+        -- unless (newNodeId == curNodeId) $ do
+        --   killThread sThread
+        --   runEKGAndSave storeForSelectedNode
+      Nothing ->
+        -- Current server wasn't stored yet, it's a first click on the href.
+        runEKGAndSave storeForSelectedNode
+ where
+  runEKGAndSave store = do
+    ekgServer <- forkServerWith store
+                   (encodeUtf8 . T.pack $ monitorHost)
+                   (fromIntegral monitorPort)
+    atomically $ putTMVar currentServer (newNodeId, serverThreadId ekgServer)

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
@@ -105,11 +105,13 @@ getMetricsFromNode
   -> IO Text
 getMetricsFromNode [] _ = return "No such a node!"
 getMetricsFromNode (anId':_) acceptedMetrics =
-  readTVarIO acceptedMetrics <&> M.lookup nodeId >>= \case
-    Nothing ->
-      return "No such a node!"
-    Just (ekgStore, _) ->
-      sampleAll ekgStore <&> renderListOfMetrics . getListOfMetrics
+  readTVarIO acceptedMetrics >>=
+    (\case
+        Nothing ->
+          return "No such a node!"
+        Just (ekgStore, _) ->
+          sampleAll ekgStore <&> renderListOfMetrics . getListOfMetrics
+    ) . M.lookup nodeId
  where
   nodeId = NodeId $ decodeUtf8 anId'
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tracer.Handlers.Metrics.Prometheus
+  ( runPrometheusServer
+  ) where
+
+import           Prelude hiding (head)
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Monad (forever)
+import           Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString as BS
+import qualified Data.HashMap.Strict as HM
+import           Data.Functor ((<&>))
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import           Data.String (IsString (..))
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import           Snap.Blaze (blaze)
+import           Snap.Core (Snap, getRequest, route, rqParams, writeText)
+import           Snap.Http.Server (Config, ConfigLog (..), defaultConfig, setAccessLog,
+                   setBind, setErrorLog, setPort, simpleHttpServe)
+import           System.Metrics (Sample, Value (..), sampleAll)
+import           System.Time.Extra (sleep)
+import           Text.Blaze.Html5 hiding (map)
+import           Text.Blaze.Html5.Attributes hiding (title)
+
+import           Cardano.Tracer.Configuration (Endpoint (..))
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes, NodeId (..))
+
+-- | Runs simple HTTP server that listens host and port and returns
+--   the list of currently connected nodes in such a format:
+--
+--   * tmp-forwarder.sock@0
+--   * tmp-forwarder.sock@1
+--   * tmp-forwarder.sock@2
+--
+--  Each of list items is a href. By clicking on it, the user will be
+--  redirected to the page with the list of metrics received from that node,
+--  in such a format:
+--
+--  rts_gc_par_tot_bytes_copied 0
+--  rts_gc_num_gcs 17
+--  rts_gc_max_bytes_slop 15888
+--  rts_gc_bytes_copied 165952
+--  ekg_server_timestamp_ms 1639569439623
+--
+runPrometheusServer
+  :: Endpoint
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> IO ()
+runPrometheusServer (Endpoint host port) connectedNodes acceptedMetrics = forever $ do
+  -- If everything is okay, the function 'simpleHttpServe' never returns.
+  -- But if there is some problem, it never throws an exception, but just stops.
+  -- So if it stopped - it will be re-started.
+  simpleHttpServe config $
+    route [ ("/",        renderListOfConnectedNodes)
+          , ("/:nodeid", renderMetricsFromNode)
+          ]
+  sleep 1.0
+ where
+  config :: Config Snap ()
+  config =
+      setPort (fromIntegral port)
+    . setBind (encodeUtf8 . T.pack $ host)
+    . setAccessLog ConfigNoLog
+    . setErrorLog ConfigNoLog
+    $ defaultConfig
+
+  renderListOfConnectedNodes :: Snap ()
+  renderListOfConnectedNodes =
+    liftIO (readTVarIO connectedNodes <&> S.toList) >>= \case
+      []   -> writeText "There are no connected nodes yet."
+      nIds -> blaze . mkPage . map mkHref $ nIds
+
+  mkPage hrefs = html $ do
+    head . title $ "Prometheus metrics"
+    body . ul $ mapM_ li hrefs
+
+  mkHref (NodeId anId) =
+    a ! href (fromString $ "http://" <> host <> ":" <> show port <> "/" <> anId')
+      $ toHtml anId'
+   where
+     anId' = T.unpack anId
+
+  renderMetricsFromNode :: Snap ()
+  renderMetricsFromNode = do
+    reqParams <- rqParams <$> getRequest
+    case M.lookup "nodeid" reqParams of
+      Nothing   -> writeText "No such a node!"
+      Just anId -> writeText =<< liftIO (getMetricsFromNode anId acceptedMetrics)
+
+type MetricName  = Text
+type MetricValue = Text
+type MetricsList = [(MetricName, MetricValue)]
+
+getMetricsFromNode
+  :: [BS.ByteString]
+  -> AcceptedMetrics
+  -> IO Text
+getMetricsFromNode [] _ = return "No such a node!"
+getMetricsFromNode (anId':_) acceptedMetrics =
+  readTVarIO acceptedMetrics <&> M.lookup nodeId >>= \case
+    Nothing ->
+      return "No such a node!"
+    Just (ekgStore, _) ->
+      sampleAll ekgStore <&> renderListOfMetrics . getListOfMetrics
+ where
+  nodeId = NodeId $ decodeUtf8 anId'
+
+  getListOfMetrics :: Sample -> MetricsList
+  getListOfMetrics = filter (not . T.null . fst) . map metricsWeNeed . HM.toList
+
+  metricsWeNeed (mName, mValue) =
+    case mValue of
+      Counter c -> (mName, T.pack $ show c)
+      Gauge g   -> (mName, T.pack $ show g)
+      Label l   -> (mName, l)
+      _         -> ("",    "") -- 'ekg-forward' doesn't support 'Distribution' yet.
+
+  renderListOfMetrics :: MetricsList -> Text
+  renderListOfMetrics [] = "No metrics were received from this node."
+  renderListOfMetrics mList = T.intercalate "\n" $
+    map (\(mName, mValue) -> prepareName mName <> " " <> mValue) mList
+
+  prepareName =
+      T.filter (`elem` (['0'..'9'] ++ ['a'..'z'] ++ ['A'..'Z'] ++ ['_']))
+    . T.replace " " "_"
+    . T.replace "-" "_"
+    . T.replace "." "_"

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Servers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Servers.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Tracer.Handlers.Metrics.Servers
+  ( runMetricsServers
+  ) where
+
+import           Control.Concurrent.Async.Extra (sequenceConcurrently)
+import           Control.Monad (void)
+
+import           Cardano.Tracer.Configuration (TracerConfig (..))
+import           Cardano.Tracer.Handlers.Metrics.Monitoring (runMonitoringServer)
+import           Cardano.Tracer.Handlers.Metrics.Prometheus (runPrometheusServer)
+import           Cardano.Tracer.Types (ConnectedNodes, AcceptedMetrics)
+
+-- | Runs metrics servers if needed:
+--
+--   1. Prometheus exporter.
+--   2. EKG monitoring web-page.
+--
+runMetricsServers
+  :: TracerConfig
+  -> ConnectedNodes
+  -> AcceptedMetrics
+  -> IO ()
+runMetricsServers TracerConfig{hasEKG, hasPrometheus} connectedNodes acceptedMetrics =
+  case (hasEKG, hasPrometheus) of
+    (Nothing,  Nothing)   -> return ()
+    (Nothing,  Just prom) -> runPrometheusServer prom connectedNodes acceptedMetrics
+    (Just ekg, Nothing)   -> runMonitoringServer ekg  connectedNodes acceptedMetrics
+    (Just ekg, Just prom) -> void . sequenceConcurrently $
+                               [ runPrometheusServer prom connectedNodes acceptedMetrics
+                               , runMonitoringServer ekg  connectedNodes acceptedMetrics
+                               ]

--- a/cardano-tracer/src/Cardano/Tracer/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Run.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | This top-level module is used by 'cardano-tracer' app.
+module Cardano.Tracer.Run
+  ( doRunCardanoTracer
+  , runCardanoTracer
+  ) where
+
+import           Control.Concurrent.Async.Extra (sequenceConcurrently)
+import           Control.Concurrent.Extra (newLock)
+import           Control.Monad (void)
+
+import           Cardano.Tracer.Acceptors.Run (runAcceptors)
+import           Cardano.Tracer.CLI (TracerParams (..))
+import           Cardano.Tracer.Configuration (TracerConfig, readTracerConfig)
+import           Cardano.Tracer.Handlers.Logs.Rotator (runLogsRotator)
+import           Cardano.Tracer.Handlers.Metrics.Servers (runMetricsServers)
+import           Cardano.Tracer.Types (DataPointRequestors, ProtocolsBrake)
+import           Cardano.Tracer.Utils (initAcceptedMetrics, initConnectedNodes,
+                   initDataPointRequestors, initProtocolsBrake, lift3M)
+
+-- | Top-level run function, called by 'cardano-tracer' app.
+runCardanoTracer :: TracerParams -> IO ()
+runCardanoTracer TracerParams{tracerConfig} = lift3M
+  doRunCardanoTracer (readTracerConfig tracerConfig)
+                     initProtocolsBrake
+                     initDataPointRequestors
+
+-- | Runs all internal services of the tracer.
+doRunCardanoTracer
+  :: TracerConfig    -- ^ Tracer's configuration.
+  -> ProtocolsBrake  -- ^ The flag we use to stop all the protocols.
+  -> DataPointRequestors -- ^ The DataPointRequestors to ask 'DataPoint's.
+  -> IO ()
+doRunCardanoTracer config protocolsBrake dpRequestors = do
+  connectedNodes <- initConnectedNodes
+  acceptedMetrics <- initAcceptedMetrics
+  currentLogLock <- newLock
+  void . sequenceConcurrently $
+    [ runLogsRotator    config currentLogLock
+    , runMetricsServers config connectedNodes acceptedMetrics
+    , runAcceptors      config connectedNodes acceptedMetrics
+                        dpRequestors protocolsBrake currentLogLock
+    ]

--- a/cardano-tracer/src/Cardano/Tracer/Types.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Types.hs
@@ -1,0 +1,40 @@
+module Cardano.Tracer.Types
+  ( AcceptedMetrics
+  , ConnectedNodes
+  , DataPointRequestors
+  , NodeId (..)
+  , ProtocolsBrake
+  ) where
+
+import           Control.Concurrent.STM.TVar (TVar)
+import           Data.Map.Strict (Map)
+import           Data.Set (Set)
+import           Data.Text (Text)
+import qualified System.Metrics as EKG
+
+import           System.Metrics.Store.Acceptor (MetricsLocalStore)
+
+import           Trace.Forward.Utils.DataPoint (DataPointRequestor)
+
+-- | Unique identifier of connected node, based on 'remoteAddress' from
+--   'ConnectionId', please see 'ouroboros-network'.
+newtype NodeId = NodeId Text
+  deriving (Eq, Ord, Show)
+
+-- | We have to create EKG.Store and MetricsLocalStore
+--   to keep all the metrics accepted from the node.
+type AcceptedMetrics = TVar (Map NodeId (EKG.Store, TVar MetricsLocalStore))
+
+-- | We have to store 'DataPointRequestor's to be able
+--   to ask particular node for some 'DataPoint's.
+type DataPointRequestors = TVar (Map NodeId DataPointRequestor)
+
+-- | This set contains ids of currently connected nodes.
+--   When the node is connected, its id will be added to this set,
+--   and when it is disconnected, its id will be deleted from this set.
+--   So, 'ConnectedNodes' is used as a "source of truth" about currently
+--   connected nodes.
+type ConnectedNodes = TVar (Set NodeId)
+
+-- | The flag we use to stop the protocols from their acceptor's side.
+type ProtocolsBrake = TVar Bool

--- a/cardano-tracer/src/Cardano/Tracer/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Utils.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tracer.Utils
+  ( applyBrake
+  , connIdToNodeId
+  , initAcceptedMetrics
+  , initConnectedNodes
+  , initDataPointRequestors
+  , initProtocolsBrake
+  , lift2M
+  , lift3M
+  , runInLoop
+  , showProblemIfAny
+  ) where
+
+import           Control.Applicative (liftA2, liftA3)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
+import           Control.Exception (SomeException, SomeAsyncException (..),
+                   fromException, try, tryJust)
+import           "contra-tracer" Control.Tracer (showTracing, stdoutTracer, traceWith)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import           Data.Tuple.Extra (uncurry3)
+import           System.Time.Extra (sleep)
+
+import           Ouroboros.Network.Socket (ConnectionId (..))
+
+import           Cardano.Tracer.Configuration (Verbosity (..))
+import           Cardano.Tracer.Types (AcceptedMetrics, ConnectedNodes,
+                   DataPointRequestors, NodeId (..), ProtocolsBrake)
+
+-- | Run monadic action in a loop. If there's an exception,
+--   it will re-run the action again, after pause that grows.
+runInLoop
+  :: IO ()           -- ^ An IO-action that can throw an exception.
+  -> Maybe Verbosity -- ^ Tracer's verbosity.
+  -> FilePath        -- ^ Local socket.
+  -> Word            -- ^ Current delay, in seconds.
+  -> IO ()
+runInLoop action verb localSocket prevDelay =
+  tryJust excludeAsyncExceptions action >>= \case
+    Left e -> do
+      case verb of
+        Just Minimum -> return ()
+        _ -> logTrace $ "cardano-tracer, connection with " <> show localSocket <> " failed: " <> show e
+      sleep $ fromIntegral currentDelay
+      runInLoop action verb localSocket currentDelay
+    Right _ -> return ()
+ where
+  excludeAsyncExceptions e =
+    case fromException e of
+      Just SomeAsyncException {} -> Nothing
+      _ -> Just e
+
+  !currentDelay =
+    if prevDelay < 60
+      then prevDelay * 2
+      else 60 -- After we reached 60+ secs delay, repeat an attempt every minute.
+
+showProblemIfAny
+  :: Maybe Verbosity -- ^ Tracer's verbosity.
+  -> IO ()           -- ^ An IO-action that can throw an exception.
+  -> IO ()
+showProblemIfAny verb action =
+  try action >>= \case
+    Left (e :: SomeException) ->
+      case verb of
+        Just Minimum -> return ()
+        _ -> logTrace $ "cardano-tracer, the problem: " <> show e
+    Right _ -> return ()
+
+logTrace :: String -> IO ()
+logTrace = traceWith $ showTracing stdoutTracer
+
+connIdToNodeId :: Show addr => ConnectionId addr -> NodeId
+connIdToNodeId ConnectionId{remoteAddress} = NodeId preparedAddress
+ where
+  -- We have to remove "wrong" symbols from 'NodeId',
+  -- to make it appropriate for the name of the subdirectory.
+  preparedAddress =
+      T.replace "\\\\.\\pipe\\" "" -- For Windows.
+    . T.replace "--" ""
+    . T.replace "LocalAddress" "" -- There are only local addresses by design.
+    . T.replace " " "-"
+    . T.replace "\"" ""
+    . T.replace "/" "-"
+    . T.pack
+    $ show remoteAddress
+
+initConnectedNodes :: IO ConnectedNodes
+initConnectedNodes = newTVarIO S.empty
+
+initAcceptedMetrics :: IO AcceptedMetrics
+initAcceptedMetrics = newTVarIO M.empty
+
+initDataPointRequestors :: IO DataPointRequestors
+initDataPointRequestors = newTVarIO M.empty
+
+initProtocolsBrake :: IO ProtocolsBrake
+initProtocolsBrake = newTVarIO False
+
+-- | Stop the protocols. As a result, 'MsgDone' will be sent and interaction
+--   between acceptor's part and forwarder's part will be finished.
+applyBrake :: ProtocolsBrake -> IO ()
+applyBrake stopProtocols = atomically $ modifyTVar' stopProtocols . const $ True
+
+-- | Like 'liftM2', but for monadic function.
+lift2M :: Monad m => (a -> b -> m c) -> m a -> m b -> m c
+lift2M f x y = liftA2 (,) x y >>= uncurry f
+
+-- | Like 'liftM3', but for monadic function.
+lift3M :: Monad m => (a -> b -> c -> m d) -> m a -> m b -> m c -> m d
+lift3M f x y z = liftA3 (,,) x y z >>= uncurry3 f

--- a/cardano-tracer/src/Cardano/Tracer/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Utils.hs
@@ -24,6 +24,7 @@ import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
 import           Control.Exception (SomeException, SomeAsyncException (..),
                    fromException, try, tryJust)
 import           "contra-tracer" Control.Tracer (showTracing, stdoutTracer, traceWith)
+import           Data.List.Extra (dropPrefix, dropSuffix, replace)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -85,13 +86,17 @@ connIdToNodeId ConnectionId{remoteAddress} = NodeId preparedAddress
   -- We have to remove "wrong" symbols from 'NodeId',
   -- to make it appropriate for the name of the subdirectory.
   preparedAddress =
-      T.replace "\\\\.\\pipe\\" "" -- For Windows.
-    . T.replace "--" ""
-    . T.replace "LocalAddress" "" -- There are only local addresses by design.
-    . T.replace " " "-"
-    . T.replace "\"" ""
-    . T.replace "/" "-"
-    . T.pack
+      T.pack
+    . dropPrefix "-"
+    . dropSuffix "-"
+    . replace "--" ""
+    . replace " " "-"
+    . replace "\"" "-"
+    . replace "/" "-"
+    . replace "\\" "-"
+    . replace "pipe" "" -- For Windows.
+    . replace "." "" -- For Windows.
+    . replace "LocalAddress" "" -- There are only local addresses by design.
     $ show remoteAddress
 
 initConnectedNodes :: IO ConnectedNodes

--- a/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Tracer.Test.DataPoint.Tests
+  ( tests
+  ) where
+
+import           Control.Concurrent.Async (withAsync)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVarIO)
+import           Data.Aeson (decode')
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           System.Time.Extra
+
+import           Trace.Forward.Protocol.DataPoint.Type
+import           Trace.Forward.Utils.DataPoint (askForDataPoints)
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Run (doRunCardanoTracer)
+import           Cardano.Tracer.Utils (applyBrake, initProtocolsBrake, initDataPointRequestors)
+
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.Utils
+
+tests :: TestTree
+tests = localOption (QuickCheckTests 1) $ testGroup "Test.DataPoint"
+  [ testProperty "ask" $ propRunInLogsStructure propDataPoint
+  ]
+
+propDataPoint :: FilePath -> FilePath -> IO Property
+propDataPoint rootDir localSock = do
+  stopProtocols <- initProtocolsBrake
+  dpRequestors <- initDataPointRequestors
+  savedDPValues :: TVar DataPointValues <- newTVarIO []
+  withAsync (doRunCardanoTracer config stopProtocols dpRequestors) . const $
+    withAsync (launchForwardersSimple Responder localSock 1000 10000) . const $ do
+      sleep 1.0
+      -- We know that there is one single "node" only (and one single requestor too).
+      ((_, dpRequestor):_) <- M.toList <$> readTVarIO dpRequestors
+      dpValues <- askForDataPoints dpRequestor ["test.data.point", "some.wrong.Name"]
+      atomically . modifyTVar' savedDPValues . const $ dpValues
+      applyBrake stopProtocols
+      sleep 0.5
+
+  dpValues <- readTVarIO savedDPValues
+  if length dpValues == 2
+    then
+      case lookup "test.data.point" dpValues of
+        Just (Just rawValue) ->
+          case decode' rawValue of
+            Just (v :: TestDataPoint) ->
+              if v == mkTestDataPoint
+                then
+                  case lookup "some.wrong.Name" dpValues of
+                    Just Nothing -> return $ property True
+                    _ -> false "Unexpected invalid value"
+                else false "Unexpected valid value"
+            Nothing -> false "Incorrect JSON for of the value DataPoint"
+        _ -> false "No value of the valid DataPoint"
+    else false "Not 2 values"
+ where
+  config = TracerConfig
+    { networkMagic   = 764824073
+    , network        = ConnectTo $ NE.fromList [LocalSocket localSock]
+    , loRequestNum   = Just 1
+    , ekgRequestFreq = Just 1.0
+    , hasEKG         = Nothing
+    , hasPrometheus  = Nothing
+    , logging        = NE.fromList [LoggingParams rootDir FileMode ForHuman]
+    , rotation       = Nothing
+    , verbosity      = Just Minimum
+    }

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -15,7 +15,7 @@ import           Codec.CBOR.Term (Term)
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async
 import           Control.Monad (forever)
-import           "contra-tracer" Control.Tracer (nullTracer)
+import           "contra-tracer" Control.Tracer (nullTracer, contramap, stdoutTracer)
 import           Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Time.Clock (getCurrentTime)
@@ -106,7 +106,7 @@ launchForwardersSimple' iomgr mode p connSize disconnSize =
   ekgConfig :: EKGF.ForwarderConfiguration
   ekgConfig =
     EKGF.ForwarderConfiguration
-      { EKGF.forwarderTracer = nullTracer
+      { EKGF.forwarderTracer = nullTracer -- contramap show stdoutTracer -- nullTracer
       , EKGF.acceptorEndpoint = EKGF.LocalPipe p
       , EKGF.reConnectFrequency = 1.0
       , EKGF.actionOnRequest = const $ return ()
@@ -115,7 +115,7 @@ launchForwardersSimple' iomgr mode p connSize disconnSize =
   tfConfig :: TOF.ForwarderConfiguration TraceObject
   tfConfig =
     TOF.ForwarderConfiguration
-      { TOF.forwarderTracer = nullTracer
+      { TOF.forwarderTracer = nullTracer -- contramap show stdoutTracer -- nullTracer
       , TOF.acceptorEndpoint = p
       , TOF.disconnectedQueueSize = disconnSize
       , TOF.connectedQueueSize = connSize
@@ -124,7 +124,7 @@ launchForwardersSimple' iomgr mode p connSize disconnSize =
   dpfConfig :: DPF.ForwarderConfiguration
   dpfConfig =
     DPF.ForwarderConfiguration
-      { DPF.forwarderTracer = nullTracer
+      { DPF.forwarderTracer = contramap show stdoutTracer -- nullTracer
       , DPF.acceptorEndpoint = p
       }
 
@@ -234,11 +234,11 @@ doListenToAcceptor snocket address timeLimits (ekgConfig, tfConfig, dpfConfig) =
 traceObjectsWriter :: ForwardSink TraceObject -> IO ()
 traceObjectsWriter sink = forever $ do
   writeToSink sink . mkTraceObject =<< getCurrentTime
-  threadDelay 50000
+  threadDelay 40000
  where
   mkTraceObject now = TraceObject
-    { toHuman     = Just "Human Message"
-    , toMachine   = Just "{\"msg\": \"forMachine\"}"
+    { toHuman     = Just "Human Message for testing if our mechanism works as we expect"
+    , toMachine   = Just "{\"msg\": \"Very big message forMachine because we have to check if it works\"}"
     , toNamespace = ["demoNamespace"]
     , toSeverity  = Info
     , toDetails   = DNormal

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -1,0 +1,248 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+
+module Cardano.Tracer.Test.Forwarder
+  ( ForwardersMode (..)
+  , TestDataPoint (..)
+  , launchForwardersSimple
+  , mkTestDataPoint
+  ) where
+
+import           Codec.CBOR.Term (Term)
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async
+import           Control.Monad (forever)
+import           "contra-tracer" Control.Tracer (nullTracer)
+import           Data.Aeson (FromJSON, ToJSON)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Time.Clock (getCurrentTime)
+import           Data.Void (Void)
+import           Data.Word (Word16)
+import           GHC.Generics
+import qualified System.Metrics as EKG
+
+import           Cardano.Logging (DetailLevel (..), SeverityS (..), TraceObject (..))
+import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
+                   forwardingCodecCBORTerm, forwardingVersionCodec)
+import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
+import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
+import           Ouroboros.Network.IOManager (IOManager, withIOManager)
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
+                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
+                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
+import           Ouroboros.Network.Protocol.Handshake.Codec (codecHandshake,
+                   cborTermVersionDataCodec, noTimeLimitsHandshake)
+import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
+import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
+                   simpleSingletonVersions)
+import           Ouroboros.Network.Snocket (Snocket, localAddressFromPath, localSnocket)
+import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..),
+                   SomeResponderApplication (..), cleanNetworkMutableState,
+                   connectToNode, newNetworkMutableState, nullNetworkConnectTracers,
+                   nullNetworkServerTracers, withServerNode)
+import qualified System.Metrics.Configuration as EKGF
+import           System.Metrics.Network.Forwarder
+
+import qualified Trace.Forward.Configuration.DataPoint as DPF
+import qualified Trace.Forward.Configuration.TraceObject as TOF
+import           Trace.Forward.Run.DataPoint.Forwarder
+import           Trace.Forward.Run.TraceObject.Forwarder
+import           Trace.Forward.Utils.DataPoint
+import           Trace.Forward.Utils.TraceObject
+
+import           Cardano.Tracer.Configuration (Verbosity (..))
+import           Cardano.Tracer.Utils
+
+data ForwardersMode = Initiator | Responder
+
+data TestDataPoint = TestDataPoint
+  { tdpName    :: !String
+  , tdpCommit  :: !String
+  , tdpVersion :: !Int
+  } deriving (Generic, Eq, FromJSON, ToJSON)
+
+mkTestDataPoint :: TestDataPoint
+mkTestDataPoint = TestDataPoint
+  { tdpName    = "tdpName for Tests"
+  , tdpCommit  = "ab23c45"
+  , tdpVersion = 32
+  }
+
+launchForwardersSimple
+  :: ForwardersMode
+  -> FilePath
+  -> Word
+  -> Word
+  -> IO ()
+launchForwardersSimple mode p connSize disconnSize = withIOManager $ \iomgr ->
+  runInLoop (launchForwardersSimple' iomgr mode p connSize disconnSize) (Just Minimum) p 1
+
+launchForwardersSimple'
+  :: IOManager
+  -> ForwardersMode
+  -> FilePath
+  -> Word
+  -> Word
+  -> IO ()
+launchForwardersSimple' iomgr mode p connSize disconnSize =
+  case mode of
+    Initiator ->
+      doConnectToAcceptor
+        (localSnocket iomgr)
+        (localAddressFromPath p)
+        noTimeLimitsHandshake
+        (ekgConfig, tfConfig, dpfConfig)
+    Responder ->
+      doListenToAcceptor
+        (localSnocket iomgr)
+        (localAddressFromPath p)
+        noTimeLimitsHandshake
+        (ekgConfig, tfConfig, dpfConfig)
+ where
+  ekgConfig :: EKGF.ForwarderConfiguration
+  ekgConfig =
+    EKGF.ForwarderConfiguration
+      { EKGF.forwarderTracer = nullTracer
+      , EKGF.acceptorEndpoint = EKGF.LocalPipe p
+      , EKGF.reConnectFrequency = 1.0
+      , EKGF.actionOnRequest = const $ return ()
+      }
+
+  tfConfig :: TOF.ForwarderConfiguration TraceObject
+  tfConfig =
+    TOF.ForwarderConfiguration
+      { TOF.forwarderTracer = nullTracer
+      , TOF.acceptorEndpoint = p
+      , TOF.disconnectedQueueSize = disconnSize
+      , TOF.connectedQueueSize = connSize
+      }
+
+  dpfConfig :: DPF.ForwarderConfiguration
+  dpfConfig =
+    DPF.ForwarderConfiguration
+      { DPF.forwarderTracer = nullTracer
+      , DPF.acceptorEndpoint = p
+      }
+
+doConnectToAcceptor
+  :: Snocket IO fd addr
+  -> addr
+  -> ProtocolTimeLimits (Handshake ForwardingVersion Term)
+  -> ( EKGF.ForwarderConfiguration
+     , TOF.ForwarderConfiguration TraceObject
+     , DPF.ForwarderConfiguration
+     )
+  -> IO ()
+doConnectToAcceptor snocket address timeLimits (ekgConfig, tfConfig, dpfConfig) = do
+  store <- EKG.newStore
+  EKG.registerGcMetrics store
+  sink <- initForwardSink tfConfig
+  dpStore <- initDataPointStore
+  writeToStore dpStore "test.data.point" $ DataPoint mkTestDataPoint
+  withAsync (traceObjectsWriter sink) $ \_ -> do
+    connectToNode
+      snocket
+      (codecHandshake forwardingVersionCodec)
+      timeLimits
+      (cborTermVersionDataCodec forwardingCodecCBORTerm)
+      nullNetworkConnectTracers
+      acceptableVersion
+      (simpleSingletonVersions
+         ForwardingV_1
+         (ForwardingVersionData $ NetworkMagic 764824073) -- Taken from mainnet shelley genesis file.
+         (forwarderApp [ (forwardEKGMetrics ekgConfig store,       1)
+                       , (forwardTraceObjectsInit tfConfig sink,   2)
+                       , (forwardDataPointsInit dpfConfig dpStore, 3)
+                       ]
+         )
+      )
+      Nothing
+      address
+ where
+  forwarderApp
+    :: [(RunMiniProtocol 'InitiatorMode LBS.ByteString IO () Void, Word16)]
+    -> OuroborosApplication 'InitiatorMode addr LBS.ByteString IO () Void
+  forwarderApp protocols =
+    OuroborosApplication $ \_connectionId _shouldStopSTM ->
+      [ MiniProtocol
+         { miniProtocolNum    = MiniProtocolNum num
+         , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
+         , miniProtocolRun    = prot
+         }
+      | (prot, num) <- protocols
+      ]
+
+doListenToAcceptor
+  :: Ord addr
+  => Snocket IO fd addr
+  -> addr
+  -> ProtocolTimeLimits (Handshake ForwardingVersion Term)
+  -> ( EKGF.ForwarderConfiguration
+     , TOF.ForwarderConfiguration TraceObject
+     , DPF.ForwarderConfiguration
+     )
+  -> IO ()
+doListenToAcceptor snocket address timeLimits (ekgConfig, tfConfig, dpfConfig) = do
+  store <- EKG.newStore
+  EKG.registerGcMetrics store
+  sink <- initForwardSink tfConfig
+  dpStore <- initDataPointStore
+  writeToStore dpStore "test.data.point" $ DataPoint mkTestDataPoint
+  withAsync (traceObjectsWriter sink) $ \_ -> do
+    networkState <- newNetworkMutableState
+    race_ (cleanNetworkMutableState networkState)
+          $ withServerNode
+              snocket
+              nullNetworkServerTracers
+              networkState
+              (AcceptedConnectionsLimit maxBound maxBound 0)
+              address
+              (codecHandshake forwardingVersionCodec)
+              timeLimits
+              (cborTermVersionDataCodec forwardingCodecCBORTerm)
+              acceptableVersion
+              (simpleSingletonVersions
+                 ForwardingV_1
+                 (ForwardingVersionData $ NetworkMagic 764824073) -- Taken from mainnet shelley genesis file.
+                 (SomeResponderApplication $
+                    forwarderApp [ (forwardEKGMetricsResp ekgConfig store,   1)
+                                 , (forwardTraceObjectsResp tfConfig sink,   2)
+                                 , (forwardDataPointsResp dpfConfig dpStore, 3)
+                                 ]
+                 )
+              )
+              nullErrorPolicies
+              $ \_ serverAsync -> wait serverAsync -- Block until async exception.
+ where
+  forwarderApp
+    :: [(RunMiniProtocol 'ResponderMode LBS.ByteString IO Void (), Word16)]
+    -> OuroborosApplication 'ResponderMode addr LBS.ByteString IO Void ()
+  forwarderApp protocols =
+    OuroborosApplication $ \_connectionId _shouldStopSTM ->
+      [ MiniProtocol
+         { miniProtocolNum    = MiniProtocolNum num
+         , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
+         , miniProtocolRun    = prot
+         }
+      | (prot, num) <- protocols
+      ]
+
+traceObjectsWriter :: ForwardSink TraceObject -> IO ()
+traceObjectsWriter sink = forever $ do
+  writeToSink sink . mkTraceObject =<< getCurrentTime
+  threadDelay 50000
+ where
+  mkTraceObject now = TraceObject
+    { toHuman     = Just "Human Message"
+    , toMachine   = Just "{\"msg\": \"forMachine\"}"
+    , toNamespace = ["demoNamespace"]
+    , toSeverity  = Info
+    , toDetails   = DNormal
+    , toTimestamp = now
+    , toHostname  = "nixos"
+    , toThreadId  = "1"
+    }

--- a/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Tracer.Test.Logs.Tests
+  ( tests
+  ) where
+
+import           Control.Concurrent.Async (withAsync)
+import           Control.Monad (filterM)
+import           Data.List.Extra (notNull)
+import qualified Data.List.NonEmpty as NE
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           System.Directory
+import           System.FilePath
+import           System.Time.Extra
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.Utils (isItLog, isItSymLink)
+import           Cardano.Tracer.Run (doRunCardanoTracer)
+import           Cardano.Tracer.Utils (applyBrake, initProtocolsBrake, initDataPointRequestors)
+
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.Utils
+
+tests :: TestTree
+tests = localOption (QuickCheckTests 1) $ testGroup "Test.Logs"
+  [ testProperty ".log"             $ propRunInLogsStructure  (propLogs ForHuman)
+  , testProperty ".json"            $ propRunInLogsStructure  (propLogs ForMachine)
+  , testProperty "multi, initiator" $ propRunInLogsStructure2 (propMultiInit ForMachine)
+  , testProperty "multi, responder" $ propRunInLogsStructure  (propMultiResp ForMachine)
+  ]
+
+propLogs :: LogFormat -> FilePath -> FilePath -> IO Property
+propLogs format rootDir localSock = do
+  stopProtocols <- initProtocolsBrake
+  dpRequestors <- initDataPointRequestors
+  withAsync (doRunCardanoTracer (config rootDir localSock) stopProtocols dpRequestors) . const $
+    withAsync (launchForwardersSimple Responder localSock 1000 10000) . const $ do
+      sleep 7.0 -- Wait till some rotation is done.
+      applyBrake stopProtocols
+      sleep 0.5
+
+  doesDirectoryExist rootDir >>= \case
+    True ->
+      -- ... and contains one node's subdir...
+      listDirectory rootDir >>= \case
+        []  -> false "root dir is empty"
+        [subDir] ->
+          withCurrentDirectory rootDir $
+            -- ... with *.log-files inside...
+            listDirectory subDir >>= \case
+              [] -> false "subdir is empty"
+              logsAndSymLink ->
+                withCurrentDirectory subDir $
+                  case filter (isItLog format) logsAndSymLink of
+                    [] -> false "subdir doesn't contain expected logs"
+                    logsWeNeed ->
+                      if length logsWeNeed > 1
+                        then
+                          -- ... and one symlink...
+                          filterM (isItSymLink format) logsAndSymLink >>= \case
+                            [] -> false "subdir doesn't contain a symlink"
+                            [symLink] -> do
+                              -- ... to the latest *.log-file.
+                              maybeLatestLog <- getSymbolicLinkTarget symLink
+                              -- The logs' names contain timestamps, so the
+                              -- latest log is the maximum one.
+                              let latestLog = maximum logsWeNeed
+                              return $ latestLog === takeFileName maybeLatestLog
+                            _ -> false "there is more than one symlink"
+                        else false "there is still 1 single log, no rotation"
+        _ -> false "root dir contains more than one subdir"
+    False -> false "root dir doesn't exist"
+ where
+  config root p = TracerConfig
+    { networkMagic   = 764824073
+    , network        = ConnectTo $ NE.fromList [LocalSocket p]
+    , loRequestNum   = Just 1
+    , ekgRequestFreq = Just 1.0
+    , hasEKG         = Nothing
+    , hasPrometheus  = Nothing
+    , logging        = NE.fromList [LoggingParams root FileMode format]
+    , rotation       = Just $ RotationParams
+                         { rpFrequencySecs = 5
+                         , rpLogLimitBytes = 100
+                         , rpMaxAgeHours   = 1
+                         , rpKeepFilesNum  = 10
+                         }
+    , verbosity      = Just Minimum
+    }
+
+propMultiInit :: LogFormat -> FilePath -> FilePath -> FilePath -> IO Property
+propMultiInit format rootDir localSock1 localSock2 = do
+  stopProtocols <- initProtocolsBrake
+  dpRequestors <- initDataPointRequestors
+  withAsync (doRunCardanoTracer (config rootDir localSock1 localSock2) stopProtocols dpRequestors) . const $
+    withAsync (launchForwardersSimple Responder localSock1 1000 10000) . const $
+      withAsync (launchForwardersSimple Responder localSock2 1000 10000) . const $ do
+        sleep 3.0 -- Wait till some work is done.
+        applyBrake stopProtocols
+        sleep 0.5
+  checkMultiResults rootDir
+ where
+  config root p1 p2 = TracerConfig
+    { networkMagic   = 764824073
+    , network        = ConnectTo $ NE.fromList [LocalSocket p1, LocalSocket p2]
+    , loRequestNum   = Just 1
+    , ekgRequestFreq = Just 1.0
+    , hasEKG         = Nothing
+    , hasPrometheus  = Nothing
+    , logging        = NE.fromList [LoggingParams root FileMode format]
+    , rotation       = Nothing
+    , verbosity      = Just Minimum
+    }
+
+propMultiResp :: LogFormat -> FilePath -> FilePath -> IO Property
+propMultiResp format rootDir localSock = do
+  stopProtocols <- initProtocolsBrake
+  dpRequestors <- initDataPointRequestors
+  withAsync (doRunCardanoTracer (config rootDir localSock) stopProtocols dpRequestors) . const $
+    withAsync (launchForwardersSimple Initiator localSock 1000 10000) . const $
+      withAsync (launchForwardersSimple Initiator localSock 1000 10000) . const $ do
+        sleep 3.0 -- Wait till some work is done.
+        applyBrake stopProtocols
+        sleep 0.5
+
+  checkMultiResults rootDir
+ where
+  config root p = TracerConfig
+    { networkMagic   = 764824073
+    , network        = AcceptAt $ LocalSocket p
+    , loRequestNum   = Just 1
+    , ekgRequestFreq = Just 1.0
+    , hasEKG         = Nothing
+    , hasPrometheus  = Nothing
+    , logging        = NE.fromList [LoggingParams root FileMode format]
+    , rotation       = Nothing
+    , verbosity      = Just Minimum
+    }
+
+checkMultiResults :: FilePath -> IO Property
+checkMultiResults rootDir =
+  -- Check if the root directory exists...
+  doesDirectoryExist rootDir >>= \case
+    True ->
+      -- ... and contains two nodes' subdirs...
+      listDirectory rootDir >>= \case
+        [] -> false "root dir is empty"
+        [subDir1, subDir2] ->
+          withCurrentDirectory rootDir $ do
+            -- ... with *.log-files inside...
+            subDir1list <- listDirectory subDir1
+            subDir2list <- listDirectory subDir2
+            return . property $ notNull subDir1list && notNull subDir2list
+        _ -> false "root dir contains not 2 subdirs"
+    False -> false "root dir doesn't exist"

--- a/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
@@ -5,7 +5,6 @@ module Cardano.Tracer.Test.Logs.Tests
   ) where
 
 import           Control.Concurrent.Async (withAsync)
-import           Control.Monad (filterM)
 import           Data.List.Extra (notNull)
 import qualified Data.List.NonEmpty as NE
 import           Test.Tasty
@@ -15,17 +14,18 @@ import           System.FilePath
 import           System.Time.Extra
 
 import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Handlers.Logs.Utils (isItLog, isItSymLink)
+import           Cardano.Tracer.Handlers.Logs.Utils (isItLog)
 import           Cardano.Tracer.Run (doRunCardanoTracer)
-import           Cardano.Tracer.Utils (applyBrake, initProtocolsBrake, initDataPointRequestors)
+import           Cardano.Tracer.Utils (applyBrake, initProtocolsBrake,
+                   initDataPointRequestors)
 
 import           Cardano.Tracer.Test.Forwarder
 import           Cardano.Tracer.Test.Utils
 
 tests :: TestTree
 tests = localOption (QuickCheckTests 1) $ testGroup "Test.Logs"
-  [ testProperty ".log"             $ propRunInLogsStructure  (propLogs ForHuman)
-  , testProperty ".json"            $ propRunInLogsStructure  (propLogs ForMachine)
+  [ testProperty ".log"  $ propRunInLogsStructure (propLogs ForHuman)
+  , testProperty ".json" $ propRunInLogsStructure (propLogs ForMachine)
   , testProperty "multi, initiator" $ propRunInLogsStructure2 (propMultiInit ForMachine)
   , testProperty "multi, responder" $ propRunInLogsStructure  (propMultiResp ForMachine)
   ]
@@ -34,54 +34,40 @@ propLogs :: LogFormat -> FilePath -> FilePath -> IO Property
 propLogs format rootDir localSock = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
-  withAsync (doRunCardanoTracer (config rootDir localSock) stopProtocols dpRequestors) . const $
-    withAsync (launchForwardersSimple Responder localSock 1000 10000) . const $ do
+  withAsync (doRunCardanoTracer (config rootDir localSock) stopProtocols dpRequestors) . const $ do
+    sleep 1.0
+    withAsync (launchForwardersSimple Initiator localSock 1000 10000) . const $ do
       sleep 7.0 -- Wait till some rotation is done.
       applyBrake stopProtocols
       sleep 0.5
 
   doesDirectoryExist rootDir >>= \case
+    False -> false "root dir doesn't exist"
     True ->
       -- ... and contains one node's subdir...
       listDirectory rootDir >>= \case
-        []  -> false "root dir is empty"
-        [subDir] ->
-          withCurrentDirectory rootDir $
-            -- ... with *.log-files inside...
-            listDirectory subDir >>= \case
-              [] -> false "subdir is empty"
-              logsAndSymLink ->
-                withCurrentDirectory subDir $
-                  case filter (isItLog format) logsAndSymLink of
-                    [] -> false "subdir doesn't contain expected logs"
-                    logsWeNeed ->
-                      if length logsWeNeed > 1
-                        then
-                          -- ... and one symlink...
-                          filterM (isItSymLink format) logsAndSymLink >>= \case
-                            [] -> false "subdir doesn't contain a symlink"
-                            [symLink] -> do
-                              -- ... to the latest *.log-file.
-                              maybeLatestLog <- getSymbolicLinkTarget symLink
-                              -- The logs' names contain timestamps, so the
-                              -- latest log is the maximum one.
-                              let latestLog = maximum logsWeNeed
-                              return $ latestLog === takeFileName maybeLatestLog
-                            _ -> false "there is more than one symlink"
-                        else false "there is still 1 single log, no rotation"
-        _ -> false "root dir contains more than one subdir"
-    False -> false "root dir doesn't exist"
+        [] -> false "root dir is empty"
+        (subDir:_) -> do
+          -- ... with *.log-files inside...
+          let pathToSubDir = rootDir </> subDir
+          listDirectory pathToSubDir >>= \case
+            [] -> false "subdir is empty"
+            logsAndSymLink ->
+              case filter (isItLog format) logsAndSymLink of
+                []        -> false "subdir doesn't contain expected logs"
+                [_oneLog] -> false "there is still 1 single log, no rotation"
+                _logs     -> return $ property True
  where
   config root p = TracerConfig
     { networkMagic   = 764824073
-    , network        = ConnectTo $ NE.fromList [LocalSocket p]
+    , network        = AcceptAt (LocalSocket p) -- ConnectTo $ NE.fromList [LocalSocket p]
     , loRequestNum   = Just 1
     , ekgRequestFreq = Just 1.0
     , hasEKG         = Nothing
     , hasPrometheus  = Nothing
     , logging        = NE.fromList [LoggingParams root FileMode format]
     , rotation       = Just $ RotationParams
-                         { rpFrequencySecs = 5
+                         { rpFrequencySecs = 3
                          , rpLogLimitBytes = 100
                          , rpMaxAgeHours   = 1
                          , rpKeepFilesNum  = 10
@@ -93,7 +79,8 @@ propMultiInit :: LogFormat -> FilePath -> FilePath -> FilePath -> IO Property
 propMultiInit format rootDir localSock1 localSock2 = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
-  withAsync (doRunCardanoTracer (config rootDir localSock1 localSock2) stopProtocols dpRequestors) . const $
+  withAsync (doRunCardanoTracer (config rootDir localSock1 localSock2) stopProtocols dpRequestors) . const $ do
+    sleep 1.0
     withAsync (launchForwardersSimple Responder localSock1 1000 10000) . const $
       withAsync (launchForwardersSimple Responder localSock2 1000 10000) . const $ do
         sleep 3.0 -- Wait till some work is done.
@@ -123,7 +110,6 @@ propMultiResp format rootDir localSock = do
         sleep 3.0 -- Wait till some work is done.
         applyBrake stopProtocols
         sleep 0.5
-
   checkMultiResults rootDir
  where
   config root p = TracerConfig
@@ -142,15 +128,14 @@ checkMultiResults :: FilePath -> IO Property
 checkMultiResults rootDir =
   -- Check if the root directory exists...
   doesDirectoryExist rootDir >>= \case
+    False -> false "root dir doesn't exist"
     True ->
       -- ... and contains two nodes' subdirs...
       listDirectory rootDir >>= \case
         [] -> false "root dir is empty"
-        [subDir1, subDir2] ->
-          withCurrentDirectory rootDir $ do
-            -- ... with *.log-files inside...
-            subDir1list <- listDirectory subDir1
-            subDir2list <- listDirectory subDir2
-            return . property $ notNull subDir1list && notNull subDir2list
+        [subDir1, subDir2] -> do
+          -- ... with *.log-files inside...
+          subDir1list <- listDirectory $ rootDir </> subDir1
+          subDir2list <- listDirectory $ rootDir </> subDir2
+          return . property $ notNull subDir1list && notNull subDir2list
         _ -> false "root dir contains not 2 subdirs"
-    False -> false "root dir doesn't exist"

--- a/cardano-tracer/test/Cardano/Tracer/Test/Network/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Network/Tests.hs
@@ -1,0 +1,91 @@
+module Cardano.Tracer.Test.Network.Tests
+  ( tests
+  ) where
+
+import           Control.Concurrent.Async (asyncBound, uninterruptibleCancel)
+import           Control.Monad.Extra (ifM)
+import qualified Data.List.NonEmpty as NE
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           System.Time.Extra (sleep)
+
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Run
+import           Cardano.Tracer.Utils
+
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.Utils
+
+data Mode = Initiate | Response
+
+tests :: TestTree
+tests = localOption (QuickCheckTests 1) $ testGroup "Test.Network"
+  [ testProperty "restart tracer"    $ propRunInLogsStructure propNetworkTracer
+  , testProperty "restart forwarder" $ propRunInLogsStructure propNetworkForwarder
+  ]
+
+propNetworkTracer, propNetworkForwarder :: FilePath -> FilePath -> IO Property
+propNetworkTracer rootDir localSock =
+  propNetwork' rootDir
+    ( lift3M doRunCardanoTracer (return $ mkConfig Initiate rootDir localSock)
+                                initProtocolsBrake
+                                initDataPointRequestors
+    , launchForwardersSimple Responder localSock 1000 10000
+    )
+propNetworkForwarder rootDir localSock =
+  propNetwork' rootDir
+    ( launchForwardersSimple Initiator localSock 1000 10000
+    , lift3M doRunCardanoTracer (return $ mkConfig Response rootDir localSock)
+                                initProtocolsBrake
+                                initDataPointRequestors
+    )
+
+propNetwork' :: FilePath -> (IO (), IO ()) -> IO Property
+propNetwork' rootDir (fstSide, sndSide) = do
+  f <- asyncBound fstSide
+  s <- asyncBound sndSide
+  -- Now sides should be connected and do some work.
+  sleep 3.0
+  -- Check if the root dir contains subdir, which is a proof that interaction
+  -- between sides already occurred.
+  ifM (doesDirectoryEmpty rootDir)
+    (false "root dir is empty after the first start")
+    $ do
+      -- Forcibly stop the first side (like killing the process in the real world).
+      uninterruptibleCancel f
+      -- Now the second side is working without the first one, and tries to re-connect.
+      sleep 3.0
+      -- Remove rootDir's content, to make sure it will be re-created later.
+      removeDirectoryContent rootDir
+      -- Start the first side again, soon the connection should be re-established.
+      f' <- asyncBound fstSide
+      -- Now it should be connected to the second side again,
+      -- and, if so, the subdir in the rootDir should be re-created.
+      sleep 3.0
+      -- Forcibly kill both sides.
+      uninterruptibleCancel s
+      uninterruptibleCancel f'
+      -- Check if the root directory isn't empty, which means that the connection
+      -- between sides was re-established and some work was performed again.
+      ifM (doesDirectoryEmpty rootDir)
+        (false "root dir is empty after restart")
+        (return $ property True)
+
+mkConfig
+  :: Mode
+  -> FilePath
+  -> FilePath
+  -> TracerConfig
+mkConfig mode root p = TracerConfig
+  { networkMagic   = 764824073
+  , network        = case mode of
+                       Initiate -> ConnectTo $ NE.fromList [LocalSocket p]
+                       Response -> AcceptAt $ LocalSocket p
+  , loRequestNum   = Just 1
+  , ekgRequestFreq = Just 1.0
+  , hasEKG         = Nothing
+  , hasPrometheus  = Nothing
+  , logging        = NE.fromList [LoggingParams root FileMode ForMachine]
+  , rotation       = Nothing
+  , verbosity      = Just Minimum
+  }

--- a/cardano-tracer/test/Cardano/Tracer/Test/Queue/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Queue/Tests.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Tracer.Test.Queue.Tests
+  ( tests
+  ) where
+
+import           Control.Concurrent.Async (withAsyncBound)
+import           GHC.IO.Handle (hDuplicate, hDuplicateTo)
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           System.Directory (removeFile)
+import           System.IO
+import           System.Time.Extra (sleep)
+
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.Utils
+
+tests :: TestTree
+tests = localOption (QuickCheckTests 1) $ testGroup "Test.Queue"
+  [ testProperty "check queue" $ propRunInLogsStructure propQueue
+  ]
+
+propQueue :: FilePath -> FilePath -> IO Property
+propQueue rootDir localSock =
+  -- withTempFile $ \tmpStdout ->
+    -- Run the forwarder only. It imitates the case when the acceptor is
+    -- misconfigured and cannot be launched, so the connection cannot be established.
+    -- In this case, the forwarder should collect trace items in its internal
+    -- "flexible queue" and periodically flush them to stdout.
+    withAsyncBound (launchForwardersSimple Responder localSock connSize disconnSize) $ \_ -> do
+      content <- getStdout rootDir
+      let flushedTraceObjectsNum = T.count "TraceObject" content
+      return $ flushedTraceObjectsNum === fromIntegral disconnSize
+
+-- | Temporarily redirect stdout to file, get its content and redirect it back.
+getStdout :: FilePath -> IO T.Text
+getStdout dir = do
+  (tmpPath, tmpHdl) <- openTempFile dir "cardano-tracer-tmp-stdout"
+  stdDup <- hDuplicate stdout
+  hDuplicateTo tmpHdl stdout
+  hClose tmpHdl
+  -- Wait till the queue will be redirected to stdout.
+  sleep 6.5
+  hDuplicateTo stdDup stdout
+  hClose stdDup
+  content <- TIO.readFile tmpPath
+  removeFile tmpPath
+  return content
+
+connSize, disconnSize :: Word
+connSize = 50
+disconnSize = 100

--- a/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
@@ -1,4 +1,4 @@
-module Cardano.Tracer.Test.Network.Tests
+module Cardano.Tracer.Test.Restart.Tests
   ( tests
   ) where
 
@@ -7,6 +7,9 @@ import           Control.Monad.Extra (ifM)
 import qualified Data.List.NonEmpty as NE
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
+import           System.Directory (getFileSize)
+import           System.Directory.Extra (listDirectories, listFiles)
+import           System.FilePath ((</>))
 import           System.Time.Extra (sleep)
 
 import           Cardano.Tracer.Configuration
@@ -19,57 +22,68 @@ import           Cardano.Tracer.Test.Utils
 data Mode = Initiate | Response
 
 tests :: TestTree
-tests = localOption (QuickCheckTests 1) $ testGroup "Test.Network"
-  [ testProperty "restart tracer"    $ propRunInLogsStructure propNetworkTracer
-  , testProperty "restart forwarder" $ propRunInLogsStructure propNetworkForwarder
+tests = localOption (QuickCheckTests 1) $ testGroup "Test.Restart"
+  [ testProperty "forwarder" $ propRunInLogsStructure propNetworkForwarder
   ]
 
-propNetworkTracer, propNetworkForwarder :: FilePath -> FilePath -> IO Property
-propNetworkTracer rootDir localSock =
-  propNetwork' rootDir
-    ( lift3M doRunCardanoTracer (return $ mkConfig Initiate rootDir localSock)
-                                initProtocolsBrake
-                                initDataPointRequestors
-    , launchForwardersSimple Responder localSock 1000 10000
-    )
+propNetworkForwarder :: FilePath -> FilePath -> IO Property
 propNetworkForwarder rootDir localSock =
-  propNetwork' rootDir
+  propNetwork' Initiator rootDir
     ( launchForwardersSimple Initiator localSock 1000 10000
     , lift3M doRunCardanoTracer (return $ mkConfig Response rootDir localSock)
                                 initProtocolsBrake
                                 initDataPointRequestors
     )
 
-propNetwork' :: FilePath -> (IO (), IO ()) -> IO Property
-propNetwork' rootDir (fstSide, sndSide) = do
+propNetwork'
+  :: ForwardersMode
+  -> FilePath
+  -> (IO (), IO ())
+  -> IO Property
+propNetwork' fmode rootDir (fstSide, sndSide) = do
   f <- asyncBound fstSide
+  sleep 1.0
   s <- asyncBound sndSide
   -- Now sides should be connected and do some work.
-  sleep 3.0
+  sleep 5.0
   -- Check if the root dir contains subdir, which is a proof that interaction
   -- between sides already occurred.
   ifM (doesDirectoryEmpty rootDir)
     (false "root dir is empty after the first start")
     $ do
+      -- Take current subdirs (it corresponds to the connection).
+      subDirs1 <- listDirectories rootDir
+      log1Size <- getLogSize subDirs1
       -- Forcibly stop the first side (like killing the process in the real world).
       uninterruptibleCancel f
-      -- Now the second side is working without the first one, and tries to re-connect.
-      sleep 3.0
-      -- Remove rootDir's content, to make sure it will be re-created later.
-      removeDirectoryContent rootDir
+      -- Now the second side is working without the first one, and is trying to re-connect.
+      sleep 5.0
       -- Start the first side again, soon the connection should be re-established.
       f' <- asyncBound fstSide
-      -- Now it should be connected to the second side again,
-      -- and, if so, the subdir in the rootDir should be re-created.
+      -- Now it should be connected to the second side again.
       sleep 3.0
       -- Forcibly kill both sides.
       uninterruptibleCancel s
       uninterruptibleCancel f'
-      -- Check if the root directory isn't empty, which means that the connection
-      -- between sides was re-established and some work was performed again.
-      ifM (doesDirectoryEmpty rootDir)
-        (false "root dir is empty after restart")
-        (return $ property True)
+      -- Take current subdirs again.
+      subDirs2 <- listDirectories rootDir
+      case fmode of
+        Responder -> do
+          log2Size <- getLogSize subDirs2
+          if log2Size > log1Size
+            then return $ property True
+            else false "No re-connected occurred (no items were added in the log)!"
+        Initiator ->
+          if subDirs1 == subDirs2
+            then false "No re-connect occurred!"
+            else return $ property True
+ where
+  getLogSize subDirs = do
+    let subDir = head subDirs -- It's safe because we already checked it's not empty.
+    fs <- listFiles (rootDir </> subDir)
+    case fs of
+      [f,_l] -> getFileSize f
+      _ -> return 0
 
 mkConfig
   :: Mode

--- a/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
@@ -1,0 +1,51 @@
+module Cardano.Tracer.Test.Utils
+  ( doesDirectoryEmpty
+  , false
+  , propRunInLogsStructure
+  , propRunInLogsStructure2
+  , removeDirectoryContent
+  ) where
+
+import           Control.Exception (finally)
+import           System.Directory.Extra (getTemporaryDirectory,
+                   listDirectories, removeFile, removePathForcibly)
+import           System.FilePath (dropDrive)
+import           System.IO.Extra (newTempDirWithin, newTempFileWithin)
+import           System.Info.Extra (isWindows)
+import           Test.Tasty.QuickCheck
+
+false :: String -> IO Property
+false msg = return . counterexample msg $ property False
+
+propRunInLogsStructure
+  :: (FilePath -> FilePath -> IO Property)
+  -> Property
+propRunInLogsStructure testAction = ioProperty $ do
+  tmpDir <- getTemporaryDirectory
+  (rootDir, deleteDir) <- newTempDirWithin tmpDir
+  (localSock, _) <- newTempFileWithin tmpDir
+  let preparedLocalSock = if isWindows then forWindows localSock else localSock
+  testAction rootDir preparedLocalSock
+    `finally` (removeFile preparedLocalSock >> deleteDir)
+
+propRunInLogsStructure2
+  :: (FilePath -> FilePath -> FilePath -> IO Property)
+  -> Property
+propRunInLogsStructure2 testAction = ioProperty $ do
+  tmpDir <- getTemporaryDirectory
+  (rootDir, deleteDir) <- newTempDirWithin tmpDir
+  (localSock1, _) <- newTempFileWithin tmpDir
+  (localSock2, _) <- newTempFileWithin tmpDir
+  let preparedLocalSock1 = if isWindows then forWindows localSock1 else localSock1
+      preparedLocalSock2 = if isWindows then forWindows localSock2 else localSock2
+  testAction rootDir preparedLocalSock1 preparedLocalSock2
+    `finally` (removeFile preparedLocalSock1 >> removeFile preparedLocalSock2 >> deleteDir)
+
+forWindows :: FilePath -> FilePath
+forWindows localSock = "\\\\.\\pipe\\" <> dropDrive localSock
+
+removeDirectoryContent :: FilePath -> IO ()
+removeDirectoryContent dir = listDirectories dir >>= mapM_ removePathForcibly
+
+doesDirectoryEmpty :: FilePath -> IO Bool
+doesDirectoryEmpty = fmap null . listDirectories

--- a/cardano-tracer/test/cardano-tracer-test.hs
+++ b/cardano-tracer/test/cardano-tracer-test.hs
@@ -2,7 +2,7 @@ import           Test.Tasty
 
 import qualified Cardano.Tracer.Test.Logs.Tests as Logs
 import qualified Cardano.Tracer.Test.DataPoint.Tests as DataPoint
-import qualified Cardano.Tracer.Test.Network.Tests as Network
+import qualified Cardano.Tracer.Test.Restart.Tests as Restart
 import qualified Cardano.Tracer.Test.Queue.Tests as Queue
 
 main :: IO ()
@@ -10,6 +10,6 @@ main = defaultMain $
   testGroup "cardano-tracer"
     [ Logs.tests
     , DataPoint.tests
-    , Network.tests
+    , Restart.tests
     , Queue.tests
     ]

--- a/cardano-tracer/test/cardano-tracer-test.hs
+++ b/cardano-tracer/test/cardano-tracer-test.hs
@@ -1,0 +1,15 @@
+import           Test.Tasty
+
+import qualified Cardano.Tracer.Test.Logs.Tests as Logs
+import qualified Cardano.Tracer.Test.DataPoint.Tests as DataPoint
+import qualified Cardano.Tracer.Test.Network.Tests as Network
+import qualified Cardano.Tracer.Test.Queue.Tests as Queue
+
+main :: IO ()
+main = defaultMain $
+  testGroup "cardano-tracer"
+    [ Logs.tests
+    , DataPoint.tests
+    , Network.tests
+    , Queue.tests
+    ]

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -188,6 +188,7 @@ let
       # systemd can't be statically linked
       packages.cardano-git-rev.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
       packages.cardano-node.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
+      packages.cardano-tracer.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
     })
     # Musl libc fully static build
     ({ pkgs, ... }:  lib.mkIf pkgs.stdenv.hostPlatform.isMusl (let

--- a/release.nix
+++ b/release.nix
@@ -141,8 +141,10 @@ let
     [ "plutus-scripts" ]
     [ "exes" "plutus-example" ] [ "haskellPackages" "plutus-example" ] [ "tests" "plutus-example" ] [ "checks" "tests" "plutus-example"]
   ] ++ onlyBuildOnDefaultSystem;
-  noMusl64Build = [ ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ["plan-nix"]]
-    ++ noCrossBuild;
+  noMusl64Build = [
+    ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ["plan-nix"]
+    [ "haskellPackages" "cardano-tracer" ] [ "tests" "cardano-tracer" ] [ "exes" "cardano-tracer" ]
+  ] ++ noCrossBuild;
 
   # Remove build jobs for which cross compiling does not make sense.
   filterProject = noBuildList: project: mapAttrsRecursiveCond (a: !(isDerivation a)) (path: value:


### PR DESCRIPTION
This PR introduces `cardano-tracer`, the last part of the new tracing infrastructure.

Previously, the node handled all the logging by itself. Moreover, it provided monitoring tools as well: two web-servers, for Prometheus and for EKG monitoring page. `cardano-tracer` is a result of _moving_ all the logging/monitoring-related stuff from the node to a separate service. As a result, the node became smaller, faster, and simpler.