### PR TITLE
Adds a capi library

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
     cardano-cli
     cardano-client-demo
     cardano-node
+    cardano-node-capi
     cardano-node-chairman
     cardano-submit-api
     cardano-testnet

--- a/cardano-node-capi/CHANGELOG.md
+++ b/cardano-node-capi/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for cardano-node-c
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cardano-node-capi/cardano-node-capi.cabal
+++ b/cardano-node-capi/cardano-node-capi.cabal
@@ -1,0 +1,19 @@
+cabal-version: 3.0
+
+name:               cardano-node-capi
+version:            0.1.0.0
+description:        ffi c library around the full node
+author:             IOHK
+maintainer:         operations@iohk.io
+
+extra-source-files: CHANGELOG.md
+
+library
+    exposed-modules:  Node
+    build-depends:    base
+                    , aeson
+                    , bytestring
+                    , cardano-node
+                    , optparse-applicative-fork
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cardano-node-capi/src/Node.hs
+++ b/cardano-node-capi/src/Node.hs
@@ -1,0 +1,28 @@
+module Node where
+
+import           Data.Aeson (eitherDecodeStrict)
+import           Cardano.Node.Run (runNode)
+
+import           Foreign.Ptr (Ptr)
+import           Foreign.C (CString, peekCString)
+import           Foreign.Marshal.Array (peekArray)
+import           Data.ByteString.Char8 (pack)
+
+import           Options.Applicative
+import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
+                   renderHelpDoc)
+
+-- | @crunNode@ is an exported C entry point to start a node.
+-- We parese the same arguments as the node CLI, but allow to
+-- pass the argumnets as @char *argv[]@ from C.
+foreign export ccall "runNode" crunNode :: Int -> Ptr CString -> IO ()
+crunNode :: Int -> Ptr CString -> IO ()
+crunNode argc argv = peekArray argc argv >>= mapM peekCString >>= \args ->
+    case execParserPure pref opts args of
+        Success pnc -> runNode pnc
+        Failure f   -> print f
+        CompletionInvoked _ -> putStrLn "Completion Invoked?"
+  where
+    pref = prefs showHelpOnEmpty
+    opts = info nodeCLIParser
+        ( fullDesc <> progDesc "Start node of the Cardano blockchain." )


### PR DESCRIPTION
This library can be consumed by other software wrapping the node through a c interface.

The core functionality is the `crunNode` exposed function. For simplicity it takes the same arguments
as the cli node.