### PR TITLE
Output as ledger compliant CDDL flag

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -79,6 +79,7 @@ library
                         Cardano.Api.SerialiseBech32
                         Cardano.Api.SerialiseCBOR
                         Cardano.Api.SerialiseJSON
+                        Cardano.Api.SerialiseLedgerCddl
                         Cardano.Api.SerialiseRaw
                         Cardano.Api.SerialiseTextEnvelope
                         Cardano.Api.SerialiseUsing

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -16,6 +16,7 @@ module Gen.Cardano.Api.Typed
   , genValueNestedRep
   , genValueNestedBundle
   , genByronKeyWitness
+  , genShelleyKeyWitness
 
   , genTxId
   , genTxIn

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -482,6 +482,10 @@ module Cardano.Api (
     readFileTextEnvelopeCddlAnyOf,
     writeTxFileTextEnvelopeCddl,
     writeTxWitnessFileTextEnvelopeCddl,
+    serialiseTxLedgerCddl,
+    deserialiseTxLedgerCddl,
+    serialiseWitnessLedgerCddl,
+    deserialiseWitnessLedgerCddl,
     TextEnvelopeCddlError(..),
 
     -- *** Reading one of several key types

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -473,6 +473,17 @@ module Cardano.Api (
     writeFileTextEnvelopeWithOwnerPermissions,
     readTextEnvelopeFromFile,
     readTextEnvelopeOfTypeFromFile,
+
+    -- ** Text envelope CDDL
+    -- | Support for serialising values in the ledger's CDDL format.
+    -- Note, this will be deprecated in the future in favour of a
+    -- single API.
+    FromSomeTypeCDDL(..),
+    readFileTextEnvelopeCddlAnyOf,
+    writeTxFileTextEnvelopeCddl,
+    writeTxWitnessFileTextEnvelopeCddl,
+    TextEnvelopeCddlError(..),
+
     -- *** Reading one of several key types
     FromSomeType(..),
     deserialiseFromTextEnvelopeAnyOf,
@@ -672,3 +683,4 @@ import           Cardano.Api.Value
 import           Cardano.Api.ValueParser
 --TODO: Remove after updating cardano-node-chairman with new IPC
 import           Cardano.Api.Protocol.Types
+import           Cardano.Api.SerialiseLedgerCddl

--- a/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
@@ -18,6 +18,12 @@ module Cardano.Api.SerialiseLedgerCddl
 
   , writeTxFileTextEnvelopeCddl
   , writeTxWitnessFileTextEnvelopeCddl
+
+  -- Exported for testing
+  , serialiseTxLedgerCddl
+  , deserialiseTxLedgerCddl
+  , serialiseWitnessLedgerCddl
+  , deserialiseWitnessLedgerCddl
   )
   where
 
@@ -94,7 +100,7 @@ data TextEnvelopeCddlError
       Text   -- ^ Actual types
   | TextEnvelopeCddlErrUnknownType Text
   | TextEnvelopeCddlErrByronKeyWitnessUnsupported
-  deriving Show
+  deriving (Show, Eq)
 
 instance Error TextEnvelopeCddlError where
   displayError (TextEnvelopeCddlErrCBORDecodingError decoderError) =
@@ -190,11 +196,11 @@ deserialiseWitnessLedgerCddl
 deserialiseWitnessLedgerCddl era TextEnvelopeCddl{teCddlRawCBOR,teCddlDescription} =
   --TODO: Parse these into types
   case teCddlDescription of
-    "Key BootstrapWitness Shelley" -> do
+    "Key BootstrapWitness ShelleyEra" -> do
       w <- first TextEnvelopeCddlErrCBORDecodingError
              $ CBOR.decodeAnnotator "Shelley Witness" fromCBOR (LBS.fromStrict teCddlRawCBOR)
       Right $ ShelleyBootstrapWitness era w
-    "Key Witness Shelley" -> do
+    "Key Witness ShelleyEra" -> do
       w <- first TextEnvelopeCddlErrCBORDecodingError
              $ CBOR.decodeAnnotator"Shelley Witness" fromCBOR (LBS.fromStrict teCddlRawCBOR)
       Right $ ShelleyKeyWitness era w

--- a/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
@@ -1,0 +1,312 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Ledger CDDL Serialisation
+--
+module Cardano.Api.SerialiseLedgerCddl
+  ( TextEnvelopeCddl(..)
+  , TextEnvelopeCddlError (..)
+  , FromSomeTypeCDDL(..)
+
+  -- * Reading one of several transaction or
+  -- key witness types
+  , readFileTextEnvelopeCddlAnyOf
+
+  , writeTxFileTextEnvelopeCddl
+  , writeTxWitnessFileTextEnvelopeCddl
+  )
+  where
+
+import           Prelude
+
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
+                   newExceptT, runExceptT)
+import           Data.Aeson
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Encode.Pretty (Config (..), defConfig, encodePretty', keyOrder)
+import           Data.Bifunctor (first)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List as List
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+import           Cardano.Binary (DecoderError)
+import qualified Cardano.Binary as CBOR
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.Tx
+
+
+-- Why have we gone this route? The serialization format of `TxBody era`
+-- differs from the CDDL. We serialize to an intermediate type in order to simplify
+-- the specification of Plutus scripts and to avoid users having to think about
+-- and construct redeemer pointers. However it turns out we can still serialize to
+-- the ledger's CDDL format and maintain the convenient script witness specification
+-- that the cli commands build and build-raw expose.
+--
+-- The long term plan is to have all relevant outputs from the cli to adhere to
+-- the ledger's CDDL spec. Modifying the existing TextEnvelope machinery to encompass
+-- this would result in a lot of unnecessary changes where the serialization
+-- already defaults to the CDDL spec. In order to reduce the number of changes, and to
+-- ease removal of the non-CDDL spec serialization, we have opted to create a separate
+-- data type to encompass this in the interim.
+
+data TextEnvelopeCddl = TextEnvelopeCddl
+  { teCddlType :: !Text
+  , teCddlDescription :: !Text
+  , teCddlRawCBOR :: !ByteString
+  } deriving (Eq, Show)
+
+instance ToJSON TextEnvelopeCddl where
+  toJSON TextEnvelopeCddl {teCddlType, teCddlDescription, teCddlRawCBOR} =
+    object [ "type"        .= teCddlType
+           , "description" .= teCddlDescription
+           , "cborHex"     .= Text.decodeUtf8 (Base16.encode teCddlRawCBOR)
+           ]
+
+instance FromJSON TextEnvelopeCddl where
+  parseJSON = withObject "TextEnvelopeCddl" $ \v ->
+                TextEnvelopeCddl <$> (v .: "type")
+                                 <*> (v .: "description")
+                                 <*> (parseJSONBase16 =<< v .: "cborHex")
+    where
+      parseJSONBase16 v =
+        either fail return . Base16.decode . Text.encodeUtf8 =<< parseJSON v
+
+
+data TextEnvelopeCddlError
+  = TextEnvelopeCddlErrCBORDecodingError DecoderError
+  | TextEnvelopeCddlAesonDecodeError FilePath String
+  | TextEnvelopeCddlUnknownKeyWitness
+  | TextEnvelopeCddlTypeError
+      [Text] -- ^ Expected types
+      Text   -- ^ Actual types
+  | TextEnvelopeCddlErrUnknownType Text
+  | TextEnvelopeCddlErrByronKeyWitnessUnsupported
+  deriving Show
+
+instance Error TextEnvelopeCddlError where
+  displayError (TextEnvelopeCddlErrCBORDecodingError decoderError) =
+    "TextEnvelopeCDDL CBOR decoding error: " <> show decoderError
+  displayError (TextEnvelopeCddlAesonDecodeError fp aesonErr) =
+    "Could not JSON decode TextEnvelopeCddl file at: " <> fp <> " Error: " <> aesonErr
+  displayError TextEnvelopeCddlUnknownKeyWitness =
+    "Unknown key witness specified"
+  displayError (TextEnvelopeCddlTypeError expTypes actType) =
+    "TextEnvelopeCddl type error: "
+       <> " Expected one of: "
+       <> List.intercalate ", "
+            [Text.unpack expType | expType <- expTypes]
+       <> " Actual: " <> Text.unpack actType
+  displayError (TextEnvelopeCddlErrUnknownType unknownType) =
+    "Unknown TextEnvelopeCddl type:" <> Text.unpack unknownType
+  displayError TextEnvelopeCddlErrByronKeyWitnessUnsupported =
+    "TextEnvelopeCddl error: Byron key witnesses are currently unsupported."
+
+serialiseTxLedgerCddl :: forall era. IsCardanoEra era => Tx era -> TextEnvelopeCddl
+serialiseTxLedgerCddl tx =
+  TextEnvelopeCddl
+    { teCddlType = genType tx
+    , teCddlDescription = "Ledger Cddl Format"
+    , teCddlRawCBOR = serialiseToCBOR tx
+    -- The SerialiseAsCBOR (Tx era) instance serializes to the Cddl format
+    }
+ where
+  genType :: Tx era -> Text
+  genType tx' = case getTxWitnesses tx' of
+                  [] -> "Unwitnessed " <> genTxType
+                  _ -> "Witnessed " <> genTxType
+
+  genTxType :: Text
+  genTxType =
+    case cardanoEra :: CardanoEra era of
+      ByronEra -> "Tx ByronEra"
+      ShelleyEra -> "Tx ShelleyEra"
+      AllegraEra -> "Tx AllegraEra"
+      MaryEra -> "Tx MaryEra"
+      AlonzoEra -> "Tx AlonzoEra"
+
+deserialiseTxLedgerCddl
+  :: IsCardanoEra era
+  => CardanoEra era
+  -> TextEnvelopeCddl
+  -> Either TextEnvelopeCddlError (Tx era)
+deserialiseTxLedgerCddl era tec =
+  first TextEnvelopeCddlErrCBORDecodingError . deserialiseTx era $ teCddlRawCBOR tec
+
+deserialiseTx
+  :: forall era. IsCardanoEra era
+  => CardanoEra era
+  -> ByteString
+  -> Either DecoderError (Tx era)
+deserialiseTx era bs =
+  case era of
+    ByronEra -> ByronTx <$> CBOR.decodeFullAnnotatedBytes
+                              "Byron Tx" fromCBOR (LBS.fromStrict bs)
+    _ -> deserialiseFromCBOR (AsTx ttoken) bs
+ where
+  ttoken :: AsType era
+  ttoken = proxyToAsType Proxy
+
+serialiseWitnessLedgerCddl :: forall era. ShelleyBasedEra era -> KeyWitness era -> TextEnvelopeCddl
+serialiseWitnessLedgerCddl sbe kw =
+  TextEnvelopeCddl
+    { teCddlType = witEra sbe
+    , teCddlDescription = genDesc kw
+    , teCddlRawCBOR = cddlSerialiseWitness kw
+    }
+ where
+  cddlSerialiseWitness :: KeyWitness era -> ByteString
+  cddlSerialiseWitness (ShelleyBootstrapWitness _ wit) = CBOR.serialize' wit
+  cddlSerialiseWitness (ShelleyKeyWitness _ wit) = CBOR.serialize' wit
+  cddlSerialiseWitness ByronKeyWitness{} = case sbe of {}
+
+  genDesc :: KeyWitness era -> Text
+  genDesc ByronKeyWitness{} = case sbe of {}
+  genDesc ShelleyBootstrapWitness{} = "Key BootstrapWitness ShelleyEra"
+  genDesc ShelleyKeyWitness{} = "Key Witness ShelleyEra"
+
+  witEra :: ShelleyBasedEra era -> Text
+  witEra ShelleyBasedEraShelley = "TxWitness ShelleyEra"
+  witEra ShelleyBasedEraAllegra = "TxWitness AllegraEra"
+  witEra ShelleyBasedEraMary = "TxWitness MaryEra"
+  witEra ShelleyBasedEraAlonzo = "TxWitness AlonzoEra"
+
+deserialiseWitnessLedgerCddl
+  :: ShelleyBasedEra era
+  -> TextEnvelopeCddl
+  -> Either TextEnvelopeCddlError (KeyWitness era)
+deserialiseWitnessLedgerCddl era TextEnvelopeCddl{teCddlRawCBOR,teCddlDescription} =
+  --TODO: Parse these into types
+  case teCddlDescription of
+    "Key BootstrapWitness Shelley" -> do
+      w <- first TextEnvelopeCddlErrCBORDecodingError
+             $ CBOR.decodeAnnotator "Shelley Witness" fromCBOR (LBS.fromStrict teCddlRawCBOR)
+      Right $ ShelleyBootstrapWitness era w
+    "Key Witness Shelley" -> do
+      w <- first TextEnvelopeCddlErrCBORDecodingError
+             $ CBOR.decodeAnnotator"Shelley Witness" fromCBOR (LBS.fromStrict teCddlRawCBOR)
+      Right $ ShelleyKeyWitness era w
+    _ -> Left TextEnvelopeCddlUnknownKeyWitness
+
+writeTxFileTextEnvelopeCddl
+  :: IsCardanoEra era
+  => FilePath
+  -> Tx era
+  -> IO (Either (FileError ()) ())
+writeTxFileTextEnvelopeCddl path tx =
+  runExceptT $ do
+    handleIOExceptT (FileIOError path) $ LBS.writeFile path txJson
+ where
+  txJson = encodePretty' textEnvelopeCddlJSONConfig (serialiseTxLedgerCddl tx) <> "\n"
+
+writeTxWitnessFileTextEnvelopeCddl
+  :: ShelleyBasedEra era
+  -> FilePath
+  -> KeyWitness era
+  -> IO (Either (FileError ()) ())
+writeTxWitnessFileTextEnvelopeCddl sbe path w =
+  runExceptT $ do
+    handleIOExceptT (FileIOError path) $ LBS.writeFile path txJson
+ where
+  txJson = encodePretty' textEnvelopeCddlJSONConfig (serialiseWitnessLedgerCddl sbe w) <> "\n"
+
+textEnvelopeCddlJSONConfig :: Config
+textEnvelopeCddlJSONConfig =
+  defConfig { confCompare = textEnvelopeCddlJSONKeyOrder }
+
+textEnvelopeCddlJSONKeyOrder :: Text -> Text -> Ordering
+textEnvelopeCddlJSONKeyOrder = keyOrder ["type", "description", "cborHex"]
+
+-- | This GADT allows us to deserialise a tx or key witness without
+--having to provide the era.
+data FromSomeTypeCDDL c b where
+  FromCDDLTx
+    :: Text -- ^ CDDL type that we want
+    -> (InAnyCardanoEra Tx -> b)
+    -> FromSomeTypeCDDL TextEnvelopeCddl b
+
+  FromCDDLWitness
+    :: Text -- ^ CDDL type that we want
+    -> (InAnyCardanoEra KeyWitness -> b)
+    -> FromSomeTypeCDDL TextEnvelopeCddl b
+
+deserialiseFromTextEnvelopeCddlAnyOf
+  :: [FromSomeTypeCDDL TextEnvelopeCddl b]
+  -> TextEnvelopeCddl
+  -> Either TextEnvelopeCddlError b
+deserialiseFromTextEnvelopeCddlAnyOf types teCddl =
+    case List.find matching types of
+      Nothing ->
+        Left (TextEnvelopeCddlTypeError expectedTypes actualType)
+
+      Just (FromCDDLTx ttoken f) -> do
+        AnyCardanoEra era <- cddlTypeToEra ttoken
+        f . InAnyCardanoEra era <$> deserialiseTxLedgerCddl era teCddl
+
+      Just (FromCDDLWitness ttoken f) -> do
+         AnyCardanoEra era <- cddlTypeToEra ttoken
+         case cardanoEraStyle era of
+           LegacyByronEra -> Left TextEnvelopeCddlErrByronKeyWitnessUnsupported
+           ShelleyBasedEra sbe ->
+             f . InAnyCardanoEra era <$> deserialiseWitnessLedgerCddl sbe teCddl
+  where
+   actualType :: Text
+   actualType = teCddlType teCddl
+
+   expectedTypes :: [Text]
+   expectedTypes = [ typ | FromCDDLTx typ _f <- types ]
+
+   matching :: FromSomeTypeCDDL TextEnvelopeCddl b -> Bool
+   matching (FromCDDLTx ttoken _f) = actualType == ttoken
+   matching (FromCDDLWitness ttoken _f)  = actualType == ttoken
+
+-- TODO: This is atrocious but the plan is to parse the 'teCddlType'
+-- field in the future.
+cddlTypeToEra :: Text -> Either TextEnvelopeCddlError AnyCardanoEra
+cddlTypeToEra "Witnessed Tx ByronEra" = return $ AnyCardanoEra ByronEra
+cddlTypeToEra "Witnessed Tx ShelleyEra" = return $ AnyCardanoEra ShelleyEra
+cddlTypeToEra "Witnessed Tx AllegraEra" = return $ AnyCardanoEra AllegraEra
+cddlTypeToEra "Witnessed Tx MaryEra" = return $ AnyCardanoEra MaryEra
+cddlTypeToEra "Witnessed Tx AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra "Unwitnessed Tx ByronEra" = return $ AnyCardanoEra ByronEra
+cddlTypeToEra "Unwitnessed Tx ShelleyEra" = return $ AnyCardanoEra ShelleyEra
+cddlTypeToEra "Unwitnessed Tx AllegraEra" = return $ AnyCardanoEra AllegraEra
+cddlTypeToEra "Unwitnessed Tx MaryEra" = return $ AnyCardanoEra MaryEra
+cddlTypeToEra "Unwitnessed Tx AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra "TxWitness ShelleyEra" = return $ AnyCardanoEra ShelleyEra
+cddlTypeToEra "TxWitness AllegraEra" = return $ AnyCardanoEra AllegraEra
+cddlTypeToEra "TxWitness MaryEra" = return $ AnyCardanoEra MaryEra
+cddlTypeToEra "TxWitness AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra unknownCddlType = Left $ TextEnvelopeCddlErrUnknownType unknownCddlType
+
+readFileTextEnvelopeCddlAnyOf
+  :: [FromSomeTypeCDDL TextEnvelopeCddl b]
+  -> FilePath
+  -> IO (Either (FileError TextEnvelopeCddlError) b)
+readFileTextEnvelopeCddlAnyOf types path =
+  runExceptT $ do
+    te <- newExceptT $ readTextEnvelopeCddlFromFile path
+    firstExceptT (FileError path) $ hoistEither $ do
+      deserialiseFromTextEnvelopeCddlAnyOf types te
+
+readTextEnvelopeCddlFromFile
+  :: FilePath
+  -> IO (Either (FileError TextEnvelopeCddlError) TextEnvelopeCddl)
+readTextEnvelopeCddlFromFile path =
+  runExceptT $ do
+    bs <- handleIOExceptT (FileIOError path) $
+            BS.readFile path
+    firstExceptT (FileError path . TextEnvelopeCddlAesonDecodeError path)
+      . hoistEither $ Aeson.eitherDecodeStrict' bs

--- a/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
@@ -35,27 +35,24 @@ module Cardano.Api.SerialiseTextEnvelope
 import           Prelude
 
 import           Data.Bifunctor (first)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List as List
 import           Data.Maybe (fromMaybe)
 import           Data.String (IsString)
-import qualified Data.ByteString as BS
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.List as List
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import qualified Data.Aeson as Aeson
-import           Data.Aeson
-                   (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
-import           Data.Aeson.Encode.Pretty
-                   (Config (..), encodePretty', defConfig, keyOrder)
+import           Data.Aeson.Encode.Pretty (Config (..), defConfig, encodePretty', keyOrder)
 
-import           Control.Monad (unless)
 import           Control.Exception (bracketOnError)
-import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
-import           Control.Monad.Trans.Except.Extra
-                   (hoistEither, firstExceptT, handleIOExceptT)
+import           Control.Monad (unless)
+import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
 
 import           System.Directory (removeFile, renameFile)
 import           System.FilePath (splitFileName, (<.>))

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -39,6 +39,7 @@ module Cardano.Api.Tx (
     makeShelleyBootstrapWitness,
     makeShelleySignature,
     getShelleyKeyWitnessVerificationKey,
+    getTxBodyAndWitnesses,
 
     -- * Data family instances
     AsType(AsTx, AsByronTx, AsShelleyTx, AsMaryTx, AsAllegraTx, AsAlonzoTx,
@@ -348,7 +349,9 @@ pattern AsShelleyWitness :: AsType (KeyWitness ShelleyEra)
 pattern AsShelleyWitness = AsKeyWitness AsShelleyEra
 {-# COMPLETE AsShelleyWitness #-}
 
-
+-- We implement a custom serialization instance that differs from
+-- cardano-ledger because we want to be able to tell the difference between
+-- on disk witnesses for the cli's 'assemble' command.
 instance IsCardanoEra era => SerialiseAsCBOR (KeyWitness era) where
     serialiseToCBOR (ByronKeyWitness wit) = CBOR.serialize' wit
 
@@ -474,7 +477,6 @@ getTxBody (ShelleyTx era tx) =
                     (TxBodyScriptData scriptDataInEra txdats redeemers)
                     (strictMaybeToMaybe auxiliaryData)
                     (TxScriptValidity txScriptValidityInEra (isValidToScriptValidity isValid))
-
 
 getTxWitnesses :: forall era. Tx era -> [KeyWitness era]
 getTxWitnesses (ByronTx Byron.ATxAux { Byron.aTaWitness = witnesses }) =

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -349,8 +349,8 @@ pattern AsShelleyWitness :: AsType (KeyWitness ShelleyEra)
 pattern AsShelleyWitness = AsKeyWitness AsShelleyEra
 {-# COMPLETE AsShelleyWitness #-}
 
--- We implement a custom serialization instance that differs from
--- cardano-ledger because we want to be able to tell the difference between
+-- This custom instance differs from cardano-ledger
+-- because we want to be able to tell the difference between
 -- on disk witnesses for the cli's 'assemble' command.
 instance IsCardanoEra era => SerialiseAsCBOR (KeyWitness era) where
     serialiseToCBOR (ByronKeyWitness wit) = CBOR.serialize' wit

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -26,10 +26,11 @@ import           Cardano.CLI.Render (customRenderHelp)
 
 import           Cardano.Config.Git.Rev (gitRev)
 import           Data.Version (showVersion)
+import           Options.Applicative.Help.Core
+import           Options.Applicative.Types (OptReader (..), Option (..), Parser (..),
+                   ParserInfo (..), ParserPrefs (..))
 import           Paths_cardano_cli (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
-import           Options.Applicative.Types (Option (..), OptReader (..), Parser (..), ParserInfo (..), ParserPrefs (..))
-import           Options.Applicative.Help.Core
 
 import qualified Data.List as L
 import qualified System.IO as IO
@@ -53,7 +54,6 @@ data ClientCommand =
 data ClientCommandErrors
   = ByronClientError ByronClientCmdError
   | ShelleyClientError ShelleyCommand ShelleyClientCmdError
-  deriving Show
 
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()
 runClientCommand (ByronCommand c) = firstExceptT ByronClientError $ runByronClientCommand c
@@ -114,7 +114,7 @@ helpAll pprefs progn rnames parserInfo = do
           OptP optP -> case optMain optP of
             CmdReader _ cs f -> do
               forM_ cs $ \c ->
-                forM_ (f c) $ \subParserInfo -> 
+                forM_ (f c) $ \subParserInfo ->
                   helpAll pprefs progn (c:rnames) subParserInfo
             _ -> return ()
           AltP pa pb -> go pa >> go pb

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -223,6 +223,7 @@ data TransactionCmd
       [MetadataFile]
       (Maybe ProtocolParamsSourceSpec)
       (Maybe UpdateProposalFile)
+      OutputSerialisation
       TxBodyFile
   | TxSign TxBodyFile [WitnessSigningData] (Maybe NetworkId) TxFile
   | TxCreateWitness TxBodyFile WitnessSigningData (Maybe NetworkId) OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -186,6 +186,7 @@ data TransactionCmd
       [MetadataFile]
       (Maybe ProtocolParamsSourceSpec)
       (Maybe UpdateProposalFile)
+      OutputSerialisation
       TxBodyFile
 
     -- | Like 'TxBuildRaw' but without the fee, and with a change output.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -686,6 +686,7 @@ pTransaction =
             <*> many pMetadataFile
             <*> optional pProtocolParamsSourceSpec
             <*> optional pUpdateProposalFile
+            <*> pOutputSerialisation
             <*> pTxBodyFile Output
 
   pChangeAddress :: Parser TxOutChangeAddress

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -901,7 +901,7 @@ pQueryCmd =
     , subParser "pool-params"
         (Opt.info pQueryPoolParams $ Opt.progDesc "Dump the pool parameters (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)")
     , subParser "leadership-schedule"
-        (Opt.info pLeadershipSchedule $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command")
+        (Opt.info pLeadershipSchedule $ Opt.progDesc "Get the slots the node is the slot leader of (advanced command)")
     ]
   where
     pQueryProtocolParameters :: Parser QueryCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -719,6 +719,7 @@ pTransaction =
                <*> many pMetadataFile
                <*> optional pProtocolParamsSourceSpec
                <*> optional pUpdateProposalFile
+               <*> pOutputSerialisation
                <*> pTxBodyFile Output
 
   pTransactionSign  :: Parser TransactionCmd
@@ -1597,6 +1598,16 @@ pOutputFormat =
     <> Opt.value OutputFormatBech32
     )
 
+pOutputSerialisation :: Parser OutputSerialisation
+pOutputSerialisation =
+  Opt.flag' OutputLedgerCDDLSerialisation
+    (  Opt.long "cddl-format"
+    <> Opt.help "Serialise in the ledger CDDL specified CBOR format."
+    ) <|>
+  Opt.flag OutputCliSerialisation OutputCliSerialisation
+    (  Opt.long "cli-format"
+    <> Opt.help "Serialise in the cardano-cli CBOR format."
+    )
 
 pMaybeOutputFile :: Parser (Maybe OutputFile)
 pMaybeOutputFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -36,7 +36,6 @@ data ShelleyClientCmdError
   | ShelleyCmdTransactionError !ShelleyTxCmdError
   | ShelleyCmdQueryError !ShelleyQueryCmdError
   | ShelleyCmdKeyError !ShelleyKeyCmdError
-  deriving Show
 
 renderShelleyClientCmdError :: ShelleyCommand -> ShelleyClientCmdError -> Text
 renderShelleyClientCmdError cmd err =

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -74,8 +74,8 @@ data OutputFormat
   | OutputFormatBech32
   deriving (Eq, Show)
 
--- | Specify whether to serialise  a value according to the ledger's CDDL spec
--- or the cli' intermediate format. Note the intermediate format is defined
+-- | Specify whether to serialise a value according to the ledger's CDDL spec
+-- or the cli's intermediate format. Note the intermediate format is defined
 -- within SerialiseAsCBOR instances. The plan is to merge TextEnvelope with
 -- SerialiseAsCBOR.
 data OutputSerialisation

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Types
   , EpochLeadershipSchedule (..)
   , GenesisFile (..)
   , OutputFormat (..)
+  , OutputSerialisation (..)
   , SigningKeyFile (..)
   , SocketPath (..)
   , ScriptFile (..)
@@ -72,6 +73,15 @@ data OutputFormat
   = OutputFormatHex
   | OutputFormatBech32
   deriving (Eq, Show)
+
+-- | Specify whether to serialise  a value according to the ledger's CDDL spec
+-- or the cli' intermediate format. Note the intermediate format is defined
+-- within SerialiseAsCBOR instances. The plan is to merge TextEnvelope with
+-- SerialiseAsCBOR.
+data OutputSerialisation
+  = OutputLedgerCDDLSerialisation
+  | OutputCliSerialisation
+  deriving Show
 
 -- | This data structure is used to allow nicely formatted output within the query stake-snapshot command.
 --

--- a/doc/reference/cardano-node-cli-reference.md
+++ b/doc/reference/cardano-node-cli-reference.md
@@ -28,6 +28,7 @@ The `address` command contains the following sub commands:
 The `stake-address` command contains the following sub commands:
 * `key-gen`: creates a single address key pair
 * `build`: builds a stake address
+* `key-hash`: prints the hash of a stake verification key
 * `registration-certificate`: creates a registration certificate
 * `delegation-certificate`: creates a stake address delegation certificate
 * `deregistration-certificate`: creates a de-registration certificate
@@ -35,13 +36,17 @@ The `stake-address` command contains the following sub commands:
 *cardano-cli transaction*
 The `transaction` command contains the following sub commands:
 * `build-raw`: builds a low-level transaction (uses the `--cardano-mode`, `--byron-mode`, `--shelley-mode` flags)
+* `build`: builds an automatically balanced transaction (automatically calculates fees)
 * `sign`: signs the transaction
 * `assemble` : combines and assembles the transaction witness(es) with a transaction body to create a transaction
 * `witness`: witnesses a transaction
 * `submit`: submits the transaction to the local node whose Unix domain socket is obtained from the CARANO_NODE_SOCKET_PATH environment variable (uses the `--cardano-mode`, `--byron-mode`, `--shelley-mode` flags)
 * `calculate-min-fee`: calculates the minimum fee for the transaction
+* `calculate-min-required-utxo`: calculates the minimum reqired ADA for a transaction output
+* `hash-script-data`: calulates the hash of script data (datums)
 * `txid`: retrieves the transaction ID
 * `policyid`: retrieves the policy ID
+* `view`: pretty prints a transaction
 
 *cardano-cli node*
 The `node` command contains the following sub commands:
@@ -63,12 +68,15 @@ The `stake-pool` command contains the following sub commands:
 The `query` command contains the following sub commands:
 * `protocol-parameters` (advanced): retrieves the node’s current pool parameters (a raw dump of `Ledger.ChainDepState`).
 * `tip`: gets the node’s current tip (slot number, hash, and block number)
+* `stake-pools`: gets the node's current set of stake pool ids
 * `utxo`: retrieves the node’s current UTxO, filtered by address
-* `ledger-state` (advanced):  dumps the current state of the node (a raw dump of `Ledger.NewEpochState`)
-* `stake-address-info`: Get the current delegations and reward accounts filtered by stake address.
-* `stake-distribution`: Get the node's current aggregated stake distribution
-* `stake-snapshot` (advanced): Get the stake snapshot information for a stake pool
-* `pool-params` (advanced): Get the current and future parameters for a stake pool
+* `ledger-state` (advanced):  dumps the current state of the node (a raw dump of `Ledger.NewEpochState`)* `stake-distribution`: gets the node's current set of stake pool ids
+* `protocol-state` (advanced): dumps the node's current protocol state
+* `stake-address-info`: gets the current delegations and reward accounts filtered by stake address.
+* `stake-distribution`: gets the node's current aggregated stake distribution
+* `stake-snapshot` (advanced): gets the stake snapshot information for a stake pool
+* `pool-params` (advanced): gets the current and future parameters for a stake pool
+* `leadership-schedule`: gets the slots the node is slot leader in for the current epoch
 
 *cardano-cli governance*
 The `governance` command contains the following sub commands:


### PR DESCRIPTION
We implement an alternative `cardano-ledger` CDDL compliant serialization for the cli. The plan is to eventually deprecate the cli's intermediate format and to fully embrace the ledger's CDDL spec. 

There is now an optional `--cddl-format` flag in the `build` and `build-raw` commands that serialize the txbody as a **key** unwitnessed transaction. Any script witnesses specified at this stage are included in the witness set.

Resolves #3370 