### PR TITLE
Retry testnet tests

### DIFF
--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -25,7 +25,6 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Util.Process as H
 
-
 -- | Submit the desired epoch to wait to.
 waitUntilEpoch
   :: (MonadCatch m, MonadIO m, MonadTest m)
@@ -41,6 +40,7 @@ waitUntilEpoch fp testnetMagic execConfig desiredEpoch = do
   exists <- liftIO $ doesFileExist fp
   when exists $ liftIO $ removeFile fp
 
+
   void $ H.execCli' execConfig
     [ "query",  "tip"
     , "--testnet-magic", show @Int testnetMagic
@@ -50,7 +50,7 @@ waitUntilEpoch fp testnetMagic execConfig desiredEpoch = do
   tipJSON <- H.leftFailM $ H.readJsonFile fp
   tip <- H.noteShowM $ H.jsonErrorFail $ fromJSON @QueryTipLocalStateOutput tipJSON
   case mEpoch tip of
-    Nothing ->
+    Nothing -> do
       H.failMessage
         callStack "waitUntilEpoch: cardano-cli query tip returned Nothing for EpochNo"
     Just currEpoch ->

--- a/scripts/plutus/example-txin-locking-plutus-script.sh
+++ b/scripts/plutus/example-txin-locking-plutus-script.sh
@@ -143,9 +143,9 @@ $CARDANO_CLI transaction sign \
   --out-file $WORK/alonzo.tx
 
 # SUBMIT $WORK/alonzo.tx
-echo "Submit the tx with plutus script and wait 5 seconds..."
+echo "Submit the tx with plutus script and wait 10 seconds..."
 $CARDANO_CLI transaction submit --tx-file $WORK/alonzo.tx --testnet-magic "$TESTNET_MAGIC"
-sleep 5
+sleep 10
 echo ""
 echo "Querying UTxO at $dummyaddress. If there is ADA at the address the Plutus script successfully executed!"
 echo ""


### PR DESCRIPTION
This will retry any testnet that failed the first time.  The hope is this is a quick fix to reduce chairman test flakiness before we are able to have proper investigation into why the chairman tests fail in the first place.