### PR TITLE
Update transaction sign command to allow for incremental signing

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -81,6 +81,7 @@ module Cardano.Api.Shelley
       ),
     ShelleySigningKey(..),
     getShelleyKeyWitnessVerificationKey,
+    getTxBodyAndWitnesses,
     makeShelleySignature,
     toShelleySigningKey,
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -46,7 +46,7 @@ import           Cardano.Api.Byron
 import           Cardano.CLI.Byron.Key (byronWitnessToVerKey)
 import           Cardano.CLI.Environment
 import           Cardano.CLI.Helpers (textShow)
-import           Cardano.CLI.Types (SocketPath (..))
+import           Cardano.CLI.Types (SocketPath (..), TxFile (..))
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
@@ -70,11 +70,6 @@ renderByronTxError err =
     TxDeserialisationFailed txFp decErr ->
       "Transaction deserialisation failed at " <> textShow txFp <> " Error: " <> textShow decErr
     EnvSocketError envSockErr -> renderEnvSocketError envSockErr
-
-
-newtype TxFile =
-  TxFile FilePath
-  deriving (Eq, Ord, Show, IsString)
 
 newtype NewTxFile =
   NewTxFile FilePath

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -33,7 +33,6 @@ module Cardano.CLI.Shelley.Commands
   , ProtocolParamsFile (..)
   , ProtocolParamsSourceSpec (..)
   , WitnessFile (..)
-  , TxBodyFile (..)
   , TxFile (..)
   , InputTxFile (..)
   , VerificationKeyBase64 (..)
@@ -75,7 +74,6 @@ data ShelleyCommand
   | GovernanceCmd   GovernanceCmd
   | GenesisCmd      GenesisCmd
   | TextViewCmd     TextViewCmd
-  deriving Show
 
 renderShelleyCommand :: ShelleyCommand -> Text
 renderShelleyCommand sc =
@@ -225,7 +223,7 @@ data TransactionCmd
       (Maybe UpdateProposalFile)
       OutputSerialisation
       TxBodyFile
-  | TxSign TxBodyFile [WitnessSigningData] (Maybe NetworkId) TxFile
+  | TxSign TxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
   | TxCreateWitness TxBodyFile WitnessSigningData (Maybe NetworkId) OutputFile
   | TxAssembleTxBodyWitness TxBodyFile [WitnessFile] OutputFile
   | TxSubmit AnyConsensusModeParams NetworkId FilePath
@@ -246,7 +244,6 @@ data TransactionCmd
       ScriptDataOrFile
   | TxGetTxId InputTxFile
   | TxView InputTxFile
-  deriving Show
 
 data InputTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
   deriving Show
@@ -535,14 +532,6 @@ newtype PrivKeyFile
 
 newtype WitnessFile
   = WitnessFile FilePath
-  deriving Show
-
-newtype TxBodyFile
-  = TxBodyFile FilePath
-  deriving Show
-
-newtype TxFile
-  = TxFile FilePath
   deriving Show
 
 -- | A raw verification key given in Base64, and decoded into a ByteString.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -34,7 +34,7 @@ module Cardano.CLI.Shelley.Commands
   , ProtocolParamsSourceSpec (..)
   , WitnessFile (..)
   , TxFile (..)
-  , InputTxFile (..)
+  , InputTxBodyOrTxFile (..)
   , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
   , MetadataFile (..)
@@ -223,7 +223,7 @@ data TransactionCmd
       (Maybe UpdateProposalFile)
       OutputSerialisation
       TxBodyFile
-  | TxSign TxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
+  | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
   | TxCreateWitness TxBodyFile WitnessSigningData (Maybe NetworkId) OutputFile
   | TxAssembleTxBodyWitness TxBodyFile [WitnessFile] OutputFile
   | TxSubmit AnyConsensusModeParams NetworkId FilePath
@@ -242,10 +242,10 @@ data TransactionCmd
       TxOutAnyEra
   | TxHashScriptData
       ScriptDataOrFile
-  | TxGetTxId InputTxFile
-  | TxView InputTxFile
+  | TxGetTxId InputTxBodyOrTxFile
+  | TxView InputTxBodyOrTxFile
 
-data InputTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
+data InputTxBodyOrTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
   deriving Show
 
 data ProtocolParamsSourceSpec

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -724,7 +724,9 @@ pTransaction =
                <*> pTxBodyFile Output
 
   pTransactionSign  :: Parser TransactionCmd
-  pTransactionSign = TxSign <$> pTxBodyFile Input
+  pTransactionSign = TxSign <$> ( TxBodyFp <$> pTxBodyFile Input <|>
+                                  TxFp <$> pTxFile Input
+                                )
                             <*> pSomeWitnessSigningData
                             <*> optional pNetworkId
                             <*> pTxFile Output

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -724,9 +724,7 @@ pTransaction =
                <*> pTxBodyFile Output
 
   pTransactionSign  :: Parser TransactionCmd
-  pTransactionSign = TxSign <$> ( TxBodyFp <$> pTxBodyFile Input <|>
-                                  TxFp <$> pTxFile Input
-                                )
+  pTransactionSign = TxSign <$> pInputTxOrTxBodyFile
                             <*> pSomeWitnessSigningData
                             <*> optional pNetworkId
                             <*> pTxFile Output
@@ -785,10 +783,10 @@ pTransaction =
                           "The script data, in the given JSON file."
 
   pTransactionId  :: Parser TransactionCmd
-  pTransactionId = TxGetTxId <$> pInputTxFile
+  pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
 
   pTransactionView :: Parser TransactionCmd
-  pTransactionView = TxView <$> pInputTxFile
+  pTransactionView = TxView <$> pInputTxOrTxBodyFile
 
 pNodeCmd :: Parser NodeCmd
 pNodeCmd =
@@ -2146,8 +2144,8 @@ pTxFile fdir =
         Input -> "tx-file"
         Output -> "out-file"
 
-pInputTxFile :: Parser InputTxFile
-pInputTxFile =
+pInputTxOrTxBodyFile :: Parser InputTxBodyOrTxFile
+pInputTxOrTxBodyFile =
   InputTxBodyFile <$> pTxBodyFile Input <|> InputTxFile <$> pTxFile Input
 
 pTxInCount :: Parser TxInCount

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -981,7 +981,7 @@ readScriptDataOrFile (ScriptDataCborFile fp) = do
 -- Transaction signing
 --
 
-runTxSign :: TxBodyOrTxFile
+runTxSign :: InputTxBodyOrTxFile
           -> [WitnessSigningData]
           -> Maybe NetworkId
           -> TxFile
@@ -993,7 +993,7 @@ runTxSign txOrTxBody witSigningData mnw (TxFile outTxFile) = do
   let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeWitness sks
 
   case txOrTxBody of
-    (TxFp (TxFile inputTxFile)) -> do
+    (InputTxFile (TxFile inputTxFile)) -> do
       anyTx <- readFileTx inputTxFile
 
       InAnyShelleyBasedEra _era tx <-
@@ -1012,7 +1012,7 @@ runTxSign txOrTxBody witSigningData mnw (TxFile outTxFile) = do
       firstExceptT ShelleyTxCmdWriteFileError . newExceptT $
         writeFileTextEnvelope outTxFile Nothing signedTx
 
-    (TxBodyFp (TxBodyFile txbodyFile)) -> do
+    (InputTxBodyFile (TxBodyFile txbodyFile)) -> do
       unwitnessed <- readFileTxBody txbodyFile
 
       case unwitnessed of
@@ -1375,7 +1375,7 @@ runTxHashScriptData scriptDataOrFile = do
     d <- readScriptDataOrFile scriptDataOrFile
     liftIO $ BS.putStrLn $ serialiseToRawBytesHex (hashScriptData d)
 
-runTxGetTxId :: InputTxFile -> ExceptT ShelleyTxCmdError IO ()
+runTxGetTxId :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
 runTxGetTxId txfile = do
     InAnyCardanoEra _era txbody <-
       case txfile of
@@ -1392,7 +1392,7 @@ runTxGetTxId txfile = do
 
     liftIO $ BS.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
 
-runTxView :: InputTxFile -> ExceptT ShelleyTxCmdError IO ()
+runTxView :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
 runTxView txfile = do
   InAnyCardanoEra era txbody <-
     case txfile of

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -22,7 +22,6 @@ module Cardano.CLI.Types
   , ScriptDatumOrFile (..)
   , TransferDirection(..)
   , TxBodyFile (..)
-  , TxBodyOrTxFile (..)
   , TxOutAnyEra (..)
   , TxOutChangeAddress (..)
   , TxOutDatumAnyEra (..)
@@ -256,7 +255,4 @@ newtype TxFile
   = TxFile FilePath
   deriving Show
 
-data TxBodyOrTxFile
-  = TxBodyFp TxBodyFile
-  | TxFp TxFile
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -7,6 +7,7 @@
 module Cardano.CLI.Types
   ( BalanceTxExecUnits (..)
   , CBORObject (..)
+  , CddlTx (..)
   , CertificateFile (..)
   , EpochLeadershipSchedule (..)
   , GenesisFile (..)
@@ -20,9 +21,12 @@ module Cardano.CLI.Types
   , ScriptWitnessFiles (..)
   , ScriptDatumOrFile (..)
   , TransferDirection(..)
+  , TxBodyFile (..)
+  , TxBodyOrTxFile (..)
   , TxOutAnyEra (..)
   , TxOutChangeAddress (..)
   , TxOutDatumAnyEra (..)
+  , TxFile (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
   , Stakes (..)
@@ -52,6 +56,8 @@ data CBORObject = CBORBlockByron Byron.EpochSlots
                 | CBORUpdateProposalByron
                 | CBORVoteByron
                 deriving Show
+
+newtype CddlTx = CddlTx {unCddlTx :: InAnyCardanoEra Tx}
 
 -- Encompasses stake certificates, stake pool certificates,
 -- genesis delegate certificates and MIR certificates.
@@ -241,4 +247,16 @@ data EpochLeadershipSchedule
   = CurrentEpoch
   | NextEpoch
   deriving Show
+
+newtype TxBodyFile
+  = TxBodyFile FilePath
+  deriving Show
+
+newtype TxFile
+  = TxFile FilePath
+  deriving Show
+
+data TxBodyOrTxFile
+  = TxBodyFp TxBodyFile
+  | TxFp TxFile
 


### PR DESCRIPTION
You can now specify an already signed transaction via `--tx-file` in order to add more signatures to it:  

`cardano-cli transaction sign (--tx-body-file FILE | --tx-file FILE) ...`

Resolves: #3545
