### PR TITLE
Disable failing test on Windows.  Tidy up presentation of tests.

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -119,6 +119,7 @@ test-suite cardano-testnet-tests
                       , filepath
                       , process
                       , tasty
+                      , tasty-expected-failure
                       , tasty-hedgehog
                       , text
                       , unordered-containers
@@ -130,6 +131,7 @@ test-suite cardano-testnet-tests
                         Spec.Plutus.Script.TxInLockingPlutus
                         Spec.Plutus.SubmitApi.TxInLockingPlutus
                         Spec.Shutdown
+                        Test.Util
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 

--- a/cardano-testnet/test/Main.hs
+++ b/cardano-testnet/test/Main.hs
@@ -6,14 +6,7 @@ module Main
 
 import           Prelude
 
-import           Hedgehog (Property, property, success)
-import           Hedgehog.Extras.Stock.OS (isWin32)
-import qualified System.Environment as E
-import           System.Info
 import           Test.Tasty (TestTree)
-import qualified Test.Tasty as T
-import qualified Test.Tasty.Hedgehog as H
-import qualified Test.Tasty.Ingredients as T
 
 import qualified Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus
 import qualified Spec.Plutus.Direct.ScriptContextEquality
@@ -22,38 +15,28 @@ import qualified Spec.Plutus.Direct.TxInLockingPlutus
 import qualified Spec.Plutus.Script.TxInLockingPlutus
 import qualified Spec.Plutus.SubmitApi.TxInLockingPlutus
 import qualified Spec.Shutdown
+import qualified System.Environment as E
+import qualified Test.Tasty as T
+import qualified Test.Tasty.Hedgehog as H
+import qualified Test.Tasty.Ingredients as T
+import qualified Test.Util as H
 
 tests :: IO TestTree
 tests = do
   pure $ T.testGroup "test/Spec.hs"
     [ T.testGroup "Spec"
       [ -- Fails to meet deadline on MacOS for an unknown reason
-        ignoreOnMac "Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus" Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus.hprop_plutus_certifying_withdrawing
-      , H.testProperty "Spec.Plutus.Direct.TxInLockingPlutus" Spec.Plutus.Direct.TxInLockingPlutus.hprop_plutus
+        H.ignoreOnMacAndWindows "Plutus.Direct.CertifyingAndWithdrawingPlutus" Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus.hprop_plutus_certifying_withdrawing
+      , H.testProperty "Plutus.Direct.TxInLockingPlutus" Spec.Plutus.Direct.TxInLockingPlutus.hprop_plutus
         -- This hangs on Windows for an unknown reason
-      , ignoreOnWindows "Spec.Plutus.Script.TxInLockingPlutus" Spec.Plutus.Script.TxInLockingPlutus.hprop_plutus
-      , H.testProperty "Spec.Plutus.SubmitApi.TxInLockingPlutus" Spec.Plutus.SubmitApi.TxInLockingPlutus.hprop_plutus
-      , ignoreOnWindows "Spec.Plutus.Direct.ScriptContextEquality"  Spec.Plutus.Direct.ScriptContextEquality.hprop_plutus_script_context_equality
-      , ignoreOnWindows "Spec.Plutus.Direct.ScriptContextEqualityMint" Spec.Plutus.Direct.ScriptContextEqualityMint.hprop_plutus_script_context_mint_equality
+      , H.ignoreOnWindows "Plutus.Script.TxInLockingPlutus" Spec.Plutus.Script.TxInLockingPlutus.hprop_plutus
+      , H.testProperty "Plutus.SubmitApi.TxInLockingPlutus" Spec.Plutus.SubmitApi.TxInLockingPlutus.hprop_plutus
+      , H.ignoreOnWindows "Plutus.Direct.ScriptContextEquality"  Spec.Plutus.Direct.ScriptContextEquality.hprop_plutus_script_context_equality
+      , H.ignoreOnWindows "Plutus.Direct.ScriptContextEqualityMint" Spec.Plutus.Direct.ScriptContextEqualityMint.hprop_plutus_script_context_mint_equality
         -- There is a blocking call on Windows that prevents graceful shutdown and we currently aren't testing the shutdown IPC flag.
-      , ignoreOnWindows "Spec.Shutdown" Spec.Shutdown.hprop_shutdown
+      , H.ignoreOnWindows "Shutdown" Spec.Shutdown.hprop_shutdown
       ]
     ]
-
-ignoreOnWindows :: String -> Property -> TestTree
-ignoreOnWindows pName prop =
-  if isWin32
-  then H.testProperty ("Property not tested on Windows: " ++ pName) $ property success
-  else H.testProperty pName prop
-
-ignoreOnMac :: String -> Property -> TestTree
-ignoreOnMac pName prop =
-  if isMacOS
-  then H.testProperty ("Property not tested on MacOS: " ++ pName) $ property success
-  else H.testProperty pName prop
-
-isMacOS :: Bool
-isMacOS = os == "darwin"
 
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients

--- a/cardano-testnet/test/Spec/Plutus/Direct/CertifyingAndWithdrawingPlutus.hs
+++ b/cardano-testnet/test/Spec/Plutus/Direct/CertifyingAndWithdrawingPlutus.hs
@@ -44,6 +44,7 @@ import           Testnet.Cardano (TestnetOptions (..), TestnetRuntime (..), defa
 import qualified Testnet.Cardano as TC
 import qualified Testnet.Conf as H
 import           Testnet.Utils (waitUntilEpoch)
+import qualified System.Info as SYS
 
 
 {-
@@ -60,6 +61,7 @@ isLinux = os == "linux"
 
 hprop_plutus_certifying_withdrawing :: Property
 hprop_plutus_certifying_withdrawing = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+  H.note_ SYS.os
   projectBase <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   conf@H.Conf { H.tempBaseAbsPath, H.tempAbsPath } <- H.noteShowM $ H.mkConf tempAbsBasePath' Nothing
 

--- a/cardano-testnet/test/Test/Util.hs
+++ b/cardano-testnet/test/Test/Util.hs
@@ -1,0 +1,40 @@
+module Test.Util
+  ( ignoreOn
+  , ignoreOnWindows
+  , ignoreOnMac
+  , ignoreOnMacAndWindows
+  ) where
+
+import           Data.Bool (bool)
+import           Hedgehog (Property)
+import           Hedgehog.Extras.Stock.OS (isWin32)
+import           Prelude
+import           Test.Tasty.ExpectedFailure (wrapTest)
+import           Test.Tasty.Providers (testPassed)
+import           Test.Tasty.Runners (TestTree, Result(resultShortDescription))
+
+import qualified Test.Tasty.Hedgehog as H
+import qualified System.Info as SYS
+
+type Os = String
+
+ignoreOnWindows :: String -> Property -> TestTree
+ignoreOnWindows pName prop =
+  bool id (ignoreOn "Windows") isWin32 $ H.testProperty pName prop
+
+ignoreOnMac :: String -> Property -> TestTree
+ignoreOnMac pName prop =
+  bool id (ignoreOn "MacOS") isMacOS $ H.testProperty pName prop
+
+ignoreOnMacAndWindows :: String -> Property -> TestTree
+ignoreOnMacAndWindows pName prop =
+  bool id (ignoreOn "MacOS and Windows") (isMacOS || isWin32) $ H.testProperty pName prop
+
+isMacOS :: Bool
+isMacOS = SYS.os == "darwin"
+
+ignoreOn :: Os -> TestTree -> TestTree
+ignoreOn os = wrapTest $ const $ return $
+  (testPassed ("IGNORED on " <> os))
+    { resultShortDescription = "IGNORED on " <> os
+    }


### PR DESCRIPTION
`Plutus.Direct.CertifyingAndWithdrawingPlutus` is failing a lot on Windows, so disable that test on Windows.

Clean up the presentation of the tests.

Before:

```
test/Spec.hs
  Spec
    Property not tested on MacOS: Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus: OK
        ✓ Property not tested on MacOS: Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus passed 100 tests.
```

After:

```
test/Spec.hs
  Spec
    Plutus.Direct.CertifyingAndWithdrawingPlutus: IGNORED on MacOS
      IGNORED on MacOS
```

The new version is better because `Spec` is not duplicated and the "not tested" text does not interfere with the test name, which means pattern matching on tests to select tests is not affected by operating system:

```
cabal test cardano-testnet --test-options '-p Spec.Plutus.Direct.CertifyingAndWithdrawingPlutus'
```