### PR TITLE
Set -O2 flag by default

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -209,6 +209,31 @@ source-repository-package
     libs/small-steps-test
     libs/non-integral
 
+-- -O2 By default
+
+package byron-spec-chain
+  optimization: 2
+package cardano-data
+  optimization: 2
+package cardano-ledger-alonzo
+  optimization: 2
+package cardano-ledger-core
+  optimization: 2
+package cardano-ledger-shelley
+  optimization: 2
+package cardano-ledger-shelley-ma
+  optimization: 2
+package cardano-protocol-tpraos
+  optimization: 2
+package compact-map
+  optimization: 2
+package non-integral
+  optimization: 2
+package set-algebra
+  optimization: 2
+package small-steps
+  optimization: 2
+
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
@@ -267,6 +292,36 @@ source-repository-package
     typed-protocols
     typed-protocols-cborg
     typed-protocols-examples
+
+-- -O2 by default
+package io-sim
+  optimization: 2
+package io-classes
+  optimization: 2
+package monoidal-synchronisation
+  optimization: 2
+package network-mux
+  optimization: 2
+package ouroboros-consensus
+  optimization: 2
+package ouroboros-consensus-byron
+  optimization: 2
+package ouroboros-consensus-cardano
+  optimization: 2
+package ouroboros-consensus-protocol
+  optimization: 2
+package ouroboros-consensus-shelley
+  optimization: 2
+package ouroboros-network
+  optimization: 2
+package ouroboros-network-framework
+  optimization: 2
+package strict-stm
+  optimization: 2
+package typed-protocols
+  optimization: 2
+package typed-protocols-cborg
+  optimization: 2
 
 source-repository-package
   type: git

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -166,6 +166,10 @@ let
       packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
     })
     {
+      # Enable harder optimisations globally.
+      ghcOptions = [ "-O2" ];
+    }
+    {
       packages = lib.genAttrs projectPackages
         (name: { configureFlags = [ "--ghc-option=-Werror" ]; });
     }


### PR DESCRIPTION
`cardano-node` was being built with `-O1` by default but we should take advantage of further optimisation with `-O2`.

See: https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/using-optimisation.html#options-optimise