### PR TITLE
DWARF debug info: enable

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -60,6 +60,8 @@ tests: False
 
 test-show-details: direct
 
+package *
+  ghc-options: -g3
 -- Then enable specific tests in this repo
 
 package cardano-api

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -174,7 +174,7 @@ let
         (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
     })
     {
-      packages.ghcOptions = "-g3";
+      ghcOptions = "-g3";
     }
     (lib.optionalAttrs profiling {
       enableLibraryProfiling = true;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -174,7 +174,7 @@ let
         (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
     })
     {
-      ghcOptions = "-g3";
+      ghcOptions = ["-g3"];
     }
     (lib.optionalAttrs profiling {
       enableLibraryProfiling = true;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -173,6 +173,9 @@ let
       packages = lib.genAttrs ["cardano-node"]
         (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
     })
+    {
+      packages.ghcOptions = "-g3";
+    }
     (lib.optionalAttrs profiling {
       enableLibraryProfiling = true;
       packages.cardano-node.components.exes.cardano-node.enableExecutableProfiling = true;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -51,7 +51,9 @@ final: prev: with final;
   }).hsPkgs;
 
   #Grab the executable component of our package.
-  inherit (cardanoNodeHaskellPackages.cardano-node.components.exes) cardano-node;
+  cardano-node =
+    cardanoNodeHaskellPackages.cardano-node.components.exes.cardano-node.override
+      { enableDWARF = true; };
   inherit (cardanoNodeHaskellPackages.cardano-cli.components.exes) cardano-cli;
   inherit (cardanoNodeHaskellPackages.cardano-topology.components.exes) cardano-topology;
   inherit (cardanoNodeHaskellPackages.tx-generator.components.exes) tx-generator;
@@ -59,7 +61,7 @@ final: prev: with final;
   inherit (cardanoNodeHaskellPackages.bech32.components.exes) bech32;
   inherit (cardanoNodeHaskellPackages.cardano-submit-api.components.exes) cardano-submit-api;
   cardano-node-profiled = cardanoNodeProfiledHaskellPackages.cardano-node.components.exes.cardano-node;
-  cardano-node-eventlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node;
+  cardano-node-eventlogged = cardanoNodeEventlogHaskellPackages.cardano-node.components.exes.cardano-node.override { enableDWARF = true; };
   cardano-node-asserted = cardanoNodeAssertedHaskellPackages.cardano-node.components.exes.cardano-node;
   tx-generator-profiled = cardanoNodeProfiledHaskellPackages.tx-generator.components.exes.tx-generator;
   plutus-scripts = callPackage ./plutus-scripts.nix { plutus-builder = plutus-example; };

--- a/shell.nix
+++ b/shell.nix
@@ -57,6 +57,8 @@ let
     in cardanoNodeProject.shellFor {
     name = "cluster-shell";
 
+    enableDWARF = true;
+
     inherit withHoogle;
 
     packages = lib.attrVals cardanoNodeProject.projectPackages;


### PR DESCRIPTION
This is to enable DWARF debug info in the closure of `cardano-node`, so as to enable near-overhead-free profiling.