### PR TITLE
bench | process:  Hydra chart rendering

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ doc                                                           @docs-access
 README.*                                                      @docs-access
 
 bench/tx-generator                                            @deepfire @MarcFontaine
-bench                                                         @deepfire @denisshevchenko @jutaro @MarcFontaine
+bench                                                         @deepfire @denisshevchenko @jutaro @MarcFontaine @cleverca22
 cardano-tracer                                                @deepfire @denisshevchenko
 nix/workbench                                                 @deepfire @denisshevchenko @jutaro @MarcFontaine
 nix/supervisord-cluster                                       @deepfire @denisshevchenko @jutaro @MarcFontaine

--- a/bench/process/membenches_v1.jq
+++ b/bench/process/membenches_v1.jq
@@ -11,29 +11,37 @@ def format_specs:
      # , post: not
      }]
 , result_specs:
-    [{ key: "RssAvg",  header: "Avg RSS, MB"
-     , path: ["RSS",  "avg"], round: true
+    [{ key: "Average-RSS",      header: "Average RSS",      unit: "MB"
+     , path: ["RSS",  "avg"]
+     , round: true
      }
-    ,{ key: "RssMax",  header: "Max RSS, MB"
-     , path: ["RSS",  "max"], round: true
+    ,{ key: "Peak-RSS",         header: "Peak RSS",         unit: "MB"
+     , path: ["RSS",  "max"]
+     , round: true
      }
-    ,{ key: "HeapAvg", header: "Avg heap, MB"
-     , path: ["Heap", "avg"], round: true
+    ,{ key: "Average-RTS-heap", header: "Average RTS heap", unit: "MB"
+     , path: ["Heap", "avg"]
+     , round: true
      }
-    ,{ key: "HeapMax", header: "Max heap, MB"
-     , path: ["Heap", "max"], round: true
+    ,{ key: "Peak-RTS-heap",    header: "Peak RTS heap",    unit: "MB"
+     , path: ["Heap", "max"]
+     , round: true
      }
-    ,{ key: "WallSec", header: "Wall, s"
-     , path: ["totaltime"], round: true
+    ,{ key: "Wall-clock-time",  header: "Wall clock time",  unit: "s"
+     , path: ["totaltime"]
+     , round: true
      }
-    ,{ key: "CpuMax",  header: "OS CPU, s"
-     , path: ["CentiCpuMax"], scale: 100, round: true
+    ,{ key: "OS-CPU-time",      header: "OS CPU time",      unit: "s"
+     , path: ["CentiCpuMax"]
+     , round: true, scale: 100
      }
-    ,{ key: "MutMax",  header: "Mutator, s"
-     , path: ["CentiMutMax"], scale: 100, round: true
+    ,{ key: "RTS-mutator-time", header: "RTS mutator time", unit: "s"
+     , path: ["CentiMutMax"]
+     , round: true, scale: 100
      }
-    ,{ key: "GCSec",   header: "GC time, s"
-     , path: ["SecGC"], round: true
+    ,{ key: "RTS-GC-time",      header: "RTS GC time",      unit: "s"
+     , path: ["SecGC"]
+     , round: true
      }
     ]
 };

--- a/bench/process/process.sh
+++ b/bench/process/process.sh
@@ -32,11 +32,15 @@ main() {
         collect )    op_collect "$@";;
         process )    op_process;;
         render )     op_render;;
+        render-html )
+                     op_render_html;;
+        render-hydra-charts )
+                     op_render_hydra_charts "$@";;
 
         report )     op_collect "$@" | op_process | op_render;;
 
         call )       eval "$@";;
-        * ) echo "ERROR:  operation must be one of:  collect process render report" >&2; exit 1;; esac
+        * ) echo "ERROR:  operation must be one of:  collect process render render-hydra-charts report" >&2; exit 1;; esac
 }
 
 hardcoded_branch='membench'
@@ -112,6 +116,25 @@ function op_render() {
     jq 'include "render";
 
         render('"$header_footer"')
+       ' --raw-output
+}
+
+function op_render_html() {
+    jq 'include "render";
+
+        render_html
+       ' --raw-output
+}
+
+function op_render_hydra_charts() {
+    local config='baseline'
+    while test $# -ge 1
+    do case "$1" in
+        --config )          config=$2; shift;;
+        * )                 break;; esac; shift; done
+    jq 'include "render";
+
+        render_hydra_charts_for_config ("'$config'")
        ' --raw-output
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
         "ouroboros-network": "ouroboros-network"
       },
       "locked": {
-        "lastModified": 1643874957,
-        "narHash": "sha256-r+Jae6pSXjlLXKVdyHYszhOMaCsXTWN28j7EXkmrEug=",
+        "lastModified": 1644381231,
+        "narHash": "sha256-eqKXimZYooQrIH8WLmwIMR5j9K2qBS/DWWkN9i8wK1c=",
         "owner": "input-output-hk",
         "repo": "cardano-memory-benchmark",
-        "rev": "0857a1ce3467b44227272e90abe0346601b9dc42",
+        "rev": "f2c18ca3cadda30b2888f551ac73a98604f9112c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
     ) // {
       overlay = import ./overlay.nix self;
       hydraJobs.x86_64-linux = {
-        membenches = membench.outputs.packages.x86_64-linux.batch-hydra-report;
+        membenches = membench.outputs.packages.x86_64-linux.batch-report;
         snapshot = membench.outputs.packages.x86_64-linux.snapshot;
       };
       nixosModules = {


### PR DESCRIPTION
1. Update report machinery -- enabling the Hydra charts in https://hydra.iohk.io/job/Cardano/cardano-memory-benchmark/x86_64-linux.batch-hydra-report#tabs-charts, and also full data as HTML: https://hydra.iohk.io/build/12677761/download/1/raw-data.html
2. Bump `membench` and adapt to its output changes: `s/batch-hydra-report/batch-report/`