### PR TITLE
Update  cli build command to calculate Plutus script cost

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -128,6 +128,7 @@ module Cardano.Api.Shelley
     fromAlonzoRdmrPtr,
     scriptDataFromJsonDetailedSchema,
     scriptDataToJsonDetailedSchema,
+    calculateExecutionUnitsLovelace,
 
     -- * Certificates
     Certificate (..),

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -133,6 +133,9 @@ module Cardano.Api.TxBody (
     fromLedgerTxOuts,
     renderTxIn,
 
+    -- * Misc helpers
+    calculateExecutionUnitsLovelace,
+
     -- * Data family instances
     AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
   ) where
@@ -2980,3 +2983,10 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
              (toShelleyNetwork nw)
              (Shelley.KeyHashObj kh)
              Shelley.StakeRefNull
+
+calculateExecutionUnitsLovelace :: ExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
+calculateExecutionUnitsLovelace euPrices eUnits =
+  case toAlonzoPrices euPrices of
+    Nothing -> Nothing
+    Just prices ->
+      return . fromShelleyLovelace $ Alonzo.txscriptfee prices (toAlonzoExUnits eUnits)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -222,7 +222,7 @@ data TransactionCmd
       (Maybe ProtocolParamsSourceSpec)
       (Maybe UpdateProposalFile)
       OutputSerialisation
-      TxBodyFile
+      TxBuildOutputOptions
   | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
   | TxCreateWitness TxBodyFile WitnessSigningData (Maybe NetworkId) OutputFile
   | TxAssembleTxBodyWitness TxBodyFile [WitnessFile] OutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -687,7 +687,7 @@ pTransaction =
             <*> optional pProtocolParamsSourceSpec
             <*> optional pUpdateProposalFile
             <*> pOutputSerialisation
-            <*> pTxBodyFile Output
+            <*> (OutputTxBodyOnly <$> pTxBodyFile Output <|> pCalculatePlutusScriptCost)
 
   pChangeAddress :: Parser TxOutChangeAddress
   pChangeAddress =
@@ -1318,6 +1318,15 @@ pProtocolParamsFile =
       <> Opt.help "Filepath of the JSON-encoded protocol parameters file"
       <> Opt.completer (Opt.bashCompleter "file")
       )
+
+pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
+pCalculatePlutusScriptCost =
+  OutputScriptCostOnly <$> Opt.strOption
+   ( Opt.long "calculate-plutus-script-cost" <>
+     Opt.metavar "FILE" <>
+     Opt.help "Output filepath of the script cost information." <>
+     Opt.completer (Opt.bashCompleter "file")
+   )
 
 pCertificateFile
   :: BalanceTxExecUnits

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -13,6 +13,7 @@ module Cardano.CLI.Types
   , GenesisFile (..)
   , OutputFormat (..)
   , OutputSerialisation (..)
+  , TxBuildOutputOptions(..)
   , SigningKeyFile (..)
   , SocketPath (..)
   , ScriptFile (..)
@@ -46,6 +47,13 @@ import           Cardano.Api
 import qualified Cardano.Ledger.Crypto as Crypto
 
 import           Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+
+-- | Specify whether to render the script cost as JSON
+-- in the cli's build command.
+data TxBuildOutputOptions = OutputScriptCostOnly FilePath
+                          | OutputTxBodyOnly TxBodyFile
+                          deriving Show
+
 
 -- | Specify what the CBOR file is
 -- i.e a block, a tx, etc


### PR DESCRIPTION
Resolves: #3590

 We introduce the  following change:
```
cardano-cli transaction build 
...
(--out-file FILE | --calculate-plutus-script-cost FILE)
```
If you are only interested in the script cost, specify the `--calculate-plutus-script-cost` option.

Example: 

```
$CARDANO_CLI transaction build \
  --alonzo-era \
  --cardano-mode \
  --testnet-magic "$TESTNET_MAGIC" \
  --change-address "$utxoaddr" \
  --tx-in "$plutusutxotxin" \
  --tx-in-collateral "$txinCollateral" \
  --tx-out "$dummyaddress+10000000" \
  --tx-in-script-file "$plutusscriptinuse" \
  --tx-in-datum-file "$datumfilepath"  \
  --protocol-params-file "$WORK/pparams.json" \
  --tx-in-redeemer-file "$redeemerfilepath" \
  --calculate-plutus-script-cost "$WORK/create-datum-output.scriptcost"
  
  > cat $WORK/create-datum-output.scriptcost
  [
    {
        "executionUnits": {
            "memory": 1700,
            "steps": 476468
        },
        "lovelaceCost": 133,
        "scriptHash": "67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656"
    }
]
  
  ```