### PR TITLE
Add IsString (Hash BlockHeader)

### DIFF
--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -55,6 +55,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import           Data.Foldable (Foldable (toList))
+import           Data.String (IsString)
 
 import           Cardano.Slotting.Block (BlockNo)
 import           Cardano.Slotting.Slot (EpochNo, SlotNo, WithOrigin (..))
@@ -257,9 +258,8 @@ data BlockHeader = BlockHeader !SlotNo
 -- The different eras do use different types, but it's all the same underlying
 -- representation.
 newtype instance Hash BlockHeader = HeaderHash SBS.ShortByteString
-  deriving (Eq, Ord, Show)
-  deriving (ToJSON, FromJSON) via UsingRawBytesHex (Hash BlockHeader)
-
+  deriving (Eq, Ord)
+  deriving (Show, IsString, ToJSON, FromJSON) via UsingRawBytesHex (Hash BlockHeader)
 
 
 instance SerialiseAsRawBytes (Hash BlockHeader) where


### PR DESCRIPTION
Hi there :wave:

This PR adds the instance `IsString (Hash BlockHeader)` following the same pattern of many other keys in `Cardano.Api`. The use case is simple, being able to refer to a specific point on the chain. E.g.

```haskell
recentPoint :: ChainPoint
recentPoint = ChainPoint (SlotNo 53427524) "5e2bde4e504a9888a4f218dafc79a7619083f97d48684fcdba9dc78190df8f99"
```

I am also changing the Show instance, as it seems to be the common pattern.