### PR TITLE
Export toLedgerEpochInfo

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -244,6 +244,7 @@ module Cardano.Api (
 
     -- ** Script execution units
     evaluateTransactionExecutionUnits,
+    toLedgerEpochInfo,
     ScriptExecutionError(..),
     TransactionValidityError(..),
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -23,6 +23,7 @@ module Cardano.Api.Fees (
 
     -- * Script execution units
     evaluateTransactionExecutionUnits,
+    toLedgerEpochInfo,
     ScriptExecutionError(..),
     TransactionValidityError(..),
 
@@ -506,12 +507,6 @@ evaluateTransactionExecutionUnits _eraInMode systemstart history pparams utxo tx
                Left err -> Left (TransactionValidityBasicFailure err)
                Right exmap -> Right (fromLedgerScriptExUnitsMap exmap)
 
-    toLedgerEpochInfo :: EraHistory mode
-                      -> EpochInfo (Either TransactionValidityError)
-    toLedgerEpochInfo (EraHistory _ interpreter) =
-        hoistEpochInfo (first TransactionValidityIntervalError . runExcept) $
-          Consensus.interpreterToEpochInfo interpreter
-
     toAlonzoCostModels :: Map AnyPlutusScriptVersion CostModel
                        -> Array.Array Alonzo.Language Alonzo.CostModel
     toAlonzoCostModels costmodels =
@@ -557,6 +552,12 @@ evaluateTransactionExecutionUnits _eraInMode systemstart history pparams utxo tx
     impossible detail = error $ "evaluateTransactionExecutionUnits: "
                              ++ "the impossible happened: " ++ detail
 
+toLedgerEpochInfo
+  :: EraHistory mode
+  -> EpochInfo (Either TransactionValidityError)
+toLedgerEpochInfo (EraHistory _ interpreter) =
+    hoistEpochInfo (first TransactionValidityIntervalError . runExcept) $
+      Consensus.interpreterToEpochInfo interpreter
 
 -- ----------------------------------------------------------------------------
 -- Transaction balance


### PR DESCRIPTION
It is a bit hard to construct `EpochInfo` value if you are not sure where exactly to look for it ([related issue in cardano-ledger]( https://github.com/input-output-hk/cardano-ledger/issues/2655#issuecomment-1039531922))
This PR purpose is to expose `toLedgerEpochInfo` so api users have more pleasant experience.