### PR TITLE
Add IsString (Hash BlockHeader)

### DIFF
--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -55,6 +55,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import           Data.Foldable (Foldable (toList))
+import           Data.String (IsString)
 
 import           Cardano.Slotting.Block (BlockNo)
 import           Cardano.Slotting.Slot (EpochNo, SlotNo, WithOrigin (..))
@@ -259,6 +260,7 @@ data BlockHeader = BlockHeader !SlotNo
 newtype instance Hash BlockHeader = HeaderHash SBS.ShortByteString
   deriving (Eq, Ord, Show)
   deriving (ToJSON, FromJSON) via UsingRawBytesHex (Hash BlockHeader)
+  deriving IsString via UsingRawBytesHex (Hash BlockHeader)
 
 
 


### PR DESCRIPTION
This PR adds the instance IsString (Hash BlockHeader) following the same
pattern of many other keys in Cardano.Api. The use case is simple, being
able to refer to a specific point on the chain.

E.g.

recentPoint :: ChainPoint
recentPoint = ChainPoint (SlotNo 53427524) "5e2bde4e504a9888a4..."

I am also changing the Show instance, as it seems to be the common
pattern.
