### PR TITLE
workbench:  fixes & updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,15 @@ cluster-shell: ## Enter Nix shell and start the workbench cluster
 	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} --arg 'autoStartCluster' true
 
 shell-dev:               ARGS += --arg 'workbenchDevMode' true ## Enter Nix shell, dev mode (workbench run from checkout)
-cluster-shell:           ARGS += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true ## Enter Nix shell, and start workbench cluster
+cluster-shell:           ARGS += --arg 'autoStartCluster' true ## Enter Nix shell, and start workbench cluster
 cluster-shell-dev:       ARGS += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true ## Enter Nix shell, dev mode, and start workbench cluster
 cluster-shell-trace:     ARGS += --arg 'autoStartCluster' true --argstr 'autoStartClusterArgs' '--trace --trace-workbench' ## Enter Nix shell, start workbench cluster, with shell tracing
 cluster-shell-dev-trace: ARGS += --arg 'autoStartCluster' true --arg 'workbenchDevMode' true --argstr 'autoStartClusterArgs' '--trace --trace-workbench' ## Enter Nix shell, dev mode, start workbench cluster, with shell tracing
-shell-dev cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace: shell
+fixed:                   ARGS += --arg 'autoStartCluster' true
+fixed:                   PROFILE = fixed-alzo
+smoke:                   ARGS += --arg 'autoStartCluster' true --run "grep TraceOpenEvent.ClosedDB run/current/node-0/stdout >/dev/null && echo 'Smoke test:  PASS' || echo 'Smoke test:  FAIL'"
+smoke:                   PROFILE = smoke-alzo
+shell-dev cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace fixed smoke: shell
 
 shell: ## Enter Nix shell, CI mode (workbench run from Nix store)
 	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} ${ARGS}

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ fixed:                   ARGS += --arg 'autoStartCluster' true
 fixed:                   PROFILE = fixed-alzo
 smoke:                   ARGS += --arg 'autoStartCluster' true --run "grep TraceOpenEvent.ClosedDB run/current/node-0/stdout >/dev/null && echo 'Smoke test:  PASS' || echo 'Smoke test:  FAIL'"
 smoke:                   PROFILE = smoke-alzo
-shell-dev cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace fixed smoke: shell
+smoke-loaded:            ARGS += --arg 'autoStartCluster' true --run "grep TraceOpenEvent.ClosedDB run/current/node-0/stdout >/dev/null && echo 'Smoke test:  PASS' || echo 'Smoke test:  FAIL'"
+smoke-loaded:            PROFILE = smoke-loaded-alzo
+shell-dev cluster-shell-dev cluster-shell-trace cluster-shell-dev-trace fixed smoke smoke-loaded: shell
 
 shell: ## Enter Nix shell, CI mode (workbench run from Nix store)
 	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} ${ARGS}

--- a/default.nix
+++ b/default.nix
@@ -45,16 +45,18 @@ let
     withHoogle = true;
   };
 
+  clusterCabal = workbench-supervisord { inherit profileName haskellPackages; useCabalRun = true; };
+  clusterNix   = workbench-supervisord { inherit profileName haskellPackages; useCabalRun = false; };
+  workbench-smoke-test = clusterNix.smoke-test { profileName = "smoke-loaded-alzo"; };
+
   packages = {
     inherit haskellPackages shell
       cardano-node cardano-node-profiled cardano-node-eventlogged
       cardano-cli db-converter cardano-ping
       locli locli-profiled
       tx-generator tx-generator-profiled
-      scripts environments dockerImage submitApiDockerImage bech32;
-
-    clusterCabal = mkSupervisordCluster { inherit profileName; useCabalRun = true; };
-    clusterNix   = mkSupervisordCluster { inherit profileName; useCabalRun = false; };
+      scripts environments dockerImage submitApiDockerImage bech32
+      clusterNix clusterCabal workbench-smoke-test;
 
     devopsShell = shell.devops;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -53,6 +53,16 @@ let
           inherit system;
           gitrev = sources.plutus-example.rev;
         }).haskellPackages.plutus-example.components.exes) plutus-example;
+
+        # This provides a supervisord-backed instance of a the workbench development environment
+        # that can be used with nix-shell or lorri.
+        # See https://input-output-hk.github.io/haskell.nix/user-guide/development/
+        workbench-supervisord =
+          { useCabalRun, profileName, haskellPackages }:
+          pkgs.callPackage ./supervisord-cluster
+            { inherit profileName useCabalRun haskellPackages;
+              workbench = pkgs.callPackage ./workbench { inherit useCabalRun; };
+            };
       })
       # And, of course, our haskell-nix-ified cabal project:
       (import ./pkgs.nix)

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -66,6 +66,9 @@ let
             ];
           });
 
+      finaliseNodeArgs =
+        { port, ... }: cfg: cfg;
+
       finaliseGeneratorService =
         svc: recursiveUpdate svc
           ({

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -55,7 +55,7 @@ let
       finaliseNodeConfig =
         { port, ... }: cfg: recursiveUpdate cfg
           ({
-            AlonzoGenesisFile    = "../genesis-alonzo.json";
+            AlonzoGenesisFile    = "../genesis.alonzo.json";
             ShelleyGenesisFile   = "../genesis-shelley.json";
             ByronGenesisFile     = "../genesis/byron/genesis.json";
           } // optionalAttrs enableEKG {
@@ -79,7 +79,7 @@ let
       finaliseGeneratorConfig =
         cfg: recursiveUpdate cfg
           ({
-            AlonzoGenesisFile    = "../genesis-alonzo.json";
+            AlonzoGenesisFile    = "../genesis.alonzo.json";
             ShelleyGenesisFile   = "../genesis-shelley.json";
             ByronGenesisFile     = "../genesis/byron/genesis.json";
           });
@@ -152,6 +152,7 @@ let
 
     export PATH=$PATH:${path}
 
+    set -x
     wb start \
         --batch-name   ${batchName} \
         --profile-name ${profileName} \

--- a/nix/supervisord-cluster/default.nix
+++ b/nix/supervisord-cluster/default.nix
@@ -181,7 +181,8 @@ let
           profile profileOut;
     in
     pkgs.runCommand "workbench-test-${profileName}"
-      { nativeBuildInputs = with haskellPackages; with pkgs; [
+      { requiredSystemFeatures = [ "benchmark" ];
+        nativeBuildInputs = with haskellPackages; with pkgs; [
           bash
           bech32
           coreutils

--- a/nix/supervisord-cluster/supervisor-conf.nix
+++ b/nix/supervisord-cluster/supervisor-conf.nix
@@ -42,6 +42,7 @@ let
         stdout_logfile = "${stateDir}/generator/stdout";
         stderr_logfile = "${stateDir}/generator/stderr";
         autostart      = false;
+        startretries   = 0;
       };
     }
     //
@@ -58,6 +59,8 @@ let
       command        = "sh start.sh";
       stdout_logfile = "${service.value.stateDir}/stdout";
       stderr_logfile = "${service.value.stateDir}/stderr";
+      startretries   = 0;
+      autorestart    = false;
     };
 
 in

--- a/nix/supervisord-cluster/supervisor-conf.nix
+++ b/nix/supervisord-cluster/supervisor-conf.nix
@@ -38,7 +38,7 @@ let
     {
       "program:generator" = {
         directory      = "${stateDir}/generator";
-        command        = "${stateDir}/generator/start.sh";
+        command        = "sh start.sh";
         stdout_logfile = "${stateDir}/generator/stdout";
         stderr_logfile = "${stateDir}/generator/stderr";
         autostart      = false;

--- a/nix/supervisord-cluster/tests/default.nix
+++ b/nix/supervisord-cluster/tests/default.nix
@@ -1,9 +1,9 @@
 { pkgs
 }: let
-  inherit (pkgs) mkSupervisordCluster cardano-cli cardanolib-py cardano-node;
+  inherit (pkgs) workbench-supervisord cardano-cli cardanolib-py cardano-node;
   stateDir = "./state-cluster-test";
   # We want a really short duration for tests
-  cluster' = mkSupervisordCluster {
+  cluster' = workbench-supervisord {
     genesisParams = {
       slotLength = 0.1;
       decentralisationParam = 0.8;

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -232,23 +232,11 @@ let
     name: decl:
     extractServiceScript (decl // { svcName = name; });
 
-  # This provides a development environment that can be used with nix-shell or
-  # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
-  # NOTE: due to some cabal limitation,
-  #  you have to remove all `source-repository-package` entries from cabal.project
-  #  after entering nix-shell for cabal to use nix provided dependencies for them.
-  mkSupervisordCluster =
-    { useCabalRun, profileName }:
-    pkgs.callPackage ./supervisord-cluster
-      { inherit profileName useCabalRun;
-        workbench = pkgs.callPackage ./workbench { inherit useCabalRun; };
-      };
 in
 {
   inherit
   defServiceModule
   mkScriptOfService
   mkServiceScript
-  mkSupervisordCluster
   ;
 }

--- a/nix/workbench/backend.sh
+++ b/nix/workbench/backend.sh
@@ -20,6 +20,8 @@ usage_backend() {
                      Start generator
     cleanup-cluster RUNDIR
                      Wipe cluster state to pristine
+    wait-pools-stopped RUNDIR
+                     Wait until all pools are stopped
     stop-cluster RUNDIR
 
     lostream-fixup-jqargs RUNDIR
@@ -44,6 +46,7 @@ case "${op}" in
     start-cluster )              backend_$WORKBENCH_BACKEND "$@";;
     start-generator )            backend_$WORKBENCH_BACKEND "$@";;
     cleanup-cluster )            backend_$WORKBENCH_BACKEND "$@";;
+    wait-pools-stopped )         backend_$WORKBENCH_BACKEND "$@";;
     stop-cluster )               backend_$WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqargs )      backend_$WORKBENCH_BACKEND "$@";;
     lostream-fixup-jqexpr )      backend_$WORKBENCH_BACKEND "$@";;

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -88,13 +88,12 @@ let
     else "nix-exes+checkout-wb";
 
   shellHook = ''
+    echo 'workbench shellHook:  workbenchDevMode=${toString workbenchDevMode} useCabalRun=${toString useCabalRun}'
     export WORKBENCH_BACKEND=supervisor
 
     ${optionalString
       workbenchDevMode
     ''
-    echo 'workbench:  dev mode enabled, calling wb directly from checkout (instead of using Nix store)' >&2
-
     export WORKBENCH_CARDANO_NODE_REPO_ROOT=$(git rev-parse --show-toplevel)
     export WORKBENCH_EXTRA_FLAGS=
 

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -107,6 +107,7 @@ let
     ${optionalString
       useCabalRun
       ''
+      . nix/workbench/lib.sh
       . nix/workbench/lib-cabal.sh
       ''}
 

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -102,14 +102,13 @@ let
       $WORKBENCH_CARDANO_NODE_REPO_ROOT/nix/workbench/wb --set-mode ${checkoutWbMode} $WORKBENCH_EXTRA_FLAGS "$@"
     }
     export -f wb
+    ''}
 
     ${optionalString
       useCabalRun
       ''
       . nix/workbench/lib-cabal.sh
       ''}
-
-    ''}
 
     export CARDANO_NODE_SOCKET_PATH=run/current/node-0/node.socket
     '';

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -196,9 +196,26 @@ let
       cp    $nodeServicesPath          $out/node-services.json
       cp    $generatorServicePath      $out/generator-service.json
       '';
+
+  with-workbench-profile =
+    { pkgs, backend, envArgs, profileName }:
+    let
+      workbenchProfiles = generateProfiles
+        { inherit pkgs backend envArgs; };
+
+      profile = workbenchProfiles.profiles."${profileName}"
+        or (throw "No such profile: ${profileName};  Known profiles: ${toString (__attrNames workbenchProfiles.profiles)}");
+
+      profileOut = profileOutput
+        { inherit profile;
+          backendProfileOutput =
+            backend.profileOutput { inherit profile; };
+        };
+    in { inherit profile profileOut; };
+
 in
 {
-  inherit workbench runWorkbench runJq;
+  inherit workbench runWorkbench runJq with-workbench-profile;
 
   inherit generateProfiles profileOutput shellHook;
 }

--- a/nix/workbench/lib-cabal.sh
+++ b/nix/workbench/lib-cabal.sh
@@ -8,10 +8,10 @@ function workbench-prebuild-executables()
     git --no-pager log -n1 --alternate-refs --pretty=format:"%Cred%cr %Cblue%h %Cgreen%D %Cblue%s%Creset" --color
     echo
 
-    echo -n "workbench:  prebuilding executables (because of useCabalRun): "
+    echo "workbench:  prebuilding executables (because of useCabalRun)"
     unset NIX_ENFORCE_PURITY
-    for exe in cardano-cli cardano-node cardano-topology
-    do echo -n "$exe "
+    for exe in cardano-node cardano-cli cardano-topology
+    do echo "workbench:    $(with_color blue prebuilding) $(with_color red $exe)"
        cabal -v0 build -- exe:$exe 2>&1 >/dev/null |
            { grep -v 'Temporary modify'; true; } || return 1
     done

--- a/nix/workbench/lib.sh
+++ b/nix/workbench/lib.sh
@@ -64,6 +64,10 @@ msg() {
     echo "workbench:  $*" >&2
 }
 
+msg_ne() {
+    echo -ne "workbench:  $*" >&2
+}
+
 fail() {
     msg "$*"
     exit 1

--- a/nix/workbench/profiles/adhoc.jq
+++ b/nix/workbench/profiles/adhoc.jq
@@ -13,12 +13,12 @@ def adhoc_profiles:
   , tolerances: { finish_patience: 4 }
   , genesis: { genesis_future_offset: "3 minutes" }
   }
-, { name: "smoke"
-  , generator: { tx_count: 100,   add_tx_size: 0, inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100
-               , init_cooldown: 25 }
-  , tolerances: { finish_patience: 4 }
-  , genesis: { genesis_future_offset: "3 minutes" }
-  }
+# , { name: "smoke"
+#   , generator: { tx_count: 100,   add_tx_size: 0, inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100
+#                , init_cooldown: 25 }
+#   , tolerances: { finish_patience: 4 }
+#   , genesis: { genesis_future_offset: "3 minutes", delegators: 4 }
+#   }
 , { name: "smoke-plutus"
   , generator: { tx_count: 100,   add_tx_size: 0, inputs_per_tx: 1, outputs_per_tx: 1,  tps: 100
                , init_cooldown: 25

--- a/nix/workbench/profiles/defaults.jq
+++ b/nix/workbench/profiles/defaults.jq
@@ -12,8 +12,8 @@ def era_defaults($era):
   ## Cluster topology and composition:
   , composition:
     { locations:                      ["LO"]
-    , n_bft_hosts:                    1
-    , n_singular_hosts:               1
+    , n_bft_hosts:                    0
+    , n_singular_hosts:               2
     , n_dense_hosts:                  1
     , dense_pool_density:             1
     , with_proxy:                     false

--- a/nix/workbench/profiles/defaults.jq
+++ b/nix/workbench/profiles/defaults.jq
@@ -71,11 +71,12 @@ def era_defaults($era):
 
   , node:
     { rts_flags_override:             []
+    , shutdown_on_slot_synced:        null
     , tracing_backend:                "iohk-monitoring"  ## or "trace-dispatcher"
     }
 
   , tolerances:
-    { cluster_startup_overhead_s:     60
+    { cluster_startup_overhead_s:     30
     , start_log_spread_s:             120
     , last_log_spread_s:              120
     , silence_since_last_block_s:     120

--- a/nix/workbench/profiles/defaults.jq
+++ b/nix/workbench/profiles/defaults.jq
@@ -76,7 +76,7 @@ def era_defaults($era):
     }
 
   , tolerances:
-    { cluster_startup_overhead_s:     30
+    { cluster_startup_overhead_s:     10
     , start_log_spread_s:             120
     , last_log_spread_s:              120
     , silence_since_last_block_s:     120

--- a/nix/workbench/profiles/derived.jq
+++ b/nix/workbench/profiles/derived.jq
@@ -125,6 +125,11 @@ def add_derived_params:
          }
      , tolerances:
          { minimum_chain_density: ($gsis.active_slots_coeff * 0.5)
+         , cluster_startup_overhead_s:
+                (($gsis.utxo + $gsis.delegators) as $dataset_size
+                | if $dataset_size < 10000 then 20
+                  else $dataset_size / 25000
+                  end)
          }
      }
    }
@@ -166,4 +171,9 @@ def profile_pretty_describe($p):
   , "  - delegators:         \($p.genesis.delegators)"
   , ""
   ]
+  | . + if $p.node.shutdown_on_slot_synced == null then []
+        else [
+    "  - terminate at slot:  \($p.node.shutdown_on_slot_synced)"
+        ] end
+  | . + [""]
   | join("\n");

--- a/nix/workbench/profiles/derived.jq
+++ b/nix/workbench/profiles/derived.jq
@@ -127,7 +127,7 @@ def add_derived_params:
          { minimum_chain_density: ($gsis.active_slots_coeff * 0.5)
          , cluster_startup_overhead_s:
                 (($gsis.utxo + $gsis.delegators) as $dataset_size
-                | if $dataset_size < 10000 then 20
+                | if $dataset_size < 10000 then 5
                   else $dataset_size / 25000
                   end)
          }

--- a/nix/workbench/profiles/node-services.nix
+++ b/nix/workbench/profiles/node-services.nix
@@ -137,13 +137,20 @@ let
 
       ## For the definition of 'nodeConfigBits', please see below.
       nodeConfig =
-       backend.finaliseNodeConfig nodeSpec
-         (recursiveUpdate
-           nodeConfigBits.base
-           (if __hasAttr "preset" profile.value
-            then readJSONMay (./presets + "/${profile.value.preset}/config.json")
-            else nodeConfigBits.era_setup_hardforks //
-                 nodeConfigBits.tracing.${profile.value.node.tracing_backend}));
+        backend.finaliseNodeConfig nodeSpec
+          (recursiveUpdate
+            nodeConfigBits.base
+            (if __hasAttr "preset" profile.value
+             then readJSONMay (./presets + "/${profile.value.preset}/config.json")
+             else nodeConfigBits.era_setup_hardforks //
+                  nodeConfigBits.tracing.${profile.value.node.tracing_backend}));
+
+      extraArgs =
+        let shutdownSlot = profile.value.node.shutdown_on_slot_synced;
+        in backend.finaliseNodeArgs nodeSpec
+          (if shutdownSlot != null
+           then ["--shutdown-on-slot-synced" (toString shutdownSlot)]
+           else []);
     };
 
   ## Given an env config, evaluate it and produce the node service.

--- a/nix/workbench/profiles/variants.jq
+++ b/nix/workbench/profiles/variants.jq
@@ -37,6 +37,20 @@ def genesis_profile_variants:
   , { genesis: { utxo: 2000000, delegators:  500000, max_block_size: 2048000 }
     , generator: { tps: 256 } }
 
+  ## Fixed
+  , { name: "fixed"
+    , scenario: "fixed"
+    , genesis: { utxo: 4000000, delegators: 1000000 }
+    , node:
+      { shutdown_on_slot_synced: 150
+      }
+    }
+  , { name: "smoke"
+    , scenario: "fixed"
+    , node:
+      { shutdown_on_slot_synced: 150
+      }
+    }
 
   ## Chainsync:
   , { name: "chainsync"

--- a/nix/workbench/profiles/variants.jq
+++ b/nix/workbench/profiles/variants.jq
@@ -47,9 +47,18 @@ def genesis_profile_variants:
     }
   , { name: "smoke"
     , scenario: "fixed"
+    , genesis: { utxo: 100, delegators: 9 }
     , node:
       { shutdown_on_slot_synced: 150
       }
+    }
+  , { name: "smoke-loaded"
+    , scenario: "fixed-loaded"
+    , genesis: { utxo: 100, delegators: 9 }
+    , node:
+      { shutdown_on_slot_synced: 150
+      }
+    , generator: { tps: 10 }
     }
 
   ## Chainsync:

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -347,6 +347,7 @@ case "$op" in
         cp $(jq '."run-script"'     -r $gtor) "$gen_dir"/run-script.json
         cp $(jq '."service-config"' -r $gtor) "$gen_dir"/service-config.json
         cp $(jq '."start"'          -r $gtor) "$gen_dir"/start.sh
+        ln -s          ../node-0/config.json  "$gen_dir"
 
         backend allocate-run "$dir"
 

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -28,6 +28,12 @@ case "$op" in
         backend start-cluster "$dir"
         ;;
 
+    fixed )
+        backend start-cluster      "$dir"
+        backend wait-pools-stopped "$dir"
+        backend stop-cluster       "$dir"
+        ;;
+
     loaded )
         backend start-cluster   "$dir"
         backend start-generator "$dir"

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -22,7 +22,7 @@ local op=${1:---help}; shift
 local usage="USAGE: wb scenario SCENARIO-OP OP-ARGS.."
 local dir=${1:?$usage}; shift
 
-msg "starting scenario: $(with_color blue $op)"
+msg "starting scenario:  $(with_color blue $op)"
 case "$op" in
     idle | default )
         backend start-cluster "$dir"

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -11,7 +11,8 @@ usage_scenario() {
                             1. start the preset-defined proxy node,
                                using its respective connected topology mode,
                                fetching the chain up to the specified slot
-                            2. restart the proxy with a disconnected topogy mode,                                   effectively making it an idle chaindb server
+                            2. restart the proxy with a disconnected topogy mode,
+                               effectively making it an idle chaindb server
                             3. start the fetcher node, connected to the proxy
 
 EOF
@@ -37,6 +38,13 @@ case "$op" in
     loaded )
         backend start-cluster   "$dir"
         backend start-generator "$dir"
+        ;;
+
+    fixed-loaded )
+        backend start-cluster      "$dir"
+        backend start-generator    "$dir"
+        backend wait-pools-stopped "$dir"
+        backend stop-cluster       "$dir"
         ;;
 
     chainsync )

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -116,8 +116,16 @@ EOF
         fi
 
         echo -n "workbench:  supervisor:  waiting for $CARDANO_NODE_SOCKET_PATH to appear: " >&2
+        local patience=20 i=0
         while test ! -S $CARDANO_NODE_SOCKET_PATH
         do echo -n '.'; sleep 1
+           i=$((i+1))
+           if test $i -ge $patience
+           then echo
+                msg "FATAL:  workbench:  supervisor:  patience ran out after ${patience}s"
+                backend-supervisor stop-cluster "$dir"
+                fatal "node startup did not succeed:  check logs in $dir/node-0"
+           fi
         done >&2
         echo >&2
 

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -18,6 +18,7 @@ usage_supervisor() {
     start-cluster RUN-DIR
     start-generator RUN-DIR
     cleanup-cluster RUN-DIR
+    wait-pools-stopped RUNDIR
     stop-cluster RUN-DIR
 
     Supervisor-specific:
@@ -115,19 +116,20 @@ EOF
         then export  CARDANO_NODE_SOCKET_PATH=$(backend_supervisor get-node-socket-path "$dir")
         fi
 
-        echo -n "workbench:  supervisor:  waiting for $CARDANO_NODE_SOCKET_PATH to appear: " >&2
-        local patience=20 i=0
+        local patience=$(jq .tolerances.cluster_startup_overhead_s $dir/profile.json) i=0
+        echo -n "workbench:  supervisor:  waiting ${patience}s for $CARDANO_NODE_SOCKET_PATH to appear: " >&2
         while test ! -S $CARDANO_NODE_SOCKET_PATH
-        do echo -n '.'; sleep 1
+        do printf "%3d" $i; sleep 1
            i=$((i+1))
            if test $i -ge $patience
            then echo
                 msg "FATAL:  workbench:  supervisor:  patience ran out after ${patience}s"
-                backend-supervisor stop-cluster "$dir"
+                backend_supervisor stop-cluster "$dir"
                 fatal "node startup did not succeed:  check logs in $dir/node-0"
            fi
+           echo -ne "\b\b\b"
         done >&2
-        echo >&2
+        echo " node-0 online after $i seconds" >&2
 
         backend_supervisor save-pids "$dir";;
 
@@ -149,6 +151,18 @@ EOF
         msg "supervisor:  resetting cluster state in:  $dir"
         rm -f $dir/*/std{out,err} $dir/node-*/*.socket $dir/*/logs/* 2>/dev/null || true
         rm -fr $dir/node-*/state-cluster/;;
+
+    wait-pools-stopped )
+        local usage="USAGE: wb supervisor $op RUN-DIR"
+        local dir=${1:?$usage}; shift
+
+        local i=0 pools=$(jq .composition.n_pool_hosts $dir/profile.json)
+        msg_ne "supervisor:  waiting until all nodes are stopped: 00000"
+        for ((pool_ix=0; pool_ix < $pools; pool_ix++))
+        do while supervisorctl status node-${pool_ix} > /dev/null
+           do echo -ne "\b\b\b\b\b\b"; printf "%6d" $i >&2; i=$((i+1)); sleep 1; done
+           done
+        echo " done." >&2;;
 
     stop-cluster )
         local usage="USAGE: wb supervisor $op RUN-DIR"

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -157,11 +157,12 @@ EOF
         local dir=${1:?$usage}; shift
 
         local i=0 pools=$(jq .composition.n_pool_hosts $dir/profile.json)
-        msg_ne "supervisor:  waiting until all nodes are stopped: 00000"
+        msg_ne "supervisor:  waiting until all pool nodes are stopped: 000000"
         for ((pool_ix=0; pool_ix < $pools; pool_ix++))
         do while supervisorctl status node-${pool_ix} > /dev/null
-           do echo -ne "\b\b\b\b\b\b"; printf "%6d" $i >&2; i=$((i+1)); sleep 1; done
-           done
+           do echo -ne "\b\b\b\b\b\b"; printf "%6d" $i;          i=$((i+1)); sleep 1; done
+              echo -ne "\b\b\b\b\b\b"; echo -n "node-${pool_ix} 000000"
+           done >&2
         echo " done." >&2;;
 
     stop-cluster )

--- a/nix/workbench/topology.sh
+++ b/nix/workbench/topology.sh
@@ -55,8 +55,6 @@ case "${op}" in
         args=( --topology-output "$outdir"/topology-nixops.json
                --dot-output      "$outdir"/topology.dot
                --size             $n_hosts
-               ## TODO:  drop this, once we fully deprecate BFT in all scenarios
-               --with-bft-node-0
 
                $(jq '.composition.locations
                     | map("--loc " + .)

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -68,7 +68,7 @@ Usage:
 
    Flags:
 
-      --batch-name NAME               Override the batch name (default: ${batchName})
+      --batch-name NAME               Override the batch name (default: ${batchName:-default})
       --no-generator | --no-gen       Don't auto-start the tx-generator
 
       --cabal                         'cabal run' mode for cardano-* executables

--- a/release.nix
+++ b/release.nix
@@ -206,8 +206,8 @@ let
       (collectJobs jobs.linux.native.shell)
       (collectJobs jobs.linux.native.devopsShell)
       (collectJobs jobs.linux.native.devShell)
+      (collectJobs jobs.linux.native.workbench-smoke-test)
       [ jobs.cardano-node-linux ]
-      [ jobs.workbench-smoke-test ]
     ]))
     # macOS builds:
     (optionals macosBuild (concatLists [

--- a/release.nix
+++ b/release.nix
@@ -130,6 +130,7 @@ let
     [ "tx-generator" ]
     [ "tx-generator-profiled" ]
     [ "locli-profiled" ]
+    [ "workbench-smoke-test" ]
   ];
   # Paths or prefix of paths for which cross-builds (mingwW64, musl64) are disabled:
   noCrossBuild = [
@@ -206,6 +207,7 @@ let
       (collectJobs jobs.linux.native.devopsShell)
       (collectJobs jobs.linux.native.devShell)
       [ jobs.cardano-node-linux ]
+      [ jobs.workbench-smoke-test ]
     ]))
     # macOS builds:
     (optionals macosBuild (concatLists [

--- a/shell.nix
+++ b/shell.nix
@@ -108,7 +108,7 @@ let
     exactDeps = true;
 
     shellHook = ''
-      echo 'nix-shell options & flags:  withHoogle=${toString withHoogle} profileName=${profileName} autoStartCluster=${toString autoStartCluster} workbenchDevMode=${toString workbenchDevMode}'
+      echo 'nix-shell top-level shellHook:  withHoogle=${toString withHoogle} profileName=${profileName} autoStartCluster=${toString autoStartCluster} workbenchDevMode=${toString workbenchDevMode}'
 
       ${cluster.workbench.shellHook}
 

--- a/shell.nix
+++ b/shell.nix
@@ -50,8 +50,8 @@ let
   haveGlibcLocales = pkgs.glibcLocales != null && stdenv.hostPlatform.libc == "glibc";
 
   shell =
-    let cluster = pkgs.commonLib.workbench-supervisord
-      { inherit profileName;
+    let cluster = pkgs.workbench-supervisord
+      { inherit haskellPackages profileName;
         useCabalRun = true;
       };
     in cardanoNodeProject.shellFor {
@@ -136,8 +136,9 @@ let
   };
 
   devops =
-    let cluster = pkgs.commonLib.workbench-supervisord
-      { profileName = "devops-alzo";
+    let cluster = pkgs.workbench-supervisord
+      { inherit haskellPackages;
+        profileName = "devops-alzo";
         useCabalRun = false;
       };
     in cardanoNodeProject.shellFor {

--- a/shell.nix
+++ b/shell.nix
@@ -50,7 +50,7 @@ let
   haveGlibcLocales = pkgs.glibcLocales != null && stdenv.hostPlatform.libc == "glibc";
 
   shell =
-    let cluster = pkgs.commonLib.mkSupervisordCluster
+    let cluster = pkgs.commonLib.workbench-supervisord
       { inherit profileName;
         useCabalRun = true;
       };
@@ -136,7 +136,7 @@ let
   };
 
   devops =
-    let cluster = pkgs.commonLib.mkSupervisordCluster
+    let cluster = pkgs.commonLib.workbench-supervisord
       { profileName = "devops-alzo";
         useCabalRun = false;
       };


### PR DESCRIPTION
This fixes both:

1. `make cluster-shell` and
2. `start-cluster` inside `make shell-dev`.
3. the BFT `node-0` is now a pool as well

..and also adds:

1. profiles that cause the node to terminate upon reaching a given slot + an accompanying scenario
2. Makefile targets `fixed`, `smoke` and `smoke-loaded` (with tx-generator loading the cluster) 
3. a mandatory Hydra jobset `workbench-smoke-loaded` for a quick and dirty 150s run