### PR TITLE
trace-dispatcher: configure verbosity.

### DIFF
--- a/trace-dispatcher/examples/Examples/Configuration.hs
+++ b/trace-dispatcher/examples/Examples/Configuration.hs
@@ -50,6 +50,7 @@ config1 = TraceConfig {
       , tofMode = Responder
       , tofConnQueueSize = 100
       , tofDisconnQueueSize = 1000
+      , tofVerbosity = Minimum
       }
     , tcNodeName = Nothing
     , tcPeerFreqency = Nothing
@@ -68,6 +69,7 @@ config2 = TraceConfig {
       , tofMode = Responder
       , tofConnQueueSize = 100
       , tofDisconnQueueSize = 1000
+      , tofVerbosity = Minimum
       }
     , tcNodeName = Just "node-1"
     , tcPeerFreqency = Nothing


### PR DESCRIPTION
Currently, there are hardcoded tracing in `trace-dispatcher` protocols (from `trace-forward` and `ekg-forward`):

1. https://github.com/input-output-hk/cardano-node/blob/master/trace-dispatcher/src/Cardano/Logging/Forwarding.hs#L86
2. https://github.com/input-output-hk/cardano-node/blob/master/trace-dispatcher/src/Cardano/Logging/Forwarding.hs#L95
3. https://github.com/input-output-hk/cardano-node/blob/master/trace-dispatcher/src/Cardano/Logging/Forwarding.hs#L104

Instead, we provide a way how to configure the verbosity. 