### PR TITLE
RTS workaround converting SIGTERM into SIGINT

### DIFF
--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -135,6 +135,5 @@ in
     '';
     config = {
       EntryPoint = [ "entrypoint" ];
-      StopSignal = "SIGINT";
     };
   }

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -577,7 +577,6 @@ in {
           NonBlocking = lib.mkIf cfg.systemdSocketActivation true;
           # time to sleep before restarting a service
           RestartSec = 1;
-          KillSignal = "SIGINT";
         };
       } (cfg.extraServiceConfig i));
 


### PR DESCRIPTION
This is important for graceful shutdown, cleaning up resources in
`bracket` statements.

Fixes #1697