### PR TITLE
Fix tracing config to allow selection of the new tracing system

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -430,7 +430,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceTxOutbound <- proxyLastToEither (Proxy @TraceTxOutbound) pTraceTxOutbound
    traceTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceTxSubmissionProtocol) pTraceTxSubmissionProtocol
    traceTxSubmission2Protocol <- proxyLastToEither (Proxy @TraceTxSubmission2Protocol) pTraceTxSubmission2Protocol
-   Right $ TracingOnLegacy $ TraceSelection
+   Right $ TraceDispatcher $ TraceSelection
              { traceVerbosity = traceVerbosity
              , traceAcceptPolicy = traceAcceptPolicy
              , traceBlockFetchClient = traceBlockFetchClient


### PR DESCRIPTION
We were previously defaulting to the legacy tracing system 