### PR TITLE
cardano-node-3644: node state ADT expand.

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -88,6 +88,7 @@ library
                        Cardano.Node.Tracing.Era.Byron
                        Cardano.Node.Tracing.Era.HardFork
                        Cardano.Node.Tracing.Era.Shelley
+                       Cardano.Node.Tracing.Peers
                        Cardano.Node.Tracing.StateRep
                        Cardano.Node.Tracing.Tracers
                        Cardano.Node.Tracing.Tracers.BlockReplayProgress

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -122,13 +122,13 @@ data BasicInfoShelleyBased = BasicInfoShelleyBased {
   , bisSlotLength        :: NominalDiffTime
   , bisEpochLength       :: Word64
   , bisSlotsPerKESPeriod :: Word64
-}
+  }
 
 data BasicInfoByron = BasicInfoByron {
     bibSystemStartTime :: UTCTime
   , bibSlotLength      :: NominalDiffTime
   , bibEpochLength     :: Word64
-}
+  }
 
 data BasicInfoNetwork = BasicInfoNetwork {
     niAddresses     :: [SocketOrSocketInfo Socket.SockAddr Socket.SockAddr]

--- a/cardano-node/src/Cardano/Node/Tracing.hs
+++ b/cardano-node/src/Cardano/Node/Tracing.hs
@@ -46,7 +46,7 @@ data Tracers peer localPeer blk p2p = Tracers
   , startupTracer         :: Tracer IO (StartupTrace blk)
   , shutdownTracer        :: Tracer IO ShutdownTrace
   , nodeInfoTracer        :: Tracer IO NodeInfo
-  , nodeStateTracer       :: Tracer IO (NodeState blk)
+  , nodeStateTracer       :: Tracer IO NodeState
   , resourcesTracer       :: Tracer IO ResourceStats
   , peersTracer           :: Tracer IO [PeerT blk]
   }

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -106,6 +106,7 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
       dpTracer
       trConfig
       p2pMode
+      p
    where
     forwarderBackendEnabled =
       any checkForwarder . concat . Map.elems $ tcOptions trConfig

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.Node.Tracing.Peers
+  ( NodePeers (..)
+  , traceNodePeers
+  ) where
+
+import           Cardano.Prelude
+import           Data.Aeson (FromJSON, ToJSON)
+
+import           Cardano.Logging
+
+import           Cardano.Node.Tracing.Tracers.Peer (PeerT, ppPeer)
+
+type PeerInfoPP = Text -- The result of 'ppPeer' function.
+
+-- | This type contains an information about current peers of the node.
+--   It will be asked by external applications as a DataPoint.
+newtype NodePeers = NodePeers [PeerInfoPP]
+
+deriving instance Generic NodePeers
+
+instance ToJSON NodePeers
+instance FromJSON NodePeers
+
+traceNodePeers
+  :: Trace IO NodePeers
+  -> [PeerT blk]
+  -> IO ()
+traceNodePeers tr ev = traceWith tr $ NodePeers (map ppPeer ev)

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -1,30 +1,208 @@
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Node.Tracing.StateRep
   ( NodeState (..)
+  , traceNodeStateChainDB
+  , traceNodeStateStartup
+  , traceNodeStateShutdown
   ) where
 
-import Cardano.Prelude
-import Data.Aeson (FromJSON, ToJSON)
+import           Cardano.Prelude
+import           Cardano.Logging
+import           Data.Aeson
+import           Data.Time.Clock
 
-import Cardano.Node.Handlers.Shutdown (ShutdownTrace (..))
+import           Cardano.Api.Protocol.Types (BlockType (..), protocolInfo)
+import qualified Cardano.Ledger.Shelley.API as SL
+import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import qualified Ouroboros.Consensus.Block.RealPoint as RP
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Cardano.CanHardFork (shelleyLedgerConfig)
+import qualified Ouroboros.Consensus.Config as Consensus
+import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
+import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+import           Ouroboros.Consensus.Shelley.Ledger.Ledger
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LgrDb
+import           Ouroboros.Network.Block (pointSlot)
 
-type PeerInfoPP = Text     -- The result of 'ppPeer' function.
-type StartupTracePP = Text -- The result of 'ppStartupInfoTrace' function.
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
+import qualified Cardano.Node.Startup as Startup
+import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin)
+import           Cardano.Tracing.OrphanInstances.Network ()
+
+instance FromJSON ChunkNo
+instance FromJSON (WithOrigin SlotNo)
+
+instance ToJSON ChunkNo
+instance ToJSON (WithOrigin SlotNo)
+
+data OpeningDbs
+  = StartedOpeningImmutableDB
+  | OpenedImmutableDB (WithOrigin SlotNo) ChunkNo
+  | StartedOpeningVolatileDB
+  | OpenedVolatileDB
+  | StartedOpeningLgrDB
+  | OpenedLgrDB
+  deriving (Generic, FromJSON, ToJSON)
+
+data Replays
+  = ReplayFromGenesis  (WithOrigin SlotNo)
+  | ReplayFromSnapshot SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
+  | ReplayedBlock      SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
+  deriving (Generic, FromJSON, ToJSON)
+
+data InitChainSelection
+  = InitChainStartedSelection
+  | InitChainSelected
+  deriving (Generic, FromJSON, ToJSON)
+
+type SyncPercentage = Word8
+
+data AddedToCurrentChain
+  = AddedToCurrentChain !EpochNo !SlotNo !SyncPercentage
+  deriving (Generic, FromJSON, ToJSON)
+
+deriving instance Generic NPV.NodeToClientVersion
+deriving instance Generic NPV.NodeToNodeVersion
+
+instance FromJSON NPV.NodeToClientVersion
+instance FromJSON NPV.NodeToNodeVersion
+
+data StartupState
+  = StartupSocketConfigError Text
+  | StartupDBValidation
+  | NetworkConfigUpdate
+  | NetworkConfigUpdateError Text
+  | P2PWarning
+  | P2PWarningDevelopementNetworkProtocols
+  | WarningDevelopmentNetworkProtocols [NPV.NodeToNodeVersion] [NPV.NodeToClientVersion]
+  deriving (Generic, FromJSON, ToJSON)
 
 -- | The representation of the current state of node.
 --   All node states prior to tracing system going online are effectively invisible.
-data NodeState blk
-  = NodeTracingOnlineConfiguring -- ^ initTraceDispatcher
-  | NodeStartup StartupTracePP
-  | NodePeers [PeerInfoPP]       -- ^ The peers information here is for demonstration only.
+data NodeState
+  = NodeTracingOnlineConfiguring
+  | NodeOpeningDbs OpeningDbs
+  | NodeReplays Replays
+  | NodeInitChainSelection InitChainSelection
+  | NodeAddBlock AddedToCurrentChain
+  | NodeStartup StartupState
   | NodeShutdown ShutdownTrace
+  deriving (Generic, FromJSON, ToJSON)
 
-deriving instance Generic (NodeState blk)
+traceNodeStateChainDB
+  :: SomeConsensusProtocol
+  -> Trace IO NodeState
+  -> ChainDB.TraceEvent blk
+  -> IO ()
+traceNodeStateChainDB scp tr ev =
+  case ev of
+    ChainDB.TraceOpenEvent ev' ->
+      case ev' of
+        ChainDB.StartedOpeningImmutableDB ->
+          traceWith tr $ NodeOpeningDbs StartedOpeningImmutableDB
+        ChainDB.OpenedImmutableDB p chunk ->
+          traceWith tr $ NodeOpeningDbs $ OpenedImmutableDB (pointSlot p) chunk
+        ChainDB.StartedOpeningVolatileDB ->
+          traceWith tr $ NodeOpeningDbs StartedOpeningVolatileDB
+        ChainDB.OpenedVolatileDB ->
+          traceWith tr $ NodeOpeningDbs OpenedVolatileDB
+        ChainDB.StartedOpeningLgrDB ->
+          traceWith tr $ NodeOpeningDbs StartedOpeningLgrDB
+        ChainDB.OpenedLgrDB ->
+          traceWith tr $ NodeOpeningDbs OpenedLgrDB
+        _ -> return ()
+    ChainDB.TraceLedgerReplayEvent ev' ->
+      case ev' of
+        LgrDb.ReplayFromGenesis (LgrDb.ReplayGoal p) ->
+          traceWith tr $ NodeReplays $ ReplayFromGenesis (pointSlot p)
+        LgrDb.ReplayFromSnapshot _ (RP.RealPoint s _) (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
+          traceWith tr $ NodeReplays $ ReplayFromSnapshot s (pointSlot rs) (pointSlot rp)
+        LgrDb.ReplayedBlock (RP.RealPoint s _) _ (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
+          traceWith tr $ NodeReplays $ ReplayedBlock s (pointSlot rs) (pointSlot rp)
+    ChainDB.TraceInitChainSelEvent ev' ->
+      case ev' of
+        ChainDB.StartedInitChainSelection ->
+          traceWith tr $ NodeInitChainSelection InitChainStartedSelection
+        ChainDB.InitalChainSelected ->
+          traceWith tr $ NodeInitChainSelection InitChainSelected
+        _ -> return ()
+    ChainDB.TraceAddBlockEvent ev' ->
+      case ev' of
+        ChainDB.AddedToCurrentChain _ (ChainDB.NewTipInfo currentTip ntEpoch sInEpoch _) _ _ -> do
+          -- The slot of the latest block consumed (our progress).
+          let RP.RealPoint slotSinceSystemStart _ = currentTip
+          -- The slot corresponding to the latest wall-clock time (our target).
+          slotNow <- getSlotForNow scp slotSinceSystemStart
+          let syncProgressPct = (unSlotNo slotSinceSystemStart `div` unSlotNo slotNow) * 100
+          traceWith tr $ NodeAddBlock $
+            AddedToCurrentChain ntEpoch (SlotNo sInEpoch) $ fromIntegral syncProgressPct
+        _ -> return ()
+    _ -> return ()
 
-instance ToJSON (NodeState blk)
+traceNodeStateStartup
+  :: Trace IO NodeState
+  -> Startup.StartupTrace blk
+  -> IO ()
+traceNodeStateStartup tr ev =
+  case ev of
+    Startup.StartupSocketConfigError e ->
+      traceWith tr $ NodeStartup $ StartupSocketConfigError (show e)
+    Startup.StartupDBValidation ->
+      traceWith tr $ NodeStartup StartupDBValidation
+    Startup.NetworkConfigUpdate ->
+      traceWith tr $ NodeStartup NetworkConfigUpdate
+    Startup.NetworkConfigUpdateError e ->
+      traceWith tr $ NodeStartup $ NetworkConfigUpdateError e
+    Startup.P2PWarning ->
+      traceWith tr $ NodeStartup P2PWarning
+    Startup.P2PWarningDevelopementNetworkProtocols ->
+      traceWith tr $ NodeStartup P2PWarningDevelopementNetworkProtocols
+    Startup.WarningDevelopmentNetworkProtocols n2ns n2cs ->
+      traceWith tr $ NodeStartup $ WarningDevelopmentNetworkProtocols n2ns n2cs
+    _ -> return ()
 
--- Strictly speaking, we mustn't provide 'FromJSON' instance here,
--- but it will be convenient for acceptor application.
-instance FromJSON (NodeState blk)
+traceNodeStateShutdown
+  :: Trace IO NodeState
+  -> ShutdownTrace
+  -> IO ()
+traceNodeStateShutdown tr = traceWith tr . NodeShutdown
+
+-- Misc.
+
+getSlotForNow
+  :: SomeConsensusProtocol
+  -> SlotNo
+  -> IO SlotNo
+getSlotForNow (SomeConsensusProtocol whichP pInfo) s = do
+  now <- getCurrentTime
+  let cfg = pInfoConfig $ protocolInfo pInfo
+  case whichP of
+    ShelleyBlockType -> do
+      let DegenLedgerConfig cfgShelley = Consensus.configLedger cfg
+          nowSinceSystemStart = now `diffUTCTime` getSystemStartTime cfgShelley
+      return . SlotNo $ floor nowSinceSystemStart
+    CardanoBlockType -> do
+      let CardanoLedgerConfig _ cfgShelley cfgAllegra cfgMary cfgAlonzo =
+            Consensus.configLedger cfg
+          latestNowSinceSystemStart = minimum
+            [ now `diffUTCTime` getSystemStartTime cfgShelley
+            , now `diffUTCTime` getSystemStartTime cfgAllegra
+            , now `diffUTCTime` getSystemStartTime cfgMary
+            , now `diffUTCTime` getSystemStartTime cfgAlonzo
+            ]
+      return . SlotNo $ floor latestNowSinceSystemStart
+    _ ->
+      -- It is assumed that Byron isn't used already.
+      return s
+ where
+  getSystemStartTime = SL.sgSystemStart . shelleyLedgerGenesis . shelleyLedgerConfig

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -35,10 +35,12 @@ import           Cardano.Node.Tracing.Tracers.Startup
 import           Trace.Forward.Utils.DataPoint (DataPoint)
 
 import           Cardano.Node.Queries (NodeKernelData)
+import           Cardano.Node.Protocol.Types (SomeConsensusProtocol)
 import           Cardano.Node.Startup
 import           Cardano.Node.TraceConstraints
 import           Cardano.Node.Tracing
-import           Cardano.Node.Tracing.StateRep (NodeState (..))
+import           Cardano.Node.Tracing.Peers
+import qualified Cardano.Node.Tracing.StateRep as SR
 import           "contra-tracer" Control.Tracer (Tracer (..))
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent)
@@ -48,6 +50,7 @@ import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import qualified Ouroboros.Consensus.Network.NodeToNode as NtN
 import           Ouroboros.Consensus.Node (NetworkP2PMode (..))
 import qualified Ouroboros.Consensus.Node.Run as Consensus
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
@@ -57,8 +60,8 @@ import           Ouroboros.Network.ConnectionId (ConnectionId)
 import qualified Ouroboros.Network.Diffusion as Diffusion
 import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
 import qualified Ouroboros.Network.Diffusion.P2P as P2P
-import           Ouroboros.Network.NodeToClient (LocalAddress, NodeToClientVersion)
-import           Ouroboros.Network.NodeToNode (NodeToNodeVersion, RemoteAddress)
+import           Ouroboros.Network.NodeToClient (LocalAddress)
+import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 -- | Construct tracers for all system components.
 --
@@ -66,7 +69,6 @@ mkDispatchTracers
   :: forall blk p2p.
   ( Consensus.RunNode blk
   , TraceConstraints blk
-
   , LogFormatting (LedgerEvent blk)
   , LogFormatting
     (TraceLabelPeer
@@ -79,8 +81,9 @@ mkDispatchTracers
   -> Trace IO DataPoint
   -> TraceConfig
   -> NetworkP2PMode p2p
+  -> SomeConsensusProtocol
   -> IO (Tracers (ConnectionId RemoteAddress) (ConnectionId LocalAddress) blk p2p)
-mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enableP2P = do
+mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enableP2P p = do
     -- Some special tracers
     -- NodeInfo tracer
     nodeInfoTr <- mkDataPointTracer
@@ -91,6 +94,10 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     nodeStateTr <- mkDataPointTracer
                 trDataPoint
                 (const ["NodeState"])
+
+    nodePeersTr <- mkDataPointTracer
+                trDataPoint
+                (const ["NodePeers"])
 
     -- Resource tracer
     resourcesTr <- mkCardanoTracer
@@ -185,25 +192,19 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     diffusionTrExtra :: Diffusion.ExtraTracers p2p <-
       mkDiffusionTracersExtra trBase trForward mbTrEKG trDataPoint trConfig enableP2P
     pure Tracers
-      { chainDBTracer = Tracer (traceWith chainDBTr')
-                        <> Tracer (traceWith replayBlockTr')
+      { chainDBTracer = Tracer (\x -> traceWith chainDBTr' x >> SR.traceNodeStateChainDB p nodeStateTr x)
+                     <> Tracer (\x -> traceWith replayBlockTr' x >> SR.traceNodeStateChainDB p nodeStateTr x)
       , consensusTracers = consensusTr
       , nodeToClientTracers = nodeToClientTr
       , nodeToNodeTracers = nodeToNodeTr
       , diffusionTracers = diffusionTr
       , diffusionTracersExtra = diffusionTrExtra
-      , startupTracer = Tracer $ \x -> do
-                          traceWith startupTr x
-                          traceWith nodeStateTr $ NodeStartup (ppStartupInfoTrace x)
-      , shutdownTracer = Tracer $ \x -> do
-                           traceWith shutdownTr x
-                           traceWith nodeStateTr $ NodeShutdown x
+      , startupTracer = Tracer $ \x -> traceWith startupTr x >> SR.traceNodeStateStartup nodeStateTr x
+      , shutdownTracer = Tracer $ \x -> traceWith shutdownTr x >> SR.traceNodeStateShutdown nodeStateTr x
       , nodeInfoTracer = Tracer (traceWith nodeInfoTr)
       , nodeStateTracer = Tracer (traceWith nodeStateTr)
       , resourcesTracer = Tracer (traceWith resourcesTr)
-      , peersTracer = Tracer $ \x -> do
-                        traceWith peersTr x
-                        traceWith nodeStateTr $ NodePeers (map ppPeer x)
+      , peersTracer = Tracer $ \x -> traceWith peersTr x >> traceNodePeers nodePeersTr x
     }
 
 mkConsensusTracers :: forall blk.


### PR DESCRIPTION
As a result of https://github.com/input-output-hk/cardano-node/pull/3591, we now have a new `DataPoint` called `NodeState`. An external application (for example, `cardano-wallet`) can ask for this `DataPoint` to know the current state of the node.

Initially, `NodeState` was a primitive ADT and contained a very small portion of information. Now it's expanded.

Also, this PR moved node's peers info in a separate `DataPoint`.

The documentation is at: https://github.com/input-output-hk/cardano-node/wiki/cardano-node-and-DataPoints:-demo