### PR TITLE
Add IsCardanoEra constraint to BlockInMode

### DIFF
--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -191,7 +191,7 @@ obtainConsensusShelleyBasedEra ShelleyBasedEraAlonzo  f = f
 -- different block types for all the eras. It is used in the ChainSync protocol.
 --
 data BlockInMode mode where
-     BlockInMode :: Block era -> EraInMode era mode -> BlockInMode mode
+     BlockInMode :: IsCardanoEra era => Block era -> EraInMode era mode -> BlockInMode mode
 
 deriving instance Show (BlockInMode mode)
 


### PR DESCRIPTION
This PR adds the `IsCardanoEra` constraint to `BlockInMode`. 

```haskell
data BlockInMode mode where
     BlockInMode :: IsCardanoEra era => Block era -> EraInMode era mode -> BlockInMode mode
```

The additional constraints makes it easier to use `BlockInMode` with types like [SomeCardanoApiTx](https://playground.plutus.iohkdev.io/doc/haddock/plutus-ledger/html/Ledger-Tx.html#t:SomeCardanoApiTx) which require IsCardanoEra.

Please let me know if I am missing something obvious.