### PR TITLE
Add --shutdown-on-slot-synced test and ensure ExitSuccess

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Spec.Chairman.Cardano
@@ -6,6 +5,7 @@ module Spec.Chairman.Cardano
   ) where
 
 import           Data.Function
+import           Data.Functor
 import           Data.Maybe
 import           Spec.Chairman.Chairman (chairmanOver)
 
@@ -23,6 +23,6 @@ hprop_chairman :: H.Property
 hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
   conf <- H.mkConf tempAbsPath' Nothing
 
-  H.TestnetRuntime { H.allNodes } <- H.testnet H.defaultTestnetOptions conf
+  allNodes <- fmap H.nodeName . H.allNodes <$> H.testnet H.defaultTestnetOptions conf
 
   chairmanOver 120 50 conf allNodes

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -125,6 +125,7 @@ test-suite cardano-testnet-tests
                         -- Spec.Plutus.Script.TxInLockingPlutus
                         -- Spec.Plutus.SubmitApi.TxInLockingPlutus
                         Spec.Shutdown
+                        Spec.ShutdownOnSlotSynced
                         Test.Util
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-testnet/test/Main.hs
+++ b/cardano-testnet/test/Main.hs
@@ -16,6 +16,7 @@ import           Test.Tasty (TestTree)
 -- import qualified Spec.Plutus.Script.TxInLockingPlutus
 -- import qualified Spec.Plutus.SubmitApi.TxInLockingPlutus
 import qualified Spec.Shutdown
+import qualified Spec.ShutdownOnSlotSynced
 import qualified System.Environment as E
 import qualified Test.Tasty as T
 import qualified Test.Tasty.Ingredients as T
@@ -36,6 +37,7 @@ tests = do
      --  , H.ignoreOnWindows "Plutus.Direct.ScriptContextEqualityMint" Spec.Plutus.Direct.ScriptContextEqualityMint.hprop_plutus_script_context_mint_equality
         -- There is a blocking call on Windows that prevents graceful shutdown and we currently aren't testing the shutdown IPC flag.
         H.ignoreOnWindows "Shutdown" Spec.Shutdown.hprop_shutdown
+      , H.ignoreOnWindows "ShutdownOnSlotSynced" Spec.ShutdownOnSlotSynced.hprop_shutdownOnSlotSynced
       ]
     ]
 

--- a/cardano-testnet/test/Spec/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Spec/ShutdownOnSlotSynced.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Spec.ShutdownOnSlotSynced
+  ( hprop_shutdownOnSlotSynced
+  ) where
+
+import           Control.Monad
+import           Data.Bool ((&&))
+import           Data.Either (Either (Right), isRight)
+import           Data.Function
+import           Data.Int
+import           Data.List (find, isInfixOf, lines, reverse, words, (++))
+import           Data.Maybe
+import           Data.Ord
+import           GHC.IO.Exception (ExitCode (ExitSuccess))
+import           GHC.Num
+import           GHC.Stack (callStack)
+import           Hedgehog (Property, assert, (===))
+import           Prelude (fromIntegral, round)
+import           Text.Read (readMaybe)
+import           Text.Show (Show (..))
+
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
+import qualified Test.Base as H
+import           Testnet.Cardano (TestnetNode (..), TestnetNodeOptions (TestnetNodeOptions),
+                   TestnetOptions (..), TestnetRuntime (..), defaultTestnetNodeOptions,
+                   defaultTestnetOptions, testnet)
+import qualified Testnet.Cardano as TC
+import qualified Testnet.Conf as H
+
+hprop_shutdownOnSlotSynced :: Property
+hprop_shutdownOnSlotSynced = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+  -- Start a local test net
+  conf <- H.noteShowM $ H.mkConf tempAbsBasePath' Nothing
+  let maxSlot = 1500
+      slotLen = 0.01
+  let fastTestnetOptions = defaultTestnetOptions
+        { epochLength = 300
+        , slotLength = slotLen
+        , bftNodeOptions =
+          [ TestnetNodeOptions
+              { TC.extraNodeCliArgs = ["--shutdown-on-slot-synced", show maxSlot]
+              }
+          , defaultTestnetNodeOptions
+          , defaultTestnetNodeOptions
+          ]
+        }
+  TC.TestnetRuntime { bftNodes = node:_ } <- testnet fastTestnetOptions conf
+
+  -- Wait for the node to exit
+  let timeout :: Int
+      timeout = round (30 + (fromIntegral maxSlot * slotLen))
+  mExitCodeRunning <- H.waitSecondsForProcess timeout (nodeProcessHandle node)
+
+  -- Check results
+  when (isRight mExitCodeRunning) $ do
+    H.cat (nodeStdout node)
+    H.cat (nodeStderr node)
+  mExitCodeRunning === Right ExitSuccess
+  log <- H.readFile (nodeStdout node)
+  slotTip <- case find (isInfixOf "Closed db with immutable tip") (reverse (lines log)) of
+    Nothing -> H.failMessage callStack "Could not find current tip in node's log."
+    Just line -> case listToMaybe (reverse (words line)) of
+      Nothing -> H.failMessage callStack "Impossible"
+      Just lastWord -> case readMaybe @Integer lastWord of
+        Nothing -> H.failMessage callStack ("Expected a node tip as the last word of the log line, but got: " ++ line)
+        Just slotTip -> H.noteShow slotTip
+
+  let epsilon = 50
+  assert (maxSlot <= slotTip && slotTip <= maxSlot + epsilon)
+  return ()

--- a/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
@@ -6,12 +6,13 @@ module Testnet.Commands.Cardano
   , runCardanoOptions
   ) where
 
-import           GHC.Enum
 import           Data.Eq
 import           Data.Function
 import           Data.Int
+import           Data.List (replicate)
 import           Data.Maybe
 import           Data.Semigroup
+import           GHC.Enum
 import           Options.Applicative
 import           System.IO (IO)
 import           Testnet.Cardano
@@ -28,12 +29,13 @@ data CardanoOptions = CardanoOptions
 
 optsTestnet :: Parser TestnetOptions
 optsTestnet = TestnetOptions
-  <$> OA.option auto
+  <$> OA.option
+      ((`replicate` defaultTestnetNodeOptions) <$> auto)
       (   OA.long "num-bft-nodes"
       <>  OA.help "Number of BFT nodes"
       <>  OA.metavar "COUNT"
       <>  OA.showDefault
-      <>  OA.value (numBftNodes defaultTestnetOptions)
+      <>  OA.value (bftNodeOptions defaultTestnetOptions)
       )
   <*> OA.option auto
       (   OA.long "num-pool-nodes"


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/cardano-node/issues/3646

This does 2 things:

1. Adds a test that starts a node with `--shutdown-on-slot-synced x` and checks that (A) the exit code is `0` and that (B) the chain tip slot is close to `x`.
2. Rethrows the `ExceptionInLinkedThread _ ExitSuccess` exception as an an unwrapped `ExitSuccess` exception. This means the process's exit code will be `0` rather than `1` (this is asserted by the new test).

Without the changes of this PR, property 1.A fails (the exit code is `1`) but 1.B succeeds.