### PR TITLE
cardano-node-3664: restore legacy metrics.

### DIFF
--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -10,6 +10,7 @@ module Cardano.Node.Configuration.Logging
   ( LoggingLayer (..)
   , EKGDirect(..)
   , createLoggingLayer
+  , nodeBasicInfo
   , shutdownLoggingLayer
   , traceCounter
   -- re-exports


### PR DESCRIPTION
Restore legacy tracing for `nodeStartTime` and `nodeBasicInfo.*`. Should fix https://github.com/input-output-hk/cardano-node/issues/3664