### PR TITLE
Fix typo in Transaction.hs

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -289,8 +289,8 @@ runTransactionCmd cmd =
                     scriptFiles metadataFiles mpparams mUpProp out
     TxSign txinfile skfiles network txoutfile ->
       runTxSign txinfile skfiles network txoutfile
-    TxSubmit anyConensusModeParams network txFp ->
-      runTxSubmit anyConensusModeParams network txFp
+    TxSubmit anyConsensusModeParams network txFp ->
+      runTxSubmit anyConsensusModeParams network txFp
     TxCalculateMinFee txbody mnw pGenesisOrParamsFile nInputs nOutputs
                       nShelleyKeyWitnesses nByronKeyWitnesses ->
       runTxCalculateMinFee txbody mnw pGenesisOrParamsFile nInputs nOutputs


### PR DESCRIPTION
This PR fixes a minor typo into `cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs`.