### PR TITLE
New tracers without prototypes

### DIFF
--- a/.github/bin/check-git-dependencies
+++ b/.github/bin/check-git-dependencies
@@ -23,8 +23,7 @@ commits () {
   done
 }
 
-cat cabal.project | \
-  grep '\(^source-repository-package\|^ *location:\|^ *tag:\)' | sed 's|^source-repository-package|-|g' | \
+grep '\(^source-repository-package\|^ *location:\|^ *tag:\)' cabal.project | sed 's|^source-repository-package|-|g' | \
   yq eval -P -j \
   > tmp/repositories.json
 
@@ -32,6 +31,9 @@ for row in $(cat tmp/repositories.json | jq -r '.[] | @base64'); do
   json="$(echo "${row}" | base64 --decode | jq -r ${1})"
   location="$(echo "$json" | jq -r .location)"
   tag="$(echo "$json" | jq -r .tag)"
+
+  if fgrep <<<$location -f .github/master-check-exceptions.list > /dev/null
+  then echo "${YELLOW}check-git-dependencies:  skipping location from master check:  ${RED}$location${NC}"; continue; fi
 
   rm -f tmp/tmp-dep-repo-result
   rm -rf tmp/dep-repo

--- a/.github/master-check-exceptions.list
+++ b/.github/master-check-exceptions.list
@@ -1,0 +1,2 @@
+vshabanov/ekg-json
+input-output-hk/iohk-monitoring-framework

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -149,7 +149,7 @@ data NodeInfo = NodeInfo
 docNodeInfoTraceEvent :: Documented NodeInfo
 docNodeInfoTraceEvent = Documented [
     DocMsg
-      (NodeInfo "" "" "" "" anyProto anyProto)
+      ["NodeInfo"]
         []
         "Basic information about this node collected at startup\
         \\n\

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -155,9 +155,9 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     replayBlockTr' <- withReplayedBlock replayBlockTr
     -- Filter out replayed blocks for this tracer
     let chainDBTr' = filterTrace
-                      (\case (_, Nothing, ChainDB.TraceLedgerReplayEvent
+                      (\case (_, ChainDB.TraceLedgerReplayEvent
                                             LedgerDB.ReplayedBlock {}) -> False
-                             (_, _, _) -> True)
+                             (_, _) -> True)
                       chainDBTr
 
     consensusTr :: Consensus.Tracers
@@ -371,11 +371,11 @@ mkNodeToClientTracers trBase trForward mbTrEKG _trDataPoint trConfig = do
     chainSyncTr <-
       mkCardanoTracer
         trBase trForward mbTrEKG
-        "ChainSyncClient"
+        "ChainSync"
         namesForTChainSync
         severityTChainSync
         allPublic
-    configureTracers trConfig docTChainSync [chainSyncTr]
+    configureTracers trConfig docTChainSyncNodeToClient [chainSyncTr]
     txMonitorTr <-
       mkCardanoTracer
         trBase trForward mbTrEKG
@@ -427,14 +427,14 @@ mkNodeToNodeTracers trBase trForward mbTrEKG _trDataPoint trConfig = do
                 namesForTChainSyncNode
                 severityTChainSyncNode
                 allPublic
-    configureTracers trConfig docTChainSync [chainSyncTracer]
+    configureTracers trConfig docTChainSyncNodeToNode [chainSyncTracer]
     chainSyncSerialisedTr <-  mkCardanoTracer
                 trBase trForward mbTrEKG
                 "ChainSyncSerialised"
                 namesForTChainSyncSerialised
                 severityTChainSyncSerialised
                 allPublic
-    configureTracers trConfig docTChainSync [chainSyncSerialisedTr]
+    configureTracers trConfig docTChainSyncNodeToNodeSerisalised [chainSyncSerialisedTr]
     blockFetchTr  <-  mkCardanoTracer
                 trBase trForward mbTrEKG
                 "BlockFetch"
@@ -636,7 +636,7 @@ mkDiffusionTracersExtra trBase trForward mbTrEKG _trDataPoint trConfig EnabledP2
       namesForInboundGovernorTransition
       severityInboundGovernorTransition
       allPublic
-    configureTracers trConfig docInboundGovernorRemote [inboundGovernorTr]
+    configureTracers trConfig docInboundGovernorTransition [inboundGovernorTransitionsTr]
     localConnectionManagerTr  <-  mkCardanoTracer
       trBase trForward mbTrEKG
       "LocalConnectionManager"

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -53,7 +53,7 @@ instance LogFormatting ReplayBlockStats where
 docReplayedBlock :: Documented ReplayBlockStats
 docReplayedBlock = Documented [
     DocMsg
-      emptyReplayBlockStats
+      ["LedgerReplay"]
       [("Block replay progress (%)",
         "Progress in percent")]
       "Counts up the percent of a block replay."
@@ -66,16 +66,14 @@ withReplayedBlock tr =
         tr'' = contramap unfold tr'
     in foldMTraceM replayBlockStats emptyReplayBlockStats tr''
   where
-    filterFunction(_, Just _, _) = True
-    filterFunction(_, Nothing, ReplayBlockStats {..}) = rpsDisplay
+    filterFunction(_, ReplayBlockStats {..}) = rpsDisplay
 
 replayBlockStats :: MonadIO m
   => ReplayBlockStats
   -> LoggingContext
-  -> Maybe TraceControl
   -> ChainDB.TraceEvent blk
   -> m ReplayBlockStats
-replayBlockStats ReplayBlockStats {..} _context _mbCtrl
+replayBlockStats ReplayBlockStats {..} _context
     (ChainDB.TraceLedgerReplayEvent (LedgerDB.ReplayedBlock pt []
                                       (LedgerDB.ReplayStart replayTo) _)) = do
       let slotno = toInteger $ unSlotNo (realPointSlot pt)
@@ -85,4 +83,4 @@ replayBlockStats ReplayBlockStats {..} _context _mbCtrl
                 || ((progress' - rpsLastProgress) > 1.0)
                 then ReplayBlockStats True progress' progress'
                 else ReplayBlockStats False progress' rpsLastProgress
-replayBlockStats st@ReplayBlockStats {} _context _mbCtrl _ = pure st
+replayBlockStats st@ReplayBlockStats {} _context _ = pure st

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -156,7 +156,7 @@ severityChainSyncClientEvent (BlockFetch.TraceLabelPeer _ e) =
 namesForChainSyncClientEvent ::
   BlockFetch.TraceLabelPeer peer (TraceChainSyncClientEvent blk) -> [Text]
 namesForChainSyncClientEvent (BlockFetch.TraceLabelPeer _ e) =
-    namesForChainSyncClientEvent' e
+    "ChainSyncClientEvent" : namesForChainSyncClientEvent' e
 
 severityChainSyncClientEvent' :: TraceChainSyncClientEvent blk -> SeverityS
 severityChainSyncClientEvent' TraceDownloadedHeader {}  = Info
@@ -167,15 +167,15 @@ severityChainSyncClientEvent' TraceTermination {}       = Notice
 
 namesForChainSyncClientEvent' :: TraceChainSyncClientEvent blk -> [Text]
 namesForChainSyncClientEvent' TraceDownloadedHeader {} =
-      ["ChainSyncClientEvent.DownloadedHeader"]
+      ["DownloadedHeader"]
 namesForChainSyncClientEvent' TraceFoundIntersection {} =
-      ["ChainSyncClientEvent.FoundIntersection"]
+      ["FoundIntersection"]
 namesForChainSyncClientEvent' TraceRolledBack {} =
-      ["ChainSyncClientEvent.RolledBack"]
+      ["RolledBack"]
 namesForChainSyncClientEvent' TraceException {} =
-      ["ChainSyncClientEvent.Exception"]
+      ["Exception"]
 namesForChainSyncClientEvent' TraceTermination {} =
-      ["ChainSyncClientEvent.Termination"]
+      ["Termination"]
 
 instance (Show (Header blk), ConvertRawHash blk, LedgerSupportsProtocol blk)
       => LogFormatting (TraceChainSyncClientEvent blk) where
@@ -212,32 +212,34 @@ instance (Show (Header blk), ConvertRawHash blk, LedgerSupportsProtocol blk)
 
 docChainSyncClientEvent ::
   Documented (BlockFetch.TraceLabelPeer peer (TraceChainSyncClientEvent blk))
-docChainSyncClientEvent = Documented [
+docChainSyncClientEvent =
+    addDocumentedNamespace
+      ["ChainSyncClientEvent"]
+      docChainSyncClientEvent'
+
+docChainSyncClientEvent' ::
+  Documented (BlockFetch.TraceLabelPeer peer (TraceChainSyncClientEvent blk))
+docChainSyncClientEvent' = Documented [
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (TraceDownloadedHeader anyProto))
+      ["DownloadedHeader"]
       []
       "While following a candidate chain, we rolled forward by downloading a\
       \ header."
   , DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (TraceRolledBack anyProto))
+      ["RolledBack"]
       []
       "While following a candidate chain, we rolled back to the given point."
   , DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (TraceFoundIntersection anyProto anyProto anyProto))
+      ["FoundIntersection"]
       []
       "We found an intersection between our chain fragment and the\
       \ candidate's chain."
   , DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (TraceException anyProto))
+      ["Exception"]
       []
       "An exception was thrown by the Chain Sync Client."
   , DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (TraceTermination anyProto))
+      ["Termination"]
       []
       "The client has terminated."
   ]
@@ -253,14 +255,19 @@ severityChainSyncServerEvent TraceChainSyncRollForward       {} = Info
 severityChainSyncServerEvent TraceChainSyncRollBackward      {} = Info
 
 namesForChainSyncServerEvent :: TraceChainSyncServerEvent blk -> [Text]
-namesForChainSyncServerEvent TraceChainSyncServerRead        {} =
-      ["ChainSyncServerEvent.ServerRead"]
-namesForChainSyncServerEvent TraceChainSyncServerReadBlocked {} =
-      ["ChainSyncServerEvent.ServerReadBlocked"]
-namesForChainSyncServerEvent TraceChainSyncRollForward       {} =
-      ["ChainSyncServerEvent.RollForward"]
-namesForChainSyncServerEvent TraceChainSyncRollBackward      {} =
-      ["ChainSyncServerEvent.RollBackward"]
+namesForChainSyncServerEvent ev =
+    "ChainSyncServerEvent" : namesForChainSyncServerEvent' ev
+
+
+namesForChainSyncServerEvent' :: TraceChainSyncServerEvent blk -> [Text]
+namesForChainSyncServerEvent' TraceChainSyncServerRead        {} =
+      ["ServerRead"]
+namesForChainSyncServerEvent' TraceChainSyncServerReadBlocked {} =
+      ["ServerReadBlocked"]
+namesForChainSyncServerEvent' TraceChainSyncRollForward       {} =
+      ["RollForward"]
+namesForChainSyncServerEvent' TraceChainSyncRollBackward      {} =
+      ["RollBackward"]
 
 instance ConvertRawHash blk
       => LogFormatting (TraceChainSyncServerEvent blk) where
@@ -297,23 +304,28 @@ instance ConvertRawHash blk
       [CounterM "cardano.node.chainSync.rollForward" Nothing]
   asMetrics _ = []
 
-
 docChainSyncServerEvent :: Documented (TraceChainSyncServerEvent blk)
-docChainSyncServerEvent = Documented [
+docChainSyncServerEvent =
+    addDocumentedNamespace
+      ["ChainSyncServerEvent", "ServerRead"]
+      docChainSyncServerEvent'
+
+docChainSyncServerEvent' :: Documented (TraceChainSyncServerEvent blk)
+docChainSyncServerEvent' = Documented [
     DocMsg
-      (TraceChainSyncServerRead anyProto anyProto)
+      ["ServerRead"]
       []
       "A server read has occurred, either for an add block or a rollback"
     , DocMsg
-      (TraceChainSyncServerReadBlocked anyProto anyProto)
+       ["ServerReadBlocked"]
       []
       "A server read has blocked, either for an add block or a rollback"
     , DocMsg
-      (TraceChainSyncRollForward anyProto)
+      ["RollForward"]
       [("cardano.node.chainSync.rollForward", "")]
       "Roll forward to the given point."
     , DocMsg
-      (TraceChainSyncRollBackward anyProto)
+      ["RollBackward"]
       []
       ""
   ]
@@ -384,7 +396,7 @@ docBlockFetchDecision ::
   Documented [BlockFetch.TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]
 docBlockFetchDecision = Documented [
     DocMsg
-      [BlockFetch.TraceLabelPeer anyProto (Right anyProto)]
+      []
       [("cardano.node.connectedPeers", "Number of connected peers")]
       "Throughout the decision making process we accumulate reasons to decline\
       \ to fetch any blocks. This message carries the intermediate and final\
@@ -428,14 +440,15 @@ namesForBlockFetchClient' BlockFetch.SendFetchRequest {} =
   ["SendFetchRequest"]
 namesForBlockFetchClient' BlockFetch.StartedFetchBatch {} =
   ["StartedFetchBatch"]
-namesForBlockFetchClient' BlockFetch.CompletedBlockFetch  {} =
-  ["CompletedBlockFetch"]
 namesForBlockFetchClient' BlockFetch.CompletedFetchBatch {} =
   ["CompletedFetchBatch"]
+namesForBlockFetchClient' BlockFetch.CompletedBlockFetch  {} =
+  ["CompletedBlockFetch"]
 namesForBlockFetchClient' BlockFetch.RejectedFetchBatch  {} =
   ["RejectedFetchBatch"]
 namesForBlockFetchClient' BlockFetch.ClientTerminating {} =
   ["ClientTerminating"]
+
 
 instance LogFormatting (BlockFetch.TraceFetchClientState header) where
   forMachine _dtal BlockFetch.AddedFetchRequest {} =
@@ -455,65 +468,58 @@ instance LogFormatting (BlockFetch.TraceFetchClientState header) where
   forMachine _dtal BlockFetch.ClientTerminating {} =
     mconcat [ "kind" .= String "ClientTerminating" ]
 
+
 docBlockFetchClient ::
   Documented (BlockFetch.TraceLabelPeer remotePeer (BlockFetch.TraceFetchClientState (Header blk)))
-docBlockFetchClient = Documented [
+docBlockFetchClient = addDocumentedNamespace [] docBlockFetchClient'
+
+docBlockFetchClient' ::
+  Documented (BlockFetch.TraceLabelPeer remotePeer (BlockFetch.TraceFetchClientState (Header blk)))
+docBlockFetchClient' = Documented [
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.AddedFetchRequest
-          anyProto
-          anyProto
-          anyProto
-          anyProto))
+      ["AddedFetchRequest"]
       []
       "The block fetch decision thread has added a new fetch instruction\
       \ consisting of one or more individual request ranges."
   ,
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.AcknowledgedFetchRequest
-          anyProto))
+      ["AcknowledgedFetchRequest"]
       []
       "Mark the point when the fetch client picks up the request added\
       \ by the block fetch decision thread. Note that this event can happen\
       \ fewer times than the 'AddedFetchRequest' due to fetch request merging."
   ,
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.StartedFetchBatch
-          anyProto
-          anyProto
-          anyProto
-          anyProto))
+      ["SendFetchRequest"]
+      []
+      "Mark the point when fetch request for a fragment is actually sent\
+       \ over the wire."
+  ,
+    DocMsg
+      ["StartedFetchBatch"]
       []
       "Mark the start of receiving a streaming batch of blocks. This will\
       \ be followed by one or more 'CompletedBlockFetch' and a final\
       \ 'CompletedFetchBatch'"
   ,
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.CompletedFetchBatch
-          anyProto
-          anyProto
-          anyProto
-          anyProto))
+      ["CompletedFetchBatch"]
+      []
+      "Mark the successful end of receiving a streaming batch of blocks"
+  ,
+    DocMsg
+      ["CompletedBlockFetch"]
       []
       "Mark the successful end of receiving a streaming batch of blocks."
   ,
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.RejectedFetchBatch
-          anyProto
-          anyProto
-          anyProto
-          anyProto))
+      ["RejectedFetchBatch"]
       []
       "If the other peer rejects our request then we have this event\
       \ instead of 'StartedFetchBatch' and 'CompletedFetchBatch'."
   ,
     DocMsg
-      (BlockFetch.TraceLabelPeer anyProto
-        (BlockFetch.ClientTerminating 1))
+      ["ClientTerminating"]
       []
       "The client is terminating.  Log the number of outstanding\
       \ requests."
@@ -544,11 +550,17 @@ instance ConvertRawHash blk => LogFormatting (TraceBlockFetchServerEvent blk) wh
   asMetrics (TraceBlockFetchServerSendBlock _p) =
     [CounterM "cardano.node.served.block" Nothing]
 
+
 docBlockFetchServer ::
   Documented (TraceBlockFetchServerEvent blk)
-docBlockFetchServer = Documented [
+docBlockFetchServer = addDocumentedNamespace [] docBlockFetchServer'
+
+
+docBlockFetchServer' ::
+  Documented (TraceBlockFetchServerEvent blk)
+docBlockFetchServer' = Documented [
     DocMsg
-      (TraceBlockFetchServerSendBlock GenesisPoint)
+      ["SendBlock"]
       [("cardano.node.served.block", "")]
       "The server sent a block to the peer."
   ]
@@ -631,37 +643,37 @@ instance LogFormatting (TraceTxSubmissionInbound txid tx) where
 docTxInbound ::
   Documented (BlockFetch.TraceLabelPeer remotePeer
     (TraceTxSubmissionInbound txid tx))
-docTxInbound = Documented [
+docTxInbound = addDocumentedNamespace [] docTxInbound'
+
+docTxInbound' ::
+  Documented (BlockFetch.TraceLabelPeer remotePeer
+    (TraceTxSubmissionInbound txid tx))
+docTxInbound' = Documented [
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxSubmissionCollected 1))
+    ["TxSubmissionCollected"]
     [ ("cardano.node.submissions.submitted", "")]
     "Number of transactions just about to be inserted."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxSubmissionProcessed (ProcessedTxCount 1 2)))
+    ["TxSubmissionProcessed"]
     [ ("cardano.node.submissions.accepted", "")
     , ("cardano.node.submissions.rejected", "")
     ]
     "Just processed transaction pass/fail breakdown."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      TraceTxInboundTerminated)
+    ["TxInboundTerminated"]
     []
     "Server received 'MsgDone'."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxInboundCanRequestMoreTxs 1))
+    ["TxInboundCanRequestMoreTxs"]
     []
     "There are no replies in flight, but we do know some more txs we\
     \ can ask for, so lets ask for them and more txids."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxInboundCannotRequestMoreTxs 1))
+    ["TxInboundCannotRequestMoreTxs"]
     []
     "There's no replies in flight, and we have no more txs we can\
     \ ask for so the only remaining thing to do is to ask for more\
@@ -722,22 +734,24 @@ instance (Show txid, Show tx)
 docTxOutbound :: forall remotePeer txid tx.
   Documented (BlockFetch.TraceLabelPeer remotePeer
     (TraceTxSubmissionOutbound txid tx))
-docTxOutbound = Documented [
+docTxOutbound =  addDocumentedNamespace [] docTxOutbound'
+
+docTxOutbound' :: forall remotePeer txid tx.
+  Documented (BlockFetch.TraceLabelPeer remotePeer
+    (TraceTxSubmissionOutbound txid tx))
+docTxOutbound' = Documented [
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxSubmissionOutboundRecvMsgRequestTxs anyProto))
+    ["RecvMsgRequest"]
     []
     "The IDs of the transactions requested."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceTxSubmissionOutboundSendMsgReplyTxs anyProto))
+    ["SendMsgReply"]
     []
     "The transactions to be sent in the response."
   ,
     DocMsg
-    (BlockFetch.TraceLabelPeer anyProto
-      (TraceControlMessage anyProto))
+    ["ControlMessage"]
     []
     ""
   ]
@@ -761,9 +775,13 @@ instance LogFormatting (TraceLocalTxSubmissionServerEvent blk) where
     mconcat [ "kind" .= String "ReceivedTx" ]
 
 docLocalTxSubmissionServer :: Documented (TraceLocalTxSubmissionServerEvent blk)
-docLocalTxSubmissionServer = Documented [
+docLocalTxSubmissionServer =
+    addDocumentedNamespace [] docLocalTxSubmissionServer'
+
+docLocalTxSubmissionServer' :: Documented (TraceLocalTxSubmissionServerEvent blk)
+docLocalTxSubmissionServer' = Documented [
     DocMsg
-    (TraceReceivedTx anyProto)
+    ["ReceivedTx"]
     []
     "A transaction was received."
   ]
@@ -847,22 +865,25 @@ instance LogFormatting MempoolSize where
       ]
 
 docMempool :: forall blk. Documented (TraceEventMempool blk)
-docMempool = Documented [
+docMempool = addDocumentedNamespace [] docMempool'
+
+docMempool' :: forall blk. Documented (TraceEventMempool blk)
+docMempool' = Documented [
     DocMsg
-      (TraceMempoolAddedTx anyProto anyProto anyProto)
+      ["AddedTx"]
       [ ("cardano.node.txsInMempool","Transactions in mempool")
       , ("cardano.node.mempoolBytes", "Byte size of the mempool")
       ]
       "New, valid transaction that was added to the Mempool."
   , DocMsg
-      (TraceMempoolRejectedTx anyProto anyProto anyProto)
+      ["RejectedTx"]
       [ ("cardano.node.txsInMempool","Transactions in mempool")
       , ("cardano.node.mempoolBytes", "Byte size of the mempool")
       ]
       "New, invalid transaction thas was rejected and thus not added to\
       \ the Mempool."
   , DocMsg
-      (TraceMempoolRemoveTxs [anyProto] anyProto)
+      ["RemoveTxs"]
       [ ("cardano.node.txsInMempool","Transactions in mempool")
       , ("cardano.node.mempoolBytes", "Byte size of the mempool")
       ]
@@ -870,7 +891,7 @@ docMempool = Documented [
       \ changes in the ledger state. These transactions have been removed\
       \ from the Mempool."
   , DocMsg
-      (TraceMempoolManuallyRemovedTxs [anyProto] [anyProto] anyProto)
+      ["ManuallyRemovedTxs"]
       [ ("cardano.node.txsInMempool","Transactions in mempool")
       , ("cardano.node.mempoolBytes", "Byte size of the mempool")
       , ("cardano.node.txsProcessedNum", "")
@@ -1193,20 +1214,20 @@ instance LogFormatting TraceStartLeadershipCheckPlus where
   asMetrics TraceStartLeadershipCheckPlus {..} =
     [IntM "cardano.node.utxoSize" (fromIntegral tsUtxoSize),
      IntM "cardano.node.delegMapSize" (fromIntegral tsDelegMapSize)]
-     -- TODO JNF: Why not deleg map size?
-
 
 docForge :: Documented (Either (TraceLabelCreds (TraceForgeEvent blk))
                                (TraceLabelCreds TraceStartLeadershipCheckPlus))
-docForge = Documented [
+docForge = addDocumentedNamespace [] docForge'
+
+docForge' :: Documented (Either (TraceLabelCreds (TraceForgeEvent blk))
+                               (TraceLabelCreds TraceStartLeadershipCheckPlus))
+docForge' = Documented [
     DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceStartLeadershipCheck anyProto)))
+      ["StartLeadershipCheck"]
       [("cardano.node.aboutToLeadSlotLast", "")]
       "Start of the leadership check."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceSlotIsImmutable anyProto anyProto anyProto)))
+      ["SlotIsImmutable"]
       [("cardano.node.slotIsImmutable", "")]
       "Leadership check failed: the tip of the ImmutableDB inhabits the\
       \  current slot\
@@ -1226,8 +1247,7 @@ docForge = Documented [
       \ \
       \ See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>"
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceBlockFromFuture anyProto anyProto)))
+      ["BlockFromFuture"]
       [("cardano.node.blockFromFuture", "")]
       "Leadership check failed: the current chain contains a block from a slot\
       \  /after/ the current slot\
@@ -1239,8 +1259,7 @@ docForge = Documented [
       \ \
       \  See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>"
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceBlockContext anyProto anyProto anyProto)))
+      ["BlockContext"]
       [("cardano.node.blockContext", "")]
       "We found out to which block we are going to connect the block we are about\
       \  to forge.\
@@ -1251,8 +1270,7 @@ docForge = Documented [
       \  Note that block number of the block we will try to forge is one more than\
       \  the recorded block number."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceNoLedgerState anyProto anyProto)))
+      ["NoLedgerState"]
       [("cardano.node.couldNotForgeSlotLast", "")]
       "Leadership check failed: we were unable to get the ledger state for the\
       \  point of the block we want to connect to\
@@ -1266,8 +1284,7 @@ docForge = Documented [
       \  we attempt to connect the new block to (that we requested the ledger\
       \  state for)."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceLedgerState anyProto anyProto)))
+      ["LedgerState"]
       [("cardano.node.ledgerState", "")]
       "We obtained a ledger state for the point of the block we want to\
       \  connect to\
@@ -1276,8 +1293,7 @@ docForge = Documented [
       \  we attempt to connect the new block to (that we requested the ledger\
       \  state for)."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceNoLedgerView anyProto anyProto)))
+      ["NoLedgerView"]
       [("cardano.node.couldNotForgeSlotLast", "")]
       "Leadership check failed: we were unable to get the ledger view for the\
       \  current slot number\
@@ -1287,15 +1303,13 @@ docForge = Documented [
       \ \
       \  We record also the failure returned by 'forecastFor'."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceLedgerView anyProto)))
+      ["LedgerView"]
       [("cardano.node.ledgerView", "")]
       "We obtained a ledger view for the current slot number\
       \ \
       \  We record the current slot number."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceForgeStateUpdateError anyProto anyProto)))
+      ["ForgeStateUpdateError"]
       [ ("cardano.node.operationalCertificateStartKESPeriod", "")
       , ("cardano.node.operationalCertificateExpiryKESPeriod", "")
       , ("cardano.node.currentKESPeriod", "")
@@ -1307,8 +1321,7 @@ docForge = Documented [
       \ \
       \  We record the error returned by 'updateForgeState'."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceNodeCannotForge anyProto anyProto)))
+      ["NodeCannotForge"]
       [("cardano.node.nodeCannotForge", "")]
       "We did the leadership check and concluded that we should lead and forge\
       \  a block, but cannot.\
@@ -1317,23 +1330,20 @@ docForge = Documented [
       \ \
       \  Records why we cannot forge a block."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceNodeNotLeader anyProto)))
+      ["NodeNotLeader"]
       [("cardano.node.nodeNotLeader", "")]
       "We did the leadership check and concluded we are not the leader\
       \ \
       \  We record the current slot number"
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceNodeIsLeader anyProto)))
+      ["NodeIsLeader"]
       [("cardano.node.nodeIsLeader", "")]
       "We did the leadership check and concluded we /are/ the leader\
       \\n\
       \  The node will soon forge; it is about to read its transactions from the\
       \  Mempool. This will be followed by ForgedBlock."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceForgedBlock anyProto anyProto anyProto anyProto)))
+      ["ForgedBlock"]
       [("cardano.node.forgedSlotLast", "")]
       "We forged a block.\
       \\n\
@@ -1350,29 +1360,25 @@ docForge = Documented [
       \\n\
       \  * ForgedInvalidBlock (hopefully never -- this would indicate a bug)"
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceDidntAdoptBlock anyProto anyProto)))
+      ["DidntAdoptBlock"]
       [("cardano.node.notAdoptedSlotLast", "")]
       "We did not adopt the block we produced, but the block was valid. We\
       \  must have adopted a block that another leader of the same slot produced\
       \  before we got the chance of adopting our own block. This is very rare,\
       \  this warrants a warning."
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceForgedInvalidBlock anyProto anyProto anyProto)))
+      ["ForgedInvalidBlock"]
       [("cardano.node.forgedInvalidSlotLast", "")]
       "We forged a block that is invalid according to the ledger in the\
       \  ChainDB. This means there is an inconsistency between the mempool\
       \  validation and the ledger validation. This is a serious error!"
   , DocMsg
-      (Left (TraceLabelCreds anyProto
-        (TraceAdoptedBlock anyProto anyProto [anyProto])))
+      ["AdoptedBlock"]
       [("cardano.node.adoptedSlotLast", "")]
       "We adopted the block we produced, we also trace the transactions\
       \  that were adopted."
   , DocMsg
-      (Right (TraceLabelCreds anyProto
-        (TraceStartLeadershipCheckPlus anyProto 0 0 0.0)))
+      ["StartLeadershipCheckPlus"]
       [ ("cardano.node.aboutToLeadSlotLast", "")
       , ("cardano.node.utxoSize", "")
       , ("cardano.node.delegMapSize", "")
@@ -1448,17 +1454,20 @@ instance Show t => LogFormatting (TraceBlockchainTimeEvent t) where
       <> ". New 'current' time: "
       <> (Text.pack . show) newTime
 
-
 docBlockchainTime :: Documented (TraceBlockchainTimeEvent t)
-docBlockchainTime = Documented [
+docBlockchainTime =
+    addDocumentedNamespace [] docBlockchainTime'
+
+docBlockchainTime' :: Documented (TraceBlockchainTimeEvent t)
+docBlockchainTime' = Documented [
     DocMsg
-      (TraceStartTimeInTheFuture anyProto anyProto)
+      ["StartTimeInTheFuture"]
       []
       "The start time of the blockchain time is in the future\
       \\n\
       \ We have to block (for 'NominalDiffTime') until that time comes."
   , DocMsg
-      (TraceCurrentSlotUnknown anyProto anyProto)
+      ["CurrentSlotUnknown"]
       []
       "Current slot is not yet known\
       \\n\
@@ -1474,7 +1483,7 @@ docBlockchainTime = Documented [
       \ current time and the upper bound should rapidly decrease with consecutive\
       \ 'CurrentSlotUnknown' messages during syncing."
   , DocMsg
-      (TraceSystemClockMovedBack anyProto anyProto)
+      ["SystemClockMovedBack"]
       []
       "The system clock moved back an acceptable time span, e.g., because of\
       \ an NTP sync.\
@@ -1494,7 +1503,7 @@ docBlockchainTime = Documented [
 --------------------------------------------------------------------------------
 
 namesForKeepAliveClient :: TraceKeepAliveClient peer -> [Text]
-namesForKeepAliveClient _ = ["KeepAliveClient"]
+namesForKeepAliveClient _ = []
 
 severityKeepAliveClient :: TraceKeepAliveClient peer -> SeverityS
 severityKeepAliveClient _ = Info
@@ -1521,7 +1530,7 @@ instance Show remotePeer => LogFormatting (TraceKeepAliveClient remotePeer) wher
 docKeepAliveClient :: Documented (TraceKeepAliveClient peer)
 docKeepAliveClient = Documented [
     DocMsg
-      (AddSample anyProto anyProto anyProto)
+      []
       []
       ""
   ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -46,27 +46,12 @@ import qualified Ouroboros.Network.Diffusion as ND
 import           Ouroboros.Network.Driver.Simple (TraceSendRecv (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 import qualified Ouroboros.Network.NodeToNode as NtN
-import           Ouroboros.Network.PeerSelection.LedgerPeers (AccPoolStake (..), NumberOfPeers (..),
-                   PoolStake (..), TraceLedgerPeers (..), UseLedgerAfter (..))
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (NumberOfPeers (..),
+                   PoolStake (..), TraceLedgerPeers (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Type (Message (..))
 import qualified Ouroboros.Network.Protocol.Handshake.Type as HS
 import           Ouroboros.Network.Snocket (LocalAddress (..))
 
-protoRemoteAddr :: NtN.RemoteAddress
-protoRemoteAddr = Socket.SockAddrUnix "loopback"
-
-protoLocalAddress :: LocalAddress
-protoLocalAddress = LocalAddress "loopback"
-
-protoSomeException :: SomeException
-protoSomeException = SomeException (AssertionFailed "just fooled")
-
-protoPeerLocal :: NtN.ConnectionId LocalAddress
-protoPeerLocal = NtN.ConnectionId protoLocalAddress protoLocalAddress
-
-protoPeerRemote :: NtN.ConnectionId NtN.RemoteAddress
-protoPeerRemote = NtN.ConnectionId protoRemoteAddr protoRemoteAddr
 
 --------------------------------------------------------------------------------
 -- Mux Tracer
@@ -151,146 +136,127 @@ instance (LogFormatting peer, Show peer) =>
 
 
 docMuxLocal :: Documented (WithMuxBearer (NtN.ConnectionId LocalAddress) MuxTrace)
-docMuxLocal = docMux protoPeerLocal
+docMuxLocal = addDocumentedNamespace  [] docMux'
 
 docMuxRemote :: Documented (WithMuxBearer (NtN.ConnectionId NtN.RemoteAddress) MuxTrace)
-docMuxRemote = docMux protoPeerRemote
+docMuxRemote = addDocumentedNamespace  [] docMux'
 
 
-docMux :: peer -> Documented (WithMuxBearer peer MuxTrace)
-docMux peer = Documented [
+docMux' :: Documented (WithMuxBearer peer MuxTrace)
+docMux' = Documented [
       DocMsg
-        (WithMuxBearer peer
-          MuxTraceRecvHeaderStart)
+        ["RecvHeaderStart"]
         []
         "Bearer receive header start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceRecvHeaderEnd anyProto))
+        ["RecvHeaderEnd"]
         []
         "Bearer receive header end."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceRecvDeltaQObservation anyProto anyProto))
-        []
-        "Bearer DeltaQ observation."
-    , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceRecvDeltaQSample 1.0 1 1 1.0 1.0 1.0 1.0 ""))
-        []
-        "Bearer DeltaQ sample."
-    , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceRecvStart 1))
+        ["RecvStart"]
         []
         "Bearer receive start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceRecvEnd 1))
+        ["RecvEnd"]
         []
         "Bearer receive end."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceSendStart anyProto))
+        ["SendStart"]
         []
         "Bearer send start."
     , DocMsg
-        (WithMuxBearer peer
-          MuxTraceSendEnd)
+        ["SendEnd"]
         []
         "Bearer send end."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceState anyProto))
+        ["State"]
         []
         "State."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceCleanExit anyProto anyProto))
+        ["CleanExit"]
         []
         "Miniprotocol terminated cleanly."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceExceptionExit
-              anyProto anyProto anyProto))
+        ["ExceptionExit"]
         []
         "Miniprotocol terminated with exception."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceChannelRecvStart anyProto))
+        ["ChannelRecvStart"]
         []
         "Channel receive start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceChannelRecvEnd anyProto 1))
+        ["ChannelRecvEnd"]
         []
         "Channel receive end."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceChannelSendStart anyProto 1))
+        ["ChannelSendStart"]
         []
         "Channel send start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceChannelSendEnd anyProto))
+        ["ChannelSendEnd"]
         []
         "Channel send end."
     , DocMsg
-        (WithMuxBearer peer
-          MuxTraceHandshakeStart)
+        ["HandshakeStart "]
         []
         "Handshake start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceHandshakeClientEnd anyProto))
+        ["HandshakeClientEnd"]
         []
         "Handshake client end."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceHandshakeClientError protoSomeException anyProto))
+        ["HandshakeServerEnd"]
+        []
+        "Handshake server end."
+    , DocMsg
+        ["HandshakeClientError"]
         []
         "Handshake client error."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceHandshakeServerError protoSomeException))
+        ["HandshakeServerError"]
         []
         "Handshake server error."
     , DocMsg
-        (WithMuxBearer peer
-          MuxTraceSDUReadTimeoutException)
+        ["RecvDeltaQObservation"]
+        []
+        "Bearer DeltaQ observation."
+    , DocMsg
+        ["RecvDeltaQSample"]
+        []
+        "Bearer DeltaQ sample."
+    , DocMsg
+        ["SDUReadTimeoutException"]
         []
         "Timed out reading SDU."
     , DocMsg
-        (WithMuxBearer peer
-          MuxTraceSDUWriteTimeoutException)
+        ["SDUWriteTimeoutException"]
         []
         "Timed out writing SDU."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceStartEagerly anyProto anyProto))
+        ["StartEagerly"]
         []
         "Eagerly started."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceStartOnDemand anyProto anyProto))
+        ["StartOnDemand"]
         []
         "Preparing to start."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceStartedOnDemand anyProto anyProto))
+        ["StartedOnDemand"]
         []
         "Started on demand."
     , DocMsg
-        (WithMuxBearer peer
-          (MuxTraceTerminating anyProto anyProto))
+        ["Terminating"]
         []
         "Terminating."
     , DocMsg
-        (WithMuxBearer peer
-          MuxTraceShutdown)
+        ["Shutdown"]
         []
         "Mux shutdown."
-  ]
+    , DocMsg
+        ["Terminating"]
+        []
+        "Terminating."
+    ]
 
 --------------------------------------------------------------------------------
 -- Handshake Tracer
@@ -320,8 +286,8 @@ namesForHandshake (WithMuxBearer _ e) = namesForHandshake' e
 namesForHandshake' ::
      TraceSendRecv (HS.Handshake nt CBOR.Term)
   -> [Text]
-namesForHandshake' (TraceSendMsg m) = namesForHandshake'' m
-namesForHandshake' (TraceRecvMsg m) = namesForHandshake'' m
+namesForHandshake' (TraceSendMsg m) = "Send" : namesForHandshake'' m
+namesForHandshake' (TraceRecvMsg m) = "Recieve" : namesForHandshake'' m
 
 namesForHandshake'' :: AnyMessageAndAgency (HS.Handshake nt CBOR.Term) -> [Text]
 namesForHandshake'' (AnyMessageAndAgency _agency msg) = namesForHandshake''' msg
@@ -341,28 +307,30 @@ instance LogFormatting (NtN.HandshakeTr NtN.RemoteAddress NtN.NodeToNodeVersion)
                                       <> ". " <> showT ev
 
 docHandshake :: Documented (NtN.HandshakeTr NtN.RemoteAddress ver)
-docHandshake = Documented [
+docHandshake = addDocumentedNamespace  ["Send"] docHandshake'
+               `addDocs` addDocumentedNamespace  ["Receive"] docHandshake'
+
+docHandshake' :: Documented (NtN.HandshakeTr adr ver)
+docHandshake' = Documented [
       DocMsg
-        (WithMuxBearer protoPeerRemote
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgProposeVersions anyProto))))
+        ["ProposeVersions"]
         []
         "Propose versions together with version parameters.  It must be\
         \ encoded to a sorted list.."
     , DocMsg
-        (WithMuxBearer protoPeerRemote
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgAcceptVersion anyProto anyProto))))
+        ["ReplyVersions"]
+        []
+        "`MsgReplyVersions` received as a response to 'MsgProposeVersions'.  It\
+        \ is not supported to explicitly send this message. It can only be\
+        \ received as a copy of 'MsgProposeVersions' in a simultaneous open\
+        \ scenario."
+    , DocMsg
+        ["AcceptVersion"]
         []
         "The remote end decides which version to use and sends chosen version.\
         \The server is allowed to modify version parameters."
     , DocMsg
-        (WithMuxBearer protoPeerRemote
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgRefuse anyProto))))
+        ["Refuse"]
         []
         "It refuses to run any version."
     ]
@@ -395,8 +363,8 @@ namesForLocalHandshake (WithMuxBearer _ e) = namesForLocalHandshake' e
 namesForLocalHandshake' ::
      TraceSendRecv (HS.Handshake nt CBOR.Term)
   -> [Text]
-namesForLocalHandshake' (TraceSendMsg m) = namesForLocalHandshake'' m
-namesForLocalHandshake' (TraceRecvMsg m) = namesForLocalHandshake'' m
+namesForLocalHandshake' (TraceSendMsg m) = "Send" : namesForLocalHandshake'' m
+namesForLocalHandshake' (TraceRecvMsg m) = "Receive" : namesForLocalHandshake'' m
 
 namesForLocalHandshake'' :: AnyMessageAndAgency (HS.Handshake nt CBOR.Term) -> [Text]
 namesForLocalHandshake'' (AnyMessageAndAgency _agency msg) = namesForLocalHandshake''' msg
@@ -416,31 +384,8 @@ instance LogFormatting (NtC.HandshakeTr NtC.LocalAddress NtC.NodeToClientVersion
                                       <> ". " <> showT ev
 
 docLocalHandshake :: Documented (NtC.HandshakeTr LocalAddress ver)
-docLocalHandshake = Documented [
-      DocMsg
-        (WithMuxBearer protoPeerLocal
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgProposeVersions anyProto))))
-        []
-        "Propose versions together with version parameters.  It must be\
-        \ encoded to a sorted list.."
-    , DocMsg
-        (WithMuxBearer protoPeerLocal
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgAcceptVersion anyProto anyProto))))
-        []
-        "The remote end decides which version to use and sends chosen version.\
-        \The server is allowed to modify version parameters."
-    , DocMsg
-        (WithMuxBearer protoPeerLocal
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (HS.MsgRefuse anyProto))))
-        []
-        "It refuses to run any version."
-    ]
+docLocalHandshake = addDocumentedNamespace  ["Send"] docHandshake'
+               `addDocs` addDocumentedNamespace  ["Receive"] docHandshake'
 
 --------------------------------------------------------------------------------
 -- DiffusionInit Tracer
@@ -563,65 +508,68 @@ instance (Show ntnAddr, Show ntcAddr) =>
     ]
 
 docDiffusionInit :: Documented (ND.InitializationTracer Socket.SockAddr NtC.LocalAddress)
-docDiffusionInit = Documented [
+docDiffusionInit =  addDocumentedNamespace  [] docDiffusionInit'
+
+docDiffusionInit' :: Documented (ND.InitializationTracer Socket.SockAddr NtC.LocalAddress)
+docDiffusionInit' = Documented [
     DocMsg
-      (ND.RunServer (pure anyProto))
+      ["RunServer"]
       []
       "RunServer "
   , DocMsg
-      (ND.RunLocalServer anyProto)
+      ["RunLocalServer"]
       []
       "RunLocalServer "
   , DocMsg
-      (ND.UsingSystemdSocket anyProto)
+     ["UsingSystemdSocket"]
       []
       "UsingSystemdSocket "
   , DocMsg
-      (ND.CreateSystemdSocketForSnocketPath anyProto)
+     ["CreateSystemdSocketForSnocketPath"]
       []
       "CreateSystemdSocketForSnocketPath "
   , DocMsg
-      (ND.CreatedLocalSocket anyProto)
+      ["CreatedLocalSocket"]
       []
       "CreatedLocalSocket "
   , DocMsg
-      (ND.ConfiguringLocalSocket anyProto anyProto)
+      ["ConfiguringLocalSocket"]
       []
       "ConfiguringLocalSocket "
   , DocMsg
-      (ND.ListeningLocalSocket anyProto anyProto)
+      ["ListeningLocalSocket"]
       []
       "ListeningLocalSocket "
   , DocMsg
-      (ND.LocalSocketUp anyProto anyProto)
+      ["LocalSocketUp"]
       []
       "LocalSocketUp "
   , DocMsg
-      (ND.CreatingServerSocket anyProto)
+      ["CreatingServerSocket"]
       []
       "CreatingServerSocket "
   , DocMsg
-      (ND.ConfiguringServerSocket anyProto)
+      ["ConfiguringServerSocket"]
       []
       "ConfiguringServerSocket "
   , DocMsg
-      (ND.ListeningServerSocket anyProto)
+      ["ListeningServerSocket"]
       []
       "ListeningServerSocket "
   , DocMsg
-      (ND.ServerSocketUp anyProto)
+      ["ServerSocketUp"]
       []
       "ServerSocketUp "
   , DocMsg
-      (ND.UnsupportedLocalSystemdSocket anyProto)
+      ["UnsupportedLocalSystemdSocket"]
       []
       "UnsupportedLocalSystemdSocket "
   , DocMsg
-      ND.UnsupportedReadySocketCase
+      ["UnsupportedReadySocketCase"]
       []
       "UnsupportedReadySocketCase "
   , DocMsg
-      (ND.DiffusionErrored anyProto)
+      ["DiffusionErrored"]
       []
       "DiffusionErrored "
   ]
@@ -701,51 +649,46 @@ instance LogFormatting TraceLedgerPeers where
       [ "kind" .= String "FallingBackToBootstrapPeers"
       ]
 
-
 docLedgerPeers :: Documented TraceLedgerPeers
-docLedgerPeers = Documented [
+docLedgerPeers =  addDocumentedNamespace  [] docLedgerPeers'
+
+docLedgerPeers' :: Documented TraceLedgerPeers
+docLedgerPeers' = Documented [
     DocMsg
-      (PickedPeer
-        (RelayAccessDomain  anyProto 1)
-        (AccPoolStake 0.5)
-        (PoolStake 0.5))
+      ["PickedPeer"]
       []
       "Trace for a peer picked with accumulated and relative stake of its pool."
   , DocMsg
-      (PickedPeers (NumberOfPeers 1) [])
+      ["PickedPeers"]
       []
       "Trace for the number of peers we wanted to pick and the list of peers picked."
   , DocMsg
-      (FetchingNewLedgerState 1)
+      ["FetchingNewLedgerState"]
       []
       "Trace for fetching a new list of peers from the ledger. Int is the number of peers\
       \ returned."
   , DocMsg
-      DisabledLedgerPeers
+      ["DisabledLedgerPeers"]
       []
       "Trace for when getting peers from the ledger is disabled, that is DontUseLedger."
   , DocMsg
-      DisabledLedgerPeers
-      []
-      "Trace for when getting peers from the ledger is disabled, that is DontUseLedger."
-  , DocMsg
-      (TraceUseLedgerAfter DontUseLedger)
+      ["TraceUseLedgerAfter"]
       []
       "Trace UseLedgerAfter value."
   , DocMsg
-      WaitingOnRequest
+      ["WaitingOnRequest"]
       []
       ""
   , DocMsg
-      WaitingOnRequest
+      ["RequestForPeers"]
       []
       "RequestForPeers (NumberOfPeers 1)"
   , DocMsg
-      (ReusingLedgerState 1 anyProto)
+      ["ReusingLedgerState"]
       []
       ""
   , DocMsg
-      FallingBackToBootstrapPeers
+      ["FallingBackToBootstrapPeers"]
       []
       ""
   ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -197,7 +197,7 @@ docMux' = Documented [
         []
         "Channel send end."
     , DocMsg
-        ["HandshakeStart "]
+        ["HandshakeStart"]
         []
         "Handshake start."
     , DocMsg

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
@@ -69,7 +69,7 @@ emptyForgeThreadStats = ForgeThreadStats 0 0 0 0 0
 docForgeStats :: Documented ForgeThreadStats
 docForgeStats = Documented [
     DocMsg
-      emptyForgeThreadStats
+      ["ForgeStats"]
       [("nodeCannotForgeNum",
         "How many times this node could not forge?")
       ,("nodeIsLeaderNum",
@@ -130,17 +130,16 @@ forgeThreadStats = foldMTraceM calculateThreadStats emptyForgingStats
 calculateThreadStats :: MonadIO m
   => ForgingStats
   -> LoggingContext
-  -> Maybe TraceControl
   -> ForgeTracerType blk
   -> m ForgingStats
-calculateThreadStats stats _context _mbCtrl
+calculateThreadStats stats _context
     (Left (TraceLabelCreds _ TraceNodeCannotForge {})) = do
       mapThreadStats
         stats
         (\fts -> (fts { ftsNodeCannotForgeNum = ftsNodeCannotForgeNum fts + 1}
                       , Nothing))
         (\fs _ ->  (fs  { fsNodeCannotForgeNum  = fsNodeCannotForgeNum fs + 1 }))
-calculateThreadStats stats _context _mbCtrl
+calculateThreadStats stats _context
     (Left (TraceLabelCreds _ (TraceNodeIsLeader (SlotNo slot')))) = do
       let slot = fromIntegral slot'
       mapThreadStats
@@ -148,14 +147,14 @@ calculateThreadStats stats _context _mbCtrl
         (\fts -> (fts { ftsNodeIsLeaderNum = ftsNodeIsLeaderNum fts + 1
                    , ftsLastSlot = slot}, Nothing))
         (\fs _ ->  (fs  { fsNodeIsLeaderNum  = fsNodeIsLeaderNum fs + 1 }))
-calculateThreadStats stats _context _mbCtrl
+calculateThreadStats stats _context
     (Left (TraceLabelCreds _ TraceForgedBlock {})) = do
       mapThreadStats
         stats
         (\fts -> (fts { ftsBlocksForgedNum = ftsBlocksForgedNum fts + 1}
                       , Nothing))
         (\fs _ ->  (fs  { fsBlocksForgedNum  = fsBlocksForgedNum fs + 1 }))
-calculateThreadStats stats _context _mbCtrl
+calculateThreadStats stats _context
     (Left (TraceLabelCreds _ (TraceNodeNotLeader (SlotNo slot')))) = do
       let slot = fromIntegral slot'
       mapThreadStats
@@ -172,7 +171,7 @@ calculateThreadStats stats _context _mbCtrl
                             Nothing -> fs
                             Just missed -> (fs { fsSlotsMissedNum =
                               fsSlotsMissedNum fs + missed}))
-calculateThreadStats stats _context _mbCtrl _message = pure stats
+calculateThreadStats stats _context _message = pure stats
 
 mapThreadStats ::
      MonadIO m

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -40,10 +41,12 @@ traceAsMaybeKESInfo
   -> Trace m (TraceLabelCreds (ForgeStateInfo blk))
 traceAsMaybeKESInfo pr (Trace tr) = Trace $
   contramap
-        (\(lc, mbC, TraceLabelCreds c e) ->
+        (\case
+          (lc, Right (TraceLabelCreds c e)) ->
             case getKESInfoFromStateInfo pr e of
-              Just kesi -> (lc, mbC, Just (TraceLabelCreds c kesi))
-              Nothing   -> (lc, mbC, Nothing))
+              Just kesi -> (lc, Right (Just (TraceLabelCreds c kesi)))
+              Nothing   -> (lc, Right Nothing)
+          (lc, Left ctrl) -> (lc, Left ctrl))
         tr
 
 --------------------------------------------------------------------------------
@@ -79,7 +82,7 @@ namesForKESInfo' _fsi = []
 docForgeKESInfo :: Documented (TraceLabelCreds HotKey.KESInfo)
 docForgeKESInfo = Documented [
     DocMsg
-      (TraceLabelCreds anyProto (HotKey.KESInfo (KESPeriod 0) (KESPeriod 1) 2))
+      []
       []
       "kesStartPeriod \
       \\nkesEndPeriod is kesStartPeriod + tpraosMaxKESEvo\

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -242,50 +242,40 @@ instance ( ConvertTxId blk
              ]
 
 docTBlockFetch :: Documented
+     (BlockFetch.TraceLabelPeer peer
+      (TraceSendRecv
+        (BlockFetch x (Point blk))))
+docTBlockFetch =
+  addDocumentedNamespace  ["NodeToNode", "Send"] docTBlockFetch'
+  `addDocs` addDocumentedNamespace  ["NodeToNode", "Recieve"] docTBlockFetch'
+
+docTBlockFetch' :: Documented
       (BlockFetch.TraceLabelPeer peer
        (TraceSendRecv
          (BlockFetch x (Point blk))))
-docTBlockFetch = Documented [
+docTBlockFetch' = Documented [
       DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgRequestRange anyProto))))
+        ["RequestRange"]
         []
         "Request range of blocks."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              MsgStartBatch)))
+        ["StartBatch"]
         []
         "Start block streaming."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              MsgNoBlocks)))
+        ["NoBlocks"]
         []
         "Respond that there are no blocks."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgBlock anyProto))))
+        ["Block"]
         []
         "Stream a single block."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              MsgBatchDone)))
+        ["BatchDone"]
         []
         "End of block streaming."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              MsgClientDone)))
+        ["ClientDone"]
         []
         "Client termination message."
   ]
@@ -465,12 +455,17 @@ docTTxSubmissionNode :: Documented
   (BlockFetch.TraceLabelPeer peer
     (TraceSendRecv
       (TXS.TxSubmission (GenTxId blk) (GenTx blk))))
-docTTxSubmissionNode = Documented [
+docTTxSubmissionNode =
+  addDocumentedNamespace  ["NodeToNode", "Send"] docTTxSubmissionNode'
+  `addDocs` addDocumentedNamespace  ["NodeToNode", "Recieve"] docTTxSubmissionNode'
+
+docTTxSubmissionNode' :: Documented
+  (BlockFetch.TraceLabelPeer peer
+    (TraceSendRecv
+      (TXS.TxSubmission (GenTxId blk) (GenTx blk))))
+docTTxSubmissionNode' = Documented [
       DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (TXS.MsgRequestTxIds anyProto 1 1))))
+        ["RequestTxIds"]
         []
         "Request a non-empty list of transaction identifiers from the client,\
         \and confirm a number of outstanding transaction identifiers.\
@@ -510,10 +505,7 @@ docTTxSubmissionNode = Documented [
         \* The non-blocking case must be used when there are non-zero remaining\
         \  unacknowledged transactions."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (TXS.MsgReplyTxIds anyProto))))
+        ["ReplyTxIds"]
         []
         "Reply with a list of transaction identifiers for available\
         \transactions, along with the size of each transaction.\
@@ -530,10 +522,7 @@ docTTxSubmissionNode = Documented [
         \the order in which they are submitted to the mempool, to preserve\
         \dependent transactions."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (TXS.MsgRequestTxs [anyProto]))))
+        ["RequestTxs"]
         []
         "Request one or more transactions corresponding to the given \
         \transaction identifiers. \
@@ -548,10 +537,7 @@ docTTxSubmissionNode = Documented [
         \It is an error to ask for transaction identifiers that are not \
         \outstanding or that were already asked for."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (TXS.MsgReplyTxs [anyProto]))))
+        ["ReplyTxs"]
         []
         "Reply with the requested transactions, or implicitly discard.\
         \\n\
@@ -564,10 +550,7 @@ docTTxSubmissionNode = Documented [
         \that this is no guarantee that the transaction is invalid, it may still \
         \be valid and available from another peer)."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              TXS.MsgDone)))
+        ["Done"]
         []
         "Termination message, initiated by the client when the server is \
         \making a blocking call for more transaction identifiers."
@@ -644,24 +627,25 @@ instance (Show txid, Show tx)
                   (MsgTalk msg)) =
     forMachine dtal (AnyMessageAndAgency (ServerAgency stok) msg)
 
-
 docTTxSubmission2Node :: Documented
   (BlockFetch.TraceLabelPeer peer
     (TraceSendRecv
       (TXS.TxSubmission2 (GenTxId blk) (GenTx blk))))
-docTTxSubmission2Node = Documented [
+docTTxSubmission2Node =
+  addDocumentedNamespace  ["NodeToNode", "Send"] docTTxSubmission2Node'
+  `addDocs` addDocumentedNamespace  ["NodeToNode", "Recieve"] docTTxSubmission2Node'
+
+docTTxSubmission2Node' :: Documented
+  (BlockFetch.TraceLabelPeer peer
+    (TraceSendRecv
+      (TXS.TxSubmission2 (GenTxId blk) (GenTx blk))))
+docTTxSubmission2Node' = Documented [
       DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              MsgHello)))
+        ["MsgHello"]
         []
         "Client side hello message."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgTalk (TXS.MsgRequestTxIds anyProto 1 1)))))
+        ["RequestTxIds"]
         []
         "Request a non-empty list of transaction identifiers from the client, \
         \and confirm a number of outstanding transaction identifiers. \
@@ -701,10 +685,7 @@ docTTxSubmission2Node = Documented [
         \* The non-blocking case must be used when there are non-zero remaining \
         \  unacknowledged transactions."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgTalk (TXS.MsgReplyTxIds anyProto)))))
+        ["ReplyTxIds"]
         []
         "Reply with a list of transaction identifiers for available\
         \transactions, along with the size of each transaction.\
@@ -721,10 +702,7 @@ docTTxSubmission2Node = Documented [
         \the order in which they are submitted to the mempool, to preserve\
         \dependent transactions."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgTalk (TXS.MsgRequestTxs [anyProto])))))
+        ["RequestTxs"]
         []
         "Request one or more transactions corresponding to the given \
         \transaction identifiers. \
@@ -739,10 +717,7 @@ docTTxSubmission2Node = Documented [
         \It is an error to ask for transaction identifiers that are not\
         \outstanding or that were already asked for."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgTalk (TXS.MsgReplyTxs [anyProto])))))
+        ["ReplyTxs"]
         []
         "Reply with the requested transactions, or implicitly discard.\
         \\n\
@@ -755,10 +730,7 @@ docTTxSubmission2Node = Documented [
         \that this is no guarantee that the transaction is invalid, it may still\
         \be valid and available from another peer)."
     , DocMsg
-        (BlockFetch.TraceLabelPeer anyProto
-          (TraceSendMsg
-            (AnyMessageAndAgency anyProto
-              (MsgTalk TXS.MsgDone))))
+        ["Done"]
         []
         "Termination message, initiated by the client when the server is\
         \making a blocking call for more transaction identifiers."

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -73,12 +73,10 @@ import           Cardano.Tracing.OrphanInstances.Network ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 
-import           Network.Mux (MiniProtocolNum (..))
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId (..))
-import           Ouroboros.Network.ConnectionManager.Types (AbstractState (..),
-                   ConnectionManagerCounters (..), ConnectionManagerTrace (..),
-                   DemotedToColdRemoteTr (..), OperationResult (..))
+import           Ouroboros.Network.ConnectionManager.Types (ConnectionManagerCounters (..),
+                   ConnectionManagerTrace (..))
 import qualified Ouroboros.Network.ConnectionManager.Types as ConnectionManager
 import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..))
 import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
@@ -145,29 +143,32 @@ instance (ToJSONKey ntnAddr, ToJSONKey RelayAccessPoint, Show ntnAddr, Show exce
   forHuman = pack . show
 
 docLocalRootPeers :: Documented (TraceLocalRootPeers ntnAddr resolverError)
-docLocalRootPeers = Documented [
+docLocalRootPeers =  addDocumentedNamespace  ["LocalRootPeers"] docLocalRootPeers'
+
+docLocalRootPeers' :: Documented (TraceLocalRootPeers ntnAddr resolverError)
+docLocalRootPeers' = Documented [
     DocMsg
-      (TraceLocalRootDomains anyProto)
+      ["LocalRootDomains"]
       []
       ""
   , DocMsg
-      (TraceLocalRootWaiting anyProto anyProto)
+      ["LocalRootWaiting"]
       []
       ""
   , DocMsg
-      (TraceLocalRootResult anyProto anyProto)
+      ["LocalRootResult"]
       []
       ""
   , DocMsg
-      (TraceLocalRootGroups anyProto)
+      ["LocalRootGroups"]
       []
       ""
   , DocMsg
-      (TraceLocalRootFailure anyProto anyProto)
+      ["LocalRootFailure"]
       []
       ""
   , DocMsg
-      (TraceLocalRootError anyProto anyProto)
+      ["LocalRootError"]
       []
       ""
   ]
@@ -207,21 +208,24 @@ instance LogFormatting TracePublicRootPeers where
   forHuman = pack . show
 
 docPublicRootPeers :: Documented TracePublicRootPeers
-docPublicRootPeers = Documented [
+docPublicRootPeers =  addDocumentedNamespace  ["PublicRootPeers"] docPublicRootPeers'
+
+docPublicRootPeers' :: Documented TracePublicRootPeers
+docPublicRootPeers' = Documented [
     DocMsg
-      (TracePublicRootRelayAccessPoint anyProto)
+      ["PublicRootRelayAccessPoint"]
       []
       ""
   , DocMsg
-      (TracePublicRootDomains anyProto)
+      ["PublicRootDomains"]
       []
       ""
   , DocMsg
-      (TracePublicRootResult anyProto anyProto)
+      ["PublicRootResult"]
       []
       ""
   , DocMsg
-      (TracePublicRootFailure anyProto anyProto)
+      ["PublicRootFailure"]
       []
       ""
   ]
@@ -233,7 +237,7 @@ docPublicRootPeers = Documented [
 namesForPeerSelection :: TracePeerSelection peeraddr -> [Text]
 namesForPeerSelection TraceLocalRootPeersChanged {} = ["LocalRootPeersChanged"]
 namesForPeerSelection TraceTargetsChanged {}        = ["TargetsChanged"]
-namesForPeerSelection TracePublicRootsRequest {}    = ["ublicRootsRequest"]
+namesForPeerSelection TracePublicRootsRequest {}    = ["PublicRootsRequest"]
 namesForPeerSelection TracePublicRootsResults {}    = ["PublicRootsResults"]
 namesForPeerSelection TracePublicRootsFailure {}    = ["PublicRootsFailure"]
 namesForPeerSelection TraceGossipRequests {}        = ["GossipRequests"]
@@ -451,120 +455,123 @@ instance LogFormatting (TracePeerSelection SockAddr) where
              , "event" .= show c ]
   forHuman = pack . show
 
-docPeerSelection :: Documented (TracePeerSelection SockAddr)
-docPeerSelection = Documented [
+docPeerSelection ::  Documented (TracePeerSelection SockAddr)
+docPeerSelection =  addDocumentedNamespace  ["PeerSelection"] docPeerSelection'
+
+docPeerSelection' :: Documented (TracePeerSelection SockAddr)
+docPeerSelection' = Documented [
     DocMsg
-      (TraceLocalRootPeersChanged anyProto anyProto)
+      ["LocalRootPeersChanged"]
       []
       ""
   , DocMsg
-      (TraceTargetsChanged anyProto anyProto)
+      ["TargetsChanged"]
       []
       ""
   , DocMsg
-      (TracePublicRootsRequest 1 1)
+      ["PublicRootsRequest"]
       []
       ""
   , DocMsg
-      (TracePublicRootsResults anyProto 1 anyProto)
+      ["PublicRootsResults"]
       []
       ""
   , DocMsg
-      (TracePublicRootsResults anyProto 1 anyProto)
+      ["PublicRootsFailure"]
       []
       ""
   , DocMsg
-      (TraceGossipRequests 1 1 anyProto anyProto)
+      ["GossipRequests"]
       []
       "target known peers, actual known peers, peers available for gossip,\
       \ peers selected for gossip"
   , DocMsg
-      (TraceGossipResults [])
+      ["GossipResults"]
       []
       ""
   , DocMsg
-      (TraceForgetColdPeers 1 1 anyProto)
+      ["ForgetColdPeers"]
       []
       "target known peers, actual known peers, selected peers"
   , DocMsg
-      (TracePromoteColdPeers 1 1 anyProto)
+      ["PromoteColdPeers"]
       []
       "target established, actual established, selected peers"
   , DocMsg
-      (TracePromoteColdLocalPeers 1 1 anyProto)
+      ["PromoteColdLocalPeers"]
       []
       "target local established, actual local established, selected peers"
   , DocMsg
-      (TracePromoteColdFailed 1 1 anyProto anyProto anyProto)
+      ["PromoteColdFailed"]
       []
       "target established, actual established, peer, delay until next\
       \ promotion, reason"
   , DocMsg
-      (TracePromoteColdDone 1 1 anyProto)
+      ["PromoteColdDone"]
       []
       "target active, actual active, selected peers"
   , DocMsg
-      (TracePromoteWarmPeers 1 1 anyProto)
+      ["PromoteWarmPeers"]
       []
       "target active, actual active, selected peers"
   , DocMsg
-      (TracePromoteWarmLocalPeers [] anyProto)
+      ["PromoteWarmLocalPeers"]
       []
       "local per-group (target active, actual active), selected peers"
   , DocMsg
-      (TracePromoteWarmFailed 1 1 anyProto anyProto)
+      ["PromoteWarmFailed"]
       []
       "target active, actual active, peer, reason"
   , DocMsg
-      (TracePromoteWarmDone 1 1 anyProto)
+      ["PromoteWarmDone"]
       []
       "target active, actual active, peer"
   , DocMsg
-      (TraceDemoteWarmPeers 1 1 anyProto)
+      ["PromoteWarmAborted"]
+      []
+      ""
+  , DocMsg
+      ["DemoteWarmPeers"]
       []
       "target established, actual established, selected peers"
   , DocMsg
-      (TraceDemoteWarmFailed 1 1 anyProto anyProto)
+      ["DemoteWarmFailed"]
       []
       "target established, actual established, peer, reason"
   , DocMsg
-      (TraceDemoteWarmDone 1 1 anyProto)
+      ["DemoteWarmDone"]
       []
       "target established, actual established, peer"
   , DocMsg
-      (TraceDemoteHotPeers 1 1 anyProto)
+      ["DemoteHotPeers"]
       []
       "target active, actual active, selected peers"
   , DocMsg
-      (TraceDemoteLocalHotPeers [] anyProto)
+      ["DemoteLocalHotPeers"]
       []
       "local per-group (target active, actual active), selected peers"
   , DocMsg
-      (TraceDemoteHotFailed 1 1 anyProto anyProto)
+      ["DemoteHotFailed"]
       []
       "target active, actual active, peer, reason"
   , DocMsg
-      (TraceDemoteHotFailed 1 1 anyProto anyProto)
-      []
-      "target active, actual active, peer, reason"
-  , DocMsg
-      (TraceDemoteHotDone 1 1 anyProto )
+      ["DemoteHotDone"]
       []
       "target active, actual active, peer"
   , DocMsg
-      (TraceDemoteAsynchronous anyProto )
+      ["DemoteAsynchronous"]
       []
       ""
   , DocMsg
-      TraceGovernorWakeup
+      ["GovernorWakeup"]
       []
       ""
   , DocMsg
-      (TraceChurnWait anyProto)
+      ["ChurnWait"]
       []
       ""
   , DocMsg
-      (TraceChurnMode anyProto)
+      ["ChurnMode"]
       []
       ""
   ]
@@ -616,7 +623,7 @@ instance Show peerConn => LogFormatting (DebugPeerSelection SockAddr peerConn) w
 docDebugPeerSelection :: Documented (DebugPeerSelection SockAddr peerConn)
 docDebugPeerSelection = Documented
   [  DocMsg
-      (TraceGovernorState anyProto anyProto anyProto)
+      ["DebugPeerSelection", "GovernorState"]
       []
       ""
   ]
@@ -650,7 +657,7 @@ instance LogFormatting PeerSelectionCounters where
 docPeerSelectionCounters :: Documented PeerSelectionCounters
 docPeerSelectionCounters = Documented
   [  DocMsg
-      (PeerSelectionCounters 1 1 1)
+      ["PeerSelectionCounters"]
       [ ("cardano.node.peerSelection.cold", "Number of cold peers")
       , ("cardano.node.peerSelection.warm", "Number of warm peers")
       , ("cardano.node.peerSelection.hot", "Number of hot peers") ]
@@ -698,21 +705,25 @@ instance LogFormatting (PeerSelectionActionsTrace SockAddr) where
   forHuman = pack . show
 
 docPeerSelectionActions :: Documented (PeerSelectionActionsTrace ntnAddr)
-docPeerSelectionActions = Documented
+docPeerSelectionActions =
+    addDocumentedNamespace  ["PeerSelectionActions"]  docPeerSelectionActions'
+
+docPeerSelectionActions' :: Documented (PeerSelectionActionsTrace ntnAddr)
+docPeerSelectionActions' = Documented
   [  DocMsg
-      (PeerStatusChanged anyProto)
+      ["StatusChanged"]
       []
       ""
   ,  DocMsg
-      (PeerStatusChangeFailure anyProto anyProto)
+      ["StatusChangeFailure"]
       []
       ""
   ,  DocMsg
-      (PeerMonitoringError anyProto anyProto)
+      ["MonitoringError"]
       []
       ""
   ,  DocMsg
-      (PeerMonitoringResult anyProto anyProto)
+      ["MonitoringResult"]
       []
       ""
   ]
@@ -967,92 +978,95 @@ instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
       , "command" .= show cerr
       ]
 
-protoConnectionHandlerTrace :: ConnectionHandlerTrace
-  ntnVersion
-  ntnVersionData
-protoConnectionHandlerTrace = TrHandshakeSuccess anyProto anyProto
-
 docConnectionManager :: Documented
   (ConnectionManagerTrace
     ntnAddr
     (ConnectionHandlerTrace
       ntnVersion
       ntnVersionData))
-docConnectionManager = Documented
+docConnectionManager = addDocumentedNamespace  ["ConnectionManager"] docConnectionManager'
+
+docConnectionManager' :: Documented
+  (ConnectionManagerTrace
+    ntnAddr
+    (ConnectionHandlerTrace
+      ntnVersion
+      ntnVersionData))
+docConnectionManager' = Documented
   [  DocMsg
-      (TrIncludeConnection anyProto anyProto)
+      ["IncludeConnection"]
       []
       ""
   ,  DocMsg
-      (TrUnregisterConnection anyProto anyProto)
+      ["UnregisterConnection"]
       []
       ""
   ,  DocMsg
-      (TrConnect Nothing anyProto)
+      ["Connect"]
       []
       ""
   ,  DocMsg
-      (TrConnectError Nothing anyProto protoSomeException)
+      ["ConnectError"]
       []
       ""
   ,  DocMsg
-      (TrTerminatingConnection anyProto anyProto)
+      ["TerminatingConnection"]
       []
       ""
   ,  DocMsg
-      (TrTerminatedConnection anyProto anyProto)
+      ["TerminatedConnection"]
       []
       ""
   ,  DocMsg
-      (TrConnectionHandler anyProto protoConnectionHandlerTrace)
+      ["ConnectionHandler"]
       []
       ""
   ,  DocMsg
-      TrShutdown
+      ["Shutdown"]
       []
       ""
   ,  DocMsg
-      (TrConnectionExists anyProto anyProto anyProto)
+     ["ConnectionExists"]
       []
       ""
   ,  DocMsg
-      (TrForbiddenConnection anyProto)
+      ["ForbiddenConnection"]
       []
       ""
   ,  DocMsg
-      (TrImpossibleConnection anyProto)
+      ["ImpossibleConnection"]
       []
       ""
   ,  DocMsg
-      (TrConnectionFailure anyProto)
+      ["ConnectionFailure"]
       []
       ""
   ,  DocMsg
-      (TrConnectionNotFound anyProto anyProto)
+      ["ConnectionNotFound"]
       []
       ""
   ,  DocMsg
-      (TrForbiddenOperation anyProto anyProto)
+      ["ForbiddenOperation"]
       []
       ""
   ,  DocMsg
-      (TrPruneConnections anyProto anyProto anyProto)
+      ["PruneConnections"]
       []
       ""
   ,  DocMsg
-      (TrConnectionCleanup anyProto)
+      ["ConnectionCleanup"]
       []
       ""
   ,  DocMsg
-      (TrConnectionTimeWait anyProto)
+      ["ConnectionTimeWait"]
       []
       ""
   ,  DocMsg
-      (TrConnectionTimeWaitDone anyProto)
+      ["ConnectionTimeWaitDone"]
       []
       ""
   ,  DocMsg
-      (TrConnectionManagerCounters anyProto)
+      ["ConnectionManagerCounters"]
       [("cardano.node.connectionManager.fullDuplexConns","")
       ,("cardano.node.connectionManager.duplexConns","")
       ,("cardano.node.connectionManager.unidirectionalConns","")
@@ -1061,11 +1075,15 @@ docConnectionManager = Documented
       ]
       ""
   ,  DocMsg
-      (TrState anyProto)
+      ["State"]
       []
       ""
   ,  DocMsg
-      (ConnectionManager.TrUnexpectedlyFalseAssertion anyProto)
+      ["UnexpectedlyFalseAssertion"]
+      []
+      ""
+  ,  DocMsg
+      ["UnknownConnection"]
       []
       ""
   ]
@@ -1077,7 +1095,7 @@ docConnectionManager = Documented
 namesForConnectionManagerTransition
     :: ConnectionManager.AbstractTransitionTrace peerAddr -> [Text]
 namesForConnectionManagerTransition ConnectionManager.TransitionTrace {} =
-    ["ConnectionManagerTransition" ]
+    []
 
 severityConnectionManagerTransition
   :: ConnectionManager.AbstractTransitionTrace peerAddr -> SeverityS
@@ -1099,7 +1117,7 @@ docConnectionManagerTransition
     :: Documented (ConnectionManager.AbstractTransitionTrace peerAddr)
 docConnectionManagerTransition = Documented
   [ DocMsg
-      (ConnectionManager.TransitionTrace anyProto anyProto)
+      ["ConnectionManagerTransition"]
       []
       ""
   ]
@@ -1151,30 +1169,34 @@ instance (Show addr, LogFormatting addr, ToJSON addr)
              ]
   forHuman = pack . show
 
+
 docServer :: Documented (ServerTrace ntnAddr)
-docServer = Documented
+docServer = addDocumentedNamespace  ["Server"] docServer'
+
+docServer' :: Documented (ServerTrace ntnAddr)
+docServer' = Documented
   [  DocMsg
-      (TrAcceptConnection anyProto)
+      ["AcceptConnection"]
       []
       ""
   ,  DocMsg
-      (TrAcceptError anyProto)
+      ["AcceptError"]
       []
       ""
   ,  DocMsg
-      (TrAcceptPolicyTrace anyProto)
+      ["AcceptPolicy"]
       []
       ""
   ,  DocMsg
-      (TrServerStarted anyProto)
+      ["Started"]
       []
       ""
   ,  DocMsg
-      TrServerStopped
+      ["Stopped"]
       []
       ""
   ,  DocMsg
-      (TrServerError anyProto)
+      ["Error"]
       []
       ""
   ]
@@ -1319,130 +1341,89 @@ instance (ToJSON addr, Show addr)
               ]
   asMetrics _ = []
 
-protoProvenance :: ConnectionManager.Provenance
-protoProvenance = ConnectionManager.Inbound
-
-protoConnectionId :: peerAddr -> ConnectionId peerAddr
-protoConnectionId pa = ConnectionId pa pa
-
-protoMiniProtocolNum :: MiniProtocolNum
-protoMiniProtocolNum = MiniProtocolNum 1
-
-protoSomeException :: SomeException
-protoSomeException = SomeException (AssertionFailed "just fooled")
-
-protoAbstractState :: AbstractState
-protoAbstractState = UnknownConnectionSt
-
-protoOperationResult :: a -> OperationResult a
-protoOperationResult = OperationSuccess
-
-protoDemotedToColdRemoteTr :: DemotedToColdRemoteTr
-protoDemotedToColdRemoteTr = CommitTr
-
-protoInboundGovernorCounters :: InboundGovernorCounters
-protoInboundGovernorCounters = InboundGovernorCounters 1 1 1 1
-
-protoRemoteAddr :: SockAddr
-protoRemoteAddr = SockAddrUnix "loopback"
-
-protoLocalAddress :: LocalAddress
-protoLocalAddress = LocalAddress "loopback"
-
--- protoIGAssertionLocation :: peerAddr -> IGAssertionLocation peerAddr
--- protoIGAssertionLocation pa = InboundGovernorLoop Nothing protoAbstractState
-
-
--- Not possible to prvide such prototype,
--- as type and constructor are not exported
--- protoIGAssertionLocation :: IGAssertionLocation peerAddr
--- protoIGAssertionLocation = InboundGovernorLoop Nothing protoAbstractState
 
 docInboundGovernorLocal ::
    Documented (InboundGovernorTrace LocalAddress)
-docInboundGovernorLocal = docInboundGovernor protoLocalAddress
+docInboundGovernorLocal =
+    addDocumentedNamespace  ["InboundGovernor"] docInboundGovernor
 
 docInboundGovernorRemote ::
    Documented (InboundGovernorTrace SockAddr)
-docInboundGovernorRemote = docInboundGovernor protoRemoteAddr
+docInboundGovernorRemote =
+    addDocumentedNamespace  ["LocalInboundGovernor"] docInboundGovernor
 
-docInboundGovernor :: peerAddr -> Documented (InboundGovernorTrace peerAddr)
-docInboundGovernor peerAddr = Documented
+docInboundGovernor :: Documented (InboundGovernorTrace peerAddr)
+docInboundGovernor = Documented
   [  DocMsg
-      (TrNewConnection protoProvenance (protoConnectionId peerAddr))
+      ["NewConnection"]
       []
       ""
   ,  DocMsg
-      (TrResponderRestarted (protoConnectionId peerAddr) protoMiniProtocolNum)
+      ["ResponderRestarted"]
       []
       ""
   ,  DocMsg
-      (TrResponderStartFailure (protoConnectionId peerAddr) protoMiniProtocolNum
-        protoSomeException)
+      ["ResponderStartFailure"]
       []
       ""
   ,  DocMsg
-      (TrResponderErrored (protoConnectionId peerAddr) protoMiniProtocolNum
-        protoSomeException)
+      ["ResponderErrored"]
       []
       ""
   ,  DocMsg
-      (TrResponderStarted  (protoConnectionId peerAddr) protoMiniProtocolNum)
+      ["ResponderStarted"]
       []
       ""
   ,  DocMsg
-      (TrResponderTerminated  (protoConnectionId peerAddr) protoMiniProtocolNum)
+      ["ResponderTerminated"]
       []
       ""
   ,  DocMsg
-      (TrPromotedToWarmRemote (protoConnectionId peerAddr)
-        (protoOperationResult protoAbstractState))
+      ["PromotedToWarmRemote"]
       []
       ""
   ,  DocMsg
-      (TrPromotedToHotRemote (protoConnectionId peerAddr))
+      ["PromotedToHotRemote"]
       []
       ""
   ,  DocMsg
-      (TrDemotedToColdRemote (protoConnectionId peerAddr)
-        (protoOperationResult protoDemotedToColdRemoteTr))
+      ["DemotedToColdRemote"]
       []
       "All mini-protocols terminated.  The boolean is true if this connection\
       \ was not used by p2p-governor, and thus the connection will be terminated."
   ,  DocMsg
-      (TrDemotedToWarmRemote (protoConnectionId peerAddr))
+      ["DemotedToWarmRemote"]
       []
       "All mini-protocols terminated.  The boolean is true if this connection\
       \ was not used by p2p-governor, and thus the connection will be terminated."
   ,  DocMsg
-      (TrWaitIdleRemote (protoConnectionId peerAddr)
-        (protoOperationResult protoAbstractState))
+      ["WaitIdleRemote"]
       []
       ""
   ,  DocMsg
-      (TrMuxCleanExit (protoConnectionId peerAddr))
+      ["MuxCleanExit"]
       []
       ""
   ,  DocMsg
-      (TrMuxErrored (protoConnectionId peerAddr) protoSomeException)
+      ["MuxErrored"]
       []
       ""
   ,  DocMsg
-      (TrInboundGovernorCounters protoInboundGovernorCounters)
+      ["InboundGovernorCounters"]
       []
       ""
   ,  DocMsg
-      (TrRemoteState Map.empty)
+      ["RemoteState"]
       []
       ""
-  -- ,  DocMsg
-  --     (InboundGovernor.TrUnexpectedlyFalseAssertion protoIGAssertionLocation)
-  --     []
-  --     ""
-  -- ,  DocMsg
-  --     (InboundGovernor.TrInboundGovernorError protoSomeException)
-  --     []
-  --     ""
+  ,  DocMsg
+      ["UnexpectedlyFalseAssertion"]
+      []
+      ""
+  ,  DocMsg
+      ["InboundGovernorError"]
+      []
+      ""
   ]
 
 --------------------------------------------------------------------------------
@@ -1451,7 +1432,7 @@ docInboundGovernor peerAddr = Documented
 
 namesForInboundGovernorTransition
   :: InboundGovernor.RemoteTransitionTrace peerAddr -> [Text]
-namesForInboundGovernorTransition _ = ["InboundGovernorTransition"]
+namesForInboundGovernorTransition _ = []
 
 severityInboundGovernorTransition
   :: InboundGovernor.RemoteTransitionTrace peerAddr -> SeverityS
@@ -1473,7 +1454,7 @@ docInboundGovernorTransition
   :: Documented (InboundGovernor.RemoteTransitionTrace peerAddr)
 docInboundGovernorTransition = Documented
   [ DocMsg
-      anyProto
+      ["InboundGovernorTransition"]
       []
       ""
   ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
@@ -67,25 +67,28 @@ instance LogFormatting ShutdownTrace where
                    , "slot"   .= toJSON slot ]
 
 docShutdown :: Documented ShutdownTrace
-docShutdown = Documented
+docShutdown = addDocumentedNamespace  [] docShutdown'
+
+docShutdown' :: Documented ShutdownTrace
+docShutdown' = Documented
   [ DocMsg
-      ShutdownRequested
+      ["ShutdownRequested"]
       []
       "Node shutdown was requested."
   ,  DocMsg
-      AbnormalShutdown
+      ["AbnormalShutdown"]
       []
       "non-isEOFerror shutdown request"
   ,  DocMsg
-      (ShutdownUnexpectedInput anyProto)
+      ["ShutdownUnexpectedInput"]
       []
       "Received shutdown request but found unexpected input in --shutdown-ipc FD: "
   , DocMsg
-      (RequestingShutdown anyProto)
+      ["RequestingShutdown"]
       []
       "Ringing the node shutdown doorbell"
   , DocMsg
-      (ShutdownArmedAtSlot anyProto)
+      ["ShutdownArmedAtSlot"]
       []
       "Setting up node shutdown at given slot."
   ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
@@ -56,8 +56,8 @@ forgeTracerTransform ::
   -> IO (Trace IO (ForgeTracerType blk))
 forgeTracerTransform nodeKern (Trace tr) = pure $ Trace $ T.arrow $ T.emit $
     \case
-      (lc, Nothing, Left (TraceLabelCreds creds
-                        (TraceStartLeadershipCheck slotNo))) -> do
+      (lc, Right (Left (TraceLabelCreds creds
+                        (TraceStartLeadershipCheck slotNo)))) -> do
         query <- mapNodeKernelDataIO
                     (\nk ->
                        (,,)
@@ -73,11 +73,11 @@ forgeTracerTransform nodeKern (Trace tr) = pure $ Trace $ T.arrow $ T.emit $
                             utxoSize
                             delegMapSize
                             (fromRational chainDensity)
-                in T.traceWith tr (lc, Nothing, Right (TraceLabelCreds creds msg)))
-      (lc, Nothing, a) ->
-          T.traceWith tr (lc, Nothing, a)
-      (lc, Just control, a) ->
-          T.traceWith tr (lc, Just control, a)
+                in T.traceWith tr (lc, Right (Right (TraceLabelCreds creds msg))))
+      (lc, Right a) ->
+          T.traceWith tr (lc, Right a)
+      (lc, Left control) ->
+          T.traceWith tr (lc, Left control)
 
 nkQueryLedger ::
      IsLedger (LedgerState blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -361,7 +361,55 @@ p2pWarningDevelopmentNetworkProtocolsMessage =
 docStartupInfo :: Documented (StartupTrace blk)
 docStartupInfo = Documented [
     DocMsg
-      (BICommon anyProto)
+      ["StartupInfo"]
+      []
+      ""
+  , DocMsg
+      ["StartupP2PInfo"]
+      []
+      ""
+  , DocMsg
+      ["StartupTime"]
+      []
+      ""
+  , DocMsg
+      ["StartupNetworkMagic"]
+      []
+      ""
+  , DocMsg
+      ["StartupSocketConfigError"]
+      []
+      ""
+  , DocMsg
+      ["StartupDBValidation"]
+      []
+      ""
+  , DocMsg
+      ["NetworkConfigUpdate"]
+      []
+      ""
+  , DocMsg
+      ["NetworkConfigUpdateError"]
+      []
+      ""
+  , DocMsg
+      ["NetworkConfig"]
+      []
+      ""
+  , DocMsg
+      ["P2PWarning"]
+      []
+      ""
+  , DocMsg
+      ["P2PWarningDevelopementNetworkProtocols"]
+      []
+      ""
+  , DocMsg
+      ["WarningDevelopmentNetworkProtocols"]
+      []
+      ""
+  , DocMsg
+      ["Common"]
       []
       "_biConfigPath_: is the path to the config in use. \
       \\n_biProtocol_: is the name of the protocol, e.g. \"Byron\", \"Shelley\" \
@@ -370,7 +418,7 @@ docStartupInfo = Documented [
       \\n_biCommit_: is the commit revision of the software running. \
       \\n_biNodeStartTime_: gives the time this node was started."
   , DocMsg
-      (BIShelley anyProto)
+      ["ShelleyBased"]
       []
       "bisEra is the current era, e.g. \"Shelley\", \"Allegra\", \"Mary\" \
       \or \"Alonzo\". \
@@ -379,13 +427,13 @@ docStartupInfo = Documented [
       \\n_bisEpochLength_: gives the number of slots which forms an epoch. \
       \\n_bisSlotsPerKESPeriod_: gives the slots per KES period."
   , DocMsg
-      (BIByron anyProto)
+      ["Byron"]
       []
       "_bibSystemStartTime_: TODO JNF \
       \\n_bibSlotLength_: gives the length of a slot as time interval. \
       \\n_bibEpochLength_: gives the number of slots which forms an epoch."
   , DocMsg
-      (BINetwork anyProto)
+      ["Network"]
       []
       "_niAddresses_: IPv4 or IPv6 socket ready to accept connections\
       \or diffusion addresses. \

--- a/configuration/cardano/membench-config-new.yaml
+++ b/configuration/cardano/membench-config-new.yaml
@@ -1,3 +1,4 @@
+# Options for the trace forwarder
 ################################################################################
 # Mainnet Cardano Node Configuration
 

--- a/doc/New Tracing Quickstart.md
+++ b/doc/New Tracing Quickstart.md
@@ -14,6 +14,14 @@ To switch to new tracing set the value `UseTraceDispatcher` to true. If you do t
 config file needs to contain several values for the configuration of new-tracing, as we
 describe next.
 
+The current tracing system has two ways to identify the message, a hierarchical name we
+call it's `Namespace` and the `Kind field` in machine representation. We base our implementation
+on the namespace, and require a one-to-one correspondence between namespaces and messages (bijective mapping).
+
+As we have two mechanisms for the same purpose for historic reasons, we will soon
+__deprecate the Kind field__, and it will disappear in the near future. So we strongly
+advice to use namespaces for any analysis tools of traces!  
+
 ### Configuration of new tracing
 
 1. Specify a filter for the severity of the messages you want to see, e.g.:
@@ -141,8 +149,15 @@ examples in cardano-node under Cardano.Node.Tracing.Tracers.
 
 ### Documentation of trace messages and further documentation
 
-[Trace messages with default config](https://github.com/input-output-hk/cardano-node/blob/master/doc/new-tracing/tracers_doc_generated.md)
+This is a document which is regenerated periodically and documents all trace-messages,  metrics and data-points in cardano-node. It as well displays the handling of these
+messages with the current default configuration:
 
-[Trace-dispatcher documentation](https://github.com/input-output-hk/cardano-node/blob/master/trace-dispatcher/doc/trace-dispatcher.md)
+[Cardano Trace Documentation](https://github.com/input-output-hk/cardano-node/blob/master/doc/new-tracing/tracers_doc_generated.md)
 
-[cardano-tracer documentation](https://github.com/input-output-hk/cardano-node/blob/master/cardano-tracer/docs/cardano-tracer.md)
+This document describes the underlying library trace-dispatcher:
+
+[trace-dispatcher: efficient, simple and flexible program tracing](https://github.com/input-output-hk/cardano-node/blob/master/trace-dispatcher/doc/trace-dispatcher.md)
+
+This document describes a seperate service for logging and monitoring Cardano nodes:
+
+[Cardano Tracer](https://github.com/input-output-hk/cardano-node/blob/master/cardano-tracer/docs/cardano-tracer.md)

--- a/trace-dispatcher/doc/trace-dispatcher.md
+++ b/trace-dispatcher/doc/trace-dispatcher.md
@@ -629,7 +629,7 @@ mkDataPointTracer :: forall dp. ToJSON dp
   -> IO (Trace IO dp)
 mkDataPointTracer trDataPoint namesFor = do
     let tr = NT.contramap DataPoint trDataPoint
-    pure $ withNamesAppended namesFor tr```
+    pure $ withNamesAppended namesFor tr
 ```
 
 Also, [there is a document](https://github.com/input-output-hk/cardano-node/wiki/cardano-node-and-DataPoints:-demo)
@@ -653,9 +653,9 @@ Because all these tracers are defined as part of the __dispatcher__ definition, 
 ## Cardano tracer
 
 We provide a standard interface to construct a tracer to be used within cardano node.
-The tracer gets as arguments the backends: 'trStdout', 'trForward' and 'mbTrEkg'.
-The tracer gets as argument a 'name', which is appended to its namespace. The tracer gets as
-arguments 'namesFor', 'severityFor' and 'privacyFor' functions, to set the logging context accordingly. The returned tracer need to be configured with a configuration for the specification of filtering, detailLevel, frequencyLimiting and backends with a configuration before use.
+The tracer gets as arguments the backends: `trStdout`, `trForward` and `mbTrEkg`.
+The tracer gets as argument a `name`, which is appended to its namespace. The tracer gets as
+arguments `namesFor`, `severityFor` and `privacyFor` functions, to set the logging context accordingly. The returned tracer need to be configured with a configuration for the specification of filtering, detailLevel, frequencyLimiting and backends with a configuration before use.
 
 ```haskell
 mkCardanoTracer :: forall evt.

--- a/trace-dispatcher/examples/Examples/EKG.hs
+++ b/trace-dispatcher/examples/Examples/EKG.hs
@@ -10,7 +10,7 @@ import           System.Remote.Monitoring (forkServer)
 
 
 countDocumented :: Documented Int
-countDocumented = Documented [DocMsg 0 [] "count"]
+countDocumented = Documented [DocMsg ["Count"] [("count", "an integer")] ""]
 
 testEKG :: IO ()
 testEKG = do

--- a/trace-dispatcher/examples/Examples/Routing.hs
+++ b/trace-dispatcher/examples/Examples/Routing.hs
@@ -27,10 +27,10 @@ testRouting = do
     t <- standardTracer
     tf <- machineFormatter "cardano" t
     let t1 = appendName "tracer1" tf
-    let t2 = appendName "tracer1" tf
+    let t2 = appendName "tracer2" tf
     configureTracers emptyTraceConfig traceForgeEventDocu [t1, t2]
     r1 <- routingTracer1 t1 t2
     r2 <- routingTracer2 t1 t2
+    traceWith r1 message1
     traceWith r1 message2
-    traceWith r2 message2
-    traceWith (t1 <> t2) message3
+    traceWith r2 message3

--- a/trace-dispatcher/examples/Examples/TestObjects.hs
+++ b/trace-dispatcher/examples/Examples/TestObjects.hs
@@ -148,13 +148,13 @@ instance LogFormatting (TraceForgeEvent LogBlock) where
 traceForgeEventDocu :: Documented (TraceForgeEvent LogBlock)
 traceForgeEventDocu = Documented
   [ DocMsg
-      (TraceStartLeadershipCheck (SlotNo 1))
+      ["TraceStartLeadershipCheck"]
       []
       "Start of the leadership check\n\
         \\n\
         \We record the current slot number."
   , DocMsg
-      (TraceSlotIsImmutable (SlotNo 1) (Point Origin) (BlockNo 1))
+      ["TraceSlotIsImmutable"]
       []
       "Leadership check failed: the tip of the ImmutableDB inhabits the\n\
         \current slot\n\
@@ -174,7 +174,7 @@ traceForgeEventDocu = Documented
         \\n\
         \See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>"
   , DocMsg
-    (TraceBlockFromFuture (SlotNo 1) (SlotNo 1))
+    ["TraceBlockFromFuture"]
     []
     "Leadership check failed: the current chain contains a block from a slot\n\
       \/after/ the current slot\n\

--- a/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
+++ b/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
@@ -72,12 +72,6 @@ documentTracers (Documented documented) tracers = do
 showT :: Show a => a -> Text
 showT = pack . show
 
--- appDoc :: (Namespace -> Namespace) -> DocMsg a -> DocMsg b
--- appDoc f DocMsg {..} = DocMsg  (f dmNamespace) dmMetricsMD dmMarkdown
---
--- mapDoc :: (Namespace -> Namespace) -> [DocMsg a] -> [DocMsg b]
--- mapDoc f = map (appDoc f)
-
 addDocumentedNamespace  :: Namespace -> Documented a -> Documented b
 addDocumentedNamespace  ns (Documented list) =
   Documented $ map

--- a/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
+++ b/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
@@ -1,23 +1,21 @@
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Logging.DocuGenerator (
-    documentMarkdown
+    addDocumentedNamespace
+  , addDocs
+  , documentMarkdown
   , buildersToText
   , docIt
   , addFiltered
   , addLimiter
   , docTracer
   , docTracerDatapoint
-  , anyProto
   , showT
   , DocuResult
-  , appDoc
-  , mapDoc
 ) where
 
 import           Cardano.Logging.Types
-import           Control.Exception (SomeException, catch)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Control.Tracer as T
 import           Data.IORef (modifyIORef, newIORef, readIORef)
@@ -27,8 +25,7 @@ import           Data.Text (Text, pack, toLower)
 import qualified Data.Text as T
 import           Data.Text.Internal.Builder (toLazyText)
 import           Data.Text.Lazy (toStrict)
-import           Data.Text.Lazy.Builder (Builder, fromString, fromText,
-                     singleton)
+import           Data.Text.Lazy.Builder (Builder, fromString, fromText, singleton)
 import           Data.Time (getZonedTime)
 import           Trace.Forward.Utils.DataPoint (DataPoint (..))
 
@@ -55,42 +52,9 @@ unpackDocu (DocuTracer b)    = b
 unpackDocu (DocuMetric b)    = b
 unpackDocu (DocuDatapoint b) = b
 
-anyProto :: a
-anyProto = undefined
 
-showT :: Show a => a -> Text
-showT = pack . show
-
-appDoc :: (a -> b) -> DocMsg a -> DocMsg b
-appDoc f DocMsg {..} = DocMsg  (f dmPrototype) dmMetricsMD dmMarkdown
-
-mapDoc :: (a -> b) -> [DocMsg a] -> [DocMsg b]
-mapDoc f = map (appDoc f)
-
-docTracer :: MonadIO m
-  => BackendConfig
-  -> Trace m FormattedMessage
-docTracer backendConfig = Trace $ T.arrow $ T.emit output
-  where
-    output p@(_, Just Document {}, FormattedMetrics m) =
-      docIt backendConfig (FormattedMetrics m) p
-    output (lk, Just c@Document {}, FormattedForwarder lo) =
-      docIt backendConfig (FormattedForwarder lo) (lk, Just c, lo)
-    output (lk, Just c@Document {}, FormattedHuman co msg) =
-      docIt backendConfig (FormattedHuman co "") (lk, Just c, msg)
-    output (lk, Just c@Document {}, FormattedMachine msg) =
-      docIt backendConfig (FormattedMachine "") (lk, Just c, msg)
-    output (_, _, _) = pure ()
-
-docTracerDatapoint :: MonadIO m
-  => BackendConfig
-  -> Trace m DataPoint
-docTracerDatapoint backendConfig = Trace $ T.arrow $ T.emit output
-  where
-    output p@(_, Just Document {}, DataPoint m) =
-      docItDatapoint backendConfig (DataPoint m) p
-    output (_, _, _) = pure ()
-
+-- | Calls the tracers in a documetation control mode,
+-- and returns a DocCollector, from which the documentation gets generated
 documentTracers :: Documented a -> [Trace IO a] -> IO DocCollector
 documentTracers (Documented documented) tracers = do
     let docIdx = zip documented [0..]
@@ -98,22 +62,48 @@ documentTracers (Documented documented) tracers = do
     mapM_ (docTrace docIdx coll) tracers
     pure coll
   where
-    docTrace docIdx dc@(DocCollector docColl) (Trace tr) =
+    docTrace docIdx dc (Trace tr) =
       mapM_
-        (\ (DocMsg {..}, idx) -> catch (
-            T.traceWith tr (emptyLoggingContext,
-                            Just (Document idx dmMarkdown dmMetricsMD dc), dmPrototype))
-            (\ (ex :: SomeException) ->
-                modifyIORef docColl
-                  (\ docMap ->
-                    Map.insert
-                      idx
-                      (case Map.lookup idx docMap of
-                        Just e  -> e { ldDoc = ldDoc e <> "Error generating doc" <> (pack . show) ex}
-                        Nothing -> emptyLogDoc ("Error generating doc" <> (pack . show) ex) [])
-                      docMap)))
+        (\ (DocMsg {..}, idx) ->
+            T.traceWith tr (emptyLoggingContext {lcNamespace = dmNamespace},
+                            Left (Document idx dmMarkdown dmMetricsMD dc)))
         docIdx
 
+showT :: Show a => a -> Text
+showT = pack . show
+
+-- appDoc :: (Namespace -> Namespace) -> DocMsg a -> DocMsg b
+-- appDoc f DocMsg {..} = DocMsg  (f dmNamespace) dmMetricsMD dmMarkdown
+--
+-- mapDoc :: (Namespace -> Namespace) -> [DocMsg a] -> [DocMsg b]
+-- mapDoc f = map (appDoc f)
+
+addDocumentedNamespace  :: Namespace -> Documented a -> Documented b
+addDocumentedNamespace  ns (Documented list) =
+  Documented $ map
+    (\ dm@DocMsg {} -> dm {dmNamespace = ns ++ dmNamespace dm})
+    list
+
+addDocs :: Documented a -> Documented a -> Documented a
+addDocs (Documented l) (Documented r) = Documented (l ++ r)
+
+docTracer :: MonadIO m =>
+     BackendConfig
+  -> Trace m FormattedMessage
+docTracer backendConfig = Trace $ T.arrow $ T.emit output
+  where
+    output p@(_, Left Document {}) =
+      docIt backendConfig p
+    output (_, _) = pure ()
+
+docTracerDatapoint :: MonadIO m =>
+     BackendConfig
+  -> Trace m DataPoint
+docTracerDatapoint backendConfig = Trace $ T.arrow $ T.emit output
+  where
+    output p@(_, Left Document {}) =
+      docItDatapoint backendConfig p
+    output (_, _) = pure ()
 
 addFiltered :: MonadIO m => TraceControl -> Maybe SeverityF -> m ()
 addFiltered (Document idx mdText mdMetrics (DocCollector docRef)) (Just sev) = do
@@ -139,52 +129,47 @@ addLimiter (Document idx mdText mdMetrics (DocCollector docRef)) (ln, lf) = do
         docMap)
 addLimiter _ _ = pure ()
 
-docIt :: MonadIO m =>
-     BackendConfig
-  -> FormattedMessage
-  -> (LoggingContext, Maybe TraceControl, a)
+docIt :: MonadIO m
+  => BackendConfig
+  -> (LoggingContext, Either TraceControl a)
   -> m ()
-docIt backend formattedMessage (LoggingContext {..},
-  Just (Document idx mdText mdMetrics (DocCollector docRef)), _msg) = do
-  liftIO $ modifyIORef docRef (\ docMap ->
-      Map.insert
-        idx
-        ((\e -> e { ldBackends  = seq backend (seq formattedMessage
-                                    ((backend, formattedMessage) : ldBackends e))
-                  , ldNamespace = seq lcNamespace
-                                    (lcNamespace : ldNamespace e)
-                  , ldSeverity  = case lcSeverity of
-                                    Nothing -> ldSeverity e
-                                    Just s  -> seq s (s : ldSeverity e)
-                  , ldPrivacy   = case lcPrivacy of
-                                    Nothing -> ldPrivacy e
-                                    Just p  -> seq p (p : ldPrivacy e)
-                  , ldDetails   = case lcDetails of
-                                    Nothing -> ldDetails e
-                                    Just d  -> seq d (d : ldDetails e)
-                  })
-          (case Map.lookup idx docMap of
-                        Just e  -> e
-                        Nothing -> seq mdText (seq mdMetrics (emptyLogDoc mdText mdMetrics))))
-        docMap)
+docIt backend (LoggingContext {..},
+  Left (Document idx mdText mdMetrics (DocCollector docRef))) = do
+    liftIO $ modifyIORef docRef (\ docMap ->
+        Map.insert
+          idx
+          ((\e -> e { ldBackends  = backend : ldBackends e
+                    , ldNamespace = lcNamespace : ldNamespace e
+                    , ldSeverity  = case lcSeverity of
+                                      Nothing -> ldSeverity e
+                                      Just s  -> s : ldSeverity e
+                    , ldPrivacy   = case lcPrivacy of
+                                      Nothing -> ldPrivacy e
+                                      Just p  -> p : ldPrivacy e
+                    , ldDetails   = case lcDetails of
+                                      Nothing -> ldDetails e
+                                      Just d  -> d : ldDetails e
+                    })
+            (case Map.lookup idx docMap of
+                          Just e  -> e
+                          Nothing -> seq mdText (seq mdMetrics (emptyLogDoc mdText mdMetrics))))
+          docMap)
 
 docItDatapoint :: MonadIO m =>
      BackendConfig
-  -> DataPoint
-  -> (LoggingContext, Maybe TraceControl, a)
+  -> (LoggingContext, Either TraceControl a)
   -> m ()
-docItDatapoint _backend _formattedMessage (LoggingContext {..},
-  Just (Document idx mdText _mdMetrics (DocCollector docRef)), _msg) = do
+docItDatapoint _backend (LoggingContext {..},
+  Left (Document idx mdText _mdMetrics (DocCollector docRef))) = do
   liftIO $ modifyIORef docRef (\ docMap ->
       Map.insert
         idx
-        ((\e -> e { ldNamespace = seq lcNamespace
-                                    (lcNamespace : ldNamespace e)
-                  , ldBackends  = [(DatapointBackend, FormattedMachine "")]
+        ((\e -> e { ldNamespace = lcNamespace : ldNamespace e
+                  , ldBackends  = [DatapointBackend]
                   })
           (case Map.lookup idx docMap of
                         Just e  -> e
-                        Nothing -> seq mdText (emptyLogDoc mdText [])))
+                        Nothing -> emptyLogDoc mdText []))
         docMap)
 
 generateTOC :: [Namespace] -> [Namespace] -> [Namespace] -> Builder
@@ -280,7 +265,7 @@ documentMarkdown (Documented documented) tracers = do
     documentItem :: (Int, LogDoc) -> DocuResult
     documentItem (_idx, ld@LogDoc {..}) =
       case ldBackends of
-        [(DatapointBackend, _)] -> DocuDatapoint $
+        [DatapointBackend] -> DocuDatapoint $
                     mconcat $ intersperse (fromText "\n\n")
                       [ namespacesBuilder (nub ldNamespace)
                       , betweenLines (fromText ldDoc)
@@ -359,19 +344,14 @@ documentMarkdown (Documented documented) tracers = do
       <> filteredBuilder (nub ldFiltered) (nub ldSeverity)
       <> limiterBuilder (nub ldLimiter)
 
-    backendsBuilder :: [(BackendConfig, FormattedMessage)] -> Builder
+    backendsBuilder :: [BackendConfig] -> Builder
     backendsBuilder [] = fromText "No backends found"
     backendsBuilder l  = fromText "Backends:\n\t\t\t"
                           <> mconcat (intersperse (fromText ",\n\t\t\t")
                                 (map backendFormatToText l))
 
-    backendFormatToText :: (BackendConfig, FormattedMessage) -> Builder
-    backendFormatToText (be, FormattedMetrics _) = asCode (fromString   (show be))
-
-    backendFormatToText (be, FormattedHuman _c _) = asCode (fromString (show be))
-    backendFormatToText (be, FormattedMachine _) = asCode (fromString (show be))
-    backendFormatToText (be, FormattedForwarder _) = asCode (fromString (show be))
-
+    backendFormatToText :: BackendConfig -> Builder
+    backendFormatToText be = asCode (fromString (show be))
 
     filteredBuilder :: [SeverityF] -> [SeverityS] -> Builder
     filteredBuilder [] _ = mempty

--- a/trace-dispatcher/src/Cardano/Logging/Trace.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Trace.hs
@@ -42,7 +42,7 @@ import           Cardano.Logging.Types
 -- | Adds a message object to a trace
 traceWith :: Monad m => Trace m a -> a -> m ()
 traceWith (Trace tr) a =
-    T.traceWith tr (emptyLoggingContext, Nothing, a)
+    T.traceWith tr (emptyLoggingContext, Right a)
 
 -- | Convenience function for tracing a message with a name
 --   As the simple name suggest, this should be the standard function
@@ -51,47 +51,47 @@ traceNamed tr n = traceWith (appendName n tr)
 
 --- | Don't process further if the result of the selector function
 ---   is False.
-filterTrace :: (Monad m) =>
-     ((LoggingContext, Maybe TraceControl, a) -> Bool)
+filterTrace :: (Monad m)
+  => ((LoggingContext, a) -> Bool)
   -> Trace m a
   -> Trace m a
 filterTrace ff (Trace tr) = Trace $ T.squelchUnless
     (\case
-      (_lc, Just _, _a)     -> True
-      (lc, mbC, a)          -> ff (lc, mbC, a))
+      (_lc, Left _)     -> True
+      (lc, Right a)     -> ff (lc, a))
       tr
 
 --- | Keep the Just values and forget about the Nothings
-filterTraceMaybe :: Monad m =>
-     Trace m a
+filterTraceMaybe :: Monad m
+  => Trace m a
   -> Trace m (Maybe a)
 filterTraceMaybe (Trace tr) = Trace $
     T.squelchUnless
       (\case
-        (_lc, _mbC, Just _) -> True
-        (_lc, _mbC, Nothing) -> False)
+        (_lc, Left _ctrl)      -> True
+        (_lc, Right (Just _)) -> True
+        (_lc, Right Nothing)  -> False)
       (T.contramap
           (\case
-            (lc, mbC, Just a)     -> (lc, mbC, a)
-            (_lc, _mbC, Nothing)  -> error "filterTraceMaybe: impossible")
+            ( lc, Right (Just a))    -> (lc, Right a)
+            (_lc, Right Nothing)     -> error "filterTraceMaybe: impossible"
+            ( lc, Left ctrl)         -> (lc, Left ctrl))
           tr)
 
 --- | Only processes messages further with a severity equal or greater as the
 --- given one
-filterTraceBySeverity :: Monad m =>
-     Maybe SeverityF
+filterTraceBySeverity :: Monad m
+  => Maybe SeverityF
   -> Trace m a
   -> Trace m a
 filterTraceBySeverity (Just minSeverity) =
-    filterTrace $
-      \case
-        (_lc, Just _, _a)  -> True
-        (lc, _, _e)        ->
-          case lcSeverity lc of
-            Just s  -> case minSeverity of
-                          SeverityF (Just fs) -> s >= fs
-                          SeverityF Nothing   -> False
-            Nothing -> True
+    filterTrace
+      (\(lc, _) -> case lcSeverity lc of
+        Just s  -> case minSeverity of
+                      SeverityF (Just fs) -> s >= fs
+                      SeverityF Nothing   -> False
+        Nothing -> True)
+
 filterTraceBySeverity Nothing = id
 
 -- | Sets a new logging context for this message
@@ -99,7 +99,7 @@ withLoggingContext :: Monad m => LoggingContext -> Trace m a -> Trace m a
 withLoggingContext lc (Trace tr) = Trace $
     T.contramap
       (\
-        (_lc, mbC, e) -> (lc, mbC, e))
+        (_lc, cont) -> (lc, cont))
       tr
 
 -- | Appends a name to the context.
@@ -109,33 +109,35 @@ appendName :: Monad m => Text -> Trace m a -> Trace m a
 appendName name (Trace tr) = Trace $
     T.contramap
       (\
-        (lc, mbC, e) -> (lc {lcNamespace = name : lcNamespace lc}, mbC, e))
+        (lc, cont) -> (lc {lcNamespace = name : lcNamespace lc}, cont))
       tr
 
 -- | Sets names for the messages in this trace based on the selector function
 withNamesAppended :: Monad m => (a -> [Text]) -> Trace m a -> Trace m a
 withNamesAppended func (Trace tr) = Trace $
     T.contramap
-      (\
-        (lc, mbC, e) -> (lc {lcNamespace = func e ++ lcNamespace lc}, mbC, e))
+      (\case
+        (lc, Right e) -> (lc {lcNamespace = func e ++ lcNamespace lc}, Right e)
+        (lc, Left ctrl) -> (lc, Left ctrl))
       tr
 
 -- | Sets severity for the messages in this trace
 setSeverity :: Monad m => SeverityS -> Trace m a -> Trace m a
 setSeverity s (Trace tr) = Trace $ T.contramap
-  (\ (lc, mbC, e) -> if isJust (lcSeverity lc)
-                        then (lc, mbC, e)
-                        else (lc {lcSeverity = Just s}, mbC, e))
+  (\ (lc, cont) -> if isJust (lcSeverity lc)
+                        then (lc, cont)
+                        else (lc {lcSeverity = Just s}, cont))
   tr
 
 -- | Sets severities for the messages in this trace based on the selector function
 withSeverity :: Monad m => (a -> SeverityS) -> Trace m a -> Trace m a
 withSeverity fs (Trace tr) = Trace $
     T.contramap
-      (\
-        (lc, mbC, e) -> if isJust (lcSeverity lc)
-                            then (lc, mbC, e)
-                            else (lc {lcSeverity = Just (fs e)}, mbC, e))
+      (\case
+        (lc, Right e) -> if isJust (lcSeverity lc)
+                            then (lc, Right e)
+                            else (lc {lcSeverity = Just (fs e)}, Right e)
+        (lc, Left e) -> (lc, Left e))
       tr
 
 --- | Only processes messages further with a privacy greater then the given one
@@ -144,10 +146,8 @@ filterTraceByPrivacy :: (Monad m) =>
   -> Trace m a
   -> Trace m a
 filterTraceByPrivacy (Just minPrivacy) = filterTrace $
-    \case
-      (_lc, Just _, _a)     -> True
-      (c, _mbC, _e) ->
-        case lcPrivacy c of
+    \(lc, _cont) ->
+        case lcPrivacy lc of
           Just s  -> fromEnum s >= fromEnum minPrivacy
           Nothing -> True
 filterTraceByPrivacy Nothing = id
@@ -167,44 +167,47 @@ privately = setPrivacy Confidential
 setPrivacy :: Monad m => Privacy -> Trace m a -> Trace m a
 setPrivacy p (Trace tr) = Trace $
   T.contramap
-    (\ (lc, mbC, v) -> if isJust (lcPrivacy lc)
-                      then (lc, mbC, v)
-                      else (lc {lcPrivacy = Just p}, mbC, v))
+    (\ (lc, cont) -> if isJust (lcPrivacy lc)
+                      then (lc, cont)
+                      else (lc {lcPrivacy = Just p}, cont))
     tr
 
 -- | Sets privacy for the messages in this trace based on the message
 withPrivacy :: Monad m => (a -> Privacy) -> Trace m a -> Trace m a
 withPrivacy fs (Trace tr) = Trace $
     T.contramap
-      (\ (lc, mbC, e) -> if isJust (lcPrivacy lc)
-                            then (lc, mbC, e)
-                            else (lc {lcPrivacy = Just (fs e)}, mbC, e))
+      (\case
+          (lc, Right e) -> if isJust (lcPrivacy lc)
+                            then (lc, Right e)
+                            else (lc {lcPrivacy = Just (fs e)}, Right e)
+          (lc, Left e)  ->  (lc, Left e))
       tr
 
 -- | Sets detail level for the messages in this trace
 setDetails :: Monad m => DetailLevel -> Trace m a -> Trace m a
 setDetails p (Trace tr) = Trace $
     T.contramap
-      (\ (lc, mbC, v) -> if isJust (lcDetails lc)
-                        then (lc, mbC, v)
-                        else (lc {lcDetails = Just p}, mbC, v))
+      (\ (lc, cont) -> if isJust (lcDetails lc)
+                        then (lc, cont)
+                        else (lc {lcDetails = Just p}, cont))
       tr
 
 -- | Sets detail level for the messages in this trace based on the message
 withDetails :: Monad m => (a -> DetailLevel) -> Trace m a -> Trace m a
 withDetails fs (Trace tr) = Trace $
   T.contramap
-    (\
-      (lc, mbC, e) -> if isJust (lcDetails lc)
-                          then (lc, mbC, e)
-                          else (lc {lcDetails = Just (fs e)}, mbC, e))
+    (\case
+      (lc, Right e) -> if isJust (lcDetails lc)
+                          then (lc, Right e)
+                          else (lc {lcDetails = Just (fs e)}, Right e)
+      (lc, Left e)  ->  (lc, Left e))
     tr
 
 -- | Folds the cata function with acc over a.
 -- Uses an MVar to store the state
 foldTraceM
   :: forall a acc m . (MonadUnliftIO m)
-  => (acc -> LoggingContext -> Maybe TraceControl -> a -> acc)
+  => (acc -> LoggingContext -> a -> acc)
   -> acc
   -> Trace m (Folding a acc)
   -> m (Trace m a)
@@ -215,21 +218,20 @@ foldTraceM cata initial (Trace tr) = do
  where
     mkTracer ref = T.emit $
       \case
-        (lc, Nothing, v) -> do
+        (lc, Right v) -> do
           x' <- modifyMVar ref $ \x ->
-            let ! accu = cata x lc Nothing v
+            let ! accu = cata x lc v
             in pure (accu,accu)
-          T.traceWith tr (lc, Nothing, Folding x')
-        (lc, Just control, v) -> do
-          let x' = cata initial lc (Just control) v
-          T.traceWith tr (lc, Just control, Folding x')
+          T.traceWith tr (lc, Right (Folding x'))
+        (lc, Left control) -> do
+          T.traceWith tr (lc, Left control)
 
 
 -- | Folds the monadic cata function with acc over a.
 -- Uses an IORef to store the state
 foldMTraceM
   :: forall a acc m . (MonadUnliftIO m)
-  => (acc -> LoggingContext -> Maybe TraceControl -> a -> m acc)
+  => (acc -> LoggingContext -> a -> m acc)
   -> acc
   -> Trace m (Folding a acc)
   -> m (Trace m a)
@@ -240,14 +242,13 @@ foldMTraceM cata initial (Trace tr) = do
  where
     mkTracer ref = T.emit $
       \case
-        (lc, Nothing, v) -> do
+        (lc, Right v) -> do
           x' <- modifyMVar ref $ \x -> do
-            ! accu <- cata x lc Nothing v
+            ! accu <- cata x lc v
             pure $ join (,) accu
-          T.traceWith tr (lc, Nothing, Folding x')
-        (lc, Just control, v) -> do
-          x' <- cata initial lc (Just control) v
-          T.traceWith tr (lc, Just control, Folding x')
+          T.traceWith tr (lc, Right (Folding x'))
+        (lc, Left control) -> do
+          T.traceWith tr (lc, Left control)
 
 -- | Allows to route to different tracers, based on the message being processed.
 --   The second argument must mappend all possible tracers of the first
@@ -259,8 +260,8 @@ routingTrace
   -> m (Trace m a)
 routingTrace rf rc = pure $ Trace $ T.arrow $ T.emit $
     \case
-      (lc, Nothing, a) -> do
+      (lc, Right a) -> do
           nt <- rf a
-          T.traceWith (unpackTrace nt) (lc, Nothing, a)
-      (lc, Just control, a) ->
-          T.traceWith (unpackTrace rc) (lc, Just control, a)
+          T.traceWith (unpackTrace nt) (lc, Right a)
+      (lc, Left control) ->
+          T.traceWith (unpackTrace rc) (lc, Left control)

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
@@ -127,8 +127,7 @@ mkCardanoTracer' trStdout trForward mbTrEkg name namesFor severityFor privacyFor
           Nothing -> pure $ Trace NT.nullTracer
           Just tr -> pure (preFormatted backends tr)
 
--- A simple dataPointTracer which supports building a namespace and entering a hook
--- function.
+-- A simple dataPointTracer which supports building a namespace.
 mkDataPointTracer :: forall dp. ToJSON dp
   => Trace IO DataPoint
   -> (dp -> [Text])

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/EKG.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/EKG.hs
@@ -34,15 +34,15 @@ ekgTracer storeOrServer = liftIO $ do
          IORef (Map.Map Text Gauge.Gauge)
       -> IORef (Map.Map Text Label.Label)
       -> IORef (Map.Map Text Counter.Counter)
-      -> (LoggingContext, Maybe TraceControl, FormattedMessage)
+      -> (LoggingContext, Either TraceControl FormattedMessage)
       -> m ()
     output rgsGauges rgsLabels rgsCounters
-      (LoggingContext{..}, Nothing, FormattedMetrics m) =
+      (LoggingContext{..}, Right (FormattedMetrics m)) =
         liftIO $ mapM_
           (setIt rgsGauges rgsLabels rgsCounters lcNamespace) m
-    output _ _ _ p@(_, Just Document {}, FormattedMetrics m) =
-      docIt EKGBackend (FormattedMetrics m) p
-    output _ _ _ (LoggingContext{}, Just _c, _v) =
+    output _ _ _ p@(_, Left Document {}) =
+      docIt EKGBackend p
+    output _ _ _ (LoggingContext{}, _) =
       pure ()
 
     setIt ::

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
@@ -14,7 +14,6 @@ import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
 
 import           Cardano.Logging.DocuGenerator
 import           Cardano.Logging.Types
-import           Cardano.Logging.Utils (uncurry3)
 
 ---------------------------------------------------------------------------
 
@@ -22,18 +21,17 @@ forwardTracer :: forall m. (MonadIO m)
   => ForwardSink TraceObject
   -> Trace m FormattedMessage
 forwardTracer forwardSink =
-  Trace $ T.arrow $ T.emit $ uncurry3 (output forwardSink)
+  Trace $ T.arrow $ T.emit $ uncurry (output forwardSink)
  where
   output ::
        ForwardSink TraceObject
     -> LoggingContext
-    -> Maybe TraceControl
-    -> FormattedMessage
+    -> Either TraceControl FormattedMessage
     -> m ()
-  output sink LoggingContext {} Nothing (FormattedForwarder lo) = liftIO $
+  output sink LoggingContext {} (Right (FormattedForwarder lo)) = liftIO $
     writeToSink sink lo
-  output _sink LoggingContext {} (Just Reset) _msg = liftIO $ do
+  output _sink LoggingContext {} (Left Reset) = liftIO $ do
     pure ()
-  output _sink lk (Just c@Document {}) (FormattedForwarder lo) = do
-    docIt Forwarder (FormattedForwarder lo) (lk, Just c, lo)
-  output _sink LoggingContext {} _ _a = pure ()
+  output _sink lk (Left c@Document {}) =
+    docIt Forwarder (lk, Left c)
+  output _sink LoggingContext {} _  = pure ()

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
@@ -18,7 +18,6 @@ import           System.IO (hFlush, stdout)
 
 import           Cardano.Logging.DocuGenerator
 import           Cardano.Logging.Types
-import           Cardano.Logging.Utils (uncurry3)
 
 import qualified Control.Tracer as T
 
@@ -34,38 +33,34 @@ standardTracer :: forall m. (MonadIO m)
   => m (Trace m FormattedMessage)
 standardTracer = do
     stateRef <- liftIO $ newIORef emptyStandardTracerState
-    pure $ Trace $ T.arrow $ T.emit $ uncurry3 (output stateRef)
+    pure $ Trace $ T.arrow $ T.emit $ uncurry (output stateRef)
   where
     output ::
          IORef StandardTracerState
       -> LoggingContext
-      -> Maybe TraceControl
-      -> FormattedMessage
+      -> Either TraceControl FormattedMessage
       -> m ()
-    output stateRef LoggingContext {} Nothing (FormattedHuman _c msg) = liftIO $ do
+    output stateRef LoggingContext {} (Right (FormattedHuman _c msg)) = liftIO $ do
       st  <- readIORef stateRef
       case stRunning st of
         Just (inChannel, _, _) -> writeChan inChannel msg
         Nothing                -> pure ()
-    output stateRef LoggingContext {} Nothing (FormattedMachine msg) = liftIO $ do
+    output stateRef LoggingContext {} (Right (FormattedMachine msg)) = liftIO $ do
       st  <- readIORef stateRef
       case stRunning st of
         Just (inChannel, _, _) -> writeChan inChannel msg
         Nothing                -> pure ()
-    output stateRef LoggingContext {} (Just Reset) _msg = liftIO $ do
+    output stateRef LoggingContext {} (Left Reset) = liftIO $ do
       st <- readIORef stateRef
       case stRunning st of
         Nothing -> when (isNothing $ stRunning st) $
                       startStdoutThread stateRef
         Just _  -> pure ()
-    output _ lk (Just c@Document {}) (FormattedHuman co msg) =
+    output _ lk c@(Left Document {}) =
        docIt
-        (Stdout (if co then HumanFormatColoured else HumanFormatUncoloured))
-        (FormattedHuman co "")
-        (lk, Just c, msg)
-    output _ lk (Just c@Document {}) (FormattedMachine msg) =
-       docIt (Stdout MachineFormat) (FormattedMachine "") (lk, Just c, msg)
-    output _stateRef LoggingContext {} _ _a = pure ()
+        (Stdout MachineFormat) -- TODO Find out the right format
+        (lk, c)
+    output _stateRef LoggingContext {} _ = pure ()
 
 -- | Forks a new thread, which writes messages to stdout
 startStdoutThread :: IORef StandardTracerState -> IO ()

--- a/trace-dispatcher/src/Cardano/Logging/Utils.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Utils.hs
@@ -2,8 +2,9 @@
 {-# LANGUAGE PackageImports #-}
 
 module Cardano.Logging.Utils (
-  runInLoop,
-  uncurry3
+    runInLoop
+  , uncurry3
+  , mapSnd
   ) where
 
 import           Control.Concurrent (threadDelay)
@@ -36,3 +37,6 @@ runInLoop action localSocket prevDelayInSecs =
 -- | Converts a curried function to a function on a triple.
 uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
 uncurry3 f (a,b,c) = f a b c
+
+mapSnd :: (a -> b) -> (c, a) -> (c, b)
+mapSnd f (x,y) = (x,f y)

--- a/trace-dispatcher/test/Cardano/Logging/Test/Messages.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Messages.hs
@@ -40,15 +40,15 @@ privacyForMessage Message3 {} = Public
 docMessage :: Documented Message
 docMessage = Documented [
     DocMsg
-      (Message1 1 1)
+      ["Message1"]
       []
       "The first message."
   , DocMsg
-      (Message2 1 "")
+      ["Message2"]
       []
       "The second message."
   , DocMsg
-      (Message3 1 1.0)
+      ["Message3"]
       [("Metrics1", "A number")]
       "The third message."
   ]

--- a/trace-dispatcher/test/Cardano/Logging/Test/Tracer.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Tracer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Logging.Test.Tracer (
@@ -16,6 +15,6 @@ testTracer :: MonadIO m
 testTracer ioRef = liftIO $
     pure $ Trace $ arrow $ emit output
   where
-    output (LoggingContext{}, Nothing, !msg) = liftIO $ do
+    output (LoggingContext{}, Right msg) = liftIO $ do
       modifyIORef ioRef (msg :)
-    output (LoggingContext{}, _, _) = pure ()
+    output (LoggingContext{}, _) = pure ()

--- a/trace-resources/src/Cardano/Logging/Resources/Types.hs
+++ b/trace-resources/src/Cardano/Logging/Resources/Types.hs
@@ -75,7 +75,7 @@ jsonEncodingOptions = defaultOptions
 docResourceStats :: Documented ResourceStats
 docResourceStats = Documented [
       DocMsg
-        anyProto
+        []
         [("stat.cputicks", "Reports the CPU ticks, sice the process was started")
         ,("mem.resident", "TODO JNF")
         ,("rts.gcLiveBytes", "TODO JNF")

--- a/trace-resources/test/trace-resources-test.hs
+++ b/trace-resources/test/trace-resources-test.hs
@@ -55,6 +55,6 @@ testTracer :: MonadIO m
 testTracer ioRef = liftIO $ do
     pure $ Trace $ arrow $ emit output'
   where
-    output' (LoggingContext{}, Nothing, msg) = liftIO $ do
+    output' (LoggingContext{}, Right msg) = liftIO $ do
       modifyIORef ioRef (msg :)
-    output' (LoggingContext{}, _, _) = pure ()
+    output' (LoggingContext{}, _) = pure ()


### PR DESCRIPTION
Remove the prototype concept from the tracer library and replace it with using Namespaces for documentation and configuration.