### PR TITLE
CI ONLY: Update dependencies and pins. 

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -105,6 +105,22 @@ jobs:
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
+    - name: Install secp256k1 (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get -y install autoconf automake libtool
+        mkdir secp256k1-sources
+        cd secp256k1-sources
+        git clone https://github.com/bitcoin-core/secp256k1.git
+        cd secp256k1
+        git reset --hard $SECP256K1_REF
+        ./autogen.sh
+        ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental
+        make
+        make check
+        sudo make install
+        cd ../..
+
     - name: Cabal update
       run: retry 2 cabal update
 

--- a/bench/locli/src/Cardano/Analysis/ChainFilter.hs
+++ b/bench/locli/src/Cardano/Analysis/ChainFilter.hs
@@ -41,8 +41,6 @@ data BlockCond
   | BSizeLEq           Word64
   deriving (FromJSON, Generic, NFData, Show, ToJSON)
 
-deriving instance NFData EpochNo
-
 data SlotCond
   = SlotGEq         SlotNo
   | SlotLEq         SlotNo

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
-index-state: 2021-12-07T00:00:00Z
+-- run `nix flake lock --update-input hackageNix` after updating index-state.
+index-state: 2022-02-18T00:00:00Z
 
 packages:
     cardano-api
@@ -154,15 +155,21 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/vshabanov/ekg-json
+  tag: 00ebe7211c981686e65730b7144fbf5350462608
+  --sha256: 1zvjm3pb38w0ijig5wk5mdkzcszpmlp5d4zxvks2jk1rkypi8gsm
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/hedgehog-extras
-  tag: edf6945007177a638fbeb8802397f3a6f4e47c14
-  --sha256: 0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9
+  tag: 967d79533c21e33387d0227a5f6cc185203fe658
+  --sha256: 0rbqb7a64aya1qizlr3im06hdydg9zr6sl3i8bvqqlf7kpa647sd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 41545ba3ac6b3095966316a99883d678b5ab8da8
-  --sha256: 0icq9y3nnl42fz536da84414av36g37894qnyw4rk3qkalksqwir
+  tag: 20bd513b7ac9dcf0749f0ceb1df3d6b07a1b57c8
+  --sha256: 0pkcd3k2fpk76igfyaf7cqrcglnjs3rs9pka68wpkyp6z7qkixmz
   subdir:
     base-deriving-via
     binary
@@ -184,11 +191,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 3df3ca8db4d52952cb750e8859b71f0a371323af
-  --sha256: 0jacfhqnj76cyjwdxz05h7rqmdasgxp9skd01f5y61xraz746x21
+  tag: 030c3b12f128f22b9d721a31b6b5ae1b75211d68
+  --sha256: 0h9qbdik8fnzv33582pvvhkjyv3wwlnshrwvwalh0yl4mmqdcz8x
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
+    eras/babbage/impl
     eras/byron/chain/executable-spec
     eras/byron/crypto
     eras/byron/crypto/test
@@ -227,8 +235,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 808724ff8a19a33d0ed06f9ef59fbd900b08553c
-  --sha256: 0298dpl29gxzs9as9ha6y0w18hqwc00ipa3hzkxv7nlfrjjz8hmz
+  tag: eb7854d1337637b8672af1227b276aa33a658f47
+  --sha256: 1ll81hlhkhj96f5v6lswjkq2h8f7zcmdrj2azqhi4ylzafn026r3
   subdir:
     contra-tracer
     iohk-monitoring
@@ -248,8 +256,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 48e498cfea694b89f99fd92ae7a86b9fcd5f29f0
-  --sha256: 1klgvlfcd1kxgjicws964k2xkxr79xf3vvgkbx4x7cyn4xfng166
+  tag: 83744fe3b752fd8200de2ea1416e34c576c74f35
+  --sha256: 0v0a3q7xfz7x6rd1bz0scixixmcd9zvqa92lbdc17vgrbrq3dq58
   subdir:
     io-sim
     io-classes
@@ -271,8 +279,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: fc5fe94d3d9525d032bcbc79ff0e1ebcfd8ef143
-  --sha256: 1gnzhns44rzvf9cw84jaqajqqbi9xdcpyy2sapa890vwf796nigv
+  tag: 4417dfea15746596f51f313ef231fb9ecb1d02fc
+  --sha256: 0nx7jbql3mmd64f0kjxrv9azzyc61b6sm2xh5dil910lw891szwh
   subdir:
     plutus-core
     plutus-ledger-api
@@ -317,5 +325,6 @@ package cardano-ledger-alonzo-test
   tests: False
 
 allow-newer:
+  *:aeson,
   monoidal-containers:aeson,
   size-based:template-haskell

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -19,8 +19,6 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import           Data.BiMap (BiMap (..), Bimap)
 import qualified Data.ByteString.Base16 as B16
-import           Data.Compact.SplitMap
-import qualified Data.Compact.SplitMap as SplitMap
 import           Data.Compact.VMap (VB, VMap, VP)
 import qualified Data.Compact.VMap as VMap
 import qualified Data.Map.Strict as Map
@@ -222,8 +220,6 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.PState crypto) where
                          , "fPParams pState" .= Shelley._fPParams pState
                          , "retiring pState" .= Shelley._retiring pState
                          ]
-instance (Ord k, ToJSONKey k, ToJSON v) =>  ToJSON (SplitMap k v) where
-  toJSON = toJSON . SplitMap.toMap
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -119,9 +119,10 @@ import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 
-import           Data.Word (Word64)
 import qualified Cardano.Protocol.TPraos.API as TPraos
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Compact.SplitMap as SplitMap
+import           Data.Word (Word64)
 
 -- ----------------------------------------------------------------------------
 -- Queries
@@ -280,7 +281,7 @@ instance IsCardanoEra era => ToJSON (UTxO era) where
 instance (IsCardanoEra era, IsShelleyBasedEra era, FromJSON (TxOut CtxUTxO era))
   => FromJSON (UTxO era) where
     parseJSON = withObject "UTxO" $ \hm -> do
-      let l = HMS.toList hm
+      let l = HMS.toList $ KeyMap.toHashMapText hm
       res <- mapM toTxIn l
       pure . UTxO $ Map.fromList res
      where

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -112,7 +112,6 @@ import           Numeric.Natural (Natural)
 
 import           Data.Aeson (Value (..), object, (.:), (.=))
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encoding as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Sequence.Strict as Seq
 import           Data.Vector (Vector)
@@ -333,12 +332,11 @@ instance Aeson.FromJSONKey AnyPlutusScriptVersion where
     fromJSONKey = Aeson.FromJSONKeyTextParser parsePlutusScriptVersion
 
 instance Aeson.ToJSONKey AnyPlutusScriptVersion where
-    toJSONKey = Aeson.ToJSONKeyText toText toAesonEncoding
+    toJSONKey = Aeson.toJSONKeyText toText
       where
         toText :: AnyPlutusScriptVersion -> Text
         toText (AnyPlutusScriptVersion PlutusScriptV1) = "PlutusScriptV1"
         toText (AnyPlutusScriptVersion PlutusScriptV2) = "PlutusScriptV2"
-        toAesonEncoding = Aeson.text . toText
 
 toAlonzoLanguage :: AnyPlutusScriptVersion -> Alonzo.Language
 toAlonzoLanguage (AnyPlutusScriptVersion PlutusScriptV1) = Alonzo.PlutusV1

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -10,10 +10,17 @@
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
 module Cardano.CLI.Run.Friendly (friendlyTxBS, friendlyTxBodyBS) where
 
+import           Cardano.Api as Api
+import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
+import           Cardano.Api.Shelley (Address (ShelleyAddress),
+                   KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness), StakeAddress (..))
+import           Cardano.CLI.Helpers (textShow)
+import           Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Shelley.API as Shelley
 import           Cardano.Prelude
-
 import           Data.Aeson (Value (..), object, toJSON, (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Map.Strict as Map
@@ -21,15 +28,6 @@ import qualified Data.Text as Text
 import           Data.Yaml (array)
 import           Data.Yaml.Pretty (setConfCompare)
 import qualified Data.Yaml.Pretty as Yaml
-
-import           Cardano.Api as Api
-import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
-import           Cardano.Api.Shelley (Address (ShelleyAddress),
-                   KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness), StakeAddress (..))
-import           Cardano.Ledger.Crypto (Crypto)
-import qualified Cardano.Ledger.Shelley.API as Shelley
-
-import           Cardano.CLI.Helpers (textShow)
 
 yamlConfig :: Yaml.Config
 yamlConfig = Yaml.defConfig & setConfCompare compare
@@ -305,7 +303,7 @@ friendlyValue v =
     [ case bundle of
         ValueNestedBundleAda q -> "lovelace" .= q
         ValueNestedBundle policy assets ->
-          friendlyPolicyId policy .= friendlyAssets assets
+          Aeson.fromText (friendlyPolicyId policy) .= friendlyAssets assets
     | bundle <- bundles
     ]
   where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -13,19 +13,18 @@ module Cardano.CLI.Shelley.Output
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
-import           Prelude
-
+import           Cardano.CLI.Shelley.Orphans ()
+import           Cardano.Ledger.Shelley.Scripts ()
+import           Cardano.Slotting.Time (SystemStart (..))
 import           Data.Aeson
+import qualified Data.Aeson.Key as Aeson
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
 import           Data.Word
-
-import           Cardano.CLI.Shelley.Orphans ()
-import           Cardano.Ledger.Shelley.Scripts ()
-import           Cardano.Slotting.Time (SystemStart (..))
+import           Prelude
 
 data QueryKesPeriodInfoOutput =
   QueryKesPeriodInfoOutput
@@ -85,11 +84,11 @@ data QueryTipLocalStateOutput = QueryTipLocalStateOutput
   } deriving Show
 
 -- | A key-value pair difference list for encoding a JSON object.
-(..=) :: (KeyValue kv, ToJSON v) => Text -> v -> [kv] -> [kv]
+(..=) :: (KeyValue kv, ToJSON v) => Aeson.Key -> v -> [kv] -> [kv]
 (..=) n v = (n .= v:)
 
 -- | A key-value pair difference list for encoding a JSON object where Nothing encodes absence of the key-value pair.
-(..=?) :: (KeyValue kv, ToJSON v) => Text -> Maybe v -> [kv] -> [kv]
+(..=?) :: (KeyValue kv, ToJSON v) => Aeson.Key -> Maybe v -> [kv] -> [kv]
 (..=?) n mv = case mv of
   Just v -> (n .= v:)
   Nothing -> id
@@ -214,4 +213,3 @@ renderScriptCosts eUnitPrices scriptMapping executionCostMapping =
             Left err -> Left (PlutusScriptCostErrExecError sWitInd scriptHash err) : accum
         Nothing -> Left (PlutusScriptCostErrPlutusScriptNotFound sWitInd) : accum
     ) [] executionCostMapping
-

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -18,7 +18,7 @@ module Cardano.CLI.Shelley.Run.Genesis
 import           Cardano.Prelude hiding (unlines)
 import           Prelude (id, unlines)
 
-import           Data.Aeson
+import           Data.Aeson hiding (Key)
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Binary.Get as Bin

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -11,11 +11,12 @@ import           Prelude (String)
 import           Test.OptParse as OP
 
 import qualified Data.Aeson as J
+import qualified Data.Aeson.Key as J
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as J
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
-import qualified Data.Text as T
 import qualified Data.Time.Clock as DT
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as H
@@ -35,7 +36,7 @@ parseSystemStart :: J.Value -> J.Parser String
 parseSystemStart = J.withObject "Object" $ \o -> o J..: "systemStart"
 
 parseHashMap :: J.Value -> J.Parser (HM.HashMap String J.Value)
-parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first T.unpack) (HM.toList hm)
+parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first J.toString) (KeyMap.toList hm)
 parseHashMap v = J.typeMismatch "Object" v
 
 parseDelegateCount :: J.Value -> J.Parser Int

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -186,7 +186,6 @@ library
                       , transformers
                       , transformers-except
                       , typed-protocols
-                      , unordered-containers
                       , yaml
 
 executable cardano-node

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ConstraintKinds  #-}
-{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 module Cardano.Node.TraceConstraints (TraceConstraints) where
 
@@ -9,23 +9,21 @@ import           Data.Aeson
 
 import           Cardano.BM.Tracing (ToObject)
 import           Cardano.Logging (LogFormatting)
-import           Cardano.Node.Queries (ConvertTxId, GetKESInfo (..),
-                     HasKESInfo (..), HasKESMetricsData (..), LedgerQueries)
+import           Cardano.Node.Queries (ConvertTxId, GetKESInfo (..), HasKESInfo (..),
+                   HasKESMetricsData (..), LedgerQueries)
 
 import           Cardano.Ledger.Alonzo (AlonzoEra)
 import           Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail)
 import           Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure)
-import           Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail)
+import           Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail)
 import           Cardano.Ledger.Crypto (StandardCrypto)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge,
-                     ConvertRawHash, ForgeStateUpdateError, Header)
+import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ConvertRawHash,
+                   ForgeStateUpdateError, Header)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
-import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent, LedgerUpdate,
-                     LedgerWarning)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,
-                     HasTxId, HasTxs (..))
+import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent, LedgerUpdate, LedgerWarning)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, HasTxId, HasTxs (..))
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -58,7 +56,7 @@ type TraceConstraints blk =
     , ToObject (ForgeStateUpdateError blk)
     , ToObject (UtxoPredicateFailure (AlonzoEra StandardCrypto))
     , ToObject (AlonzoBbodyPredFail (AlonzoEra StandardCrypto))
-    , ToObject (AlonzoPredFail (AlonzoEra StandardCrypto))
+    , ToObject (UtxowPredicateFail (AlonzoEra StandardCrypto))
 
     , LogFormatting (LedgerUpdate blk)
     , LogFormatting (LedgerWarning blk)
@@ -73,5 +71,5 @@ type TraceConstraints blk =
     , LogFormatting (ForgeStateUpdateError blk)
     , LogFormatting (UtxoPredicateFailure (AlonzoEra StandardCrypto))
     , LogFormatting (AlonzoBbodyPredFail (AlonzoEra StandardCrypto))
-    , LogFormatting (AlonzoPredFail (AlonzoEra StandardCrypto))
+    , LogFormatting (UtxowPredicateFail (AlonzoEra StandardCrypto))
     )

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
@@ -47,36 +47,36 @@ import           Cardano.Crypto.Signing (VerificationKey)
 
 instance LogFormatting ApplyMempoolPayloadErr where
   forMachine _dtal (MempoolTxErr utxoValidationErr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolTxErr"
       , "error" .= String (show utxoValidationErr)
       ]
   forMachine _dtal (MempoolDlgErr delegScheduleError) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolDlgErr"
       , "error" .= String (show delegScheduleError)
       ]
   forMachine _dtal (MempoolUpdateProposalErr iFaceErr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolUpdateProposalErr"
       , "error" .= String (show iFaceErr)
       ]
   forMachine _dtal (MempoolUpdateVoteErr iFaceErrr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolUpdateVoteErr"
       , "error" .= String (show iFaceErrr)
       ]
 
 instance LogFormatting ByronLedgerUpdate where
   forMachine dtal (ByronUpdatedProtocolUpdates protocolUpdates) =
-    mkObject
+    mconcat
       [ "kind"            .= String "ByronUpdatedProtocolUpdates"
       , "protocolUpdates" .= map (forMachine dtal) protocolUpdates
       ]
 
 instance LogFormatting ProtocolUpdate where
   forMachine dtal (ProtocolUpdate updateVersion updateState) =
-    mkObject
+    mconcat
       [ "kind"                  .= String "ProtocolUpdate"
       , "protocolUpdateVersion" .= updateVersion
       , "protocolUpdateState"   .= forMachine dtal updateState
@@ -85,112 +85,112 @@ instance LogFormatting ProtocolUpdate where
 instance LogFormatting UpdateState where
   forMachine _dtal updateState = case updateState of
       UpdateRegistered slot ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateRegistered"
           , "slot" .= slot
           ]
       UpdateActive votes ->
-        mkObject
+        mconcat
           [ "kind"  .= String "UpdateActive"
           , "votes" .= map (Text.pack . show) (Set.toList votes)
           ]
       UpdateConfirmed slot ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateConfirmed"
           , "slot" .= slot
           ]
       UpdateStablyConfirmed endorsements ->
-        mkObject
+        mconcat
           [ "kind"         .= String "UpdateStablyConfirmed"
           , "endorsements" .= map (Text.pack . show) (Set.toList endorsements)
           ]
       UpdateCandidate slot epoch ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateCandidate"
           , "slot" .= slot
           , "epoch" .= epoch
           ]
       UpdateStableCandidate transitionEpoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "UpdateStableCandidate"
           , "transitionEpoch" .= transitionEpoch
           ]
 
 instance LogFormatting (GenTx ByronBlock) where
   forMachine dtal tx =
-    mkObject $
+    mconcat $
         ( "txid" .= txId tx )
      :  [ "tx"   .= condense tx | dtal == DDetailed ]
 
 instance LogFormatting ChainValidationError where
   forMachine _dtal ChainValidationBoundaryTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBoundaryTooLarge" ]
   forMachine _dtal ChainValidationBlockAttributesTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBlockAttributesTooLarge" ]
   forMachine _dtal (ChainValidationBlockTooLarge _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBlockTooLarge" ]
   forMachine _dtal ChainValidationHeaderAttributesTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationHeaderAttributesTooLarge" ]
   forMachine _dtal (ChainValidationHeaderTooLarge _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationHeaderTooLarge" ]
   forMachine _dtal (ChainValidationDelegationPayloadError err) =
-    mkObject
+    mconcat
       [ "kind" .= String err ]
   forMachine _dtal (ChainValidationInvalidDelegation _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidDelegation" ]
   forMachine _dtal (ChainValidationGenesisHashMismatch _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationGenesisHashMismatch" ]
   forMachine _dtal (ChainValidationExpectedGenesisHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationExpectedGenesisHash" ]
   forMachine _dtal (ChainValidationExpectedHeaderHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationExpectedHeaderHash" ]
   forMachine _dtal (ChainValidationInvalidHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidHash" ]
   forMachine _dtal (ChainValidationMissingHash _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationMissingHash" ]
   forMachine _dtal (ChainValidationUnexpectedGenesisHash _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUnexpectedGenesisHash" ]
   forMachine _dtal (ChainValidationInvalidSignature _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidSignature" ]
   forMachine _dtal (ChainValidationDelegationSchedulingError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationDelegationSchedulingError" ]
   forMachine _dtal (ChainValidationProtocolMagicMismatch _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationProtocolMagicMismatch" ]
   forMachine _dtal ChainValidationSignatureLight =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationSignatureLight" ]
   forMachine _dtal (ChainValidationTooManyDelegations _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationTooManyDelegations" ]
   forMachine _dtal (ChainValidationUpdateError _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUpdateError" ]
   forMachine _dtal (ChainValidationUTxOValidationError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUTxOValidationError" ]
   forMachine _dtal (ChainValidationProofValidationError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationProofValidationError" ]
 
 
 instance LogFormatting (Header ByronBlock) where
   forMachine _dtal b =
-    mkObject $
+    mconcat $
         [ "kind" .= String "ByronBlock"
         , "hash" .= condense (blockHash b)
         , "slotNo" .= condense (blockSlot b)
@@ -208,7 +208,7 @@ instance LogFormatting (Header ByronBlock) where
 
 instance LogFormatting ByronOtherHeaderEnvelopeError where
   forMachine _dtal (UnexpectedEBBInSlot slot) =
-    mkObject
+    mconcat
       [ "kind" .= String "UnexpectedEBBInSlot"
       , "slot" .= slot
       ]

--- a/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
@@ -79,7 +79,7 @@ instance All (Compose LogFormatting GenTx) xs => LogFormatting (GenTx (HardForkB
 instance All (LogFormatting `Compose` WrapApplyTxErr) xs => LogFormatting (HardForkApplyTxErr xs) where
     forMachine dtal (HardForkApplyTxErrFromEra err) = forMachine dtal err
     forMachine _dtal (HardForkApplyTxErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkApplyTxErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "txEra"      .= otherEraName
@@ -105,7 +105,7 @@ instance All (LogFormatting `Compose` WrapLedgerErr) xs => LogFormatting (HardFo
     forMachine dtal (HardForkLedgerErrorFromEra err) = forMachine dtal err
 
     forMachine _dtal (HardForkLedgerErrorWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkLedgerErrorWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -134,7 +134,7 @@ instance ( All (LogFormatting `Compose` WrapLedgerWarning) xs
       HardForkWarningInEra err -> forMachine dtal err
 
       HardForkWarningTransitionMismatch toEra eraParams epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkWarningTransitionMismatch"
           , "toEra"           .= condense toEra
           , "eraParams"       .= forMachine dtal eraParams
@@ -142,20 +142,20 @@ instance ( All (LogFormatting `Compose` WrapLedgerWarning) xs
           ]
 
       HardForkWarningTransitionInFinalEra fromEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkWarningTransitionInFinalEra"
           , "fromEra"         .= condense fromEra
           , "transitionEpoch" .= epoch
           ]
 
       HardForkWarningTransitionUnconfirmed toEra ->
-        mkObject
+        mconcat
           [ "kind"  .= String "HardForkWarningTransitionUnconfirmed"
           , "toEra" .= condense toEra
           ]
 
       HardForkWarningTransitionReconfirmed fromEra toEra prevEpoch newEpoch ->
-        mkObject
+        mconcat
           [ "kind"                .= String "HardForkWarningTransitionReconfirmed"
           , "fromEra"             .= condense fromEra
           , "toEra"               .= condense toEra
@@ -174,7 +174,7 @@ instance LogFormatting (LedgerWarning blk) => LogFormatting (WrapLedgerWarning b
 
 instance LogFormatting EraParams where
     forMachine _dtal EraParams{ eraEpochSize, eraSlotLength, eraSafeZone} =
-      mkObject
+      mconcat
         [ "epochSize"  .= unEpochSize eraEpochSize
         , "slotLength" .= getSlotLength eraSlotLength
         , "safeZone"   .= eraSafeZone
@@ -194,7 +194,7 @@ instance ( All (LogFormatting `Compose` WrapLedgerUpdate) xs
       HardForkUpdateInEra err -> forMachine dtal err
 
       HardForkUpdateTransitionConfirmed fromEra toEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkUpdateTransitionConfirmed"
           , "fromEra"         .= condense fromEra
           , "toEra"           .= condense toEra
@@ -202,7 +202,7 @@ instance ( All (LogFormatting `Compose` WrapLedgerUpdate) xs
           ]
 
       HardForkUpdateTransitionDone fromEra toEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkUpdateTransitionDone"
           , "fromEra"         .= condense fromEra
           , "toEra"           .= condense toEra
@@ -210,7 +210,7 @@ instance ( All (LogFormatting `Compose` WrapLedgerUpdate) xs
           ]
 
       HardForkUpdateTransitionRolledBack fromEra toEra ->
-        mkObject
+        mconcat
           [ "kind"    .= String "HardForkUpdateTransitionRolledBack"
           , "fromEra" .= condense fromEra
           , "toEra"   .= condense toEra
@@ -234,7 +234,7 @@ instance All (LogFormatting `Compose` WrapEnvelopeErr) xs => LogFormatting (Hard
     forMachine dtal (HardForkEnvelopeErrFromEra err) = forMachine dtal err
 
     forMachine _dtal (HardForkEnvelopeErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkEnvelopeErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -260,7 +260,7 @@ instance All (LogFormatting `Compose` WrapValidationErr) xs => LogFormatting (Ha
     forMachine dtal (HardForkValidationErrFromEra err) = forMachine dtal err
 
     forMachine _dtal (HardForkValidationErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkValidationErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -305,7 +305,7 @@ instance LogFormatting (CannotForge blk) => LogFormatting (WrapCannotForge blk) 
 
 instance All (LogFormatting `Compose` WrapForgeStateInfo) xs => LogFormatting (OneEraForgeStateInfo xs) where
     forMachine dtal forgeStateInfo =
-        mkObject
+        mconcat
           [ "kind" .= String "HardForkForgeStateInfo"
           , "forgeStateInfo" .= toJSON forgeStateInfo'
           ]
@@ -331,7 +331,7 @@ instance LogFormatting (ForgeStateInfo blk) => LogFormatting (WrapForgeStateInfo
 
 instance All (LogFormatting `Compose` WrapForgeStateUpdateError) xs => LogFormatting (OneEraForgeStateUpdateError xs) where
     forMachine dtal forgeStateUpdateError =
-        mkObject
+        mconcat
           [ "kind" .= String "HardForkForgeStateUpdateError"
           , "forgeStateUpdateError" .= toJSON forgeStateUpdateError'
           ]

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -18,7 +18,6 @@ module Cardano.Node.Tracing.Era.Shelley () where
 import           Data.Aeson (ToJSON (..), Value (..), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
-import qualified Data.HashMap.Strict as HMS
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
@@ -52,7 +51,7 @@ import qualified Cardano.Ledger.Alonzo as Alonzo
 import           Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail)
 import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo
-import           Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoPredFail (..))
+import           Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.AuxiliaryData as Core
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
@@ -94,6 +93,7 @@ import           Cardano.Protocol.TPraos.Rules.Prtcl
                    PrtlSeqFailure (WrongBlockNoPrtclSeq, WrongBlockSequencePrtclSeq, WrongSlotIntervalPrtclSeq))
 import           Cardano.Protocol.TPraos.Rules.Tickn (TicknPredicateFailure)
 import           Cardano.Tracing.OrphanInstances.Shelley ()
+import qualified Data.Aeson.Key as Aeson
 
 {- HLINT ignore "Use :" -}
 
@@ -106,12 +106,12 @@ instance (  ToJSON (SupportsMempool.TxId (GenTx (ShelleyBlock era)))
          ,  ShelleyBasedEra era)
          => LogFormatting (GenTx (ShelleyBlock era)) where
   forMachine dtal tx =
-    mkObject $
+    mconcat $
         ( "txid" .= txId tx )
       : [ "tx"   .= condense tx | dtal == DDetailed ]
 
 instance ShelleyBasedEra era => LogFormatting (Header (ShelleyBlock era)) where
-  forMachine _dtal b = mkObject
+  forMachine _dtal b = mconcat
         [ "kind" .= String "ShelleyBlock"
         , "hash" .= condense (blockHash b)
         , "slotNo" .= condense (blockSlot b)
@@ -125,17 +125,17 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => LogFormatting (ApplyTxError era) where
   forMachine dtal (ApplyTxError predicateFailures) =
-    HMS.unions $ map (forMachine dtal) predicateFailures
+    mconcat $ map (forMachine dtal) predicateFailures
 
 instance Core.Crypto era => LogFormatting (TPraosCannotForge era) where
   forMachine _dtal (TPraosCannotForgeKeyNotUsableYet wallClockPeriod keyStartPeriod) =
-    mkObject
+    mconcat
       [ "kind" .= String "TPraosCannotForgeKeyNotUsableYet"
       , "keyStart" .= keyStartPeriod
       , "wallClock" .= wallClockPeriod
       ]
   forMachine _dtal (TPraosCannotForgeWrongVRF genDlgVRFHash coreNodeVRFHash) =
-    mkObject
+    mconcat
       [ "kind" .= String "TPraosCannotLeadWrongVRF"
       , "expected" .= genDlgVRFHash
       , "actual" .= coreNodeVRFHash
@@ -149,13 +149,13 @@ instance LogFormatting HotKey.KESInfo where
         kesPeriodsUntilExpiry = max 0 (oCertExpiryKesPeriod - currKesPeriod)
     in
       if kesPeriodsUntilExpiry > 7
-        then mkObject
+        then mconcat
               [ "kind" .= String "KESInfo"
               , "startPeriod" .= startKesPeriod
               , "endPeriod" .= currKesPeriod
               , "evolution" .= endKesPeriod
               ]
-        else mkObject
+        else mconcat
               [ "kind" .= String "ExpiryLogMessage"
               , "keyExpiresIn" .= kesPeriodsUntilExpiry
               , "startPeriod" .= startKesPeriod
@@ -212,13 +212,13 @@ instance LogFormatting HotKey.KESInfo where
 
 instance LogFormatting HotKey.KESEvolutionError where
   forMachine dtal (HotKey.KESCouldNotEvolve kesInfo targetPeriod) =
-    mkObject
+    mconcat
       [ "kind" .= String "KESCouldNotEvolve"
       , "kesInfo" .= forMachine dtal kesInfo
       , "targetPeriod" .= targetPeriod
       ]
   forMachine dtal (HotKey.KESKeyAlreadyPoisoned kesInfo targetPeriod) =
-    mkObject
+    mconcat
       [ "kind" .= String "KESKeyAlreadyPoisoned"
       , "kesInfo" .= forMachine dtal kesInfo
       , "targetPeriod" .= targetPeriod
@@ -230,7 +230,7 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "BBODY" era))
          ) => LogFormatting (ShelleyLedgerError era) where
   forMachine dtal (BBodyError (BlockTransitionError fs)) =
-    mkObject [ "kind" .= String "BBodyError"
+    mconcat [ "kind" .= String "BBodyError"
              , "failures" .= map (forMachine dtal) fs
              ]
 
@@ -238,50 +238,50 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.PParamsDelta era)
          ) => LogFormatting (ShelleyLedgerUpdate era) where
   forMachine dtal (ShelleyUpdatedProtocolUpdates updates) =
-    mkObject [ "kind" .= String "ShelleyUpdatedProtocolUpdates"
+    mconcat [ "kind" .= String "ShelleyUpdatedProtocolUpdates"
              , "updates" .= map (forMachine dtal) updates
              ]
 
 instance (Ledger.Era era, ToJSON (Core.PParamsDelta era))
          => LogFormatting (ProtocolUpdate era) where
   forMachine dtal ProtocolUpdate{protocolUpdateProposal, protocolUpdateState} =
-    mkObject [ "proposal" .= forMachine dtal protocolUpdateProposal
+    mconcat [ "proposal" .= forMachine dtal protocolUpdateProposal
              , "state"    .= forMachine dtal protocolUpdateState
              ]
 
 instance ToJSON (Core.PParamsDelta era)
          => LogFormatting (UpdateProposal era) where
   forMachine _dtal UpdateProposal{proposalParams, proposalVersion, proposalEpoch} =
-    mkObject [ "params"  .= proposalParams
+    mconcat [ "params"  .= proposalParams
              , "version" .= proposalVersion
              , "epoch"   .= proposalEpoch
              ]
 
 instance Core.Crypto crypto => LogFormatting (UpdateState crypto) where
   forMachine _dtal UpdateState{proposalVotes, proposalReachedQuorum} =
-    mkObject [ "proposal"      .= proposalVotes
+    mconcat [ "proposal"      .= proposalVotes
              , "reachedQuorum" .= proposalReachedQuorum
              ]
 
 instance Core.Crypto crypto => LogFormatting (ChainTransitionError crypto) where
   forMachine dtal (ChainTransitionError fs) =
-    mkObject [ "kind" .= String "ChainTransitionError"
+    mconcat [ "kind" .= String "ChainTransitionError"
              , "failures" .= map (forMachine dtal) fs
              ]
 
 instance LogFormatting ChainPredicateFailure where
   forMachine _dtal (HeaderSizeTooLargeCHAIN hdrSz maxHdrSz) =
-    mkObject [ "kind" .= String "HeaderSizeTooLarge"
+    mconcat [ "kind" .= String "HeaderSizeTooLarge"
              , "headerSize" .= hdrSz
              , "maxHeaderSize" .= maxHdrSz
              ]
   forMachine _dtal (BlockSizeTooLargeCHAIN blkSz maxBlkSz) =
-    mkObject [ "kind" .= String "BlockSizeTooLarge"
+    mconcat [ "kind" .= String "BlockSizeTooLarge"
              , "blockSize" .= blkSz
              , "maxBlockSize" .= maxBlkSz
              ]
   forMachine _dtal (ObsoleteNodeCHAIN currentPtcl supportedPtcl) =
-    mkObject [ "kind" .= String "ObsoleteNode"
+    mconcat [ "kind" .= String "ObsoleteNode"
              , "explanation" .= String explanation
              , "currentProtocol" .= currentPtcl
              , "supportedProtocol" .= supportedPtcl ]
@@ -294,17 +294,17 @@ instance LogFormatting ChainPredicateFailure where
 
 instance LogFormatting (PrtlSeqFailure crypto) where
   forMachine _dtal (WrongSlotIntervalPrtclSeq (SlotNo lastSlot) (SlotNo currSlot)) =
-    mkObject [ "kind" .= String "WrongSlotInterval"
+    mconcat [ "kind" .= String "WrongSlotInterval"
              , "lastSlot" .= lastSlot
              , "currentSlot" .= currSlot
              ]
   forMachine _dtal (WrongBlockNoPrtclSeq lab currentBlockNo) =
-    mkObject [ "kind" .= String "WrongBlockNo"
+    mconcat [ "kind" .= String "WrongBlockNo"
              , "lastAppliedBlockNo" .= showLastAppBlockNo lab
              , "currentBlockNo" .= (String . textShow $ unBlockNo currentBlockNo)
              ]
   forMachine _dtal (WrongBlockSequencePrtclSeq lastAppliedHash currentHash) =
-    mkObject [ "kind" .= String "WrongBlockSequence"
+    mconcat [ "kind" .= String "WrongBlockSequence"
              , "lastAppliedBlockHash" .= String (textShow lastAppliedHash)
              , "currentBlockHash" .= String (textShow currentHash)
              ]
@@ -316,12 +316,12 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGERS" era))
          ) => LogFormatting (BbodyPredicateFailure era) where
   forMachine _dtal (WrongBlockBodySizeBBODY actualBodySz claimedBodySz) =
-    mkObject [ "kind" .= String "WrongBlockBodySizeBBODY"
+    mconcat [ "kind" .= String "WrongBlockBodySizeBBODY"
              , "actualBlockBodySize" .= actualBodySz
              , "claimedBlockBodySize" .= claimedBodySz
              ]
   forMachine _dtal (InvalidBodyHashBBODY actualHash claimedHash) =
-    mkObject [ "kind" .= String "InvalidBodyHashBBODY"
+    mconcat [ "kind" .= String "InvalidBodyHashBBODY"
              , "actualBodyHash" .= textShow actualHash
              , "claimedBodyHash" .= textShow claimedHash
              ]
@@ -346,42 +346,42 @@ instance ( ShelleyBasedEra era
   forMachine dtal (UtxowFailure f)  = forMachine dtal f
   forMachine dtal (DelegsFailure f) = forMachine dtal f
 
-instance LogFormatting (AlonzoPredFail (Alonzo.AlonzoEra StandardCrypto)) where
+instance LogFormatting (UtxowPredicateFail (Alonzo.AlonzoEra StandardCrypto)) where
   forMachine dtal (WrappedShelleyEraFailure utxoPredFail) =
     forMachine dtal utxoPredFail
   forMachine _ (MissingRedeemers scripts) =
-    mkObject [ "kind" .= String "MissingRedeemers"
+    mconcat [ "kind" .= String "MissingRedeemers"
              , "scripts" .= renderMissingRedeemers scripts
              ]
   forMachine _ (MissingRequiredDatums required received) =
-    mkObject [ "kind" .= String "MissingRequiredDatums"
+    mconcat [ "kind" .= String "MissingRequiredDatums"
              , "required" .= map (Crypto.hashToTextAsHex . SafeHash.extractHash)
                                  (Set.toList required)
              , "received" .= map (Crypto.hashToTextAsHex . SafeHash.extractHash)
                                  (Set.toList received)
              ]
   forMachine _ (PPViewHashesDontMatch ppHashInTxBody ppHashFromPParams) =
-    mkObject [ "kind" .= String "PPViewHashesDontMatch"
+    mconcat [ "kind" .= String "PPViewHashesDontMatch"
              , "fromTxBody" .= renderScriptIntegrityHash
                                   (strictMaybeToMaybe ppHashInTxBody)
              , "fromPParams" .= renderScriptIntegrityHash
                                   (strictMaybeToMaybe ppHashFromPParams)
              ]
   forMachine _ (MissingRequiredSigners missingKeyWitnesses) =
-    mkObject [ "kind" .= String "MissingRequiredSigners"
+    mconcat [ "kind" .= String "MissingRequiredSigners"
              , "witnesses" .= Set.toList missingKeyWitnesses
              ]
   forMachine _ (UnspendableUTxONoDatumHash txins) =
-    mkObject [ "kind" .= String "MissingRequiredSigners"
+    mconcat [ "kind" .= String "MissingRequiredSigners"
              , "txins" .= Set.toList txins
              ]
   forMachine _ (NonOutputSupplimentaryDatums disallowed acceptable) =
-    mkObject [ "kind" .= String "NonOutputSupplimentaryDatums"
+    mconcat [ "kind" .= String "NonOutputSupplimentaryDatums"
              , "disallowed" .= Set.toList disallowed
              , "acceptable" .= Set.toList acceptable
              ]
   forMachine _ (ExtraRedeemers rdmrs) =
-    mkObject [ "kind" .= String "ExtraRedeemers"
+    mconcat [ "kind" .= String "ExtraRedeemers"
              , "rdmrs" .= map (Api.renderScriptWitnessIndex . Api.fromAlonzoRdmrPtr) rdmrs
              ]
 
@@ -398,7 +398,8 @@ renderMissingRedeemers :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash Stan
 renderMissingRedeemers scripts = Aeson.object $ map renderTuple  scripts
  where
   renderTuple :: (Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto) -> Aeson.Pair
-  renderTuple (scriptPurpose, sHash) =  renderScriptHash sHash .= renderScriptPurpose scriptPurpose
+  renderTuple (scriptPurpose, sHash) =
+    Aeson.fromText (renderScriptHash sHash) .= renderScriptPurpose scriptPurpose
 
 renderScriptPurpose :: Alonzo.ScriptPurpose StandardCrypto -> Aeson.Value
 renderScriptPurpose (Alonzo.Minting pid) =
@@ -418,44 +419,44 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "UTXO" era))
          ) => LogFormatting (UtxowPredicateFailure era) where
   forMachine _dtal (InvalidWitnessesUTXOW wits') =
-    mkObject [ "kind" .= String "InvalidWitnessesUTXOW"
+    mconcat [ "kind" .= String "InvalidWitnessesUTXOW"
              , "invalidWitnesses" .= map textShow wits'
              ]
   forMachine _dtal (MissingVKeyWitnessesUTXOW (WitHashes wits')) =
-    mkObject [ "kind" .= String "MissingVKeyWitnessesUTXOW"
+    mconcat [ "kind" .= String "MissingVKeyWitnessesUTXOW"
              , "missingWitnesses" .= wits'
              ]
   forMachine _dtal (MissingScriptWitnessesUTXOW missingScripts) =
-    mkObject [ "kind" .= String "MissingScriptWitnessesUTXOW"
+    mconcat [ "kind" .= String "MissingScriptWitnessesUTXOW"
              , "missingScripts" .= missingScripts
              ]
   forMachine _dtal (ScriptWitnessNotValidatingUTXOW failedScripts) =
-    mkObject [ "kind" .= String "ScriptWitnessNotValidatingUTXOW"
+    mconcat [ "kind" .= String "ScriptWitnessNotValidatingUTXOW"
              , "failedScripts" .= failedScripts
              ]
   forMachine dtal (UtxoFailure f) = forMachine dtal f
   forMachine _dtal (MIRInsufficientGenesisSigsUTXOW genesisSigs) =
-    mkObject [ "kind" .= String "MIRInsufficientGenesisSigsUTXOW"
+    mconcat [ "kind" .= String "MIRInsufficientGenesisSigsUTXOW"
              , "genesisSigs" .= genesisSigs
              ]
   forMachine _dtal (MissingTxBodyMetadataHash metadataHash) =
-    mkObject [ "kind" .= String "MissingTxBodyMetadataHash"
+    mconcat [ "kind" .= String "MissingTxBodyMetadataHash"
              , "metadataHash" .= metadataHash
              ]
   forMachine _dtal (MissingTxMetadata txBodyMetadataHash) =
-    mkObject [ "kind" .= String "MissingTxMetadata"
+    mconcat [ "kind" .= String "MissingTxMetadata"
              , "txBodyMetadataHash" .= txBodyMetadataHash
              ]
   forMachine _dtal (ConflictingMetadataHash txBodyMetadataHash fullMetadataHash) =
-    mkObject [ "kind" .= String "ConflictingMetadataHash"
+    mconcat [ "kind" .= String "ConflictingMetadataHash"
              , "txBodyMetadataHash" .= txBodyMetadataHash
              , "fullMetadataHash" .= fullMetadataHash
              ]
   forMachine _dtal InvalidMetadata =
-    mkObject [ "kind" .= String "InvalidMetadata"
+    mconcat [ "kind" .= String "InvalidMetadata"
              ]
   forMachine _dtal (ExtraneousScriptWitnessesUTXOW shashes) =
-    mkObject [ "kind" .= String "ExtraneousScriptWitnessesUTXOW"
+    mconcat [ "kind" .= String "ExtraneousScriptWitnessesUTXOW"
              , "scriptHashes" .= Set.map Api.fromShelleyScriptHash shashes
              ]
 
@@ -466,38 +467,38 @@ instance ( ShelleyBasedEra era
          )
       => LogFormatting (UtxoPredicateFailure era) where
   forMachine _dtal (BadInputsUTxO badInputs) =
-    mkObject [ "kind" .= String "BadInputsUTxO"
+    mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
              , "error" .= renderBadInputsUTxOErr badInputs
              ]
   forMachine _dtal (ExpiredUTxO ttl slot) =
-    mkObject [ "kind" .= String "ExpiredUTxO"
+    mconcat [ "kind" .= String "ExpiredUTxO"
              , "ttl"  .= ttl
              , "slot" .= slot ]
   forMachine _dtal (MaxTxSizeUTxO txsize maxtxsize) =
-    mkObject [ "kind" .= String "MaxTxSizeUTxO"
+    mconcat [ "kind" .= String "MaxTxSizeUTxO"
              , "size" .= txsize
              , "maxSize" .= maxtxsize ]
   -- TODO: Add the minimum allowed UTxO value to OutputTooSmallUTxO
   forMachine _dtal (OutputTooSmallUTxO badOutputs) =
-    mkObject [ "kind" .= String "OutputTooSmallUTxO"
+    mconcat [ "kind" .= String "OutputTooSmallUTxO"
              , "outputs" .= badOutputs
              , "error" .= String "The output is smaller than the allow minimum \
                                  \UTxO value defined in the protocol parameters"
              ]
   forMachine _dtal (OutputBootAddrAttrsTooBig badOutputs) =
-    mkObject [ "kind" .= String "OutputBootAddrAttrsTooBig"
+    mconcat [ "kind" .= String "OutputBootAddrAttrsTooBig"
              , "outputs" .= badOutputs
              , "error" .= String "The Byron address attributes are too big"
              ]
   forMachine _dtal InputSetEmptyUTxO =
-    mkObject [ "kind" .= String "InputSetEmptyUTxO" ]
+    mconcat [ "kind" .= String "InputSetEmptyUTxO" ]
   forMachine _dtal (FeeTooSmallUTxO minfee txfee) =
-    mkObject [ "kind" .= String "FeeTooSmallUTxO"
+    mconcat [ "kind" .= String "FeeTooSmallUTxO"
              , "minimum" .= minfee
              , "fee" .= txfee ]
   forMachine _dtal (ValueNotConservedUTxO consumed produced) =
-    mkObject [ "kind" .= String "ValueNotConservedUTxO"
+    mconcat [ "kind" .= String "ValueNotConservedUTxO"
              , "consumed" .= consumed
              , "produced" .= produced
              , "error" .= renderValueNotConservedErr consumed produced
@@ -505,12 +506,12 @@ instance ( ShelleyBasedEra era
   forMachine dtal (UpdateFailure f) = forMachine dtal f
 
   forMachine _dtal (WrongNetwork network addrs) =
-    mkObject [ "kind" .= String "WrongNetwork"
+    mconcat [ "kind" .= String "WrongNetwork"
              , "network" .= network
              , "addrs"   .= addrs
              ]
   forMachine _dtal (WrongNetworkWithdrawal network addrs) =
-    mkObject [ "kind" .= String "WrongNetworkWithdrawal"
+    mconcat [ "kind" .= String "WrongNetworkWithdrawal"
              , "network" .= network
              , "addrs"   .= addrs
              ]
@@ -522,57 +523,57 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "PPUP" era))
          ) => LogFormatting (MA.UtxoPredicateFailure era) where
   forMachine _dtal (MA.BadInputsUTxO badInputs) =
-    mkObject [ "kind" .= String "BadInputsUTxO"
+    mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
              , "error" .= renderBadInputsUTxOErr badInputs
              ]
   forMachine _dtal (MA.OutsideValidityIntervalUTxO validityInterval slot) =
-    mkObject [ "kind" .= String "ExpiredUTxO"
+    mconcat [ "kind" .= String "ExpiredUTxO"
              , "validityInterval" .= validityInterval
              , "slot" .= slot ]
   forMachine _dtal (MA.MaxTxSizeUTxO txsize maxtxsize) =
-    mkObject [ "kind" .= String "MaxTxSizeUTxO"
+    mconcat [ "kind" .= String "MaxTxSizeUTxO"
              , "size" .= txsize
              , "maxSize" .= maxtxsize ]
   forMachine _dtal MA.InputSetEmptyUTxO =
-    mkObject [ "kind" .= String "InputSetEmptyUTxO" ]
+    mconcat [ "kind" .= String "InputSetEmptyUTxO" ]
   forMachine _dtal (MA.FeeTooSmallUTxO minfee txfee) =
-    mkObject [ "kind" .= String "FeeTooSmallUTxO"
+    mconcat [ "kind" .= String "FeeTooSmallUTxO"
              , "minimum" .= minfee
              , "fee" .= txfee ]
   forMachine _dtal (MA.ValueNotConservedUTxO consumed produced) =
-    mkObject [ "kind" .= String "ValueNotConservedUTxO"
+    mconcat [ "kind" .= String "ValueNotConservedUTxO"
              , "consumed" .= consumed
              , "produced" .= produced
              , "error" .= renderValueNotConservedErr consumed produced
              ]
   forMachine _dtal (MA.WrongNetwork network addrs) =
-    mkObject [ "kind" .= String "WrongNetwork"
+    mconcat [ "kind" .= String "WrongNetwork"
              , "network" .= network
              , "addrs"   .= addrs
              ]
   forMachine _dtal (MA.WrongNetworkWithdrawal network addrs) =
-    mkObject [ "kind" .= String "WrongNetworkWithdrawal"
+    mconcat [ "kind" .= String "WrongNetworkWithdrawal"
              , "network" .= network
              , "addrs"   .= addrs
              ]
   -- TODO: Add the minimum allowed UTxO value to OutputTooSmallUTxO
   forMachine _dtal (MA.OutputTooSmallUTxO badOutputs) =
-    mkObject [ "kind" .= String "OutputTooSmallUTxO"
+    mconcat [ "kind" .= String "OutputTooSmallUTxO"
              , "outputs" .= badOutputs
              , "error" .= String "The output is smaller than the allow minimum \
                                  \UTxO value defined in the protocol parameters"
              ]
   forMachine dtal (MA.UpdateFailure f) = forMachine dtal f
   forMachine _dtal (MA.OutputBootAddrAttrsTooBig badOutputs) =
-    mkObject [ "kind" .= String "OutputBootAddrAttrsTooBig"
+    mconcat [ "kind" .= String "OutputBootAddrAttrsTooBig"
              , "outputs" .= badOutputs
              , "error" .= String "The Byron address attributes are too big"
              ]
   forMachine _dtal MA.TriesToForgeADA =
-    mkObject [ "kind" .= String "TriesToForgeADA" ]
+    mconcat [ "kind" .= String "TriesToForgeADA" ]
   forMachine _dtal (MA.OutputTooBigUTxO badOutputs) =
-    mkObject [ "kind" .= String "OutputTooBigUTxO"
+    mconcat [ "kind" .= String "OutputTooBigUTxO"
              , "outputs" .= badOutputs
              , "error" .= String "Too many asset ids in the tx output"
              ]
@@ -588,16 +589,16 @@ renderValueNotConservedErr consumed produced = String $
 
 instance Core.Crypto (Ledger.Crypto era) => LogFormatting (PpupPredicateFailure era) where
   forMachine _dtal (NonGenesisUpdatePPUP proposalKeys genesisKeys) =
-    mkObject [ "kind" .= String "NonGenesisUpdatePPUP"
+    mconcat [ "kind" .= String "NonGenesisUpdatePPUP"
              , "keys" .= proposalKeys Set.\\ genesisKeys ]
   forMachine _dtal (PPUpdateWrongEpoch currEpoch intendedEpoch votingPeriod) =
-    mkObject [ "kind" .= String "PPUpdateWrongEpoch"
+    mconcat [ "kind" .= String "PPUpdateWrongEpoch"
              , "currentEpoch" .= currEpoch
              , "intendedEpoch" .= intendedEpoch
              , "votingPeriod"  .= String (show votingPeriod)
              ]
   forMachine _dtal (PVCannotFollowPPUP badPv) =
-    mkObject [ "kind" .= String "PVCannotFollowPPUP"
+    mconcat [ "kind" .= String "PVCannotFollowPPUP"
              , "badProtocolVersion" .= badPv
              ]
 
@@ -606,11 +607,11 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "DELPL" era))
          ) => LogFormatting (DelegsPredicateFailure era) where
   forMachine _dtal (DelegateeNotRegisteredDELEG targetPool) =
-    mkObject [ "kind" .= String "DelegateeNotRegisteredDELEG"
+    mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
              , "targetPool" .= targetPool
              ]
   forMachine _dtal (WithdrawalsNotInRewardsDELEGS incorrectWithdrawals) =
-    mkObject [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
+    mconcat [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
              , "incorrectWithdrawals" .= incorrectWithdrawals
              ]
   forMachine dtal (DelplFailure f) = forMachine dtal f
@@ -626,43 +627,43 @@ instance ( LogFormatting (PredicateFailure (Core.EraRule "POOL" era))
 instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
           => LogFormatting (DelegPredicateFailure era) where
   forMachine _dtal (StakeKeyAlreadyRegisteredDELEG alreadyRegistered) =
-    mkObject [ "kind" .= String "StakeKeyAlreadyRegisteredDELEG"
+    mconcat [ "kind" .= String "StakeKeyAlreadyRegisteredDELEG"
              , "credential" .= String (textShow alreadyRegistered)
              , "error" .= String "Staking credential already registered"
              ]
   forMachine _dtal (StakeKeyInRewardsDELEG alreadyRegistered) =
-    mkObject [ "kind" .= String "StakeKeyInRewardsDELEG"
+    mconcat [ "kind" .= String "StakeKeyInRewardsDELEG"
              , "credential" .= String (textShow alreadyRegistered)
              , "error" .= String "Staking credential registered in rewards map"
              ]
   forMachine _dtal (StakeKeyNotRegisteredDELEG notRegistered) =
-    mkObject [ "kind" .= String "StakeKeyNotRegisteredDELEG"
+    mconcat [ "kind" .= String "StakeKeyNotRegisteredDELEG"
              , "credential" .= String (textShow notRegistered)
              , "error" .= String "Staking credential not registered"
              ]
   forMachine _dtal (StakeKeyNonZeroAccountBalanceDELEG remBalance) =
-    mkObject [ "kind" .= String "StakeKeyNonZeroAccountBalanceDELEG"
+    mconcat [ "kind" .= String "StakeKeyNonZeroAccountBalanceDELEG"
              , "remainingBalance" .= remBalance
              ]
   forMachine _dtal (StakeDelegationImpossibleDELEG unregistered) =
-    mkObject [ "kind" .= String "StakeDelegationImpossibleDELEG"
+    mconcat [ "kind" .= String "StakeDelegationImpossibleDELEG"
              , "credential" .= String (textShow unregistered)
              , "error" .= String "Cannot delegate this stake credential because it is not registered"
              ]
   forMachine _dtal WrongCertificateTypeDELEG =
-    mkObject [ "kind" .= String "WrongCertificateTypeDELEG" ]
+    mconcat [ "kind" .= String "WrongCertificateTypeDELEG" ]
   forMachine _dtal (GenesisKeyNotInMappingDELEG (KeyHash genesisKeyHash)) =
-    mkObject [ "kind" .= String "GenesisKeyNotInMappingDELEG"
+    mconcat [ "kind" .= String "GenesisKeyNotInMappingDELEG"
              , "unknownKeyHash" .= String (textShow genesisKeyHash)
              , "error" .= String "This genesis key is not in the delegation mapping"
              ]
   forMachine _dtal (DuplicateGenesisDelegateDELEG (KeyHash genesisKeyHash)) =
-    mkObject [ "kind" .= String "DuplicateGenesisDelegateDELEG"
+    mconcat [ "kind" .= String "DuplicateGenesisDelegateDELEG"
              , "duplicateKeyHash" .= String (textShow genesisKeyHash)
              , "error" .= String "This genesis key has already been delegated to"
              ]
   forMachine _dtal (InsufficientForInstantaneousRewardsDELEG mirpot neededMirAmount reserves) =
-    mkObject [ "kind" .= String "InsufficientForInstantaneousRewardsDELEG"
+    mconcat [ "kind" .= String "InsufficientForInstantaneousRewardsDELEG"
              , "pot" .= String (case mirpot of
                                   ReservesMIR -> "Reserves"
                                   TreasuryMIR -> "Treasury")
@@ -670,22 +671,22 @@ instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
              , "reserves" .= reserves
              ]
   forMachine _dtal (MIRCertificateTooLateinEpochDELEG currSlot boundSlotNo) =
-    mkObject [ "kind" .= String "MIRCertificateTooLateinEpochDELEG"
+    mconcat [ "kind" .= String "MIRCertificateTooLateinEpochDELEG"
              , "currentSlotNo" .= currSlot
              , "mustBeSubmittedBeforeSlotNo" .= boundSlotNo
              ]
   forMachine _dtal (DuplicateGenesisVRFDELEG vrfKeyHash) =
-    mkObject [ "kind" .= String "DuplicateGenesisVRFDELEG"
+    mconcat [ "kind" .= String "DuplicateGenesisVRFDELEG"
              , "keyHash" .= vrfKeyHash
              ]
   forMachine _dtal MIRTransferNotCurrentlyAllowed =
-    mkObject [ "kind" .= String "MIRTransferNotCurrentlyAllowed"
+    mconcat [ "kind" .= String "MIRTransferNotCurrentlyAllowed"
              ]
   forMachine _dtal MIRNegativesNotCurrentlyAllowed =
-    mkObject [ "kind" .= String "MIRNegativesNotCurrentlyAllowed"
+    mconcat [ "kind" .= String "MIRNegativesNotCurrentlyAllowed"
              ]
   forMachine _dtal (InsufficientForTransferDELEG mirpot attempted available) =
-    mkObject [ "kind" .= String "DuplicateGenesisVRFDELEG"
+    mconcat [ "kind" .= String "DuplicateGenesisVRFDELEG"
              , "pot" .= String (case mirpot of
                                   ReservesMIR -> "Reserves"
                                   TreasuryMIR -> "Treasury")
@@ -693,10 +694,10 @@ instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
              , "available" .= available
              ]
   forMachine _dtal MIRProducesNegativeUpdate =
-    mkObject [ "kind" .= String "MIRProducesNegativeUpdate"
+    mconcat [ "kind" .= String "MIRProducesNegativeUpdate"
              ]
   forMachine _dtal (MIRNegativeTransfer mirpot coin) =
-    mkObject [ "kind" .= String "MIRProducesNegativeUpdate"
+    mconcat [ "kind" .= String "MIRProducesNegativeUpdate"
              , "pot" .= String (case mirpot of
                                   ReservesMIR -> "Reserves"
                                   TreasuryMIR -> "Treasury")
@@ -705,24 +706,24 @@ instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
 
 instance LogFormatting (PoolPredicateFailure era) where
   forMachine _dtal (StakePoolNotRegisteredOnKeyPOOL (KeyHash unregStakePool)) =
-    mkObject [ "kind" .= String "StakePoolNotRegisteredOnKeyPOOL"
+    mconcat [ "kind" .= String "StakePoolNotRegisteredOnKeyPOOL"
              , "unregisteredKeyHash" .= String (textShow unregStakePool)
              , "error" .= String "This stake pool key hash is unregistered"
              ]
   forMachine _dtal (StakePoolRetirementWrongEpochPOOL currentEpoch intendedRetireEpoch maxRetireEpoch) =
-    mkObject [ "kind" .= String "StakePoolRetirementWrongEpochPOOL"
+    mconcat [ "kind" .= String "StakePoolRetirementWrongEpochPOOL"
              , "currentEpoch" .= String (textShow currentEpoch)
              , "intendedRetirementEpoch" .= String (textShow intendedRetireEpoch)
              , "maxEpochForRetirement" .= String (textShow maxRetireEpoch)
              ]
   forMachine _dtal (StakePoolCostTooLowPOOL certCost protCost) =
-    mkObject [ "kind" .= String "StakePoolCostTooLowPOOL"
+    mconcat [ "kind" .= String "StakePoolCostTooLowPOOL"
              , "certificateCost" .= String (textShow certCost)
              , "protocolParCost" .= String (textShow protCost)
              , "error" .= String "The stake pool cost is too low"
              ]
   forMachine _dtal (PoolMedataHashTooBig poolID hashSize) =
-    mkObject [ "kind" .= String "PoolMedataHashTooBig"
+    mconcat [ "kind" .= String "PoolMedataHashTooBig"
              , "hashSize" .= String (textShow poolID)
              , "poolID" .= String (textShow hashSize)
              , "error" .= String "The stake pool metadata hash is too large"
@@ -731,22 +732,22 @@ instance LogFormatting (PoolPredicateFailure era) where
 -- Apparently this should never happen according to the Shelley exec spec
   forMachine _dtal (WrongCertificateTypePOOL index) =
     case index of
-      0 -> mkObject [ "kind" .= String "WrongCertificateTypePOOL"
+      0 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
                     , "error" .= String "Wrong certificate type: Delegation certificate"
                     ]
-      1 -> mkObject [ "kind" .= String "WrongCertificateTypePOOL"
+      1 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
                     , "error" .= String "Wrong certificate type: MIR certificate"
                     ]
-      2 -> mkObject [ "kind" .= String "WrongCertificateTypePOOL"
+      2 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
                     , "error" .= String "Wrong certificate type: Genesis certificate"
                     ]
-      k -> mkObject [ "kind" .= String "WrongCertificateTypePOOL"
+      k -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
                     , "certificateType" .= k
                     , "error" .= String "Wrong certificate type: Unknown certificate type"
                     ]
 
   forMachine _dtal (WrongNetworkPOOL networkId listedNetworkId poolId) =
-    mkObject [ "kind" .= String "WrongNetworkPOOL"
+    mconcat [ "kind" .= String "WrongNetworkPOOL"
              , "networkId" .= String (textShow networkId)
              , "listedNetworkId" .= String (textShow listedNetworkId)
              , "poolId" .= String (textShow poolId)
@@ -769,7 +770,7 @@ instance ( LogFormatting (PredicateFailure (Core.EraRule "EPOCH" era))
   forMachine dtal (EpochFailure f) = forMachine dtal f
   forMachine dtal (MirFailure f) = forMachine dtal f
   forMachine _dtal (CorruptRewardUpdate update) =
-    mkObject [ "kind" .= String "CorruptRewardUpdate"
+    mconcat [ "kind" .= String "CorruptRewardUpdate"
              , "update" .= String (show update) ]
 
 
@@ -792,7 +793,7 @@ instance LogFormatting (SnapPredicateFailure era) where
 -- TODO: Need to elaborate more on this error
 instance LogFormatting (NewppPredicateFailure era) where
   forMachine _dtal (UnexpectedDepositPot outstandingDeposits depositPot) =
-    mkObject [ "kind" .= String "UnexpectedDepositPot"
+    mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "outstandingDeposits" .= String (textShow outstandingDeposits)
              , "depositPot" .= String (textShow depositPot)
              ]
@@ -813,51 +814,51 @@ instance Core.Crypto crypto => LogFormatting (PrtclPredicateFailure crypto) wher
 
 instance Core.Crypto crypto => LogFormatting (OverlayPredicateFailure crypto) where
   forMachine _dtal (UnknownGenesisKeyOVERLAY (KeyHash genKeyHash)) =
-    mkObject [ "kind" .= String "UnknownGenesisKeyOVERLAY"
+    mconcat [ "kind" .= String "UnknownGenesisKeyOVERLAY"
              , "unknownKeyHash" .= String (textShow genKeyHash)
              ]
   forMachine _dtal (VRFKeyBadLeaderValue seedNonce (SlotNo currSlotNo) prevHashNonce leaderElecVal) =
-    mkObject [ "kind" .= String "VRFKeyBadLeaderValueOVERLAY"
+    mconcat [ "kind" .= String "VRFKeyBadLeaderValueOVERLAY"
              , "seedNonce" .= String (textShow seedNonce)
              , "currentSlot" .= String (textShow currSlotNo)
              , "previousHashAsNonce" .= String (textShow prevHashNonce)
              , "leaderElectionValue" .= String (textShow leaderElecVal)
              ]
   forMachine _dtal (VRFKeyBadNonce seedNonce (SlotNo currSlotNo) prevHashNonce blockNonce) =
-    mkObject [ "kind" .= String "VRFKeyBadNonceOVERLAY"
+    mconcat [ "kind" .= String "VRFKeyBadNonceOVERLAY"
              , "seedNonce" .= String (textShow seedNonce)
              , "currentSlot" .= String (textShow currSlotNo)
              , "previousHashAsNonce" .= String (textShow prevHashNonce)
              , "blockNonce" .= String (textShow blockNonce)
              ]
   forMachine _dtal (VRFKeyWrongVRFKey issuerHash regVRFKeyHash unregVRFKeyHash) =
-    mkObject [ "kind" .= String "VRFKeyWrongVRFKeyOVERLAY"
+    mconcat [ "kind" .= String "VRFKeyWrongVRFKeyOVERLAY"
              , "poolHash" .= textShow issuerHash
              , "registeredVRFKeHash" .= textShow regVRFKeyHash
              , "unregisteredVRFKeyHash" .= textShow unregVRFKeyHash
              ]
   --TODO: Pipe slot number with VRFKeyUnknown
   forMachine _dtal (VRFKeyUnknown (KeyHash kHash)) =
-    mkObject [ "kind" .= String "VRFKeyUnknownOVERLAY"
+    mconcat [ "kind" .= String "VRFKeyUnknownOVERLAY"
              , "keyHash" .= String (textShow kHash)
              ]
   forMachine _dtal (VRFLeaderValueTooBig leadElecVal weightOfDelegPool actSlotCoefff) =
-    mkObject [ "kind" .= String "VRFLeaderValueTooBigOVERLAY"
+    mconcat [ "kind" .= String "VRFLeaderValueTooBigOVERLAY"
              , "leaderElectionValue" .= String (textShow leadElecVal)
              , "delegationPoolWeight" .= String (textShow weightOfDelegPool)
              , "activeSlotCoefficient" .= String (textShow actSlotCoefff)
              ]
   forMachine _dtal (NotActiveSlotOVERLAY notActiveSlotNo) =
     -- TODO: Elaborate on NotActiveSlot error
-    mkObject [ "kind" .= String "NotActiveSlotOVERLAY"
+    mconcat [ "kind" .= String "NotActiveSlotOVERLAY"
              , "slot" .= String (textShow notActiveSlotNo)
              ]
   forMachine _dtal (WrongGenesisColdKeyOVERLAY actual expected) =
-    mkObject [ "kind" .= String "WrongGenesisColdKeyOVERLAY"
+    mconcat [ "kind" .= String "WrongGenesisColdKeyOVERLAY"
              , "actual" .= actual
              , "expected" .= expected ]
   forMachine _dtal (WrongGenesisVRFKeyOVERLAY issuer actual expected) =
-    mkObject [ "kind" .= String "WrongGenesisVRFKeyOVERLAY"
+    mconcat [ "kind" .= String "WrongGenesisVRFKeyOVERLAY"
              , "issuer" .= issuer
              , "actual" .= actual
              , "expected" .= expected ]
@@ -866,14 +867,14 @@ instance Core.Crypto crypto => LogFormatting (OverlayPredicateFailure crypto) wh
 
 instance LogFormatting (OcertPredicateFailure crypto) where
   forMachine _dtal (KESBeforeStartOCERT (KESPeriod oCertstart) (KESPeriod current)) =
-    mkObject [ "kind" .= String "KESBeforeStartOCERT"
+    mconcat [ "kind" .= String "KESBeforeStartOCERT"
              , "opCertKESStartPeriod" .= String (textShow oCertstart)
              , "currentKESPeriod" .= String (textShow current)
              , "error" .= String "Your operational certificate's KES start period \
                                  \is before the KES current period."
              ]
   forMachine _dtal (KESAfterEndOCERT (KESPeriod current) (KESPeriod oCertstart) maxKESEvolutions) =
-    mkObject [ "kind" .= String "KESAfterEndOCERT"
+    mconcat [ "kind" .= String "KESAfterEndOCERT"
              , "currentKESPeriod" .= String (textShow current)
              , "opCertKESStartPeriod" .= String (textShow oCertstart)
              , "maxKESEvolutions" .= String  (textShow maxKESEvolutions)
@@ -881,25 +882,25 @@ instance LogFormatting (OcertPredicateFailure crypto) where
                                  \greater than the max number of KES + the KES current period"
              ]
   forMachine _dtal (CounterTooSmallOCERT lastKEScounterUsed currentKESCounter) =
-    mkObject [ "kind" .= String "CounterTooSmallOCert"
+    mconcat [ "kind" .= String "CounterTooSmallOCert"
              , "currentKESCounter" .= String (textShow currentKESCounter)
              , "lastKESCounter" .= String (textShow lastKEScounterUsed)
              , "error" .= String "The operational certificate's last KES counter is greater \
                                  \than the current KES counter."
              ]
   forMachine _dtal (InvalidSignatureOCERT oCertCounter oCertKESStartPeriod) =
-    mkObject [ "kind" .= String "InvalidSignatureOCERT"
+    mconcat [ "kind" .= String "InvalidSignatureOCERT"
              , "opCertKESStartPeriod" .= String (textShow oCertKESStartPeriod)
              , "opCertCounter" .= String (textShow oCertCounter)
              ]
   forMachine _dtal (InvalidKesSignatureOCERT currKESPeriod startKESPeriod expectedKESEvolutions err) =
-    mkObject [ "kind" .= String "InvalidKesSignatureOCERT"
+    mconcat [ "kind" .= String "InvalidKesSignatureOCERT"
              , "opCertKESStartPeriod" .= String (textShow startKESPeriod)
              , "opCertKESCurrentPeriod" .= String (textShow currKESPeriod)
              , "opCertExpectedKESEvolutions" .= String (textShow expectedKESEvolutions)
              , "error" .= err ]
   forMachine _dtal (NoCounterForKeyHashOCERT (KeyHash stakePoolKeyHash)) =
-    mkObject [ "kind" .= String "NoCounterForKeyHashOCERT"
+    mconcat [ "kind" .= String "NoCounterForKeyHashOCERT"
              , "stakePoolKeyHash" .= String (textShow stakePoolKeyHash)
              , "error" .= String "A counter was not found for this stake pool key hash"
              ]
@@ -910,7 +911,7 @@ instance LogFormatting (UpdnPredicateFailure crypto) where
 
 instance LogFormatting (UpecPredicateFailure era) where
   forMachine _dtal (NewPpFailure (UnexpectedDepositPot totalOutstanding depositPot)) =
-    mkObject [ "kind" .= String "UnexpectedDepositPot"
+    mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "totalOutstanding" .=  String (textShow totalOutstanding)
              , "depositPot" .= String (textShow depositPot)
              ]
@@ -921,45 +922,45 @@ instance LogFormatting (UpecPredicateFailure era) where
 
 instance LogFormatting (Alonzo.UtxoPredicateFailure (Alonzo.AlonzoEra StandardCrypto)) where
   forMachine _dtal (Alonzo.BadInputsUTxO badInputs) =
-    mkObject [ "kind" .= String "BadInputsUTxO"
+    mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
              , "error" .= renderBadInputsUTxOErr badInputs
              ]
   forMachine _dtal (Alonzo.OutsideValidityIntervalUTxO validtyInterval slot) =
-    mkObject [ "kind" .= String "ExpiredUTxO"
+    mconcat [ "kind" .= String "ExpiredUTxO"
              , "validityInterval" .= validtyInterval
              , "slot" .= slot
              ]
   forMachine _dtal (Alonzo.MaxTxSizeUTxO txsize maxtxsize) =
-    mkObject [ "kind" .= String "MaxTxSizeUTxO"
+    mconcat [ "kind" .= String "MaxTxSizeUTxO"
              , "size" .= txsize
              , "maxSize" .= maxtxsize
              ]
   forMachine _dtal Alonzo.InputSetEmptyUTxO =
-    mkObject [ "kind" .= String "InputSetEmptyUTxO" ]
+    mconcat [ "kind" .= String "InputSetEmptyUTxO" ]
   forMachine _dtal (Alonzo.FeeTooSmallUTxO minfee currentFee) =
-    mkObject [ "kind" .= String "FeeTooSmallUTxO"
+    mconcat [ "kind" .= String "FeeTooSmallUTxO"
              , "minimum" .= minfee
              , "fee" .= currentFee
              ]
   forMachine _dtal (Alonzo.ValueNotConservedUTxO consumed produced) =
-    mkObject [ "kind" .= String "ValueNotConservedUTxO"
+    mconcat [ "kind" .= String "ValueNotConservedUTxO"
              , "consumed" .= consumed
              , "produced" .= produced
              , "error" .= renderValueNotConservedErr consumed produced
              ]
   forMachine _dtal (Alonzo.WrongNetwork network addrs) =
-    mkObject [ "kind" .= String "WrongNetwork"
+    mconcat [ "kind" .= String "WrongNetwork"
              , "network" .= network
              , "addrs"   .= addrs
              ]
   forMachine _dtal (Alonzo.WrongNetworkWithdrawal network addrs) =
-    mkObject [ "kind" .= String "WrongNetworkWithdrawal"
+    mconcat [ "kind" .= String "WrongNetworkWithdrawal"
              , "network" .= network
              , "addrs"   .= addrs
              ]
   forMachine _dtal (Alonzo.OutputTooSmallUTxO badOutputs) =
-    mkObject [ "kind" .= String "OutputTooSmallUTxO"
+    mconcat [ "kind" .= String "OutputTooSmallUTxO"
              , "outputs" .= badOutputs
              , "error" .= String "The output is smaller than the allow minimum \
                                  \UTxO value defined in the protocol parameters"
@@ -967,67 +968,67 @@ instance LogFormatting (Alonzo.UtxoPredicateFailure (Alonzo.AlonzoEra StandardCr
   forMachine dtal (Alonzo.UtxosFailure predFailure) =
     forMachine dtal predFailure
   forMachine _dtal (Alonzo.OutputBootAddrAttrsTooBig txouts) =
-    mkObject [ "kind" .= String "OutputBootAddrAttrsTooBig"
+    mconcat [ "kind" .= String "OutputBootAddrAttrsTooBig"
              , "outputs" .= txouts
              , "error" .= String "The Byron address attributes are too big"
              ]
   forMachine _dtal Alonzo.TriesToForgeADA =
-    mkObject [ "kind" .= String "TriesToForgeADA" ]
+    mconcat [ "kind" .= String "TriesToForgeADA" ]
   forMachine _dtal (Alonzo.OutputTooBigUTxO badOutputs) =
-    mkObject [ "kind" .= String "OutputTooBigUTxO"
+    mconcat [ "kind" .= String "OutputTooBigUTxO"
              , "outputs" .= badOutputs
              , "error" .= String "Too many asset ids in the tx output"
              ]
   forMachine _dtal (Alonzo.InsufficientCollateral computedBalance suppliedFee) =
-    mkObject [ "kind" .= String "InsufficientCollateral"
+    mconcat [ "kind" .= String "InsufficientCollateral"
              , "balance" .= computedBalance
              , "txfee" .= suppliedFee
              ]
   forMachine _dtal (Alonzo.ScriptsNotPaidUTxO utxos) =
-    mkObject [ "kind" .= String "ScriptsNotPaidUTxO"
+    mconcat [ "kind" .= String "ScriptsNotPaidUTxO"
              , "utxos" .= utxos
              ]
   forMachine _dtal (Alonzo.ExUnitsTooBigUTxO pParamsMaxExUnits suppliedExUnits) =
-    mkObject [ "kind" .= String "ExUnitsTooBigUTxO"
+    mconcat [ "kind" .= String "ExUnitsTooBigUTxO"
              , "maxexunits" .= pParamsMaxExUnits
              , "exunits" .= suppliedExUnits
              ]
   forMachine _dtal (Alonzo.CollateralContainsNonADA inputs) =
-    mkObject [ "kind" .= String "CollateralContainsNonADA"
+    mconcat [ "kind" .= String "CollateralContainsNonADA"
              , "inputs" .= inputs
              ]
   forMachine _dtal (Alonzo.WrongNetworkInTxBody actualNetworkId netIdInTxBody) =
-    mkObject [ "kind" .= String "WrongNetworkInTxBody"
+    mconcat [ "kind" .= String "WrongNetworkInTxBody"
              , "networkid" .= actualNetworkId
              , "txbodyNetworkId" .= netIdInTxBody
              ]
   forMachine _dtal (Alonzo.OutsideForecast slotNum) =
-    mkObject [ "kind" .= String "OutsideForecast"
+    mconcat [ "kind" .= String "OutsideForecast"
              , "slot" .= slotNum
              ]
   forMachine _dtal (Alonzo.TooManyCollateralInputs maxCollateralInputs numberCollateralInputs) =
-    mkObject [ "kind" .= String "TooManyCollateralInputs"
+    mconcat [ "kind" .= String "TooManyCollateralInputs"
              , "max" .= maxCollateralInputs
              , "inputs" .= numberCollateralInputs
              ]
   forMachine _dtal Alonzo.NoCollateralInputs =
-    mkObject [ "kind" .= String "NoCollateralInputs" ]
+    mconcat [ "kind" .= String "NoCollateralInputs" ]
 
 instance LogFormatting (Alonzo.UtxosPredicateFailure (Alonzo.AlonzoEra StandardCrypto)) where
   forMachine _ (Alonzo.ValidationTagMismatch isValidating reason) =
-    mkObject [ "kind" .= String "ValidationTagMismatch"
+    mconcat [ "kind" .= String "ValidationTagMismatch"
              , "isvalidating" .= isValidating
              , "reason" .= reason
              ]
   forMachine _ (Alonzo.CollectErrors errors) =
-    mkObject [ "kind" .= String "CollectErrors"
+    mconcat [ "kind" .= String "CollectErrors"
              , "errors" .= errors
              ]
   forMachine dtal (Alonzo.UpdateFailure pFailure) =
     forMachine dtal pFailure
 
 instance LogFormatting (AlonzoBbodyPredFail (Alonzo.AlonzoEra StandardCrypto)) where
-  forMachine _ err = mkObject [ "kind" .= String "AlonzoBbodyPredFail"
+  forMachine _ err = mconcat [ "kind" .= String "AlonzoBbodyPredFail"
                             , "error" .= String (show err)
                             ]
 

--- a/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
@@ -10,7 +10,7 @@ module Cardano.Node.Tracing.Formatting
 import           Cardano.Prelude ()
 import           Data.Aeson (Value (String), toJSON, (.=))
 
-import           Cardano.Logging (LogFormatting (..), mkObject)
+import           Cardano.Logging (LogFormatting (..))
 import           Cardano.Prelude hiding (Show, show)
 
 import           Cardano.Node.Tracing.Render (renderHeaderHashForDetails)
@@ -31,16 +31,16 @@ instance LogFormatting () where
 
 instance LogFormatting SlotNo where
   forMachine _dtal slot =
-    mkObject [ "kind" .= String "SlotNo"
+    mconcat [ "kind" .= String "SlotNo"
              , "slot" .= toJSON (unSlotNo slot) ]
 
 instance forall blk. ConvertRawHash blk
       => LogFormatting (Point blk) where
   forMachine _dtal GenesisPoint =
-    mkObject
+    mconcat
       [ "kind" .= String "GenesisPoint" ]
   forMachine dtal (BlockPoint slot h) =
-    mkObject
+    mconcat
       [ "kind" .= String "BlockPoint"
       , "slot" .= toJSON (unSlotNo slot)
       , "headerHash" .= renderHeaderHashForDetails (Proxy @blk) dtal h
@@ -48,7 +48,7 @@ instance forall blk. ConvertRawHash blk
 
 instance ConvertRawHash blk
       => LogFormatting (RealPoint blk) where
-  forMachine dtal p = mkObject
+  forMachine dtal p = mconcat
         [ "kind" .= String "Point"
         , "slot" .= unSlotNo (realPointSlot p)
         , "hash" .= renderHeaderHashForDetails (Proxy @blk) dtal (realPointHash p)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -42,7 +42,7 @@ severityReplayBlockStats _ = Info
 
 instance LogFormatting ReplayBlockStats where
   forMachine _dtal ReplayBlockStats {..} =
-    mkObject
+    mconcat
       [ "kind" .= String "ReplayBlockStats"
       , "progress" .= String (pack $ show rpsProgress)
       ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -103,6 +103,7 @@ severityMux' MuxTraceStartOnDemand {}         = Debug
 severityMux' MuxTraceStartedOnDemand {}       = Debug
 severityMux' MuxTraceTerminating {}           = Debug
 severityMux' MuxTraceShutdown {}              = Debug
+severityMux' MuxTraceTCPInfo {}               = Debug
 
 namesForMux :: WithMuxBearer peer MuxTrace -> [Text]
 namesForMux (WithMuxBearer _ mt) = namesForMux' mt
@@ -135,13 +136,14 @@ namesForMux' MuxTraceStartOnDemand {}         = ["StartOnDemand"]
 namesForMux' MuxTraceStartedOnDemand {}       = ["StartedOnDemand"]
 namesForMux' MuxTraceTerminating {}           = ["Terminating"]
 namesForMux' MuxTraceShutdown {}              = ["Shutdown"]
+namesForMux' MuxTraceTCPInfo {}               = ["TCPInfo"]
 
 
 
 instance (LogFormatting peer, Show peer) =>
     LogFormatting (WithMuxBearer peer MuxTrace) where
   forMachine dtal (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "MuxTrace"
+    mconcat [ "kind" .= String "MuxTrace"
              , "bearer" .= forMachine dtal b
              , "event" .= showT ev ]
   forHuman (WithMuxBearer b ev) = "With mux bearer " <> showT b
@@ -332,7 +334,7 @@ namesForHandshake''' HS.MsgRefuse {}          = ["Refuse"]
 
 instance LogFormatting (NtN.HandshakeTr NtN.RemoteAddress NtN.NodeToNodeVersion) where
   forMachine _dtal (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "HandshakeTrace"
+    mconcat [ "kind" .= String "HandshakeTrace"
              , "bearer" .= show b
              , "event" .= show ev ]
   forHuman (WithMuxBearer b ev) = "With mux bearer " <> showT b
@@ -407,7 +409,7 @@ namesForLocalHandshake''' HS.MsgRefuse {}          = ["Refuse"]
 
 instance LogFormatting (NtC.HandshakeTr NtC.LocalAddress NtC.NodeToClientVersion) where
   forMachine _dtal (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "LocalHandshakeTrace"
+    mconcat [ "kind" .= String "LocalHandshakeTrace"
              , "bearer" .= show b
              , "event" .= show ev ]
   forHuman (WithMuxBearer b ev) = "With mux bearer " <> showT b
@@ -495,67 +497,67 @@ namesForDiffusionInit  ND.DiffusionErrored {}                  =
 
 instance (Show ntnAddr, Show ntcAddr) =>
   LogFormatting (ND.InitializationTracer ntnAddr ntcAddr)  where
-  forMachine _dtal (ND.RunServer sockAddr) = mkObject
+  forMachine _dtal (ND.RunServer sockAddr) = mconcat
     [ "kind" .= String "RunServer"
     , "socketAddress" .= String (pack (show sockAddr))
     ]
 
-  forMachine _dtal (ND.RunLocalServer localAddress) = mkObject
+  forMachine _dtal (ND.RunLocalServer localAddress) = mconcat
     [ "kind" .= String "RunLocalServer"
     , "localAddress" .= String (pack (show localAddress))
     ]
-  forMachine _dtal (ND.UsingSystemdSocket localAddress) = mkObject
+  forMachine _dtal (ND.UsingSystemdSocket localAddress) = mconcat
     [ "kind" .= String "UsingSystemdSocket"
     , "path" .= String (pack . show $ localAddress)
     ]
 
-  forMachine _dtal (ND.CreateSystemdSocketForSnocketPath localAddress) = mkObject
+  forMachine _dtal (ND.CreateSystemdSocketForSnocketPath localAddress) = mconcat
     [ "kind" .= String "CreateSystemdSocketForSnocketPath"
     , "path" .= String (pack . show $ localAddress)
     ]
-  forMachine _dtal (ND.CreatedLocalSocket localAddress) = mkObject
+  forMachine _dtal (ND.CreatedLocalSocket localAddress) = mconcat
     [ "kind" .= String "CreatedLocalSocket"
     , "path" .= String (pack . show $ localAddress)
     ]
-  forMachine _dtal (ND.ConfiguringLocalSocket localAddress socket) = mkObject
+  forMachine _dtal (ND.ConfiguringLocalSocket localAddress socket) = mconcat
     [ "kind" .= String "ConfiguringLocalSocket"
     , "path" .= String (pack . show $ localAddress)
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.ListeningLocalSocket localAddress socket) = mkObject
+  forMachine _dtal (ND.ListeningLocalSocket localAddress socket) = mconcat
     [ "kind" .= String "ListeningLocalSocket"
     , "path" .=  String (pack . show $ localAddress)
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.LocalSocketUp localAddress fd) = mkObject
+  forMachine _dtal (ND.LocalSocketUp localAddress fd) = mconcat
     [ "kind" .= String "LocalSocketUp"
     , "path" .= String (pack . show $ localAddress)
     , "socket" .= String (pack (show fd))
     ]
-  forMachine _dtal (ND.CreatingServerSocket socket) = mkObject
+  forMachine _dtal (ND.CreatingServerSocket socket) = mconcat
     [ "kind" .= String "CreatingServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.ListeningServerSocket socket) = mkObject
+  forMachine _dtal (ND.ListeningServerSocket socket) = mconcat
     [ "kind" .= String "ListeningServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.ServerSocketUp socket) = mkObject
+  forMachine _dtal (ND.ServerSocketUp socket) = mconcat
     [ "kind" .= String "ServerSocketUp"
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.ConfiguringServerSocket socket) = mkObject
+  forMachine _dtal (ND.ConfiguringServerSocket socket) = mconcat
     [ "kind" .= String "ConfiguringServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  forMachine _dtal (ND.UnsupportedLocalSystemdSocket path) = mkObject
+  forMachine _dtal (ND.UnsupportedLocalSystemdSocket path) = mconcat
     [ "kind" .= String "UnsupportedLocalSystemdSocket"
     , "path" .= String (pack (show path))
     ]
-  forMachine _dtal ND.UnsupportedReadySocketCase = mkObject
+  forMachine _dtal ND.UnsupportedReadySocketCase = mconcat
     [ "kind" .= String "UnsupportedReadySocketCase"
     ]
-  forMachine _dtal (ND.DiffusionErrored exception) = mkObject
+  forMachine _dtal (ND.DiffusionErrored exception) = mconcat
     [ "kind" .= String "DiffusionErrored"
     , "path" .= String (pack (show exception))
     ]
@@ -653,49 +655,49 @@ namesForLedgerPeers FallingBackToBootstrapPeers {} = ["FallingBackToBootstrapPee
 
 instance LogFormatting TraceLedgerPeers where
   forMachine _dtal (PickedPeer addr _ackStake stake) =
-    mkObject
+    mconcat
       [ "kind" .= String "PickedPeer"
       , "address" .= show addr
       , "relativeStake" .= (realToFrac (unPoolStake stake) :: Double)
       ]
   forMachine _dtal (PickedPeers (NumberOfPeers n) addrs) =
-    mkObject
+    mconcat
       [ "kind" .= String "PickedPeers"
       , "desiredCount" .= n
       , "count" .= length addrs
       , "addresses" .= show addrs
       ]
   forMachine _dtal (FetchingNewLedgerState cnt) =
-    mkObject
+    mconcat
       [ "kind" .= String "FetchingNewLedgerState"
       , "numberOfPools" .= cnt
       ]
   forMachine _dtal DisabledLedgerPeers =
-    mkObject
+    mconcat
       [ "kind" .= String "DisabledLedgerPeers"
       ]
   forMachine _dtal (TraceUseLedgerAfter ula) =
-    mkObject
+    mconcat
       [ "kind" .= String "UseLedgerAfter"
       , "useLedgerAfter" .= UseLedger ula
       ]
   forMachine _dtal WaitingOnRequest =
-    mkObject
+    mconcat
       [ "kind" .= String "WaitingOnRequest"
       ]
   forMachine _dtal (RequestForPeers (NumberOfPeers np)) =
-    mkObject
+    mconcat
       [ "kind" .= String "RequestForPeers"
       , "numberOfPeers" .= np
       ]
   forMachine _dtal (ReusingLedgerState cnt age) =
-    mkObject
+    mconcat
       [ "kind" .= String "ReusingLedgerState"
       , "numberOfPools" .= cnt
       , "ledgerStateAge" .= age
       ]
   forMachine _dtal FallingBackToBootstrapPeers =
-    mkObject
+    mconcat
       [ "kind" .= String "FallingBackToBootstrapPeers"
       ]
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
@@ -47,7 +47,7 @@ instance LogFormatting ForgeThreadStats where
     <> " slots missed "   <> showT ftsSlotsMissedNum
     <> " last slot "      <> showT ftsLastSlot
   forMachine _dtal ForgeThreadStats {..} =
-    mkObject [ "kind" .= String "ForgeThreadStats"
+    mconcat [ "kind" .= String "ForgeThreadStats"
              , "nodeCannotForgeNum" .= String (show ftsNodeCannotForgeNum)
              , "nodeIsLeaderNum"    .= String (show ftsNodeIsLeaderNum)
              , "blocksForgedNum"    .= String (show ftsBlocksForgedNum)
@@ -107,7 +107,7 @@ instance LogFormatting ForgingStats where
     <> " blocks forged "  <> showT fsBlocksForgedNum
     <> " slots missed "   <> showT fsSlotsMissedNum
   forMachine _dtal ForgingStats {..} =
-    mkObject [ "kind" .= String "ForgingStats"
+    mconcat [ "kind" .= String "ForgingStats"
              , "nodeCannotForgeNum" .= String (show fsNodeCannotForgeNum)
              , "nodeIsLeaderNum"    .= String (show fsNodeIsLeaderNum)
              , "blocksForgedNum"    .= String (show fsBlocksForgedNum)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
@@ -50,9 +50,9 @@ import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Type as LTS
 
 instance LogFormatting (AnyMessageAndAgency ps)
       => LogFormatting (TraceSendRecv ps) where
-  forMachine dtal (TraceSendMsg m) = mkObject
+  forMachine dtal (TraceSendMsg m) = mconcat
     [ "kind" .= String "Send" , "msg" .= forMachine dtal m ]
-  forMachine dtal (TraceRecvMsg m) = mkObject
+  forMachine dtal (TraceRecvMsg m) = mconcat
     [ "kind" .= String "Recv" , "msg" .= forMachine dtal m ]
 
   forHuman (TraceSendMsg m) = "Send: " <> forHuman m
@@ -111,35 +111,35 @@ namesForTChainSync (BlockFetch.TraceLabelPeer _ v) = "NodeToClient" : namesTChai
 
 instance LogFormatting (AnyMessageAndAgency (ChainSync blk pt tip)) where
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgRequestNext{}) =
-     mkObject [ "kind" .= String "MsgRequestNext"
+     mconcat [ "kind" .= String "MsgRequestNext"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgAwaitReply{}) =
-     mkObject [ "kind" .= String "MsgAwaitReply"
+     mconcat [ "kind" .= String "MsgAwaitReply"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgRollForward{}) =
-     mkObject [ "kind" .= String "MsgRollForward"
+     mconcat [ "kind" .= String "MsgRollForward"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgRollBackward{}) =
-     mkObject [ "kind" .= String "MsgRollBackward"
+     mconcat [ "kind" .= String "MsgRollBackward"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgFindIntersect{}) =
-     mkObject [ "kind" .= String "MsgFindIntersect"
+     mconcat [ "kind" .= String "MsgFindIntersect"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgIntersectFound{}) =
-     mkObject [ "kind" .= String "MsgIntersectFound"
+     mconcat [ "kind" .= String "MsgIntersectFound"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgIntersectNotFound{}) =
-     mkObject [ "kind" .= String "MsgIntersectNotFound"
+     mconcat [ "kind" .= String "MsgIntersectNotFound"
               , "agency" .= String (pack $ show stok)
               ]
    forMachine _dtal (AnyMessageAndAgency stok ChainSync.MsgDone{}) =
-     mkObject [ "kind" .= String "MsgDone"
+     mconcat [ "kind" .= String "MsgDone"
               , "agency" .= String (pack $ show stok)
               ]
 
@@ -260,47 +260,47 @@ namesForTTxMonitor (TraceLabelPeer _ v) = namesForTTxMonitor' v
 
 instance LogFormatting (AnyMessageAndAgency (LTM.LocalTxMonitor txid tx slotNo)) where
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgAcquire {}) =
-    mkObject [ "kind" .= String "MsgAcquire"
+    mconcat [ "kind" .= String "MsgAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgAcquired {}) =
-    mkObject [ "kind" .= String "MsgAcquired"
+    mconcat [ "kind" .= String "MsgAcquired"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgAwaitAcquire {}) =
-    mkObject [ "kind" .= String "MsgAwaitAcquire"
+    mconcat [ "kind" .= String "MsgAwaitAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgNextTx {}) =
-    mkObject [ "kind" .= String "MsgNextTx"
+    mconcat [ "kind" .= String "MsgNextTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgReplyNextTx {}) =
-    mkObject [ "kind" .= String "MsgReplyNextTx"
+    mconcat [ "kind" .= String "MsgReplyNextTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgHasTx {}) =
-    mkObject [ "kind" .= String "MsgHasTx"
+    mconcat [ "kind" .= String "MsgHasTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgReplyHasTx {}) =
-    mkObject [ "kind" .= String "MsgReplyHasTx"
+    mconcat [ "kind" .= String "MsgReplyHasTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgGetSizes {}) =
-    mkObject [ "kind" .= String "MsgGetSizes"
+    mconcat [ "kind" .= String "MsgGetSizes"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgReplyGetSizes {}) =
-    mkObject [ "kind" .= String "MsgReplyGetSizes"
+    mconcat [ "kind" .= String "MsgReplyGetSizes"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgRelease {}) =
-    mkObject [ "kind" .= String "MsgRelease"
+    mconcat [ "kind" .= String "MsgRelease"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTM.MsgDone {}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 
@@ -412,19 +412,19 @@ namesForTTxSubmission (BlockFetch.TraceLabelPeer _ v) = namesTTxSubmission v
 
 instance LogFormatting (AnyMessageAndAgency (LTS.LocalTxSubmission tx err)) where
   forMachine _dtal (AnyMessageAndAgency stok LTS.MsgSubmitTx{}) =
-    mkObject [ "kind" .= String "MsgSubmitTx"
+    mconcat [ "kind" .= String "MsgSubmitTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTS.MsgAcceptTx{}) =
-    mkObject [ "kind" .= String "MsgAcceptTx"
+    mconcat [ "kind" .= String "MsgAcceptTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTS.MsgRejectTx{}) =
-    mkObject [ "kind" .= String "MsgRejectTx"
+    mconcat [ "kind" .= String "MsgRejectTx"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LTS.MsgDone{}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 
@@ -511,35 +511,35 @@ namesForTStateQuery (BlockFetch.TraceLabelPeer _ v) = namesForTStateQuery' v
 instance (forall result. Show (Query blk result))
       => LogFormatting (AnyMessageAndAgency (LSQ.LocalStateQuery blk pt (Query blk))) where
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgAcquire{}) =
-    mkObject [ "kind" .= String "MsgAcquire"
+    mconcat [ "kind" .= String "MsgAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgAcquired{}) =
-    mkObject [ "kind" .= String "MsgAcquired"
+    mconcat [ "kind" .= String "MsgAcquired"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgFailure{}) =
-    mkObject [ "kind" .= String "MsgFailure"
+    mconcat [ "kind" .= String "MsgFailure"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgQuery{}) =
-    mkObject [ "kind" .= String "MsgQuery"
+    mconcat [ "kind" .= String "MsgQuery"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgResult{}) =
-    mkObject [ "kind" .= String "MsgResult"
+    mconcat [ "kind" .= String "MsgResult"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgRelease{}) =
-    mkObject [ "kind" .= String "MsgRelease"
+    mconcat [ "kind" .= String "MsgRelease"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgReAcquire{}) =
-    mkObject [ "kind" .= String "MsgReAcquire"
+    mconcat [ "kind" .= String "MsgReAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _dtal (AnyMessageAndAgency stok LSQ.MsgDone{}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -203,14 +203,14 @@ instance ( ConvertTxId blk
          )
       => LogFormatting (AnyMessageAndAgency (BlockFetch blk (Point blk))) where
   forMachine DMinimal (AnyMessageAndAgency stok (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
              ]
 
   forMachine dtal (AnyMessageAndAgency stok (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
@@ -221,23 +221,23 @@ instance ( ConvertTxId blk
         presentTx =  String . renderTxIdForDetails dtal . txId
 
   forMachine _v (AnyMessageAndAgency stok MsgRequestRange{}) =
-    mkObject [ "kind" .= String "MsgRequestRange"
+    mconcat [ "kind" .= String "MsgRequestRange"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgStartBatch{}) =
-    mkObject [ "kind" .= String "MsgStartBatch"
+    mconcat [ "kind" .= String "MsgStartBatch"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgNoBlocks{}) =
-    mkObject [ "kind" .= String "MsgNoBlocks"
+    mconcat [ "kind" .= String "MsgNoBlocks"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgBatchDone{}) =
-    mkObject [ "kind" .= String "MsgBatchDone"
+    mconcat [ "kind" .= String "MsgBatchDone"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgClientDone{}) =
-    mkObject [ "kind" .= String "MsgClientDone"
+    mconcat [ "kind" .= String "MsgClientDone"
              , "agency" .= String (pack $ show stok)
              ]
 
@@ -341,14 +341,14 @@ instance ( ConvertTxId blk
          )
       => LogFormatting (AnyMessageAndAgency (BlockFetch (Serialised blk) (Point blk))) where
   forMachine DMinimal (AnyMessageAndAgency stok (MsgBlock _blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
             -- , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
             -- , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
              ]
 
   forMachine _dtal (AnyMessageAndAgency stok (MsgBlock _blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
           -- , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
           --  , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
@@ -359,23 +359,23 @@ instance ( ConvertTxId blk
       --   presentTx =  String . renderTxIdForDetails dtal . txId
 
   forMachine _v (AnyMessageAndAgency stok MsgRequestRange{}) =
-    mkObject [ "kind" .= String "MsgRequestRange"
+    mconcat [ "kind" .= String "MsgRequestRange"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgStartBatch{}) =
-    mkObject [ "kind" .= String "MsgStartBatch"
+    mconcat [ "kind" .= String "MsgStartBatch"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgNoBlocks{}) =
-    mkObject [ "kind" .= String "MsgNoBlocks"
+    mconcat [ "kind" .= String "MsgNoBlocks"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgBatchDone{}) =
-    mkObject [ "kind" .= String "MsgBatchDone"
+    mconcat [ "kind" .= String "MsgBatchDone"
              , "agency" .= String (pack $ show stok)
              ]
   forMachine _v (AnyMessageAndAgency stok MsgClientDone{}) =
-    mkObject [ "kind" .= String "MsgClientDone"
+    mconcat [ "kind" .= String "MsgClientDone"
              , "agency" .= String (pack $ show stok)
              ]
 
@@ -434,29 +434,29 @@ namesForTxSubmissionNode (BlockFetch.TraceLabelPeer _ v) =
 instance (Show txid, Show tx)
       => LogFormatting (AnyMessageAndAgency (STX.TxSubmission txid tx)) where
   forMachine _dtal (AnyMessageAndAgency stok (STX.MsgRequestTxs txids)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgRequestTxs"
       , "agency" .= String (pack $ show stok)
       , "txIds" .= String (pack $ show txids)
       ]
   forMachine _dtal (AnyMessageAndAgency stok (STX.MsgReplyTxs txs)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgReplyTxs"
       , "agency" .= String (pack $ show stok)
       , "txs" .= String (pack $ show txs)
       ]
   forMachine _dtal (AnyMessageAndAgency stok STX.MsgRequestTxIds {}) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgRequestTxIds"
       , "agency" .= String (pack $ show stok)
       ]
   forMachine _dtal (AnyMessageAndAgency stok (STX.MsgReplyTxIds _)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgReplyTxIds"
       , "agency" .= String (pack $ show stok)
       ]
   forMachine _dtal (AnyMessageAndAgency stok STX.MsgDone) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgDone"
       , "agency" .= String (pack $ show stok)
       ]
@@ -631,7 +631,7 @@ instance (Show txid, Show tx)
                    -- function as total.
                    stok@(ClientAgency TokHello)
                    MsgHello) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgHello"
       , "agency" .= String (pack $ show stok)
       ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
@@ -56,31 +56,31 @@ import           Ouroboros.Network.Subscription.Worker (ConnectResult (..), Subs
 instance LogFormatting NtN.RemoteAddress where
     forMachine _dtal (Socket.SockAddrInet port addr) =
         let ip = IP.fromHostAddress addr in
-        mkObject [ "addr" .= show ip
+        mconcat [ "addr" .= show ip
                  , "port" .= show port
                  ]
     forMachine _dtal (Socket.SockAddrInet6 port _ addr _) =
         let ip = IP.fromHostAddress6 addr in
-        mkObject [ "addr" .= show ip
+        mconcat [ "addr" .= show ip
                  , "port" .= show port
                  ]
     forMachine _dtal (Socket.SockAddrUnix path) =
-        mkObject [ "path" .= show path ]
+        mconcat [ "path" .= show path ]
 
 
 instance LogFormatting NtN.RemoteConnectionId where
     forMachine dtal (NtN.ConnectionId l r) =
-        mkObject [ "local" .= forMachine dtal l
+        mconcat [ "local" .= forMachine dtal l
                  , "remote" .= forMachine dtal r
                  ]
 
 instance LogFormatting LocalAddress where
     forMachine _dtal (LocalAddress path) =
-        mkObject ["path" .= path]
+        mconcat ["path" .= path]
 
 instance LogFormatting NtC.LocalConnectionId where
     forMachine dtal (NtC.ConnectionId l r) =
-        mkObject [ "local" .= forMachine dtal l
+        mconcat [ "local" .= forMachine dtal l
                  , "remote" .= forMachine dtal r
                  ]
 
@@ -149,7 +149,7 @@ namesForIPSubscription(WithIPList _ _ e) = "IP" : namesForSubscription e
 
 instance LogFormatting (WithIPList (SubscriptionTrace Socket.SockAddr)) where
   forMachine _dtal (WithIPList localAddresses dests ev) =
-    mkObject [ "kind" .= String "IP SubscriptionTrace"
+    mconcat [ "kind" .= String "IP SubscriptionTrace"
              , "localAddresses" .= String (pack $ show localAddresses)
              , "dests" .= String (pack $ show dests)
              , "event" .= String (pack $ show ev)]
@@ -208,7 +208,7 @@ severityDNSSubscription NtN.WithDomainName {..} = case wdnEvent of
 
 instance LogFormatting (WithDomainName (SubscriptionTrace Socket.SockAddr)) where
   forMachine _dtal (WithDomainName dom ev) =
-    mkObject [ "kind" .= String "DNS SubscriptionTrace"
+    mconcat [ "kind" .= String "DNS SubscriptionTrace"
              , "domain" .= String (pack $ show dom)
              , "event" .= String (pack $ show ev)]
   forHuman (WithDomainName dom ev) =
@@ -327,7 +327,7 @@ namesForDNSResolver (NtN.WithDomainName _ ev) = case ev of
 
 instance LogFormatting (WithDomainName DnsTrace) where
   forMachine _dtal (WithDomainName dom ev) =
-    mkObject [ "kind" .= String "DnsTrace"
+    mconcat [ "kind" .= String "DnsTrace"
              , "domain" .= String (pack $ show dom)
              , "event" .= String (pack $ show ev)]
   forHuman (WithDomainName dom ev) =
@@ -412,7 +412,7 @@ namesForErrorPolicy (WithAddr _ ev) = case ev of
 
 instance Show addr => LogFormatting (NtN.WithAddr addr NtN.ErrorPolicyTrace) where
     forMachine _dtal (NtN.WithAddr addr ev) =
-      mkObject [ "kind" .= String "ErrorPolicyTrace"
+      mconcat [ "kind" .= String "ErrorPolicyTrace"
                , "address" .= show addr
                , "event" .= show ev ]
     forHuman (NtN.WithAddr addr ev) = "With address " <> showT addr <> ". " <> showT ev
@@ -532,16 +532,16 @@ namesForAcceptPolicy NtN.ServerTraceAcceptConnectionResume {} =
 
 instance LogFormatting NtN.AcceptConnectionsPolicyTrace where
     forMachine _dtal (NtN.ServerTraceAcceptConnectionRateLimiting delay numOfConnections) =
-      mkObject [ "kind" .= String "ServerTraceAcceptConnectionRateLimiting"
+      mconcat [ "kind" .= String "ServerTraceAcceptConnectionRateLimiting"
                , "delay" .= show delay
                , "numberOfConnection" .= show numOfConnections
                ]
     forMachine _dtal (NtN.ServerTraceAcceptConnectionHardLimit softLimit) =
-      mkObject [ "kind" .= String "ServerTraceAcceptConnectionHardLimit"
+      mconcat [ "kind" .= String "ServerTraceAcceptConnectionHardLimit"
                , "softLimit" .= show softLimit
                ]
     forMachine _dtal (NtN.ServerTraceAcceptConnectionResume numOfConnections) =
-      mkObject [ "kind" .= String "ServerTraceAcceptConnectionResume"
+      mconcat [ "kind" .= String "ServerTraceAcceptConnectionResume"
                , "numberOfConnection" .= show numOfConnections
                ]
     forHuman   = showT

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -115,30 +115,30 @@ severityLocalRootPeers _ = Info
 instance (ToJSONKey ntnAddr, ToJSONKey RelayAccessPoint, Show ntnAddr, Show exception) =>
     LogFormatting (TraceLocalRootPeers ntnAddr exception) where
   forMachine _dtal (TraceLocalRootDomains groups) =
-    mkObject [ "kind" .= String "LocalRootDomains"
+    mconcat [ "kind" .= String "LocalRootDomains"
              , "localRootDomains" .= toJSON groups
              ]
   forMachine _dtal (TraceLocalRootWaiting d dt) =
-    mkObject [ "kind" .= String "LocalRootWaiting"
+    mconcat [ "kind" .= String "LocalRootWaiting"
              , "domainAddress" .= toJSON d
              , "diffTime" .= show dt
              ]
   forMachine _dtal (TraceLocalRootResult d res) =
-    mkObject [ "kind" .= String "LocalRootResult"
+    mconcat [ "kind" .= String "LocalRootResult"
              , "domainAddress" .= toJSON d
              , "result" .= toJSONList res
              ]
   forMachine _dtal (TraceLocalRootGroups groups) =
-    mkObject [ "kind" .= String "LocalRootGroups"
+    mconcat [ "kind" .= String "LocalRootGroups"
              , "localRootGroups" .= toJSON groups
              ]
   forMachine _dtal (TraceLocalRootFailure d exception) =
-    mkObject [ "kind" .= String "LocalRootFailure"
+    mconcat [ "kind" .= String "LocalRootFailure"
              , "domainAddress" .= toJSON d
              , "reason" .= show exception
              ]
   forMachine _dtal (TraceLocalRootError d exception) =
-    mkObject [ "kind" .= String "LocalRootError"
+    mconcat [ "kind" .= String "LocalRootError"
              , "domainAddress" .= toJSON d
              , "reason" .= show exception
              ]
@@ -187,20 +187,20 @@ severityPublicRootPeers _ = Info
 
 instance LogFormatting TracePublicRootPeers where
   forMachine _dtal (TracePublicRootRelayAccessPoint relays) =
-    mkObject [ "kind" .= String "PublicRootRelayAddresses"
+    mconcat [ "kind" .= String "PublicRootRelayAddresses"
              , "relayAddresses" .= toJSONList relays
              ]
   forMachine _dtal (TracePublicRootDomains domains) =
-    mkObject [ "kind" .= String "PublicRootDomains"
+    mconcat [ "kind" .= String "PublicRootDomains"
              , "domainAddresses" .= toJSONList domains
              ]
   forMachine _dtal (TracePublicRootResult b res) =
-    mkObject [ "kind" .= String "PublicRootResult"
+    mconcat [ "kind" .= String "PublicRootResult"
              , "domain" .= show b
              , "result" .= toJSONList res
              ]
   forMachine _dtal (TracePublicRootFailure b d) =
-    mkObject [ "kind" .= String "PublicRootFailure"
+    mconcat [ "kind" .= String "PublicRootFailure"
              , "domain" .= show b
              , "reason" .= show d
              ]
@@ -293,63 +293,63 @@ severityPeerSelection TraceChurnMode             {} = Info
 
 instance LogFormatting (TracePeerSelection SockAddr) where
   forMachine _dtal (TraceLocalRootPeersChanged lrp lrp') =
-    mkObject [ "kind" .= String "LocalRootPeersChanged"
+    mconcat [ "kind" .= String "LocalRootPeersChanged"
              , "previous" .= toJSON lrp
              , "current" .= toJSON lrp'
              ]
   forMachine _dtal (TraceTargetsChanged pst pst') =
-    mkObject [ "kind" .= String "TargetsChanged"
+    mconcat [ "kind" .= String "TargetsChanged"
              , "previous" .= toJSON pst
              , "current" .= toJSON pst'
              ]
   forMachine _dtal (TracePublicRootsRequest tRootPeers nRootPeers) =
-    mkObject [ "kind" .= String "PublicRootsRequest"
+    mconcat [ "kind" .= String "PublicRootsRequest"
              , "targetNumberOfRootPeers" .= tRootPeers
              , "numberOfRootPeers" .= nRootPeers
              ]
   forMachine _dtal (TracePublicRootsResults res group dt) =
-    mkObject [ "kind" .= String "PublicRootsResults"
+    mconcat [ "kind" .= String "PublicRootsResults"
              , "result" .= toJSONList (toList res)
              , "group" .= group
              , "diffTime" .= dt
              ]
   forMachine _dtal (TracePublicRootsFailure err group dt) =
-    mkObject [ "kind" .= String "PublicRootsFailure"
+    mconcat [ "kind" .= String "PublicRootsFailure"
              , "reason" .= show err
              , "group" .= group
              , "diffTime" .= dt
              ]
   forMachine _dtal (TraceGossipRequests targetKnown actualKnown aps sps) =
-    mkObject [ "kind" .= String "GossipRequests"
+    mconcat [ "kind" .= String "GossipRequests"
              , "targetKnown" .= targetKnown
              , "actualKnown" .= actualKnown
              , "availablePeers" .= toJSONList (toList aps)
              , "selectedPeers" .= toJSONList (toList sps)
              ]
   forMachine _dtal (TraceGossipResults res) =
-    mkObject [ "kind" .= String "GossipResults"
+    mconcat [ "kind" .= String "GossipResults"
              , "result" .= toJSONList (map ( bimap show id <$> ) res)
              ]
   forMachine _dtal (TraceForgetColdPeers targetKnown actualKnown sp) =
-    mkObject [ "kind" .= String "ForgeColdPeers"
+    mconcat [ "kind" .= String "ForgeColdPeers"
              , "targetKnown" .= targetKnown
              , "actualKnown" .= actualKnown
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteColdPeers targetKnown actualKnown sp) =
-    mkObject [ "kind" .= String "PromoteColdPeers"
+    mconcat [ "kind" .= String "PromoteColdPeers"
              , "targetEstablished" .= targetKnown
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteColdLocalPeers tLocalEst aLocalEst sp) =
-    mkObject [ "kind" .= String "PromoteColdLocalPeers"
+    mconcat [ "kind" .= String "PromoteColdLocalPeers"
              , "targetLocalEstablished" .= tLocalEst
              , "actualLocalEstablished" .= aLocalEst
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteColdFailed tEst aEst p d err) =
-    mkObject [ "kind" .= String "PromoteColdFailed"
+    mconcat [ "kind" .= String "PromoteColdFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
@@ -357,97 +357,97 @@ instance LogFormatting (TracePeerSelection SockAddr) where
              , "reason" .= show err
              ]
   forMachine _dtal (TracePromoteColdDone tEst aEst p) =
-    mkObject [ "kind" .= String "PromoteColdDone"
+    mconcat [ "kind" .= String "PromoteColdDone"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              ]
   forMachine _dtal (TracePromoteWarmPeers tActive aActive sp) =
-    mkObject [ "kind" .= String "PromoteWarmPeers"
+    mconcat [ "kind" .= String "PromoteWarmPeers"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteWarmLocalPeers taa sp) =
-    mkObject [ "kind" .= String "PromoteWarmLocalPeers"
+    mconcat [ "kind" .= String "PromoteWarmLocalPeers"
              , "targetActualActive" .= toJSONList taa
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteWarmFailed tActive aActive p err) =
-    mkObject [ "kind" .= String "PromoteWarmFailed"
+    mconcat [ "kind" .= String "PromoteWarmFailed"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   forMachine _dtal (TracePromoteWarmDone tActive aActive p) =
-    mkObject [ "kind" .= String "PromoteWarmDone"
+    mconcat [ "kind" .= String "PromoteWarmDone"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   forMachine _dtal (TracePromoteWarmAborted tActive aActive p) =
-    mkObject [ "kind" .= String "PromoteWarmAborted"
+    mconcat [ "kind" .= String "PromoteWarmAborted"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   forMachine _dtal (TraceDemoteWarmPeers tEst aEst sp) =
-    mkObject [ "kind" .= String "DemoteWarmPeers"
+    mconcat [ "kind" .= String "DemoteWarmPeers"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TraceDemoteWarmFailed tEst aEst p err) =
-    mkObject [ "kind" .= String "DemoteWarmFailed"
+    mconcat [ "kind" .= String "DemoteWarmFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   forMachine _dtal (TraceDemoteWarmDone tEst aEst p) =
-    mkObject [ "kind" .= String "DemoteWarmDone"
+    mconcat [ "kind" .= String "DemoteWarmDone"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              ]
   forMachine _dtal (TraceDemoteHotPeers tActive aActive sp) =
-    mkObject [ "kind" .= String "DemoteHotPeers"
+    mconcat [ "kind" .= String "DemoteHotPeers"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TraceDemoteLocalHotPeers taa sp) =
-    mkObject [ "kind" .= String "DemoteLocalHotPeers"
+    mconcat [ "kind" .= String "DemoteLocalHotPeers"
              , "targetActualActive" .= toJSONList taa
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TraceDemoteHotFailed tActive aActive p err) =
-    mkObject [ "kind" .= String "DemoteHotFailed"
+    mconcat [ "kind" .= String "DemoteHotFailed"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   forMachine _dtal (TraceDemoteHotDone tActive aActive p) =
-    mkObject [ "kind" .= String "DemoteHotDone"
+    mconcat [ "kind" .= String "DemoteHotDone"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   forMachine _dtal (TraceDemoteAsynchronous msp) =
-    mkObject [ "kind" .= String "DemoteAsynchronous"
+    mconcat [ "kind" .= String "DemoteAsynchronous"
              , "state" .= toJSON msp
              ]
   forMachine _dtal TraceGovernorWakeup =
-    mkObject [ "kind" .= String "GovernorWakeup"
+    mconcat [ "kind" .= String "GovernorWakeup"
              ]
   forMachine _dtal (TraceChurnWait dt) =
-    mkObject [ "kind" .= String "ChurnWait"
+    mconcat [ "kind" .= String "ChurnWait"
              , "diffTime" .= toJSON dt
              ]
   forMachine _dtal (TraceChurnMode c) =
-    mkObject [ "kind" .= String "ChurnMode"
+    mconcat [ "kind" .= String "ChurnMode"
              , "event" .= show c ]
   forHuman = pack . show
 
@@ -576,7 +576,7 @@ peerSelectionTargetsToObject
                          targetNumberOfEstablishedPeers,
                          targetNumberOfActivePeers } =
     Object $
-      mkObject [ "roots" .= targetNumberOfRootPeers
+      mconcat [ "roots" .= targetNumberOfRootPeers
                , "knownPeers" .= targetNumberOfKnownPeers
                , "established" .= targetNumberOfEstablishedPeers
                , "active" .= targetNumberOfActivePeers
@@ -595,18 +595,18 @@ severityDebugPeerSelection _ = Debug
 instance Show peerConn => LogFormatting (DebugPeerSelection SockAddr peerConn) where
   forMachine DNormal (TraceGovernorState blockedAt wakeupAfter
                    PeerSelectionState { targets, knownPeers, establishedPeers, activePeers }) =
-    mkObject [ "kind" .= String "DebugPeerSelection"
+    mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
              , "wakeupAfter" .= String (pack $ show wakeupAfter)
              , "targets" .= peerSelectionTargetsToObject targets
              , "numberOfPeers" .=
-                 Object (mkObject [ "known" .= KnownPeers.size knownPeers
+                 Object (mconcat [ "known" .= KnownPeers.size knownPeers
                                   , "established" .= EstablishedPeers.size establishedPeers
                                   , "active" .= Set.size activePeers
                                   ])
              ]
   forMachine _ (TraceGovernorState blockedAt wakeupAfter ev) =
-    mkObject [ "kind" .= String "DebugPeerSelection"
+    mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
              , "wakeupAfter" .= String (pack $ show wakeupAfter)
              , "peerSelectionState" .= String (pack $ show ev)
@@ -629,7 +629,7 @@ severityPeerSelectionCounters _ = Info
 
 instance LogFormatting PeerSelectionCounters where
   forMachine _dtal ev =
-    mkObject [ "kind" .= String "PeerSelectionCounters"
+    mconcat [ "kind" .= String "PeerSelectionCounters"
              , "coldPeers" .= coldPeers ev
              , "warmPeers" .= warmPeers ev
              , "hotPeers" .= hotPeers ev
@@ -677,21 +677,21 @@ severityPeerSelectionActions PeerMonitoringResult {}    = Debug
 -- For that an export is needed at ouroboros-network
 instance LogFormatting (PeerSelectionActionsTrace SockAddr) where
   forMachine _dtal (PeerStatusChanged ps) =
-    mkObject [ "kind" .= String "PeerStatusChanged"
+    mconcat [ "kind" .= String "PeerStatusChanged"
              , "peerStatusChangeType" .= show ps
              ]
   forMachine _dtal (PeerStatusChangeFailure ps f) =
-    mkObject [ "kind" .= String "PeerStatusChangeFailure"
+    mconcat [ "kind" .= String "PeerStatusChangeFailure"
              , "peerStatusChangeType" .= show ps
              , "reason" .= show f
              ]
   forMachine _dtal (PeerMonitoringError connId s) =
-    mkObject [ "kind" .= String "PeerMonitoridngError"
+    mconcat [ "kind" .= String "PeerMonitoridngError"
              , "connectionId" .= toJSON connId
              , "reason" .= show s
              ]
   forMachine _dtal (PeerMonitoringResult connId wf) =
-    mkObject [ "kind" .= String "PeerMonitoringResult"
+    mconcat [ "kind" .= String "PeerMonitoringResult"
              , "connectionId" .= toJSON connId
              , "withProtocolTemp" .= show wf
              ]
@@ -744,6 +744,7 @@ namesForConnectionManager TrConnectionManagerCounters {} = ["ConnectionManagerCo
 namesForConnectionManager TrState {} = ["State"]
 namesForConnectionManager ConnectionManager.TrUnexpectedlyFalseAssertion {} =
                             ["UnexpectedlyFalseAssertion"]
+namesForConnectionManager TrUnknownConnection {} = ["UnknownConnection"]
 
 severityConnectionManager ::
   ConnectionManagerTrace addr
@@ -778,129 +779,130 @@ severityConnectionManager TrConnectionManagerCounters {}          = Info
 severityConnectionManager TrState {}                              = Info
 severityConnectionManager ConnectionManager.TrUnexpectedlyFalseAssertion {} =
                             Error
+severityConnectionManager TrUnknownConnection {}                  = Debug
 
 instance (Show addr, Show versionNumber, Show agreedOptions, LogFormatting addr,
           ToJSON addr, ToJSON versionNumber, ToJSON agreedOptions)
       => LogFormatting (ConnectionManagerTrace addr (ConnectionHandlerTrace versionNumber agreedOptions)) where
     forMachine dtal (TrIncludeConnection prov peerAddr) =
-        mkObject $ reverse
+        mconcat $ reverse
           [ "kind" .= String "IncludeConnection"
           , "remoteAddress" .= forMachine dtal peerAddr
           , "provenance" .= String (pack . show $ prov)
           ]
     forMachine dtal (TrUnregisterConnection prov peerAddr) =
-        mkObject $ reverse
+        mconcat $ reverse
           [ "kind" .= String "UnregisterConnection"
           , "remoteAddress" .= forMachine dtal peerAddr
           , "provenance" .= String (pack . show $ prov)
           ]
     forMachine _dtal (TrConnect (Just localAddress) remoteAddress) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectTo"
           , "connectionId" .= toJSON ConnectionId { localAddress, remoteAddress }
           ]
     forMachine dtal (TrConnect Nothing remoteAddress) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectTo"
           , "remoteAddress" .= forMachine dtal remoteAddress
           ]
     forMachine _dtal (TrConnectError (Just localAddress) remoteAddress err) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectError"
           , "connectionId" .= toJSON ConnectionId { localAddress, remoteAddress }
           , "reason" .= String (pack . show $ err)
           ]
     forMachine dtal (TrConnectError Nothing remoteAddress err) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectError"
           , "remoteAddress" .= forMachine dtal remoteAddress
           , "reason" .= String (pack . show $ err)
           ]
     forMachine _dtal (TrTerminatingConnection prov connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "TerminatingConnection"
           , "provenance" .= String (pack . show $ prov)
           , "connectionId" .= toJSON connId
           ]
     forMachine dtal (TrTerminatedConnection prov remoteAddress) =
-        mkObject
+        mconcat
           [ "kind" .= String "TerminatedConnection"
           , "provenance" .= String (pack . show $ prov)
           , "remoteAddress" .= forMachine dtal remoteAddress
           ]
     forMachine dtal (TrConnectionHandler connId a) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionHandler"
           , "connectionId" .= toJSON connId
           , "connectionHandler" .= forMachine dtal a
           ]
     forMachine _dtal TrShutdown =
-        mkObject
+        mconcat
           [ "kind" .= String "Shutdown"
           ]
     forMachine dtal (TrConnectionExists prov remoteAddress inState) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionExists"
           , "provenance" .= String (pack . show $ prov)
           , "remoteAddress" .= forMachine dtal remoteAddress
           , "state" .= toJSON inState
           ]
     forMachine _dtal (TrForbiddenConnection connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ForbiddenConnection"
           , "connectionId" .= toJSON connId
           ]
     forMachine _dtal (TrImpossibleConnection connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ImpossibleConnection"
           , "connectionId" .= toJSON connId
           ]
     forMachine _dtal (TrConnectionFailure connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionFailure"
           , "connectionId" .= toJSON connId
           ]
     forMachine dtal (TrConnectionNotFound prov remoteAddress) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionNotFound"
           , "remoteAddress" .= forMachine dtal remoteAddress
           , "provenance" .= String (pack . show $ prov)
           ]
     forMachine dtal (TrForbiddenOperation remoteAddress connState) =
-        mkObject
+        mconcat
           [ "kind" .= String "ForbiddenOperation"
           , "remoteAddress" .= forMachine dtal remoteAddress
           , "connectionState" .= toJSON connState
           ]
     forMachine dtal (TrPruneConnections pruningSet numberPruned chosenPeers) =
-        mkObject
+        mconcat
           [ "kind" .= String "PruneConnections"
           , "prunedPeers" .= toJSON pruningSet
           , "numberPrunedPeers" .= toJSON numberPruned
           , "choiceSet" .= toJSON (forMachine dtal `Set.map` chosenPeers)
           ]
     forMachine _dtal (TrConnectionCleanup connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionCleanup"
           , "connectionId" .= toJSON connId
           ]
     forMachine _dtal (TrConnectionTimeWait connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionTimeWait"
           , "connectionId" .= toJSON connId
           ]
     forMachine _dtal (TrConnectionTimeWaitDone connId) =
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionTimeWaitDone"
           , "connectionId" .= toJSON connId
           ]
     forMachine _dtal (TrConnectionManagerCounters cmCounters) =
-        mkObject
+        mconcat
           [ "kind"  .= String "ConnectionManagerCounters"
           , "state" .= toJSON cmCounters
           ]
     forMachine _dtal (TrState cmState) =
-        mkObject
+        mconcat
           [ "kind"  .= String "ConnectionManagerState"
           , "state" .= listValue (\(addr, connState) ->
                                          object
@@ -910,10 +912,15 @@ instance (Show addr, Show versionNumber, Show agreedOptions, LogFormatting addr,
                                        (Map.toList cmState)
           ]
     forMachine _dtal (ConnectionManager.TrUnexpectedlyFalseAssertion info) =
-        mkObject
+        mconcat
           [ "kind" .= String "UnexpectedlyFalseAssertion"
           , "info" .= String (pack . show $ info)
           ]
+    forMachine _dtal (TrUnknownConnection info) =
+      mconcat
+        [ "kind" .= String "UnknownConnection"
+        , "info" .= String (pack . show $ info)
+        ]
     forHuman = pack . show
     asMetrics (TrConnectionManagerCounters ConnectionManagerCounters {..}) =
           [ IntM
@@ -937,23 +944,23 @@ instance (Show addr, Show versionNumber, Show agreedOptions, LogFormatting addr,
 instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
   => LogFormatting (ConnectionHandlerTrace versionNumber agreedOptions) where
   forMachine _dtal (TrHandshakeSuccess versionNumber agreedOptions) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeSuccess"
       , "versionNumber" .= toJSON versionNumber
       , "agreedOptions" .= toJSON agreedOptions
       ]
   forMachine _dtal (TrHandshakeClientError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeClientError"
       , "reason" .= toJSON err
       ]
   forMachine _dtal (TrHandshakeServerError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeServerError"
       , "reason" .= toJSON err
       ]
   forMachine _dtal (TrError e err cerr) =
-    mkObject
+    mconcat
       [ "kind" .= String "Error"
       , "context" .= show e
       , "reason" .= show err
@@ -1079,7 +1086,7 @@ severityConnectionManagerTransition _ = Debug
 instance (Show peerAddr, ToJSON peerAddr)
       => LogFormatting (ConnectionManager.AbstractTransitionTrace peerAddr) where
     forMachine _dtal (ConnectionManager.TransitionTrace peerAddr tr) =
-      mkObject $ reverse
+      mconcat $ reverse
         [ "kind"    .= String "ConnectionManagerTransition"
         , "address" .= toJSON peerAddr
         , "from"    .= toJSON (ConnectionManager.fromState tr)
@@ -1120,26 +1127,26 @@ severityServer TrServerError {}       = Critical
 instance (Show addr, LogFormatting addr, ToJSON addr)
       => LogFormatting (ServerTrace addr) where
   forMachine dtal (TrAcceptConnection peerAddr)     =
-    mkObject [ "kind" .= String "AcceptConnection"
+    mconcat [ "kind" .= String "AcceptConnection"
              , "address" .= forMachine dtal peerAddr
              ]
   forMachine _dtal (TrAcceptError exception)         =
-    mkObject [ "kind" .= String "AcceptErroor"
+    mconcat [ "kind" .= String "AcceptErroor"
              , "reason" .= show exception
              ]
   forMachine dtal (TrAcceptPolicyTrace policyTrace) =
-    mkObject [ "kind" .= String "AcceptPolicyTrace"
+    mconcat [ "kind" .= String "AcceptPolicyTrace"
              , "policy" .= forMachine dtal policyTrace
              ]
   forMachine dtal (TrServerStarted peerAddrs)       =
-    mkObject [ "kind" .= String "AcceptPolicyTrace"
+    mconcat [ "kind" .= String "AcceptPolicyTrace"
              , "addresses" .= toJSON (forMachine dtal `map` peerAddrs)
              ]
   forMachine _dtal TrServerStopped                   =
-    mkObject [ "kind" .= String "ServerStopped"
+    mconcat [ "kind" .= String "ServerStopped"
              ]
   forMachine _dtal (TrServerError exception)         =
-    mkObject [ "kind" .= String "ServerError"
+    mconcat [ "kind" .= String "ServerError"
              , "reason" .= show exception
              ]
   forHuman = pack . show
@@ -1219,86 +1226,86 @@ severityInboundGovernor InboundGovernor.TrInboundGovernorError {}       = Error
 instance (ToJSON addr, Show addr)
       => LogFormatting (InboundGovernorTrace addr) where
   forMachine _dtal (TrNewConnection p connId)            =
-    mkObject [ "kind" .= String "NewConnection"
+    mconcat [ "kind" .= String "NewConnection"
              , "provenance" .= show p
              , "connectionId" .= toJSON connId
              ]
   forMachine _dtal (TrResponderRestarted connId m)       =
-    mkObject [ "kind" .= String "ResponderStarted"
+    mconcat [ "kind" .= String "ResponderStarted"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   forMachine _dtal (TrResponderStartFailure connId m s)  =
-    mkObject [ "kind" .= String "ResponderStartFailure"
+    mconcat [ "kind" .= String "ResponderStartFailure"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              , "reason" .= show s
              ]
   forMachine _dtal (TrResponderErrored connId m s)       =
-    mkObject [ "kind" .= String "ResponderErrored"
+    mconcat [ "kind" .= String "ResponderErrored"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              , "reason" .= show s
              ]
   forMachine _dtal (TrResponderStarted connId m)         =
-    mkObject [ "kind" .= String "ResponderStarted"
+    mconcat [ "kind" .= String "ResponderStarted"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   forMachine _dtal (TrResponderTerminated connId m)      =
-    mkObject [ "kind" .= String "ResponderTerminated"
+    mconcat [ "kind" .= String "ResponderTerminated"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   forMachine _dtal (TrPromotedToWarmRemote connId opRes) =
-    mkObject [ "kind" .= String "PromotedToWarmRemote"
+    mconcat [ "kind" .= String "PromotedToWarmRemote"
              , "connectionId" .= toJSON connId
              , "result" .= toJSON opRes
              ]
   forMachine _dtal (TrPromotedToHotRemote connId)        =
-    mkObject [ "kind" .= String "PromotedToHotRemote"
+    mconcat [ "kind" .= String "PromotedToHotRemote"
              , "connectionId" .= toJSON connId
              ]
   forMachine _dtal (TrDemotedToColdRemote connId od)     =
-    mkObject [ "kind" .= String "DemotedToColdRemote"
+    mconcat [ "kind" .= String "DemotedToColdRemote"
              , "connectionId" .= toJSON connId
              , "result" .= show od
              ]
   forMachine _dtal (TrDemotedToWarmRemote connId)     =
-    mkObject [ "kind" .= String "DemotedToWarmRemote"
+    mconcat [ "kind" .= String "DemotedToWarmRemote"
              , "connectionId" .= toJSON connId
              ]
   forMachine _dtal (TrWaitIdleRemote connId opRes) =
-    mkObject [ "kind" .= String "WaitIdleRemote"
+    mconcat [ "kind" .= String "WaitIdleRemote"
              , "connectionId" .= toJSON connId
              , "result" .= toJSON opRes
              ]
   forMachine _dtal (TrMuxCleanExit connId)               =
-    mkObject [ "kind" .= String "MuxCleanExit"
+    mconcat [ "kind" .= String "MuxCleanExit"
              , "connectionId" .= toJSON connId
              ]
   forMachine _dtal (TrMuxErrored connId s)               =
-    mkObject [ "kind" .= String "MuxErrored"
+    mconcat [ "kind" .= String "MuxErrored"
              , "connectionId" .= toJSON connId
              , "reason" .= show s
              ]
   forMachine _dtal (TrInboundGovernorCounters counters) =
-    mkObject [ "kind" .= String "InboundGovernorCounters"
+    mconcat [ "kind" .= String "InboundGovernorCounters"
              , "idlePeers" .= idlePeersRemote counters
              , "coldPeers" .= coldPeersRemote counters
              , "warmPeers" .= warmPeersRemote counters
              , "hotPeers" .= hotPeersRemote counters
              ]
   forMachine _dtal (TrRemoteState st) =
-    mkObject [ "kind" .= String "RemoteState"
+    mconcat [ "kind" .= String "RemoteState"
              , "remoteSt" .= toJSON st
              ]
   forMachine _dtal (InboundGovernor.TrUnexpectedlyFalseAssertion info) =
-    mkObject [ "kind" .= String "UnexpectedlyFalseAssertion"
+    mconcat [ "kind" .= String "UnexpectedlyFalseAssertion"
              , "remoteSt" .= String (pack . show $ info)
              ]
   forMachine _dtal (InboundGovernor.TrInboundGovernorError err) =
-    mkObject [ "kind" .= String "InboundGovernorError"
+    mconcat [ "kind" .= String "InboundGovernorError"
              , "remoteSt" .= String (pack . show $ err)
              ]
   forHuman = pack . show
@@ -1453,7 +1460,7 @@ severityInboundGovernorTransition _ = Debug
 instance (Show peerAddr, ToJSON peerAddr)
       => LogFormatting (InboundGovernor.RemoteTransitionTrace peerAddr) where
     forMachine _dtal (InboundGovernor.TransitionTrace peerAddr tr) =
-      mkObject $ reverse
+      mconcat $ reverse
         [ "kind"    .= String "ConnectionManagerTransition"
         , "address" .= toJSON peerAddr
         , "from"    .= toJSON (ConnectionManager.fromState tr)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -126,9 +126,9 @@ severityPeers :: [PeerT blk] -> SeverityS
 severityPeers _ = Notice
 
 instance LogFormatting [PeerT blk] where
-  forMachine DMinimal _ = mkObject [ "kind"  .= String "NodeKernelPeers"]
-  forMachine _ []       = mkObject [ "kind"  .= String "NodeKernelPeers"]
-  forMachine dtal xs    = mkObject
+  forMachine DMinimal _ = mconcat [ "kind"  .= String "NodeKernelPeers"]
+  forMachine _ []       = mconcat [ "kind"  .= String "NodeKernelPeers"]
+  forMachine dtal xs    = mconcat
     [ "kind"  .= String "NodeKernelPeers"
     , "peers" .= toJSON (foldl' (\acc x -> forMachine dtal x : acc) [] xs)
     ]
@@ -137,7 +137,7 @@ instance LogFormatting [PeerT blk] where
 
 instance LogFormatting (PeerT blk) where
   forMachine _dtal (PeerT cid _af status inflight) =
-    mkObject [ "peerAddress"   .= String (Text.pack . show . remoteAddress $ cid)
+    mconcat [ "peerAddress"   .= String (Text.pack . show . remoteAddress $ cid)
              , "peerStatus"    .= String (Text.pack . ppStatus $ status)
              , "peerSlotNo"    .= String (Text.pack . ppMaxSlotNo . peerFetchMaxSlotNo $ inflight)
              , "peerReqsInF"   .= String (show . peerFetchReqsInFlight $ inflight)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
@@ -15,7 +15,7 @@ module Cardano.Node.Tracing.Tracers.Shutdown
 import           Cardano.Logging
 import           Cardano.Node.Handlers.Shutdown
 import           Data.Aeson (ToJSON (..), Value (..), (.=))
-import           Data.Monoid ((<>))
+import           Data.Monoid (mconcat, (<>))
 import           Data.Text (Text, pack)
 import           Prelude (show)
 
@@ -53,17 +53,17 @@ instance LogFormatting ShutdownTrace where
 
   forMachine _ = \case
     ShutdownRequested ->
-          mkObject [ "kind"   .= String "ShutdownRequested" ]
+          mconcat [ "kind"   .= String "ShutdownRequested" ]
     AbnormalShutdown  ->
-          mkObject [ "kind"   .= String "AbnormalShutdown" ]
+          mconcat [ "kind"   .= String "AbnormalShutdown" ]
     ShutdownUnexpectedInput text ->
-          mkObject [ "kind"   .= String "AbnormalShutdown"
+          mconcat [ "kind"   .= String "AbnormalShutdown"
                    , "unexpected" .= String text ]
     RequestingShutdown reason ->
-          mkObject [ "kind"   .= String "RequestingShutdown"
+          mconcat [ "kind"   .= String "RequestingShutdown"
                    , "reason" .= String reason ]
     ShutdownArmedAtSlot slot  ->
-          mkObject [ "kind"   .= String "ShutdownArmedAtSlot"
+          mconcat [ "kind"   .= String "ShutdownArmedAtSlot"
                    , "slot"   .= toJSON slot ]
 
 docShutdown :: Documented ShutdownTrace

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -148,7 +148,7 @@ instance ( Show (BlockNodeToNodeVersion blk)
                                  localSocket
                                  supportedNodeToNodeVersions
                                  supportedNodeToClientVersions)
-      = mkObject (
+      = mconcat (
         [ "kind" .= String "StartupInfo"
         , "nodeAddresses" .= toJSON (map ppN2NSocketInfo addresses)
         , "localSocket" .= case localSocket of
@@ -174,10 +174,10 @@ instance ( Show (BlockNodeToNodeVersion blk)
                   Just (v, _) -> String (pack . show $ v)
             ])
   forMachine _dtal (StartupP2PInfo diffusionMode) =
-      mkObject [ "kind" .= String "StartupP2PInfo"
+      mconcat [ "kind" .= String "StartupP2PInfo"
                , "diffusionMode" .= String (showT diffusionMode) ]
   forMachine _dtal (StartupTime time) =
-      mkObject [ "kind" .= String "StartupTime"
+      mconcat [ "kind" .= String "StartupTime"
                , "startupTime" .= String ( showT
                                          . (ceiling :: POSIXTime -> Int)
                                          . utcTimeToPOSIXSeconds
@@ -185,54 +185,54 @@ instance ( Show (BlockNodeToNodeVersion blk)
                                          )
                ]
   forMachine _dtal (StartupNetworkMagic networkMagic) =
-      mkObject [ "kind" .= String "StartupNetworkMagic"
+      mconcat [ "kind" .= String "StartupNetworkMagic"
                , "networkMagic" .= String (showT . unNetworkMagic
                                           $ networkMagic) ]
   forMachine _dtal (StartupSocketConfigError err) =
-      mkObject [ "kind" .= String "StartupSocketConfigError"
+      mconcat [ "kind" .= String "StartupSocketConfigError"
                , "error" .= String (showT err) ]
   forMachine _dtal StartupDBValidation =
-      mkObject [ "kind" .= String "StartupDBValidation"
+      mconcat [ "kind" .= String "StartupDBValidation"
                , "message" .= String "start db validation" ]
   forMachine _dtal NetworkConfigUpdate =
-      mkObject [ "kind" .= String "NetworkConfigUpdate"
+      mconcat [ "kind" .= String "NetworkConfigUpdate"
                , "message" .= String "ntework configuration update" ]
   forMachine _dtal (NetworkConfigUpdateError err) =
-      mkObject [ "kind" .= String "NetworkConfigUpdateError"
+      mconcat [ "kind" .= String "NetworkConfigUpdateError"
                , "error" .= String err ]
   forMachine _dtal (NetworkConfig localRoots publicRoots useLedgerAfter) =
-      mkObject [ "kind" .= String "NetworkConfig"
+      mconcat [ "kind" .= String "NetworkConfig"
                , "localRoots" .= toJSON localRoots
                , "publicRoots" .= toJSON publicRoots
                , "useLedgerAfter" .= UseLedger useLedgerAfter
                ]
   forMachine _dtal P2PWarning =
-      mkObject [ "kind" .= String "P2PWarning"
+      mconcat [ "kind" .= String "P2PWarning"
                , "message" .= String p2pWarningMessage ]
   forMachine _dtal P2PWarningDevelopementNetworkProtocols =
-      mkObject [ "kind" .= String "P2PWarningDevelopementNetworkProtocols"
+      mconcat [ "kind" .= String "P2PWarningDevelopementNetworkProtocols"
                , "message" .= String p2pWarningDevelopmentNetworkProtocolsMessage ]
   forMachine _ver (WarningDevelopmentNetworkProtocols ntnVersions ntcVersions) =
-      mkObject [ "kind" .= String "WarningDevelopmentNetworkProtocols"
+      mconcat [ "kind" .= String "WarningDevelopmentNetworkProtocols"
                , "message" .= String "enabled development network protocols"
                , "nodeToNodeDevelopmentVersions" .= String (showT ntnVersions)
                , "nodeToClientDevelopmentVersions" .= String (showT ntcVersions)
                ]
   forMachine _dtal (BINetwork BasicInfoNetwork {..}) =
-      mkObject [ "kind" .= String "BasicInfoNetwork"
+      mconcat [ "kind" .= String "BasicInfoNetwork"
                , "addresses" .= String (showT niAddresses)
                , "diffusionMode"  .= String (showT niDiffusionMode)
                , "dnsProducers" .= String (showT niDnsProducers)
                , "ipProducers" .= String (showT niIpProducers)
                ]
   forMachine _dtal (BIByron BasicInfoByron {..}) =
-      mkObject [ "kind" .= String "BasicInfoByron"
+      mconcat [ "kind" .= String "BasicInfoByron"
                , "systemStartTime" .= String (showT bibSystemStartTime)
                , "slotLength"  .= String (showT bibSlotLength)
                , "epochLength" .= String (showT bibEpochLength)
                ]
   forMachine _dtal (BIShelley BasicInfoShelleyBased {..}) =
-      mkObject [ "kind" .= String "BasicInfoShelleyBased"
+      mconcat [ "kind" .= String "BasicInfoShelleyBased"
                , "era"  .= String bisEra
                , "systemStartTime" .= String (showT bisSystemStartTime)
                , "slotLength"  .= String (showT bisSlotLength)
@@ -240,7 +240,7 @@ instance ( Show (BlockNodeToNodeVersion blk)
                , "slotsPerKESPeriod" .= String (showT bisSlotsPerKESPeriod)
                ]
   forMachine _dtal (BICommon BasicInfoCommon {..}) =
-      mkObject [ "kind" .= String "BasicInfoCommon"
+      mconcat [ "kind" .= String "BasicInfoCommon"
                , "configPath" .= String (pack biConfigPath)
                , "networkMagic"  .= String (showT biNetworkMagic)
                , "protocol" .= String biProtocol

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -26,6 +26,7 @@ import           Cardano.Prelude
 import           Prelude (String)
 
 import           Data.Aeson
+import qualified Data.Aeson.Key as Aeson
 import           Data.Aeson.Types
 import qualified Data.Text as Text
 import           Generic.Data (gmappend)
@@ -606,7 +607,7 @@ proxyLastToEither name (Last x) =
   maybe (Left $ "Default value not specified for " <> proxyName name) Right x
 
 parseTracer :: KnownSymbol name => Proxy name -> Object -> Parser (Last (OnOff name))
-parseTracer p obj = Last <$> obj .:? proxyName p
+parseTracer p obj = Last <$> obj .:? Aeson.fromText (proxyName p)
 
 lastToEither :: String -> Last a -> Either String a
 lastToEither errMsg (Last x) = maybe (Left errMsg) Right x

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -16,9 +16,9 @@ import           Data.Aeson (Value (..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
-import           Cardano.Tracing.Render (renderTxId)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
+import           Cardano.Tracing.Render (renderTxId)
 
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
@@ -45,36 +45,36 @@ import           Cardano.Crypto.Signing (VerificationKey)
 
 instance ToObject ApplyMempoolPayloadErr where
   toObject _verb (MempoolTxErr utxoValidationErr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolTxErr"
       , "error" .= String (show utxoValidationErr)
       ]
   toObject _verb (MempoolDlgErr delegScheduleError) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolDlgErr"
       , "error" .= String (show delegScheduleError)
       ]
   toObject _verb (MempoolUpdateProposalErr iFaceErr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolUpdateProposalErr"
       , "error" .= String (show iFaceErr)
       ]
   toObject _verb (MempoolUpdateVoteErr iFaceErrr) =
-    mkObject
+    mconcat
       [ "kind" .= String "MempoolUpdateVoteErr"
       , "error" .= String (show iFaceErrr)
       ]
 
 instance ToObject ByronLedgerUpdate where
   toObject verb (ByronUpdatedProtocolUpdates protocolUpdates) =
-    mkObject
+    mconcat
       [ "kind"            .= String "ByronUpdatedProtocolUpdates"
       , "protocolUpdates" .= map (toObject verb) protocolUpdates
       ]
 
 instance ToObject ProtocolUpdate where
   toObject verb (ProtocolUpdate updateVersion updateState) =
-    mkObject
+    mconcat
       [ "kind"                  .= String "ProtocolUpdate"
       , "protocolUpdateVersion" .= updateVersion
       , "protocolUpdateState"   .= toObject verb updateState
@@ -83,39 +83,39 @@ instance ToObject ProtocolUpdate where
 instance ToObject UpdateState where
   toObject _verb updateState = case updateState of
       UpdateRegistered slot ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateRegistered"
           , "slot" .= slot
           ]
       UpdateActive votes ->
-        mkObject
+        mconcat
           [ "kind"  .= String "UpdateActive"
           , "votes" .= map (Text.pack . show) (Set.toList votes)
           ]
       UpdateConfirmed slot ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateConfirmed"
           , "slot" .= slot
           ]
       UpdateStablyConfirmed endorsements ->
-        mkObject
+        mconcat
           [ "kind"         .= String "UpdateStablyConfirmed"
           , "endorsements" .= map (Text.pack . show) (Set.toList endorsements)
           ]
       UpdateCandidate slot epoch ->
-        mkObject
+        mconcat
           [ "kind" .= String "UpdateCandidate"
           , "slot" .= slot
           , "epoch" .= epoch
           ]
       UpdateStableCandidate transitionEpoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "UpdateStableCandidate"
           , "transitionEpoch" .= transitionEpoch
           ]
 
 instance ToObject (GenTx ByronBlock) where
-  toObject _ tx = mkObject [ "txid" .= Text.take 8 (renderTxId (txId tx)) ]
+  toObject _ tx = mconcat [ "txid" .= Text.take 8 (renderTxId (txId tx)) ]
 
 
 instance ToJSON (TxId (GenTx ByronBlock)) where
@@ -124,73 +124,73 @@ instance ToJSON (TxId (GenTx ByronBlock)) where
 
 instance ToObject ChainValidationError where
   toObject _verb ChainValidationBoundaryTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBoundaryTooLarge" ]
   toObject _verb ChainValidationBlockAttributesTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBlockAttributesTooLarge" ]
   toObject _verb (ChainValidationBlockTooLarge _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationBlockTooLarge" ]
   toObject _verb ChainValidationHeaderAttributesTooLarge =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationHeaderAttributesTooLarge" ]
   toObject _verb (ChainValidationHeaderTooLarge _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationHeaderTooLarge" ]
   toObject _verb (ChainValidationDelegationPayloadError err) =
-    mkObject
+    mconcat
       [ "kind" .= String err ]
   toObject _verb (ChainValidationInvalidDelegation _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidDelegation" ]
   toObject _verb (ChainValidationGenesisHashMismatch _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationGenesisHashMismatch" ]
   toObject _verb (ChainValidationExpectedGenesisHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationExpectedGenesisHash" ]
   toObject _verb (ChainValidationExpectedHeaderHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationExpectedHeaderHash" ]
   toObject _verb (ChainValidationInvalidHash _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidHash" ]
   toObject _verb (ChainValidationMissingHash _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationMissingHash" ]
   toObject _verb (ChainValidationUnexpectedGenesisHash _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUnexpectedGenesisHash" ]
   toObject _verb (ChainValidationInvalidSignature _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationInvalidSignature" ]
   toObject _verb (ChainValidationDelegationSchedulingError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationDelegationSchedulingError" ]
   toObject _verb (ChainValidationProtocolMagicMismatch _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationProtocolMagicMismatch" ]
   toObject _verb ChainValidationSignatureLight =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationSignatureLight" ]
   toObject _verb (ChainValidationTooManyDelegations _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationTooManyDelegations" ]
   toObject _verb (ChainValidationUpdateError _ _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUpdateError" ]
   toObject _verb (ChainValidationUTxOValidationError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationUTxOValidationError" ]
   toObject _verb (ChainValidationProofValidationError _) =
-    mkObject
+    mconcat
       [ "kind" .= String "ChainValidationProofValidationError" ]
 
 
 instance ToObject (Header ByronBlock) where
   toObject _verb b =
-    mkObject $
+    mconcat $
         [ "kind" .= String "ByronBlock"
         , "hash" .= condense (blockHash b)
         , "slotNo" .= condense (blockSlot b)
@@ -208,7 +208,7 @@ instance ToObject (Header ByronBlock) where
 
 instance ToObject ByronOtherHeaderEnvelopeError where
   toObject _verb (UnexpectedEBBInSlot slot) =
-    mkObject
+    mconcat
       [ "kind" .= String "UnexpectedEBBInSlot"
       , "slot" .= slot
       ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -57,9 +57,9 @@ import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..),
                    chunkNoToInt)
 import           Ouroboros.Consensus.Storage.LedgerDB.Types
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Types as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Types as LedgerDB
 
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -71,8 +71,9 @@ import           Ouroboros.Network.Point (withOrigin)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 -- TODO: 'TraceCacheEvent' should be exported by the 'Impl' module
-import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
+import qualified Data.Aeson as Aeson
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmDB
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 
 
@@ -392,9 +393,9 @@ instance HasSeverityAnnotation a => HasSeverityAnnotation (Consensus.TraceLabelC
 
 instance ToObject a => ToObject (Consensus.TraceLabelCreds a) where
   toObject verb (Consensus.TraceLabelCreds creds val) =
-    mkObject [ "credentials" .= toJSON creds
-             , "val"         .= toObject verb val
-             ]
+    mconcat [ "credentials" .= toJSON creds
+            , "val"         .= toObject verb val
+            ]
 
 instance (HasPrivacyAnnotation a, HasSeverityAnnotation a, ToObject a)
       => Transformable Text IO (Consensus.TraceLabelCreds a) where
@@ -629,7 +630,7 @@ instance ( ConvertRawHash blk
 
 instance ToObject BFT.BftValidationErr where
   toObject _verb (BFT.BftInvalidSignature err) =
-    mkObject
+    mconcat
       [ "kind" .= String "BftInvalidSignature"
       , "error" .= String (pack err)
       ]
@@ -637,9 +638,9 @@ instance ToObject BFT.BftValidationErr where
 
 instance ToObject LedgerDB.DiskSnapshot where
   toObject MinimalVerbosity snap = toObject NormalVerbosity snap
-  toObject NormalVerbosity _ = mkObject [ "kind" .= String "snapshot" ]
+  toObject NormalVerbosity _ = mconcat [ "kind" .= String "snapshot" ]
   toObject MaximalVerbosity snap =
-    mkObject [ "kind" .= String "snapshot"
+    mconcat [ "kind" .= String "snapshot"
              , "snapshot" .= String (pack $ show snap) ]
 
 
@@ -657,19 +658,19 @@ instance ( StandardHash blk
          )
       => ToObject (HeaderEnvelopeError blk) where
   toObject _verb (UnexpectedBlockNo expect act) =
-    mkObject
+    mconcat
       [ "kind" .= String "UnexpectedBlockNo"
       , "expected" .= condense expect
       , "actual" .= condense act
       ]
   toObject _verb (UnexpectedSlotNo expect act) =
-    mkObject
+    mconcat
       [ "kind" .= String "UnexpectedSlotNo"
       , "expected" .= condense expect
       , "actual" .= condense act
       ]
   toObject _verb (UnexpectedPrevHash expect act) =
-    mkObject
+    mconcat
       [ "kind" .= String "UnexpectedPrevHash"
       , "expected" .= String (pack $ show expect)
       , "actual" .= String (pack $ show act)
@@ -684,12 +685,12 @@ instance ( StandardHash blk
          )
       => ToObject (HeaderError blk) where
   toObject verb (HeaderProtocolError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HeaderProtocolError"
       , "error" .= toObject verb err
       ]
   toObject verb (HeaderEnvelopeError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HeaderEnvelopeError"
       , "error" .= toObject verb err
       ]
@@ -702,12 +703,12 @@ instance ( ConvertRawHash blk
          , ToObject (ValidationErr (BlockProtocol blk)))
       => ToObject (ChainDB.InvalidBlockReason blk) where
   toObject verb (ChainDB.ValidationError extvalerr) =
-    mkObject
+    mconcat
       [ "kind" .= String "ValidationError"
       , "error" .= toObject verb extvalerr
       ]
   toObject verb (ChainDB.InFutureExceedsClockSkew point) =
-    mkObject
+    mconcat
       [ "kind" .= String "InFutureExceedsClockSkew"
       , "point" .= toObject verb point
       ]
@@ -716,23 +717,23 @@ instance ( ConvertRawHash blk
 instance (Show (PBFT.PBftVerKeyHash c))
       => ToObject (PBFT.PBftValidationErr c) where
   toObject _verb (PBFT.PBftInvalidSignature text) =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftInvalidSignature"
       , "error" .= String text
       ]
   toObject _verb (PBFT.PBftNotGenesisDelegate vkhash _ledgerView) =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftNotGenesisDelegate"
       , "vk" .= String (pack $ show vkhash)
       ]
   toObject _verb (PBFT.PBftExceededSignThreshold vkhash numForged) =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftExceededSignThreshold"
       , "vk" .= String (pack $ show vkhash)
       , "numForged" .= String (pack (show numForged))
       ]
   toObject _verb PBFT.PBftInvalidSlot =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftInvalidSlot"
       ]
 
@@ -740,12 +741,12 @@ instance (Show (PBFT.PBftVerKeyHash c))
 instance (Show (PBFT.PBftVerKeyHash c))
       => ToObject (PBFT.PBftCannotForge c) where
   toObject _verb (PBFT.PBftCannotForgeInvalidDelegation vkhash) =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftCannotForgeInvalidDelegation"
       , "vk" .= String (pack $ show vkhash)
       ]
   toObject _verb (PBFT.PBftCannotForgeThresholdExceeded numForged) =
-    mkObject
+    mconcat
       [ "kind" .= String "PBftCannotForgeThresholdExceeded"
       , "numForged" .= numForged
       ]
@@ -753,7 +754,7 @@ instance (Show (PBFT.PBftVerKeyHash c))
 
 instance ConvertRawHash blk
       => ToObject (RealPoint blk) where
-  toObject verb p = mkObject
+  toObject verb p = mconcat
         [ "kind" .= String "Point"
         , "slot" .= unSlotNo (realPointSlot p)
         , "hash" .= renderHeaderHashForVerbosity (Proxy @blk) verb (realPointHash p) ]
@@ -773,34 +774,34 @@ instance ( ConvertRawHash blk
       => ToObject (ChainDB.TraceEvent blk) where
   toObject verb (ChainDB.TraceAddBlockEvent ev) = case ev of
     ChainDB.IgnoreBlockOlderThanK pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockOlderThanK"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockOlderThanK"
                , "block" .= toObject verb pt ]
     ChainDB.IgnoreBlockAlreadyInVolatileDB pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockAlreadyInVolatileDB"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.IgnoreBlockAlreadyInVolatileDB"
                , "block" .= toObject verb pt ]
     ChainDB.IgnoreInvalidBlock pt reason ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.IgnoreInvalidBlock"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.IgnoreInvalidBlock"
                , "block" .= toObject verb pt
                , "reason" .= show reason ]
     ChainDB.AddedBlockToQueue pt sz ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.AddedBlockToQueue"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.AddedBlockToQueue"
                , "block" .= toObject verb pt
                , "queueSize" .= toJSON sz ]
     ChainDB.BlockInTheFuture pt slot ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
                , "block" .= toObject verb pt
                , "slot" .= toObject verb slot ]
     ChainDB.StoreButDontChange pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.StoreButDontChange"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.StoreButDontChange"
                , "block" .= toObject verb pt ]
     ChainDB.TryAddToCurrentChain pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.TryAddToCurrentChain"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.TryAddToCurrentChain"
                , "block" .= toObject verb pt ]
     ChainDB.TrySwitchToAFork pt _ ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.TrySwitchToAFork"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.TrySwitchToAFork"
                , "block" .= toObject verb pt ]
     ChainDB.AddedToCurrentChain events _ base extended ->
-      mkObject $
+      mconcat $
                [ "kind" .= String "TraceAddBlockEvent.AddedToCurrentChain"
                , "newtip" .= renderPointForVerbosity verb (AF.headPoint extended)
                , "chainLengthDelta" .= extended `chainLengthΔ` base
@@ -810,7 +811,7 @@ instance ( ConvertRawHash blk
             ++ [ "events" .= toJSON (map (toObject verb) events)
                | not (null events) ]
     ChainDB.SwitchedToAFork events _ old new ->
-      mkObject $
+      mconcat $
                [ "kind" .= String "TraceAddBlockEvent.SwitchedToAFork"
                , "newtip" .= renderPointForVerbosity verb (AF.headPoint new)
                , "chainLengthDelta" .= new `chainLengthΔ` old
@@ -823,33 +824,33 @@ instance ( ConvertRawHash blk
                | not (null events) ]
     ChainDB.AddBlockValidation ev' -> case ev' of
       ChainDB.InvalidBlock err pt ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidBlock"
+        mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.InvalidBlock"
                  , "block" .= toObject verb pt
                  , "error" .= show err ]
       ChainDB.ValidCandidate c ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.ValidCandidate"
+        mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.ValidCandidate"
                  , "block" .= renderPointForVerbosity verb (AF.headPoint c) ]
       ChainDB.CandidateContainsFutureBlocks c hdrs ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateContainsFutureBlocks"
+        mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateContainsFutureBlocks"
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
       ChainDB.CandidateContainsFutureBlocksExceedingClockSkew c hdrs ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateContainsFutureBlocksExceedingClockSkew"
+        mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateContainsFutureBlocksExceedingClockSkew"
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
       ChainDB.UpdateLedgerDbTraceEvent (LedgerDB.StartedPushingBlockToTheLedgerDb (LedgerDB.PushStart start) (LedgerDB.PushGoal goal) (LedgerDB.Pushing curr)) ->
-        mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDb"
+        mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDb"
                  , "startingBlock" .= renderRealPoint start
                  , "currentBlock" .= renderRealPoint curr
                  , "targetBlock" .= renderRealPoint goal
                  ]
 
     ChainDB.AddedBlockToVolatileDB pt (BlockNo bn) _ ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.AddedBlockToVolatileDB"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.AddedBlockToVolatileDB"
                , "block" .= toObject verb pt
                , "blockNo" .= show bn ]
     ChainDB.ChainSelectionForFutureBlock pt ->
-      mkObject [ "kind" .= String "TraceAddBlockEvent.ChainSelectionForFutureBlock"
+      mconcat [ "kind" .= String "TraceAddBlockEvent.ChainSelectionForFutureBlock"
                , "block" .= toObject verb pt ]
    where
      addedHdrsNewChain
@@ -863,108 +864,108 @@ instance ( ConvertRawHash blk
          Nothing -> [] -- No sense to do validation here.
      chainLengthΔ :: AF.AnchoredFragment (Header blk) -> AF.AnchoredFragment (Header blk) -> Int
      chainLengthΔ = on (-) (fromWithOrigin (-1) . fmap (fromIntegral . unBlockNo) . AF.headBlockNo)
-  toObject MinimalVerbosity (ChainDB.TraceLedgerReplayEvent _ev) = emptyObject -- no output
+  toObject MinimalVerbosity (ChainDB.TraceLedgerReplayEvent _ev) = mempty -- no output
   toObject verb (ChainDB.TraceLedgerReplayEvent ev) = case ev of
     LedgerDB.ReplayFromGenesis _replayTo ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
+      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
     LedgerDB.ReplayFromSnapshot snap tip' _replayFrom _replayTo ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
+      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
                , "snapshot" .= toObject verb snap
                , "tip" .= show tip' ]
     LedgerDB.ReplayedBlock pt _ledgerEvents _ (LedgerDB.ReplayGoal replayTo)  ->
-      mkObject [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
+      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
                , "slot" .= unSlotNo (realPointSlot pt)
                , "tip"  .= withOrigin 0 unSlotNo (pointSlot replayTo) ]
 
-  toObject MinimalVerbosity (ChainDB.TraceLedgerEvent _ev) = emptyObject -- no output
+  toObject MinimalVerbosity (ChainDB.TraceLedgerEvent _ev) = mempty -- no output
   toObject verb (ChainDB.TraceLedgerEvent ev) = case ev of
     LedgerDB.TookSnapshot snap pt ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.TookSnapshot"
+      mconcat [ "kind" .= String "TraceLedgerEvent.TookSnapshot"
                , "snapshot" .= toObject verb snap
                , "tip" .= show pt ]
     LedgerDB.DeletedSnapshot snap ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.DeletedSnapshot"
+      mconcat [ "kind" .= String "TraceLedgerEvent.DeletedSnapshot"
                , "snapshot" .= toObject verb snap ]
     LedgerDB.InvalidSnapshot snap failure ->
-      mkObject [ "kind" .= String "TraceLedgerEvent.InvalidSnapshot"
+      mconcat [ "kind" .= String "TraceLedgerEvent.InvalidSnapshot"
                , "snapshot" .= toObject verb snap
                , "failure" .= show failure ]
 
   toObject verb (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB pt ->
-      mkObject [ "kind" .= String "TraceCopyToImmutableDBEvent.CopiedBlockToImmutableDB"
+      mconcat [ "kind" .= String "TraceCopyToImmutableDBEvent.CopiedBlockToImmutableDB"
                , "slot" .= toObject verb pt ]
     ChainDB.NoBlocksToCopyToImmutableDB ->
-      mkObject [ "kind" .= String "TraceCopyToImmutableDBEvent.NoBlocksToCopyToImmutableDB" ]
+      mconcat [ "kind" .= String "TraceCopyToImmutableDBEvent.NoBlocksToCopyToImmutableDB" ]
 
   toObject verb (ChainDB.TraceGCEvent ev) = case ev of
     ChainDB.PerformedGC slot ->
-      mkObject [ "kind" .= String "TraceGCEvent.PerformedGC"
+      mconcat [ "kind" .= String "TraceGCEvent.PerformedGC"
                , "slot" .= toObject verb slot ]
     ChainDB.ScheduledGC slot difft ->
-      mkObject $ [ "kind" .= String "TraceGCEvent.ScheduledGC"
+      mconcat $ [ "kind" .= String "TraceGCEvent.ScheduledGC"
                  , "slot" .= toObject verb slot ] <>
                  [ "difft" .= String ((pack . show) difft) | verb >= MaximalVerbosity]
 
   toObject verb (ChainDB.TraceOpenEvent ev) = case ev of
     ChainDB.StartedOpeningDB ->
-      mkObject ["kind" .= String "TraceOpenEvent.StartedOpeningDB"]
+      mconcat ["kind" .= String "TraceOpenEvent.StartedOpeningDB"]
     ChainDB.StartedOpeningImmutableDB ->
-      mkObject ["kind" .= String "TraceOpenEvent.StartedOpeningImmutableDB"]
+      mconcat ["kind" .= String "TraceOpenEvent.StartedOpeningImmutableDB"]
     ChainDB.StartedOpeningVolatileDB ->
-      mkObject ["kind" .= String "TraceOpenEvent.StartedOpeningVolatileDB"]
+      mconcat ["kind" .= String "TraceOpenEvent.StartedOpeningVolatileDB"]
     ChainDB.StartedOpeningLgrDB ->
-      mkObject ["kind" .= String "TraceOpenEvent.StartedOpeningLgrDB"]
+      mconcat ["kind" .= String "TraceOpenEvent.StartedOpeningLgrDB"]
     ChainDB.OpenedDB immTip tip' ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedDB"
+      mconcat [ "kind" .= String "TraceOpenEvent.OpenedDB"
                , "immtip" .= toObject verb immTip
                , "tip" .= toObject verb tip' ]
     ChainDB.ClosedDB immTip tip' ->
-      mkObject [ "kind" .= String "TraceOpenEvent.ClosedDB"
+      mconcat [ "kind" .= String "TraceOpenEvent.ClosedDB"
                , "immtip" .= toObject verb immTip
                , "tip" .= toObject verb tip' ]
     ChainDB.OpenedImmutableDB immTip epoch ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedImmutableDB"
+      mconcat [ "kind" .= String "TraceOpenEvent.OpenedImmutableDB"
                , "immtip" .= toObject verb immTip
                , "epoch" .= String ((pack . show) epoch) ]
     ChainDB.OpenedVolatileDB ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedVolatileDB" ]
+      mconcat [ "kind" .= String "TraceOpenEvent.OpenedVolatileDB" ]
     ChainDB.OpenedLgrDB ->
-      mkObject [ "kind" .= String "TraceOpenEvent.OpenedLgrDB" ]
+      mconcat [ "kind" .= String "TraceOpenEvent.OpenedLgrDB" ]
 
   toObject _verb (ChainDB.TraceFollowerEvent ev) = case ev of
     ChainDB.NewFollower ->
-      mkObject [ "kind" .= String "TraceFollowerEvent.NewFollower" ]
+      mconcat [ "kind" .= String "TraceFollowerEvent.NewFollower" ]
     ChainDB.FollowerNoLongerInMem _ ->
-      mkObject [ "kind" .= String "TraceFollowerEvent.FollowerNoLongerInMem" ]
+      mconcat [ "kind" .= String "TraceFollowerEvent.FollowerNoLongerInMem" ]
     ChainDB.FollowerSwitchToMem _ _ ->
-      mkObject [ "kind" .= String "TraceFollowerEvent.FollowerSwitchToMem" ]
+      mconcat [ "kind" .= String "TraceFollowerEvent.FollowerSwitchToMem" ]
     ChainDB.FollowerNewImmIterator _ _ ->
-      mkObject [ "kind" .= String "TraceFollowerEvent.FollowerNewImmIterator" ]
+      mconcat [ "kind" .= String "TraceFollowerEvent.FollowerNewImmIterator" ]
   toObject verb (ChainDB.TraceInitChainSelEvent ev) = case ev of
     ChainDB.InitalChainSelected ->
-      mkObject ["kind" .= String "TraceFollowerEvent.InitalChainSelected"]
+      mconcat ["kind" .= String "TraceFollowerEvent.InitalChainSelected"]
     ChainDB.StartedInitChainSelection ->
-      mkObject ["kind" .= String "TraceFollowerEvent.StartedInitChainSelection"]
+      mconcat ["kind" .= String "TraceFollowerEvent.StartedInitChainSelection"]
     ChainDB.InitChainSelValidation ev' -> case ev' of
       ChainDB.InvalidBlock err pt ->
-         mkObject [ "kind" .= String "TraceInitChainSelEvent.InvalidBlock"
+         mconcat [ "kind" .= String "TraceInitChainSelEvent.InvalidBlock"
                   , "block" .= toObject verb pt
                   , "error" .= show err ]
       ChainDB.ValidCandidate c ->
-        mkObject [ "kind" .= String "TraceInitChainSelEvent.ValidCandidate"
+        mconcat [ "kind" .= String "TraceInitChainSelEvent.ValidCandidate"
                  , "block" .= renderPointForVerbosity verb (AF.headPoint c) ]
       ChainDB.CandidateContainsFutureBlocks c hdrs ->
-        mkObject [ "kind" .= String "TraceInitChainSelEvent.CandidateContainsFutureBlocks"
+        mconcat [ "kind" .= String "TraceInitChainSelEvent.CandidateContainsFutureBlocks"
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
       ChainDB.CandidateContainsFutureBlocksExceedingClockSkew c hdrs ->
-        mkObject [ "kind" .= String "TraceInitChainSelEvent.CandidateContainsFutureBlocksExceedingClockSkew"
+        mconcat [ "kind" .= String "TraceInitChainSelEvent.CandidateContainsFutureBlocksExceedingClockSkew"
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
       ChainDB.UpdateLedgerDbTraceEvent
         (StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr) ) ->
-          mkObject [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDbTraceEvent.StartedPushingBlockToTheLedgerDb"
+          mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDbTraceEvent.StartedPushingBlockToTheLedgerDb"
                    , "startingBlock" .= renderRealPoint start
                    , "currentBlock" .= renderRealPoint curr
                    , "targetBlock" .= renderRealPoint goal
@@ -972,163 +973,163 @@ instance ( ConvertRawHash blk
 
   toObject _verb (ChainDB.TraceIteratorEvent ev) = case ev of
     ChainDB.UnknownRangeRequested unkRange ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.UnknownRangeRequested"
+      mconcat [ "kind" .= String "TraceIteratorEvent.UnknownRangeRequested"
                , "range" .= String (showT unkRange)
                ]
     ChainDB.StreamFromVolatileDB streamFrom streamTo realPt ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.StreamFromVolatileDB"
+      mconcat [ "kind" .= String "TraceIteratorEvent.StreamFromVolatileDB"
                , "from" .= String (showT streamFrom)
                , "to" .= String (showT streamTo)
                , "point" .= String (Text.pack . show $ map renderRealPoint realPt)
                ]
     ChainDB.StreamFromImmutableDB streamFrom streamTo ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.StreamFromImmutableDB"
+      mconcat [ "kind" .= String "TraceIteratorEvent.StreamFromImmutableDB"
                , "from" .= String (showT streamFrom)
                , "to" .= String (showT streamTo)
                ]
     ChainDB.StreamFromBoth streamFrom streamTo realPt ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.StreamFromBoth"
+      mconcat [ "kind" .= String "TraceIteratorEvent.StreamFromBoth"
                , "from" .= String (showT streamFrom)
                , "to" .= String (showT streamTo)
                , "point" .= String (Text.pack . show $ map renderRealPoint realPt)
                ]
     ChainDB.BlockMissingFromVolatileDB realPt ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.BlockMissingFromVolatileDB"
+      mconcat [ "kind" .= String "TraceIteratorEvent.BlockMissingFromVolatileDB"
                , "point" .= String (renderRealPoint realPt)
                ]
     ChainDB.BlockWasCopiedToImmutableDB realPt ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.BlockWasCopiedToImmutableDB"
+      mconcat [ "kind" .= String "TraceIteratorEvent.BlockWasCopiedToImmutableDB"
                , "point" .= String (renderRealPoint realPt)
                ]
     ChainDB.BlockGCedFromVolatileDB realPt ->
-      mkObject [ "kind" .= String "TraceIteratorEvent.BlockGCedFromVolatileDB"
+      mconcat [ "kind" .= String "TraceIteratorEvent.BlockGCedFromVolatileDB"
                , "point" .= String (renderRealPoint realPt)
                ]
     ChainDB.SwitchBackToVolatileDB ->
-      mkObject ["kind" .= String "TraceIteratorEvent.SwitchBackToVolatileDB"
+      mconcat ["kind" .= String "TraceIteratorEvent.SwitchBackToVolatileDB"
                ]
   toObject verb (ChainDB.TraceImmutableDBEvent ev) = case ev of
     ImmDB.ChunkValidationEvent traceChunkValidation -> toObject verb traceChunkValidation
     ImmDB.NoValidLastLocation ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.NoValidLastLocation" ]
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.NoValidLastLocation" ]
     ImmDB.ValidatedLastLocation chunkNo immTip ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.ValidatedLastLocation"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.ValidatedLastLocation"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                , "immTip" .= String (renderTipHash immTip)
                , "blockNo" .= String (renderTipBlockNo immTip)
                ]
     ImmDB.ChunkFileDoesntFit expectPrevHash actualPrevHash ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.ChunkFileDoesntFit"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.ChunkFileDoesntFit"
                , "expectedPrevHash" .= String (renderChainHash (Text.decodeLatin1 . toRawHash (Proxy @blk)) expectPrevHash)
                , "actualPrevHash" .= String (renderChainHash (Text.decodeLatin1 . toRawHash (Proxy @blk)) actualPrevHash)
                ]
     ImmDB.Migrating txt ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.Migrating"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.Migrating"
                , "info" .= String txt
                ]
     ImmDB.DeletingAfter immTipWithInfo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.DeletingAfter"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.DeletingAfter"
                , "immTipHash" .= String (renderWithOrigin renderTipHash immTipWithInfo)
                , "immTipBlockNo" .= String (renderWithOrigin renderTipBlockNo immTipWithInfo)
                ]
-    ImmDB.DBAlreadyClosed -> mkObject [ "kind" .= String "TraceImmutableDBEvent.DBAlreadyClosed" ]
-    ImmDB.DBClosed -> mkObject [ "kind" .= String "TraceImmutableDBEvent.DBClosed" ]
+    ImmDB.DBAlreadyClosed -> mconcat [ "kind" .= String "TraceImmutableDBEvent.DBAlreadyClosed" ]
+    ImmDB.DBClosed -> mconcat [ "kind" .= String "TraceImmutableDBEvent.DBClosed" ]
     ImmDB.TraceCacheEvent cacheEv ->
       case cacheEv of
         ImmDB.TraceCurrentChunkHit chunkNo nbPastChunksInCache ->
-          mkObject [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TraceCurrentChunkHit"
+          mconcat [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TraceCurrentChunkHit"
                    , "chunkNo" .= String (renderChunkNo chunkNo)
                    , "noPastChunks" .= String (showT nbPastChunksInCache)
                    ]
         ImmDB.TracePastChunkHit chunkNo nbPastChunksInCache ->
-          mkObject [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkHit"
+          mconcat [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkHit"
                    , "chunkNo" .= String (renderChunkNo chunkNo)
                    , "noPastChunks" .= String (showT nbPastChunksInCache)
                    ]
         ImmDB.TracePastChunkMiss chunkNo nbPastChunksInCache ->
-          mkObject [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkMiss"
+          mconcat [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkMiss"
                    , "chunkNo" .= String (renderChunkNo chunkNo)
                    , "noPastChunks" .= String (showT nbPastChunksInCache)
                    ]
         ImmDB.TracePastChunkEvict chunkNo nbPastChunksInCache ->
-          mkObject [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkEvict"
+          mconcat [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunkEvict"
                    , "chunkNo" .= String (renderChunkNo chunkNo)
                    , "noPastChunks" .= String (showT nbPastChunksInCache)
                    ]
         ImmDB.TracePastChunksExpired chunkNos nbPastChunksInCache ->
-          mkObject [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunksExpired"
+          mconcat [ "kind" .= String "TraceImmDbEvent.TraceCacheEvent.TracePastChunksExpired"
                    , "chunkNos" .= String (Text.pack . show $ map renderChunkNo chunkNos)
                    , "noPastChunks" .= String (showT nbPastChunksInCache)
                    ]
   toObject _verb (ChainDB.TraceVolatileDBEvent ev) = case ev of
-    VolDb.DBAlreadyClosed -> mkObject [ "kind" .= String "TraceVolatileDbEvent.DBAlreadyClosed"]
+    VolDb.DBAlreadyClosed -> mconcat [ "kind" .= String "TraceVolatileDbEvent.DBAlreadyClosed"]
     VolDb.BlockAlreadyHere blockId ->
-      mkObject [ "kind" .= String "TraceVolatileDbEvent.BlockAlreadyHere"
+      mconcat [ "kind" .= String "TraceVolatileDbEvent.BlockAlreadyHere"
                , "blockId" .= String (showT blockId)
                ]
     VolDb.Truncate pErr fsPath blockOffset ->
-      mkObject [ "kind" .= String "TraceVolatileDbEvent.Truncate"
+      mconcat [ "kind" .= String "TraceVolatileDbEvent.Truncate"
                , "parserError" .= String (showT pErr)
                , "file" .= String (showT fsPath)
                , "blockOffset" .= String (showT blockOffset)
                ]
     VolDb.InvalidFileNames fsPaths ->
-      mkObject [ "kind" .= String "TraceVolatileDBEvent.InvalidFileNames"
+      mconcat [ "kind" .= String "TraceVolatileDBEvent.InvalidFileNames"
                , "files" .= String (Text.pack . show $ map show fsPaths)
                ]
 
 instance ConvertRawHash blk => ToObject (ImmDB.TraceChunkValidation blk ChunkNo) where
   toObject verb ev = case ev of
     ImmDB.RewriteSecondaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.RewriteSecondaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.RewriteSecondaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.RewritePrimaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.RewritePrimaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.RewritePrimaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.MissingPrimaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.MissingPrimaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.MissingPrimaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.MissingSecondaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.MissingSecondaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.MissingSecondaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.InvalidPrimaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.InvalidPrimaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.InvalidPrimaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.InvalidSecondaryIndex chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.InvalidSecondaryIndex"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.InvalidSecondaryIndex"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.InvalidChunkFile chunkNo (ImmDB.ChunkErrHashMismatch hashPrevBlock prevHashOfBlock) ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrHashMismatch"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrHashMismatch"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                , "hashPrevBlock" .= String (Text.decodeLatin1 . toRawHash (Proxy @blk) $ hashPrevBlock)
                , "prevHashOfBlock" .= String (renderChainHash (Text.decodeLatin1 . toRawHash (Proxy @blk)) prevHashOfBlock)
                ]
     ImmDB.InvalidChunkFile chunkNo (ImmDB.ChunkErrCorrupt pt) ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrCorrupt"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrCorrupt"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                , "block" .= String (renderPointForVerbosity verb pt)
                ]
     ImmDB.ValidatedChunk chunkNo _ ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.ValidatedChunk"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.ValidatedChunk"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.MissingChunkFile chunkNo ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.MissingChunkFile"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.MissingChunkFile"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                ]
     ImmDB.InvalidChunkFile chunkNo (ImmDB.ChunkErrRead readIncErr) ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrRead"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.InvalidChunkFile.ChunkErrRead"
                , "chunkNo" .= String (renderChunkNo chunkNo)
                , "error" .= String (showT readIncErr)
                ]
     ImmDB.StartedValidatingChunk initialChunk finalChunk ->
-      mkObject [ "kind" .= String "TraceImmutableDBEvent.StartedValidatingChunk"
+      mconcat [ "kind" .= String "TraceImmutableDBEvent.StartedValidatingChunk"
                , "initialChunk" .= renderChunkNo initialChunk
                , "finalChunk" .= renderChunkNo finalChunk
                ]
@@ -1136,18 +1137,18 @@ instance ConvertRawHash blk => ToObject (ImmDB.TraceChunkValidation blk ChunkNo)
 
 instance ConvertRawHash blk => ToObject (TraceBlockFetchServerEvent blk) where
   toObject _verb (TraceBlockFetchServerSendBlock blk) =
-    mkObject [ "kind"  .= String "TraceBlockFetchServerSendBlock"
+    mconcat [ "kind"  .= String "TraceBlockFetchServerSendBlock"
              , "block" .= String (renderChainHash @blk (renderHeaderHash (Proxy @blk)) $ pointHash blk)
              ]
 
-tipToObject :: forall blk. ConvertRawHash blk => Tip blk -> [(Text, Value)]
+tipToObject :: forall blk. ConvertRawHash blk => Tip blk -> Aeson.Object
 tipToObject = \case
-  TipGenesis ->
+  TipGenesis -> mconcat
     [ "slot"    .= toJSON (0 :: Int)
     , "block"   .= String "genesis"
     , "blockNo" .= toJSON ((-1) :: Int)
     ]
-  Tip slot hash blockno ->
+  Tip slot hash blockno -> mconcat
     [ "slot"    .= slot
     , "block"   .= String (renderHeaderHash (Proxy @blk) hash)
     , "blockNo" .= blockno
@@ -1157,47 +1158,52 @@ instance (ConvertRawHash blk, LedgerSupportsProtocol blk)
       => ToObject (TraceChainSyncClientEvent blk) where
   toObject verb ev = case ev of
     TraceDownloadedHeader h ->
-      mkObject $
+      mconcat
                [ "kind" .= String "ChainSyncClientEvent.TraceDownloadedHeader"
-               ] <> tipToObject (tipFromHeader h)
+               , tipToObject (tipFromHeader h)
+               ]
     TraceRolledBack tip ->
-      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceRolledBack"
+      mconcat [ "kind" .= String "ChainSyncClientEvent.TraceRolledBack"
                , "tip" .= toObject verb tip ]
     TraceException exc ->
-      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceException"
+      mconcat [ "kind" .= String "ChainSyncClientEvent.TraceException"
                , "exception" .= String (pack $ show exc) ]
     TraceFoundIntersection _ _ _ ->
-      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceFoundIntersection" ]
+      mconcat [ "kind" .= String "ChainSyncClientEvent.TraceFoundIntersection" ]
     TraceTermination reason ->
-      mkObject [ "kind" .= String "ChainSyncClientEvent.TraceTermination"
+      mconcat [ "kind" .= String "ChainSyncClientEvent.TraceTermination"
                , "reason" .= String (pack $ show reason) ]
 
 instance ConvertRawHash blk
       => ToObject (TraceChainSyncServerEvent blk) where
   toObject verb ev = case ev of
     TraceChainSyncServerRead tip AddBlock{} ->
-      mkObject $
+      mconcat
         [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock"
-        ] <> tipToObject tip
+        , tipToObject tip
+        ]
     TraceChainSyncServerRead tip RollBack{} ->
-      mkObject $
+      mconcat
         [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.RollBack"
-        ] <> tipToObject tip
+        , tipToObject tip
+        ]
     TraceChainSyncServerReadBlocked tip AddBlock{} ->
-      mkObject $
+      mconcat
         [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock"
-        ] <> tipToObject tip
+        , tipToObject tip
+        ]
     TraceChainSyncServerReadBlocked tip RollBack{} ->
-      mkObject $
+      mconcat
         [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.RollBack"
-        ] <> tipToObject tip
+        , tipToObject tip
+        ]
 
     TraceChainSyncRollForward point ->
-      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollForward"
+      mconcat [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollForward"
                , "point" .= toObject verb point
                ]
     TraceChainSyncRollBackward point ->
-      mkObject [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollBackward"
+      mconcat [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncRollBackward"
                , "point" .= toObject verb point
                ]
 
@@ -1205,26 +1211,26 @@ instance ( Show (ApplyTxErr blk), ToObject (ApplyTxErr blk), ToObject (GenTx blk
            ToJSON (GenTxId blk), LedgerSupportsMempool blk
          ) => ToObject (TraceEventMempool blk) where
   toObject verb (TraceMempoolAddedTx tx _mpSzBefore mpSzAfter) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceMempoolAddedTx"
       , "tx" .= toObject verb (txForgetValidated tx)
       , "mempoolSize" .= toObject verb mpSzAfter
       ]
   toObject verb (TraceMempoolRejectedTx tx txApplyErr mpSz) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceMempoolRejectedTx"
       , "err" .= toObject verb txApplyErr
       , "tx" .= toObject verb tx
       , "mempoolSize" .= toObject verb mpSz
       ]
   toObject verb (TraceMempoolRemoveTxs txs mpSz) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceMempoolRemoveTxs"
       , "txs" .= map (toObject verb . txForgetValidated) txs
       , "mempoolSize" .= toObject verb mpSz
       ]
   toObject verb (TraceMempoolManuallyRemovedTxs txs0 txs1 mpSz) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceMempoolManuallyRemovedTxs"
       , "txsRemoved" .= txs0
       , "txsInvalidated" .= map (toObject verb . txForgetValidated) txs1
@@ -1233,7 +1239,7 @@ instance ( Show (ApplyTxErr blk), ToObject (ApplyTxErr blk), ToObject (GenTx blk
 
 instance ToObject MempoolSize where
   toObject _verb MempoolSize{msNumTxs, msNumBytes} =
-    mkObject
+    mconcat
       [ "numTxs" .= msNumTxs
       , "bytes" .= msNumBytes
       ]
@@ -1257,74 +1263,74 @@ instance ( tx ~ GenTx blk
          , ToObject (ForgeStateUpdateError blk))
       => ToObject (TraceForgeEvent blk) where
   toObject _verb (TraceStartLeadershipCheck slotNo) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceStartLeadershipCheck"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject verb (TraceSlotIsImmutable slotNo tipPoint tipBlkNo) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceSlotIsImmutable"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "tip" .= renderPointForVerbosity verb tipPoint
       , "tipBlockNo" .= toJSON (unBlockNo tipBlkNo)
       ]
   toObject _verb (TraceBlockFromFuture currentSlot tip) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceBlockFromFuture"
       , "current slot" .= toJSON (unSlotNo currentSlot)
       , "tip" .= toJSON (unSlotNo tip)
       ]
   toObject verb (TraceBlockContext currentSlot tipBlkNo tipPoint) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceBlockContext"
       , "current slot" .= toJSON (unSlotNo currentSlot)
       , "tip" .= renderPointForVerbosity verb tipPoint
       , "tipBlockNo" .= toJSON (unBlockNo tipBlkNo)
       ]
   toObject _verb (TraceNoLedgerState slotNo _pt) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceNoLedgerState"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject _verb (TraceLedgerState slotNo _pt) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceLedgerState"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject _verb (TraceNoLedgerView slotNo _) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceNoLedgerView"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject _verb (TraceLedgerView slotNo) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceLedgerView"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject verb (TraceForgeStateUpdateError slotNo reason) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceForgeStateUpdateError"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "reason" .= toObject verb reason
       ]
   toObject verb (TraceNodeCannotForge slotNo reason) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceNodeCannotForge"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "reason" .= toObject verb reason
       ]
   toObject _verb (TraceNodeNotLeader slotNo) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceNodeNotLeader"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject _verb (TraceNodeIsLeader slotNo) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceNodeIsLeader"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject _verb (TraceForgedBlock slotNo _ blk _) =
-    mkObject
+    mconcat
       [ "kind"      .= String "TraceForgedBlock"
       , "slot"      .= toJSON (unSlotNo slotNo)
       , "block"     .= String (renderHeaderHash (Proxy @blk) $ blockHash blk)
@@ -1332,18 +1338,18 @@ instance ( tx ~ GenTx blk
       , "blockPrev" .= String (renderChainHash @blk (renderHeaderHash (Proxy @blk)) $ blockPrevHash blk)
       ]
   toObject _verb (TraceDidntAdoptBlock slotNo _) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceDidntAdoptBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       ]
   toObject verb (TraceForgedInvalidBlock slotNo _ reason) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceForgedInvalidBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "reason" .= toObject verb reason
       ]
   toObject MaximalVerbosity (TraceAdoptedBlock slotNo blk txs) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "blockHash" .= renderHeaderHashForVerbosity
@@ -1354,7 +1360,7 @@ instance ( tx ~ GenTx blk
       , "txIds" .= toJSON (map (show . txId . txForgetValidated) txs)
       ]
   toObject verb (TraceAdoptedBlock slotNo blk _txs) =
-    mkObject
+    mconcat
       [ "kind" .= String "TraceAdoptedBlock"
       , "slot" .= toJSON (unSlotNo slotNo)
       , "blockHash" .= renderHeaderHashForVerbosity
@@ -1367,4 +1373,4 @@ instance ( tx ~ GenTx blk
 
 instance ToObject (TraceLocalTxSubmissionServerEvent blk) where
   toObject _verb _ =
-    mkObject [ "kind" .= String "TraceLocalTxSubmissionServerEvent" ]
+    mconcat [ "kind" .= String "TraceLocalTxSubmissionServerEvent" ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
@@ -29,15 +29,15 @@ import           Cardano.Tracing.OrphanInstances.Consensus ()
 
 import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateInfo,
-                     ForgeStateUpdateError)
+                   ForgeStateUpdateError)
 import           Ouroboros.Consensus.BlockchainTime (getSlotLength)
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch (..),
-                     OneEraCannotForge (..), OneEraEnvelopeErr (..), OneEraForgeStateInfo (..),
-                     OneEraForgeStateUpdateError (..), OneEraLedgerError (..),
-                     OneEraLedgerUpdate (..), OneEraLedgerWarning (..), OneEraValidationErr (..),
-                     mkEraMismatch)
+                   OneEraCannotForge (..), OneEraEnvelopeErr (..), OneEraForgeStateInfo (..),
+                   OneEraForgeStateUpdateError (..), OneEraLedgerError (..),
+                   OneEraLedgerUpdate (..), OneEraLedgerWarning (..), OneEraValidationErr (..),
+                   mkEraMismatch)
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
 import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams (..), SafeZone)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
@@ -97,7 +97,7 @@ instance ToJSON (TxId (GenTx blk)) => ToJSON (WrapGenTxId blk) where
 instance All (ToObject `Compose` WrapApplyTxErr) xs => ToObject (HardForkApplyTxErr xs) where
     toObject verb (HardForkApplyTxErrFromEra err) = toObject verb err
     toObject _verb (HardForkApplyTxErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkApplyTxErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "txEra"      .= otherEraName
@@ -123,7 +123,7 @@ instance All (ToObject `Compose` WrapLedgerErr) xs => ToObject (HardForkLedgerEr
     toObject verb (HardForkLedgerErrorFromEra err) = toObject verb err
 
     toObject _verb (HardForkLedgerErrorWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkLedgerErrorWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -152,7 +152,7 @@ instance ( All (ToObject `Compose` WrapLedgerWarning) xs
       HardForkWarningInEra err -> toObject verb err
 
       HardForkWarningTransitionMismatch toEra eraParams epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkWarningTransitionMismatch"
           , "toEra"           .= condense toEra
           , "eraParams"       .= toObject verb eraParams
@@ -160,20 +160,20 @@ instance ( All (ToObject `Compose` WrapLedgerWarning) xs
           ]
 
       HardForkWarningTransitionInFinalEra fromEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkWarningTransitionInFinalEra"
           , "fromEra"         .= condense fromEra
           , "transitionEpoch" .= epoch
           ]
 
       HardForkWarningTransitionUnconfirmed toEra ->
-        mkObject
+        mconcat
           [ "kind"  .= String "HardForkWarningTransitionUnconfirmed"
           , "toEra" .= condense toEra
           ]
 
       HardForkWarningTransitionReconfirmed fromEra toEra prevEpoch newEpoch ->
-        mkObject
+        mconcat
           [ "kind"                .= String "HardForkWarningTransitionReconfirmed"
           , "fromEra"             .= condense fromEra
           , "toEra"               .= condense toEra
@@ -192,7 +192,7 @@ instance ToObject (LedgerWarning blk) => ToObject (WrapLedgerWarning blk) where
 
 instance ToObject EraParams where
     toObject _verb EraParams{ eraEpochSize, eraSlotLength, eraSafeZone} =
-      mkObject
+      mconcat
         [ "epochSize"  .= unEpochSize eraEpochSize
         , "slotLength" .= getSlotLength eraSlotLength
         , "safeZone"   .= eraSafeZone
@@ -212,7 +212,7 @@ instance ( All (ToObject `Compose` WrapLedgerUpdate) xs
       HardForkUpdateInEra err -> toObject verb err
 
       HardForkUpdateTransitionConfirmed fromEra toEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkUpdateTransitionConfirmed"
           , "fromEra"         .= condense fromEra
           , "toEra"           .= condense toEra
@@ -220,7 +220,7 @@ instance ( All (ToObject `Compose` WrapLedgerUpdate) xs
           ]
 
       HardForkUpdateTransitionDone fromEra toEra epoch ->
-        mkObject
+        mconcat
           [ "kind"            .= String "HardForkUpdateTransitionDone"
           , "fromEra"         .= condense fromEra
           , "toEra"           .= condense toEra
@@ -228,7 +228,7 @@ instance ( All (ToObject `Compose` WrapLedgerUpdate) xs
           ]
 
       HardForkUpdateTransitionRolledBack fromEra toEra ->
-        mkObject
+        mconcat
           [ "kind"    .= String "HardForkUpdateTransitionRolledBack"
           , "fromEra" .= condense fromEra
           , "toEra"   .= condense toEra
@@ -252,7 +252,7 @@ instance All (ToObject `Compose` WrapEnvelopeErr) xs => ToObject (HardForkEnvelo
     toObject verb (HardForkEnvelopeErrFromEra err) = toObject verb err
 
     toObject _verb (HardForkEnvelopeErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkEnvelopeErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -278,7 +278,7 @@ instance All (ToObject `Compose` WrapValidationErr) xs => ToObject (HardForkVali
     toObject verb (HardForkValidationErrFromEra err) = toObject verb err
 
     toObject _verb (HardForkValidationErrWrongEra mismatch) =
-      mkObject
+      mconcat
         [ "kind"       .= String "HardForkValidationErrWrongEra"
         , "currentEra" .= ledgerEraName
         , "blockEra"   .= otherEraName
@@ -323,7 +323,7 @@ instance ToObject (CannotForge blk) => ToObject (WrapCannotForge blk) where
 
 instance All (ToObject `Compose` WrapForgeStateInfo) xs => ToObject (OneEraForgeStateInfo xs) where
     toObject verb forgeStateInfo =
-        mkObject
+        mconcat
           [ "kind" .= String "HardForkForgeStateInfo"
           , "forgeStateInfo" .= toJSON forgeStateInfo'
           ]
@@ -349,7 +349,7 @@ instance ToObject (ForgeStateInfo blk) => ToObject (WrapForgeStateInfo blk) wher
 
 instance All (ToObject `Compose` WrapForgeStateUpdateError) xs => ToObject (OneEraForgeStateUpdateError xs) where
     toObject verb forgeStateUpdateError =
-        mkObject
+        mconcat
           [ "kind" .= String "HardForkForgeStateUpdateError"
           , "forgeStateUpdateError" .= toJSON forgeStateUpdateError'
           ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -334,7 +334,7 @@ instance HasTextFormatter (Identity (SubscriptionTrace LocalAddress)) where
 
 instance ToObject (Identity (SubscriptionTrace LocalAddress)) where
   toObject _verb (Identity ev) =
-    mkObject [ "kind" .= ("SubscriptionTrace" :: String)
+    mconcat [ "kind" .= ("SubscriptionTrace" :: String)
              , "event" .= show ev
              ]
 
@@ -369,6 +369,7 @@ instance HasSeverityAnnotation (WithMuxBearer peer MuxTrace) where
     MuxTraceStartedOnDemand _ _ -> Info
     MuxTraceShutdown -> Debug
     MuxTraceTerminating {} -> Debug
+    MuxTraceTCPInfo {} -> Debug
 
 instance HasPrivacyAnnotation (TraceLocalRootPeers RemoteAddress exception)
 instance HasSeverityAnnotation (TraceLocalRootPeers RemoteAddress exception) where
@@ -461,6 +462,7 @@ instance HasSeverityAnnotation (ConnectionManagerTrace addr (ConnectionHandlerTr
       TrConnectionManagerCounters {}          -> Info
       TrState {}                              -> Info
       ConnMgr.TrUnexpectedlyFalseAssertion {} -> Error
+      TrUnknownConnection {}                  -> Debug
 
 instance HasPrivacyAnnotation (ConnMgr.AbstractTransitionTrace addr)
 instance HasSeverityAnnotation (ConnMgr.AbstractTransitionTrace addr) where
@@ -740,14 +742,14 @@ instance ( ConvertTxId blk
          )
       => ToObject (AnyMessageAndAgency (BlockFetch blk (Point blk))) where
   toObject MinimalVerbosity (AnyMessageAndAgency stok (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
              ]
 
   toObject verb (AnyMessageAndAgency stok (MsgBlock blk)) =
-    mkObject [ "kind" .= String "MsgBlock"
+    mconcat [ "kind" .= String "MsgBlock"
              , "agency" .= String (pack $ show stok)
              , "blockHash" .= renderHeaderHash (Proxy @blk) (blockHash blk)
              , "blockSize" .= toJSON (estimateBlockSize (getHeader blk))
@@ -758,23 +760,23 @@ instance ( ConvertTxId blk
         presentTx =  String . renderTxIdForVerbosity verb . txId
 
   toObject _v (AnyMessageAndAgency stok MsgRequestRange{}) =
-    mkObject [ "kind" .= String "MsgRequestRange"
+    mconcat [ "kind" .= String "MsgRequestRange"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _v (AnyMessageAndAgency stok MsgStartBatch{}) =
-    mkObject [ "kind" .= String "MsgStartBatch"
+    mconcat [ "kind" .= String "MsgStartBatch"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _v (AnyMessageAndAgency stok MsgNoBlocks{}) =
-    mkObject [ "kind" .= String "MsgNoBlocks"
+    mconcat [ "kind" .= String "MsgNoBlocks"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _v (AnyMessageAndAgency stok MsgBatchDone{}) =
-    mkObject [ "kind" .= String "MsgBatchDone"
+    mconcat [ "kind" .= String "MsgBatchDone"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _v (AnyMessageAndAgency stok MsgClientDone{}) =
-    mkObject [ "kind" .= String "MsgClientDone"
+    mconcat [ "kind" .= String "MsgClientDone"
              , "agency" .= String (pack $ show stok)
              ]
 
@@ -786,19 +788,19 @@ instance ( ToObject (AnyMessageAndAgency ps)
   toObject verb (AnyMessageAndAgency stok msg) =
     case (stok, msg) of
       (_, Hello.MsgHello) ->
-        mkObject [ "kind" .= String "MsgHello"
+        mconcat [ "kind" .= String "MsgHello"
                  , "agency" .= String (pack $ show stok)
                  ]
       ( ClientAgency (Hello.TokClientTalk tok)
         , Hello.MsgTalk msg' ) ->
-        mkObject [ "kind" .= String "MsgTalk"
+        mconcat [ "kind" .= String "MsgTalk"
                  , "message" .=
                      toObject verb
                        (AnyMessageAndAgency (ClientAgency tok) msg')
                  ]
       ( ServerAgency (Hello.TokServerTalk tok)
         , Hello.MsgTalk msg' ) ->
-        mkObject [ "kind" .= String "MsgTalk"
+        mconcat [ "kind" .= String "MsgTalk"
                  , "message" .=
                      toObject verb
                        (AnyMessageAndAgency (ServerAgency tok) msg')
@@ -807,162 +809,162 @@ instance ( ToObject (AnyMessageAndAgency ps)
 instance (forall result. Show (query result))
       => ToObject (AnyMessageAndAgency (LocalStateQuery blk pt query)) where
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgAcquire{}) =
-    mkObject [ "kind" .= String "MsgAcquire"
+    mconcat [ "kind" .= String "MsgAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgAcquired{}) =
-    mkObject [ "kind" .= String "MsgAcquired"
+    mconcat [ "kind" .= String "MsgAcquired"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgFailure{}) =
-    mkObject [ "kind" .= String "MsgFailure"
+    mconcat [ "kind" .= String "MsgFailure"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgQuery{}) =
-    mkObject [ "kind" .= String "MsgQuery"
+    mconcat [ "kind" .= String "MsgQuery"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgResult{}) =
-    mkObject [ "kind" .= String "MsgResult"
+    mconcat [ "kind" .= String "MsgResult"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgRelease{}) =
-    mkObject [ "kind" .= String "MsgRelease"
+    mconcat [ "kind" .= String "MsgRelease"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgReAcquire{}) =
-    mkObject [ "kind" .= String "MsgReAcquire"
+    mconcat [ "kind" .= String "MsgReAcquire"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalStateQuery.MsgDone{}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 
 instance ToObject (AnyMessageAndAgency (LocalTxMonitor txid tx slotno)) where
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgAcquire {}) =
-    mkObject [ "kind" .= String "MsgAcuire"
+    mconcat [ "kind" .= String "MsgAcuire"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgAcquired {}) =
-    mkObject [ "kind" .= String "MsgAcuired"
+    mconcat [ "kind" .= String "MsgAcuired"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgAwaitAcquire {}) =
-    mkObject [ "kind" .= String "MsgAwaitAcuire"
+    mconcat [ "kind" .= String "MsgAwaitAcuire"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgNextTx {}) =
-    mkObject [ "kind" .= String "MsgNextTx"
+    mconcat [ "kind" .= String "MsgNextTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgReplyNextTx {}) =
-    mkObject [ "kind" .= String "MsgReplyNextTx"
+    mconcat [ "kind" .= String "MsgReplyNextTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgHasTx {}) =
-    mkObject [ "kind" .= String "MsgHasTx"
+    mconcat [ "kind" .= String "MsgHasTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgReplyHasTx {}) =
-    mkObject [ "kind" .= String "MsgReplyHasTx"
+    mconcat [ "kind" .= String "MsgReplyHasTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgGetSizes {}) =
-    mkObject [ "kind" .= String "MsgGetSizes"
+    mconcat [ "kind" .= String "MsgGetSizes"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgReplyGetSizes {}) =
-    mkObject [ "kind" .= String "MsgReplyGetSizes"
+    mconcat [ "kind" .= String "MsgReplyGetSizes"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgRelease {}) =
-    mkObject [ "kind" .= String "MsgRelease"
+    mconcat [ "kind" .= String "MsgRelease"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxMonitor.MsgDone {}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 
 instance ToObject (AnyMessageAndAgency (LocalTxSubmission tx err)) where
   toObject _verb (AnyMessageAndAgency stok LocalTxSub.MsgSubmitTx{}) =
-    mkObject [ "kind" .= String "MsgSubmitTx"
+    mconcat [ "kind" .= String "MsgSubmitTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxSub.MsgAcceptTx{}) =
-    mkObject [ "kind" .= String "MsgAcceptTx"
+    mconcat [ "kind" .= String "MsgAcceptTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxSub.MsgRejectTx{}) =
-    mkObject [ "kind" .= String "MsgRejectTx"
+    mconcat [ "kind" .= String "MsgRejectTx"
              , "agency" .= String (pack $ show stok)
              ]
   toObject _verb (AnyMessageAndAgency stok LocalTxSub.MsgDone{}) =
-    mkObject [ "kind" .= String "MsgDone"
+    mconcat [ "kind" .= String "MsgDone"
              , "agency" .= String (pack $ show stok)
              ]
 
 instance ToObject (AnyMessageAndAgency (ChainSync blk pt tip)) where
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgRequestNext{}) =
-     mkObject [ "kind" .= String "MsgRequestNext"
+     mconcat [ "kind" .= String "MsgRequestNext"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgAwaitReply{}) =
-     mkObject [ "kind" .= String "MsgAwaitReply"
+     mconcat [ "kind" .= String "MsgAwaitReply"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgRollForward{}) =
-     mkObject [ "kind" .= String "MsgRollForward"
+     mconcat [ "kind" .= String "MsgRollForward"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgRollBackward{}) =
-     mkObject [ "kind" .= String "MsgRollBackward"
+     mconcat [ "kind" .= String "MsgRollBackward"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgFindIntersect{}) =
-     mkObject [ "kind" .= String "MsgFindIntersect"
+     mconcat [ "kind" .= String "MsgFindIntersect"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgIntersectFound{}) =
-     mkObject [ "kind" .= String "MsgIntersectFound"
+     mconcat [ "kind" .= String "MsgIntersectFound"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgIntersectNotFound{}) =
-     mkObject [ "kind" .= String "MsgIntersectNotFound"
+     mconcat [ "kind" .= String "MsgIntersectNotFound"
               , "agency" .= String (pack $ show stok)
               ]
    toObject _verb (AnyMessageAndAgency stok ChainSync.MsgDone{}) =
-     mkObject [ "kind" .= String "MsgDone"
+     mconcat [ "kind" .= String "MsgDone"
               , "agency" .= String (pack $ show stok)
               ]
 
 instance (Show txid, Show tx)
       => ToObject (AnyMessageAndAgency (TxSubmission txid tx)) where
   toObject _verb (AnyMessageAndAgency stok (MsgRequestTxs txids)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgRequestTxs"
       , "agency" .= String (pack $ show stok)
       , "txIds" .= String (pack $ show txids)
       ]
   toObject _verb (AnyMessageAndAgency stok (MsgReplyTxs txs)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgReplyTxs"
       , "agency" .= String (pack $ show stok)
       , "txs" .= String (pack $ show txs)
       ]
   toObject _verb (AnyMessageAndAgency stok MsgRequestTxIds{}) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgRequestTxIds"
       , "agency" .= String (pack $ show stok)
       ]
   toObject _verb (AnyMessageAndAgency stok (MsgReplyTxIds _)) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgReplyTxIds"
       , "agency" .= String (pack $ show stok)
       ]
   toObject _verb (AnyMessageAndAgency stok MsgDone) =
-    mkObject
+    mconcat
       [ "kind" .= String "MsgDone"
       , "agency" .= String (pack $ show stok)
       ]
@@ -989,91 +991,91 @@ instance Aeson.ToJSON ConnectionManagerCounters where
 
 instance ToObject (FetchDecision [Point header]) where
   toObject _verb (Left decline) =
-    mkObject [ "kind" .= String "FetchDecision declined"
+    mconcat [ "kind" .= String "FetchDecision declined"
              , "declined" .= String (pack (show decline))
              ]
   toObject _verb (Right results) =
-    mkObject [ "kind" .= String "FetchDecision results"
+    mconcat [ "kind" .= String "FetchDecision results"
              , "length" .= String (pack $ show $ length results)
              ]
 
 -- TODO: use 'ToJSON' constraints
 instance (Show ntnAddr, Show ntcAddr) => ToObject (ND.InitializationTracer ntnAddr ntcAddr) where
-  toObject _verb (ND.RunServer sockAddr) = mkObject
+  toObject _verb (ND.RunServer sockAddr) = mconcat
     [ "kind" .= String "RunServer"
     , "socketAddress" .= String (pack (show sockAddr))
     ]
 
-  toObject _verb (ND.RunLocalServer localAddress) = mkObject
+  toObject _verb (ND.RunLocalServer localAddress) = mconcat
     [ "kind" .= String "RunLocalServer"
     , "localAddress" .= String (pack (show localAddress))
     ]
-  toObject _verb (ND.UsingSystemdSocket localAddress) = mkObject
+  toObject _verb (ND.UsingSystemdSocket localAddress) = mconcat
     [ "kind" .= String "UsingSystemdSocket"
     , "path" .= String (pack . show $ localAddress)
     ]
 
-  toObject _verb (ND.CreateSystemdSocketForSnocketPath localAddress) = mkObject
+  toObject _verb (ND.CreateSystemdSocketForSnocketPath localAddress) = mconcat
     [ "kind" .= String "CreateSystemdSocketForSnocketPath"
     , "path" .= String (pack . show $ localAddress)
     ]
-  toObject _verb (ND.CreatedLocalSocket localAddress) = mkObject
+  toObject _verb (ND.CreatedLocalSocket localAddress) = mconcat
     [ "kind" .= String "CreatedLocalSocket"
     , "path" .= String (pack . show $ localAddress)
     ]
-  toObject _verb (ND.ConfiguringLocalSocket localAddress socket) = mkObject
+  toObject _verb (ND.ConfiguringLocalSocket localAddress socket) = mconcat
     [ "kind" .= String "ConfiguringLocalSocket"
     , "path" .= String (pack . show $ localAddress)
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.ListeningLocalSocket localAddress socket) = mkObject
+  toObject _verb (ND.ListeningLocalSocket localAddress socket) = mconcat
     [ "kind" .= String "ListeningLocalSocket"
     , "path" .= String (pack . show $ localAddress)
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.LocalSocketUp localAddress fd) = mkObject
+  toObject _verb (ND.LocalSocketUp localAddress fd) = mconcat
     [ "kind" .= String "LocalSocketUp"
     , "path" .= String (pack . show $ localAddress)
     , "socket" .= String (pack (show fd))
     ]
-  toObject _verb (ND.CreatingServerSocket socket) = mkObject
+  toObject _verb (ND.CreatingServerSocket socket) = mconcat
     [ "kind" .= String "CreatingServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.ListeningServerSocket socket) = mkObject
+  toObject _verb (ND.ListeningServerSocket socket) = mconcat
     [ "kind" .= String "ListeningServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.ServerSocketUp socket) = mkObject
+  toObject _verb (ND.ServerSocketUp socket) = mconcat
     [ "kind" .= String "ServerSocketUp"
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.ConfiguringServerSocket socket) = mkObject
+  toObject _verb (ND.ConfiguringServerSocket socket) = mconcat
     [ "kind" .= String "ConfiguringServerSocket"
     , "socket" .= String (pack (show socket))
     ]
-  toObject _verb (ND.UnsupportedLocalSystemdSocket path) = mkObject
+  toObject _verb (ND.UnsupportedLocalSystemdSocket path) = mconcat
     [ "kind" .= String "UnsupportedLocalSystemdSocket"
     , "path" .= String (pack (show path))
     ]
-  toObject _verb ND.UnsupportedReadySocketCase = mkObject
+  toObject _verb ND.UnsupportedReadySocketCase = mconcat
     [ "kind" .= String "UnsupportedReadySocketCase"
     ]
-  toObject _verb (ND.DiffusionErrored exception) = mkObject
+  toObject _verb (ND.DiffusionErrored exception) = mconcat
     [ "kind" .= String "DiffusionErrored"
     , "path" .= String (pack (show exception))
     ]
 
 instance ToObject (NtC.HandshakeTr LocalAddress NodeToClientVersion) where
   toObject _verb (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "LocalHandshakeTrace"
+    mconcat [ "kind" .= String "LocalHandshakeTrace"
              , "bearer" .= show b
              , "event" .= show ev ]
 
 
 instance ToObject (NtN.HandshakeTr RemoteAddress NodeToNodeVersion) where
   toObject _verb (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "HandshakeTrace"
+    mconcat [ "kind" .= String "HandshakeTrace"
              , "bearer" .= show b
              , "event" .= show ev ]
 
@@ -1084,16 +1086,16 @@ instance Aeson.ToJSONKey LocalAddress where
 
 instance ToObject NtN.AcceptConnectionsPolicyTrace where
   toObject _verb (NtN.ServerTraceAcceptConnectionRateLimiting delay numOfConnections) =
-    mkObject [ "kind" .= String "ServerTraceAcceptConnectionRateLimiting"
+    mconcat [ "kind" .= String "ServerTraceAcceptConnectionRateLimiting"
              , "delay" .= show delay
              , "numberOfConnection" .= show numOfConnections
              ]
   toObject _verb (NtN.ServerTraceAcceptConnectionHardLimit softLimit) =
-    mkObject [ "kind" .= String "ServerTraceAcceptConnectionHardLimit"
+    mconcat [ "kind" .= String "ServerTraceAcceptConnectionHardLimit"
              , "softLimit" .= show softLimit
              ]
   toObject _verb (NtN.ServerTraceAcceptConnectionResume numOfConnections) =
-    mkObject [ "kind" .= String "ServerTraceAcceptConnectionResume"
+    mconcat [ "kind" .= String "ServerTraceAcceptConnectionResume"
              , "numberOfConnection" .= show numOfConnections
              ]
 
@@ -1101,10 +1103,10 @@ instance ToObject NtN.AcceptConnectionsPolicyTrace where
 instance ConvertRawHash blk
       => ToObject (Point blk) where
   toObject _verb GenesisPoint =
-    mkObject
+    mconcat
       [ "kind" .= String "GenesisPoint" ]
   toObject verb (BlockPoint slot h) =
-    mkObject
+    mconcat
       [ "kind" .= String "BlockPoint"
       , "slot" .= toJSON (unSlotNo slot)
       , "headerHash" .= renderHeaderHashForVerbosity (Proxy @blk) verb h
@@ -1113,17 +1115,17 @@ instance ConvertRawHash blk
 
 instance ToObject SlotNo where
   toObject _verb slot =
-    mkObject [ "kind" .= String "SlotNo"
+    mconcat [ "kind" .= String "SlotNo"
              , "slot" .= toJSON (unSlotNo slot) ]
 
 instance (HasHeader header, ConvertRawHash header)
   => ToObject (TraceFetchClientState header) where
   toObject _verb BlockFetch.AddedFetchRequest {} =
-    mkObject [ "kind" .= String "AddedFetchRequest" ]
+    mconcat [ "kind" .= String "AddedFetchRequest" ]
   toObject _verb BlockFetch.AcknowledgedFetchRequest {} =
-    mkObject [ "kind" .= String "AcknowledgedFetchRequest" ]
+    mconcat [ "kind" .= String "AcknowledgedFetchRequest" ]
   toObject _verb (BlockFetch.SendFetchRequest af) =
-    mkObject [ "kind" .= String "SendFetchRequest"
+    mconcat [ "kind" .= String "SendFetchRequest"
              , "head" .= String (renderChainHash
                                   (renderHeaderHash (Proxy @header))
                                   (AF.headHash af))
@@ -1139,7 +1141,7 @@ instance (HasHeader header, ConvertRawHash header)
           (firstHdr AS.:< _, _ AS.:> lastHdr) ->
             blockNo lastHdr - blockNo firstHdr + 1
   toObject _verb (BlockFetch.CompletedBlockFetch pt _ _ _ delay blockSize) =
-    mkObject [ "kind"  .= String "CompletedBlockFetch"
+    mconcat [ "kind"  .= String "CompletedBlockFetch"
              , "delay" .= (realToFrac delay :: Double)
              , "size"  .= blockSize
              , "block" .= String
@@ -1148,62 +1150,62 @@ instance (HasHeader header, ConvertRawHash header)
                   BlockPoint _ h -> renderHeaderHash (Proxy @header) h)
              ]
   toObject _verb BlockFetch.CompletedFetchBatch {} =
-    mkObject [ "kind" .= String "CompletedFetchBatch" ]
+    mconcat [ "kind" .= String "CompletedFetchBatch" ]
   toObject _verb BlockFetch.StartedFetchBatch {} =
-    mkObject [ "kind" .= String "StartedFetchBatch" ]
+    mconcat [ "kind" .= String "StartedFetchBatch" ]
   toObject _verb BlockFetch.RejectedFetchBatch {} =
-    mkObject [ "kind" .= String "RejectedFetchBatch" ]
+    mconcat [ "kind" .= String "RejectedFetchBatch" ]
   toObject _verb (BlockFetch.ClientTerminating outstanding) =
-    mkObject [ "kind" .= String "ClientTerminating"
+    mconcat [ "kind" .= String "ClientTerminating"
              , "outstanding" .= outstanding
              ]
 
 
 instance (ToObject peer)
       => ToObject [TraceLabelPeer peer (FetchDecision [Point header])] where
-  toObject MinimalVerbosity _ = emptyObject
-  toObject _ [] = emptyObject
-  toObject _ xs = mkObject
+  toObject MinimalVerbosity _ = mempty
+  toObject _ [] = mempty
+  toObject _ xs = mconcat
     [ "kind"  .= String "PeersFetch"
     , "peers" .= toJSON
       (foldl' (\acc x -> toObject MaximalVerbosity x : acc) [] xs) ]
 
 instance (ToObject peer, ToObject a) => ToObject (TraceLabelPeer peer a) where
   toObject verb (TraceLabelPeer peerid a) =
-    mkObject [ "peer" .= toObject verb peerid ] <> toObject verb a
+    mconcat [ "peer" .= toObject verb peerid ] <> toObject verb a
 
 
 instance ToObject (AnyMessageAndAgency ps)
       => ToObject (TraceSendRecv ps) where
-  toObject verb (TraceSendMsg m) = mkObject
+  toObject verb (TraceSendMsg m) = mconcat
     [ "kind" .= String "Send" , "msg" .= toObject verb m ]
-  toObject verb (TraceRecvMsg m) = mkObject
+  toObject verb (TraceRecvMsg m) = mconcat
     [ "kind" .= String "Recv" , "msg" .= toObject verb m ]
 
 
 instance ToObject (TraceTxSubmissionInbound txid tx) where
   toObject _verb (TraceTxSubmissionCollected count) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionCollected"
       , "count" .= toJSON count
       ]
   toObject _verb (TraceTxSubmissionProcessed processed) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionProcessed"
       , "accepted" .= toJSON (ptxcAccepted processed)
       , "rejected" .= toJSON (ptxcRejected processed)
       ]
   toObject _verb TraceTxInboundTerminated =
-    mkObject
+    mconcat
       [ "kind" .= String "TxInboundTerminated"
       ]
   toObject _verb (TraceTxInboundCanRequestMoreTxs count) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxInboundCanRequestMoreTxs"
       , "count" .= toJSON count
       ]
   toObject _verb (TraceTxInboundCannotRequestMoreTxs count) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxInboundCannotRequestMoreTxs"
       , "count" .= toJSON count
       ]
@@ -1229,25 +1231,25 @@ instance Aeson.ToJSON SockAddr where
 instance (Show txid, Show tx)
       => ToObject (TraceTxSubmissionOutbound txid tx) where
   toObject MaximalVerbosity (TraceTxSubmissionOutboundRecvMsgRequestTxs txids) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionOutboundRecvMsgRequestTxs"
       , "txIds" .= String (pack $ show txids)
       ]
   toObject _verb (TraceTxSubmissionOutboundRecvMsgRequestTxs _txids) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionOutboundRecvMsgRequestTxs"
       ]
   toObject MaximalVerbosity (TraceTxSubmissionOutboundSendMsgReplyTxs txs) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionOutboundSendMsgReplyTxs"
       , "txs" .= String (pack $ show txs)
       ]
   toObject _verb (TraceTxSubmissionOutboundSendMsgReplyTxs _txs) =
-    mkObject
+    mconcat
       [ "kind" .= String "TxSubmissionOutboundSendMsgReplyTxs"
       ]
   toObject _verb (TraceControlMessage controlMessage) =
-    mkObject
+    mconcat
       [ "kind" .= String "ControlMessage"
       , "controlMessage" .= String (pack $ show controlMessage)
       ]
@@ -1255,7 +1257,7 @@ instance (Show txid, Show tx)
 
 instance Show remotePeer => ToObject (TraceKeepAliveClient remotePeer) where
   toObject _verb (AddSample peer rtt pgsv) =
-    mkObject
+    mconcat
       [ "kind" .= String "KeepAliveClient AddSample"
       , "address" .= show peer
       , "rtt" .= rtt
@@ -1273,63 +1275,63 @@ instance Show remotePeer => ToObject (TraceKeepAliveClient remotePeer) where
 
 instance ToObject TraceLedgerPeers where
   toObject _verb (PickedPeer addr _ackStake stake) =
-    mkObject
+    mconcat
       [ "kind" .= String "PickedPeer"
       , "address" .= show addr
       , "relativeStake" .= (realToFrac (unPoolStake stake) :: Double)
       ]
   toObject _verb (PickedPeers (NumberOfPeers n) addrs) =
-    mkObject
+    mconcat
       [ "kind" .= String "PickedPeers"
       , "desiredCount" .= n
       , "count" .= length addrs
       , "addresses" .= show addrs
       ]
   toObject _verb (FetchingNewLedgerState cnt) =
-    mkObject
+    mconcat
       [ "kind" .= String "FetchingNewLedgerState"
       , "numberOfPools" .= cnt
       ]
   toObject _verb DisabledLedgerPeers =
-    mkObject
+    mconcat
       [ "kind" .= String "DisabledLedgerPeers"
       ]
   toObject _verb (TraceUseLedgerAfter ula) =
-    mkObject
+    mconcat
       [ "kind" .= String "UseLedgerAfter"
       , "useLedgerAfter" .= UseLedger ula
       ]
   toObject _verb WaitingOnRequest =
-    mkObject
+    mconcat
       [ "kind" .= String "WaitingOnRequest"
       ]
   toObject _verb (RequestForPeers (NumberOfPeers np)) =
-    mkObject
+    mconcat
       [ "kind" .= String "RequestForPeers"
       , "numberOfPeers" .= np
       ]
   toObject _verb (ReusingLedgerState cnt age) =
-    mkObject
+    mconcat
       [ "kind" .= String "ReusingLedgerState"
       , "numberOfPools" .= cnt
       , "ledgerStateAge" .= age
       ]
   toObject _verb FallingBackToBootstrapPeers =
-    mkObject
+    mconcat
       [ "kind" .= String "FallingBackToBootstrapPeers"
       ]
 
 
 instance Show addr => ToObject (WithAddr addr ErrorPolicyTrace) where
   toObject _verb (WithAddr addr ev) =
-    mkObject [ "kind" .= String "ErrorPolicyTrace"
+    mconcat [ "kind" .= String "ErrorPolicyTrace"
              , "address" .= show addr
              , "event" .= show ev ]
 
 
 instance ToObject (WithIPList (SubscriptionTrace SockAddr)) where
   toObject _verb (WithIPList localAddresses dests ev) =
-    mkObject [ "kind" .= String "WithIPList SubscriptionTrace"
+    mconcat [ "kind" .= String "WithIPList SubscriptionTrace"
              , "localAddresses" .= show localAddresses
              , "dests" .= show dests
              , "event" .= show ev ]
@@ -1337,21 +1339,21 @@ instance ToObject (WithIPList (SubscriptionTrace SockAddr)) where
 
 instance ToObject (WithDomainName DnsTrace) where
   toObject _verb (WithDomainName dom ev) =
-    mkObject [ "kind" .= String "DnsTrace"
+    mconcat [ "kind" .= String "DnsTrace"
              , "domain" .= show dom
              , "event" .= show ev ]
 
 
 instance ToObject (WithDomainName (SubscriptionTrace SockAddr)) where
   toObject _verb (WithDomainName dom ev) =
-    mkObject [ "kind" .= String "SubscriptionTrace"
+    mconcat [ "kind" .= String "SubscriptionTrace"
              , "domain" .= show dom
              , "event" .= show ev ]
 
 
 instance ToObject peer => ToObject (WithMuxBearer peer MuxTrace) where
   toObject verb (WithMuxBearer b ev) =
-    mkObject [ "kind" .= String "MuxTrace"
+    mconcat [ "kind" .= String "MuxTrace"
              , "bearer" .= toObject verb b
              , "event" .= show ev ]
 
@@ -1359,30 +1361,30 @@ instance Aeson.ToJSONKey RelayAccessPoint where
 
 instance Show exception => ToObject (TraceLocalRootPeers RemoteAddress exception) where
   toObject _verb (TraceLocalRootDomains groups) =
-    mkObject [ "kind" .= String "LocalRootDomains"
+    mconcat [ "kind" .= String "LocalRootDomains"
              , "localRootDomains" .= toJSON groups
              ]
   toObject _verb (TraceLocalRootWaiting d dt) =
-    mkObject [ "kind" .= String "LocalRootWaiting"
+    mconcat [ "kind" .= String "LocalRootWaiting"
              , "domainAddress" .= toJSON d
              , "diffTime" .= show dt
              ]
   toObject _verb (TraceLocalRootResult d res) =
-    mkObject [ "kind" .= String "LocalRootResult"
+    mconcat [ "kind" .= String "LocalRootResult"
              , "domainAddress" .= toJSON d
              , "result" .= Aeson.toJSONList res
              ]
   toObject _verb (TraceLocalRootGroups groups) =
-    mkObject [ "kind" .= String "LocalRootGroups"
+    mconcat [ "kind" .= String "LocalRootGroups"
              , "localRootGroups" .= toJSON groups
              ]
   toObject _verb (TraceLocalRootFailure d dexception) =
-    mkObject [ "kind" .= String "LocalRootFailure"
+    mconcat [ "kind" .= String "LocalRootFailure"
              , "domainAddress" .= toJSON d
              , "reason" .= show dexception
              ]
   toObject _verb (TraceLocalRootError d dexception) =
-    mkObject [ "kind" .= String "LocalRootError"
+    mconcat [ "kind" .= String "LocalRootError"
              , "domainAddress" .= toJSON d
              , "reason" .= show dexception
              ]
@@ -1392,20 +1394,20 @@ instance ToJSON IP where
 
 instance ToObject TracePublicRootPeers where
   toObject _verb (TracePublicRootRelayAccessPoint relays) =
-    mkObject [ "kind" .= String "PublicRootRelayAddresses"
+    mconcat [ "kind" .= String "PublicRootRelayAddresses"
              , "relayAddresses" .= Aeson.toJSONList relays
              ]
   toObject _verb (TracePublicRootDomains domains) =
-    mkObject [ "kind" .= String "PublicRootDomains"
+    mconcat [ "kind" .= String "PublicRootDomains"
              , "domainAddresses" .= Aeson.toJSONList domains
              ]
   toObject _verb (TracePublicRootResult b res) =
-    mkObject [ "kind" .= String "PublicRootResult"
+    mconcat [ "kind" .= String "PublicRootResult"
              , "domain" .= show b
              , "result" .= Aeson.toJSONList res
              ]
   toObject _verb (TracePublicRootFailure b d) =
-    mkObject [ "kind" .= String "PublicRootFailure"
+    mconcat [ "kind" .= String "PublicRootFailure"
              , "domain" .= show b
              , "reason" .= show d
              ]
@@ -1437,63 +1439,63 @@ instance ToJSON PeerSelectionTargets where
 
 instance ToObject (TracePeerSelection SockAddr) where
   toObject _verb (TraceLocalRootPeersChanged lrp lrp') =
-    mkObject [ "kind" .= String "LocalRootPeersChanged"
+    mconcat [ "kind" .= String "LocalRootPeersChanged"
              , "previous" .= toJSON lrp
              , "current" .= toJSON lrp'
              ]
   toObject _verb (TraceTargetsChanged pst pst') =
-    mkObject [ "kind" .= String "TargetsChanged"
+    mconcat [ "kind" .= String "TargetsChanged"
              , "previous" .= toJSON pst
              , "current" .= toJSON pst'
              ]
   toObject _verb (TracePublicRootsRequest tRootPeers nRootPeers) =
-    mkObject [ "kind" .= String "PublicRootsRequest"
+    mconcat [ "kind" .= String "PublicRootsRequest"
              , "targetNumberOfRootPeers" .= tRootPeers
              , "numberOfRootPeers" .= nRootPeers
              ]
   toObject _verb (TracePublicRootsResults res group dt) =
-    mkObject [ "kind" .= String "PublicRootsResults"
+    mconcat [ "kind" .= String "PublicRootsResults"
              , "result" .= Aeson.toJSONList (toList res)
              , "group" .= group
              , "diffTime" .= dt
              ]
   toObject _verb (TracePublicRootsFailure err group dt) =
-    mkObject [ "kind" .= String "PublicRootsFailure"
+    mconcat [ "kind" .= String "PublicRootsFailure"
              , "reason" .= show err
              , "group" .= group
              , "diffTime" .= dt
              ]
   toObject _verb (TraceGossipRequests targetKnown actualKnown aps sps) =
-    mkObject [ "kind" .= String "GossipRequests"
+    mconcat [ "kind" .= String "GossipRequests"
              , "targetKnown" .= targetKnown
              , "actualKnown" .= actualKnown
              , "availablePeers" .= Aeson.toJSONList (toList aps)
              , "selectedPeers" .= Aeson.toJSONList (toList sps)
              ]
   toObject _verb (TraceGossipResults res) =
-    mkObject [ "kind" .= String "GossipResults"
+    mconcat [ "kind" .= String "GossipResults"
              , "result" .= Aeson.toJSONList (map ( bimap show id <$> ) res)
              ]
   toObject _verb (TraceForgetColdPeers targetKnown actualKnown sp) =
-    mkObject [ "kind" .= String "ForgeColdPeers"
+    mconcat [ "kind" .= String "ForgeColdPeers"
              , "targetKnown" .= targetKnown
              , "actualKnown" .= actualKnown
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteColdPeers targetKnown actualKnown sp) =
-    mkObject [ "kind" .= String "PromoteColdPeers"
+    mconcat [ "kind" .= String "PromoteColdPeers"
              , "targetEstablished" .= targetKnown
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteColdLocalPeers tLocalEst aLocalEst sp) =
-    mkObject [ "kind" .= String "PromoteColdLocalPeers"
+    mconcat [ "kind" .= String "PromoteColdLocalPeers"
              , "targetLocalEstablished" .= tLocalEst
              , "actualLocalEstablished" .= aLocalEst
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteColdFailed tEst aEst p d err) =
-    mkObject [ "kind" .= String "PromoteColdFailed"
+    mconcat [ "kind" .= String "PromoteColdFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
@@ -1501,97 +1503,97 @@ instance ToObject (TracePeerSelection SockAddr) where
              , "reason" .= show err
              ]
   toObject _verb (TracePromoteColdDone tEst aEst p) =
-    mkObject [ "kind" .= String "PromoteColdDone"
+    mconcat [ "kind" .= String "PromoteColdDone"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              ]
   toObject _verb (TracePromoteWarmPeers tActive aActive sp) =
-    mkObject [ "kind" .= String "PromoteWarmPeers"
+    mconcat [ "kind" .= String "PromoteWarmPeers"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteWarmLocalPeers taa sp) =
-    mkObject [ "kind" .= String "PromoteWarmLocalPeers"
+    mconcat [ "kind" .= String "PromoteWarmLocalPeers"
              , "targetActualActive" .= Aeson.toJSONList taa
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteWarmFailed tActive aActive p err) =
-    mkObject [ "kind" .= String "PromoteWarmFailed"
+    mconcat [ "kind" .= String "PromoteWarmFailed"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   toObject _verb (TracePromoteWarmDone tActive aActive p) =
-    mkObject [ "kind" .= String "PromoteWarmDone"
+    mconcat [ "kind" .= String "PromoteWarmDone"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   toObject _verb (TracePromoteWarmAborted tActive aActive p) =
-    mkObject [ "kind" .= String "PromoteWarmAborted"
+    mconcat [ "kind" .= String "PromoteWarmAborted"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   toObject _verb (TraceDemoteWarmPeers tEst aEst sp) =
-    mkObject [ "kind" .= String "DemoteWarmPeers"
+    mconcat [ "kind" .= String "DemoteWarmPeers"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TraceDemoteWarmFailed tEst aEst p err) =
-    mkObject [ "kind" .= String "DemoteWarmFailed"
+    mconcat [ "kind" .= String "DemoteWarmFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   toObject _verb (TraceDemoteWarmDone tEst aEst p) =
-    mkObject [ "kind" .= String "DemoteWarmDone"
+    mconcat [ "kind" .= String "DemoteWarmDone"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              ]
   toObject _verb (TraceDemoteHotPeers tActive aActive sp) =
-    mkObject [ "kind" .= String "DemoteHotPeers"
+    mconcat [ "kind" .= String "DemoteHotPeers"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TraceDemoteLocalHotPeers taa sp) =
-    mkObject [ "kind" .= String "DemoteLocalHotPeers"
+    mconcat [ "kind" .= String "DemoteLocalHotPeers"
              , "targetActualActive" .= Aeson.toJSONList taa
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TraceDemoteHotFailed tActive aActive p err) =
-    mkObject [ "kind" .= String "DemoteHotFailed"
+    mconcat [ "kind" .= String "DemoteHotFailed"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              , "reason" .= show err
              ]
   toObject _verb (TraceDemoteHotDone tActive aActive p) =
-    mkObject [ "kind" .= String "DemoteHotDone"
+    mconcat [ "kind" .= String "DemoteHotDone"
              , "targetActive" .= tActive
              , "actualActive" .= aActive
              , "peer" .= toJSON p
              ]
   toObject _verb (TraceDemoteAsynchronous msp) =
-    mkObject [ "kind" .= String "DemoteAsynchronous"
+    mconcat [ "kind" .= String "DemoteAsynchronous"
              , "state" .= toJSON msp
              ]
   toObject _verb TraceGovernorWakeup =
-    mkObject [ "kind" .= String "GovernorWakeup"
+    mconcat [ "kind" .= String "GovernorWakeup"
              ]
   toObject _verb (TraceChurnWait dt) =
-    mkObject [ "kind" .= String "ChurnWait"
+    mconcat [ "kind" .= String "ChurnWait"
              , "diffTime" .= toJSON dt
              ]
   toObject _verb (TraceChurnMode c) =
-    mkObject [ "kind" .= String "ChurnMode"
+    mconcat [ "kind" .= String "ChurnMode"
              , "event" .= show c ]
 
 -- Connection manager abstract state.  For explanation of each state see
@@ -1640,7 +1642,7 @@ peerSelectionTargetsToObject
                          targetNumberOfEstablishedPeers,
                          targetNumberOfActivePeers } =
     Object $
-      mkObject [ "roots" .= targetNumberOfRootPeers
+      mconcat [ "roots" .= targetNumberOfRootPeers
                , "knownPeers" .= targetNumberOfKnownPeers
                , "established" .= targetNumberOfEstablishedPeers
                , "active" .= targetNumberOfActivePeers
@@ -1650,18 +1652,18 @@ instance Show peerConn => ToObject (DebugPeerSelection SockAddr peerConn) where
   toObject verb (TraceGovernorState blockedAt wakeupAfter
                    PeerSelectionState { targets, knownPeers, establishedPeers, activePeers })
       | verb <= NormalVerbosity =
-    mkObject [ "kind" .= String "DebugPeerSelection"
+    mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
              , "wakeupAfter" .= String (pack $ show wakeupAfter)
              , "targets" .= peerSelectionTargetsToObject targets
              , "numberOfPeers" .=
-                 Object (mkObject [ "known" .= KnownPeers.size knownPeers
+                 Object (mconcat [ "known" .= KnownPeers.size knownPeers
                                   , "established" .= EstablishedPeers.size establishedPeers
                                   , "active" .= Set.size activePeers
                                   ])
              ]
   toObject _ (TraceGovernorState blockedAt wakeupAfter ev) =
-    mkObject [ "kind" .= String "DebugPeerSelection"
+    mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
              , "wakeupAfter" .= String (pack $ show wakeupAfter)
              , "peerSelectionState" .= String (pack $ show ev)
@@ -1671,28 +1673,28 @@ instance Show peerConn => ToObject (DebugPeerSelection SockAddr peerConn) where
 -- For that an export is needed at ouroboros-network
 instance ToObject (PeerSelectionActionsTrace SockAddr) where
   toObject _verb (PeerStatusChanged ps) =
-    mkObject [ "kind" .= String "PeerStatusChanged"
+    mconcat [ "kind" .= String "PeerStatusChanged"
              , "peerStatusChangeType" .= show ps
              ]
   toObject _verb (PeerStatusChangeFailure ps f) =
-    mkObject [ "kind" .= String "PeerStatusChangeFailure"
+    mconcat [ "kind" .= String "PeerStatusChangeFailure"
              , "peerStatusChangeType" .= show ps
              , "reason" .= show f
              ]
   toObject _verb (PeerMonitoringError connId s) =
-    mkObject [ "kind" .= String "PeerMonitoridngError"
+    mconcat [ "kind" .= String "PeerMonitoridngError"
              , "connectionId" .= toJSON connId
              , "reason" .= show s
              ]
   toObject _verb (PeerMonitoringResult connId wf) =
-    mkObject [ "kind" .= String "PeerMonitoringResult"
+    mconcat [ "kind" .= String "PeerMonitoringResult"
              , "connectionId" .= toJSON connId
              , "withProtocolTemp" .= show wf
              ]
 
 instance ToObject PeerSelectionCounters where
   toObject _verb ev =
-    mkObject [ "kind" .= String "PeerSelectionCounters"
+    mconcat [ "kind" .= String "PeerSelectionCounters"
              , "coldPeers" .= coldPeers ev
              , "warmPeers" .= warmPeers ev
              , "hotPeers" .= hotPeers ev
@@ -1783,23 +1785,23 @@ instance ToJSON NodeToClientVersionData where
 instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
   => ToObject (ConnectionHandlerTrace versionNumber agreedOptions) where
   toObject _verb (TrHandshakeSuccess versionNumber agreedOptions) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeSuccess"
       , "versionNumber" .= toJSON versionNumber
       , "agreedOptions" .= toJSON agreedOptions
       ]
   toObject _verb (TrHandshakeClientError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeClientError"
       , "reason" .= toJSON err
       ]
   toObject _verb (TrHandshakeServerError err) =
-    mkObject
+    mconcat
       [ "kind" .= String "HandshakeServerError"
       , "reason" .= toJSON err
       ]
   toObject _verb (TrError e err cerr) =
-    mkObject
+    mconcat
       [ "kind" .= String "Error"
       , "context" .= show e
       , "reason" .= show err
@@ -1812,124 +1814,124 @@ instance (Show addr, Show versionNumber, Show agreedOptions, ToObject addr,
   toObject verb ev =
     case ev of
       TrIncludeConnection prov peerAddr ->
-        mkObject $ reverse
+        mconcat $ reverse
           [ "kind" .= String "IncludeConnection"
           , "remoteAddress" .= toObject verb peerAddr
           , "provenance" .= String (pack . show $ prov)
           ]
       TrUnregisterConnection prov peerAddr ->
-        mkObject $ reverse
+        mconcat $ reverse
           [ "kind" .= String "UnregisterConnection"
           , "remoteAddress" .= toObject verb peerAddr
           , "provenance" .= String (pack . show $ prov)
           ]
       TrConnect (Just localAddress) remoteAddress ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectTo"
           , "connectionId" .= toJSON ConnectionId { localAddress, remoteAddress }
           ]
       TrConnect Nothing remoteAddress ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectTo"
           , "remoteAddress" .= toObject verb remoteAddress
           ]
       TrConnectError (Just localAddress) remoteAddress err ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectError"
           , "connectionId" .= toJSON ConnectionId { localAddress, remoteAddress }
           , "reason" .= String (pack . show $ err)
           ]
       TrConnectError Nothing remoteAddress err ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectError"
           , "remoteAddress" .= toObject verb remoteAddress
           , "reason" .= String (pack . show $ err)
           ]
       TrTerminatingConnection prov connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "TerminatingConnection"
           , "provenance" .= String (pack . show $ prov)
           , "connectionId" .= toJSON connId
           ]
       TrTerminatedConnection prov remoteAddress ->
-        mkObject
+        mconcat
           [ "kind" .= String "TerminatedConnection"
           , "provenance" .= String (pack . show $ prov)
           , "remoteAddress" .= toObject verb remoteAddress
           ]
       TrConnectionHandler connId a ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionHandler"
           , "connectionId" .= toJSON connId
           , "connectionHandler" .= toObject verb a
           ]
       TrShutdown ->
-        mkObject
+        mconcat
           [ "kind" .= String "Shutdown"
           ]
       TrConnectionExists prov remoteAddress inState ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionExists"
           , "provenance" .= String (pack . show $ prov)
           , "remoteAddress" .= toObject verb remoteAddress
           , "state" .= toJSON inState
           ]
       TrForbiddenConnection connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ForbiddenConnection"
           , "connectionId" .= toJSON connId
           ]
       TrImpossibleConnection connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ImpossibleConnection"
           , "connectionId" .= toJSON connId
           ]
       TrConnectionFailure connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionFailure"
           , "connectionId" .= toJSON connId
           ]
       TrConnectionNotFound prov remoteAddress ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionNotFound"
           , "remoteAddress" .= toObject verb remoteAddress
           , "provenance" .= String (pack . show $ prov)
           ]
       TrForbiddenOperation remoteAddress connState ->
-        mkObject
+        mconcat
           [ "kind" .= String "ForbiddenOperation"
           , "remoteAddress" .= toObject verb remoteAddress
           , "connectionState" .= toJSON connState
           ]
       TrPruneConnections pruningSet numberPruned chosenPeers ->
-        mkObject
+        mconcat
           [ "kind" .= String "PruneConnections"
           , "prunedPeers" .= toJSON pruningSet
           , "numberPrunedPeers" .= toJSON numberPruned
           , "choiceSet" .= toJSON (toObject verb `Set.map` chosenPeers)
           ]
       TrConnectionCleanup connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionCleanup"
           , "connectionId" .= toJSON connId
           ]
       TrConnectionTimeWait connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionTimeWait"
           , "connectionId" .= toJSON connId
           ]
       TrConnectionTimeWaitDone connId ->
-        mkObject
+        mconcat
           [ "kind" .= String "ConnectionTimeWaitDone"
           , "connectionId" .= toJSON connId
           ]
       TrConnectionManagerCounters cmCounters ->
-        mkObject
+        mconcat
           [ "kind"  .= String "ConnectionManagerCounters"
           , "state" .= toJSON cmCounters
           ]
       TrState cmState ->
-        mkObject
+        mconcat
           [ "kind"  .= String "ConnectionManagerState"
           , "state" .= listValue (\(addr, connState) ->
                                          Aeson.object
@@ -1939,9 +1941,13 @@ instance (Show addr, Show versionNumber, Show agreedOptions, ToObject addr,
                                        (Map.toList cmState)
           ]
       ConnMgr.TrUnexpectedlyFalseAssertion info ->
-        mkObject
+        mconcat
           [ "kind" .= String "UnexpectedlyFalseAssertion"
           , "info" .= String (pack . show $ info)
+          ]
+      TrUnknownConnection {} ->
+        mconcat
+          [ "kind" .= String "UnknownConnection"
           ]
 
 instance ToJSON state => ToJSON (ConnMgr.MaybeUnknown state) where
@@ -1963,7 +1969,7 @@ instance ToJSON state => ToJSON (ConnMgr.MaybeUnknown state) where
 instance (Show addr, ToObject addr, ToJSON addr)
       => ToObject (ConnMgr.AbstractTransitionTrace addr) where
     toObject _verb (ConnMgr.TransitionTrace addr tr) =
-      mkObject [ "kind"    .= String "ConnectionManagerTransition"
+      mconcat [ "kind"    .= String "ConnectionManagerTransition"
                , "address" .= toJSON addr
                , "from"    .= toJSON (ConnMgr.fromState tr)
                , "to"      .= toJSON (ConnMgr.toState   tr)
@@ -1972,26 +1978,26 @@ instance (Show addr, ToObject addr, ToJSON addr)
 instance (Show addr, ToObject addr, ToJSON addr)
       => ToObject (ServerTrace addr) where
   toObject verb (TrAcceptConnection peerAddr)     =
-    mkObject [ "kind" .= String "AcceptConnection"
+    mconcat [ "kind" .= String "AcceptConnection"
              , "address" .= toObject verb peerAddr
              ]
   toObject _verb (TrAcceptError exception)         =
-    mkObject [ "kind" .= String "AcceptErroor"
+    mconcat [ "kind" .= String "AcceptErroor"
              , "reason" .= show exception
              ]
   toObject verb (TrAcceptPolicyTrace policyTrace) =
-    mkObject [ "kind" .= String "AcceptPolicyTrace"
+    mconcat [ "kind" .= String "AcceptPolicyTrace"
              , "policy" .= toObject verb policyTrace
              ]
   toObject verb (TrServerStarted peerAddrs)       =
-    mkObject [ "kind" .= String "AcceptPolicyTrace"
+    mconcat [ "kind" .= String "AcceptPolicyTrace"
              , "addresses" .= toJSON (toObject verb `map` peerAddrs)
              ]
   toObject _verb TrServerStopped                   =
-    mkObject [ "kind" .= String "ServerStopped"
+    mconcat [ "kind" .= String "ServerStopped"
              ]
   toObject _verb (TrServerError exception)         =
-    mkObject [ "kind" .= String "ServerError"
+    mconcat [ "kind" .= String "ServerError"
              , "reason" .= show exception
              ]
 
@@ -2023,123 +2029,123 @@ instance ToJSON addr => Aeson.ToJSONKey (ConnectionId addr) where
 instance ToObject NtN.RemoteAddress where
     toObject _verb (SockAddrInet port addr) =
         let ip = IP.fromHostAddress addr in
-        mkObject [ "addr" .= show ip
+        mconcat [ "addr" .= show ip
                  , "port" .= show port
                  ]
     toObject _verb (SockAddrInet6 port _ addr _) =
         let ip = IP.fromHostAddress6 addr in
-        mkObject [ "addr" .= show ip
+        mconcat [ "addr" .= show ip
                  , "port" .= show port
                  ]
     toObject _verb (SockAddrUnix path) =
-        mkObject [ "path" .= show path ]
+        mconcat [ "path" .= show path ]
 
 
 instance ToObject NtN.RemoteConnectionId where
     toObject verb (NtN.ConnectionId l r) =
-        mkObject [ "local" .= toObject verb l
+        mconcat [ "local" .= toObject verb l
                  , "remote" .= toObject verb r
                  ]
 
 instance ToObject LocalAddress where
     toObject _verb (LocalAddress path) =
-        mkObject ["path" .= path]
+        mconcat ["path" .= path]
 
 instance ToObject NtC.LocalConnectionId where
     toObject verb (NtC.ConnectionId l r) =
-        mkObject [ "local" .= toObject verb l
+        mconcat [ "local" .= toObject verb l
                  , "remote" .= toObject verb r
                  ]
 instance (ToJSON addr, Show addr)
       => ToObject (InboundGovernorTrace addr) where
   toObject _verb (TrNewConnection p connId)            =
-    mkObject [ "kind" .= String "NewConnection"
+    mconcat [ "kind" .= String "NewConnection"
              , "provenance" .= show p
              , "connectionId" .= toJSON connId
              ]
   toObject _verb (TrResponderRestarted connId m)       =
-    mkObject [ "kind" .= String "ResponderStarted"
+    mconcat [ "kind" .= String "ResponderStarted"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   toObject _verb (TrResponderStartFailure connId m s)  =
-    mkObject [ "kind" .= String "ResponderStartFailure"
+    mconcat [ "kind" .= String "ResponderStartFailure"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              , "reason" .= show s
              ]
   toObject _verb (TrResponderErrored connId m s)       =
-    mkObject [ "kind" .= String "ResponderErrored"
+    mconcat [ "kind" .= String "ResponderErrored"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              , "reason" .= show s
              ]
   toObject _verb (TrResponderStarted connId m)         =
-    mkObject [ "kind" .= String "ResponderStarted"
+    mconcat [ "kind" .= String "ResponderStarted"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   toObject _verb (TrResponderTerminated connId m)      =
-    mkObject [ "kind" .= String "ResponderTerminated"
+    mconcat [ "kind" .= String "ResponderTerminated"
              , "connectionId" .= toJSON connId
              , "miniProtocolNum" .= toJSON m
              ]
   toObject _verb (TrPromotedToWarmRemote connId opRes) =
-    mkObject [ "kind" .= String "PromotedToWarmRemote"
+    mconcat [ "kind" .= String "PromotedToWarmRemote"
              , "connectionId" .= toJSON connId
              , "result" .= toJSON opRes
              ]
   toObject _verb (TrPromotedToHotRemote connId)        =
-    mkObject [ "kind" .= String "PromotedToHotRemote"
+    mconcat [ "kind" .= String "PromotedToHotRemote"
              , "connectionId" .= toJSON connId
              ]
   toObject _verb (TrDemotedToColdRemote connId od)     =
-    mkObject [ "kind" .= String "DemotedToColdRemote"
+    mconcat [ "kind" .= String "DemotedToColdRemote"
              , "connectionId" .= toJSON connId
              , "result" .= show od
              ]
   toObject _verb (TrDemotedToWarmRemote connId)     =
-    mkObject [ "kind" .= String "DemotedToWarmRemote"
+    mconcat [ "kind" .= String "DemotedToWarmRemote"
              , "connectionId" .= toJSON connId
              ]
   toObject _verb (TrWaitIdleRemote connId opRes) =
-    mkObject [ "kind" .= String "WaitIdleRemote"
+    mconcat [ "kind" .= String "WaitIdleRemote"
              , "connectionId" .= toJSON connId
              , "result" .= toJSON opRes
              ]
   toObject _verb (TrMuxCleanExit connId)               =
-    mkObject [ "kind" .= String "MuxCleanExit"
+    mconcat [ "kind" .= String "MuxCleanExit"
              , "connectionId" .= toJSON connId
              ]
   toObject _verb (TrMuxErrored connId s)               =
-    mkObject [ "kind" .= String "MuxErrored"
+    mconcat [ "kind" .= String "MuxErrored"
              , "connectionId" .= toJSON connId
              , "reason" .= show s
              ]
   toObject _verb (TrInboundGovernorCounters counters) =
-    mkObject [ "kind" .= String "InboundGovernorCounters"
+    mconcat [ "kind" .= String "InboundGovernorCounters"
              , "idlePeers" .= idlePeersRemote counters
              , "coldPeers" .= coldPeersRemote counters
              , "warmPeers" .= warmPeersRemote counters
              , "hotPeers" .= hotPeersRemote counters
              ]
   toObject _verb (TrRemoteState st) =
-    mkObject [ "kind" .= String "RemoteState"
+    mconcat [ "kind" .= String "RemoteState"
              , "remoteSt" .= toJSON st
              ]
   toObject _verb (InboundGovernor.TrUnexpectedlyFalseAssertion info) =
-    mkObject [ "kind" .= String "UnexpectedlyFalseAssertion"
+    mconcat [ "kind" .= String "UnexpectedlyFalseAssertion"
              , "remoteSt" .= String (pack . show $ info)
              ]
   toObject _verb (InboundGovernor.TrInboundGovernorError err) =
-    mkObject [ "kind" .= String "InboundGovernorError"
+    mconcat [ "kind" .= String "InboundGovernorError"
              , "remoteSt" .= String (pack . show $ err)
              ]
 
 instance ToJSON addr
       => ToObject (Server.RemoteTransitionTrace addr) where
     toObject _verb (ConnMgr.TransitionTrace addr tr) =
-      mkObject [ "kind"    .= String "InboundGovernorTransition"
+      mconcat [ "kind"    .= String "InboundGovernorTransition"
                , "address" .= toJSON addr
                , "from"    .= toJSON (ConnMgr.fromState tr)
                , "to"      .= toJSON (ConnMgr.toState   tr)

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -22,13 +22,12 @@ import           NoThunks.Class (AllowThunk (..), NoThunks)
 import           Text.Printf (printf)
 
 import           Cardano.BM.Data.LogItem (LOContent (..))
-import           Cardano.BM.Data.Tracer (emptyObject, mkObject)
 import           Cardano.BM.Trace (traceNamedObject)
 import           Cardano.BM.Tracing
 
 import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Network.ConnectionId (remoteAddress)
 import           Ouroboros.Consensus.Util.Orphans ()
+import           Ouroboros.Network.ConnectionId (remoteAddress)
 
 import qualified Ouroboros.Network.AnchoredFragment as Net
 import           Ouroboros.Network.Block (unSlotNo)
@@ -121,9 +120,9 @@ tracePeers tr peers = do
 -- | Instances for converting [Peer blk] to Object.
 
 instance ToObject [Peer blk] where
-  toObject MinimalVerbosity _ = emptyObject
-  toObject _ [] = emptyObject
-  toObject verb xs = mkObject
+  toObject MinimalVerbosity _ = mempty
+  toObject _ [] = mempty
+  toObject verb xs = mconcat
     [ "kind"  .= String "NodeKernelPeers"
     , "peers" .= toJSON
       (foldl' (\acc x -> toObject verb x : acc) [] xs)
@@ -131,10 +130,10 @@ instance ToObject [Peer blk] where
 
 instance ToObject (Peer blk) where
   toObject _verb (Peer cid _af status inflight) =
-    mkObject [ "peerAddress"   .= String (Text.pack . show . remoteAddress $ cid)
-             , "peerStatus"    .= String (Text.pack . ppStatus $ status)
-             , "peerSlotNo"    .= String (Text.pack . ppMaxSlotNo . peerFetchMaxSlotNo $ inflight)
-             , "peerReqsInF"   .= String (show . peerFetchReqsInFlight $ inflight)
-             , "peerBlocksInF" .= String (show . Set.size . peerFetchBlocksInFlight $ inflight)
-             , "peerBytesInF"  .= String (show . peerFetchBytesInFlight $ inflight)
-             ]
+    mconcat [ "peerAddress"   .= String (Text.pack . show . remoteAddress $ cid)
+            , "peerStatus"    .= String (Text.pack . ppStatus $ status)
+            , "peerSlotNo"    .= String (Text.pack . ppMaxSlotNo . peerFetchMaxSlotNo $ inflight)
+            , "peerReqsInF"   .= String (show . peerFetchReqsInFlight $ inflight)
+            , "peerBlocksInF" .= String (show . Set.size . peerFetchBlocksInFlight $ inflight)
+            , "peerBytesInF"  .= String (show . peerFetchBytesInFlight $ inflight)
+            ]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -34,7 +34,6 @@ import           GHC.Clock (getMonotonicTimeNSec)
 
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Data.Aeson (ToJSON (..), Value (..))
-import qualified Data.HashMap.Strict as Map
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as Pq
 import qualified Data.Map.Strict as SMap
@@ -45,7 +44,7 @@ import qualified System.Metrics.Gauge as Gauge
 import qualified System.Metrics.Label as Label
 import qualified System.Remote.Monitoring as EKG
 
-import "contra-tracer" Control.Tracer
+import           "contra-tracer" Control.Tracer
 import           Control.Tracer.Transformers
 
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..), WithOrigin (..))
@@ -105,8 +104,8 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.Types as LedgerDB
 
 import           Cardano.Tracing.Config
 import           Cardano.Tracing.Metrics
-import           Cardano.Tracing.Startup ()
 import           Cardano.Tracing.Shutdown ()
+import           Cardano.Tracing.Startup ()
 
 import           Cardano.Node.Configuration.Logging
 import           Cardano.Node.TraceConstraints
@@ -124,6 +123,7 @@ import qualified Cardano.Node.STM as STM
 import qualified Control.Concurrent.STM as STM
 
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
+import qualified Data.Aeson.KeyMap as KeyMap
 
 {- HLINT ignore "Redundant bracket" -}
 {- HLINT ignore "Use record patterns" -}
@@ -940,7 +940,7 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
                 traceCounter "delegMapSize" tr delegMapSize
         traceNamedObject (appendName "LeadershipCheck" tr)
           ( meta
-          , LogStructured $ Map.fromList $
+          , LogStructured $ KeyMap.fromList $
             [("kind", String "TraceStartLeadershipCheck")
             ,("credentials", String creds)
             ,("slot", toJSON $ unSlotNo slot)]

--- a/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
@@ -8,8 +8,7 @@ module Cardano.TxSubmit.Tracing.ToObjectOrphans () where
 
 import           Cardano.BM.Data.Severity (Severity (Debug, Error, Notice, Warning))
 import           Cardano.BM.Data.Tracer (HasPrivacyAnnotation, HasSeverityAnnotation (..),
-                   HasTextFormatter, ToObject (toObject), Transformable (..), mkObject,
-                   trStructured)
+                   HasTextFormatter, ToObject (toObject), Transformable (..), trStructured)
 import           Data.Aeson ((.=))
 import           Data.String (String)
 import           Data.Text (Text)
@@ -17,6 +16,7 @@ import           Ouroboros.Network.NodeToClient (ErrorPolicyTrace (..), WithAddr
 import           System.IO (IO)
 import           Text.Show (Show (..))
 
+import           Data.Monoid (mconcat)
 import qualified Network.Socket as Socket
 
 instance HasPrivacyAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace)
@@ -41,6 +41,6 @@ instance Transformable Text IO (WithAddr Socket.SockAddr ErrorPolicyTrace) where
 
 instance ToObject (WithAddr Socket.SockAddr ErrorPolicyTrace) where
   toObject _verb (WithAddr addr ev) =
-    mkObject [ "kind" .= ("ErrorPolicyTrace" :: String)
-             , "address" .= show addr
-             , "event" .= show ev ]
+    mconcat [ "kind" .= ("ErrorPolicyTrace" :: String)
+            , "address" .= show addr
+            , "event" .= show ev ]

--- a/cardano-testnet/src/Testnet/Byron.hs
+++ b/cardano-testnet/src/Testnet/Byron.hs
@@ -239,7 +239,7 @@ testnet testnetOptions H.Conf {..} = do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> "node-" <> si)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
     -- TODO: Better error message need to indicate a sprocket was not created
-    H.waitByDeadlineM deadline $ H.doesSprocketExist sprocket
+    H.assertByDeadlineM deadline $ H.doesSprocketExist sprocket
 
   forM_ nodeIndexes $ \i -> do
     si <- H.noteShow $ show @Int i

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -844,7 +844,7 @@ testnet testnetOptions H.Conf {..} = do
   forM_ allNodeNames $ \node -> do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.waitByDeadlineM deadline $ H.doesSprocketExist sprocket
+    H.assertByDeadlineM deadline $ H.doesSprocketExist sprocket
 
   forM_ allNodeNames $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -472,7 +472,7 @@ testnet testnetOptions H.Conf {..} = do
   forM_ allNodes $ \node -> do
     sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
-    H.waitByDeadlineM deadline $ H.doesSprocketExist sprocket
+    H.assertByDeadlineM deadline $ H.doesSprocketExist sprocket
 
   forM_ allNodes $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"

--- a/flake.lock
+++ b/flake.lock
@@ -292,10 +292,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
         "type": "github"
       },
       "original": {
@@ -597,11 +597,11 @@
     "cabal-34": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
         "type": "github"
       },
       "original": {
@@ -903,11 +903,11 @@
     "cabal-36": {
       "flake": false,
       "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
         "type": "github"
       },
       "original": {
@@ -1159,7 +1159,7 @@
     },
     "cardano-mainnet-mirror_10": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1178,7 +1178,7 @@
     },
     "cardano-mainnet-mirror_11": {
       "inputs": {
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1197,7 +1197,7 @@
     },
     "cardano-mainnet-mirror_12": {
       "inputs": {
-        "nixpkgs": "nixpkgs_15"
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1216,7 +1216,7 @@
     },
     "cardano-mainnet-mirror_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1235,7 +1235,7 @@
     },
     "cardano-mainnet-mirror_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1254,7 +1254,7 @@
     },
     "cardano-mainnet-mirror_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1273,7 +1273,7 @@
     },
     "cardano-mainnet-mirror_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1292,7 +1292,7 @@
     },
     "cardano-mainnet-mirror_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1311,7 +1311,7 @@
     },
     "cardano-mainnet-mirror_7": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1330,7 +1330,7 @@
     },
     "cardano-mainnet-mirror_8": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1349,7 +1349,7 @@
     },
     "cardano-mainnet-mirror_9": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -2359,11 +2359,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -2936,11 +2936,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1648689423,
-        "narHash": "sha256-5zEPRdHArPtFv/6gRVZXcxG2Wps5qoUAxBjbxd7UjQ4=",
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "aa3358e56f0184f636254ed8124275c84e66c43b",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
         "type": "github"
       },
       "original": {
@@ -2952,11 +2952,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1646961339,
-        "narHash": "sha256-hsXNxSugSyOALfOt0I+mXrKioJ/nWX49/RhF/88N6D0=",
+        "lastModified": 1648689423,
+        "narHash": "sha256-5zEPRdHArPtFv/6gRVZXcxG2Wps5qoUAxBjbxd7UjQ4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5dea95d408c29b56a14faae378ae4e39d63126f4",
+        "rev": "aa3358e56f0184f636254ed8124275c84e66c43b",
         "type": "github"
       },
       "original": {
@@ -3232,7 +3232,6 @@
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "nix-tools": "nix-tools",
         "nixpkgs": [
           "cardano-node-workbench",
@@ -3246,11 +3245,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1648689547,
-        "narHash": "sha256-ea8Celj9aPb1HG8mGNorqMr5+3xZzjuhjF89Mj4hSLU=",
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3fbb17e63c4e052c8289858fa6444d1c66ab6f52",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
         "type": "github"
       },
       "original": {
@@ -3623,7 +3622,7 @@
           "hackageNix"
         ],
         "hpc-coveralls": "hpc-coveralls_2",
-        "hydra": "hydra_2",
+        "hydra": "hydra",
         "nix-tools": "nix-tools_2",
         "nixpkgs": [
           "nixpkgs"
@@ -3636,11 +3635,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1647960987,
-        "narHash": "sha256-Jb2xIncXlqvkMmEGsMDdWScdLGhEegNCdhSJswsOAkI=",
+        "lastModified": 1648689547,
+        "narHash": "sha256-ea8Celj9aPb1HG8mGNorqMr5+3xZzjuhjF89Mj4hSLU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "53ffd8eac65e3f029865b00f7eca49373388b691",
+        "rev": "3fbb17e63c4e052c8289858fa6444d1c66ab6f52",
         "type": "github"
       },
       "original": {
@@ -3660,7 +3659,7 @@
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_3",
-        "hydra": "hydra_3",
+        "hydra": "hydra_2",
         "nix-tools": "nix-tools_3",
         "nixpkgs": [
           "node-measured",
@@ -4215,7 +4214,6 @@
       "inputs": {
         "nix": "nix",
         "nixpkgs": [
-          "cardano-node-workbench",
           "haskellNix",
           "hydra",
           "nix",
@@ -4238,29 +4236,6 @@
     "hydra_2": {
       "inputs": {
         "nix": "nix_2",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1646878427,
-        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "hydra_3": {
-      "inputs": {
-        "nix": "nix_3",
         "nixpkgs": [
           "node-measured",
           "cardano-node-workbench",
@@ -4291,11 +4266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648032999,
-        "narHash": "sha256-3uCz+gJppvM7z6CUCkBbFSu60WgIE+e3oXwXiAiGWSY=",
+        "lastModified": 1645693195,
+        "narHash": "sha256-UDemE2MFEi/L8Xmwi1/FuKU9ka3QqDye6k7rVW6ryeE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5e667b374153327c7bdfdbfab8ef19b1f27d4aac",
+        "rev": "29c9a3b6704b5c0df3bb4a3e65240749883c50a0",
         "type": "github"
       },
       "original": {
@@ -4521,11 +4496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646330344,
-        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
+        "lastModified": 1648032999,
+        "narHash": "sha256-3uCz+gJppvM7z6CUCkBbFSu60WgIE+e3oXwXiAiGWSY=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "rev": "5e667b374153327c7bdfdbfab8ef19b1f27d4aac",
         "type": "github"
       },
       "original": {
@@ -4713,22 +4688,6 @@
       }
     },
     "lowdown-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "lowdown-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1633514407,
@@ -5193,11 +5152,11 @@
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
         "type": "github"
       },
       "original": {
@@ -5497,29 +5456,8 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-regression": "nixpkgs-regression_2"
-      },
-      "locked": {
-        "lastModified": 1643066034,
-        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.6.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_3": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_5",
-        "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
         "lastModified": 1643066034,
@@ -5840,11 +5778,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1642244250,
-        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
         "type": "github"
       },
       "original": {
@@ -6128,11 +6066,11 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1644510859,
-        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
         "type": "github"
       },
       "original": {
@@ -6444,28 +6382,13 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-regression_3": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "indirect"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
         "type": "github"
       },
       "original": {
@@ -6817,20 +6740,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_15": {
-      "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1632864508,
@@ -6848,21 +6757,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1642336556,
         "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
@@ -6875,7 +6769,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -6887,6 +6781,20 @@
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
         "type": "indirect"
       }
     },
@@ -6970,11 +6878,11 @@
         "utils": "utils_14"
       },
       "locked": {
-        "lastModified": 1648681325,
-        "narHash": "sha256-6oWDYmMb+V4x0jCoYDzKfBJMpr7Mx5zA3WMpNHspuSw=",
+        "lastModified": 1648734062,
+        "narHash": "sha256-q/fUV411/Apxkrr6SeMy83ft5bWGqiAv+DS1UhPQyCg=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "78675fbf8986c87c0d2356b727a0ec2060f1adba",
+        "rev": "0e204ec3d17a1daed36a071589c95c0b1d2cb79f",
         "type": "github"
       },
       "original": {
@@ -7058,11 +6966,11 @@
     "node-process_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1648681325,
-        "narHash": "sha256-6oWDYmMb+V4x0jCoYDzKfBJMpr7Mx5zA3WMpNHspuSw=",
+        "lastModified": 1648734062,
+        "narHash": "sha256-q/fUV411/Apxkrr6SeMy83ft5bWGqiAv+DS1UhPQyCg=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "78675fbf8986c87c0d2356b727a0ec2060f1adba",
+        "rev": "0e204ec3d17a1daed36a071589c95c0b1d2cb79f",
         "type": "github"
       },
       "original": {
@@ -7599,11 +7507,11 @@
     "plutus-apps": {
       "flake": false,
       "locked": {
-        "lastModified": 1648635956,
-        "narHash": "sha256-qwPhjV07SIahycFpaxqSSOztJLOlmLdgj/TjgVrjkBE=",
+        "lastModified": 1647347289,
+        "narHash": "sha256-dxKZ1Zvflyt6igYm39POV6X/0giKbfb4U7D1TvevQls=",
         "owner": "input-output-hk",
         "repo": "plutus-apps",
-        "rev": "b86ee21775422f9c0ca5ff66195014a497575d2d",
+        "rev": "2a40552f4654d695f21783c86e8ae59243ce9dfa",
         "type": "github"
       },
       "original": {
@@ -7647,11 +7555,11 @@
     "plutus-apps_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1647347289,
-        "narHash": "sha256-dxKZ1Zvflyt6igYm39POV6X/0giKbfb4U7D1TvevQls=",
+        "lastModified": 1648635956,
+        "narHash": "sha256-qwPhjV07SIahycFpaxqSSOztJLOlmLdgj/TjgVrjkBE=",
         "owner": "input-output-hk",
         "repo": "plutus-apps",
-        "rev": "2a40552f4654d695f21783c86e8ae59243ce9dfa",
+        "rev": "b86ee21775422f9c0ca5ff66195014a497575d2d",
         "type": "github"
       },
       "original": {
@@ -7840,11 +7748,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1648603096,
-        "narHash": "sha256-d1WKzMnk+2ZOXz3YSSqYHrMSHRVSZth+eS/pO5iSwVE=",
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "c2bdc5825795d3a6938aa74e598da57591b2e150",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
         "type": "github"
       },
       "original": {
@@ -8000,11 +7908,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1647911723,
-        "narHash": "sha256-SfHe7QWAH4A1gHj1LSEFNXMJACvzbgQn2KkjdJOkCQ4=",
+        "lastModified": 1648603096,
+        "narHash": "sha256-d1WKzMnk+2ZOXz3YSSqYHrMSHRVSZth+eS/pO5iSwVE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "00701d47768afdf1788a8bb1b84e3b1c7bf71581",
+        "rev": "c2bdc5825795d3a6938aa74e598da57591b2e150",
         "type": "github"
       },
       "original": {
@@ -8127,11 +8035,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -8262,11 +8170,11 @@
     },
     "utils_18": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,6 +80,86 @@
         "type": "github"
       }
     },
+    "HTTP_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "HTTP_2": {
       "flake": false,
       "locked": {
@@ -293,7 +373,7 @@
         "type": "github"
       }
     },
-    "cabal-32_2": {
+    "cabal-32_14": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -310,7 +390,7 @@
         "type": "github"
       }
     },
-    "cabal-32_3": {
+    "cabal-32_15": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -318,6 +398,91 @@
         "owner": "haskell",
         "repo": "cabal",
         "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
         "type": "github"
       },
       "original": {
@@ -514,7 +679,7 @@
         "type": "github"
       }
     },
-    "cabal-34_2": {
+    "cabal-34_14": {
       "flake": false,
       "locked": {
         "lastModified": 1622475795,
@@ -531,7 +696,7 @@
         "type": "github"
       }
     },
-    "cabal-34_3": {
+    "cabal-34_15": {
       "flake": false,
       "locked": {
         "lastModified": 1622475795,
@@ -539,6 +704,91 @@
         "owner": "haskell",
         "repo": "cabal",
         "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
         "type": "github"
       },
       "original": {
@@ -684,7 +934,7 @@
         "type": "github"
       }
     },
-    "cabal-36_2": {
+    "cabal-36_11": {
       "flake": false,
       "locked": {
         "lastModified": 1640163203,
@@ -701,7 +951,7 @@
         "type": "github"
       }
     },
-    "cabal-36_3": {
+    "cabal-36_12": {
       "flake": false,
       "locked": {
         "lastModified": 1640163203,
@@ -709,6 +959,74 @@
         "owner": "haskell",
         "repo": "cabal",
         "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
         "type": "github"
       },
       "original": {
@@ -839,9 +1157,9 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_2": {
+    "cardano-mainnet-mirror_10": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -858,7 +1176,45 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_3": {
+    "cardano-mainnet-mirror_11": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_14"
+      },
+      "locked": {
+        "lastModified": 1642701714,
+        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-mainnet-mirror",
+        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "cardano-mainnet-mirror",
+        "type": "github"
+      }
+    },
+    "cardano-mainnet-mirror_12": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_15"
+      },
+      "locked": {
+        "lastModified": 1642701714,
+        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-mainnet-mirror",
+        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "cardano-mainnet-mirror",
+        "type": "github"
+      }
+    },
+    "cardano-mainnet-mirror_2": {
       "inputs": {
         "nixpkgs": "nixpkgs_4"
       },
@@ -877,26 +1233,7 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_4": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_5"
-      },
-      "locked": {
-        "lastModified": 1642701714,
-        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
-        "owner": "input-output-hk",
-        "repo": "cardano-mainnet-mirror",
-        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "nix",
-        "repo": "cardano-mainnet-mirror",
-        "type": "github"
-      }
-    },
-    "cardano-mainnet-mirror_5": {
+    "cardano-mainnet-mirror_3": {
       "inputs": {
         "nixpkgs": "nixpkgs_6"
       },
@@ -915,7 +1252,7 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_6": {
+    "cardano-mainnet-mirror_4": {
       "inputs": {
         "nixpkgs": "nixpkgs_7"
       },
@@ -934,7 +1271,7 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_7": {
+    "cardano-mainnet-mirror_5": {
       "inputs": {
         "nixpkgs": "nixpkgs_8"
       },
@@ -953,7 +1290,7 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_8": {
+    "cardano-mainnet-mirror_6": {
       "inputs": {
         "nixpkgs": "nixpkgs_9"
       },
@@ -972,7 +1309,7 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror_9": {
+    "cardano-mainnet-mirror_7": {
       "inputs": {
         "nixpkgs": "nixpkgs_10"
       },
@@ -991,13 +1328,52 @@
         "type": "github"
       }
     },
+    "cardano-mainnet-mirror_8": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_11"
+      },
+      "locked": {
+        "lastModified": 1642701714,
+        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-mainnet-mirror",
+        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "cardano-mainnet-mirror",
+        "type": "github"
+      }
+    },
+    "cardano-mainnet-mirror_9": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_12"
+      },
+      "locked": {
+        "lastModified": 1642701714,
+        "narHash": "sha256-SR3luE+ePX6U193EKE/KSEuVzWAW0YsyPYDC4hOvALs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-mainnet-mirror",
+        "rev": "819488be9eabbba6aaa7c931559bc584d8071e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "cardano-mainnet-mirror",
+        "type": "github"
+      }
+    },
     "cardano-node-snapshot": {
       "inputs": {
-        "customConfig": "customConfig_4",
-        "haskellNix": "haskellNix_4",
-        "iohkNix": "iohkNix_4",
-        "membench": "membench_3",
+        "customConfig": "customConfig_6",
+        "haskellNix": "haskellNix_6",
+        "iohkNix": "iohkNix_6",
+        "membench": "membench_4",
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -1005,7 +1381,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example",
-        "utils": "utils_4"
+        "utils": "utils_5"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -1024,11 +1400,12 @@
     },
     "cardano-node-snapshot_2": {
       "inputs": {
-        "customConfig": "customConfig_5",
-        "haskellNix": "haskellNix_5",
-        "iohkNix": "iohkNix_5",
-        "membench": "membench_4",
+        "customConfig": "customConfig_7",
+        "haskellNix": "haskellNix_7",
+        "iohkNix": "iohkNix_7",
+        "membench": "membench_5",
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -1037,7 +1414,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_2"
+        "utils": "utils_3"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1056,11 +1433,12 @@
     },
     "cardano-node-snapshot_3": {
       "inputs": {
-        "customConfig": "customConfig_8",
-        "haskellNix": "haskellNix_8",
-        "iohkNix": "iohkNix_8",
-        "membench": "membench_6",
+        "customConfig": "customConfig_10",
+        "haskellNix": "haskellNix_10",
+        "iohkNix": "iohkNix_10",
+        "membench": "membench_7",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -1068,7 +1446,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_3",
-        "utils": "utils_8"
+        "utils": "utils_9"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -1087,11 +1465,12 @@
     },
     "cardano-node-snapshot_4": {
       "inputs": {
-        "customConfig": "customConfig_9",
-        "haskellNix": "haskellNix_9",
-        "iohkNix": "iohkNix_9",
-        "membench": "membench_7",
+        "customConfig": "customConfig_11",
+        "haskellNix": "haskellNix_11",
+        "iohkNix": "iohkNix_11",
+        "membench": "membench_8",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -1100,7 +1479,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_6"
+        "utils": "utils_7"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1119,10 +1498,41 @@
     },
     "cardano-node-snapshot_5": {
       "inputs": {
-        "customConfig": "customConfig_12",
-        "haskellNix": "haskellNix_12",
-        "iohkNix": "iohkNix_12",
-        "membench": "membench_9",
+        "customConfig": "customConfig_14",
+        "haskellNix": "haskellNix_14",
+        "iohkNix": "iohkNix_14",
+        "membench": "membench_10",
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "utils": "utils_11"
+      },
+      "locked": {
+        "lastModified": 1644954571,
+        "narHash": "sha256-c6MM1mQoS/AnTIrwaRmITK4L4i9lLNtkjOUHiseBtUs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "30d62b86e7b98da28ef8ad9412e4e00a1ba1231d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "30d62b86e7b98da28ef8ad9412e4e00a1ba1231d",
+        "type": "github"
+      }
+    },
+    "cardano-node-snapshot_6": {
+      "inputs": {
+        "customConfig": "customConfig_17",
+        "haskellNix": "haskellNix_17",
+        "iohkNix": "iohkNix_17",
+        "membench": "membench_12",
         "nixpkgs": [
           "node-snapshot",
           "membench",
@@ -1130,7 +1540,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_10"
+        "utils": "utils_15"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1200,6 +1610,43 @@
       }
     },
     "cardano-node-workbench_3": {
+      "inputs": {
+        "cardano-node-workbench": "cardano-node-workbench_4",
+        "customConfig": "customConfig_3",
+        "flake-compat": "flake-compat_3",
+        "haskellNix": "haskellNix_3",
+        "hostNixpkgs": [
+          "node-measured",
+          "cardano-node-workbench",
+          "nixpkgs"
+        ],
+        "iohkNix": "iohkNix_3",
+        "membench": "membench_2",
+        "nixpkgs": [
+          "node-measured",
+          "cardano-node-workbench",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "plutus-apps": "plutus-apps_2",
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1647983004,
+        "narHash": "sha256-29kzatjbzREnXoT6Yh89OC82C5qI8eCVZhm4OeSjrgw=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "ed9932c52aaa535b71f72a5b4cc0cecb3344a5a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "ed9932c52aaa535b71f72a5b4cc0cecb3344a5a3",
+        "type": "github"
+      }
+    },
+    "cardano-node-workbench_4": {
       "flake": false,
       "locked": {
         "lastModified": 1647605822,
@@ -1216,7 +1663,24 @@
         "type": "github"
       }
     },
-    "cardano-node-workbench_4": {
+    "cardano-node-workbench_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647605822,
+        "narHash": "sha256-bhgSsshidZ7dOPpXdG88pIqhy5VgXWi3LXtR78oDiEo=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "44ac30fb04d02d41ba005ca5228db9b5e9b887d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "44ac30fb04d02d41ba005ca5228db9b5e9b887d2",
+        "type": "github"
+      }
+    },
+    "cardano-node-workbench_6": {
       "flake": false,
       "locked": {
         "lastModified": 1647605822,
@@ -1298,6 +1762,86 @@
       }
     },
     "cardano-shell_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_18": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -1516,6 +2060,81 @@
         "type": "github"
       }
     },
+    "customConfig_14": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_15": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_16": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_17": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_18": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "customConfig_2": {
       "locked": {
         "lastModified": 1630400035,
@@ -1656,11 +2275,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1638445031,
-        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
         "type": "github"
       },
       "original": {
@@ -1671,6 +2290,23 @@
       }
     },
     "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1638445031,
@@ -1687,7 +2323,24 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1638445031,
+        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1638445031,
@@ -1779,7 +2432,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_14": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -1794,13 +2447,88 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_15": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_16": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_17": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_18": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -1984,6 +2712,91 @@
         "type": "github"
       }
     },
+    "ghc-8.6.5-iohk_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
     "ghc-8.6.5-iohk_2": {
       "flake": false,
       "locked": {
@@ -2123,11 +2936,27 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1648084640,
-        "narHash": "sha256-VZtCnrP+pQX/t1u1faiPppDq3R6siaxFlfYN/IRyETY=",
+        "lastModified": 1648689423,
+        "narHash": "sha256-5zEPRdHArPtFv/6gRVZXcxG2Wps5qoUAxBjbxd7UjQ4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e7a26675f853b5c206256bcabeed4f8c1153ba99",
+        "rev": "aa3358e56f0184f636254ed8124275c84e66c43b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646961339,
+        "narHash": "sha256-hsXNxSugSyOALfOt0I+mXrKioJ/nWX49/RhF/88N6D0=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5dea95d408c29b56a14faae378ae4e39d63126f4",
         "type": "github"
       },
       "original": {
@@ -2139,11 +2968,11 @@
     "hackage_10": {
       "flake": false,
       "locked": {
-        "lastModified": 1639098768,
-        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
         "type": "github"
       },
       "original": {
@@ -2155,11 +2984,11 @@
     "hackage_11": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073363,
-        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
         "type": "github"
       },
       "original": {
@@ -2187,6 +3016,70 @@
     "hackage_13": {
       "flake": false,
       "locked": {
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_17": {
+      "flake": false,
+      "locked": {
         "lastModified": 1639098768,
         "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
         "owner": "input-output-hk",
@@ -2203,11 +3096,11 @@
     "hackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073363,
-        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "lastModified": 1648084640,
+        "narHash": "sha256-VZtCnrP+pQX/t1u1faiPppDq3R6siaxFlfYN/IRyETY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "rev": "e7a26675f853b5c206256bcabeed4f8c1153ba99",
         "type": "github"
       },
       "original": {
@@ -2267,11 +3160,11 @@
     "hackage_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1639098768,
-        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
         "type": "github"
       },
       "original": {
@@ -2283,11 +3176,11 @@
     "hackage_7": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073363,
-        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
         "type": "github"
       },
       "original": {
@@ -2353,11 +3246,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1648084808,
-        "narHash": "sha256-o6nWoBaYhd+AMVJPravY8Z10HGP1ILx8tU6YcIaUQ9M=",
+        "lastModified": 1648689547,
+        "narHash": "sha256-ea8Celj9aPb1HG8mGNorqMr5+3xZzjuhjF89Mj4hSLU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7ae4953cff38a84d6f5f94a3f5648edf1ce84705",
+        "rev": "3fbb17e63c4e052c8289858fa6444d1c66ab6f52",
         "type": "github"
       },
       "original": {
@@ -2371,17 +3264,18 @@
         "HTTP": "HTTP_10",
         "cabal-32": "cabal-32_10",
         "cabal-34": "cabal-34_10",
+        "cabal-36": "cabal-36_9",
         "cardano-shell": "cardano-shell_10",
         "flake-utils": "flake-utils_10",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
-        "hackage": "hackage_10",
+        "hackage": "hackage_9",
         "hpc-coveralls": "hpc-coveralls_10",
         "nix-tools": "nix-tools_10",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
-          "plutus-example",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_10",
@@ -2392,11 +3286,11 @@
         "stackage": "stackage_10"
       },
       "locked": {
-        "lastModified": 1639098904,
-        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
         "type": "github"
       },
       "original": {
@@ -2410,15 +3304,20 @@
         "HTTP": "HTTP_11",
         "cabal-32": "cabal-32_11",
         "cabal-34": "cabal-34_11",
-        "cabal-36": "cabal-36_9",
+        "cabal-36": "cabal-36_10",
         "cardano-shell": "cardano-shell_11",
         "flake-utils": "flake-utils_11",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_11",
-        "hackage": "hackage_11",
+        "hackage": "hackage_10",
         "hpc-coveralls": "hpc-coveralls_11",
         "nix-tools": "nix-tools_11",
         "nixpkgs": [
-          "node-snapshot",
+          "node-measured",
+          "node-process",
+          "membench",
+          "cardano-node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_11",
@@ -2447,17 +3346,18 @@
         "HTTP": "HTTP_12",
         "cabal-32": "cabal-32_12",
         "cabal-34": "cabal-34_12",
-        "cabal-36": "cabal-36_10",
         "cardano-shell": "cardano-shell_12",
         "flake-utils": "flake-utils_12",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_12",
-        "hackage": "hackage_12",
+        "hackage": "hackage_11",
         "hpc-coveralls": "hpc-coveralls_12",
         "nix-tools": "nix-tools_12",
         "nixpkgs": [
-          "node-snapshot",
+          "node-measured",
+          "node-process",
           "membench",
           "cardano-node-snapshot",
+          "plutus-example",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_12",
@@ -2466,6 +3366,44 @@
         "nixpkgs-unstable": "nixpkgs-unstable_12",
         "old-ghc-nix": "old-ghc-nix_12",
         "stackage": "stackage_12"
+      },
+      "locked": {
+        "lastModified": 1639098904,
+        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_13": {
+      "inputs": {
+        "HTTP": "HTTP_13",
+        "cabal-32": "cabal-32_13",
+        "cabal-34": "cabal-34_13",
+        "cabal-36": "cabal-36_11",
+        "cardano-shell": "cardano-shell_13",
+        "flake-utils": "flake-utils_13",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_13",
+        "hackage": "hackage_12",
+        "hpc-coveralls": "hpc-coveralls_13",
+        "nix-tools": "nix-tools_13",
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_13",
+        "nixpkgs-2105": "nixpkgs-2105_13",
+        "nixpkgs-2111": "nixpkgs-2111_13",
+        "nixpkgs-unstable": "nixpkgs-unstable_13",
+        "old-ghc-nix": "old-ghc-nix_13",
+        "stackage": "stackage_13"
       },
       "locked": {
         "lastModified": 1643073543,
@@ -2481,28 +3419,182 @@
         "type": "github"
       }
     },
-    "haskellNix_13": {
+    "haskellNix_14": {
       "inputs": {
-        "HTTP": "HTTP_13",
-        "cabal-32": "cabal-32_13",
-        "cabal-34": "cabal-34_13",
-        "cardano-shell": "cardano-shell_13",
-        "flake-utils": "flake-utils_13",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_13",
+        "HTTP": "HTTP_14",
+        "cabal-32": "cabal-32_14",
+        "cabal-34": "cabal-34_14",
+        "cabal-36": "cabal-36_12",
+        "cardano-shell": "cardano-shell_14",
+        "flake-utils": "flake-utils_14",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_14",
         "hackage": "hackage_13",
-        "hpc-coveralls": "hpc-coveralls_13",
-        "nix-tools": "nix-tools_13",
+        "hpc-coveralls": "hpc-coveralls_14",
+        "nix-tools": "nix-tools_14",
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_14",
+        "nixpkgs-2105": "nixpkgs-2105_14",
+        "nixpkgs-2111": "nixpkgs-2111_14",
+        "nixpkgs-unstable": "nixpkgs-unstable_14",
+        "old-ghc-nix": "old-ghc-nix_14",
+        "stackage": "stackage_14"
+      },
+      "locked": {
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_15": {
+      "inputs": {
+        "HTTP": "HTTP_15",
+        "cabal-32": "cabal-32_15",
+        "cabal-34": "cabal-34_15",
+        "cardano-shell": "cardano-shell_15",
+        "flake-utils": "flake-utils_15",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_15",
+        "hackage": "hackage_14",
+        "hpc-coveralls": "hpc-coveralls_15",
+        "nix-tools": "nix-tools_15",
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "plutus-example",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_15",
+        "nixpkgs-2105": "nixpkgs-2105_15",
+        "nixpkgs-2111": "nixpkgs-2111_15",
+        "nixpkgs-unstable": "nixpkgs-unstable_15",
+        "old-ghc-nix": "old-ghc-nix_15",
+        "stackage": "stackage_15"
+      },
+      "locked": {
+        "lastModified": 1639098904,
+        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_16": {
+      "inputs": {
+        "HTTP": "HTTP_16",
+        "cabal-32": "cabal-32_16",
+        "cabal-34": "cabal-34_16",
+        "cabal-36": "cabal-36_13",
+        "cardano-shell": "cardano-shell_16",
+        "flake-utils": "flake-utils_16",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_16",
+        "hackage": "hackage_15",
+        "hpc-coveralls": "hpc-coveralls_16",
+        "nix-tools": "nix-tools_16",
+        "nixpkgs": [
+          "node-snapshot",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_16",
+        "nixpkgs-2105": "nixpkgs-2105_16",
+        "nixpkgs-2111": "nixpkgs-2111_16",
+        "nixpkgs-unstable": "nixpkgs-unstable_16",
+        "old-ghc-nix": "old-ghc-nix_16",
+        "stackage": "stackage_16"
+      },
+      "locked": {
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_17": {
+      "inputs": {
+        "HTTP": "HTTP_17",
+        "cabal-32": "cabal-32_17",
+        "cabal-34": "cabal-34_17",
+        "cabal-36": "cabal-36_14",
+        "cardano-shell": "cardano-shell_17",
+        "flake-utils": "flake-utils_17",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_17",
+        "hackage": "hackage_16",
+        "hpc-coveralls": "hpc-coveralls_17",
+        "nix-tools": "nix-tools_17",
+        "nixpkgs": [
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_17",
+        "nixpkgs-2105": "nixpkgs-2105_17",
+        "nixpkgs-2111": "nixpkgs-2111_17",
+        "nixpkgs-unstable": "nixpkgs-unstable_17",
+        "old-ghc-nix": "old-ghc-nix_17",
+        "stackage": "stackage_17"
+      },
+      "locked": {
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_18": {
+      "inputs": {
+        "HTTP": "HTTP_18",
+        "cabal-32": "cabal-32_18",
+        "cabal-34": "cabal-34_18",
+        "cardano-shell": "cardano-shell_18",
+        "flake-utils": "flake-utils_18",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_18",
+        "hackage": "hackage_17",
+        "hpc-coveralls": "hpc-coveralls_18",
+        "nix-tools": "nix-tools_18",
         "nixpkgs": [
           "node-snapshot",
           "plutus-example",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_13",
-        "nixpkgs-2105": "nixpkgs-2105_13",
-        "nixpkgs-2111": "nixpkgs-2111_13",
-        "nixpkgs-unstable": "nixpkgs-unstable_13",
-        "old-ghc-nix": "old-ghc-nix_13",
-        "stackage": "stackage_13"
+        "nixpkgs-2003": "nixpkgs-2003_18",
+        "nixpkgs-2105": "nixpkgs-2105_18",
+        "nixpkgs-2111": "nixpkgs-2111_18",
+        "nixpkgs-unstable": "nixpkgs-unstable_18",
+        "old-ghc-nix": "old-ghc-nix_18",
+        "stackage": "stackage_18"
       },
       "locked": {
         "lastModified": 1639098904,
@@ -2527,8 +3619,11 @@
         "cardano-shell": "cardano-shell_2",
         "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "hackage": "hackage_2",
+        "hackage": [
+          "hackageNix"
+        ],
         "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra_2",
         "nix-tools": "nix-tools_2",
         "nixpkgs": [
           "nixpkgs"
@@ -2541,11 +3636,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1643073543,
-        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "lastModified": 1647960987,
+        "narHash": "sha256-Jb2xIncXlqvkMmEGsMDdWScdLGhEegNCdhSJswsOAkI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "rev": "53ffd8eac65e3f029865b00f7eca49373388b691",
         "type": "github"
       },
       "original": {
@@ -2563,11 +3658,13 @@
         "cardano-shell": "cardano-shell_3",
         "flake-utils": "flake-utils_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
-        "hackage": "hackage_3",
+        "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_3",
+        "hydra": "hydra_3",
         "nix-tools": "nix-tools_3",
         "nixpkgs": [
           "node-measured",
+          "cardano-node-workbench",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_3",
@@ -2578,11 +3675,11 @@
         "stackage": "stackage_3"
       },
       "locked": {
-        "lastModified": 1643073543,
-        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "lastModified": 1648084808,
+        "narHash": "sha256-o6nWoBaYhd+AMVJPravY8Z10HGP1ILx8tU6YcIaUQ9M=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "rev": "7ae4953cff38a84d6f5f94a3f5648edf1ce84705",
         "type": "github"
       },
       "original": {
@@ -2600,13 +3697,11 @@
         "cardano-shell": "cardano-shell_4",
         "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
-        "hackage": "hackage_4",
+        "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_4",
         "nix-tools": "nix-tools_4",
         "nixpkgs": [
           "node-measured",
-          "membench",
-          "cardano-node-snapshot",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_4",
@@ -2639,15 +3734,12 @@
         "cardano-shell": "cardano-shell_5",
         "flake-utils": "flake-utils_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
-        "hackage": "hackage_5",
+        "hackage": "hackage_4",
         "hpc-coveralls": "hpc-coveralls_5",
         "nix-tools": "nix-tools_5",
         "nixpkgs": [
           "node-measured",
-          "membench",
-          "cardano-node-snapshot",
-          "membench",
-          "cardano-node-snapshot",
+          "node-measured",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_5",
@@ -2676,17 +3768,18 @@
         "HTTP": "HTTP_6",
         "cabal-32": "cabal-32_6",
         "cabal-34": "cabal-34_6",
+        "cabal-36": "cabal-36_6",
         "cardano-shell": "cardano-shell_6",
         "flake-utils": "flake-utils_6",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
-        "hackage": "hackage_6",
+        "hackage": "hackage_5",
         "hpc-coveralls": "hpc-coveralls_6",
         "nix-tools": "nix-tools_6",
         "nixpkgs": [
           "node-measured",
+          "node-measured",
           "membench",
           "cardano-node-snapshot",
-          "plutus-example",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_6",
@@ -2697,11 +3790,11 @@
         "stackage": "stackage_6"
       },
       "locked": {
-        "lastModified": 1639098904,
-        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
         "type": "github"
       },
       "original": {
@@ -2715,15 +3808,20 @@
         "HTTP": "HTTP_7",
         "cabal-32": "cabal-32_7",
         "cabal-34": "cabal-34_7",
-        "cabal-36": "cabal-36_6",
+        "cabal-36": "cabal-36_7",
         "cardano-shell": "cardano-shell_7",
         "flake-utils": "flake-utils_7",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
-        "hackage": "hackage_7",
+        "hackage": "hackage_6",
         "hpc-coveralls": "hpc-coveralls_7",
         "nix-tools": "nix-tools_7",
         "nixpkgs": [
-          "node-process",
+          "node-measured",
+          "node-measured",
+          "membench",
+          "cardano-node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_7",
@@ -2752,17 +3850,18 @@
         "HTTP": "HTTP_8",
         "cabal-32": "cabal-32_8",
         "cabal-34": "cabal-34_8",
-        "cabal-36": "cabal-36_7",
         "cardano-shell": "cardano-shell_8",
         "flake-utils": "flake-utils_8",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
-        "hackage": "hackage_8",
+        "hackage": "hackage_7",
         "hpc-coveralls": "hpc-coveralls_8",
         "nix-tools": "nix-tools_8",
         "nixpkgs": [
-          "node-process",
+          "node-measured",
+          "node-measured",
           "membench",
           "cardano-node-snapshot",
+          "plutus-example",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_8",
@@ -2773,11 +3872,11 @@
         "stackage": "stackage_8"
       },
       "locked": {
-        "lastModified": 1643073543,
-        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "lastModified": 1639098904,
+        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
         "type": "github"
       },
       "original": {
@@ -2795,15 +3894,12 @@
         "cardano-shell": "cardano-shell_9",
         "flake-utils": "flake-utils_9",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
-        "hackage": "hackage_9",
+        "hackage": "hackage_8",
         "hpc-coveralls": "hpc-coveralls_9",
         "nix-tools": "nix-tools_9",
         "nixpkgs": [
+          "node-measured",
           "node-process",
-          "membench",
-          "cardano-node-snapshot",
-          "membench",
-          "cardano-node-snapshot",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_9",
@@ -2892,6 +3988,86 @@
       }
     },
     "hpc-coveralls_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_18": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -3059,6 +4235,54 @@
         "type": "indirect"
       }
     },
+    "hydra_2": {
+      "inputs": {
+        "nix": "nix_2",
+        "nixpkgs": [
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_3": {
+      "inputs": {
+        "nix": "nix_3",
+        "nixpkgs": [
+          "node-measured",
+          "cardano-node-workbench",
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
     "iohkNix": {
       "inputs": {
         "nixpkgs": [
@@ -3083,6 +4307,57 @@
     "iohkNix_10": {
       "inputs": {
         "nixpkgs": [
+          "node-measured",
+          "node-process",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_11": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
+          "node-process",
+          "membench",
+          "cardano-node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_12": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3104,7 +4379,76 @@
         "type": "github"
       }
     },
-    "iohkNix_11": {
+    "iohkNix_13": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_14": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_15": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "plutus-example",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1633964277,
+        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_16": {
       "inputs": {
         "nixpkgs": [
           "node-snapshot",
@@ -3125,7 +4469,7 @@
         "type": "github"
       }
     },
-    "iohkNix_12": {
+    "iohkNix_17": {
       "inputs": {
         "nixpkgs": [
           "node-snapshot",
@@ -3148,7 +4492,7 @@
         "type": "github"
       }
     },
-    "iohkNix_13": {
+    "iohkNix_18": {
       "inputs": {
         "nixpkgs": [
           "node-snapshot",
@@ -3177,11 +4521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645693195,
-        "narHash": "sha256-UDemE2MFEi/L8Xmwi1/FuKU9ka3QqDye6k7rVW6ryeE=",
+        "lastModified": 1646330344,
+        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "29c9a3b6704b5c0df3bb4a3e65240749883c50a0",
+        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
         "type": "github"
       },
       "original": {
@@ -3194,6 +4538,28 @@
       "inputs": {
         "nixpkgs": [
           "node-measured",
+          "cardano-node-workbench",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1648032999,
+        "narHash": "sha256-3uCz+gJppvM7z6CUCkBbFSu60WgIE+e3oXwXiAiGWSY=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "5e667b374153327c7bdfdbfab8ef19b1f27d4aac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_4": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
           "nixpkgs"
         ]
       },
@@ -3211,46 +4577,20 @@
         "type": "github"
       }
     },
-    "iohkNix_4": {
-      "inputs": {
-        "nixpkgs": [
-          "node-measured",
-          "membench",
-          "cardano-node-snapshot",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1631778944,
-        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
     "iohkNix_5": {
       "inputs": {
         "nixpkgs": [
           "node-measured",
-          "membench",
-          "cardano-node-snapshot",
-          "membench",
-          "cardano-node-snapshot",
+          "node-measured",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1631778944,
-        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "lastModified": 1645693195,
+        "narHash": "sha256-UDemE2MFEi/L8Xmwi1/FuKU9ka3QqDye6k7rVW6ryeE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "rev": "29c9a3b6704b5c0df3bb4a3e65240749883c50a0",
         "type": "github"
       },
       "original": {
@@ -3262,6 +4602,57 @@
     "iohkNix_6": {
       "inputs": {
         "nixpkgs": [
+          "node-measured",
+          "node-measured",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_7": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
+          "node-measured",
+          "membench",
+          "cardano-node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631778944,
+        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_8": {
+      "inputs": {
+        "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -3283,9 +4674,10 @@
         "type": "github"
       }
     },
-    "iohkNix_7": {
+    "iohkNix_9": {
       "inputs": {
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "nixpkgs"
         ]
@@ -3304,55 +4696,39 @@
         "type": "github"
       }
     },
-    "iohkNix_8": {
-      "inputs": {
-        "nixpkgs": [
-          "node-process",
-          "membench",
-          "cardano-node-snapshot",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1631778944,
-        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
-    "iohkNix_9": {
-      "inputs": {
-        "nixpkgs": [
-          "node-process",
-          "membench",
-          "cardano-node-snapshot",
-          "membench",
-          "cardano-node-snapshot",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1631778944,
-        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
     "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1633514407,
@@ -3383,17 +4759,149 @@
         "type": "github"
       }
     },
-    "membench_2": {
+    "membench_10": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_2",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_10",
         "cardano-node-measured": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "cardano-node-process": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "cardano-node-snapshot": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ],
+        "ouroboros-network": "ouroboros-network_7"
+      },
+      "locked": {
+        "lastModified": 1644547122,
+        "narHash": "sha256-8nWK+ScMACvRQLbA27gwXNoZver+Wx/cF7V37044koY=",
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "rev": "9d8ff4b9394de0421ee95caa511d01163de88b77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "type": "github"
+      }
+    },
+    "membench_11": {
+      "inputs": {
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_11",
+        "cardano-node-measured": [
+          "node-snapshot"
+        ],
+        "cardano-node-process": [
+          "node-snapshot"
+        ],
+        "cardano-node-snapshot": "cardano-node-snapshot_6",
+        "nixpkgs": [
+          "node-snapshot",
+          "nixpkgs"
+        ],
+        "ouroboros-network": "ouroboros-network_10"
+      },
+      "locked": {
+        "lastModified": 1645070579,
+        "narHash": "sha256-AxL6tCOnzYnE6OquoFzj+X1bLDr1PQx3d8/vXm+rbfA=",
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "rev": "65643e000186de1335e24ec89159db8ba85e1c1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "type": "github"
+      }
+    },
+    "membench_12": {
+      "inputs": {
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_12",
+        "cardano-node-measured": [
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "cardano-node-process": [
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "cardano-node-snapshot": [
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot"
+        ],
+        "nixpkgs": [
+          "node-snapshot",
+          "membench",
+          "cardano-node-snapshot",
+          "nixpkgs"
+        ],
+        "ouroboros-network": "ouroboros-network_9"
+      },
+      "locked": {
+        "lastModified": 1644547122,
+        "narHash": "sha256-8nWK+ScMACvRQLbA27gwXNoZver+Wx/cF7V37044koY=",
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "rev": "9d8ff4b9394de0421ee95caa511d01163de88b77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "type": "github"
+      }
+    },
+    "membench_2": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-memory-benchmark",
+        "type": "github"
+      }
+    },
+    "membench_3": {
+      "inputs": {
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_3",
+        "cardano-node-measured": [
+          "node-measured",
           "node-measured"
         ],
         "cardano-node-process": [
+          "node-measured",
           "node-measured"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot",
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "nixpkgs"
         ],
@@ -3413,21 +4921,24 @@
         "type": "github"
       }
     },
-    "membench_3": {
+    "membench_4": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_3",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_4",
         "cardano-node-measured": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-process": [
           "node-measured",
+          "node-measured",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot_2",
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -3449,10 +4960,11 @@
         "type": "github"
       }
     },
-    "membench_4": {
+    "membench_5": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_4",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_5",
         "cardano-node-measured": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -3461,6 +4973,7 @@
         ],
         "cardano-node-process": [
           "node-measured",
+          "node-measured",
           "membench",
           "cardano-node-snapshot",
           "membench",
@@ -3468,12 +4981,14 @@
         ],
         "cardano-node-snapshot": [
           "node-measured",
+          "node-measured",
           "membench",
           "cardano-node-snapshot",
           "membench",
           "cardano-node-snapshot"
         ],
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -3497,17 +5012,20 @@
         "type": "github"
       }
     },
-    "membench_5": {
+    "membench_6": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_5",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_6",
         "cardano-node-measured": [
+          "node-measured",
           "node-process"
         ],
         "cardano-node-process": [
+          "node-measured",
           "node-process"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot_3",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "nixpkgs"
         ],
@@ -3527,21 +5045,24 @@
         "type": "github"
       }
     },
-    "membench_6": {
+    "membench_7": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_6",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_7",
         "cardano-node-measured": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-process": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot_4",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3563,10 +5084,11 @@
         "type": "github"
       }
     },
-    "membench_7": {
+    "membench_8": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_7",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_8",
         "cardano-node-measured": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3574,6 +5096,7 @@
           "cardano-node-snapshot"
         ],
         "cardano-node-process": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3581,6 +5104,7 @@
           "cardano-node-snapshot"
         ],
         "cardano-node-snapshot": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3588,6 +5112,7 @@
           "cardano-node-snapshot"
         ],
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -3611,17 +5136,20 @@
         "type": "github"
       }
     },
-    "membench_8": {
+    "membench_9": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_8",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_9",
         "cardano-node-measured": [
+          "node-measured",
           "node-snapshot"
         ],
         "cardano-node-process": [
+          "node-measured",
           "node-snapshot"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot_5",
         "nixpkgs": [
+          "node-measured",
           "node-snapshot",
           "nixpkgs"
         ],
@@ -3633,46 +5161,6 @@
         "owner": "input-output-hk",
         "repo": "cardano-memory-benchmark",
         "rev": "65643e000186de1335e24ec89159db8ba85e1c1a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-memory-benchmark",
-        "type": "github"
-      }
-    },
-    "membench_9": {
-      "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_9",
-        "cardano-node-measured": [
-          "node-snapshot",
-          "membench",
-          "cardano-node-snapshot"
-        ],
-        "cardano-node-process": [
-          "node-snapshot",
-          "membench",
-          "cardano-node-snapshot"
-        ],
-        "cardano-node-snapshot": [
-          "node-snapshot",
-          "membench",
-          "cardano-node-snapshot"
-        ],
-        "nixpkgs": [
-          "node-snapshot",
-          "membench",
-          "cardano-node-snapshot",
-          "nixpkgs"
-        ],
-        "ouroboros-network": "ouroboros-network_7"
-      },
-      "locked": {
-        "lastModified": 1644547122,
-        "narHash": "sha256-8nWK+ScMACvRQLbA27gwXNoZver+Wx/cF7V37044koY=",
-        "owner": "input-output-hk",
-        "repo": "cardano-memory-benchmark",
-        "rev": "9d8ff4b9394de0421ee95caa511d01163de88b77",
         "type": "github"
       },
       "original": {
@@ -3782,7 +5270,7 @@
         "type": "github"
       }
     },
-    "nix-tools_2": {
+    "nix-tools_14": {
       "flake": false,
       "locked": {
         "lastModified": 1636018067,
@@ -3798,7 +5286,7 @@
         "type": "github"
       }
     },
-    "nix-tools_3": {
+    "nix-tools_15": {
       "flake": false,
       "locked": {
         "lastModified": 1636018067,
@@ -3806,6 +5294,86 @@
         "owner": "input-output-hk",
         "repo": "nix-tools",
         "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -3910,6 +5478,64 @@
         "type": "github"
       }
     },
+    "nixTools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_3": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_3",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-regression": "nixpkgs-regression_3"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1642336556,
@@ -3989,6 +5615,86 @@
       }
     },
     "nixpkgs-2003_13": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_14": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_15": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_16": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_17": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_18": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -4150,11 +5856,11 @@
     },
     "nixpkgs-2105_10": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
         "type": "github"
       },
       "original": {
@@ -4182,6 +5888,22 @@
     },
     "nixpkgs-2105_12": {
       "locked": {
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_13": {
+      "locked": {
         "lastModified": 1640283157,
         "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
@@ -4196,7 +5918,71 @@
         "type": "github"
       }
     },
-    "nixpkgs-2105_13": {
+    "nixpkgs-2105_14": {
+      "locked": {
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_15": {
+      "locked": {
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_16": {
+      "locked": {
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_17": {
+      "locked": {
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_18": {
       "locked": {
         "lastModified": 1630481079,
         "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
@@ -4214,11 +6000,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1640283157,
-        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
         "type": "github"
       },
       "original": {
@@ -4230,11 +6016,11 @@
     },
     "nixpkgs-2105_3": {
       "locked": {
-        "lastModified": 1640283157,
-        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
         "type": "github"
       },
       "original": {
@@ -4278,11 +6064,11 @@
     },
     "nixpkgs-2105_6": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
         "type": "github"
       },
       "original": {
@@ -4310,11 +6096,11 @@
     },
     "nixpkgs-2105_8": {
       "locked": {
-        "lastModified": 1640283157,
-        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
         "type": "github"
       },
       "original": {
@@ -4358,11 +6144,11 @@
     },
     "nixpkgs-2111_10": {
       "locked": {
-        "lastModified": 1638410074,
-        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
         "type": "github"
       },
       "original": {
@@ -4390,6 +6176,22 @@
     },
     "nixpkgs-2111_12": {
       "locked": {
+        "lastModified": 1638410074,
+        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_13": {
+      "locked": {
         "lastModified": 1640283207,
         "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
@@ -4404,7 +6206,71 @@
         "type": "github"
       }
     },
-    "nixpkgs-2111_13": {
+    "nixpkgs-2111_14": {
+      "locked": {
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_15": {
+      "locked": {
+        "lastModified": 1638410074,
+        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_16": {
+      "locked": {
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_17": {
+      "locked": {
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_18": {
       "locked": {
         "lastModified": 1638410074,
         "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
@@ -4422,11 +6288,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1640283207,
-        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
         "type": "github"
       },
       "original": {
@@ -4438,11 +6304,11 @@
     },
     "nixpkgs-2111_3": {
       "locked": {
-        "lastModified": 1640283207,
-        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
         "type": "github"
       },
       "original": {
@@ -4486,11 +6352,11 @@
     },
     "nixpkgs-2111_6": {
       "locked": {
-        "lastModified": 1638410074,
-        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
         "type": "github"
       },
       "original": {
@@ -4518,11 +6384,11 @@
     },
     "nixpkgs-2111_8": {
       "locked": {
-        "lastModified": 1640283207,
-        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "lastModified": 1638410074,
+        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
         "type": "github"
       },
       "original": {
@@ -4563,6 +6429,36 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-regression_2": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-regression_3": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1644486793,
@@ -4581,11 +6477,11 @@
     },
     "nixpkgs-unstable_10": {
       "locked": {
-        "lastModified": 1635295995,
-        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
         "type": "github"
       },
       "original": {
@@ -4613,6 +6509,22 @@
     },
     "nixpkgs-unstable_12": {
       "locked": {
+        "lastModified": 1635295995,
+        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_13": {
+      "locked": {
         "lastModified": 1641285291,
         "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
@@ -4627,7 +6539,71 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable_13": {
+    "nixpkgs-unstable_14": {
+      "locked": {
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_15": {
+      "locked": {
+        "lastModified": 1635295995,
+        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_16": {
+      "locked": {
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_17": {
+      "locked": {
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_18": {
       "locked": {
         "lastModified": 1635295995,
         "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
@@ -4645,11 +6621,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1641285291,
-        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
         "type": "github"
       },
       "original": {
@@ -4661,11 +6637,11 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1641285291,
-        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
         "type": "github"
       },
       "original": {
@@ -4709,11 +6685,11 @@
     },
     "nixpkgs-unstable_6": {
       "locked": {
-        "lastModified": 1635295995,
-        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
         "type": "github"
       },
       "original": {
@@ -4741,11 +6717,11 @@
     },
     "nixpkgs-unstable_8": {
       "locked": {
-        "lastModified": 1641285291,
-        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "lastModified": 1635295995,
+        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
         "type": "github"
       },
       "original": {
@@ -4785,6 +6761,76 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1632864508,
@@ -4802,15 +6848,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -4830,15 +6877,16 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -4900,23 +6948,62 @@
     },
     "node-measured": {
       "inputs": {
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_2",
         "cardano-node-workbench": "cardano-node-workbench_3",
-        "customConfig": "customConfig_3",
-        "flake-compat": "flake-compat_3",
-        "haskellNix": "haskellNix_3",
+        "customConfig": "customConfig_4",
+        "flake-compat": "flake-compat_4",
+        "haskellNix": "haskellNix_4",
         "hostNixpkgs": [
           "node-measured",
           "nixpkgs"
         ],
-        "iohkNix": "iohkNix_3",
-        "membench": "membench_2",
+        "iohkNix": "iohkNix_4",
         "nixpkgs": [
           "node-measured",
           "haskellNix",
           "nixpkgs-2105"
         ],
+        "node-measured": "node-measured_2",
+        "node-process": "node-process",
+        "node-snapshot": "node-snapshot",
+        "plutus-apps": "plutus-apps_3",
+        "utils": "utils_14"
+      },
+      "locked": {
+        "lastModified": 1648681325,
+        "narHash": "sha256-6oWDYmMb+V4x0jCoYDzKfBJMpr7Mx5zA3WMpNHspuSw=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "78675fbf8986c87c0d2356b727a0ec2060f1adba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
+    "node-measured_2": {
+      "inputs": {
+        "cardano-node-workbench": "cardano-node-workbench_5",
+        "customConfig": "customConfig_5",
+        "flake-compat": "flake-compat_5",
+        "haskellNix": "haskellNix_5",
+        "hostNixpkgs": [
+          "node-measured",
+          "node-measured",
+          "nixpkgs"
+        ],
+        "iohkNix": "iohkNix_5",
+        "membench": "membench_3",
+        "nixpkgs": [
+          "node-measured",
+          "node-measured",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
         "plutus-example": "plutus-example_2",
-        "utils": "utils_5"
+        "utils": "utils_6"
       },
       "locked": {
         "lastModified": 1647614422,
@@ -4934,23 +7021,25 @@
     },
     "node-process": {
       "inputs": {
-        "cardano-node-workbench": "cardano-node-workbench_4",
-        "customConfig": "customConfig_7",
-        "flake-compat": "flake-compat_4",
-        "haskellNix": "haskellNix_7",
+        "cardano-node-workbench": "cardano-node-workbench_6",
+        "customConfig": "customConfig_9",
+        "flake-compat": "flake-compat_6",
+        "haskellNix": "haskellNix_9",
         "hostNixpkgs": [
+          "node-measured",
           "node-process",
           "nixpkgs"
         ],
-        "iohkNix": "iohkNix_7",
-        "membench": "membench_5",
+        "iohkNix": "iohkNix_9",
+        "membench": "membench_6",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "haskellNix",
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_4",
-        "utils": "utils_9"
+        "utils": "utils_10"
       },
       "locked": {
         "lastModified": 1647614422,
@@ -4966,19 +7055,65 @@
         "type": "github"
       }
     },
+    "node-process_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648681325,
+        "narHash": "sha256-6oWDYmMb+V4x0jCoYDzKfBJMpr7Mx5zA3WMpNHspuSw=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "78675fbf8986c87c0d2356b727a0ec2060f1adba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "node-snapshot": {
       "inputs": {
-        "customConfig": "customConfig_11",
-        "haskellNix": "haskellNix_11",
-        "iohkNix": "iohkNix_11",
-        "membench": "membench_8",
+        "customConfig": "customConfig_13",
+        "haskellNix": "haskellNix_13",
+        "iohkNix": "iohkNix_13",
+        "membench": "membench_9",
         "nixpkgs": [
+          "node-measured",
           "node-snapshot",
           "haskellNix",
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_5",
-        "utils": "utils_12"
+        "utils": "utils_13"
+      },
+      "locked": {
+        "lastModified": 1645120669,
+        "narHash": "sha256-2MKfGsYS5n69+pfqNHb4IH/E95ok1MD7mhEYfUpRcz4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "7f00e3ea5a61609e19eeeee4af35241571efdf5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "7f00e3ea5a61609e19eeeee4af35241571efdf5c",
+        "type": "github"
+      }
+    },
+    "node-snapshot_2": {
+      "inputs": {
+        "customConfig": "customConfig_16",
+        "haskellNix": "haskellNix_16",
+        "iohkNix": "iohkNix_16",
+        "membench": "membench_11",
+        "nixpkgs": [
+          "node-snapshot",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "plutus-example": "plutus-example_6",
+        "utils": "utils_17"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -5064,6 +7199,91 @@
       }
     },
     "old-ghc-nix_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_18": {
       "flake": false,
       "locked": {
         "lastModified": 1631092763,
@@ -5232,6 +7452,22 @@
         "type": "github"
       }
     },
+    "ouroboros-network_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643385024,
+        "narHash": "sha256-9R4Z1jBsTcEgBHxhzjCJnroEcdfMsTjf8kwg6uPue+Q=",
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "8e97076176d465f5f4f86d5b5596220272630649",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "type": "github"
+      }
+    },
     "ouroboros-network_2": {
       "flake": false,
       "locked": {
@@ -5344,14 +7580,30 @@
         "type": "github"
       }
     },
+    "ouroboros-network_9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643385024,
+        "narHash": "sha256-9R4Z1jBsTcEgBHxhzjCJnroEcdfMsTjf8kwg6uPue+Q=",
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "8e97076176d465f5f4f86d5b5596220272630649",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "type": "github"
+      }
+    },
     "plutus-apps": {
       "flake": false,
       "locked": {
-        "lastModified": 1648036874,
-        "narHash": "sha256-GIL9uHQwlyD4qEpwUGlhN9o9blwhElmlKPOPjC3n714=",
+        "lastModified": 1648635956,
+        "narHash": "sha256-qwPhjV07SIahycFpaxqSSOztJLOlmLdgj/TjgVrjkBE=",
         "owner": "input-output-hk",
         "repo": "plutus-apps",
-        "rev": "c9f2601e342a2fc0e2b5870ce656ef434b0efa32",
+        "rev": "b86ee21775422f9c0ca5ff66195014a497575d2d",
         "type": "github"
       },
       "original": {
@@ -5376,12 +7628,45 @@
         "type": "github"
       }
     },
+    "plutus-apps_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648036874,
+        "narHash": "sha256-GIL9uHQwlyD4qEpwUGlhN9o9blwhElmlKPOPjC3n714=",
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "c9f2601e342a2fc0e2b5870ce656ef434b0efa32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "type": "github"
+      }
+    },
+    "plutus-apps_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647347289,
+        "narHash": "sha256-dxKZ1Zvflyt6igYm39POV6X/0giKbfb4U7D1TvevQls=",
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "2a40552f4654d695f21783c86e8ae59243ce9dfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "type": "github"
+      }
+    },
     "plutus-example": {
       "inputs": {
-        "customConfig": "customConfig_6",
-        "haskellNix": "haskellNix_6",
-        "iohkNix": "iohkNix_6",
+        "customConfig": "customConfig_8",
+        "haskellNix": "haskellNix_8",
+        "iohkNix": "iohkNix_8",
         "nixpkgs": [
+          "node-measured",
           "node-measured",
           "membench",
           "cardano-node-snapshot",
@@ -5389,7 +7674,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_3"
+        "utils": "utils_4"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -5425,10 +7710,11 @@
     },
     "plutus-example_3": {
       "inputs": {
-        "customConfig": "customConfig_10",
-        "haskellNix": "haskellNix_10",
-        "iohkNix": "iohkNix_10",
+        "customConfig": "customConfig_12",
+        "haskellNix": "haskellNix_12",
+        "iohkNix": "iohkNix_12",
         "nixpkgs": [
+          "node-measured",
           "node-process",
           "membench",
           "cardano-node-snapshot",
@@ -5436,7 +7722,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_7"
+        "utils": "utils_8"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -5472,16 +7758,45 @@
     },
     "plutus-example_5": {
       "inputs": {
-        "customConfig": "customConfig_13",
-        "haskellNix": "haskellNix_13",
-        "iohkNix": "iohkNix_13",
+        "customConfig": "customConfig_15",
+        "haskellNix": "haskellNix_15",
+        "iohkNix": "iohkNix_15",
+        "nixpkgs": [
+          "node-measured",
+          "node-snapshot",
+          "plutus-example",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "utils": "utils_12"
+      },
+      "locked": {
+        "lastModified": 1640022647,
+        "narHash": "sha256-M+YnF7Zj/7QK2pu0T75xNVaX0eEeijtBH8yz+jEHIMM=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      }
+    },
+    "plutus-example_6": {
+      "inputs": {
+        "customConfig": "customConfig_18",
+        "haskellNix": "haskellNix_18",
+        "iohkNix": "iohkNix_18",
         "nixpkgs": [
           "node-snapshot",
           "plutus-example",
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_11"
+        "utils": "utils_16"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -5504,30 +7819,32 @@
         "cardano-node-workbench": "cardano-node-workbench",
         "customConfig": "customConfig_2",
         "flake-compat": "flake-compat_2",
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix_2",
         "hostNixpkgs": [
           "nixpkgs"
         ],
         "iohkNix": "iohkNix_2",
+        "nixTools": "nixTools",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-2105"
+          "nixpkgs-unstable"
         ],
         "node-measured": "node-measured",
-        "node-process": "node-process",
-        "node-snapshot": "node-snapshot",
-        "plutus-apps": "plutus-apps_2",
-        "utils": "utils_13"
+        "node-process": "node-process_2",
+        "node-snapshot": "node-snapshot_2",
+        "plutus-apps": "plutus-apps_4",
+        "utils": "utils_18"
       }
     },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1648084749,
-        "narHash": "sha256-kJ6ddC4yb5BAi2lqvXG1Q18EYkEHnhG22mDHPDMQAiE=",
+        "lastModified": 1648603096,
+        "narHash": "sha256-d1WKzMnk+2ZOXz3YSSqYHrMSHRVSZth+eS/pO5iSwVE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "d11ec4ac2be255d814560c5f50d5b72cdf314158",
+        "rev": "c2bdc5825795d3a6938aa74e598da57591b2e150",
         "type": "github"
       },
       "original": {
@@ -5539,11 +7856,11 @@
     "stackage_10": {
       "flake": false,
       "locked": {
-        "lastModified": 1639012797,
-        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
         "type": "github"
       },
       "original": {
@@ -5571,6 +7888,22 @@
     "stackage_12": {
       "flake": false,
       "locked": {
+        "lastModified": 1639012797,
+        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_13": {
+      "flake": false,
+      "locked": {
         "lastModified": 1643073493,
         "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
         "owner": "input-output-hk",
@@ -5584,7 +7917,71 @@
         "type": "github"
       }
     },
-    "stackage_13": {
+    "stackage_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639012797,
+        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_16": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_17": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_18": {
       "flake": false,
       "locked": {
         "lastModified": 1639012797,
@@ -5603,11 +8000,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073493,
-        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "lastModified": 1647911723,
+        "narHash": "sha256-SfHe7QWAH4A1gHj1LSEFNXMJACvzbgQn2KkjdJOkCQ4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "rev": "00701d47768afdf1788a8bb1b84e3b1c7bf71581",
         "type": "github"
       },
       "original": {
@@ -5619,11 +8016,11 @@
     "stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073493,
-        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "lastModified": 1648084749,
+        "narHash": "sha256-kJ6ddC4yb5BAi2lqvXG1Q18EYkEHnhG22mDHPDMQAiE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "rev": "d11ec4ac2be255d814560c5f50d5b72cdf314158",
         "type": "github"
       },
       "original": {
@@ -5667,11 +8064,11 @@
     "stackage_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1639012797,
-        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
         "type": "github"
       },
       "original": {
@@ -5699,11 +8096,11 @@
     "stackage_8": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073493,
-        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "lastModified": 1639012797,
+        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
         "type": "github"
       },
       "original": {
@@ -5730,11 +8127,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
         "type": "github"
       },
       "original": {
@@ -5760,11 +8157,11 @@
     },
     "utils_11": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -5775,11 +8172,11 @@
     },
     "utils_12": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -5803,7 +8200,7 @@
         "type": "github"
       }
     },
-    "utils_2": {
+    "utils_14": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
@@ -5818,7 +8215,22 @@
         "type": "github"
       }
     },
-    "utils_3": {
+    "utils_15": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_16": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -5833,13 +8245,73 @@
         "type": "github"
       }
     },
-    "utils_4": {
+    "utils_17": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_18": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_3": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_4": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -5880,11 +8352,11 @@
     },
     "utils_7": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -5895,11 +8367,11 @@
     },
     "utils_8": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,20 @@
 
   inputs = {
     # IMPORTANT: report any change to nixpkgs channel in nix/default.nix:
-    nixpkgs.follows = "haskellNix/nixpkgs-2105";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     hostNixpkgs.follows = "nixpkgs";
+    hackageNix = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+    nixTools = {
+        url = "github:input-output-hk/nix-tools";
+        flake = false;
+      };
     haskellNix = {
       url = "github:input-output-hk/haskell.nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.hackage.follows = "hackageNix";
     };
     utils.url = "github:numtide/flake-utils";
     iohkNix = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -32,7 +32,7 @@ haskell-nix.cabalProject' ({ pkgs
       # removes socket files
       && lib.elem type [ "regular" "directory" "symlink" ];
   };
-  compiler-nix-name = "ghc8105";
+  compiler-nix-name = "ghc8107";
   cabalProjectLocal = ''
     allow-newer: terminfo:base
   '' + lib.optionalString pkgs.stdenv.hostPlatform.isWindows ''

--- a/trace-dispatcher/examples/Examples/Configuration.hs
+++ b/trace-dispatcher/examples/Examples/Configuration.hs
@@ -7,7 +7,7 @@ module Examples.Configuration (
 
 import           Control.Monad.IO.Class
 import qualified Data.Aeson as AE
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Map as Map
 import           Data.Text (Text)
 
@@ -19,7 +19,7 @@ newtype TestMessage = TestMessage Text
 instance LogFormatting TestMessage where
   forHuman (TestMessage text)         = text
   forMachine _verb (TestMessage text) =
-         HM.fromList
+         KeyMap.fromList
            [ "kind" AE..= AE.String "TestMessage"
            , "text" AE..= AE.String text
            ]

--- a/trace-dispatcher/examples/Examples/TestObjects.hs
+++ b/trace-dispatcher/examples/Examples/TestObjects.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Examples.TestObjects (
     traceForgeEventDocu
@@ -23,7 +23,7 @@ module Examples.TestObjects (
 
 import           Cardano.Logging
 import qualified Data.Aeson as AE
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Kind (Type)
 import           Data.Text (pack)
 import           Data.Word (Word64)
@@ -120,19 +120,19 @@ instance LogFormatting (TraceForgeEvent LogBlock) where
       (unSlotNo currentSlot)
 
   forMachine _verb (TraceStartLeadershipCheck slotNo) =
-    HM.fromList
+    KeyMap.fromList
       [ "kind" AE..= AE.String "TraceStartLeadershipCheck"
       , "slot" AE..= AE.toJSON (unSlotNo slotNo)
       ]
   forMachine _verb (TraceSlotIsImmutable slotNo tipPoint tipBlkNo) =
-    HM.fromList
+    KeyMap.fromList
       [ "kind" AE..= AE.String "TraceSlotIsImmutable"
       , "slot" AE..= AE.toJSON (unSlotNo slotNo)
       , "tip" AE..= showT tipPoint
       , "tipBlockNo" AE..= AE.toJSON (unBlockNo tipBlkNo)
       ]
   forMachine _verb (TraceBlockFromFuture currentSlot tip) =
-    HM.fromList
+    KeyMap.fromList
       [ "kind" AE..= AE.String "TraceBlockFromFuture"
       , "current slot" AE..= AE.toJSON (unSlotNo currentSlot)
       , "tip" AE..= AE.toJSON (unSlotNo tip)

--- a/trace-dispatcher/src/Cardano/Logging/FrequencyLimiter.hs
+++ b/trace-dispatcher/src/Cardano/Logging/FrequencyLimiter.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Logging.FrequencyLimiter (
@@ -50,16 +50,16 @@ instance LogFormatting LimitingMessage where
     ". Suppressed " <> pack (show num) <> " messages."
   forHuman (RememberLimiting txt num) = "Frequency limiting still active for " <> txt <>
     ". Suppressed so far " <> pack (show num) <> " messages."
-  forMachine _dtl (StartLimiting txt) = mkObject
+  forMachine _dtl (StartLimiting txt) = mconcat
         [ "kind" .= String "StartLimiting"
         , "name" .= String txt
         ]
-  forMachine _dtl (StopLimiting txt num) = mkObject
+  forMachine _dtl (StopLimiting txt num) = mconcat
         [ "kind" .= String "StopLimiting"
         , "name" .= String txt
         , "numSuppressed" .= Number (fromIntegral num)
         ]
-  forMachine _dtl (RememberLimiting txt num) = mkObject
+  forMachine _dtl (RememberLimiting txt num) = mconcat
         [ "kind" .= String "RememberLimiting"
         , "name" .= String txt
         , "numSuppressed" .= Number (fromIntegral num)

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Cardano.Logging.Types (
@@ -432,17 +432,17 @@ instance LogFormatting b => LogFormatting (Folding a b) where
   asMetrics (Folding b)    =  asMetrics b
 
 instance LogFormatting Double where
-  forMachine _dtal d = mkObject [ "val" .= AE.String ((pack . show) d)]
+  forMachine _dtal d = "val" .= AE.String ((pack . show) d)
   forHuman           = pack . show
   asMetrics d        = [DoubleM "" d]
 
 instance LogFormatting Int where
-  forMachine _dtal i = mkObject [ "val" .= AE.String ((pack . show) i)]
+  forMachine _dtal i = "val" .= AE.String ((pack . show) i)
   forHuman           = pack . show
   asMetrics i        = [IntM "" (fromIntegral i)]
 
 instance LogFormatting Integer where
-  forMachine _dtal i = mkObject [ "val" .= AE.String ((pack . show) i)]
+  forMachine _dtal i = "val" .= AE.String ((pack . show) i)
   forHuman           = pack . show
   asMetrics i        = [IntM "" i]
 

--- a/trace-dispatcher/test/Cardano/Logging/Test/Types.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Types.hs
@@ -24,24 +24,24 @@ data Message =
 
 instance LogFormatting Message where
   forMachine _dtal (Message1 mid i) =
-    mkObject [ "kind" .= String "Message1"
-             , "mid" .= ("<" <> showT mid <> ">")
-             , "workload" .= String (showT i)
-             ]
+    mconcat [ "kind" .= String "Message1"
+            , "mid" .= ("<" <> showT mid <> ">")
+            , "workload" .= String (showT i)
+            ]
   forMachine DMinimal (Message2 mid _s) =
-    mkObject [ "mid" .= ("<" <> showT mid <> ">")
-             , "kind" .= String "Message2"
-             ]
+    mconcat [ "mid" .= ("<" <> showT mid <> ">")
+            , "kind" .= String "Message2"
+            ]
   forMachine _dtal (Message2 mid s) =
-    mkObject [ "kind" .= String "Message2"
-             , "mid" .= String ("<" <> showT mid <> ">")
-             , "workload" .= String s
-             ]
+    mconcat [ "kind" .= String "Message2"
+            , "mid" .= String ("<" <> showT mid <> ">")
+            , "workload" .= String s
+            ]
   forMachine _dtal (Message3 mid d) =
-    mkObject [ "kind" .= String "Message3"
-             , "mid" .= String (showT mid)
-             , "workload" .= String (showT d)
-             ]
+    mconcat [ "kind" .= String "Message3"
+            , "mid" .= String (showT mid)
+            , "workload" .= String (showT d)
+            ]
   forHuman (Message1 mid i) =
       "Message1 <" <> showT mid <> "> " <> showT i
   forHuman (Message2 mid s) =

--- a/trace-resources/src/Cardano/Logging/Resources/Types.hs
+++ b/trace-resources/src/Cardano/Logging/Resources/Types.hs
@@ -102,7 +102,7 @@ instance LogFormatting ResourceStats where
                   <> ", Threads "              <> (pack . show) (rThreads rs)
                   <> "."
 
-    forMachine _dtal rs = mkObject
+    forMachine _dtal rs = mconcat
       [ "kind"          .= String "ResourceStats"
       , "CentiCpu"      .= Number (fromIntegral $ rCentiCpu rs)
       , "CentiGC"       .= Number (fromIntegral $ rCentiGC rs)


### PR DESCRIPTION
- The `cardano-base`, `cardano-ledger`, `plutus` and `ouroboros-network`
  dependencies have been updated to recent versions.
- Since the downstream libraries have been updated to more recent
  index-state and hackage revisions, we synchronise this here.
- As a consequence of this update, we switch to a newer version of
  `aeson`, necessitating updates in `ekg-json` and `hedgehog-extras`.
- We switch to ghc8107, to be in sync with other packages.
- Update with additional tracing details.