### PR TITLE
Support inline datums

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -168,6 +168,8 @@ friendlyTxOut (TxOut addr amount mdatum) =
    renderDatum TxOutDatumNone = Aeson.Null
    renderDatum (TxOutDatumHash _ h) =
      Aeson.String $ serialiseToRawBytesHexText h
+   renderDatum (TxOutDatumInline _ sData) =
+     scriptDataToJson ScriptDataJsonDetailedSchema sData
    renderDatum (TxOutDatum _ sData) =
      scriptDataToJson ScriptDataJsonDetailedSchema sData
 


### PR DESCRIPTION
With the latest works from `plutus` and `cardano-ledger` we could set up a (simulated) development environment for Plutus V2 & Babbage. That said, we still need #3739 to do any significant testing out of the Plutus V2 scripts and transactions. This is the first experiment to tackle it.

The PR basically adds a new constructor `TxOutDatumInline` to `TxOutDatum`, and rename `TxOutDatum'` to `TxOutDatumHash'` to further distinguish the use cases. Personally, I would remove `TxOutDatum` and export `TxOutDatumHash'` as `TxOutDatum` is now a very generic name for a quite specific case (datum hash in UTxO but with full value in a transaction context) but would want to hear others' thoughts first before trying such a pervasive change.