### PR TITLE
stakeKey registration stake.skey witness not needed

### DIFF
--- a/doc/stake-pool-operations/register_key.md
+++ b/doc/stake-pool-operations/register_key.md
@@ -29,7 +29,7 @@ For the transaction draft, --tx.out, --invalid-hereafter and --fee can be set to
     --tx-body-file tx.draft \
     --tx-in-count 1 \
     --tx-out-count 1 \
-    --witness-count 2 \
+    --witness-count 1 \
     --byron-witness-count 0 \
     --mainnet \
     --protocol-params-file protocol.json
@@ -79,7 +79,6 @@ Sign it:
     cardano-cli transaction sign \
     --tx-body-file tx.raw \
     --signing-key-file payment.skey \
-    --signing-key-file stake.skey \
     --mainnet \
     --out-file tx.signed
 


### PR DESCRIPTION
Since the start of Shelley we sign a stakeKey registration also with the stake.skey. Turnes out, this is wrong and not needed at all. 😱 

According to https://hydra.iohk.io/build/6752481/download/1/delegation_design_spec.pdf
Chapter 3.3: "We do not require a witness to register a stake address (besides, of course, any witnesses needed for the transaction that is used to post the certificate)."

So only the certificate is needed and the witness for the payment of course.