### PR TITLE
Pin secp256k1 to specific ref. 

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -16,6 +16,10 @@ jobs:
         ghc: ["8.10.7"]
         os: [ubuntu-latest]
 
+    env:
+      # current ref from: 27.02.2022
+      SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+
     steps:
     - uses: actions/checkout@v1
 
@@ -44,6 +48,22 @@ jobs:
         sudo apt-get -y install libsystemd0 libsystemd-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
+
+    - name: Install secp256k1 (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get -y install autoconf automake libtool
+        mkdir secp256k1-sources
+        cd secp256k1-sources
+        git clone https://github.com/bitcoin-core/secp256k1.git
+        cd secp256k1
+        git reset --hard $SECP256K1_REF
+        ./autogen.sh
+        ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental
+        make
+        make check
+        sudo make install
+        cd ../..
 
     - name: Cabal update
       run: cabal update

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,6 +28,10 @@ jobs:
         ghc: ["8.10.7"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
+    env:
+      # current ref from: 27.02.2022
+      SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+
     steps:
 
     - name: Get path to bash
@@ -120,6 +124,33 @@ jobs:
         make check
         sudo make install
         cd ../..
+
+    - name: Install secp256k1 (MacOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install autoconf automake libtool
+        mkdir secp256k1-sources
+        cd secp256k1-sources
+        git clone https://github.com/bitcoin-core/secp256k1.git
+        cd secp256k1
+        git reset --hard $SECP256K1_REF
+        ./autogen.sh
+        ./configure --enable-module-schnorrsig --enable-experimental
+        make
+        make check
+        sudo make install
+        cd ../..
+
+    - name: Configure to not use secp256k1 (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        echo "FIXME: can't install from sources, so instead libsecp256k1 support is disabled"
+        cat >> cabal.project <<EOF
+        package cardano-crypto-class
+          flags: -secp256k1-support
+        package cardano-crypto-tests
+          flags: -secp256k1-support
+        EOF
 
     - name: Cabal update
       run: retry 2 cabal update

--- a/cabal.project
+++ b/cabal.project
@@ -168,8 +168,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 20bd513b7ac9dcf0749f0ceb1df3d6b07a1b57c8
-  --sha256: 0pkcd3k2fpk76igfyaf7cqrcglnjs3rs9pka68wpkyp6z7qkixmz
+  tag: 394c4637c24d82325bd04ceb99c8e8df5617e663
+  --sha256: 02q8y69za5b0vsnj9qga1364vkmfc1kh35d0yshw1lf7nw9bls8m
   subdir:
     base-deriving-via
     binary

--- a/flake.lock
+++ b/flake.lock
@@ -4521,11 +4521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646330344,
-        "narHash": "sha256-EbhMDeneH26wDi+x5kz8nfru/dE9JZ241hJed4a8lz8=",
+        "lastModified": 1648032999,
+        "narHash": "sha256-3uCz+gJppvM7z6CUCkBbFSu60WgIE+e3oXwXiAiGWSY=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "rev": "5e667b374153327c7bdfdbfab8ef19b1f27d4aac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update cardano-base. Ensure GithubActions build on MacOS 

Looks like Windows is still failing for some weird reason, but at least MacOS is good.