### PR TITLE
Update cardano-api's TxOut with inline datum

### DIFF
--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -781,7 +781,7 @@ genTxOutDatumHash era = case era of
     AlonzoEra  -> Gen.choice
                     [ pure TxOutDatumNone
                     , TxOutDatumHash ScriptDataInAlonzoEra <$> genHashScriptData
-                    , TxOutDatum     ScriptDataInAlonzoEra <$> genScriptData
+                    , TxOutDatumInTx ScriptDataInAlonzoEra <$> genScriptData
                     ]
     BabbageEra -> pure TxOutDatumNone -- TODO: Babbage Era
 

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -783,7 +783,12 @@ genTxOutDatumHash era = case era of
                     , TxOutDatumHash ScriptDataInAlonzoEra <$> genHashScriptData
                     , TxOutDatumInTx ScriptDataInAlonzoEra <$> genScriptData
                     ]
-    BabbageEra -> pure TxOutDatumNone -- TODO: Babbage Era
+    BabbageEra -> Gen.choice
+                    [ pure TxOutDatumNone
+                    , TxOutDatumHash ScriptDataInBabbageEra <$> genHashScriptData
+                    , TxOutDatumInTx ScriptDataInBabbageEra <$> genScriptData
+                    , TxOutDatumInline InlineDatumSupportedInBabbageEra <$> genScriptData
+                    ]
 
 mkDummyHash :: forall h a. CRYPTO.HashAlgorithm h => Int -> CRYPTO.Hash h a
 mkDummyHash = coerce . CRYPTO.hashWithSerialiser @h CBOR.toCBOR

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -218,6 +218,7 @@ module Cardano.Api (
     WithdrawalsSupportedInEra(..),
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
+    InlineDatumSupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -169,7 +169,7 @@ friendlyTxOut (TxOut addr amount mdatum) =
    renderDatum TxOutDatumNone = Aeson.Null
    renderDatum (TxOutDatumHash _ h) =
      Aeson.String $ serialiseToRawBytesHexText h
-   renderDatum (TxOutDatum _ sData) =
+   renderDatum (TxOutDatumInTx _ sData) =
      scriptDataToJson ScriptDataJsonDetailedSchema sData
    renderDatum (TxOutDatumInline _ _) = panic "TODO: Babbage"
 

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -171,7 +171,7 @@ friendlyTxOut (TxOut addr amount mdatum) =
      Aeson.String $ serialiseToRawBytesHexText h
    renderDatum (TxOutDatum _ sData) =
      scriptDataToJson ScriptDataJsonDetailedSchema sData
-   renderDatum (TxOutInlineDatum _ _) = panic "TODO: Babbage"
+   renderDatum (TxOutDatumInline _ _) = panic "TODO: Babbage"
 
 friendlyStakeReference :: Crypto crypto => Shelley.StakeReference crypto -> Aeson.Value
 friendlyStakeReference = \case

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -685,7 +685,7 @@ toTxOutInAnyEra era (TxOutAnyEra addr val mDatumHash) =
       sData <- readScriptDataOrFile fileOrSdata
       TxOut <$> toAddressInAnyEra era addr
             <*> toTxOutValueInAnyEra era val
-            <*> pure (TxOutDatum supported sData)
+            <*> pure (TxOutDatumInTx supported sData)
 
     (Nothing, _) ->
       txFeatureMismatch era TxFeatureTxOutDatum


### PR DESCRIPTION
Updates the TxOut data type with the ability to specify an inline datum and propagate the changes throughout the api and cli.