### PR TITLE
Remove hint of "string" support for ScriptData

### DIFF
--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -637,7 +637,7 @@ instance Error ScriptDataJsonSchemaError where
      ++ LBS.unpack (Aeson.encode v)
     displayError (ScriptDataJsonBadObject v) =
         "JSON object does not match the schema.\nExpected a single field named "
-     ++ "\"int\", \"bytes\", \"string\", \"list\" or \"map\".\n"
+     ++ "\"int\", \"bytes\", \"list\" or \"map\".\n"
      ++ "Unexpected object field(s): "
      ++ LBS.unpack (Aeson.encode (KeyMap.fromList $ first Aeson.fromText <$> v))
     displayError (ScriptDataJsonBadMapPair v) =


### PR DESCRIPTION
There's no attempt to support string in the code. Probably a copy/paste error from tx metadata. This keeps confusing people in Discord and forums so we should remove.
Fixes https://forum.cardano.org/t/cardano-cli-script-data-file-format/89304 and https://github.com/input-output-hk/cardano-node/issues/3129