### PR TITLE
Fix scripts/byron-to-alonzo/mkfiles.sh and accompanying update proposal scripts

### DIFF
--- a/scripts/byron-to-alonzo/mkfiles.sh
+++ b/scripts/byron-to-alonzo/mkfiles.sh
@@ -328,7 +328,7 @@ $SED -i shelley/genesis.spec.json \
     -e 's/"minFeeB": 0/"minFeeB": 155381/' \
     -e 's/"minUTxOValue": 0/"minUTxOValue": 1000000/' \
     -e 's/"decentralisationParam": 1.0/"decentralisationParam": 0.7/' \
-    -e 's/"major": 0/"major": 5/' \
+    -e 's/"major": 0/"major": 2/' \
     -e 's/"rho": 0.0/"rho": 0.1/' \
     -e 's/"tau": 0.0/"tau": 0.1/' \
     -e 's/"updateQuorum": 5/"updateQuorum": 2/'
@@ -583,23 +583,33 @@ echo "$ROOT/run/all.sh"
 echo
 echo "In order to do the protocol updates, proceed as follows:"
 echo
-echo "  0. wait for the nodes to start producing blocks"
-echo "  1. invoke ./scripts/byron-to-alonzo/update-1.sh"
+echo "  0. invoke ./scripts/byron-to-alonzo/mkfiles.sh"
+echo "  1. wait for the nodes to start producing blocks"
+echo "  2. invoke ./scripts/byron-to-alonzo/update-1.sh <N>"
+echo "     if you are early enough in the epoch N = current epoch"
+echo "     if not N = current epoch + 1. This applies for all update proposals"
 echo "     wait for the next epoch for the update to take effect"
 echo
-echo "  2. invoke ./scripts/byron-to-alonzo/update-2.sh"
-echo "  3. restart the nodes"
+echo "  3. invoke ./scripts/byron-to-alonzo/update-2.sh"
+echo "  4. restart the nodes"
 echo "     wait for the next epoch for the update to take effect"
+echo "     you should be in the Shelley era if the update was successful"
 echo
-echo "  4. invoke ./scripts/byron-to-alonzo/update-3.sh <N>"
+echo "  5. invoke ./scripts/byron-to-alonzo/update-3.sh <N>"
 echo "     Here, <N> the current epoch (2 if you're quick)."
 echo "     If you provide the wrong epoch, you will see an error"
 echo "     that will tell you the current epoch, and can run"
 echo "     the script again."
-echo "  5. restart the nodes"
+echo "  6. restart the nodes"
 echo "     wait for the next epoch for the update to take effect"
-echo "  6. invoke ./scripts/byron-to-alonzo/update-4.sh <N>"
-echo "  7. restart the nodes"
+echo "     you should be in the Allegra era if the update was successful"
+echo "  7. invoke ./scripts/byron-to-alonzo/update-4.sh <N>"
+echo "  8. restart the nodes"
+echo "     wait for the next epoch for the update to take effect"
+echo "     you should be in the Mary era if the update was successful"
+echo "  9. invoke ./scripts/byron-to-alonzo/update-5.sh <N>"
+echo "     wait for the next epoch for the update to take effect"
+echo "     you should be in the Alonzo era if the update was successful"
 echo
 echo "You can observe the status of the updates by grepping the logs, via"
 echo

--- a/scripts/byron-to-alonzo/update-3.sh
+++ b/scripts/byron-to-alonzo/update-3.sh
@@ -63,11 +63,12 @@ cardano-cli key convert-byron-key \
 cardano-cli transaction build-raw \
             --shelley-era \
             --invalid-hereafter 100000 \
-            --fee 0 \
+            --fee 231501 \
             --tx-in ${TXID0}#0\
             --tx-in ${TXID1}#0\
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
+            --tx-out $(cat addresses/user1.addr)+9017768499 \
             --certificate-file addresses/pool-owner1-stake.reg.cert \
             --certificate-file node-pool1/registration.cert \
             --certificate-file addresses/user1-stake.reg.cert \

--- a/scripts/byron-to-alonzo/update-4.sh
+++ b/scripts/byron-to-alonzo/update-4.sh
@@ -43,11 +43,13 @@ cardano-cli governance create-update-proposal \
 
 cardano-cli transaction build-raw \
             --allegra-era \
-            --fee 0 \
+            --fee 186181 \
             --tx-in $TXID2#0\
             --tx-in $TXID2#1\
+            --tx-in $TXID2#2\
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
+            --tx-out $(cat addresses/user1.addr)+9017582318 \
             --update-proposal-file update-proposal-mary \
             --out-file tx3.txbody
 

--- a/scripts/byron-to-alonzo/update-5.sh
+++ b/scripts/byron-to-alonzo/update-5.sh
@@ -43,11 +43,13 @@ cardano-cli governance create-update-proposal \
 
 cardano-cli transaction build-raw \
             --mary-era \
-            --fee 0 \
+            --fee 186181 \
             --tx-in $TXID2#0\
             --tx-in $TXID2#1\
+            --tx-in $TXID2#2\
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
             --tx-out $(cat addresses/user1.addr)+$((${COINS_IN_INPUT} / 2)) \
+            --tx-out $(cat addresses/user1.addr)+9017396137 \
             --update-proposal-file update-proposal-alonzo \
             --out-file tx4.txbody
 
@@ -73,4 +75,3 @@ popd
 
 echo "Restart the nodes now to endorse the update."
 
-cardano-cli transaction submit --cardano-mode --testnet-magic 42 --tx-file mary.tx


### PR DESCRIPTION
`mkfiles.sh` was generating a shelley genesis file with a major protocol version of 5 instead of 2. This would result in the ledger rejecting the update proposal when trying to transition from Shelley to Allegra.

Resolves: #3729 