### PR TITLE
bump haskell.nix + scripts fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3636,11 +3636,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1647960987,
-        "narHash": "sha256-Jb2xIncXlqvkMmEGsMDdWScdLGhEegNCdhSJswsOAkI=",
+        "lastModified": 1649639788,
+        "narHash": "sha256-nBzRclDcVCEwrIMOYTNOZltd0bUhSyTk0c3UIrjqFhI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "53ffd8eac65e3f029865b00f7eca49373388b691",
+        "rev": "fd74389bcf72b419f25cb6fe81c951b02ede4985",
         "type": "github"
       },
       "original": {
@@ -4521,11 +4521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648032999,
-        "narHash": "sha256-3uCz+gJppvM7z6CUCkBbFSu60WgIE+e3oXwXiAiGWSY=",
+        "lastModified": 1649070135,
+        "narHash": "sha256-UFKqcOSdPWk3TYUCPHF22p1zf7aXQpCmmgf7UMg7fWA=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5e667b374153327c7bdfdbfab8ef19b1f27d4aac",
+        "rev": "cecab9c71d1064f05f1615eead56ac0b9196bc20",
         "type": "github"
       },
       "original": {
@@ -5353,11 +5353,11 @@
     "nix-tools_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
         "type": "github"
       },
       "original": {
@@ -6000,11 +6000,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1642244250,
-        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
         "type": "github"
       },
       "original": {
@@ -6288,11 +6288,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1644510859,
-        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
         "type": "github"
       },
       "original": {
@@ -6621,11 +6621,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
@@ -8000,11 +8000,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1647911723,
-        "narHash": "sha256-SfHe7QWAH4A1gHj1LSEFNXMJACvzbgQn2KkjdJOkCQ4=",
+        "lastModified": 1649639721,
+        "narHash": "sha256-i/nyHyfpvw6en4phdjLS96DhJI95MVX3KubfUJwDtuU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "00701d47768afdf1788a8bb1b84e3b1c7bf71581",
+        "rev": "9d1954e8bf7ce40ce21d59794d19a8d1ddf06cd6",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -70,8 +70,6 @@ haskell-nix.cabalProject' ({ pkgs
       # version info. It uses the "gitrev" argument, if set. Otherwise,
       # the revision is sourced from the local git work tree.
       setGitRev = ''${pkgs.buildPackages.haskellBuildUtils}/bin/set-git-rev "${gitrev}" $out/bin/*'';
-      # package with libsodium:
-      setLibSodium = "ln -s ${pkgs.libsodium-vrf}/bin/libsodium-23.dll $out/bin/libsodium-23.dll";
     in
     [
       # Allow reinstallation of Win32
@@ -141,15 +139,8 @@ haskell-nix.cabalProject' ({ pkgs
         # stamp executables with the git revision, add shell completion, strip/rewrite:
         packages = lib.mapAttrs
           (name: exes: {
-            # For checks:
-            postInstall = lib.mkIf pkgs.stdenv.hostPlatform.isWindows ''
-              if [ -d $out/bin ]; then
-                ${setLibSodium}
-              fi
-            '';
             components.exes = lib.genAttrs exes (exe: {
               postInstall = ''
-                ${lib.optionalString pkgs.stdenv.hostPlatform.isWindows setLibSodium}
                 ${setGitRev}
                 ${lib.optionalString (pkgs.stdenv.hostPlatform.isMusl) ''
                   ${pkgs.buildPackages.binutils-unwrapped}/bin/*strip $out/bin/*

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -22,14 +22,16 @@ let
         })
       ];
     };
-
-  in pkgs.writeScriptBin "cardano-node-${service.environment}" ''
+  scriptBin = pkgs.writeScriptBin "cardano-node-${service.environment}" ''
     #!${pkgs.runtimeShell}
     export PATH=$PATH:${makeBinPath [ pkgs.coreutils ]}
     set -euo pipefail
     mkdir -p "$(dirname "${service.socketPath}")"
     ${service.script} $@
   '';
+  in scriptBin // {
+    exePath = "${scriptBin}/bin/cardano-node-${service.environment}";
+  };
 
 in forEnvironments (environment: recurseIntoAttrs rec {
   node = mkScript environment;


### PR DESCRIPTION
recent haskell.nix has improved filtering and other fixes that improve cache hits and eval time.

Also fix running scripts from flake.