### PR TITLE
Fix scripts/byron-to-alonzo/mkfiles.sh script

### DIFF
--- a/scripts/byron-to-alonzo/mkfiles.sh
+++ b/scripts/byron-to-alonzo/mkfiles.sh
@@ -311,10 +311,10 @@ mkdir shelley
 
 # Copy the QA testnet alonzo genesis which is equivalent to the mainnet
 
+cp ../configuration/cardano/shelley_qa-alonzo-genesis.json shelley/genesis.alonzo.spec.json
+
 cardano-cli genesis create --testnet-magic ${NETWORK_MAGIC} --genesis-dir shelley
 
-# Then edit the genesis.spec.json ...
-cp ../configuration/cardano/shelley_qa-alonzo-genesis.json shelley/genesis.alonzo.spec.json
 # We're going to use really quick epochs (300 seconds), by using short slots 0.2s
 # and K=10, but we'll keep long KES periods so we don't have to bother
 # cycling KES keys


### PR DESCRIPTION
to work on new versions of cardano-cli which do not create an alonzo genesis file