### PR TITLE
Vasil cardano-cli update

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -165,6 +165,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      (Maybe TxOutAnyEra)
+      -- ^ Return collateral
       (Maybe Lovelace)
       -- ^ Total collateral
       [TxIn]
@@ -206,6 +208,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      (Maybe TxOutAnyEra)
+      -- ^ Return collateral
       (Maybe Lovelace)
       -- ^ Total collateral
       [TxIn]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -165,6 +165,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      (Maybe Lovelace)
+      -- ^ Total collateral
       [TxIn]
       -- ^ Reference inputs
       [RequiredSigner]
@@ -204,6 +206,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      (Maybe Lovelace)
+      -- ^ Total collateral
       [TxIn]
       -- ^ Reference inputs
       [TxOutAnyEra]

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -165,6 +165,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      [TxIn]
+      -- ^ Reference inputs
       [RequiredSigner]
       -- ^ Required signers
       [TxOutAnyEra]
@@ -202,6 +204,8 @@ data TransactionCmd
       -- ^ Transaction inputs with optional spending scripts
       [TxIn]
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+      [TxIn]
+      -- ^ Reference inputs
       [TxOutAnyEra]
       -- ^ Normal outputs
       TxOutChangeAddress

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2002,6 +2002,7 @@ pTxOut =
                       \the multi-asset syntax (including simply Lovelace)."
           )
     <*> pTxOutDatum
+    <*> pRefScriptFp
 
 
 pTxOutDatum :: Parser TxOutDatumAnyEra
@@ -2048,7 +2049,14 @@ pTxOutDatum =
           "The script datum to embed in the tx output as an inline datum, \
           \in the given JSON file."
 
-
+pRefScriptFp :: Parser ReferenceScriptAnyEra
+pRefScriptFp =
+  ReferenceScriptAnyEra <$> Opt.strOption
+    (  Opt.long "reference-script-file"
+    <> Opt.metavar "FILE"
+    <> Opt.help "Reference script input file."
+    <> Opt.completer (Opt.bashCompleter "file")
+    ) <|> pure ReferenceScriptAnyEraNone
 
 pMintMultiAsset
   :: BalanceTxExecUnits
@@ -2954,7 +2962,8 @@ parseStakeAddress = do
       Nothing   -> fail $ "invalid address: " <> Text.unpack str
       Just addr -> pure addr
 
-parseTxOutAnyEra :: Parsec.Parser (TxOutDatumAnyEra -> TxOutAnyEra)
+parseTxOutAnyEra
+  :: Parsec.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutAnyEra)
 parseTxOutAnyEra = do
     addr <- parseAddressAny
     Parsec.spaces

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -671,6 +671,7 @@ pTransaction =
             <*> some (pTxIn AutoBalance)
             <*> many pRequiredSigner
             <*> many pTxInCollateral
+            <*> optional pTotalCollateral
             <*> many pReferenceTxIn
             <*> many pTxOut
             <*> pChangeAddress
@@ -705,6 +706,7 @@ pTransaction =
                <*> optional pScriptValidity
                <*> some (pTxIn ManualBalance)
                <*> many pTxInCollateral
+               <*> optional pTotalCollateral
                <*> many pReferenceTxIn
                <*> many pRequiredSigner
                <*> many pTxOut
@@ -1960,6 +1962,17 @@ pTxInCollateral =
       <> Opt.metavar "TX-IN"
       <> Opt.help "TxId#TxIx"
       )
+
+pTotalCollateral :: Parser Lovelace
+pTotalCollateral =
+  Opt.option (Lovelace <$> readerFromParsecParser decimal)
+    (  Opt.long "tx-total-collateral"
+    <> Opt.metavar "INTEGER"
+    <> Opt.help "The total amount of collateral that will be collected \
+                 \as fees in the event of a Plutus script failure. Must be used \
+                 \in conjuction with \"--tx-out-return-collateral\"."
+    )
+
 
 pReferenceTxIn :: Parser TxIn
 pReferenceTxIn =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -671,6 +671,7 @@ pTransaction =
             <*> some (pTxIn AutoBalance)
             <*> many pRequiredSigner
             <*> many pTxInCollateral
+            <*> optional pReturnCollateral
             <*> optional pTotalCollateral
             <*> many pReferenceTxIn
             <*> many pTxOut
@@ -706,6 +707,7 @@ pTransaction =
                <*> optional pScriptValidity
                <*> some (pTxIn ManualBalance)
                <*> many pTxInCollateral
+               <*> optional pReturnCollateral
                <*> optional pTotalCollateral
                <*> many pReferenceTxIn
                <*> many pRequiredSigner
@@ -1962,6 +1964,21 @@ pTxInCollateral =
       <> Opt.metavar "TX-IN"
       <> Opt.help "TxId#TxIx"
       )
+
+pReturnCollateral :: Parser TxOutAnyEra
+pReturnCollateral =
+  Opt.option (readerFromParsecParser parseTxOutAnyEra)
+          (  Opt.long "tx-out-return-collateral"
+          <> Opt.metavar "ADDRESS VALUE"
+          -- TODO alonzo: Update the help text to describe the new syntax as well.
+          <> Opt.help "The transaction output as ADDRESS VALUE where ADDRESS is \
+                      \the Bech32-encoded address followed by the value in \
+                      \Lovelace. In the situation where your collateral txin \
+                      \over collateralizes the transaction, you can optionally \
+                      \specify a tx out of your choosing to return the excess Lovelace."
+          )
+    <*> pTxOutDatum
+    <*> pRefScriptFp
 
 pTotalCollateral :: Parser Lovelace
 pTotalCollateral =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2009,6 +2009,7 @@ pTxOutDatum =
       pTxOutDatumByHashOnly
   <|> pTxOutDatumByHashOf
   <|> pTxOutDatumByValue
+  <|> pTxOutInlineDatumByValue
   <|> pure TxOutDatumByNone
   where
     pTxOutDatumByHashOnly =
@@ -2037,6 +2038,17 @@ pTxOutDatum =
           \given here in JSON syntax."
           "The script datum to embed in the tx for this output, \
           \in the given JSON file."
+
+    pTxOutInlineDatumByValue =
+      TxOutInlineDatumByValue <$>
+        pScriptDataOrFile
+          "tx-out-inline-datum"
+          "The script datum to embed in the tx output as an inline datum, \
+          \given here in JSON syntax."
+          "The script datum to embed in the tx output as an inline datum, \
+          \in the given JSON file."
+
+
 
 pMintMultiAsset
   :: BalanceTxExecUnits

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -671,6 +671,7 @@ pTransaction =
             <*> some (pTxIn AutoBalance)
             <*> many pRequiredSigner
             <*> many pTxInCollateral
+            <*> many pReferenceTxIn
             <*> many pTxOut
             <*> pChangeAddress
             <*> optional (pMintMultiAsset AutoBalance)
@@ -704,6 +705,7 @@ pTransaction =
                <*> optional pScriptValidity
                <*> some (pTxIn ManualBalance)
                <*> many pTxInCollateral
+               <*> many pReferenceTxIn
                <*> many pRequiredSigner
                <*> many pTxOut
                <*> optional (pMintMultiAsset ManualBalance)
@@ -1955,6 +1957,14 @@ pTxInCollateral :: Parser TxIn
 pTxInCollateral =
     Opt.option (readerFromParsecParser parseTxIn)
       (  Opt.long "tx-in-collateral"
+      <> Opt.metavar "TX-IN"
+      <> Opt.help "TxId#TxIx"
+      )
+
+pReferenceTxIn :: Parser TxIn
+pReferenceTxIn =
+    Opt.option (readerFromParsecParser parseTxIn)
+      (  Opt.long "tx-in-reference"
       <> Opt.metavar "TX-IN"
       <> Opt.help "TxId#TxIx"
       )

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -866,7 +866,7 @@ writeFilteredUTxOs shelleyBasedEra' mOutFile utxo =
           ShelleyBasedEraAllegra -> writeUTxo fpath utxo
           ShelleyBasedEraMary -> writeUTxo fpath utxo
           ShelleyBasedEraAlonzo -> writeUTxo fpath utxo
-          ShelleyBasedEraBabbage -> panic "TODO: Babbage"
+          ShelleyBasedEraBabbage -> writeUTxo fpath utxo
  where
    writeUTxo fpath utxo' =
      handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
@@ -885,7 +885,9 @@ printFilteredUTxOs shelleyBasedEra' (UTxO utxo) = do
       mapM_ (printUtxo shelleyBasedEra') $ Map.toList utxo
     ShelleyBasedEraAlonzo ->
       mapM_ (printUtxo shelleyBasedEra') $ Map.toList utxo
-    ShelleyBasedEraBabbage -> panic "TODO: Babbage"
+    ShelleyBasedEraBabbage ->
+      mapM_ (printUtxo shelleyBasedEra') $ Map.toList utxo
+
  where
    title :: Text
    title =
@@ -930,7 +932,14 @@ printUtxo shelleyBasedEra' txInOutTuple =
              , textShowN 6 index
              , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
              ]
-    ShelleyBasedEraBabbage -> panic "TODO: Babbage"
+    ShelleyBasedEraBabbage ->
+      let (TxIn (TxId txhash) (TxIx index), TxOut _ value mDatum _) = txInOutTuple
+      in Text.putStrLn $
+           mconcat
+             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+             , textShowN 6 index
+             , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
+             ]
  where
   textShowN :: Show a => Int -> a -> Text
   textShowN len x =
@@ -1318,7 +1327,8 @@ obtainLedgerEraClassConstraints ShelleyBasedEraShelley f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAllegra f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraMary    f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAlonzo  f = f
-obtainLedgerEraClassConstraints ShelleyBasedEraBabbage _f = panic "TODO: Babbage"
+obtainLedgerEraClassConstraints ShelleyBasedEraBabbage _f =
+  panic "TODO: Babbage era - depends on consensus exposing a babbage era"
 
 
 eligibleLeaderSlotsConstaints
@@ -1338,4 +1348,4 @@ eligibleLeaderSlotsConstaints ShelleyBasedEraShelley f = f
 eligibleLeaderSlotsConstaints ShelleyBasedEraAllegra f = f
 eligibleLeaderSlotsConstaints ShelleyBasedEraMary    f = f
 eligibleLeaderSlotsConstaints ShelleyBasedEraAlonzo  f = f
-eligibleLeaderSlotsConstaints ShelleyBasedEraBabbage _f = panic "TODO: Babbage"
+eligibleLeaderSlotsConstaints ShelleyBasedEraBabbage f = f

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -330,6 +330,7 @@ data TxOutAnyEra = TxOutAnyEra
 data TxOutDatumAnyEra = TxOutDatumByHashOnly (Hash ScriptData)
                       | TxOutDatumByHashOf    ScriptDataOrFile
                       | TxOutDatumByValue     ScriptDataOrFile
+                      | TxOutInlineDatumByValue ScriptDataOrFile
                       | TxOutDatumByNone
   deriving (Eq, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -21,6 +21,7 @@ module Cardano.CLI.Types
   , OutputFormat (..)
   , OutputSerialisation (..)
   , TxBuildOutputOptions(..)
+  , ReferenceScriptAnyEra (..)
   , SigningKeyFile (..)
   , SocketPath (..)
   , ScriptFile (..)
@@ -325,6 +326,7 @@ data TxOutAnyEra = TxOutAnyEra
                      AddressAny
                      Value
                      TxOutDatumAnyEra
+                     ReferenceScriptAnyEra
   deriving (Eq, Show)
 
 data TxOutDatumAnyEra = TxOutDatumByHashOnly (Hash ScriptData)
@@ -332,6 +334,11 @@ data TxOutDatumAnyEra = TxOutDatumByHashOnly (Hash ScriptData)
                       | TxOutDatumByValue     ScriptDataOrFile
                       | TxOutInlineDatumByValue ScriptDataOrFile
                       | TxOutDatumByNone
+  deriving (Eq, Show)
+
+data ReferenceScriptAnyEra
+  = ReferenceScriptAnyEraNone
+  | ReferenceScriptAnyEra FilePath
   deriving (Eq, Show)
 
 -- | A partially-specified transaction output indented to use as a change


### PR DESCRIPTION
Add the following options to the `build` and `build-raw` command:
- `--tx-out-inline-datum` - specify an inline datum in a tx output
- `--tx-in-reference` - specify a reference tx input
- `--reference-script-file` - specify a reference script
- `--tx-out-return-collateral` - specify a return collateral tx out
- `--tx-total-collateral` - specify the total collateral that will be collected in the event of a Plutus script failure 
