### PR TITLE
refactor: make renderScriptWitnessIndex output more explicit

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -3446,13 +3446,13 @@ data ScriptWitnessIndex =
 
 renderScriptWitnessIndex :: ScriptWitnessIndex -> String
 renderScriptWitnessIndex (ScriptWitnessIndexTxIn index) =
-  "transaction input " <> show index <> " (in the order of the TxIds)"
+  "transaction input " <> show index <> " (in ascending order of the TxIds)"
 renderScriptWitnessIndex (ScriptWitnessIndexMint index) =
-  "policyId " <> show index <> " (in the order of the PolicyIds)"
+  "policyId " <> show index <> " (in ascending order of the PolicyIds)"
 renderScriptWitnessIndex (ScriptWitnessIndexCertificate index) =
   "certificate " <> show index <> " (in the list order of the certificates)"
 renderScriptWitnessIndex (ScriptWitnessIndexWithdrawal index) =
-  "withdrawal " <> show index <> " (in the order of the StakeAddresses)"
+  "withdrawal " <> show index <> " (in ascending order of the StakeAddresses)"
 
 toAlonzoRdmrPtr :: ScriptWitnessIndex -> Alonzo.RdmrPtr
 toAlonzoRdmrPtr widx =


### PR DESCRIPTION
This change is made due to a [question on the cardano stackexchange](https://cardano.stackexchange.com/questions/7988/how-to-determine-the-order-of-transaction-input-in-the-order-of-the-txids).

From below error message it wasn't clear, in what order the TxIds were.

```
Command failed: transaction build  Error: The following scripts have execution failures:
the script for transaction input 0 (in the order of the TxIds) failed with: [...]
```

Therefore I propose to change the `renderScriptWitnessIndex` to explicitly say that the script witnesses are ordered in ascending order.
