### PR TITLE
tx-generator: remove mutable state

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -22,7 +22,7 @@ action a = case a of
   Delay t -> delay t
   ImportGenesisFund era wallet submitMode genesisKey fundKey -> importGenesisFund era wallet submitMode genesisKey fundKey
   CreateChange era sourceWallet dstWallet payMode submitMode value count -> createChange era sourceWallet dstWallet payMode submitMode value count
-  RunBenchmark era sourceWallet submitMode spendMode thread count tps -> runBenchmark era sourceWallet submitMode spendMode thread count tps
+  RunBenchmark era sourceWallet submitMode spendMode thread auxArgs tps -> runBenchmark era sourceWallet submitMode spendMode thread auxArgs tps
   WaitBenchmark thread -> waitBenchmark thread
   CancelBenchmark thread -> cancelBenchmark thread
   WaitForEra era -> waitForEra era

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -102,6 +102,12 @@ instance ToJSON Action where
 instance FromJSON Action where
   parseJSON = genericParseJSON jsonOptionsUnTaggedSum
 
+instance ToJSON RunBenchmarkAux where
+  toJSON     = genericToJSON jsonOptionsUnTaggedSum
+  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
+instance FromJSON RunBenchmarkAux where
+  parseJSON = genericParseJSON jsonOptionsUnTaggedSum
+
 scanScriptFile :: FilePath -> IO Value
 scanScriptFile filePath = do
   input <- BS.readFile filePath

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
@@ -43,11 +43,8 @@ printJSON = BSL.putStrLn $ prettyPrint $ testScript "/dev/zero" DiscardTX
 testScript :: FilePath -> SubmitMode -> [Action]
 testScript protocolFile submitMode =
   [ SetProtocolParameters (UseLocalProtocolFile protocolFile)
-  , Set (TNumberOfInputsPerTx ==>  2)
-  , Set (TNumberOfOutputsPerTx ==>  2)
   , Set (TTxAdditionalSize ==>  39)
   , Set (TFee ==>  Lovelace 212345)
-  , Set (TMinValuePerUTxO ==>  Lovelace 1000000)
   , Set (TTTL ==> SlotNo 1000000)
   , Set (TNetworkId ==> Testnet (NetworkMagic {unNetworkMagic = 42}))
   , InitWallet wallet
@@ -64,7 +61,7 @@ testScript protocolFile submitMode =
   , RunBenchmark era wallet
     submitMode
     SpendOutput
-    (ThreadName "walletBasedBenchmark") 4000 (TPSRate 10.0)
+    (ThreadName "walletBasedBenchmark") extraArgs (TPSRate 10.0)
   ]
   where
     era = AnyCardanoEra AllegraEra
@@ -73,3 +70,12 @@ testScript protocolFile submitMode =
     addr = PayToAddr key
     createChange val count
       = CreateChange era wallet wallet submitMode addr (Lovelace val) count
+    extraArgs = RunBenchmarkAux {
+        auxTxCount = 4000
+      , auxFee = 1000000
+      , auxOutputsPerTx = 2
+      , auxInputsPerTx = 2
+      , auxInputs = 8000
+      , auxOutputs = 8000
+      , auxMinValuePerUTxO = 10500000
+      }

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -24,11 +24,7 @@ import           Cardano.Benchmarking.Types
 
 -- Some boiler plate; ToDo may generate this.
 data Tag v where
-  TNumberOfInputsPerTx  :: Tag NumberOfInputsPerTx
-  TNumberOfOutputsPerTx :: Tag NumberOfOutputsPerTx
-  TNumberOfTxs          :: Tag NumberOfTxs
   TFee                  :: Tag Lovelace
-  TMinValuePerUTxO      :: Tag Lovelace
   TTTL                  :: Tag SlotNo
   TTxAdditionalSize     :: Tag TxAdditionalSize
   TLocalSocket          :: Tag String
@@ -43,11 +39,7 @@ deriving instance Show (Tag v)
 deriving instance Eq (Tag v)
 
 data Sum where
-  SNumberOfInputsPerTx  :: !NumberOfInputsPerTx  -> Sum
-  SNumberOfOutputsPerTx :: !NumberOfOutputsPerTx -> Sum
-  SNumberOfTxs          :: !NumberOfTxs          -> Sum
   SFee                  :: !Lovelace             -> Sum
-  SMinValuePerUTxO      :: !Lovelace             -> Sum
   STTL                  :: !SlotNo               -> Sum
   STxAdditionalSize     :: !TxAdditionalSize     -> Sum
   SLocalSocket          :: !String               -> Sum
@@ -56,11 +48,7 @@ data Sum where
 
 taggedToSum :: Applicative f => DSum Tag f -> f Sum
 taggedToSum x = case x of
-  (TNumberOfInputsPerTx  :=> v) -> SNumberOfInputsPerTx  <$> v
-  (TNumberOfOutputsPerTx :=> v) -> SNumberOfOutputsPerTx <$> v
-  (TNumberOfTxs          :=> v) -> SNumberOfTxs          <$> v
   (TFee                  :=> v) -> SFee                  <$> v
-  (TMinValuePerUTxO      :=> v) -> SMinValuePerUTxO      <$> v
   (TTTL                  :=> v) -> STTL                  <$> v
   (TTxAdditionalSize     :=> v) -> STxAdditionalSize     <$> v
   (TLocalSocket          :=> v) -> SLocalSocket          <$> v
@@ -68,11 +56,7 @@ taggedToSum x = case x of
 
 sumToTagged :: Applicative f => Sum -> DSum Tag f
 sumToTagged x = case x of
-  SNumberOfInputsPerTx  v -> TNumberOfInputsPerTx  ==> v
-  SNumberOfOutputsPerTx v -> TNumberOfOutputsPerTx ==> v
-  SNumberOfTxs          v -> TNumberOfTxs          ==> v
   SFee                  v -> TFee                  ==> v
-  SMinValuePerUTxO      v -> TMinValuePerUTxO      ==> v
   STTL                  v -> TTTL                  ==> v
   STxAdditionalSize     v -> TTxAdditionalSize     ==> v
   SLocalSocket          v -> TLocalSocket          ==> v

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -22,7 +22,7 @@ import           Cardano.Api (AnyCardanoEra, ExecutionUnits, Lovelace, ScriptDat
 
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
-import           Cardano.Benchmarking.Types (TPSRate, NumberOfTxs, NodeIPv4Address)
+import           Cardano.Benchmarking.Types (TPSRate, NodeIPv4Address)
 
 data Action where
   Set                :: !SetKeyVal -> Action
@@ -35,7 +35,7 @@ data Action where
   AddFund            :: !AnyCardanoEra -> !WalletName -> !TxIn -> !Lovelace -> !KeyName -> Action
   ImportGenesisFund  :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !KeyName -> !KeyName -> Action
   CreateChange       :: !AnyCardanoEra -> !WalletName -> !WalletName -> !SubmitMode -> !PayMode -> !Lovelace -> !Int -> Action
-  RunBenchmark       :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !SpendMode -> !ThreadName -> !NumberOfTxs -> !TPSRate -> Action
+  RunBenchmark       :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !SpendMode -> !ThreadName -> !RunBenchmarkAux -> !TPSRate -> Action
   WaitBenchmark      :: !ThreadName -> Action
   CancelBenchmark    :: !ThreadName -> Action
   Reserved           :: [String] -> Action
@@ -78,3 +78,15 @@ data ScriptBudget where
   CheckScriptBudget  :: !ExecutionUnits -> ScriptBudget
   deriving (Show, Eq)
 deriving instance Generic ScriptBudget
+
+data RunBenchmarkAux = RunBenchmarkAux {
+    auxTxCount :: Int
+  , auxFee :: Lovelace
+  , auxOutputsPerTx :: Int
+  , auxInputsPerTx :: Int
+  , auxInputs :: Int
+  , auxOutputs ::Int
+  , auxMinValuePerUTxO :: Lovelace
+  }
+  deriving (Show, Eq)
+deriving instance Generic RunBenchmarkAux


### PR DESCRIPTION
Remove some data that was passed around as mutable state in tx-generator.
Instead: provide the data a explicit argument.