### PR TITLE
cardano-node: register GC metrics.

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -80,6 +80,7 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
  where
   mkTracers trConfig = do
     ekgStore <- EKG.newStore
+    EKG.registerGcMetrics ekgStore
     ekgTrace <- ekgTracer (Left ekgStore)
 
     stdoutTrace <- standardTracer


### PR DESCRIPTION
Add predefined RTS GC metrics in `EKG.Store`.