### PR TITLE
Script data deserialisation fix and properties

### DIFF
--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -181,7 +181,7 @@ genScriptData =
         , ScriptDataBytes  <$> genByteString
         ]
         -- The Gen.recursive combinator calls these with the size halved
-        [ ScriptDataConstructor <$> genInteger
+        [ ScriptDataConstructor <$> genConstructorInteger
                                 <*> genScriptDataList
         , ScriptDataList <$> genScriptDataList
         , ScriptDataMap  <$> genScriptDataMap
@@ -189,6 +189,13 @@ genScriptData =
   where
     genInteger :: Gen Integer
     genInteger = Gen.integral
+                  (Range.linear
+                    (-fromIntegral (maxBound :: Word64) :: Integer)
+                    (2 * fromIntegral (maxBound :: Word64) :: Integer))
+
+
+    genConstructorInteger :: Gen Integer
+    genConstructorInteger = Gen.integral
                   (Range.linear
                     0 -- TODO: Alonzo should be -> (-fromIntegral (maxBound :: Word64) :: Integer)
                       -- Wrapping bug needs to be fixed in Plutus library

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -188,11 +188,7 @@ validateScriptData d =
       err:_ -> Left err
   where
     -- collect all errors in a monoidal fold style:
-    collect (ScriptDataNumber n) =
-        [ ScriptDataNumberOutOfRange n
-        |    n >         fromIntegral (maxBound :: Word64)
-          || n < negate (fromIntegral (maxBound :: Word64))
-        ]
+    collect (ScriptDataNumber _n) = mempty
     collect (ScriptDataBytes bs) =
         [ ScriptDataBytesTooLong len
         | let len = BS.length bs
@@ -221,13 +217,9 @@ scriptDataByteStringMaxLength = 64
 --
 data ScriptDataRangeError =
 
-    -- | The number is outside the maximum range of @-2^64-1 .. 2^64-1@.
+    -- | The constructor number is outside the maximum range of @-2^64-1 .. 2^64-1@.
     --
-    ScriptDataNumberOutOfRange !Integer
-
-    -- | The number is outside the maximum range of @-2^64-1 .. 2^64-1@.
-    --
-  | ScriptDataConstructorOutOfRange !Integer
+    ScriptDataConstructorOutOfRange !Integer
 
     -- | The length of a byte string metadatum value exceeds the maximum of
     -- 64 bytes.
@@ -236,10 +228,6 @@ data ScriptDataRangeError =
   deriving (Eq, Show)
 
 instance Error ScriptDataRangeError where
-  displayError (ScriptDataNumberOutOfRange n) =
-      "Number in script data value "
-        <> show n
-        <> " is outside the range -(2^64-1) .. 2^64-1."
   displayError (ScriptDataConstructorOutOfRange n) =
       "Constructor numbers in script data value "
         <> show n

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -151,6 +151,10 @@ prop_roundtrip_script_PlutusScriptV2_CBOR =
   roundtrip_CBOR (AsScript AsPlutusScriptV2)
                  (genScript (PlutusScriptLanguage PlutusScriptV2))
 
+prop_roundtrip_ScriptData_CBOR :: Property
+prop_roundtrip_ScriptData_CBOR =
+  roundtrip_CBOR AsScriptData genScriptData
+
 prop_roundtrip_UpdateProposal_CBOR :: Property
 prop_roundtrip_UpdateProposal_CBOR =
   roundtrip_CBOR AsUpdateProposal genUpdateProposal

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -128,6 +128,12 @@ prop_roundtrip_ScriptData =
     sData <- H.forAll genScriptData
     sData === fromAlonzoData (toAlonzoData sData)
 
+prop_roundtrip_ScriptData_JSON :: Property
+prop_roundtrip_ScriptData_JSON =
+  H.property $ do
+    sData <- H.forAll genScriptData
+    H.tripping sData scriptDataToJsonDetailedSchema scriptDataFromJsonDetailedSchema
+
 -- -----------------------------------------------------------------------------
 
 tests :: TestTree


### PR DESCRIPTION
- Adds roundtrips for `CBOR` and `JSON` `ScriptData` encoding
- Improves generator to generate large numbers (negative and outside of `Word64` bound)
- Fixes deserialisation of `ScriptData` containing large numbers that were failing a superfluous bounds check