### PR TITLE
Updated docker-compose.yml with latest versions & added CARDANO_NODE_SOCKET_PATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.34.1}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.4}
     environment:
       - NETWORK=${NETWORK:-mainnet}
       - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - NETWORK=${NETWORK:-mainnet}
       - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
     volumes:
-      - node-db:/data/db
+      - ./node-db:/data/db
       - node-ipc:/ipc
     logging:
       driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.34.1}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.35.4}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.34.1}
     environment:
       - NETWORK=${NETWORK:-mainnet}
+      - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
     volumes:
       - node-db:/data/db
       - node-ipc:/ipc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.33.0}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.34.1}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -15,7 +15,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.33.0}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.34.1}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:


### PR DESCRIPTION
Updated docker-compose.yml with latest versions(1.34.1) for cardano-node & cardano-submit-api, additionally added variable CARDANO_NODE_SOCKET_PATH, so we can run now:

`docker exec -ti cardano-node-iog_cardano-node_1 /usr/local/bin/cardano-cli query tip --testnet-magic 1097911063`