### PR TITLE
trace-dispatcher: seperate routing of metrics

### DIFF
--- a/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
+++ b/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
@@ -127,6 +127,17 @@ docIt :: MonadIO m
   => BackendConfig
   -> (LoggingContext, Either TraceControl a)
   -> m ()
+docIt EKGBackend (LoggingContext{},
+  Left (Document idx mdText mdMetrics (DocCollector docRef))) = do
+    liftIO $ modifyIORef docRef (\ docMap ->
+        Map.insert
+          idx
+          ((\e -> e { ldBackends  = EKGBackend : ldBackends e
+                    })
+            (case Map.lookup idx docMap of
+                          Just e  -> e
+                          Nothing -> seq mdText (seq mdMetrics (emptyLogDoc mdText mdMetrics))))
+          docMap)
 docIt backend (LoggingContext {..},
   Left (Document idx mdText mdMetrics (DocCollector docRef))) = do
     liftIO $ modifyIORef docRef (\ docMap ->

--- a/trace-dispatcher/src/Cardano/Logging/Formatter.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Formatter.hs
@@ -89,8 +89,8 @@ forwardFormatter application (Trace tr) = do
           T.traceWith tr ( nlc
                          , Right (FormattedForwarder to))
         (lc, Left ctrl) -> do
-          T.traceWith tr ( lc
-                         , Left ctrl)
+          T.traceWith tr (lc { lcNamespace = application : lcNamespace lc}
+                            , Left ctrl)
 
 -- | Format this trace for human readability
 -- The boolean value tells, if this representation is for the console and should be colored

--- a/trace-dispatcher/test/Cardano/Logging/Test/Oracles.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Oracles.hs
@@ -36,7 +36,6 @@ oracleMessages conf ScriptRes {..} =
                       && privacyForMessage msg == Public
           isCorrectForwarder = includedExactlyOnce msg srForwardRes == inForwarder
           inEKG = elem EKGBackend backends
-                      && fromEnum (severityForMessage msg) >= fromEnum filterSeverity
                       && not (null (asMetrics msg))
           isCorrectEKG = includedExactlyOnce msg srEkgRes == inEKG
           res = isCorrectStdout && isCorrectForwarder && isCorrectEKG


### PR DESCRIPTION
Metrics should be send in any case, and not be filtered by configuration.