### PR TITLE
Fix datum in tx and ref scripts

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -233,6 +233,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Typed.Orphans
                         Test.Cardano.Api.Typed.RawBytes
                         Test.Cardano.Api.Typed.Script
+                        Test.Cardano.Api.Typed.TxBody
                         Test.Cardano.Api.Typed.Value
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -44,6 +44,7 @@ module Gen.Cardano.Api.Typed
   , genStakeAddress
   , genTx
   , genTxBody
+  , genTxBodyContent
   , genLovelace
   , genValue
   , genValueDefault

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -619,6 +619,15 @@ scriptLanguageSupportedInEra era lang =
       (AlonzoEra, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InAlonzo
 
+      (BabbageEra, SimpleScriptLanguage SimpleScriptV1) ->
+        Just SimpleScriptV1InBabbage
+
+      (BabbageEra, SimpleScriptLanguage SimpleScriptV2) ->
+        Just SimpleScriptV2InBabbage
+
+      (BabbageEra, PlutusScriptLanguage PlutusScriptV1) ->
+        Just PlutusScriptV1InBabbage
+
       (BabbageEra, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InBabbage
 

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -1441,21 +1441,14 @@ fromShelleyScriptToReferenceScript sbe script =
    scriptInEraToRefScript $ fromShelleyBasedScript sbe script
 
 scriptInEraToRefScript :: ScriptInEra era -> ReferenceScript era
-scriptInEraToRefScript sIne@(ScriptInEra langInEra s) =
-  let sLang = languageOfScriptLanguageInEra langInEra
-      era = shelleyBasedToCardanoEra $ eraOfScriptInEra sIne
-  in case refInsScriptsAndInlineDatsSupportedInEra era of
-       Nothing -> ReferenceScriptNone
-       Just supp ->
-         case sLang of
-           PlutusScriptLanguage PlutusScriptV2 ->
-             ReferenceScript supp $ toScriptInAnyLang s
-           SimpleScriptLanguage SimpleScriptV1 ->
-             ReferenceScriptNone
-           SimpleScriptLanguage SimpleScriptV2 ->
-             ReferenceScriptNone
-           PlutusScriptLanguage PlutusScriptV1 ->
-             ReferenceScriptNone
+scriptInEraToRefScript sIne@(ScriptInEra _ s) =
+  case refInsScriptsAndInlineDatsSupportedInEra era of
+    Nothing -> ReferenceScriptNone
+    Just supp ->
+      -- Any script can be a reference script
+      ReferenceScript supp $ toScriptInAnyLang s
+ where
+  era = shelleyBasedToCardanoEra $ eraOfScriptInEra sIne
 
 -- Helpers
 

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -134,6 +134,7 @@ module Cardano.Api.Shelley
     ReferenceTxInsScriptsInlineDatumsSupportedInEra(..),
     refInsScriptsAndInlineDatsSupportedInEra,
     refScriptToShelleyScript,
+    fromShelleyScriptToReferenceScript,
 
     -- * Certificates
     Certificate (..),

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -2248,8 +2248,15 @@ fromLedgerTxOuts era body scriptdata =
       , txout <- toList (Alonzo.outputs' body) ]
 
     ShelleyBasedEraBabbage ->
-      map (fromBabbageTxOut ScriptDataInBabbageEra ReferenceTxInsScriptsInlineDatumsInBabbageEra  MultiAssetInBabbageEra)
-          (toList $ Babbage.outputs body)
+      [ fromBabbageTxOut
+          MultiAssetInBabbageEra
+          ScriptDataInBabbageEra
+          ReferenceTxInsScriptsInlineDatumsInBabbageEra
+          txdatums
+          txouts
+      | let txdatums = selectTxDatums scriptdata
+      , txouts <- toList (Babbage.outputs body)
+      ]
   where
     selectTxDatums  TxBodyNoScriptData                            = Map.empty
     selectTxDatums (TxBodyScriptData _ (Alonzo.TxDats' datums) _) = datums
@@ -2288,20 +2295,39 @@ fromBabbageTxOut
   => ShelleyLedgerEra era ~ ledgerera
   => Ledger.Crypto ledgerera ~ StandardCrypto
   => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
-  => ScriptDataSupportedInEra era
+  => MultiAssetSupportedInEra era
+  -> ScriptDataSupportedInEra era
   -> ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-  -> MultiAssetSupportedInEra era
+  -> Map (Alonzo.DataHash StandardCrypto)
+         (Alonzo.Data ledgerera)
   -> Babbage.TxOut ledgerera
   -> TxOut CtxTx era
-fromBabbageTxOut s i m (Babbage.TxOut addr val datum mRefScript) =
+fromBabbageTxOut multiAssetInEra scriptDataInEra inlineDatumsInEra txdatums txout =
    TxOut
      (fromShelleyAddr shelleyBasedEra addr)
-     (TxOutValue m (fromMaryValue val))
-     (fromBabbageTxOutDatum s i datum)
+     (TxOutValue multiAssetInEra (fromMaryValue val))
+     babbageTxOutDatum
      (case mRefScript of
        SNothing -> ReferenceScriptNone
        SJust rScript -> fromShelleyScriptToReferenceScript shelleyBasedEra rScript
      )
+ where
+   -- NOTE: This is different to 'fromBabbageTxOutDatum' as it may resolve
+   -- 'DatumHash' values using the datums included in the transaction.
+   babbageTxOutDatum =
+     case datum of
+       Babbage.NoDatum -> TxOutDatumNone
+       Babbage.DatumHash dh -> resolveDatumInTx dh
+       Babbage.Datum d ->
+         TxOutDatumInline inlineDatumsInEra $
+           binaryDataToScriptData inlineDatumsInEra d
+
+   resolveDatumInTx dh
+      | Just d <- Map.lookup dh txdatums
+                  = TxOutDatumInTx' scriptDataInEra (ScriptDataHash dh) (fromAlonzoData d)
+      | otherwise = TxOutDatumHash scriptDataInEra (ScriptDataHash dh)
+
+   (Babbage.TxOut addr val datum mRefScript) = txout
 
 fromLedgerTxTotalCollateral
   :: ShelleyBasedEra era

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Test.Cardano.Api.Typed.TxBody
@@ -6,13 +8,15 @@ module Test.Cardano.Api.Typed.TxBody
 
 import           Cardano.Prelude
 
-import           Hedgehog (Property, footnoteShow, failure, (===))
+import           Hedgehog (Property, failure, footnoteShow, (===))
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree)
 import           Test.Tasty.Hedgehog (testProperty)
 import           Test.Tasty.TH (testGroupGenerator)
 
 import           Cardano.Api
+import           Cardano.Api.Shelley
+import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import           Gen.Cardano.Api.Typed
 import           Test.Cardano.Api.Typed.Orphans ()
 
@@ -22,13 +26,28 @@ import           Test.Cardano.Api.Typed.Orphans ()
 prop_roundtrip_txbodycontent_txouts:: Property
 prop_roundtrip_txbodycontent_txouts =
   H.property $ do
-    content <- H.forAll $ genTxBodyContent BabbageEra
+    content <- H.forAll $ upgradeSimpleScripts ShelleyBasedEraBabbage <$> genTxBodyContent BabbageEra
     body <- case makeTransactionBody content of
       Left err -> footnoteShow err >> failure
       Right body -> pure body
+    footnoteShow body
     -- NOTE: This tests 'getTxBodyContent' and 'fromLedgerTxBody'
     let (TxBody content') = body
     txOuts content === txOuts content'
+ where
+  -- FIXME: This vvv is not the only case in which the propery is unstable
+  -- NOTE: SimpleV1 scripts are "interpreted" as SimpleV2 on the conversion
+  -- back. So to be able to re-use the genTxBodyContent generator, we "upgrade"
+  -- those scripts directly by doing the conversion once "a priori".
+  upgradeSimpleScripts :: ShelleyBasedEra era -> TxBodyContent BuildTx era -> TxBodyContent BuildTx era
+  upgradeSimpleScripts sbe content@TxBodyContent{txOuts} =
+    content{txOuts = map (upgradeSimpleRefScript sbe) txOuts }
+
+  upgradeSimpleRefScript sbe (TxOut address value datum refScript) =
+    TxOut address value datum $
+      case refScriptToShelleyScript (shelleyBasedToCardanoEra sbe) refScript of
+        SJust ledgerScript -> fromShelleyScriptToReferenceScript sbe ledgerScript
+        SNothing -> ReferenceScriptNone
 
 tests :: TestTree
 tests = $testGroupGenerator

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Api.Typed.TxBody
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import           Hedgehog (Property, footnoteShow, failure, (===))
+import qualified Hedgehog as H
+import           Test.Tasty (TestTree)
+import           Test.Tasty.Hedgehog (testProperty)
+import           Test.Tasty.TH (testGroupGenerator)
+
+import           Cardano.Api
+import           Gen.Cardano.Api.Typed
+import           Test.Cardano.Api.Typed.Orphans ()
+
+{- HLINT ignore "Use camelCase" -}
+
+-- | Check the txOuts in a TxBodyContent after a ledger roundtrip.
+prop_roundtrip_txbodycontent_txouts:: Property
+prop_roundtrip_txbodycontent_txouts =
+  H.property $ do
+    content <- H.forAll $ genTxBodyContent BabbageEra
+    body <- case makeTransactionBody content of
+      Left err -> footnoteShow err >> failure
+      Right body -> pure body
+    -- NOTE: This tests 'getTxBodyContent' and 'fromLedgerTxBody'
+    let (TxBody content') = body
+    txOuts content === txOuts content'
+
+tests :: TestTree
+tests = $testGroupGenerator

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -17,6 +17,7 @@ import qualified Test.Cardano.Api.Typed.JSON
 import qualified Test.Cardano.Api.Typed.Ord
 import qualified Test.Cardano.Api.Typed.RawBytes
 import qualified Test.Cardano.Api.Typed.Script
+import qualified Test.Cardano.Api.Typed.TxBody
 import qualified Test.Cardano.Api.Typed.Value
 
 main :: IO ()
@@ -41,5 +42,6 @@ tests =
     , Test.Cardano.Api.Typed.Ord.tests
     , Test.Cardano.Api.Typed.RawBytes.tests
     , Test.Cardano.Api.Typed.Script.tests
+    , Test.Cardano.Api.Typed.TxBody.tests
     , Test.Cardano.Api.Typed.Value.tests
     ]


### PR DESCRIPTION
:snowflake: Add a roundtrip property `TxBodyContent -> TxBody -> TxBodyContent`

This helped in fixing the :bug: and uncover the two additional gaps in the code. I'm not 100% happy with the current implementation of the property though! I needed to accept two exceptions to the general `===`:

  1. `SimpleScriptV1` reference scripts may become `SimpleScriptV2`
  2. A `TxOutDatumHash` + a matching `ScriptData` may become a `TxOutDatumTx`

:snowflake: Resolve datum hash + matching datum in transaction to `TxOutDatumInTx`, fixes #3866 

:snowflake: Add missing script languages to `scriptLanguageSupportedInEra` for `BabbageEra`

:snowflake: Allow scripts in any language as refeference scripts