### PR TITLE
Fix datum in tx and ref scripts

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -233,6 +233,7 @@ test-suite cardano-api-test
                         Test.Cardano.Api.Typed.Orphans
                         Test.Cardano.Api.Typed.RawBytes
                         Test.Cardano.Api.Typed.Script
+                        Test.Cardano.Api.Typed.TxBody
                         Test.Cardano.Api.Typed.Value
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -44,6 +44,7 @@ module Gen.Cardano.Api.Typed
   , genStakeAddress
   , genTx
   , genTxBody
+  , genTxBodyContent
   , genLovelace
   , genValue
   , genValueDefault

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -619,6 +619,15 @@ scriptLanguageSupportedInEra era lang =
       (AlonzoEra, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InAlonzo
 
+      (BabbageEra, SimpleScriptLanguage SimpleScriptV1) ->
+        Just SimpleScriptV1InBabbage
+
+      (BabbageEra, SimpleScriptLanguage SimpleScriptV2) ->
+        Just SimpleScriptV2InBabbage
+
+      (BabbageEra, PlutusScriptLanguage PlutusScriptV1) ->
+        Just PlutusScriptV1InBabbage
+
       (BabbageEra, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InBabbage
 

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -1441,21 +1441,14 @@ fromShelleyScriptToReferenceScript sbe script =
    scriptInEraToRefScript $ fromShelleyBasedScript sbe script
 
 scriptInEraToRefScript :: ScriptInEra era -> ReferenceScript era
-scriptInEraToRefScript sIne@(ScriptInEra langInEra s) =
-  let sLang = languageOfScriptLanguageInEra langInEra
-      era = shelleyBasedToCardanoEra $ eraOfScriptInEra sIne
-  in case refInsScriptsAndInlineDatsSupportedInEra era of
-       Nothing -> ReferenceScriptNone
-       Just supp ->
-         case sLang of
-           PlutusScriptLanguage PlutusScriptV2 ->
-             ReferenceScript supp $ toScriptInAnyLang s
-           SimpleScriptLanguage SimpleScriptV1 ->
-             ReferenceScriptNone
-           SimpleScriptLanguage SimpleScriptV2 ->
-             ReferenceScriptNone
-           PlutusScriptLanguage PlutusScriptV1 ->
-             ReferenceScriptNone
+scriptInEraToRefScript sIne@(ScriptInEra _ s) =
+  case refInsScriptsAndInlineDatsSupportedInEra era of
+    Nothing -> ReferenceScriptNone
+    Just supp ->
+      -- Any script can be a reference script
+      ReferenceScript supp $ toScriptInAnyLang s
+ where
+  era = shelleyBasedToCardanoEra $ eraOfScriptInEra sIne
 
 -- Helpers
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Api.Typed.TxBody
+  ( tests
+  ) where
+
+import           Cardano.Prelude
+
+import           Hedgehog (Property, annotateShow, failure, (===), MonadTest)
+import qualified Hedgehog as H
+import           Test.Tasty (TestTree)
+import           Test.Tasty.Hedgehog (testProperty)
+import           Test.Tasty.TH (testGroupGenerator)
+
+import           Cardano.Api
+import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleyScript)
+import           Data.Type.Equality (TestEquality (testEquality))
+import           Gen.Cardano.Api.Typed
+import           Test.Cardano.Api.Typed.Orphans ()
+
+{- HLINT ignore "Use camelCase" -}
+
+-- | Check the txOuts in a TxBodyContent after a ledger roundtrip.
+prop_roundtrip_txbodycontent_txouts:: Property
+prop_roundtrip_txbodycontent_txouts =
+  H.property $ do
+    content <- H.forAll $ genTxBodyContent BabbageEra
+    -- Create the ledger body & auxiliaries
+    body <- case makeTransactionBody content of
+      Left err -> annotateShow err >> failure
+      Right body -> pure body
+    annotateShow body
+    -- Convert ledger body back via 'getTxBodyContent' and 'fromLedgerTxBody'
+    let (TxBody content') = body
+    matchTxOuts (txOuts content) (txOuts content')
+ where
+  matchTxOuts :: MonadTest m => [TxOut CtxTx BabbageEra] -> [TxOut CtxTx BabbageEra] -> m ()
+  matchTxOuts as bs =
+    mapM_ matchTxOut $ zip as bs
+
+  matchTxOut :: MonadTest m => (TxOut CtxTx BabbageEra, TxOut CtxTx BabbageEra) -> m ()
+  matchTxOut (a, b) = do
+    let TxOut aAddress aValue aDatum aRefScript = a
+    let TxOut bAddress bValue bDatum bRefScript = b
+    aAddress === bAddress
+    aValue === bValue
+    matchDatum (aDatum, bDatum)
+    matchRefScript (aRefScript, bRefScript)
+
+  -- NOTE: We accept TxOutDatumInTx instead of TxOutDatumHash as it may be
+  -- correctly resolved given a datum matching the hash was generated.
+  matchDatum :: MonadTest m => (TxOutDatum CtxTx era, TxOutDatum CtxTx era) -> m ()
+  matchDatum = \case
+    (TxOutDatumHash _ dh, TxOutDatumInTx _ d) ->
+      dh === hashScriptData d
+    (a, b) ->
+      a === b
+
+  -- NOTE: After Allegra, all eras interpret SimpleScriptV1 as SimpleScriptV2
+  -- because V2 is a superset of V1. So we accept that as a valid conversion.
+  matchRefScript :: MonadTest m => (ReferenceScript BabbageEra, ReferenceScript BabbageEra) -> m ()
+  matchRefScript (a, b)
+    | isSimpleScriptV1 a && isSimpleScriptV2 b =
+      refScriptToShelleyScript BabbageEra a === refScriptToShelleyScript BabbageEra b
+    | otherwise =
+      a === b
+
+  isSimpleScriptV1 :: ReferenceScript era -> Bool
+  isSimpleScriptV1 = isLang (SimpleScriptLanguage SimpleScriptV1)
+
+  isSimpleScriptV2 :: ReferenceScript era -> Bool
+  isSimpleScriptV2 = isLang (SimpleScriptLanguage SimpleScriptV2)
+
+  isLang :: ScriptLanguage a -> ReferenceScript era -> Bool
+  isLang expected = \case
+    (ReferenceScript _ (ScriptInAnyLang actual _)) -> isJust $ testEquality expected actual
+    _ -> False
+
+tests :: TestTree
+tests = $testGroupGenerator

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -17,6 +17,7 @@ import qualified Test.Cardano.Api.Typed.JSON
 import qualified Test.Cardano.Api.Typed.Ord
 import qualified Test.Cardano.Api.Typed.RawBytes
 import qualified Test.Cardano.Api.Typed.Script
+import qualified Test.Cardano.Api.Typed.TxBody
 import qualified Test.Cardano.Api.Typed.Value
 
 main :: IO ()
@@ -41,5 +42,6 @@ tests =
     , Test.Cardano.Api.Typed.Ord.tests
     , Test.Cardano.Api.Typed.RawBytes.tests
     , Test.Cardano.Api.Typed.Script.tests
+    , Test.Cardano.Api.Typed.TxBody.tests
     , Test.Cardano.Api.Typed.Value.tests
     ]


### PR DESCRIPTION
(Couldn't reopen https://github.com/input-output-hk/cardano-node/pull/3881, so created this one)

:snowflake: Add a roundtrip property `TxBodyContent -> TxBody -> TxBodyContent`

This helped in fixing the :bug: and uncover the two additional gaps in the code. I'm not 100% happy with the current implementation of the property though! I needed to accept two exceptions to the general `===`:

  1. `SimpleScriptV1` reference scripts may become `SimpleScriptV2`
  2. A `TxOutDatumHash` + a matching `ScriptData` may become a `TxOutDatumTx`

:snowflake: Resolve datum hash + matching datum in transaction to `TxOutDatumInTx`, fixes #3866 

:snowflake: Add missing script languages to `scriptLanguageSupportedInEra` for `BabbageEra`

:snowflake: Allow scripts in any language as refeference scripts