### PR TITLE
Follow up for new consensus tracers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -257,8 +257,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea202b7b21983140d1944ccfde8750b891b59699
-  --sha256: 0bixx0b61sjzls7hzwjlgmvl0yk1ckd40cfazda8b3smqvxfrphq
+  tag: 73e0865a5e7bbe765539732f120661f48d629ca3
+  --sha256: 1g55hwv87ch9dfk1pcf6ng601rc4hfy2r7krqsy31kz4w0xm0xy0
   subdir:
     monoidal-synchronisation
     network-mux

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -16,7 +16,6 @@ module Cardano.Node.Tracing.Render
   , renderPointForDetails
   , renderRealPoint
   , renderRealPointAsPhrase
-  , renderEnclosed
   , renderSlotNo
   , renderTip
   , renderTipForDetails
@@ -43,7 +42,6 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkN
 import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, StandardHash, Tip,
                    getTipPoint)
-import Ouroboros.Consensus.Util.Enclose (Enclosing'(FallingEdgeWith, RisingEdge))
 
 condenseT :: Condense a => a -> Text
 condenseT = Text.pack . condense
@@ -96,10 +94,6 @@ renderRealPointAsPhrase (RealPoint slotNo headerHash) =
   renderHeaderHash (Proxy @blk) headerHash
     <> " at slot "
     <> renderSlotNo slotNo
-
-renderEnclosed :: (t -> Text) -> Enclosing' t -> Text
-renderEnclosed _ RisingEdge = "RisingEdge"
-renderEnclosed rdr (FallingEdgeWith t) = "FallingEdgeWith " <> rdr t
 
 renderPointForDetails
   :: forall blk.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -297,7 +297,7 @@ instance ( LogFormatting (Header blk)
         RisingEdge ->
           "About to add block to queue: " <> renderRealPointAsPhrase pt
         FallingEdgeWith sz ->
-          "Block added to queue: " <> renderRealPointAsPhrase pt <> " queue size " <> condenseT sz
+          "Block added to queue: " <> renderRealPointAsPhrase pt <> ", queue size " <> condenseT sz
   forHuman (ChainDB.PoppedBlockFromQueue edgePt) =
       case edgePt of
         RisingEdge ->
@@ -323,8 +323,8 @@ instance ( LogFormatting (Header blk)
   forHuman (ChainDB.AddBlockValidation ev') = forHuman ev'
   forHuman (ChainDB.AddedBlockToVolatileDB pt _ _ enclosing) =
       case enclosing of
-        RisingEdge         -> "Chain about to add block " <> renderRealPointAsPhrase pt
-        FallingEdgeWith () -> "Chain added block " <> renderRealPointAsPhrase pt
+        RisingEdge  -> "Chain about to add block " <> renderRealPointAsPhrase pt
+        FallingEdge -> "Chain added block " <> renderRealPointAsPhrase pt
   forHuman (ChainDB.ChainSelectionForFutureBlock pt) =
       "Chain selection run for block previously from future: " <> renderRealPointAsPhrase pt
   forHuman (ChainDB.PipeliningEvent ev') = forHuman ev'
@@ -341,10 +341,14 @@ instance ( LogFormatting (Header blk)
   forMachine dtal (ChainDB.AddedBlockToQueue pt edgeSz) =
       mconcat [ "kind" .= String "AddedBlockToQueue"
                , "block" .= forMachine dtal pt
-               , case edgeSz of RisingEdge -> "risingEdge" .= True; FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
+               , case edgeSz of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
   forMachine dtal (ChainDB.PoppedBlockFromQueue edgePt) =
       mconcat [ "kind" .= String "TraceAddBlockEvent.PoppedBlockFromQueue"
-               , case edgePt of RisingEdge -> "risingEdge" .= True; FallingEdgeWith pt -> "block" .= forMachine dtal pt ]
+               , case edgePt of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith pt -> "block" .= forMachine dtal pt ]
   forMachine dtal (ChainDB.BlockInTheFuture pt slot) =
       mconcat [ "kind" .= String "BlockInTheFuture"
                , "block" .= forMachine dtal pt
@@ -417,8 +421,8 @@ instance ( ConvertRawHash (Header blk)
          ) => LogFormatting (ChainDB.TracePipeliningEvent blk) where
   forHuman (ChainDB.SetTentativeHeader hdr enclosing) =
       case enclosing of
-        RisingEdge         -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
-        FallingEdgeWith () -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+        RisingEdge  -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+        FallingEdge -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
   forHuman (ChainDB.TrapTentativeHeader hdr) =
       "Discovered trap tentative header " <> renderPointAsPhrase (blockPoint hdr)
   forHuman (ChainDB.OutdatedTentativeHeader hdr) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -263,8 +263,8 @@ docChainSyncClientEvent' = Documented [
 severityChainSyncServerEvent :: TraceChainSyncServerEvent blk -> SeverityS
 severityChainSyncServerEvent (TraceChainSyncServerUpdate _tip _upd _blocking enclosing) =
     case enclosing of
-      RisingEdge         -> Info
-      FallingEdgeWith () -> Debug
+      RisingEdge  -> Info
+      FallingEdge -> Debug
 
 namesForChainSyncServerEvent :: TraceChainSyncServerEvent blk -> [Text]
 namesForChainSyncServerEvent ev =
@@ -303,8 +303,6 @@ instance ConvertRawHash blk
                ]
                <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 
-  asMetrics (TraceChainSyncServerUpdate _tip (AddBlock _hdr) _blocking FallingEdge) =
-      [CounterM "cardano.node.chainSync.rollForward" Nothing]
   asMetrics _ = []
 
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -271,92 +271,54 @@ namesForChainSyncServerEvent ev =
     "ChainSyncServerEvent" : namesForChainSyncServerEvent' ev
 
 namesForChainSyncServerEvent' :: TraceChainSyncServerEvent blk -> [Text]
-namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update NonBlocking _enclosing) =
-      ["ServerRead"]
-namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update Blocking _enclosing) =
-      ["ServerReadBlocked"]
+namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update _blocking _enclosing) =
+      ["Update"]
 
 instance ConvertRawHash blk
       => LogFormatting (TraceChainSyncServerEvent blk) where
-  forMachine _dtal (TraceChainSyncServerUpdate tip (AddBlock _hdr) NonBlocking enclosing) =
+  forMachine dtal (TraceChainSyncServerUpdate tip update blocking enclosing) =
       mconcat $
-               [ "kind" .= String "ChainSyncServerRead.AddBlock"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (RollBack _pt) NonBlocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerRead.RollBack"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (AddBlock _pt) Blocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerReadBlocked.AddBlock"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (RollBack _pt) Blocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerReadBlocked.RollBack"
-               , tipToObject tip
+               [ "kind" .= String "ChainSyncServer.Update"
+               , "tip" .= tipToObject tip
+               , case update of
+                   AddBlock pt -> "addBlock" .= renderPointForDetails dtal pt
+                   RollBack pt -> "rollBackTo" .= renderPointForDetails dtal pt
+               , "blockingRead" .= case blocking of Blocking -> True; NonBlocking -> False
                ]
                <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 
+  asMetrics (TraceChainSyncServerUpdate _tip (AddBlock _pt) _blocking FallingEdge) =
+      [CounterM "cardano.node.chainSync.rollForward" Nothing]
   asMetrics _ = []
 
 
 docChainSyncServerEventHeader :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventHeader =
     addDocumentedNamespace
-      ["ChainSyncServerEvent", "ServerRead"]
+      ["ChainSyncServerEvent", "Update"]
       docChainSyncServerEventHeader'
 
 -- | Metrics documented here, but implemented specially
 docChainSyncServerEventHeader' :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventHeader' = Documented [
     DocMsg
-      ["ServerRead"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
+      ["Update"]
+      [("cardano.node.metrics.served.header", "A counter triggered only on header event")]
       "A server read has occurred, either for an add block or a rollback"
-    , DocMsg
-       ["ServerReadBlocked"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      "A server read has blocked, either for an add block or a rollback"
-    , DocMsg
-      ["RollForward"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      "Roll forward to the given point."
-    , DocMsg
-      ["RollBackward"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      ""
   ]
 
 docChainSyncServerEventBlock :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventBlock =
     addDocumentedNamespace
-      ["ChainSyncServerEvent", "ServerRead"]
+      ["ChainSyncServerEvent", "Update"]
       docChainSyncServerEventBlock'
 
 docChainSyncServerEventBlock' :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventBlock' = Documented [
     DocMsg
-      ["ServerRead"]
+      ["Update"]
       []
       "A server read has occurred, either for an add block or a rollback"
-    , DocMsg
-       ["ServerReadBlocked"]
-      []
-      "A server read has blocked, either for an add block or a rollback"
-    , DocMsg
-      ["RollForward"]
-      []
-      "Roll forward to the given point."
-    , DocMsg
-      ["RollBackward"]
-      []
-      ""
   ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1250,29 +1250,15 @@ instance (ConvertRawHash blk, LedgerSupportsProtocol blk)
 
 instance ConvertRawHash blk
       => ToObject (TraceChainSyncServerEvent blk) where
-  toObject _verb ev = case ev of
-    TraceChainSyncServerUpdate tip AddBlock{} NonBlocking enclosing ->
+  toObject verb ev = case ev of
+    TraceChainSyncServerUpdate tip update blocking enclosing ->
       mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip RollBack{} NonBlocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.RollBack"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip AddBlock{} Blocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip RollBack{} Blocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.RollBack"
-        , tipToObject tip
+        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerUpdate"
+        , "tip" .= tipToObject tip
+        , case update of
+            AddBlock pt -> "addBlock" .= renderPointForVerbosity verb pt
+            RollBack pt -> "rollBackTo" .= renderPointForVerbosity verb pt
+        , "blockingRead" .= case blocking of Blocking -> True; NonBlocking -> False
         ]
         <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -66,7 +66,7 @@ import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.Enclose (Enclosing' (..))
+import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -502,14 +502,14 @@ instance ( ConvertRawHash blk
               "Pushing ledger state for block " <> renderRealPointAsPhrase curr <> ". Progress: " <>
               showProgressT (fromIntegral atDiff) (fromIntegral toDiff) <> "%"
         ChainDB.AddedBlockToVolatileDB pt _ _ enclosing -> case enclosing of
-          RisingEdge         -> "Chain about to add block " <> renderRealPointAsPhrase pt
-          FallingEdgeWith () -> "Chain added block " <> renderRealPointAsPhrase pt
+          RisingEdge  -> "Chain about to add block " <> renderRealPointAsPhrase pt
+          FallingEdge -> "Chain added block " <> renderRealPointAsPhrase pt
         ChainDB.ChainSelectionForFutureBlock pt ->
           "Chain selection run for block previously from future: " <> renderRealPointAsPhrase pt
         ChainDB.PipeliningEvent ev' -> case ev' of
           ChainDB.SetTentativeHeader hdr enclosing -> case enclosing of
-            RisingEdge         -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
-            FallingEdgeWith () -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+            RisingEdge  -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+            FallingEdge -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
           ChainDB.TrapTentativeHeader hdr -> "Discovered trap tentative header " <> renderPointAsPhrase (blockPoint hdr)
           ChainDB.OutdatedTentativeHeader hdr -> "Tentative header is now outdated" <> renderPointAsPhrase (blockPoint hdr)
 
@@ -836,10 +836,14 @@ instance ( ConvertRawHash blk
     ChainDB.AddedBlockToQueue pt edgeSz ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.AddedBlockToQueue"
                , "block" .= toObject verb pt
-               , case edgeSz of RisingEdge -> "risingEdge" .= True; FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
+               , case edgeSz of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
     ChainDB.PoppedBlockFromQueue edgePt ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.PoppedBlockFromQueue"
-               , case edgePt of RisingEdge -> "risingEdge" .= True; FallingEdgeWith pt -> "block" .= toObject verb pt ]
+               , case edgePt of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith pt -> "block" .= toObject verb pt ]
     ChainDB.BlockInTheFuture pt slot ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
                , "block" .= toObject verb pt

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -610,7 +610,7 @@ sendEKGDirectDouble ekgDirect name val = do
 --------------------------------------------------------------------------------
 
 isRollForward :: TraceChainSyncServerEvent blk -> Bool
-isRollForward (TraceChainSyncServerUpdate _tip (AddBlock _hdr) _blocking FallingEdge) = True
+isRollForward (TraceChainSyncServerUpdate _tip (AddBlock _pt) _blocking FallingEdge) = True
 isRollForward _ = False
 
 mkConsensusTracers


### PR DESCRIPTION
Closes [CAD-4312](https://input-output.atlassian.net/browse/CAD-4312).

Depends on https://github.com/input-output-hk/ouroboros-network/pull/3766

The main change is that the ChainSync server messages are now formatted differently, see e.g. this example output:

```json
{
  "app": [],
  "at": "2022-05-23T19:42:21.01Z",
  "data": {
    "addBlock": "71e2a42387752e21ecc5b7a612891c09080b6f386554f910602b1e8c7f9a9929@4",
    "blockingRead": true,
    "kind": "ChainSyncServerEvent.TraceChainSyncServerUpdate",
    "risingEdge": true,
    "tip": {
      "block": "f299119bb639c5df14e8f72b5b21580062c731b3b30ab4532c9c8dc2239ccc02",
      "blockNo": 4,
      "slot": 3
    }
  },
  "env": "1.33.0:9da8e",
  "host": "sewagema",
  "loc": null,
  "msg": "",
  "ns": [
    "cardano.node.ChainSyncHeaderServer"
  ],
  "pid": "3273648",
  "sev": "Info",
  "thread": "71"
}
{
  "app": [],
  "at": "2022-05-23T19:42:21.01Z",
  "data": {
    "addBlock": "71e2a42387752e21ecc5b7a612891c09080b6f386554f910602b1e8c7f9a9929@4",
    "blockingRead": true,
    "kind": "ChainSyncServerEvent.TraceChainSyncServerUpdate",
    "tip": {
      "block": "f299119bb639c5df14e8f72b5b21580062c731b3b30ab4532c9c8dc2239ccc02",
      "blockNo": 4,
      "slot": 3
    }
  },
  "env": "1.33.0:9da8e",
  "host": "sewagema",
  "loc": null,
  "msg": "",
  "ns": [
    "cardano.node.ChainSyncHeaderServer"
  ],
  "pid": "3273648",
  "sev": "Info",
  "thread": "71"
}
```
In particular, note the `"risingEdge": true` in the first message.