### PR TITLE
Install a dummy SIGHUP handler for non p2p mode

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -423,6 +423,14 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
               }
       DisabledP2PMode -> do
+#ifdef UNIX
+        _ <- Signals.installHandler
+              Signals.sigHUP
+              (Signals.Catch $ do
+                traceWith (startupTracer tracers) NetworkConfigUpdateUnsupported
+              )
+              Nothing
+#endif
         eitherTopology <- TopologyNonP2P.readTopologyFile nc
         nt <- either (\err -> panic $ "Cardano.Node.Run.handleSimpleNodeNonP2P.readTopologyFile: " <> err) pure eitherTopology
         let (ipProducerAddrs, dnsProducerAddrs) = producerAddressesNonP2P nt

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -79,6 +79,10 @@ data StartupTrace blk =
   --
   | NetworkConfigUpdate
 
+  -- | Re-configuration of network config is not supported.
+  --
+  | NetworkConfigUpdateUnsupported
+
   -- | Log network configuration update error.
   --
   | NetworkConfigUpdateError Text

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -130,6 +130,7 @@ namesStartupInfo = \case
   StartupSocketConfigError {}               -> ["StartupSocketConfigError"]
   StartupDBValidation {}                    -> ["StartupDBValidation"]
   NetworkConfigUpdate {}                    -> ["NetworkConfigUpdate"]
+  NetworkConfigUpdateUnsupported            -> ["NetworkConfigUpdateUnsupported"]
   NetworkConfigUpdateError {}               -> ["NetworkConfigUpdateError"]
   NetworkConfig {}                          -> ["NetworkConfig"]
   P2PWarning {}                             -> ["P2PWarning"]
@@ -198,7 +199,10 @@ instance ( Show (BlockNodeToNodeVersion blk)
                , "message" .= String "start db validation" ]
   forMachine _dtal NetworkConfigUpdate =
       mconcat [ "kind" .= String "NetworkConfigUpdate"
-               , "message" .= String "ntework configuration update" ]
+               , "message" .= String "network configuration update" ]
+  forMachine _dtal NetworkConfigUpdateUnsupported =
+      mconcat [ "kind" .= String "NetworkConfigUpdate"
+              , "message" .= String "network topology reconfiguration is not supported in non-p2p mode" ]
   forMachine _dtal (NetworkConfigUpdateError err) =
       mconcat [ "kind" .= String "NetworkConfigUpdateError"
                , "error" .= String err ]
@@ -299,6 +303,8 @@ ppStartupInfoTrace (StartupSocketConfigError err) =
 ppStartupInfoTrace StartupDBValidation = "Performing DB validation"
 
 ppStartupInfoTrace NetworkConfigUpdate = "Performing topology configuration update"
+ppStartupInfoTrace NetworkConfigUpdateUnsupported =
+  "Network topology reconfiguration is not supported in non-p2p mode"
 ppStartupInfoTrace (NetworkConfigUpdateError err) = err
 ppStartupInfoTrace (NetworkConfig localRoots publicRoots useLedgerAfter) =
     pack

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -27,6 +27,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 instance HasSeverityAnnotation (StartupTrace blk) where
     getSeverityAnnotation (StartupSocketConfigError _) = Error
     getSeverityAnnotation (NetworkConfigUpdateError _) = Error
+    getSeverityAnnotation NetworkConfigUpdateUnsupported = Warning
     getSeverityAnnotation P2PWarning = Warning
     getSeverityAnnotation P2PWarningDevelopementNetworkProtocols = Warning
     getSeverityAnnotation WarningDevelopmentNetworkProtocols {} = Warning


### PR DESCRIPTION
When sending SIGHUP handler, p2p will reload the configuration, while
non-p2p will exit.  Instead of that we install a dummy handler, which
logs that topology reloading for non-p2p is not supported, which
prevents haskell runtime to use the default signal handler (which forces
the process to exit).

Fixes #3872.
