### PR TITLE
support the babbage era in the API function cddlTypeToEra

### DIFF
--- a/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
@@ -290,15 +290,18 @@ cddlTypeToEra "Witnessed Tx ShelleyEra" = return $ AnyCardanoEra ShelleyEra
 cddlTypeToEra "Witnessed Tx AllegraEra" = return $ AnyCardanoEra AllegraEra
 cddlTypeToEra "Witnessed Tx MaryEra" = return $ AnyCardanoEra MaryEra
 cddlTypeToEra "Witnessed Tx AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra "Witnessed Tx BabbageEra" = return $ AnyCardanoEra BabbageEra
 cddlTypeToEra "Unwitnessed Tx ByronEra" = return $ AnyCardanoEra ByronEra
 cddlTypeToEra "Unwitnessed Tx ShelleyEra" = return $ AnyCardanoEra ShelleyEra
 cddlTypeToEra "Unwitnessed Tx AllegraEra" = return $ AnyCardanoEra AllegraEra
 cddlTypeToEra "Unwitnessed Tx MaryEra" = return $ AnyCardanoEra MaryEra
 cddlTypeToEra "Unwitnessed Tx AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra "Unwitnessed Tx BabbageEra" = return $ AnyCardanoEra BabbageEra
 cddlTypeToEra "TxWitness ShelleyEra" = return $ AnyCardanoEra ShelleyEra
 cddlTypeToEra "TxWitness AllegraEra" = return $ AnyCardanoEra AllegraEra
 cddlTypeToEra "TxWitness MaryEra" = return $ AnyCardanoEra MaryEra
 cddlTypeToEra "TxWitness AlonzoEra" = return $ AnyCardanoEra AlonzoEra
+cddlTypeToEra "TxWitness BabbageEra" = return $ AnyCardanoEra BabbageEra
 cddlTypeToEra unknownCddlType = Left $ TextEnvelopeCddlErrUnknownType unknownCddlType
 
 readFileTextEnvelopeCddlAnyOf

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -110,7 +110,6 @@ library
                       , cardano-crypto-wrapper
                       , cardano-data
                       , cardano-ledger-alonzo
-                      , cardano-ledger-babbage
                       , cardano-ledger-byron
                       , cardano-ledger-core
                       , cardano-ledger-shelley-ma

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -143,7 +143,6 @@ library
                       , cardano-protocol-tpraos
                       , cardano-slotting
                       , cborg >= 0.2.4 && < 0.3
-                      , vector-map
                       , contra-tracer
                       , containers
                       , directory


### PR DESCRIPTION
This allows us to sign babbage era transaction bodies in the CDDL format. I've also removed two unused packages, `cardano-ledger-babbage` in the CLI, and `vector-map` in node.

resolves #3899
