### PR TITLE
Updated iohkNix to latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4521,11 +4521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649070135,
-        "narHash": "sha256-UFKqcOSdPWk3TYUCPHF22p1zf7aXQpCmmgf7UMg7fWA=",
+        "lastModified": 1653579289,
+        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "cecab9c71d1064f05f1615eead56ac0b9196bc20",
+        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This bumps iohkNix version to include this recent patch: https://github.com/input-output-hk/iohk-nix/commit/edb2d2df2ebe42bbdf03a0711115cf6213c9d366