### PR TITLE
Update deps for Ledger, Consensus, et al

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/PlutusExample.hs
@@ -81,8 +81,8 @@ preExecuteScript protocolParameters (PlutusScript _ (PlutusScriptSerialised scri
     Just (CostModel x) -> Right x
     Nothing -> Left "costModel unavailable"
   evaluationContext <- case Plutus.mkEvaluationContext costModel of
-    Just x -> Right x
-    Nothing -> Left "evaluationContext unavailable"
+    Right x  -> Right x
+    Left err -> Left $ "evaluationContext unavailable: " <> show err
   let
     apiVersion = protocolParamProtocolVersion protocolParameters
     protocolVersion = Plutus.ProtocolVersion (fromIntegral $ fst apiVersion) (fromIntegral $ snd apiVersion)

--- a/cabal.project
+++ b/cabal.project
@@ -194,8 +194,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: c415253fff9a5ce9d7575230fc9098bcfee97653
-  --sha256: 1m4hq8yxcm7ny5vjzqkrl9qn9zmpr8c9xs0c98ix9hm9xd79fapc
+  tag: f31c29add34c1d81938bdb505e568ba3b1115d8d
+  --sha256: 090n2pm1p7y793n4q2368amlmk1vsbnkknb6fmgv0xrriyn5fx4g
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -239,8 +239,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: eb7854d1337637b8672af1227b276aa33a658f47
-  --sha256: 1ll81hlhkhj96f5v6lswjkq2h8f7zcmdrj2azqhi4ylzafn026r3
+  tag: 066f7002aac5a0efc20e49643fea45454f226caa
+  --sha256: 0s6x4in11k5ba7nl7la896g28sznf9185xlqg9c604jqz58vj9nj
   subdir:
     contra-tracer
     iohk-monitoring
@@ -260,8 +260,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ea202b7b21983140d1944ccfde8750b891b59699
-  --sha256: 0bixx0b61sjzls7hzwjlgmvl0yk1ckd40cfazda8b3smqvxfrphq
+  tag: c254d02b9de67cabc71d26e3f27a2a3d13538d21
+  --sha256: 083kr0zaddgmq71j4am7kb93cdi05sjv7rqslzmdfp73mkxi4sfn
   subdir:
     monoidal-synchronisation
     network-mux
@@ -277,8 +277,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/io-sim
-  tag: 606de33fa2f467d108fb1efb86daeb3348bf34e3
-  --sha256: 048djqfdkzrbmdz670knbkjy12wddpvsmhm4x5yldg3w9lwqi1yx
+  tag: f4183f274d88d0ad15817c7052df3a6a8b40e6dc
+  --sha256: 0vb2pd9hl89v2y5hrhrsm69yx0jf98vppjmfncj2fraxr3p3lldw
   subdir:
     io-classes
     io-sim
@@ -287,8 +287,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/typed-protocols
-  tag: 91c3fba44d68439df207796171cd6f867354b76b
-  --sha256: 1h1nh10859kd7j8bb55y577jfdp42aqpppx8fn0pm6fra5748a50
+  tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
+  --sha256: 1lr97b2z7l0rpsmmz92rsv27qzd5vavz10cf7n25svya4kkiysp5
   subdir:
     typed-protocols
     typed-protocols-cborg
@@ -297,8 +297,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: fec94223a985e34d3b270460c8f150002f41b85b
-  --sha256: 1mwknikvbpv9lj43c3ya24v7wpcbpcsrk0fnh6knpi7ds4rmj9j0
+  tag: d24a7540e4659b57ce2ab25dadb968991e232191
+  --sha256: 15glaghkaa5kh1ayfkw2jahkqq3955kmfzplmb210gvrlnlghlaa
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -139,6 +139,7 @@ library
                       , parsec
                       , plutus-ledger-api
                       , prettyprinter
+                      , prettyprinter-configurable
                       , scientific
                       , serialise
                       , small-steps

--- a/cardano-api/gen/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Gen/Cardano/Api.hs
@@ -26,6 +26,7 @@ import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Coin as Ledger
 import           Cardano.Ledger.Shelley.Metadata (Metadata (..), Metadatum (..))
 
+
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Internal.Range as Range

--- a/cardano-api/gen/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Gen/Cardano/Api.hs
@@ -92,7 +92,7 @@ genCostModels = do
   CostModel cModel <- genCostModel
   lang <- genLanguage
   case Alonzo.mkCostModel lang cModel of
-    Left err -> panic . Text.pack $ "genCostModels: " <> err
+    Left err -> panic . Text.pack $ "genCostModels: " <> show err
     Right alonzoCostModel ->
       Alonzo.CostModels . conv <$> Gen.list (Range.linear 1 3) (return alonzoCostModel)
  where

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -813,7 +813,7 @@ genCostModel = case Plutus.defaultCostModelParams of
       eCostModel <- Alonzo.mkCostModel <$> genPlutusLanguage
                                        <*> mapM (const $ Gen.integral (Range.linear 0 5000)) dcm
       case eCostModel of
-        Left err -> panic $ Text.pack $ "genCostModel: " <> err
+        Left err -> panic $ Text.pack $ "genCostModel: " <> show err
         Right cModel -> return . CostModel $ Alonzo.getCostModelParams cModel
 
 genPlutusLanguage :: Gen Language

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -526,11 +526,8 @@ evaluateTransactionExecutionUnits _eraInMode systemstart history pparams utxo tx
              (toLedgerEpochInfo history)
              systemstart
              cModelArray
-        of Left  err   -> Left err
-           Right exmapResult ->
-             case exmapResult of
-               Left err -> Left (TransactionValidityBasicFailure err)
-               Right exmap -> Right (fromLedgerScriptExUnitsMap exmap)
+        of Left err -> Left (TransactionValidityBasicFailure err)
+           Right exmap -> Right (fromLedgerScriptExUnitsMap exmap)
 
     evalBabbage :: forall ledgerera.
                   ShelleyLedgerEra era ~ ledgerera
@@ -551,16 +548,12 @@ evaluateTransactionExecutionUnits _eraInMode systemstart history pparams utxo tx
              (toLedgerEpochInfo history)
              systemstart
              costModelsArray
-        of Left  err   -> Left err
-           Right exmapResult ->
-             case exmapResult of
-               Left err -> Left (TransactionValidityBasicFailure err)
-               Right exmap -> Right (fromLedgerScriptExUnitsMap exmap)
+        of Left err    -> Left (TransactionValidityBasicFailure err)
+           Right exmap -> Right (fromLedgerScriptExUnitsMap exmap)
 
-    toLedgerEpochInfo :: EraHistory mode
-                      -> EpochInfo (Either TransactionValidityError)
+    toLedgerEpochInfo :: EraHistory mode -> EpochInfo (Either Text.Text)
     toLedgerEpochInfo (EraHistory _ interpreter) =
-        hoistEpochInfo (first TransactionValidityIntervalError . runExcept) $
+        hoistEpochInfo (first (Text.pack . show) . runExcept) $
           Consensus.interpreterToEpochInfo interpreter
 
     toAlonzoCostModelsArray

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -21,6 +21,7 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import           Data.BiMap (BiMap (..), Bimap)
 import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Short as Short
 import qualified Data.Map.Strict as Map
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -74,7 +75,7 @@ instance ToJSON (Mary.Value era) where
 instance ToJSONKey Mary.AssetName where
   toJSONKey = toJSONKeyText render
     where
-      render = Text.decodeLatin1 . B16.encode . Mary.assetName
+      render = Text.decodeLatin1 . B16.encode . Short.fromShort . Mary.assetName
 
 instance ToJSON (Mary.PolicyID era) where
   toJSON (Mary.PolicyID (Shelley.ScriptHash h)) = Aeson.String (hashToText h)
@@ -85,7 +86,7 @@ instance ToJSONKey (Mary.PolicyID era) where
       render (Mary.PolicyID (Shelley.ScriptHash h)) = hashToText h
 
 instance ToJSON Mary.AssetName where
-  toJSON = Aeson.String . Text.decodeLatin1 . B16.encode . Mary.assetName
+  toJSON = Aeson.String . Text.decodeLatin1 . B16.encode . Short.fromShort . Mary.assetName
 
 instance ToJSON Shelley.AccountState where
   toJSON (Shelley.AccountState tr rs) = object [ "treasury" .= tr

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -752,12 +752,12 @@ newtype CostModel = CostModel (Map Text Integer)
 validateCostModel :: PlutusScriptVersion lang
                   -> CostModel
                   -> Either InvalidCostModel ()
-validateCostModel PlutusScriptV1 (CostModel m)
-  | Alonzo.isCostModelParamsWellFormed m = Right ()
-  | otherwise                        = Left (InvalidCostModel (CostModel m))
-validateCostModel PlutusScriptV2 (CostModel m)
-  | Alonzo.isCostModelParamsWellFormed m = Right ()
-  | otherwise                        = Left (InvalidCostModel (CostModel m))
+validateCostModel PlutusScriptV1 (CostModel m) =
+    bimap (\_err -> InvalidCostModel (CostModel m)) id
+  $ Alonzo.assertWellFormedCostModelParams m
+validateCostModel PlutusScriptV2 (CostModel m) =
+    bimap (\_err -> InvalidCostModel (CostModel m)) id
+  $ Alonzo.assertWellFormedCostModelParams m
 
 -- TODO alonzo: it'd be nice if the library told us what was wrong
 newtype InvalidCostModel = InvalidCostModel CostModel
@@ -797,7 +797,7 @@ fromAlonzoScriptLanguage Alonzo.PlutusV1 = AnyPlutusScriptVersion PlutusScriptV1
 fromAlonzoScriptLanguage Alonzo.PlutusV2 = AnyPlutusScriptVersion PlutusScriptV2
 
 toAlonzoCostModel :: CostModel -> Alonzo.Language -> Either String Alonzo.CostModel
-toAlonzoCostModel (CostModel m) l = Alonzo.mkCostModel l m
+toAlonzoCostModel (CostModel m) l = bimap show id $ Alonzo.mkCostModel l m
 
 fromAlonzoCostModel :: Alonzo.CostModel -> CostModel
 fromAlonzoCostModel m = CostModel $ Alonzo.getCostModelParams m

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -65,6 +65,7 @@ import           Data.Aeson.Types (Parser, ToJSONKey)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Short as Short
 import qualified Data.Map.Merge.Strict as Map
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -277,7 +278,7 @@ toMaryValue v =
     toMaryPolicyID (PolicyId sh) = Mary.PolicyID (toShelleyScriptHash sh)
 
     toMaryAssetName :: AssetName -> Mary.AssetName
-    toMaryAssetName (AssetName n) = Mary.AssetName n
+    toMaryAssetName (AssetName n) = Mary.AssetName $ Short.toShort n
 
 
 fromMaryValue :: Mary.Value StandardCrypto -> Value
@@ -294,7 +295,7 @@ fromMaryValue (Mary.Value lovelace other) =
     fromMaryPolicyID (Mary.PolicyID sh) = PolicyId (fromShelleyScriptHash sh)
 
     fromMaryAssetName :: Mary.AssetName -> AssetName
-    fromMaryAssetName (Mary.AssetName n) = AssetName n
+    fromMaryAssetName (Mary.AssetName n) = AssetName $ Short.fromShort n
 
 -- | Calculate cost of making a UTxO entry for a given 'Value' and
 -- mininimum UTxO value derived from the 'ProtocolParameters'

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -16,7 +16,6 @@ module Cardano.Node.Tracing.Render
   , renderPointForDetails
   , renderRealPoint
   , renderRealPointAsPhrase
-  , renderEnclosed
   , renderSlotNo
   , renderTip
   , renderTipForDetails
@@ -43,7 +42,6 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkN
 import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, StandardHash, Tip,
                    getTipPoint)
-import Ouroboros.Consensus.Util.Enclose (Enclosing'(FallingEdgeWith, RisingEdge))
 
 condenseT :: Condense a => a -> Text
 condenseT = Text.pack . condense
@@ -96,10 +94,6 @@ renderRealPointAsPhrase (RealPoint slotNo headerHash) =
   renderHeaderHash (Proxy @blk) headerHash
     <> " at slot "
     <> renderSlotNo slotNo
-
-renderEnclosed :: (t -> Text) -> Enclosing' t -> Text
-renderEnclosed _ RisingEdge = "RisingEdge"
-renderEnclosed rdr (FallingEdgeWith t) = "FallingEdgeWith " <> rdr t
 
 renderPointForDetails
   :: forall blk.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -297,7 +297,7 @@ instance ( LogFormatting (Header blk)
         RisingEdge ->
           "About to add block to queue: " <> renderRealPointAsPhrase pt
         FallingEdgeWith sz ->
-          "Block added to queue: " <> renderRealPointAsPhrase pt <> " queue size " <> condenseT sz
+          "Block added to queue: " <> renderRealPointAsPhrase pt <> ", queue size " <> condenseT sz
   forHuman (ChainDB.PoppedBlockFromQueue edgePt) =
       case edgePt of
         RisingEdge ->
@@ -323,8 +323,8 @@ instance ( LogFormatting (Header blk)
   forHuman (ChainDB.AddBlockValidation ev') = forHuman ev'
   forHuman (ChainDB.AddedBlockToVolatileDB pt _ _ enclosing) =
       case enclosing of
-        RisingEdge         -> "Chain about to add block " <> renderRealPointAsPhrase pt
-        FallingEdgeWith () -> "Chain added block " <> renderRealPointAsPhrase pt
+        RisingEdge  -> "Chain about to add block " <> renderRealPointAsPhrase pt
+        FallingEdge -> "Chain added block " <> renderRealPointAsPhrase pt
   forHuman (ChainDB.ChainSelectionForFutureBlock pt) =
       "Chain selection run for block previously from future: " <> renderRealPointAsPhrase pt
   forHuman (ChainDB.PipeliningEvent ev') = forHuman ev'
@@ -341,10 +341,14 @@ instance ( LogFormatting (Header blk)
   forMachine dtal (ChainDB.AddedBlockToQueue pt edgeSz) =
       mconcat [ "kind" .= String "AddedBlockToQueue"
                , "block" .= forMachine dtal pt
-               , case edgeSz of RisingEdge -> "risingEdge" .= True; FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
+               , case edgeSz of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
   forMachine dtal (ChainDB.PoppedBlockFromQueue edgePt) =
       mconcat [ "kind" .= String "TraceAddBlockEvent.PoppedBlockFromQueue"
-               , case edgePt of RisingEdge -> "risingEdge" .= True; FallingEdgeWith pt -> "block" .= forMachine dtal pt ]
+               , case edgePt of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith pt -> "block" .= forMachine dtal pt ]
   forMachine dtal (ChainDB.BlockInTheFuture pt slot) =
       mconcat [ "kind" .= String "BlockInTheFuture"
                , "block" .= forMachine dtal pt
@@ -417,8 +421,8 @@ instance ( ConvertRawHash (Header blk)
          ) => LogFormatting (ChainDB.TracePipeliningEvent blk) where
   forHuman (ChainDB.SetTentativeHeader hdr enclosing) =
       case enclosing of
-        RisingEdge         -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
-        FallingEdgeWith () -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+        RisingEdge  -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+        FallingEdge -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
   forHuman (ChainDB.TrapTentativeHeader hdr) =
       "Discovered trap tentative header " <> renderPointAsPhrase (blockPoint hdr)
   forHuman (ChainDB.OutdatedTentativeHeader hdr) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -263,8 +263,8 @@ docChainSyncClientEvent' = Documented [
 severityChainSyncServerEvent :: TraceChainSyncServerEvent blk -> SeverityS
 severityChainSyncServerEvent (TraceChainSyncServerUpdate _tip _upd _blocking enclosing) =
     case enclosing of
-      RisingEdge         -> Info
-      FallingEdgeWith () -> Debug
+      RisingEdge  -> Info
+      FallingEdge -> Debug
 
 namesForChainSyncServerEvent :: TraceChainSyncServerEvent blk -> [Text]
 namesForChainSyncServerEvent ev =
@@ -303,8 +303,6 @@ instance ConvertRawHash blk
                ]
                <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 
-  asMetrics (TraceChainSyncServerUpdate _tip (AddBlock _hdr) _blocking FallingEdge) =
-      [CounterM "cardano.node.chainSync.rollForward" Nothing]
   asMetrics _ = []
 
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -271,92 +271,54 @@ namesForChainSyncServerEvent ev =
     "ChainSyncServerEvent" : namesForChainSyncServerEvent' ev
 
 namesForChainSyncServerEvent' :: TraceChainSyncServerEvent blk -> [Text]
-namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update NonBlocking _enclosing) =
-      ["ServerRead"]
-namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update Blocking _enclosing) =
-      ["ServerReadBlocked"]
+namesForChainSyncServerEvent' (TraceChainSyncServerUpdate _tip _update _blocking _enclosing) =
+      ["Update"]
 
 instance ConvertRawHash blk
       => LogFormatting (TraceChainSyncServerEvent blk) where
-  forMachine _dtal (TraceChainSyncServerUpdate tip (AddBlock _hdr) NonBlocking enclosing) =
+  forMachine dtal (TraceChainSyncServerUpdate tip update blocking enclosing) =
       mconcat $
-               [ "kind" .= String "ChainSyncServerRead.AddBlock"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (RollBack _pt) NonBlocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerRead.RollBack"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (AddBlock _pt) Blocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerReadBlocked.AddBlock"
-               , tipToObject tip
-               ]
-               <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-  forMachine _dtal (TraceChainSyncServerUpdate tip (RollBack _pt) Blocking enclosing) =
-      mconcat $
-               [ "kind" .= String "ChainSyncServerReadBlocked.RollBack"
-               , tipToObject tip
+               [ "kind" .= String "ChainSyncServer.Update"
+               , "tip" .= tipToObject tip
+               , case update of
+                   AddBlock pt -> "addBlock" .= renderPointForDetails dtal pt
+                   RollBack pt -> "rollBackTo" .= renderPointForDetails dtal pt
+               , "blockingRead" .= case blocking of Blocking -> True; NonBlocking -> False
                ]
                <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 
+  asMetrics (TraceChainSyncServerUpdate _tip (AddBlock _pt) _blocking FallingEdge) =
+      [CounterM "cardano.node.chainSync.rollForward" Nothing]
   asMetrics _ = []
 
 
 docChainSyncServerEventHeader :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventHeader =
     addDocumentedNamespace
-      ["ChainSyncServerEvent", "ServerRead"]
+      ["ChainSyncServerEvent", "Update"]
       docChainSyncServerEventHeader'
 
 -- | Metrics documented here, but implemented specially
 docChainSyncServerEventHeader' :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventHeader' = Documented [
     DocMsg
-      ["ServerRead"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
+      ["Update"]
+      [("cardano.node.metrics.served.header", "A counter triggered only on header event")]
       "A server read has occurred, either for an add block or a rollback"
-    , DocMsg
-       ["ServerReadBlocked"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      "A server read has blocked, either for an add block or a rollback"
-    , DocMsg
-      ["RollForward"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      "Roll forward to the given point."
-    , DocMsg
-      ["RollBackward"]
-      [("cardano.node.metrics.served.header", "A counter triggered ony on header event")]
-      ""
   ]
 
 docChainSyncServerEventBlock :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventBlock =
     addDocumentedNamespace
-      ["ChainSyncServerEvent", "ServerRead"]
+      ["ChainSyncServerEvent", "Update"]
       docChainSyncServerEventBlock'
 
 docChainSyncServerEventBlock' :: Documented (TraceChainSyncServerEvent blk)
 docChainSyncServerEventBlock' = Documented [
     DocMsg
-      ["ServerRead"]
+      ["Update"]
       []
       "A server read has occurred, either for an add block or a rollback"
-    , DocMsg
-       ["ServerReadBlocked"]
-      []
-      "A server read has blocked, either for an add block or a rollback"
-    , DocMsg
-      ["RollForward"]
-      []
-      "Roll forward to the given point."
-    , DocMsg
-      ["RollBackward"]
-      []
-      ""
   ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1250,29 +1250,15 @@ instance (ConvertRawHash blk, LedgerSupportsProtocol blk)
 
 instance ConvertRawHash blk
       => ToObject (TraceChainSyncServerEvent blk) where
-  toObject _verb ev = case ev of
-    TraceChainSyncServerUpdate tip AddBlock{} NonBlocking enclosing ->
+  toObject verb ev = case ev of
+    TraceChainSyncServerUpdate tip update blocking enclosing ->
       mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip RollBack{} NonBlocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerRead.RollBack"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip AddBlock{} Blocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock"
-        , tipToObject tip
-        ]
-        <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
-    TraceChainSyncServerUpdate tip RollBack{} Blocking enclosing ->
-      mconcat $
-        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.RollBack"
-        , tipToObject tip
+        [ "kind" .= String "ChainSyncServerEvent.TraceChainSyncServerUpdate"
+        , "tip" .= tipToObject tip
+        , case update of
+            AddBlock pt -> "addBlock" .= renderPointForVerbosity verb pt
+            RollBack pt -> "rollBackTo" .= renderPointForVerbosity verb pt
+        , "blockingRead" .= case blocking of Blocking -> True; NonBlocking -> False
         ]
         <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -66,7 +66,7 @@ import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.Enclose (Enclosing' (..))
+import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -502,14 +502,14 @@ instance ( ConvertRawHash blk
               "Pushing ledger state for block " <> renderRealPointAsPhrase curr <> ". Progress: " <>
               showProgressT (fromIntegral atDiff) (fromIntegral toDiff) <> "%"
         ChainDB.AddedBlockToVolatileDB pt _ _ enclosing -> case enclosing of
-          RisingEdge         -> "Chain about to add block " <> renderRealPointAsPhrase pt
-          FallingEdgeWith () -> "Chain added block " <> renderRealPointAsPhrase pt
+          RisingEdge  -> "Chain about to add block " <> renderRealPointAsPhrase pt
+          FallingEdge -> "Chain added block " <> renderRealPointAsPhrase pt
         ChainDB.ChainSelectionForFutureBlock pt ->
           "Chain selection run for block previously from future: " <> renderRealPointAsPhrase pt
         ChainDB.PipeliningEvent ev' -> case ev' of
           ChainDB.SetTentativeHeader hdr enclosing -> case enclosing of
-            RisingEdge         -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
-            FallingEdgeWith () -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+            RisingEdge  -> "About to set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
+            FallingEdge -> "Set tentative header to " <> renderPointAsPhrase (blockPoint hdr)
           ChainDB.TrapTentativeHeader hdr -> "Discovered trap tentative header " <> renderPointAsPhrase (blockPoint hdr)
           ChainDB.OutdatedTentativeHeader hdr -> "Tentative header is now outdated" <> renderPointAsPhrase (blockPoint hdr)
 
@@ -836,10 +836,14 @@ instance ( ConvertRawHash blk
     ChainDB.AddedBlockToQueue pt edgeSz ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.AddedBlockToQueue"
                , "block" .= toObject verb pt
-               , case edgeSz of RisingEdge -> "risingEdge" .= True; FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
+               , case edgeSz of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith sz -> "queueSize" .= toJSON sz ]
     ChainDB.PoppedBlockFromQueue edgePt ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.PoppedBlockFromQueue"
-               , case edgePt of RisingEdge -> "risingEdge" .= True; FallingEdgeWith pt -> "block" .= toObject verb pt ]
+               , case edgePt of
+                   RisingEdge         -> "risingEdge" .= True
+                   FallingEdgeWith pt -> "block" .= toObject verb pt ]
     ChainDB.BlockInTheFuture pt slot ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
                , "block" .= toObject verb pt

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -1026,6 +1026,7 @@ instance ToJSON (Alonzo.CollectError StandardCrypto) where
               Alonzo.InlineDatumsNotSupported -> String "Inline datums not supported"
               Alonzo.ReferenceScriptsNotSupported -> String "Reference scripts not supported"
               Alonzo.ReferenceInputsNotSupported -> String "Reference inputs not supported"
+              Alonzo.TimeTranslationPastHorizon -> String "Time translation requested past the horizon"
           ]
 
 instance ToJSON Alonzo.TagMismatchDescription where

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -610,7 +610,7 @@ sendEKGDirectDouble ekgDirect name val = do
 --------------------------------------------------------------------------------
 
 isRollForward :: TraceChainSyncServerEvent blk -> Bool
-isRollForward (TraceChainSyncServerUpdate _tip (AddBlock _hdr) _blocking FallingEdge) = True
+isRollForward (TraceChainSyncServerUpdate _tip (AddBlock _pt) _blocking FallingEdge) = True
 isRollForward _ = False
 
 mkConsensusTracers


### PR DESCRIPTION
This PR does two things.

- It updates many dependencies.

- The necessary integration is just trivial refactoring. Beyond that, this PR also updates the log representation of some tracer events; typo fixes and a new shape for ChainSync server events.

```
           cardano-ledger f31c29add - Merge pull request #2819 from input-output-hk/andre/babbage (6 days ago) <Alexey Kuleshevich>
iohk-monitoring-framework 066f700   - Merge #627 (5 days ago) <iohk-bors[bot]>
                   io-sim f4183f2   - Merge pull request #2 from input-output-hk/coot/check-stylish-script (12 days ago) <Marcin Szamotulski>
        ouroboros-network c254d02b9 - Merge #3766 (5 hours ago) <iohk-bors[bot]>
                   plutus d24a7540e - Backport: PLT-250: mkEvaluationContext now lives in MonadError CostModelApplyError (#4641) (9 days ago) <Nikolaos Bezirgiannis>
          typed-protocols 181601b   - Merge pull request #4 from input-output-hk/coot/check-stylish (12 days ago) <Marcin Szamotulski>
```