### PR TITLE
membench:  provide the baseline profile again

### DIFF
--- a/nix/custom-config.nix
+++ b/nix/custom-config.nix
@@ -17,7 +17,7 @@ self: {
     rtsflags = "";
     limit2 = "6553M";
     variantTable = {
-      new-tracing = { legacyTracing = false; };
+      baseline = { legacyTracing = false; };
     };
     shelleyGenesisHash = "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
   };


### PR DESCRIPTION
This must fix

```
membench | report:  generating e8aafabc94769e131e13b311d1d75c8f64ca4911-1vars-5runs-config-baseline-report-78675fb
jq: error (at <stdin>:385): render_hydra_charts_for_config: unknown config baseline
```