### PR TITLE
cardano-node:  implement --shutdown-on-block-synced

### DIFF
--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -1,14 +1,21 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Node.Handlers.Shutdown
-  (
+  ( SlotOrBlock (..)
+  , parseShutdownOnLimit
+
   -- * Generalised shutdown handling
-    ShutdownConfig (..)
+  , ShutdownConfig (..)
   , withShutdownHandling
 
   , ShutdownTrace (..)
@@ -20,27 +27,50 @@ module Cardano.Node.Handlers.Shutdown
 where
 
 import           Data.Aeson (FromJSON, ToJSON)
-import           Generic.Data (Generic)
 import           Generic.Data.Orphans ()
-import           Prelude
+import           Cardano.Prelude
 
-import           Control.Concurrent.Async (race_)
-import           Control.Exception
-import           Control.Monad
-import           Data.Text (Text, pack)
+import           Data.Text (pack)
 import qualified GHC.IO.Handle.FD as IO (fdToHandle)
-import           System.Exit
+import qualified Options.Applicative as Opt
 import qualified System.IO as IO
 import qualified System.IO.Error as IO
 import           System.Posix.Types (Fd (Fd))
 
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           "contra-tracer" Control.Tracer
+import           Ouroboros.Consensus.Block (Header)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
-import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo, pointSlot)
+import           Ouroboros.Network.Block (HasHeader, BlockNo (..), SlotNo (..), pointSlot)
 
+
+data SlotOrBlock f
+  = ASlot  !(f SlotNo)
+  | ABlock !(f BlockNo)
+  deriving (Generic)
+
+deriving instance Eq (SlotOrBlock Identity)
+deriving instance Show (SlotOrBlock Identity)
+deriving instance FromJSON (SlotOrBlock Identity)
+deriving instance ToJSON (SlotOrBlock Identity)
+
+parseShutdownOnLimit :: Opt.Parser (Maybe (SlotOrBlock Identity))
+parseShutdownOnLimit =
+    optional (Opt.option (ASlot . Identity . SlotNo <$> Opt.auto) (
+         Opt.long "shutdown-on-slot-synced"
+      <> Opt.metavar "SLOT"
+      <> Opt.help "Shut down the process after ChainDB is synced up to the specified slot"
+      <> Opt.hidden
+    ))
+    <|>
+    optional (Opt.option (ABlock . Identity . BlockNo <$> Opt.auto) (
+         Opt.long "shutdown-on-block-synced"
+      <> Opt.metavar "BLOCK"
+      <> Opt.help "Shut down the process after ChainDB is synced up to the specified block"
+      <> Opt.hidden
+    ))
 
 data ShutdownTrace
   = ShutdownRequested
@@ -51,14 +81,21 @@ data ShutdownTrace
   -- ^ Received shutdown request but found unexpected input in --shutdown-ipc FD:
   | RequestingShutdown Text
   -- ^ Ringing the node shutdown doorbell for reason
-  | ShutdownArmedAtSlot SlotNo
-  -- ^ Will terminate upon reaching maxSlot
+  | ShutdownArmedAt (SlotOrBlock Identity)
+  -- ^ Will terminate upon reaching a ChainDB sync limit
   deriving (Generic, FromJSON, ToJSON)
+
+deriving instance FromJSON BlockNo
+deriving instance ToJSON BlockNo
+
+newtype AndWithOrigin a = AndWithOrigin (a, WithOrigin a) deriving (Eq)
+
+deriving instance Eq (SlotOrBlock AndWithOrigin)
 
 data ShutdownConfig
   = ShutdownConfig
-    { scIPC          :: !(Maybe Fd)
-    , scOnSlotSynced :: !(Maybe MaxSlotNo)
+    { scIPC         :: !(Maybe Fd)
+    , scOnSyncLimit :: !(Maybe (SlotOrBlock Identity))
     }
     deriving (Eq, Show)
 
@@ -92,28 +129,40 @@ withShutdownHandling ShutdownConfig{scIPC = Just fd} tr action = do
 -- | Spawn a thread that would cause node to shutdown upon ChainDB reaching the
 -- configuration-defined slot.
 maybeSpawnOnSlotSyncedShutdownHandler
-  :: ShutdownConfig
+  :: HasHeader (Header blk)
+  => ShutdownConfig
   -> Tracer IO ShutdownTrace
   -> ResourceRegistry IO
   -> ChainDB.ChainDB IO blk
   -> IO ()
 maybeSpawnOnSlotSyncedShutdownHandler sc tr registry chaindb =
-  case scOnSlotSynced sc of
-    Just (MaxSlotNo maxSlot) -> do
-      traceWith tr (ShutdownArmedAtSlot maxSlot)
-      spawnSlotLimitTerminator maxSlot
-    _ -> pure ()
+  case scOnSyncLimit sc of
+    Nothing -> pure ()
+    Just lim -> do
+      traceWith tr (ShutdownArmedAt lim)
+      spawnLimitTerminator lim
  where
-  spawnSlotLimitTerminator :: SlotNo -> IO ()
-  spawnSlotLimitTerminator maxSlot =
+  spawnLimitTerminator :: SlotOrBlock Identity -> IO ()
+  spawnLimitTerminator limit =
     void $ forkLinkedWatcher registry "slotLimitTerminator" Watcher {
-        wFingerprint = id
+        wFingerprint = identity
       , wInitial     = Nothing
+      , wReader      =
+          case limit of
+            ASlot  (Identity x) -> ASlot  . AndWithOrigin . (x,) <$>
+                                   (pointSlot <$> ChainDB.getTipPoint chaindb)
+            ABlock (Identity x) -> ABlock . AndWithOrigin . (x,) <$>
+                                   ChainDB.getTipBlockNo chaindb
       , wNotify      = \case
-          Origin -> pure ()
-          At cur -> when (cur >= maxSlot) $ do
-            traceWith tr (RequestingShutdown $ "spawnSlotLimitTerminator: reached target "
-                                                 <> (pack . show) cur)
-            throwIO ExitSuccess
-      , wReader      = pointSlot <$> ChainDB.getTipPoint chaindb
+          ASlot (AndWithOrigin (lim, At cur)) ->
+              when (cur >= lim) $ do
+                traceWith tr (RequestingShutdown $ "spawnLimitTerminator: reached target slot "
+                              <> (pack . show) cur)
+                throwIO ExitSuccess
+          ABlock (AndWithOrigin (lim, At cur)) ->
+              when (cur >= lim) $ do
+                traceWith tr (RequestingShutdown $ "spawnLimitTerminator: reached target block "
+                              <> (pack . show) cur)
+                throwIO ExitSuccess
+          _ -> pure ()
       }

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -23,7 +23,8 @@ import           Ouroboros.Consensus.Mempool.API (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
 
-import           Cardano.Node.Configuration.NodeAddress
+import           Cardano.Node.Configuration.NodeAddress (NodeHostIPv4Address (NodeHostIPv4Address),
+                   NodeHostIPv6Address (NodeHostIPv6Address), PortNumber, SocketPath (SocketPath))
 import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..), lastOption)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
@@ -91,7 +92,7 @@ nodeRunParser = do
              }
            , pncValidateDB = validate
            , pncShutdownConfig =
-               Last . Just $ ShutdownConfig (getLast shutdownIPC) (join $ getLast shutdownOnLimit)
+               Last . Just $ ShutdownConfig (getLast shutdownIPC) (getLast shutdownOnLimit)
            , pncProtocolConfig = mempty
            , pncMaxConcurrencyBulkSync = mempty
            , pncMaxConcurrencyDeadline = mempty

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -65,7 +65,7 @@ nodeRunParser = do
 
   validate <- lastOption parseValidateDB
   shutdownIPC <- lastOption parseShutdownIPC
-  shutdownOnLimit <- lastOption parseShutdownOnLimit
+  shutdownOnLimit <- lastOption parseShutdownOn
 
   maybeMempoolCapacityOverride <- lastOption parseMempoolCapacityOverride
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
@@ -14,7 +14,7 @@ module Cardano.Node.Tracing.Tracers.Shutdown
 
 import           Cardano.Logging
 import           Cardano.Node.Handlers.Shutdown
-import           Data.Aeson (ToJSON (..), Value (..), (.=))
+import           Data.Aeson (Value (..), (.=))
 import           Data.Monoid (mconcat, (<>))
 import           Data.Text (Text, pack)
 import           Prelude (show)
@@ -29,7 +29,7 @@ namesForShutdown = \case
   AbnormalShutdown{}          -> ["AbnormalShutdown"]
   ShutdownUnexpectedInput{}   -> ["ShutdownUnexpectedInput"]
   RequestingShutdown{}        -> ["RequestingShutdown"]
-  ShutdownArmedAtSlot{}       -> ["ShutdownArmedAtSlot"]
+  ShutdownArmedAt{}           -> ["ShutdownArmedAt"]
 
 severityShutdown :: ShutdownTrace -> SeverityS
 severityShutdown = \case
@@ -37,7 +37,7 @@ severityShutdown = \case
   AbnormalShutdown{}          -> Error
   ShutdownUnexpectedInput{}   -> Error
   RequestingShutdown{}        -> Warning
-  ShutdownArmedAtSlot{}       -> Warning
+  ShutdownArmedAt{}           -> Warning
 
 ppShutdownTrace :: ShutdownTrace -> Text
 ppShutdownTrace = \case
@@ -46,7 +46,7 @@ ppShutdownTrace = \case
   ShutdownUnexpectedInput text  ->
     "Received shutdown request but found unexpected input in --shutdown-ipc FD: " <> text
   RequestingShutdown reason     -> "Ringing the node shutdown doorbell:  " <> reason
-  ShutdownArmedAtSlot slot      -> "Will terminate upon reaching " <> pack (show slot)
+  ShutdownArmedAt lim           -> "Will terminate upon reaching " <> pack (show lim)
 
 instance LogFormatting ShutdownTrace where
   forHuman = ppShutdownTrace
@@ -58,13 +58,13 @@ instance LogFormatting ShutdownTrace where
           mconcat [ "kind"   .= String "AbnormalShutdown" ]
     ShutdownUnexpectedInput text ->
           mconcat [ "kind"   .= String "AbnormalShutdown"
-                   , "unexpected" .= String text ]
+                  , "unexpected" .= String text ]
     RequestingShutdown reason ->
           mconcat [ "kind"   .= String "RequestingShutdown"
-                   , "reason" .= String reason ]
-    ShutdownArmedAtSlot slot  ->
-          mconcat [ "kind"   .= String "ShutdownArmedAtSlot"
-                   , "slot"   .= toJSON slot ]
+                  , "reason" .= String reason ]
+    ShutdownArmedAt lim ->
+          mconcat [ "kind"   .= String "ShutdownArmedAt"
+                  , "limit"  .= lim ]
 
 docShutdown :: Documented ShutdownTrace
 docShutdown = addDocumentedNamespace  [] docShutdown'
@@ -88,7 +88,7 @@ docShutdown' = Documented
       []
       "Ringing the node shutdown doorbell"
   , DocMsg
-      ["ShutdownArmedAtSlot"]
+      ["ShutdownArmedAt"]
       []
-      "Setting up node shutdown at given slot."
+      "Setting up node shutdown at given slot / block."
   ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -58,7 +58,7 @@ import           Cardano.BM.Stats
 import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
                    Severity (..), ToObject (..), Tracer (..), TracingVerbosity (..),
                    Transformable (..))
-import           Cardano.Slotting.Block (BlockNo (..))
+import           Cardano.Node.Handlers.Shutdown ()
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash (..))
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Network.Block (HeaderHash, Tip (..))
@@ -102,7 +102,6 @@ instance ToJSON (OneEraHash xs) where
     toJSON . Text.decodeLatin1 . B16.encode . SBS.fromShort $ bs
 
 deriving newtype instance ToJSON ByronHash
-deriving newtype instance ToJSON BlockNo
 
 instance HasPrivacyAnnotation  ResourceStats
 instance HasSeverityAnnotation ResourceStats where

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -84,7 +84,7 @@ testPartialCliConfig :: PartialNodeConfiguration
 testPartialCliConfig =
   PartialNodeConfiguration
     { pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
-    , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . ASlot . Identity $ SlotNo 42)
+    , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
     , pncConfigFile   = mempty
     , pncTopologyFile = mempty
     , pncDatabaseFile = mempty
@@ -117,7 +117,7 @@ eExpectedConfig = do
                     (return $ PartialTracingOnLegacy defaultPartialTraceConfiguration)
   return $ NodeConfiguration
     { ncSocketConfig = SocketConfig mempty mempty mempty mempty
-    , ncShutdownConfig = ShutdownConfig Nothing (Just . ASlot . Identity $ SlotNo 42)
+    , ncShutdownConfig = ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
     , ncConfigFile = ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
     , ncTopologyFile = TopologyFile "configuration/cardano/mainnet-topology.json"
     , ncDatabaseFile = DbFile "mainnet/db/"

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -17,7 +17,7 @@ import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartia
                    partialTraceSelectionToEither)
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
-import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DiffusionMode (InitiatorAndResponderDiffusionMode))
 
@@ -84,7 +84,7 @@ testPartialCliConfig :: PartialNodeConfiguration
 testPartialCliConfig =
   PartialNodeConfiguration
     { pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
-    , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . MaxSlotNo $ SlotNo 42)
+    , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . ASlot . Identity $ SlotNo 42)
     , pncConfigFile   = mempty
     , pncTopologyFile = mempty
     , pncDatabaseFile = mempty
@@ -117,7 +117,7 @@ eExpectedConfig = do
                     (return $ PartialTracingOnLegacy defaultPartialTraceConfiguration)
   return $ NodeConfiguration
     { ncSocketConfig = SocketConfig mempty mempty mempty mempty
-    , ncShutdownConfig = ShutdownConfig Nothing (Just . MaxSlotNo $ SlotNo 42)
+    , ncShutdownConfig = ShutdownConfig Nothing (Just . ASlot . Identity $ SlotNo 42)
     , ncConfigFile = ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
     , ncTopologyFile = TopologyFile "configuration/cardano/mainnet-topology.json"
     , ncDatabaseFile = DbFile "mainnet/db/"

--- a/doc/new-tracing/tracers_doc_generated.md
+++ b/doc/new-tracing/tracers_doc_generated.md
@@ -597,7 +597,7 @@
 1. __Shutdown__
 	1. [AbnormalShutdown](#cardanonodeshutdownabnormalshutdown)
 	1. [RequestingShutdown](#cardanonodeshutdownrequestingshutdown)
-	1. [ShutdownArmedAtSlot](#cardanonodeshutdownshutdownarmedatslot)
+	1. [ShutdownArmedAtSlotBlock](#cardanonodeshutdownshutdownarmedatslotblock)
 	1. [ShutdownRequested](#cardanonodeshutdownshutdownrequested)
 	1. [ShutdownUnexpectedInput](#cardanonodeshutdownshutdownunexpectedinput)
 1. __Startup__
@@ -8973,11 +8973,11 @@ Backends:
 			`EKGBackend`
 Filtered  by config value: `Notice`
 
-### Cardano.Node.Shutdown.ShutdownArmedAtSlot
+### Cardano.Node.Shutdown.ShutdownArmedAtSlotBlock
 
 
 ***
-Setting up node shutdown at given slot.
+Setting up node shutdown at given slot / block.
 ***
 
 


### PR DESCRIPTION
This:

1. adds `--shutdown-on-block-synced BLOCKNO` option, in parallel to `--shutdown-on-slot-synced SLOTNO`
2. integrates it into the workbench