### PR TITLE
tx-generator: zero config legacy tracing

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/NodeConfig.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
 module Cardano.Benchmarking.Script.NodeConfig
   ( startProtocol
   , shutDownLogging
@@ -6,8 +10,9 @@ module Cardano.Benchmarking.Script.NodeConfig
 import           Paths_tx_generator (version)
 import           Prelude
 
+import           Data.Bifunctor (second)
 import           Data.Monoid
-import           Data.Text (pack)
+import           Data.Text as Text
 import           Data.Version (showVersion)
 
 import           Control.Concurrent (threadDelay)
@@ -15,8 +20,14 @@ import           Control.Monad (forM_)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except
 
-import           Cardano.Tracing.Config (TraceOptions(..))
+import           Cardano.BM.Data.Backend
+import           Cardano.BM.Tracing
+import qualified Cardano.BM.Configuration.Model as CM
+import           Cardano.BM.Setup (setupTrace_)
+import           Cardano.BM.Data.LogItem (mapLogObject)
 
+import           Cardano.Tracing.Config (TraceOptions(..))
+import           Cardano.BM.Data.Output
 import           Cardano.Node.Configuration.Logging (LoggingLayer, createLoggingLayer, shutdownLoggingLayer)
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Handlers.Shutdown
@@ -50,6 +61,33 @@ makeLegacyLoggingLayer nc ptcl = liftToAction $ withExceptT NodeConfigError $
     nc {ncTraceConfig=TracingOff}
     ptcl
 
+initLegacyTracer :: ActionM ()
+initLegacyTracer = do
+  baseTracer <- liftIO $ do
+    c <- defaultConfigStdout
+    CM.setDefaultBackends c [KatipBK ]
+    CM.setSetupBackends c [KatipBK ]
+    CM.setDefaultBackends c [KatipBK ]
+    CM.setSetupScribes c [ ScribeDefinition {
+                              scName = "cli"
+                            , scFormat = ScJson
+                            , scKind = StdoutSK
+                            , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
+                            , scRotation = Nothing
+                            }
+                         ]
+    CM.setScribes c "cardano.cli" (Just ["StdoutSK::cli"])
+    (tr :: Trace IO String, _switchboard) <- setupTrace_ c "cardano"
+
+    let tr' = appendName "cli" tr
+    return tr'
+
+  let
+    (bt :: Trace IO Text.Text)  = contramap (second $ mapLogObject Text.unpack) baseTracer
+  set Store.BenchTracers $ initTracers bt bt
+
 makeNodeConfig :: FilePath -> ActionM NodeConfiguration
 makeNodeConfig logConfig = liftToAction $ ExceptT $ do
  let configFp = ConfigYamlFilePath logConfig
@@ -80,16 +118,12 @@ startProtocol filePath = do
   set Genesis $ Core.getGenesis protocol
   set (User TNetworkId) $ protocolToNetworkId protocol
   case ncTraceConfig nodeConfig of
-    TraceDispatcher _ -> do
-      set Store.LoggingLayer Nothing
-      set Store.BenchTracers createStdoutTracers
+    TraceDispatcher _ -> initLegacyTracer
     TracingOnLegacy _ -> do
       loggingLayer <- makeLegacyLoggingLayer nodeConfig protocol
       set Store.LoggingLayer $ Just loggingLayer
       set Store.BenchTracers $ createLoggingLayerTracers loggingLayer
-    TracingOff -> do
-      set Store.LoggingLayer Nothing
-      set Store.BenchTracers createStdoutTracers
+    TracingOff -> initLegacyTracer
 
 shutDownLogging :: ActionM ()
 shutDownLogging = do

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/NodeConfig.hs
@@ -82,14 +82,14 @@ startProtocol filePath = do
   case ncTraceConfig nodeConfig of
     TraceDispatcher _ -> do
       set Store.LoggingLayer Nothing
-      set Store.BenchTracers createDebugTracers
+      set Store.BenchTracers createStdoutTracers
     TracingOnLegacy _ -> do
       loggingLayer <- makeLegacyLoggingLayer nodeConfig protocol
       set Store.LoggingLayer $ Just loggingLayer
       set Store.BenchTracers $ createLoggingLayerTracers loggingLayer
     TracingOff -> do
       set Store.LoggingLayer Nothing
-      set Store.BenchTracers createDebugTracers
+      set Store.BenchTracers createStdoutTracers
 
 shutDownLogging :: ActionM ()
 shutDownLogging = do

--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -21,8 +21,9 @@ module Cardano.Benchmarking.Tracer
   , TraceBenchTxSubmit(..)
   , TraceLowLevelSubmit(..)
   , createLoggingLayerTracers
-  , createStdoutTracers
-  , createDebugTracers  
+  , createTracers
+  , createDebugTracers
+  , initTracers
   ) where
 
 
@@ -33,7 +34,7 @@ import qualified Data.Text as T
 import           Data.Time.Clock (DiffTime, NominalDiffTime, getCurrentTime)
 import           Prelude (Show (..), String)
 
-import           Control.Tracer (stdoutTracer)
+import           Control.Tracer (debugTracer)
 
 import           Cardano.Api
 import qualified Codec.CBOR.Term as CBOR
@@ -74,15 +75,13 @@ data BenchTracers =
   , btN2N_        :: Tracer IO NodeToNodeSubmissionTrace
   }
 
-createDebugTracers :: BenchTracers
-createDebugTracers = initTracers tr tr
+createTracers :: Tracer IO String -> BenchTracers
+createTracers baseTr = initTracers tr tr
   where
-    tr = contramap (\(_,t) -> BSL.unpack $ encode t) stdoutTracer
+    tr = contramap (\(_,t) -> BSL.unpack $ encode t) baseTr
 
-createStdoutTracers :: BenchTracers
-createStdoutTracers = initTracers tr tr
-  where
-    tr = contramap (\(_,t) -> BSL.unpack $ encode t) stdoutTracer
+createDebugTracers :: BenchTracers
+createDebugTracers = createTracers debugTracer
 
 createLoggingLayerTracers :: LoggingLayer -> BenchTracers
 createLoggingLayerTracers loggingLayer

--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -21,7 +21,8 @@ module Cardano.Benchmarking.Tracer
   , TraceBenchTxSubmit(..)
   , TraceLowLevelSubmit(..)
   , createLoggingLayerTracers
-  , createDebugTracers
+  , createStdoutTracers
+  , createDebugTracers  
   ) where
 
 
@@ -32,7 +33,7 @@ import qualified Data.Text as T
 import           Data.Time.Clock (DiffTime, NominalDiffTime, getCurrentTime)
 import           Prelude (Show (..), String)
 
-import           Control.Tracer (debugTracer)
+import           Control.Tracer (stdoutTracer)
 
 import           Cardano.Api
 import qualified Codec.CBOR.Term as CBOR
@@ -76,7 +77,12 @@ data BenchTracers =
 createDebugTracers :: BenchTracers
 createDebugTracers = initTracers tr tr
   where
-    tr = contramap (\(_,t) -> BSL.unpack $ encode t) debugTracer
+    tr = contramap (\(_,t) -> BSL.unpack $ encode t) stdoutTracer
+
+createStdoutTracers :: BenchTracers
+createStdoutTracers = initTracers tr tr
+  where
+    tr = contramap (\(_,t) -> BSL.unpack $ encode t) stdoutTracer
 
 createLoggingLayerTracers :: LoggingLayer -> BenchTracers
 createLoggingLayerTracers loggingLayer


### PR DESCRIPTION
This is a fallback until the tx-generator has been ported to the new tracing infrastructure.
The fallback kicks in, if the tx-generator is started with a node configuration that uses the tracing infrastructure.