### PR TITLE
Reference script integration

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -87,6 +87,7 @@ library
                         Cardano.Api.StakePoolMetadata
                         Cardano.Api.Tx
                         Cardano.Api.TxBody
+                        Cardano.Api.TxIn
                         Cardano.Api.TxMetadata
                         Cardano.Api.TxSubmit.ErrorRender
                         Cardano.Api.TxSubmit.Types

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -577,7 +577,7 @@ genTxInsCollateral era =
                           [ pure TxInsCollateralNone
                           , TxInsCollateral supported <$> Gen.list (Range.linear 0 10) genTxIn
                           ]
-genTxInsReference :: CardanoEra era -> Gen (TxInsReference era)
+genTxInsReference :: CardanoEra era -> Gen (TxInsReference BuildTx era)
 genTxInsReference era =
     case refInsScriptsAndInlineDatsSupportedInEra era of
       Nothing        -> pure TxInsReferenceNone

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -966,7 +966,7 @@ fromShelleyScriptHash = ScriptHash
 
 
 -- ----------------------------------------------------------------------------
--- The simple native script language
+-- The simple script language
 --
 
 data SimpleScript lang where

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -115,6 +115,7 @@ module Cardano.Api.Shelley
     toShelleyScriptHash,
     fromShelleyScriptHash,
     PlutusScript(..),
+    PlutusScriptOrReferenceInput(..),
     toPlutusData,
     fromPlutusData,
     toAlonzoData,

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -188,7 +188,8 @@ import qualified Text.Parsec.String as Parsec
 import           Cardano.Binary (Annotated (..), reAnnotate, recoverBytes)
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.Serialization as CBOR (decodeNullMaybe, encodeNullMaybe, mkSized, sizedValue)
+import qualified Cardano.Ledger.Serialization as CBOR (decodeNullMaybe, encodeNullMaybe, mkSized,
+                   sizedValue)
 import           Cardano.Slotting.Slot (SlotNo (..))
 
 import qualified Cardano.Chain.Common as Byron
@@ -1166,16 +1167,16 @@ data TxInsCollateral era where
 deriving instance Eq   (TxInsCollateral era)
 deriving instance Show (TxInsCollateral era)
 
-data TxInsReference era where
+data TxInsReference build era where
 
-     TxInsReferenceNone :: TxInsReference era
+     TxInsReferenceNone :: TxInsReference build era
 
      TxInsReference     :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
                         -> [TxIn]
-                        -> TxInsReference era
+                        -> TxInsReference build era
 
-deriving instance Eq   (TxInsReference era)
-deriving instance Show (TxInsReference era)
+deriving instance Eq   (TxInsReference build era)
+deriving instance Show (TxInsReference build era)
 
 -- ----------------------------------------------------------------------------
 -- Transaction output values (era-dependent)
@@ -1518,7 +1519,7 @@ data TxBodyContent build era =
      TxBodyContent {
        txIns              :: TxIns build era,
        txInsCollateral    :: TxInsCollateral era,
-       txInsReference     :: TxInsReference era,
+       txInsReference     :: TxInsReference build era,
        txOuts             :: [TxOut CtxTx era],
        txTotalCollateral  :: TxTotalCollateral era,
        txReturnCollateral :: TxReturnCollateral CtxTx era,
@@ -1928,6 +1929,44 @@ instance IsCardanoEra era => HasTextEnvelope (TxBody era) where
         AlonzoEra  -> "TxBodyAlonzo"
         BabbageEra -> "TxBodyBabbage"
 
+-- | Calculate the transaction identifier for a 'TxBody'.
+--
+getTxId :: forall era. TxBody era -> TxId
+getTxId (ByronTxBody tx) =
+    TxId
+  . fromMaybe impossible
+  . Crypto.hashFromBytesShort
+  . Byron.abstractHashToShort
+  . Byron.hashDecoded
+  $ tx
+  where
+    impossible =
+      error "getTxId: byron and shelley hash sizes do not match"
+
+getTxId (ShelleyTxBody era tx _ _ _ _) =
+  obtainConstraints era $ getTxIdShelley era tx
+ where
+  obtainConstraints
+    :: ShelleyBasedEra era
+    -> (( Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
+        , Ledger.UsesTxBody (ShelleyLedgerEra era)
+        ) => a)
+    -> a
+  obtainConstraints ShelleyBasedEraShelley f = f
+  obtainConstraints ShelleyBasedEraAllegra f = f
+  obtainConstraints ShelleyBasedEraMary    f = f
+  obtainConstraints ShelleyBasedEraAlonzo  f = f
+  obtainConstraints ShelleyBasedEraBabbage f = f
+
+getTxIdShelley
+  :: Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.UsesTxBody (ShelleyLedgerEra era)
+  => ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxId
+getTxIdShelley _ tx =
+    TxId
+  . Crypto.castHash
+  . (\(Ledger.TxId txhash) -> SafeHash.extractHash txhash)
+  $ Ledger.txid tx
 
 -- ----------------------------------------------------------------------------
 -- Constructing transaction bodies
@@ -2063,13 +2102,14 @@ fromLedgerTxInsCollateral era body =
       ShelleyBasedEraBabbage -> toList $ Babbage.collateral body
 
 fromLedgerTxInsReference
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxInsReference era
+  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxInsReference ViewTx era
 fromLedgerTxInsReference era txBody =
   case refInsScriptsAndInlineDatsSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxInsReferenceNone
     Just suppInEra ->
       let ledgerRefInputs = obtainReferenceInputsHasFieldConstraint suppInEra $ getField @"referenceInputs" txBody
-      in TxInsReference suppInEra $ map fromShelleyTxIn $ Set.toList ledgerRefInputs
+      in TxInsReference suppInEra
+           $ map fromShelleyTxIn . Set.toList $ ledgerRefInputs
  where
   obtainReferenceInputsHasFieldConstraint
     :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
@@ -2702,8 +2742,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraShelley
     maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
     scripts :: [Ledger.Script StandardShelley]
-    scripts =
-      [ toShelleyScript (scriptWitnessScript scriptwitness)
+    scripts = catMaybes
+      [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness)
           <- collectTxBodyScriptWitnesses txbodycontent
       ]
@@ -2783,8 +2823,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraAllegra
     maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
     scripts :: [Ledger.Script StandardAllegra]
-    scripts =
-      [ toShelleyScript (scriptWitnessScript scriptwitness)
+    scripts = catMaybes
+      [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness)
           <- collectTxBodyScriptWitnesses txbodycontent
       ]
@@ -2880,8 +2920,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraMary
     maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
     scripts :: [Ledger.Script StandardMary]
-    scripts =
-      [ toShelleyScript (scriptWitnessScript scriptwitness)
+    scripts = catMaybes
+      [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness)
           <- collectTxBodyScriptWitnesses txbodycontent
       ]
@@ -3012,8 +3052,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
     witnesses = collectTxBodyScriptWitnesses txbodycontent
 
     scripts :: [Ledger.Script StandardAlonzo]
-    scripts =
-      [ toShelleyScript (scriptWitnessScript scriptwitness)
+    scripts = catMaybes
+      [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness) <- witnesses
       ]
 
@@ -3119,15 +3159,14 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
     return $
       ShelleyTxBody era
         (Babbage.TxBody
-           { Babbage.inputs = Set.fromList (map (toShelleyTxIn . fst) txIns)
+           { Babbage.inputs = Set.fromList $ map (toShelleyTxIn . fst) txIns
            , Babbage.collateral =
                case txInsCollateral of
                 TxInsCollateralNone     -> Set.empty
                 TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins)
            , Babbage.referenceInputs =
-               case txInsReference of
-                 TxInsReferenceNone -> Set.empty
-                 TxInsReference _ txins -> Set.fromList (map toShelleyTxIn txins)
+               Set.fromList (map toShelleyTxIn referenceTxIns)
+
            , Babbage.outputs = Seq.fromList (map (CBOR.mkSized . toShelleyTxOutAny era) txOuts)
            , Babbage.collateralReturn =
                case txReturnCollateral of
@@ -3192,6 +3231,12 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
         txAuxData
         txScriptValidity
   where
+    referenceTxIns :: [TxIn]
+    referenceTxIns =
+      case txInsReference of
+        TxInsReferenceNone -> []
+        TxInsReference _ refTxins -> refTxins
+
     maxShelleyTxInIx :: Word
     maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
@@ -3199,8 +3244,8 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
     witnesses = collectTxBodyScriptWitnesses txbodycontent
 
     scripts :: [Ledger.Script StandardBabbage]
-    scripts =
-      [ toShelleyScript (scriptWitnessScript scriptwitness)
+    scripts = catMaybes
+      [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness) <- witnesses
       ]
 
@@ -3221,6 +3266,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
                     (PlutusScriptWitness
                        _ _ _ (ScriptDatumForTxIn d) _ _)) <- witnesses
             ]
+
     redeemers :: Alonzo.Redeemers StandardBabbage
     redeemers =
       Alonzo.Redeemers $
@@ -3232,10 +3278,15 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
 
     languages :: Set Alonzo.Language
     languages =
-      Set.fromList
-        [ toAlonzoLanguage (AnyPlutusScriptVersion v)
-        | (_, AnyScriptWitness (PlutusScriptWitness _ v _ _ _ _)) <- witnesses
+      Set.fromList $ catMaybes
+        [ getScriptLanguage sw
+        | (_, AnyScriptWitness sw) <- witnesses
         ]
+
+    getScriptLanguage :: ScriptWitness witctx era -> Maybe Alonzo.Language
+    getScriptLanguage (PlutusScriptWitness _ v _ _ _ _) =
+      Just $ toAlonzoLanguage (AnyPlutusScriptVersion v)
+    getScriptLanguage SimpleScriptWitness{} = Nothing
 
     txAuxData :: Maybe (Ledger.AuxiliaryData StandardBabbage)
     txAuxData
@@ -3356,96 +3407,6 @@ fromAlonzoRdmrPtr (Alonzo.RdmrPtr tag n) =
       Alonzo.Mint  -> ScriptWitnessIndexMint        (fromIntegral n)
       Alonzo.Cert  -> ScriptWitnessIndexCertificate (fromIntegral n)
       Alonzo.Rewrd -> ScriptWitnessIndexWithdrawal  (fromIntegral n)
-
-
-mapTxScriptWitnesses :: forall era.
-                        (forall witctx. ScriptWitnessIndex
-                                     -> ScriptWitness witctx era
-                                     -> ScriptWitness witctx era)
-                     -> TxBodyContent BuildTx era
-                     -> TxBodyContent BuildTx era
-mapTxScriptWitnesses f txbodycontent@TxBodyContent {
-                         txIns,
-                         txWithdrawals,
-                         txCertificates,
-                         txMintValue
-                       } =
-    txbodycontent {
-      txIns          = mapScriptWitnessesTxIns        txIns
-    , txMintValue    = mapScriptWitnessesMinting      txMintValue
-    , txCertificates = mapScriptWitnessesCertificates txCertificates
-    , txWithdrawals  = mapScriptWitnessesWithdrawals  txWithdrawals
-    }
-  where
-    mapScriptWitnessesTxIns
-      :: [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
-      -> [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
-    mapScriptWitnessesTxIns txins =
-        [ (txin, BuildTxWith wit')
-          -- The tx ins are indexed in the map order by txid
-        | (ix, (txin, BuildTxWith wit)) <- zip [0..] (orderTxIns txins)
-        , let wit' = case wit of
-                       KeyWitness{}              -> wit
-                       ScriptWitness ctx witness -> ScriptWitness ctx witness'
-                         where
-                           witness' = f (ScriptWitnessIndexTxIn ix) witness
-        ]
-
-    mapScriptWitnessesWithdrawals
-      :: TxWithdrawals BuildTx era
-      -> TxWithdrawals BuildTx era
-    mapScriptWitnessesWithdrawals  TxWithdrawalsNone = TxWithdrawalsNone
-    mapScriptWitnessesWithdrawals (TxWithdrawals supported withdrawals) =
-      TxWithdrawals supported
-        [ (addr, withdrawal, BuildTxWith (adjustWitness (f (ScriptWitnessIndexWithdrawal ix)) wit))
-          -- The withdrawals are indexed in the map order by stake credential
-        | (ix, (addr, withdrawal, BuildTxWith wit)) <- zip [0..] (orderStakeAddrs withdrawals)
-        ]
-      where
-        adjustWitness
-          :: (ScriptWitness witctx era -> ScriptWitness witctx era)
-          -> Witness witctx era
-          -> Witness witctx era
-        adjustWitness _ (KeyWitness ctx) = KeyWitness ctx
-        adjustWitness g (ScriptWitness ctx witness') = ScriptWitness ctx (g witness')
-
-    mapScriptWitnessesCertificates
-      :: TxCertificates BuildTx era
-      -> TxCertificates BuildTx era
-    mapScriptWitnessesCertificates  TxCertificatesNone = TxCertificatesNone
-    mapScriptWitnessesCertificates (TxCertificates supported certs
-                                                   (BuildTxWith witnesses)) =
-      TxCertificates supported certs $ BuildTxWith $ Map.fromList
-        [ (stakecred, ScriptWitness ctx witness')
-          -- The certs are indexed in list order
-        | (ix, cert) <- zip [0..] certs
-        , stakecred  <- maybeToList (selectStakeCredential cert)
-        , ScriptWitness ctx witness
-                     <- maybeToList (Map.lookup stakecred witnesses)
-        , let witness' = f (ScriptWitnessIndexCertificate ix) witness
-        ]
-
-    selectStakeCredential cert =
-      case cert of
-        StakeAddressDeregistrationCertificate stakecred   -> Just stakecred
-        StakeAddressDelegationCertificate     stakecred _ -> Just stakecred
-        _                                                 -> Nothing
-
-    mapScriptWitnessesMinting
-      :: TxMintValue BuildTx era
-      -> TxMintValue BuildTx era
-    mapScriptWitnessesMinting  TxMintNone = TxMintNone
-    mapScriptWitnessesMinting (TxMintValue supported value
-                                           (BuildTxWith witnesses)) =
-      TxMintValue supported value $ BuildTxWith $ Map.fromList
-        [ (policyid, witness')
-          -- The minting policies are indexed in policy id order in the value
-        | let ValueNestedRep bundle = valueToNestedRep value
-        , (ix, ValueNestedBundle policyid _) <- zip [0..] bundle
-        , witness <- maybeToList (Map.lookup policyid witnesses)
-        , let witness' = f (ScriptWitnessIndexMint ix) witness
-        ]
-
 
 collectTxBodyScriptWitnesses :: forall era.
                                 TxBodyContent BuildTx era

--- a/cardano-api/src/Cardano/Api/TxIn.hs
+++ b/cardano-api/src/Cardano/Api/TxIn.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+
+-- | Transaction bodies
+--
+module Cardano.Api.TxIn (
+    -- * Transaction inputs
+    TxIn(..),
+    TxIx(..),
+
+    -- * Transaction Ids
+    TxId(..),
+    parseTxId,
+
+    -- * Data family instances
+    AsType(AsTxId),
+
+    -- * Internal conversion functions
+    toByronTxId,
+    toShelleyTxId,
+    fromShelleyTxId,
+    toByronTxIn,
+    fromByronTxIn,
+    toShelleyTxIn,
+    fromShelleyTxIn,
+    renderTxIn,
+  ) where
+
+import           Prelude
+
+import           Control.Applicative (some)
+import           Data.Aeson (withText)
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
+
+import qualified Data.ByteString.Char8 as BSC
+import           Data.String
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Text.Parsec ((<?>))
+import qualified Text.Parsec as Parsec
+import qualified Text.Parsec.Language as Parsec
+import qualified Text.Parsec.String as Parsec
+import qualified Text.Parsec.Token as Parsec
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Crypto.Hashing as Byron
+
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Shelley
+import qualified Cardano.Ledger.SafeHash as SafeHash
+
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import qualified Cardano.Ledger.TxIn as Ledger
+
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseJSON
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.Utils
+
+{- HLINT ignore "Redundant flip" -}
+{- HLINT ignore "Use section" -}
+
+-- ----------------------------------------------------------------------------
+-- Transaction Ids
+--
+
+newtype TxId = TxId (Shelley.Hash StandardCrypto Shelley.EraIndependentTxBody)
+  -- We use the Shelley representation and convert to/from the Byron one
+  deriving stock (Eq, Ord)
+  deriving (Show, IsString)         via UsingRawBytesHex TxId
+  deriving (ToJSON, FromJSON)       via UsingRawBytesHex TxId
+  deriving (ToJSONKey, FromJSONKey) via UsingRawBytesHex TxId
+
+instance HasTypeProxy TxId where
+    data AsType TxId = AsTxId
+    proxyToAsType _ = AsTxId
+
+instance SerialiseAsRawBytes TxId where
+    serialiseToRawBytes (TxId h) = Crypto.hashToBytes h
+    deserialiseFromRawBytes AsTxId bs = TxId <$> Crypto.hashFromBytes bs
+
+toByronTxId :: TxId -> Byron.TxId
+toByronTxId (TxId h) =
+    Byron.unsafeHashFromBytes (Crypto.hashToBytes h)
+
+toShelleyTxId :: TxId -> Ledger.TxId StandardCrypto
+toShelleyTxId (TxId h) =
+    Ledger.TxId (SafeHash.unsafeMakeSafeHash (Crypto.castHash h))
+
+fromShelleyTxId :: Ledger.TxId StandardCrypto -> TxId
+fromShelleyTxId (Ledger.TxId h) =
+    TxId (Crypto.castHash (SafeHash.extractHash h))
+
+
+-- ----------------------------------------------------------------------------
+-- Transaction inputs
+--
+
+data TxIn = TxIn TxId TxIx
+  deriving (Eq, Ord, Show)
+
+instance ToJSON TxIn where
+  toJSON txIn = Aeson.String $ renderTxIn txIn
+
+instance ToJSONKey TxIn where
+  toJSONKey = toJSONKeyText renderTxIn
+
+instance FromJSON TxIn where
+  parseJSON = withText "TxIn" $ runParsecParser parseTxIn
+
+instance FromJSONKey TxIn where
+  fromJSONKey = Aeson.FromJSONKeyTextParser $ runParsecParser parseTxIn
+
+parseTxId :: Parsec.Parser TxId
+parseTxId = do
+  str <- some Parsec.hexDigit <?> "transaction id (hexadecimal)"
+  failEitherWith
+    (\e -> "Incorrect transaction id format: " ++ displayError e) $
+    deserialiseFromRawBytesHex AsTxId $ BSC.pack str
+
+parseTxIn :: Parsec.Parser TxIn
+parseTxIn = TxIn <$> parseTxId <*> (Parsec.char '#' *> parseTxIx)
+
+parseTxIx :: Parsec.Parser TxIx
+parseTxIx = TxIx . fromIntegral <$> decimal
+
+decimal :: Parsec.Parser Integer
+Parsec.TokenParser { Parsec.decimal = decimal } = Parsec.haskell
+
+
+renderTxIn :: TxIn -> Text
+renderTxIn (TxIn txId (TxIx ix)) =
+  serialiseToRawBytesHexText txId <> "#" <> Text.pack (show ix)
+
+
+newtype TxIx = TxIx Word
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (Enum)
+  deriving newtype (ToJSON, FromJSON)
+
+fromByronTxIn :: Byron.TxIn -> TxIn
+fromByronTxIn (Byron.TxInUtxo txId index) =
+  let shortBs = Byron.abstractHashToShort txId
+      mApiHash = Crypto.hashFromBytesShort shortBs
+  in case mApiHash of
+       Just apiHash -> TxIn (TxId apiHash) (TxIx . fromIntegral $ toInteger index)
+       Nothing -> error $ "Error converting Byron era TxId: " <> show txId
+
+toByronTxIn :: TxIn -> Byron.TxIn
+toByronTxIn (TxIn txid (TxIx txix)) =
+    Byron.TxInUtxo (toByronTxId txid) (fromIntegral txix)
+
+-- | This function may overflow on the transaction index. Call sites must ensure
+-- that all uses of this function are appropriately guarded.
+toShelleyTxIn :: TxIn -> Ledger.TxIn StandardCrypto
+toShelleyTxIn (TxIn txid (TxIx txix)) =
+    Ledger.TxIn (toShelleyTxId txid) (Ledger.TxIx $ fromIntegral txix)
+
+fromShelleyTxIn :: Ledger.TxIn StandardCrypto -> TxIn
+fromShelleyTxIn (Ledger.TxIn txid (Ledger.TxIx txix)) =
+    TxIn (fromShelleyTxId txid) (TxIx (fromIntegral txix))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -170,8 +170,6 @@ data TransactionCmd
       -- ^ Return collateral
       (Maybe Lovelace)
       -- ^ Total collateral
-      [TxIn]
-      -- ^ Reference inputs
       [RequiredSigner]
       -- ^ Required signers
       [TxOutAnyEra]
@@ -213,8 +211,6 @@ data TransactionCmd
       -- ^ Return collateral
       (Maybe Lovelace)
       -- ^ Total collateral
-      [TxIn]
-      -- ^ Reference inputs
       [TxOutAnyEra]
       -- ^ Normal outputs
       TxOutChangeAddress

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -256,15 +256,13 @@ pPlutusReferenceScriptWitnessFiles witctx autoBalanceExecUnits =
   pAnyScriptLang =
     Opt.flag' (AnyScriptLanguage $ SimpleScriptLanguage SimpleScriptV1)
       (  Opt.long "simple-script-v1"
-      <> Opt.help "Specify a simple script v1 reference script."
+      <> Opt.help "Specify a simple script v1 reference script. \
+                  \See documentation at doc/reference/simple-scripts.md"
       ) <|>
     Opt.flag' (AnyScriptLanguage $ SimpleScriptLanguage SimpleScriptV2)
       (  Opt.long "simple-script-v2"
-      <> Opt.help "Specify a simple script v2 reference script."
-      ) <|>
-    Opt.flag' (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV1)
-      (  Opt.long "plutus-script-v1"
-      <> Opt.help "Specify a plutus script v1 reference script."
+      <> Opt.help "Specify a simple script v2 reference script. \
+                  \See documentation at doc/reference/simple-scripts.md"
       ) <|>
     Opt.flag' (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV2)
       (  Opt.long "plutus-script-v2"
@@ -2189,7 +2187,7 @@ pTxOutDatum =
 pRefScriptFp :: Parser ReferenceScriptAnyEra
 pRefScriptFp =
   ReferenceScriptAnyEra <$> Opt.strOption
-    (  Opt.long "reference-script-file"
+    (  Opt.long "tx-out-reference-script-file"
     <> Opt.metavar "FILE"
     <> Opt.help "Reference script input file."
     <> Opt.completer (Opt.bashCompleter "file")

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -52,9 +52,9 @@ import           Data.Word (Word64)
 
 import qualified Cardano.Chain.Slotting as Byron
 
-import           Cardano.Api (AddressAny, EpochNo, ExecutionUnits, Hash, InAnyCardanoEra,
-                   PaymentKey, ScriptData, SlotNo (SlotNo), Tx, Value, WitCtxMint, WitCtxStake,
-                   WitCtxTxIn)
+import           Cardano.Api (AddressAny, AnyScriptLanguage, EpochNo, ExecutionUnits, Hash,
+                   InAnyCardanoEra, PaymentKey, ScriptData, SlotNo (SlotNo), Tx, TxIn, Value,
+                   WitCtxMint, WitCtxStake, WitCtxTxIn)
 
 import qualified Cardano.Ledger.Crypto as Crypto
 
@@ -288,10 +288,21 @@ data ScriptWitnessFiles witctx where
                               -> ScriptWitnessFiles witctx
 
      PlutusScriptWitnessFiles :: ScriptFile
-                              -> ScriptDatumOrFile witctx
+                              -> ScriptDatumOrFile witctx -- TODO: Babbage Modify to allow specification of inline datums
                               -> ScriptRedeemerOrFile
                               -> ExecutionUnits
                               -> ScriptWitnessFiles witctx
+
+     -- TODO: SimpleReferenceScriptWitnessFiles :: ScriptWitnessFiles witctx
+
+     PlutusReferenceScriptWitnessFiles
+       :: TxIn
+       -> AnyScriptLanguage
+       -> ScriptDatumOrFile witctx -- TODO: Babbage Modify to allow specification of inline datums
+       -> ScriptRedeemerOrFile
+       -> ExecutionUnits
+       -> ScriptWitnessFiles witctx
+
 
 deriving instance Show (ScriptWitnessFiles witctx)
 

--- a/doc/reference/plutus/reference-script-example.md
+++ b/doc/reference/plutus/reference-script-example.md
@@ -1,0 +1,146 @@
+# Plutus Scripts
+
+## What is a reference script?
+
+A reference script is a script that exists at a particular transaction output. It can be used to witness, for example, a UTxO at the corresponding script address of said reference script. Why is this useful? It means we no longer have to include the script in the transaction, greatly reducing its size
+
+### An example of using a Plutus V2 reference script
+
+Below is an example that shows how to use a Plutus spending script. We will walk though the [shell script example of how to use a reference script to spend a tx input](scripts/plutus/example-reference-script-usage.sh).This is a step-by-step process involving:
+
++ the creation of the `Required Redeemer` Plutus txin script
++ the creation of the `Required Redeemer` Plutus script at a transaction output (creation of the reference script)
++ sending ADA and a datum to the Plutus script address
++ spending ADA at the Plutus script address using the Plutus reference script
+
+In this example we will use the [Required Redeemer](scripts/plutus/scripts/v2/required-redeemer.plutus) Plutus spending script. In order to execute a reference Plutus spending script, we require the following:
+
+- Collateral tx input(s) - these are provided and are forfeited in the event the Plutus script fails to execute.
+- A Plutus tx output with accompanying datum hash. This is the tx output that sits at the Plutus script address. It must have a datum hash, otherwise, it is unspendable.
+- The reference transaction input containing the corresponding Plutus script. We must create the transaction output containing the reference Plutus script.
+
+#### Creating the `Required Redeemer` Plutus spending script
+
+The plutus-example executable will automagically generate several Plutus scripts in the CLI-compatible text envelope format.
+
+Run the following commands:
+
+```bash
+git clone git@github.com:input-output-hk/plutus-apps.git
+
+cd plutus-apps/plutus-example
+
+cabal run exe:plutus-example
+```
+
+This will output `required-redeemer.plutus` in the `generated-plutus-scripts/v2` dir.
+
+#### Setting up a local Babbage node cluster
+
+There is a convenient script that will set up a Babbage cluster immediately on your local machine.
+
+Run the following command:
+
+```bash
+cabal install cardano-cli
+cabal install cardano-node
+./scripts/babbage/mkfiles.sh
+```
+
+To start your babbage cluster you need to run the `example/run/all.sh` shell script.
+The remainder of this guide briefly talks about the [shell script example](scripts/plutus/example-reference-script-usage.sh) that automatically does everything for you.
+
+#### Creating a reference script at a transaction output and
+#### sending ADA to the script address (with a datum)
+
+In order to use a reference script we must first create said reference script at a particular address. Note you cannot create a reference script at the same correspnding script address, this will result in a failure when trying to spend the transaction input at the script address.
+
+```bash
+cardano-cli transaction build \
+  --babbage-era \
+  --cardano-mode \
+  --testnet-magic 42 \
+  --change-address "$utxoaddr" \
+  --tx-in "$txin" \
+  --tx-out "$utxoaddr+$lovelace" \
+  --tx-out "$plutusscriptaddr+$lovelace" \
+  --tx-out-datum-hash "$scriptdatumhash" \
+  --tx-out "$dummyaddress+$lovelaceattxindiv3" \
+  --reference-script-file "$plutusscriptinuse" \
+  --protocol-params-file "$WORK/pparams.json" \
+  --out-file "$WORK/create-datum-output.body"
+```
+
+There are a couple things happening in the following `build` command.
+Firstly we are sending ADA to the plutus script address along with a datum. This is reflected in the following lines:
+
+```bash
+...
+--tx-out "$plutusscriptaddr+$lovelace" \
+--tx-out-datum-hash "$scriptdatumhash" \
+...
+```
+
+We have seen this before in the [plutus-spending-script-example.md](doc/reference/plutus/plutus-spending-script-example.md).
+
+Secondly we are creating a reference script at an address, which cannot be the same as the reference script address, of our choosing in the following lines:
+
+```bash
+...
+--tx-out "$dummyaddress+$lovelaceattxindiv3" \
+--reference-script-file "$plutusscriptinuse" \
+...
+```
+
+Specifying the `--reference-script-file` after the `--tx-out` option will construct a transaction that creates a reference script at that transaction output.
+
+We sign and then submit as usual:
+
+```bash
+cardano-cli transaction sign \
+  --tx-body-file $WORK/create-datum-output.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file $UTXO_SKEY \
+  --out-file $WORK/create-datum-output.tx
+```
+
+
+#### Spending ADA at the script address
+
+Now that there is ADA at our script address, we must construct the appropriate transaction in order to spend it.
+Because we are using the `build` command we only have to concern ourselves with the following:
+
+`$plutusutxotxin` - This is the tx input that sits at the Plutus script address (NB: It has a datum hash).
+`tx-in-reference` -This specifies the reference input you are using to witness a transaction input.
+`plutus-script-v2`- This specifies the version of the reference script at the reference input. There are no restrictions on the type of script we can have at a reference input.
+`reference-tx-in-datum-file` - This is the datum to be used with the reference script.
+`reference-tx-in-redeemer-file` - This is the redeemer to be used with the reference script.
+
+```bash
+cardano-cli transaction build \
+  --babbage-era \
+  --cardano-mode \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --change-address "$utxoaddr" \
+  --tx-in "$txin1" \
+  --tx-in-collateral "$txinCollateral" \
+  --out-file "$WORK/test-alonzo-ref-script.body" \
+  --tx-in "$plutuslockedutxotxin" \
+  --tx-in-reference "$plutusreferencescripttxin" \
+  --plutus-script-v2 \
+  --reference-tx-in-datum-file "$datumfilepath"  \
+  --reference-tx-in-redeemer-file "$redeemerfilepath" \
+  --tx-out "$dummyaddress2+10000000" \
+  --protocol-params-file "$WORK/pparams.json"
+
+cardano-cli transaction sign \
+  --tx-body-file $WORK/test-alonzo-ref-script.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file "${UTXO_SKEY}" \
+  --out-file $WORK/alonzo-ref-script.tx
+```
+
+If there is ADA at `$dummyaddress2` then the Plutus script was successfully executed. Conversely, if the Plutus script failed, the collateral input would have been consumed.
+
+You can use the [example-txin-locking-plutus-script.sh](../../../scripts/plutus/example-txin-locking-plutus-script.sh) in conjunction with [mkfiles.sh alonzo](../../../scripts/byron-to-alonzo/mkfiles.sh) script to automagically run the `AlwaysSucceeds` script.
+

--- a/doc/reference/plutus/reference-script-example.md
+++ b/doc/reference/plutus/reference-script-example.md
@@ -2,16 +2,16 @@
 
 ## What is a reference script?
 
-A reference script is a script that exists at a particular transaction output. It can be used to witness, for example, a UTxO at the corresponding script address of said reference script. Why is this useful? It means we no longer have to include the script in the transaction, greatly reducing its size
+A reference script is a script that exists at a particular transaction output. It can be used to witness, for example, a UTxO at the corresponding script address of said reference script. This is useful because the script does not have to be included in the transaction anymore, which significantly reduces the transaction size.
 
 ### An example of using a Plutus V2 reference script
 
-Below is an example that shows how to use a Plutus spending script. We will walk though the [shell script example of how to use a reference script to spend a tx input](scripts/plutus/example-reference-script-usage.sh).This is a step-by-step process involving:
+Below is an example that shows how to use a Plutus spending script. Here we discuss a [shell script example of how to use a reference script to spend a tx input](scripts/plutus/example-reference-script-usage.sh). This is a step-by-step process involving:
 
 + the creation of the `Required Redeemer` Plutus txin script
 + the creation of the `Required Redeemer` Plutus script at a transaction output (creation of the reference script)
-+ sending ADA and a datum to the Plutus script address
-+ spending ADA at the Plutus script address using the Plutus reference script
++ sending ada and a datum to the Plutus script address
++ spending ada at the Plutus script address using the Plutus reference script
 
 In this example we will use the [Required Redeemer](scripts/plutus/scripts/v2/required-redeemer.plutus) Plutus spending script. In order to execute a reference Plutus spending script, we require the following:
 
@@ -47,13 +47,14 @@ cabal install cardano-node
 ./scripts/babbage/mkfiles.sh
 ```
 
-To start your babbage cluster you need to run the `example/run/all.sh` shell script.
-The remainder of this guide briefly talks about the [shell script example](scripts/plutus/example-reference-script-usage.sh) that automatically does everything for you.
+To start your babbage cluster, you need to run the `example/run/all.sh` shell script.
+The remainder of this guide provides a brief walkthrough of the [shell script example](scripts/plutus/example-reference-script-usage.sh) that automatically creates a reference script and spends the utxo at
+the reference script's corresponding script address.
 
 #### Creating a reference script at a transaction output and
-#### sending ADA to the script address (with a datum)
+#### sending ada to the script address (with a datum)
 
-In order to use a reference script we must first create said reference script at a particular address. Note you cannot create a reference script at the same correspnding script address, this will result in a failure when trying to spend the transaction input at the script address.
+In order to use a reference script, we must first create this script at a particular transaction output.
 
 ```bash
 cardano-cli transaction build \
@@ -66,13 +67,14 @@ cardano-cli transaction build \
   --tx-out "$plutusscriptaddr+$lovelace" \
   --tx-out-datum-hash "$scriptdatumhash" \
   --tx-out "$dummyaddress+$lovelaceattxindiv3" \
-  --reference-script-file "$plutusscriptinuse" \
+  --tx-out-reference-script-file "$plutusscriptinuse" \
   --protocol-params-file "$WORK/pparams.json" \
   --out-file "$WORK/create-datum-output.body"
 ```
 
-There are a couple things happening in the following `build` command.
-Firstly we are sending ADA to the plutus script address along with a datum. This is reflected in the following lines:
+The following should be noted about this build command:
+
+Firstly, we are sending ada to the plutus script address along with a datum hash. This is reflected in the following lines:
 
 ```bash
 ...
@@ -83,12 +85,12 @@ Firstly we are sending ADA to the plutus script address along with a datum. This
 
 We have seen this before in the [plutus-spending-script-example.md](doc/reference/plutus/plutus-spending-script-example.md).
 
-Secondly we are creating a reference script at an address, which cannot be the same as the reference script address, of our choosing in the following lines:
+Secondly, we are creating a reference script at a tx output:
 
 ```bash
 ...
 --tx-out "$dummyaddress+$lovelaceattxindiv3" \
---reference-script-file "$plutusscriptinuse" \
+--tx-out-reference-script-file "$plutusscriptinuse" \
 ...
 ```
 
@@ -105,14 +107,14 @@ cardano-cli transaction sign \
 ```
 
 
-#### Spending ADA at the script address
+#### Spending ada at the script address
 
-Now that there is ADA at our script address, we must construct the appropriate transaction in order to spend it.
-Because we are using the `build` command we only have to concern ourselves with the following:
+Now that there is ada at our script address, we must construct the appropriate transaction in order to spend it.
+Because we are using the `build` command, we should only note the following:
 
 `$plutusutxotxin` - This is the tx input that sits at the Plutus script address (NB: It has a datum hash).
-`tx-in-reference` -This specifies the reference input you are using to witness a transaction input.
-`plutus-script-v2`- This specifies the version of the reference script at the reference input. There are no restrictions on the type of script we can have at a reference input.
+`tx-in-reference` - This specifies the reference input you are using to witness a transaction input.
+`plutus-script-v2`- This specifies the version of the reference script at the reference input.
 `reference-tx-in-datum-file` - This is the datum to be used with the reference script.
 `reference-tx-in-redeemer-file` - This is the redeemer to be used with the reference script.
 
@@ -140,7 +142,7 @@ cardano-cli transaction sign \
   --out-file $WORK/alonzo-ref-script.tx
 ```
 
-If there is ADA at `$dummyaddress2` then the Plutus script was successfully executed. Conversely, if the Plutus script failed, the collateral input would have been consumed.
+If there is ada at `$dummyaddress2`, then the Plutus script was successfully executed. Conversely, if the Plutus script failed, the collateral input would have been consumed.
 
 You can use the [example-txin-locking-plutus-script.sh](../../../scripts/plutus/example-txin-locking-plutus-script.sh) in conjunction with [mkfiles.sh alonzo](../../../scripts/byron-to-alonzo/mkfiles.sh) script to automagically run the `AlwaysSucceeds` script.
 

--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -151,7 +151,7 @@ $SED -i "${ROOT}/genesis/shelley/genesis.json" \
     -e 's/"minFeeB": 0/"minFeeB": 155381/' \
     -e 's/"minUTxOValue": 0/"minUTxOValue": 1000000/' \
     -e 's/"decentralisationParam": 1.0/"decentralisationParam": 0.7/' \
-    -e 's/"major": 0/"major": 2/' \
+    -e 's/"major": 0/"major": 7/' \
     -e 's/"rho": 0.0/"rho": 0.1/' \
     -e 's/"tau": 0.0/"tau": 0.1/' \
     -e 's/"updateQuorum": 5/"updateQuorum": 2/'

--- a/scripts/plutus/example-reference-script-usage.sh
+++ b/scripts/plutus/example-reference-script-usage.sh
@@ -50,7 +50,9 @@ lovelaceattxindiv3=$(expr $lovelaceattxin / 4)
 $CARDANO_CLI query protocol-parameters --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/pparams.json
 dummyaddress=addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4
 
-# We first create the reference script at the utxoaddr
+# We first:
+# - Create the reference script at the utxoaddr
+# - Send ADA and a datum to the reference script address
 $CARDANO_CLI transaction build \
   --babbage-era \
   --cardano-mode \
@@ -116,6 +118,7 @@ echo "$plutusreferencescripttxin"
 echo "Plutus input we are trying to spend"
 echo "$plutuslockedutxotxin"
 
+# Alternative build-raw method
 #$CARDANO_CLI transaction build-raw \
 #  --babbage-era \
 #  --script-valid \

--- a/scripts/plutus/example-reference-script-usage.sh
+++ b/scripts/plutus/example-reference-script-usage.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# Unofficial bash strict mode.
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -e
+set -o pipefail
+
+export WORK="${WORK:-example/work}"
+export BASE="${BASE:-.}"
+export CARDANO_CLI="${CARDANO_CLI:-cardano-cli}"
+export CARDANO_NODE_SOCKET_PATH="${CARDANO_NODE_SOCKET_PATH:-example/node-spo1/node.sock}"
+export TESTNET_MAGIC="${TESTNET_MAGIC:-42}"
+export UTXO_VKEY="${UTXO_VKEY:-example/stake-delegator-keys/payment1.vkey}"
+export UTXO_SKEY="${UTXO_SKEY:-example/stake-delegator-keys/payment1.skey}"
+export RESULT_FILE="${RESULT_FILE:-$WORK/result.out}"
+
+echo "Socket path: $CARDANO_NODE_SOCKET_PATH"
+echo "Socket path: $(pwd)"
+
+ls -al "$CARDANO_NODE_SOCKET_PATH"
+
+plutusscriptinuse="$BASE/scripts/plutus/scripts/v2/required-redeemer.plutus"
+## This datum hash is the hash of the untyped 42
+scriptdatumhash="9e1199a988ba72ffd6e9c269cadb3b53b5f360ff99f112d9b2ee30c4d74ad88b"
+datumfilepath="$BASE/scripts/plutus/data/42.datum"
+redeemerfilepath="$BASE/scripts/plutus/data/42.redeemer"
+echo "Script at: $plutusscriptinuse"
+#
+#
+#
+## Step 1: Create a tx output with a datum hash at the script address. In order for a tx output to be locked
+## by a plutus script, it must have a datahash. We also need collateral tx inputs so we split the utxo
+## in order to accommodate this.
+#
+#
+plutusscriptaddr=$($CARDANO_CLI address build --payment-script-file "$plutusscriptinuse"  --testnet-magic "$TESTNET_MAGIC")
+echo "Plutus Script Address"
+echo "$plutusscriptaddr"
+mkdir -p "$WORK"
+
+utxoaddr=$($CARDANO_CLI address build --testnet-magic "$TESTNET_MAGIC" --payment-verification-key-file "$UTXO_VKEY" --stake-verification-key-file example/stake-delegator-keys/staking1.vkey)
+
+$CARDANO_CLI query utxo --address "$utxoaddr" --cardano-mode --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/utxo-1.json
+cat $WORK/utxo-1.json
+
+txin=$(jq -r 'keys[0]' $WORK/utxo-1.json)
+lovelaceattxin=$(jq -r ".[\"$txin\"].value.lovelace" $WORK/utxo-1.json)
+lovelaceattxindiv3=$(expr $lovelaceattxin / 4)
+
+$CARDANO_CLI query protocol-parameters --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/pparams.json
+dummyaddress=addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4
+
+# We first create the reference script at the utxoaddr
+$CARDANO_CLI transaction build \
+  --babbage-era \
+  --cardano-mode \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --change-address "$utxoaddr" \
+  --tx-in "$txin" \
+  --tx-out "$utxoaddr+$lovelaceattxindiv3" \
+  --tx-out "$plutusscriptaddr+$lovelaceattxindiv3" \
+  --tx-out-datum-hash "$scriptdatumhash" \
+  --tx-out "$dummyaddress+$lovelaceattxindiv3" \
+  --reference-script-file "$plutusscriptinuse" \
+  --protocol-params-file "$WORK/pparams.json" \
+  --out-file "$WORK/create-datum-output.body"
+
+$CARDANO_CLI transaction sign \
+  --tx-body-file $WORK/create-datum-output.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file $UTXO_SKEY \
+  --out-file $WORK/create-datum-output.tx
+
+# SUBMIT
+$CARDANO_CLI transaction submit --tx-file $WORK/create-datum-output.tx --testnet-magic "$TESTNET_MAGIC"
+echo "Pausing for 5 seconds..."
+sleep 5
+
+$CARDANO_CLI query utxo --address "$dummyaddress" --cardano-mode --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/dummy-address-ref-script.json
+cat $WORK/dummy-address-ref-script.json
+# Get reference script txin
+plutusreferencescripttxin=$(jq -r 'keys[0]' $WORK/dummy-address-ref-script.json)
+
+# Step 2
+# After "locking" the tx output at the script address, let's spend the utxo as the script address using the corresponding reference script
+
+## Get funding inputs
+$CARDANO_CLI query utxo --address "$utxoaddr" --cardano-mode --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/utxo-2.json
+
+txin1=$(jq -r 'keys[0]' $WORK/utxo-2.json)
+txinCollateral=$(jq -r 'keys[1]' $WORK/utxo-2.json)
+lovelaceattxin1=$(jq -r ".[\"$txin1\"].value.lovelace" $WORK/utxo-2.json)
+lovelaceattxindiv31=$(expr $lovelaceattxin1 / 3)
+
+
+# Get input at plutus script that we will attempt to spend
+$CARDANO_CLI query utxo --address $plutusscriptaddr --testnet-magic "$TESTNET_MAGIC" --out-file $WORK/plutusutxo.json
+plutuslockedutxotxin=$(jq -r 'keys[0]' $WORK/plutusutxo.json)
+lovelaceatplutusscriptaddr=$(jq -r ".[\"$plutuslockedutxotxin\"].value.lovelace" $WORK/plutusutxo.json)
+
+dummyaddress2=addr_test1vzq57nyrwdwne9vzjxr908qqkdxwuavlgzl20qveua303vq024qkk
+
+
+echo "Plutus txin"
+echo "$plutuslockedutxotxin"
+
+echo "Collateral"
+echo "$txinCollateral"
+
+echo "Funding utxo"
+echo "$txin1"
+
+echo "Plutus reference script txin"
+echo "$plutusreferencescripttxin"
+
+echo "Plutus input we are trying to spend"
+echo "$plutuslockedutxotxin"
+
+#$CARDANO_CLI transaction build-raw \
+#  --babbage-era \
+#  --script-valid \
+#  --tx-in "$txin1" \
+#  --tx-in-collateral "$txinCollateral" \
+#  --out-file "$WORK/test-alonzo-ref-script.body" \
+#  --tx-in "$plutuslockedutxotxin" \
+#  --tx-in-reference "$plutusreferencescripttxin" \
+#  --plutus-script-v2 \
+#  --reference-tx-in-datum-file "$datumfilepath"  \
+#  --reference-tx-in-redeemer-file "$redeemerfilepath" \
+#  --reference-tx-in-execution-units "(1000022165, 1000065)" \
+#  --tx-out "$dummyaddress2+10000000" \
+#  --tx-out "$utxoaddr+149988741087" \
+#  --fee "1000000" \
+#  --protocol-params-file "$WORK/pparams.json"
+
+$CARDANO_CLI transaction build \
+  --babbage-era \
+  --cardano-mode \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --change-address "$utxoaddr" \
+  --tx-in "$txin1" \
+  --tx-in-collateral "$txinCollateral" \
+  --out-file "$WORK/test-alonzo-ref-script.body" \
+  --tx-in "$plutuslockedutxotxin" \
+  --tx-in-reference "$plutusreferencescripttxin" \
+  --plutus-script-v2 \
+  --reference-tx-in-datum-file "$datumfilepath"  \
+  --reference-tx-in-redeemer-file "$redeemerfilepath" \
+  --tx-out "$dummyaddress2+10000000" \
+  --protocol-params-file "$WORK/pparams.json"
+
+$CARDANO_CLI transaction sign \
+  --tx-body-file $WORK/test-alonzo-ref-script.body \
+  --testnet-magic "$TESTNET_MAGIC" \
+  --signing-key-file "${UTXO_SKEY}" \
+  --out-file $WORK/alonzo-ref-script.tx
+
+# SUBMIT $WORK/alonzo.tx
+echo "Submit the tx using reference script and wait 5 seconds..."
+$CARDANO_CLI transaction submit --tx-file $WORK/alonzo-ref-script.tx --testnet-magic "$TESTNET_MAGIC"
+sleep 5
+echo ""
+echo "Querying UTxO at $dummyaddress2. If there is ADA at the address the Plutus reference script successfully executed!"
+echo ""
+$CARDANO_CLI query utxo --address "$dummyaddress2"  --testnet-magic "$TESTNET_MAGIC" \
+  | tee "$RESULT_FILE"

--- a/scripts/plutus/example-reference-script-usage.sh
+++ b/scripts/plutus/example-reference-script-usage.sh
@@ -63,7 +63,7 @@ $CARDANO_CLI transaction build \
   --tx-out "$plutusscriptaddr+$lovelaceattxindiv3" \
   --tx-out-datum-hash "$scriptdatumhash" \
   --tx-out "$dummyaddress+$lovelaceattxindiv3" \
-  --reference-script-file "$plutusscriptinuse" \
+  --tx-out-reference-script-file "$plutusscriptinuse" \
   --protocol-params-file "$WORK/pparams.json" \
   --out-file "$WORK/create-datum-output.body"
 


### PR DESCRIPTION
- Implements a shell script that uses a spending plutus v2 reference script. Currently only `build-raw` is working with reference scripts.
- Updates the api and cli to enable the usage of reference scripts
- Adds documentation outlining how to use reference scripts 