### PR TITLE
CAD-3915 define the `BackingStoreSelector` flag

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds #-}
 
 module Cardano.Benchmarking.Script.Core
 where
@@ -25,6 +26,7 @@ import           Control.Concurrent (threadDelay)
 import           Control.Tracer (nullTracer)
 
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
+import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 import           Cardano.Api
 import           Cardano.Api.Shelley (ProtocolParameters, protocolParamMaxTxExUnits, protocolParamPrices)
 
@@ -171,7 +173,7 @@ queryRemoteProtocolParameters = do
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
   era <- queryEra
   let
-    callQuery :: forall a. Show a => QueryInMode CardanoMode (Either a ProtocolParameters) -> ActionM ProtocolParameters
+    callQuery :: forall a. Show a => QueryInMode CardanoMode SmallL (Either a ProtocolParameters) -> ActionM ProtocolParameters
     callQuery query = do
       res <- liftIO $ queryNodeLocalState localNodeConnectInfo (Just $ chainTipToChainPoint chainTip) query
       case res of

--- a/cabal.project
+++ b/cabal.project
@@ -260,8 +260,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 09cd230888c0c2a69d6848d7204911fc4844d5d8
-  --sha256: 1bz3qzd49rb3mrc9smxz4ya2v4dnavhkkap47wk01rfsg7vizqp0
+  tag: f0d19edb5e5fc5644e22a4f3e90ba99d1e3a3d41
+  --sha256: 1bkb7ql295swc17dg4yyv3dhxi2ry7lfpbvrl2xcaw8d20q3xq9q
   subdir:
     monoidal-synchronisation
     network-mux

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -13,7 +13,6 @@
 
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.
-{-# LANGUAGE DataKinds #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 

--- a/cardano-client-demo/ChainSyncClientWithLedgerState.hs
+++ b/cardano-client-demo/ChainSyncClientWithLedgerState.hs
@@ -23,6 +23,7 @@ import           Data.Word (Word32)
 import qualified GHC.TypeLits as GHC
 import           System.Environment (getArgs)
 import           System.FilePath ((</>))
+import Ouroboros.Consensus.HardFork.Combinator.Util.Functors (Flip)
 
 -- | Connects to a local cardano node, requests the blocks and prints out some
 -- information from each ledger state. To run this, you must first start a local
@@ -127,7 +128,7 @@ chainSyncClient = ChainSyncClient $ do
             return clientStIdle
         }
 
-    printLedgerState :: TSP.Telescope (SOP.K C.Past) (C.Current C.LedgerState) xs -> IO ()
+    printLedgerState :: TSP.Telescope (SOP.K C.Past) (C.Current (Flip C.LedgerState mk)) xs -> IO ()
     printLedgerState ls = case ls of
       TSP.TZ (C.Current bound _) -> putStrLn $ "curren't era bounds: " <> show bound
       TSP.TS _ ls' -> printLedgerState ls'

--- a/cardano-client-demo/LedgerState.hs
+++ b/cardano-client-demo/LedgerState.hs
@@ -42,7 +42,7 @@ main = do
       (BlockInMode (Block (BlockHeader _slotNo _blockHeaderHash (BlockNo blockNoI)) _transactions) _era)
       blockCount -> do
         case ledgerState of
-            LedgerStateShelley (Shelley.ShelleyLedgerState shelleyTipWO _ _) -> case shelleyTipWO of
+            LedgerStateShelley (Shelley.ShelleyLedgerState shelleyTipWO _ _ _) -> case shelleyTipWO of
               Origin -> putStrLn "."
               At (Shelley.ShelleyTip _ _ hash) -> print hash
             _ -> when (blockNoI `mod` 100 == 0) (print blockNoI)

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -270,13 +270,13 @@ main = do
                    case ledgerState of
                      LedgerStateByron _                                     ->
                        ("byron",   EpochNo 0, Nothing)
-                     LedgerStateShelley (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateShelley (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("shelley", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateAllegra (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateAllegra (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("allegra", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateMary    (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateMary    (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("mary",    L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateAlonzo    (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateAlonzo    (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("alonzo",  L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
 
              let txBodyComponents = map ( (\(TxBody txbc) -> txbc) . getTxBody ) transactions

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -59,7 +59,8 @@ library
 
   hs-source-dirs:      src
 
-  exposed-modules:     Cardano.Node.Configuration.Logging
+  exposed-modules:     Cardano.Node.Configuration.LedgerDB
+                       Cardano.Node.Configuration.Logging
                        Cardano.Node.Configuration.NodeAddress
                        Cardano.Node.Configuration.POM
                        Cardano.Node.Configuration.Socket
@@ -170,6 +171,7 @@ library
                       , ouroboros-consensus-shelley
                       , ouroboros-network
                       , ouroboros-network-framework
+                      , prefix-units
                       , psqueues
                       , safe-exceptions
                       , scientific

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -1,0 +1,22 @@
+module Cardano.Node.Configuration.LedgerDB (
+    BackingStoreSelectorFlag(..)
+  ) where
+
+import           Prelude
+
+-- | Choose the LedgerDB Backend
+--
+-- As of UTxO-HD, the LedgerDB now uses either an in-memory backend or LMDB to
+-- keep track of differences in the UTxO set.
+--
+-- - 'InMemory': uses more memory than the minimum requirements but is somewhat
+--   faster.
+-- - 'LMDB': uses less memory but is somewhat slower.
+--
+-- See 'Ouroboros.Consnesus.Storage.LedgerDB.OnDisk.BackingStoreSelector'.
+data BackingStoreSelectorFlag =
+    LMDB (Maybe Int) -- ^ A map size can be specified, this is the maximum disk
+                     -- space the LMDB database can fill. If not provided, the
+                     -- default of 12Gi will be used.
+  | InMemory
+  deriving (Eq, Show)

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -30,6 +30,7 @@ import           Data.Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime)
+import           Data.Prefix.Units
 import           Data.Yaml (decodeFileThrow)
 import           Generic.Data (gmappend)
 import           Generic.Data.Orphans ()
@@ -38,6 +39,7 @@ import           System.FilePath (takeDirectory, (</>))
 
 import qualified Cardano.Chain.Update as Byron
 import           Cardano.Crypto (RequiresNetworkMagic (..))
+import           Cardano.Node.Configuration.LedgerDB
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Protocol.Types (Protocol (..))
@@ -116,6 +118,9 @@ data NodeConfiguration
 
        , ncMaybeMempoolCapacityOverride :: !(Maybe MempoolCapacityBytesOverride)
 
+         -- UTxO-HD configuration
+       , ncLedgerDBBackend :: !BackingStoreSelectorFlag
+
          -- | Protocol idleness timeout, see
          -- 'Ouroboros.Network.Diffusion.daProtocolIdleTimeout'.
          --
@@ -171,6 +176,9 @@ data PartialNodeConfiguration
 
          -- Configuration for testing purposes
        , pncMaybeMempoolCapacityOverride :: !(Last MempoolCapacityBytesOverride)
+
+         -- UTxO-HD configuration
+       , pncLedgerDBBackend :: !(Last BackingStoreSelectorFlag)
 
          -- Network timeouts
        , pncProtocolIdleTimeout   :: !(Last DiffTime)
@@ -244,6 +252,8 @@ instance FromJSON PartialNodeConfiguration where
                                                                <*> parseHardForkProtocol v)
       pncMaybeMempoolCapacityOverride <- Last <$> parseMempoolCapacityBytesOverride v
 
+      pncLedgerDBBackend <- Last <$> parseLedgerDBBackend v
+
       -- Network timeouts
       pncProtocolIdleTimeout   <- Last <$> v .:? "ProtocolIdleTimeout"
       pncTimeWaitTimeout       <- Last <$> v .:? "TimeWaitTimeout"
@@ -285,6 +295,7 @@ instance FromJSON PartialNodeConfiguration where
            , pncValidateDB = mempty
            , pncShutdownConfig = mempty
            , pncMaybeMempoolCapacityOverride
+           , pncLedgerDBBackend
            , pncProtocolIdleTimeout
            , pncTimeWaitTimeout
            , pncAcceptedConnectionsLimit
@@ -306,6 +317,22 @@ instance FromJSON PartialNodeConfiguration where
                     "Invalid value for 'MempoolCapacityBytesOverride'.  \
                     \Expecting byte count or NoOverride.  Value was: " <> show invalid
               Nothing -> return Nothing
+
+      parseLedgerDBBackend v = do
+        maybeString :: Maybe String <- v .:? "LedgerDBBackend"
+        case maybeString of
+           Just "InMemory" -> return $ Just InMemory
+           Just "LMDB"     -> do
+             maybeMapSize :: Maybe String <- v .:? "LMDBMapSize"
+             mapSize <- case maybeMapSize of
+               Nothing -> return Nothing
+               Just s  -> case parseValue ParseBinary s of
+                 Left e      -> fail ("Malformed LMDBMapSize: " <> e)
+                 Right units -> return $ Just units
+             return . Just . LMDB $ mapSize
+           Nothing         -> return Nothing
+           Just whatever   -> fail $ "Malformed LedgerDBBackend" <> whatever
+
       parseByronProtocol v = do
         primary   <- v .:? "ByronGenesisFile"
         secondary <- v .:? "GenesisFile"
@@ -428,6 +455,7 @@ defaultPartialNodeConfiguration =
     , pncLogMetrics = mempty
     , pncTraceConfig = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncLedgerDBBackend = Last . Just $ LMDB Nothing
     , pncProtocolIdleTimeout   = Last (Just 5)
     , pncTimeWaitTimeout       = Last (Just 60)
     , pncAcceptedConnectionsLimit =
@@ -484,6 +512,9 @@ makeNodeConfiguration pnc = do
   ncAcceptedConnectionsLimit <-
     lastToEither "Missing AcceptedConnectionsLimit" $
       pncAcceptedConnectionsLimit pnc
+  ncLedgerDBBackend <-
+    lastToEither "Missing LedgerDBBackend"
+    $ pncLedgerDBBackend pnc
   enableP2P <-
     lastToEither "Missing EnableP2P"
     $ pncEnableP2P pnc
@@ -517,6 +548,7 @@ makeNodeConfiguration pnc = do
              , ncTraceConfig = if loggingSwitch then traceConfig
                                                 else TracingOff
              , ncMaybeMempoolCapacityOverride = getLast $ pncMaybeMempoolCapacityOverride pnc
+             , ncLedgerDBBackend
              , ncProtocolIdleTimeout
              , ncTimeWaitTimeout
              , ncAcceptedConnectionsLimit

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -9,6 +9,7 @@ import           Cardano.Prelude
 
 import           Data.Time.Clock (secondsToDiffTime)
 
+import           Cardano.Node.Configuration.LedgerDB
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
@@ -68,6 +69,7 @@ testPartialYamlConfig =
     , pncProtocolFiles = mempty
     , pncValidateDB = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncLedgerDBBackend = Last $ Just $ LMDB Nothing
     , pncProtocolIdleTimeout = mempty
     , pncTimeWaitTimeout = mempty
     , pncAcceptedConnectionsLimit = mempty
@@ -100,6 +102,7 @@ testPartialCliConfig =
     , pncLogMetrics = mempty
     , pncTraceConfig = Last (Just $ PartialTracingOnLegacy defaultPartialTraceConfiguration)
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncLedgerDBBackend = Last $ Just $ LMDB Nothing
     , pncProtocolIdleTimeout = mempty
     , pncTimeWaitTimeout = mempty
     , pncAcceptedConnectionsLimit = mempty
@@ -135,6 +138,7 @@ eExpectedConfig = do
     , ncLogMetrics = True
     , ncTraceConfig = traceOptions
     , ncMaybeMempoolCapacityOverride = Nothing
+    , ncLedgerDBBackend = LMDB Nothing
     , ncProtocolIdleTimeout = 5
     , ncTimeWaitTimeout = 60
     , ncAcceptedConnectionsLimit =

--- a/nix/lmdb-mingw.patch
+++ b/nix/lmdb-mingw.patch
@@ -1,0 +1,21 @@
+diff --git a/libraries/liblmdb/Makefile b/libraries/liblmdb/Makefile
+index 612484e..2e6b562 100644
+--- a/libraries/liblmdb/Makefile
++++ b/libraries/liblmdb/Makefile
+@@ -27,6 +27,7 @@ CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+ LDLIBS	=
+ SOLIBS	=
+ SOEXT	= .so
++BINEXT  =
+ prefix	= /usr/local
+ exec_prefix = $(prefix)
+ bindir = $(exec_prefix)/bin
+@@ -49,7 +50,7 @@ install: $(ILIBS) $(IPROGS) $(IHDRS)
+ 	mkdir -p $(DESTDIR)$(libdir)
+ 	mkdir -p $(DESTDIR)$(includedir)
+ 	mkdir -p $(DESTDIR)$(mandir)/man1
+-	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
++	for f in $(IPROGS); do cp $$f$(BINEXT) $(DESTDIR)$(bindir); done
+ 	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
+ 	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+ 	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -109,4 +109,14 @@ final: prev: with final; {
       });
     };
   };
+
+  # for LMDB cross compilation
+  # remove once our nixpkgs pin contains https://github.com/NixOS/nixpkgs/pull/171686
+  lmdb = prev.lmdb.overrideAttrs (oldAttrs:
+    lib.optionalAttrs prev.stdenv.hostPlatform.isWindows{
+      makeFlags = oldAttrs.makeFlags ++ [ "SOEXT=.dll" "BINEXT=.exe" ];
+      buildInputs = [ prev.windows.pthreads ];
+      patches = [ ./lmdb-mingw.patch ];
+    }
+  );
 }


### PR DESCRIPTION
Defines new flags:
```
  --in-memory-ledger-db-backend
                           Use the InMemory ledger DB backend. Incompatible with
                           `--lmdb-ledger-db-backend`.
  --lmdb-ledger-db-backend MAPSIZE
                           Use the LMDB ledger DB backend. The mapsize argument
                           must be a number followed by a unit, for example 10Gi
                           for 10 Gibibytes. Incompatible with
                           `--in-memory-ledger-db-backend`.
```
and new options for the JSON config:
```
LedgerDBBackend: (LMDB|InMemory)
LMDBMapSize: <N><Unit> -- for example 12Gi
```

Needs [this PR in ouroboros-network](https://github.com/input-output-hk/ouroboros-network/pull/3795)