### PR TITLE
flake.nix:  disable membenches :cry:

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -269,7 +269,7 @@
               "dockerImage/submit-api" = pkgs.submitApiDockerImage;
               ## TODO: drop external membench, once we bump 'node-snapshot'
               # snapshot = membench.outputs.packages.x86_64-linux.snapshot;
-              membenches = pkgs.membench-node-this-5.batch-report;
+              # membenches = pkgs.membench-node-this-5.batch-report;
               # workbench-smoke-test =
               #   (pkgs.supervisord-workbench-for-profile
               #     {


### PR DESCRIPTION
..for they are broken.  Sigh.

Here's hoping this is temporary.

And we have better grounds for membenches reimplementation, anyway -- the `workbench chaindb` command -- which can also check for snapshot validity, to avoid the outdated snapshots breaking the benchmark.