### PR TITLE
cardano-tracer: remove Cardano.Node prefix

### DIFF
--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
@@ -37,7 +37,7 @@ updateErasSettings connected settings savedTO = do
   savedTraceObjects <- readTVarIO savedTO
   forM_ connected $ \nodeId ->
     whenJust (M.lookup nodeId savedTraceObjects) $ \savedTOForNode ->
-      whenJust (M.lookup "Cardano.Node.Startup.ShelleyBased" savedTOForNode) $ \(trObValue, _, _) ->
+      whenJust (M.lookup "Startup.ShelleyBased" savedTOForNode) $ \(trObValue, _, _) ->
         -- Example: "Era Alonzo, Slot length 1s, Epoch length 432000, Slots per KESPeriod 129600"
         case T.words $ T.replace "," "" trObValue of
           [_, era, _, _, slotLen, _, _, epochLen, _, _, _, kesPeriod] ->

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Nodes.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Nodes.hs
@@ -208,7 +208,7 @@ setChunkValidationProgress connected savedTO = do
       let nodeChunkValidationElId = anId <> "__node-chunk-validation"
       forM_ (M.toList savedTOForNode) $ \(namespace, (trObValue, _, _)) ->
         case namespace of
-          "Cardano.Node.ChainDB.ImmDbEvent.ChunkValidation.ValidatedChunk" ->
+          "ChainDB.ImmutableDBEvent.ChunkValidation.ValidatedChunk" ->
             -- In this case we don't need to check if the value differs from displayed one,
             -- because this 'TraceObject' is forwarded only with new values, and after 100%
             -- the node doesn't forward it anymore.
@@ -219,7 +219,7 @@ setChunkValidationProgress connected savedTO = do
                 setTextValue nodeChunkValidationElId $
                              T.init progressPct <> "&nbsp;%: no. " <> current <> " from " <> T.init from
               _ -> return ()
-          "Cardano.Node.ChainDB.ImmDbEvent.ValidatedLastLocation" ->
+          "ChainDB.ImmutableDBEvent.ValidatedLastLocation" ->
             setTextAndClasses nodeChunkValidationElId "100&nbsp;%" "rt-view-percent-done"
           _ -> return ()
 
@@ -234,7 +234,7 @@ setLedgerDBProgress connected savedTO = do
       let nodeLedgerDBUpdateElId = anId <> "__node-update-ledger-db"
       forM_ (M.toList savedTOForNode) $ \(namespace, (trObValue, _, _)) ->
         case namespace of
-          "Cardano.Node.ChainDB.InitChainSelEvent.UpdateLedgerDb" ->
+          "ChainDB.InitChainSelEvent.UpdateLedgerDb" ->
             -- In this case we don't need to check if the value differs from displayed one,
             -- because this 'TraceObject' is forwarded only with new values, and after 100%
             -- the node doesn't forward it anymore.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
@@ -36,8 +36,7 @@ updateNodesPeers window displayedPeers savedTO = do
   forM_ (M.toList savedTraceObjects) $ \(nodeId, savedTOForNode) ->
     forM_ (M.toList savedTOForNode) $ \(namespace, (trObValue, _, _)) ->
       case namespace of
-        "Cardano.Node.Peers" ->
-          doUpdatePeers window nodeId displayedPeers trObValue
+        "Peers" -> doUpdatePeers window nodeId displayedPeers trObValue
         _ -> return ()
 
 doUpdatePeers


### PR DESCRIPTION
Remove `"Cardano.Node"`-prefix, fix outdated names of some metrics.