### PR TITLE
Dynamic block forging for the P2P mode

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -1,6 +1,7 @@
 {- HLINT ignore "Eta reduce" -}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Benchmarking.OuroborosImports
   (
@@ -44,8 +45,8 @@ import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesis)
 
 type CardanoBlock = Consensus.CardanoBlock StandardCrypto
 
-toProtocolInfo :: SomeConsensusProtocol -> ProtocolInfo IO CardanoBlock
-toProtocolInfo (SomeConsensusProtocol CardanoBlockType info) = protocolInfo info
+toProtocolInfo :: SomeConsensusProtocol -> ProtocolInfo CardanoBlock
+toProtocolInfo (SomeConsensusProtocol CardanoBlockType info) = fst $ protocolInfo @IO info
 toProtocolInfo _ = error "toProtocolInfo unknown protocol"
 
 protocolToTopLevelConfig :: SomeConsensusProtocol -> TopLevelConfig CardanoBlock

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                       , attoparsec
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
@@ -193,7 +193,7 @@ test-suite tx-generator-apitest
                       , bytestring
                       , filepath
                       , optparse-applicative-fork
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-node
                       , plutus-tx
@@ -209,7 +209,7 @@ test-suite tx-generator-apitest
                      , bytestring
                      , filepath
                      , optparse-applicative-fork
-                     , cardano-api ^>= 8.2
+                     , cardano-api ^>= 8.5
                      , cardano-cli ^>= 8.2
                      , cardano-node
                      , transformers

--- a/cabal.project
+++ b/cabal.project
@@ -108,3 +108,39 @@ package snap-server
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-cli
+  tag: 3fbf9e18a5c44043982b9382d357502d8fe5a78d
+  --sha256: sha256-Q1pXMt4P2QOTUjQIj3Y7sVHoLvxItklnhN9rhNRYyTc=
+  subdir:
+    cardano-cli
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  tag: d639fbdacaf9abd47db28250964d5168743b3520
+  --sha256: sha256-Um0QL6LGpTqyb5iW/VFRpQk+YgMVjcEHI2UQ+nqqbIo=
+  subdir:
+    ouroboros-consensus
+    ouroboros-consensus-diffusion
+    ouroboros-consensus-cardano
+    ouroboros-consensus-protocol
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-api
+  tag: a5aff8c19063f8679b757cdc15b44239065d5815
+  --sha256: sha256-GWrck5RLD3uP68uesrVh6bszyCJI2z+a09sTsbFzaUE=
+  subdir:
+    cardano-api
+
+-- Needed because consensus uses it
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/io-sim
+  tag: ec202298c420378ef90b3fc0126c39e0f52290a3
+  --sha256: 1p6pn83kwp66x2m0cw9a27blfcpmw0lrra72qd0pi5bj3v1bcrl9
+  subdir:
+    strict-mvar

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Chairman.Commands.Run
   ( cmdRun
@@ -120,7 +121,7 @@ run RunOpts
 
   let (k , nId) = case p of
             SomeConsensusProtocol _ runP ->
-              let ProtocolInfo { pInfoConfig } = Api.protocolInfo runP
+              let ProtocolInfo { pInfoConfig } = fst $ Api.protocolInfo @IO runP
               in ( Consensus.configSecurityParam pInfoConfig
                  , fromNetworkMagic . getNetworkMagic $ Consensus.configBlock pInfoConfig
                  )

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -234,7 +234,7 @@ test-suite cardano-node-test
                       , aeson >= 1.5.6.0
                       , bytestring
                       , cardano-crypto-class
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-slotting >= 0.1

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Configuration.Logging
   ( LoggingLayer (..)
@@ -329,7 +330,7 @@ nodeBasicInfo :: NodeConfiguration
               -> IO [LogObject Text]
 nodeBasicInfo nc (SomeConsensusProtocol whichP pForInfo) nodeStartTime' = do
   meta <- mkLOMeta Notice Public
-  let cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  let cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
       protocolDependentItems =
         case whichP of
           Api.ByronBlockType ->

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -87,6 +87,8 @@ data NodeConfiguration
        , ncValidateDB      :: !Bool
        , ncShutdownConfig  :: !ShutdownConfig
 
+       , ncStartAsNonProducingNode :: !Bool
+
         -- Protocol-specific parameters:
        , ncProtocolConfig :: !NodeProtocolConfiguration
 
@@ -158,6 +160,8 @@ data PartialNodeConfiguration
        , pncProtocolFiles   :: !(Last ProtocolFilepaths)
        , pncValidateDB      :: !(Last Bool)
        , pncShutdownConfig  :: !(Last ShutdownConfig)
+
+       , pncStartAsNonProducingNode :: !(Last Bool)
 
          -- Protocol-specific parameters:
        , pncProtocolConfig :: !(Last NodeProtocolConfiguration)
@@ -309,6 +313,7 @@ instance FromJSON PartialNodeConfiguration where
            , pncProtocolFiles = mempty
            , pncValidateDB = mempty
            , pncShutdownConfig = mempty
+           , pncStartAsNonProducingNode = Last $ Just False
            , pncMaybeMempoolCapacityOverride
            , pncProtocolIdleTimeout
            , pncTimeWaitTimeout
@@ -466,6 +471,7 @@ defaultPartialNodeConfiguration =
     , pncProtocolFiles = mempty
     , pncValidateDB = Last $ Just False
     , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing Nothing
+    , pncStartAsNonProducingNode = Last $ Just False
     , pncProtocolConfig = mempty
     , pncMaxConcurrencyBulkSync = mempty
     , pncMaxConcurrencyDeadline = mempty
@@ -500,6 +506,7 @@ makeNodeConfiguration pnc = do
   topologyFile <- lastToEither "Missing TopologyFile" $ pncTopologyFile pnc
   databaseFile <- lastToEither "Missing DatabaseFile" $ pncDatabaseFile pnc
   validateDB <- lastToEither "Missing ValidateDB" $ pncValidateDB pnc
+  startAsNonProducingNode <- lastToEither "Missing StartAsNonProducingNode" $ pncStartAsNonProducingNode pnc
   protocolConfig <- lastToEither "Missing ProtocolConfig" $ pncProtocolConfig pnc
   loggingSwitch <- lastToEither "Missing LoggingSwitch" $ pncLoggingSwitch pnc
   logMetrics <- lastToEither "Missing LogMetrics" $ pncLogMetrics pnc
@@ -555,6 +562,7 @@ makeNodeConfiguration pnc = do
                    Nothing -> ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing Nothing
              , ncValidateDB = validateDB
              , ncShutdownConfig = shutdownConfig
+             , ncStartAsNonProducingNode = startAsNonProducingNode
              , ncProtocolConfig = protocolConfig
              , ncSocketConfig = socketConfig
              , ncDiffusionMode = diffusionMode

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -16,7 +16,6 @@ module Cardano.Node.Configuration.TopologyP2P
   , NodeHostIPv6Address(..)
   , NodeSetup(..)
   , PeerAdvertise(..)
-  , UseLedger(..)
   , nodeAddressToSockAddr
   , readTopologyFile
   , readTopologyFileOrError
@@ -27,7 +26,6 @@ where
 import           Control.Exception (IOException)
 import qualified Control.Exception as Exception
 import           Control.Exception.Base (Exception (..))
-import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
@@ -39,7 +37,6 @@ import           Data.Word (Word64)
 import           "contra-tracer" Control.Tracer (Tracer, traceWith)
 
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Cardano.Node.Configuration.NodeAddress
 import           Cardano.Node.Configuration.Topology (TopologyError (..))
@@ -49,26 +46,6 @@ import           Cardano.Node.Types
 import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
-
-
-
--- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
--- 'ToJSON' instances.
---
--- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
--- chain root peers.
---
-newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
-
-instance FromJSON UseLedger where
-  parseJSON (Data.Aeson.Number n) =
-    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
-              else return $ UseLedger   DontUseLedger
-  parseJSON _ = mzero
-
-instance ToJSON UseLedger where
-  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
-  toJSON (UseLedger DontUseLedger)               = Number (-1)
 
 data NodeSetup = NodeSetup
   { nodeId          :: !Word64

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -62,6 +62,7 @@ nodeRunParser = do
   shelleyVRFFile  <- optional parseVrfKeyFilePath
   shelleyCertFile <- optional parseOperationalCertFilePath
   shelleyBulkCredsFile <- optional parseBulkCredsFilePath
+  startAsNonProducingNode <- lastOption parseStartAsNonProducingNode
 
   -- Node Address
   nIPv4Address <- lastOption parseHostIPv4Addr
@@ -102,6 +103,7 @@ nodeRunParser = do
            , pncValidateDB = validate
            , pncShutdownConfig =
                Last . Just $ ShutdownConfig (getLast shutdownIPC) (getLast shutdownOnLimit)
+           , pncStartAsNonProducingNode = startAsNonProducingNode
            , pncProtocolConfig = mempty
            , pncMaxConcurrencyBulkSync = mempty
            , pncMaxConcurrencyDeadline = mempty
@@ -312,6 +314,14 @@ parseVrfKeyFilePath =
         <> help "Path to the VRF signing key."
         <> completer (bashCompleter "file")
     )
+
+parseStartAsNonProducingNode :: Parser Bool
+parseStartAsNonProducingNode =
+  switch (
+    long "start-as-non-producing-node"
+      <> help ("Start the node as a non block producing node even if "
+            ++ "credentials are specified.")
+  )
 
 -- TODO revisit because it sucks
 parseSnapshotInterval :: Parser SnapshotInterval

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -60,5 +60,5 @@ data SomeConsensusProtocol where
                                           , TraceConstraints blk
                                           )
                            => Api.BlockType blk
-                           -> Api.ProtocolInfoArgs IO blk
+                           -> Api.ProtocolInfoArgs blk
                            -> SomeConsensusProtocol

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -402,6 +402,8 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
           , rnTraceNTC       = nodeToClientTracers tracers
           , rnProtocolInfo   = pInfo
           , rnNodeKernelHook = \registry nodeKernel -> do
+              -- set the initial block forging
+              snd (Api.protocolInfo runP) >>= setBlockForging nodeKernel
               maybeSpawnOnSlotSyncedShutdownHandler
                 (ncShutdownConfig nc)
                 (shutdownTracer tracers)

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -160,7 +160,7 @@ runNode cmdPc = do
     let networkMagic :: Api.NetworkMagic =
           case p of
             SomeConsensusProtocol _ runP ->
-              let ProtocolInfo { pInfoConfig } = Api.protocolInfo runP
+              let ProtocolInfo { pInfoConfig } = fst $ Api.protocolInfo @IO runP
               in getNetworkMagic $ Consensus.configBlock pInfoConfig
 
     case p of
@@ -193,13 +193,13 @@ handleNodeWithTracers
   -> NodeConfiguration
   -> SomeConsensusProtocol
   -> Api.NetworkMagic
-  -> Api.ProtocolInfoArgs IO blk
+  -> Api.ProtocolInfoArgs blk
   -> IO ()
 handleNodeWithTracers cmdPc nc p networkMagic runP = do
   -- This IORef contains node kernel structure which holds node kernel.
   -- Used for ledger queries and peer connection status.
   nodeKernelData <- mkNodeKernelData
-  let ProtocolInfo { pInfoConfig = cfg } = Api.protocolInfo runP
+  let ProtocolInfo { pInfoConfig = cfg } = fst $ Api.protocolInfo @IO runP
   case ncEnableP2P nc of
     SomeNetworkP2PMode p2pMode -> do
       let fp = maybe  "No file path found!"
@@ -325,7 +325,7 @@ handlePeersListSimple tr nodeKern = forever $ do
 
 handleSimpleNode
   :: forall blk p2p . Api.Protocol IO blk
-  => Api.ProtocolInfoArgs IO blk
+  => Api.ProtocolInfoArgs blk
   -> NetworkP2PMode p2p
   -> Tracers RemoteConnectionId LocalConnectionId blk p2p
   -> NodeConfiguration
@@ -344,7 +344,7 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
     traceWith (startupTracer tracers)
       StartupDBValidation
 
-  let pInfo = Api.protocolInfo runP
+  let pInfo = fst $ Api.protocolInfo @IO runP
 
   (publicIPv4SocketOrAddr, publicIPv6SocketOrAddr, localSocketOrPath) <- do
     result <- runExceptT (gatherConfiguredSockets $ ncSocketConfig nc)

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -49,6 +49,7 @@ import           Cardano.Logging
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import           Cardano.Node.Protocol (ProtocolInstantiationError)
 
 import           Cardano.Git.Rev (gitRev)
 import           Paths_cardano_node (version)
@@ -76,6 +77,17 @@ data StartupTrace blk =
   | StartupSocketConfigError SocketConfigError
 
   | StartupDBValidation
+
+  -- | Log that the block forging is being updated
+  | BlockForgingUpdate
+
+  -- | Protocol instantiation error when updating block forging
+  | BlockForgingUpdateError ProtocolInstantiationError
+
+  -- | Mismatched block type
+  | BlockForgingBlockTypeMismatch
+       Api.SomeBlockType -- ^ expected
+       Api.SomeBlockType -- ^ provided
 
   -- | Log that the network configuration is being updated.
   --

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Startup where
 
@@ -199,7 +200,7 @@ prepareNodeInfo nc (SomeConsensusProtocol whichP pForInfo) tc nodeStartTime = do
     , niSystemStartTime = systemStartTime
     }
  where
-  cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
 
   systemStartTime :: UTCTime
   systemStartTime =

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -79,7 +79,7 @@ data StartupTrace blk =
   | StartupDBValidation
 
   -- | Log that the block forging is being updated
-  | BlockForgingUpdate
+  | BlockForgingUpdate EnabledBlockForging
 
   -- | Protocol instantiation error when updating block forging
   | BlockForgingUpdateError ProtocolInstantiationError
@@ -133,7 +133,9 @@ data StartupTrace blk =
   | BIByron BasicInfoByron
   | BINetwork BasicInfoNetwork
 
-
+data EnabledBlockForging = EnabledBlockForging
+                         | DisabledBlockForging
+                         deriving (Eq, Show)
 
 data BasicInfoCommon = BasicInfoCommon {
     biConfigPath    :: FilePath

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -15,7 +15,7 @@ import           Data.Text (pack)
 import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
-import           Cardano.Node.Configuration.TopologyP2P (UseLedger (..))
+import           Cardano.Node.Types (UseLedger(..))
 
 import qualified Data.List as List
 import qualified Ouroboros.Network.Diffusion as ND

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing -Wno-orphans #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Tracing.Tracers.Startup
 
@@ -68,7 +69,7 @@ getStartupInfo
   -> IO [StartupTrace blk]
 getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
   nodeStartTime <- getCurrentTime
-  let cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  let cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
       basicInfoCommon = BICommon $ BasicInfoCommon {
                 biProtocol = pack . show $ ncProtocol nc
               , biVersion  = pack . showVersion $ version

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -17,6 +17,7 @@ module Cardano.Node.Types
   , MaxConcurrencyBulkSync(..)
   , MaxConcurrencyDeadline(..)
     -- * Networking
+  , UseLedger(..)
   , TopologyFile(..)
   , NodeDiffusionMode (..)
     -- * Consensus protocol configuration
@@ -38,6 +39,8 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word16, Word8)
 
+import           Control.Monad (MonadPlus (..))
+
 import           Cardano.Api
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
@@ -46,6 +49,7 @@ import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 --TODO: things will probably be clearer if we don't use these newtype wrappers and instead
 -- use records with named fields in the CLI code.
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
 -- | Errors for the cardano-config module.
 data ConfigError =
@@ -273,6 +277,25 @@ data NodeHardForkProtocolConfiguration =
      , npcTestConwayHardForkAtVersion       :: Maybe Word
      }
   deriving (Eq, Show)
+
+-- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
+-- 'ToJSON' instances.
+--
+-- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
+-- chain root peers.
+--
+newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
+
+instance FromJSON UseLedger where
+  parseJSON (Data.Aeson.Number n) =
+    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
+              else return $ UseLedger   DontUseLedger
+  parseJSON _ = mzero
+
+instance ToJSON UseLedger where
+  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
+  toJSON (UseLedger DontUseLedger)               = Number (-1)
+
 
 newtype TopologyFile = TopologyFile
   { unTopology :: FilePath }

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -39,8 +39,8 @@ import           Network.TypedProtocol.Core (PeerHasAgency (..))
 import           Network.Mux (MiniProtocolNum (..), MuxTrace (..), WithMuxBearer (..))
 import           Network.Socket (SockAddr (..))
 
-import           Cardano.Node.Configuration.TopologyP2P (UseLedger (..))
 import           Cardano.Node.Queries (ConvertTxId)
+import           Cardano.Node.Types (UseLedger(..))
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.Render
 

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -22,12 +22,13 @@ import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Vector as Vector
 
+import           Cardano.Node.Types (UseLedger(..))
 import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPAddress (..),
                    NodeHostIPv4Address (..), NodeHostIPv6Address (..), NodeIPAddress,
                    NodeIPv4Address, NodeIPv6Address)
 import           Cardano.Node.Configuration.TopologyP2P (LocalRootPeersGroup (..),
                    LocalRootPeersGroups (..), NetworkTopology (..), NodeSetup (..),
-                   PeerAdvertise (..), PublicRootPeers (..), RootConfig (..), UseLedger (..))
+                   PeerAdvertise (..), PublicRootPeers (..), RootConfig (..))
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -52,9 +52,10 @@ testPartialYamlConfig =
     { pncProtocolConfig = Last . Just
                         . NodeProtocolConfigurationShelley
                         $ NodeShelleyProtocolConfiguration
-                            (GenesisFile "dummmy-genesis-file") Nothing
+                            (GenesisFile "dummmsy-genesis-file") Nothing
     , pncSocketConfig = Last . Just $ SocketConfig (Last Nothing) mempty mempty mempty
     , pncShutdownConfig = Last Nothing
+    , pncStartAsNonProducingNode = Last $ Just False
     , pncDiffusionMode = Last Nothing
     , pncSnapshotInterval = mempty
     , pncExperimentalProtocolsEnabled = Last Nothing
@@ -88,6 +89,7 @@ testPartialCliConfig =
   PartialNodeConfiguration
     { pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
     , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
+    , pncStartAsNonProducingNode = Last $ Just $ False
     , pncConfigFile   = mempty
     , pncTopologyFile = mempty
     , pncDatabaseFile = mempty
@@ -123,6 +125,7 @@ eExpectedConfig = do
   return $ NodeConfiguration
     { ncSocketConfig = SocketConfig mempty mempty mempty mempty
     , ncShutdownConfig = ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
+    , ncStartAsNonProducingNode = False
     , ncConfigFile = ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
     , ncTopologyFile = TopologyFile "configuration/cardano/mainnet-topology.json"
     , ncDatabaseFile = DbFile "mainnet/db/"

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
@@ -86,7 +86,7 @@ library
                         Testnet.Process.Cli
                         Testnet.Process.Run
                         Testnet.Runtime
-                        Testnet.Topology 
+                        Testnet.Topology
 
   other-modules:        Parsers.Babbage
                         Parsers.Byron
@@ -176,7 +176,7 @@ test-suite cardano-testnet-test
   build-depends:        aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-testnet

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -33,6 +33,7 @@ import           Cardano.Api hiding (Value)
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
@@ -188,7 +189,7 @@ mkTopologyConfig i numBftNodes' allPorts True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 
 testnet :: TestnetOptions -> H.Conf -> H.Integration [String]

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -45,6 +45,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPo
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Aeson as J
@@ -180,7 +181,7 @@ mkTopologyConfig numNodes allPorts port True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 cardanoTestnet :: CardanoTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
 cardanoTestnet testnetOptions H.Conf {H.tempAbsPath} = do

--- a/cardano-testnet/src/Testnet/Start/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Start/Shelley.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPo
 import           Cardano.Api hiding (Value)
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
@@ -152,7 +153,7 @@ mkTopologyConfig numPraosNodes allPorts port True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 shelleyTestnet :: ShelleyTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
 shelleyTestnet testnetOptions H.Conf {H.tempAbsPath} = do


### PR DESCRIPTION
## Description:

This PR introduces dynamic updates to the block forging configuration, enabling and disabling block forging through the SIGHUP signal. It addresses issue [input-output-hk/ouroboros-network#3159](https://github.com/input-output-hk/ouroboros-network/issues/3159) and relies on changes in [ouroboros-consensus#140](https://github.com/input-output-hk/ouroboros-consensus/pull/140) and [cardano-api#45](https://github.com/input-output-hk/cardano-api/pull/45).

**Main changes**:

- **Dependencies Update:** The `ouroboros-consensus` and `cardano-api` dependencies have been updated to accommodate the changes needed for this feature.

- **Improved Import Structure:** The `UseLedger` type was moved to prevent cyclic imports, improving the overall import structure.

- Adding of `SomeBlockType` and `ReflBlockType`


**How it works**:

Block forging can now be dynamically enabled/disabled through SIGHUP signal. This is done by triggering the node to read the block forging credential files upon receiving the signal. To disable block forging, one must move/rename/delete the file at the specified path (for the credential flags) and then send the SIGHUP signal. The code will then disable block forging and trace the appropriate log messages.
