### PR TITLE
Disable development eras configuration flag 

### DIFF
--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -953,10 +953,10 @@ hashScript (PlutusScript PlutusScriptV1 (PlutusScriptSerialised script)) =
     ScriptHash
   . Ledger.hashScript @(ShelleyLedgerEra AlonzoEra)
   $ Alonzo.PlutusScript Alonzo.PlutusV1 script
--- TODO: Babbage era PV2 only exists in Babbage era onwards!
+
 hashScript (PlutusScript PlutusScriptV2 (PlutusScriptSerialised script)) =
     ScriptHash
-  . Ledger.hashScript @(ShelleyLedgerEra AlonzoEra)
+  . Ledger.hashScript @(ShelleyLedgerEra BabbageEra)
   $ Alonzo.PlutusScript Alonzo.PlutusV2 script
 
 toShelleyScriptHash :: ScriptHash -> Shelley.ScriptHash StandardCrypto

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -85,7 +85,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcAlonzoGenesisFileHash
                            }
                            NodeHardForkProtocolConfiguration {
-                            npcTestEnableDevelopmentHardForkEras,
+                            -- npcTestEnableDevelopmentHardForkEras,
                             -- During testing of the Alonzo era, we conditionally declared that we
                             -- knew about the Alonzo era. We do so only when a config option for
                             -- testing development/unstable eras is used. This lets us include
@@ -207,10 +207,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Babbage era. Since Babbage is currently the last known
           -- protocol version then this is also the Babbage protocol version.
-          Praos.babbageProtVer =
-            if npcTestEnableDevelopmentHardForkEras
-            then ProtVer 7 0  -- Advertise we can support Babbage
-            else ProtVer 6 0, -- Otherwise we only advertise we know about (the second) Alonzo
+          Praos.babbageProtVer = ProtVer 7 0,
           Praos.babbageMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -198,7 +198,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Alonzo era. That is, it is the version of protocol
           -- /after/ Alonzo, i.e. Babbage.
-          alonzoProtVer = ProtVer 6 0,
+          alonzoProtVer = ProtVer 7 0,
           alonzoMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }

--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -102,7 +102,6 @@ $SED -i "${ROOT}/configuration.yaml" \
   echo "TestMaryHardForkAtEpoch: 0" >> "${ROOT}/configuration.yaml"
   echo "TestAlonzoHardForkAtEpoch: 0" >> "${ROOT}/configuration.yaml"
   echo "TestBabbageHardForkAtEpoch: 0" >> "${ROOT}/configuration.yaml"
-  echo "TestEnableDevelopmentHardForkEras: True" >> "${ROOT}/configuration.yaml"
   echo "TestEnableDevelopmentNetworkProtocols: True" >> "${ROOT}/configuration.yaml"
 
 # Copy the cost mode


### PR DESCRIPTION
This lets us advertise that we know about the Babbage era and we no longer require the `"TestEnableDevelopmentHardForkEras"` config flag