### PR TITLE
Updated node and CLI version to 1.35.0

### DIFF
--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                  cardano-topology
-version:               1.33.0
+version:               1.35.0
 description:           A cardano topology generator
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api
-version:                1.33.0
+version:                1.35.0
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-cli
-version:                1.33.0
+version:                1.35.0
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-chairman
-version:                1.33.0
+version:                1.35.0
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                1.33.0
+version:                1.35.0
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-testnet
-version:                1.33.0
+version:                1.35.0
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.33.0}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.0}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -15,7 +15,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.33.0}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.35.0}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:


### PR DESCRIPTION
These changes update the version number for cardano-node, cardano-cli and other tools to be 1.35.0 (was 1.33.0)
