### PR TITLE
Expose Key interface in Cardano.Api.Shelley

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -42,9 +42,7 @@ module Cardano.Api (
     AsType(..),
     -- * Cryptographic key interface
     -- $keys
-    Key,
-    VerificationKey,
-    SigningKey(..),
+    Key(SigningKey, VerificationKey),
     getVerificationKey,
     verificationKeyHash,
     castVerificationKey,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -12,6 +12,7 @@ module Cardano.Api.Shelley
 
     -- * Cryptographic key interface
     -- $keys
+    Key(..),
     VerificationKey(..),
     SigningKey(..),
 


### PR DESCRIPTION
Sorry for this unsolicited PR, it is of *not* crucial for us, but we wanted to get also your feedback on:

In the Hydra project we are using the cardano-api quite heavily and thought we could distinguish Hydra key types using the same framework, but just with a new `Hydra` key role. 

Unfortunately it was not possible because some of the type class definition was not exported.

This PR exposes the full type class to be able to define instances of it and having a `Hydra` key role, this yields `SigningKey Hydra` and `VerificationKey Hydra` key types.

See also this PR: https://github.com/input-output-hk/hydra-poc/pull/398