### PR TITLE
Workbench fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PROFILE ?= default-${ERA}
 REV     ?= master
 ARGS    ?=
 CMD     ?=
+RUN     ?=
 
 lint hlint:
 	hlint bench cardano-{api,cli,client-demo,node,node-capi,node-chairman,submit-api,testnet,tracer}
@@ -43,10 +44,10 @@ ci-targets:  $(CI_TARGETS)
 ##
 ## Base targets:
 ##
-shell:                                           ## Nix shell, (workbench from /nix/store), vars: PROFILE, CMD
-	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} ${ARGS} ${if ${CMD},--run "${CMD}"}
+shell:                                           ## Nix shell, (workbench from /nix/store), vars: PROFILE, CMD, RUN
+	nix-shell --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} ${ARGS} ${if ${CMD},--command "${CMD}"} ${if ${RUN},--run "${RUN}"}
 shell-dev shell-prof shell-nix: shell
-shell-nix: ARGS += --arg 'workbenchDevMode' false ## Nix shell, (workbench from Nix store), vars: PROFILE, CMD
+shell-nix: ARGS += --arg 'workbenchDevMode' false ## Nix shell, (workbench from Nix store), vars: PROFILE, CMD, RUN
 shell-prof: ARGS += --arg 'profiled' true        ## Nix shell, everything Haskell built profiled
 
 list-profiles:                                   ## List workbench profiles

--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -88,40 +88,40 @@ type ACouple t = (t, t)
 
 interpreters :: ACouple (Map Text (Object -> Parser LOBody))
 interpreters = (Map.fromList *** Map.fromList) . unzip . fmap ent $
-  [ (,,) "TraceStartLeadershipCheck" "Cardano.Node.Forge.StartLeadershipCheck" $
+  [ (,,) "TraceStartLeadershipCheck" "Forge.StartLeadershipCheck" $
     \v -> LOTraceStartLeadershipCheck
             <$> v .: "slot"
             <*> (v .:? "utxoSize"     <&> fromMaybe 0)
             <*> (v .:? "chainDensity" <&> fromMaybe 0)
 
-  , (,,) "TraceBlockContext" "Cardano.Node.Forge.BlockContext" $
+  , (,,) "TraceBlockContext" "Forge.BlockContext" $
     \v -> LOBlockContext
             <$> v .: "tipBlockNo"
 
-  , (,,) "TraceNodeIsLeader" "Cardano.Node.Forge.NodeIsLeader" $
+  , (,,) "TraceNodeIsLeader" "Forge.NodeIsLeader" $
     \v -> LOTraceLeadershipDecided
             <$> v .: "slot"
             <*> pure True
 
-  , (,,) "TraceNodeNotLeader" "Cardano.Node.Forge.NodeNotLeader" $
+  , (,,) "TraceNodeNotLeader" "Forge.NodeNotLeader" $
     \v -> LOTraceLeadershipDecided
             <$> v .: "slot"
             <*> pure False
 
-  , (,,) "TraceMempoolAddedTx" "Cardano.Node.Mempool.AddedTx" $
+  , (,,) "TraceMempoolAddedTx" "Mempool.AddedTx" $
     \v -> do
       x :: Object <- v .: "mempoolSize"
       LOMempoolTxs <$> x .: "numTxs"
 
-  , (,,) "TraceMempoolRemoveTxs" "Cardano.Node.Mempool.RemoveTxs" $
+  , (,,) "TraceMempoolRemoveTxs" "Mempool.RemoveTxs" $
     \v -> do
       x :: Object <- v .: "mempoolSize"
       LOMempoolTxs <$> x .: "numTxs"
 
-  , (,,) "TraceMempoolRejectedTx" "Cardano.Node.Mempool.RejectedTx" $
+  , (,,) "TraceMempoolRejectedTx" "Mempool.RejectedTx" $
     \_ -> pure LOMempoolRejectedTx
 
-  , (,,) "TraceLedgerEvent.TookSnapshot" "Cardano.Node.LedgerEvent.TookSnapshot" $
+  , (,,) "TraceLedgerEvent.TookSnapshot" "LedgerEvent.TookSnapshot" $
     \_ -> pure LOLedgerTookSnapshot
 
   , (,,) "TraceBenchTxSubSummary" "TraceBenchTxSubSummary" $
@@ -137,7 +137,7 @@ interpreters = (Map.fromList *** Map.fromList) . unzip . fmap ent $
   , (,,) "TraceBenchTxSubServAck" "TraceBenchTxSubServAck" $
     \v -> LOTxsAcked <$> v .: "txIds"
 
-  , (,,) "Resources" "Cardano.Node.Resources" $
+  , (,,) "Resources" "Resources" $
     \v -> LOResources <$> parsePartialResourceStates (Object v)
 
   , (,,) "TraceTxSubmissionCollected" "TraceTxSubmissionCollected" $
@@ -149,13 +149,13 @@ interpreters = (Map.fromList *** Map.fromList) . unzip . fmap ent $
             <$> v .: "accepted"
             <*> v .: "rejected"
 
-  , (,,) "TraceForgedBlock" "Cardano.Node.Forge.ForgedBlock" $
+  , (,,) "TraceForgedBlock" "Forge.ForgedBlock" $
     \v -> LOBlockForged
             <$> v .: "block"
             <*> v .: "blockPrev"
             <*> v .: "blockNo"
             <*> v .: "slot"
-  , (,,) "TraceAddBlockEvent.AddedToCurrentChain" "Cardano.Node.ChainDB.AddBlockEvent.AddedToCurrentChain" $
+  , (,,) "TraceAddBlockEvent.AddedToCurrentChain" "ChainDB.AddBlockEvent.AddedToCurrentChain" $
     \v -> LOBlockAddedToCurrentChain
             <$> ((v .: "newtip")     <&> hashFromPoint)
             <*> pure Nothing
@@ -163,35 +163,35 @@ interpreters = (Map.fromList *** Map.fromList) . unzip . fmap ent $
                 -- Compat for node versions 1.27 and older:
                  <&> fromMaybe 1)
   -- TODO: we should clarify the distinction between the two cases (^ and v).
-  , (,,) "TraceAdoptedBlock" "Cardano.Node.Forge.AdoptedBlock" $
+  , (,,) "TraceAdoptedBlock" "Forge.AdoptedBlock" $
     \v -> LOBlockAddedToCurrentChain
             <$> v .: "blockHash"
             <*> ((v .: "blockSize") <&> Just)
             <*> pure 1
-  , (,,) "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock" "Cardano.Node.ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.AddBlock" $
+  , (,,) "ChainSyncServerEvent.TraceChainSyncServerRead.AddBlock" "ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.AddBlock" $
     \v -> LOChainSyncServerSendHeader
             <$> v .: "block"
             <*> v .: "blockNo"
             <*> v .: "slot"
-  , (,,) "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock" "Cardano.Node.ChainSyncServerHeader.ChainSyncServerEvent.ServerReadBlocked.AddBlock" $
+  , (,,) "ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock" "ChainSyncServerHeader.ChainSyncServerEvent.ServerReadBlocked.AddBlock" $
     \v -> LOChainSyncServerSendHeader
             <$> v .: "block"
             <*> v .: "blockNo"
             <*> v .: "slot"
   -- v, but not ^ -- how is that possible?
-  , (,,) "TraceBlockFetchServerSendBlock" "Cardano.Node.BlockFetchServer.SendBlock" $
+  , (,,) "TraceBlockFetchServerSendBlock" "BlockFetchServer.SendBlock" $
     \v -> LOBlockFetchServerSending
             <$> v .: "block"
-  , (,,) "SendFetchRequest" "Cardano.Node.BlockFetchClient.SendFetchRequest" $
+  , (,,) "SendFetchRequest" "BlockFetchClient.SendFetchRequest" $
     \v -> LOBlockFetchClientRequested
             <$> v .: "head"
             <*> v .: "length"
-  , (,,) "ChainSyncClientEvent.TraceDownloadedHeader" "Cardano.Node.ChainSyncClient.ChainSyncClientEvent.DownloadedHeader" $
+  , (,,) "ChainSyncClientEvent.TraceDownloadedHeader" "ChainSyncClient.ChainSyncClientEvent.DownloadedHeader" $
     \v -> LOChainSyncClientSeenHeader
             <$> v .: "block"
             <*> v .: "blockNo"
             <*> v .: "slot"
-  , (,,) "CompletedBlockFetch" "Cardano.Node.BlockFetchClient.CompletedBlockFetch" $
+  , (,,) "CompletedBlockFetch" "BlockFetchClient.CompletedBlockFetch" $
     \v -> LOBlockFetchClientCompletedFetch
             <$> v .: "block"
   ]

--- a/lib.mk
+++ b/lib.mk
@@ -15,7 +15,7 @@ ifeq ($(5)$(6),truetrue)
 $(1): CMD := start-cluster
 endif
 ifeq ($(5)$(6),truefalse)
-$(1): CMD := start-cluster && exit || exit 1
+$(1): RUN := start-cluster
 endif
 ifeq ($(3)$(4)$(5)$(6),falsetruefalsefalse)
 define EXTRA_HELP +=

--- a/lib.mk
+++ b/lib.mk
@@ -12,7 +12,7 @@ ifeq ($(7),true)
 $(1): ARGS += --arg 'profiled' true
 endif
 ifeq ($(5)$(6),truetrue)
-$(1): CMD := start-cluster
+$(1): CMD := start-cluster; return
 endif
 ifeq ($(5)$(6),truefalse)
 $(1): RUN := start-cluster

--- a/nix/workbench/profiles/variants.jq
+++ b/nix/workbench/profiles/variants.jq
@@ -210,20 +210,24 @@ def all_profile_variants:
      .generator.epochs                = 4
     ) as $for_4ep
   |
-    ({} |
-     .node.shutdown_on_block_synced   = 1
+    ({}
+     | .node.shutdown_on_block_synced   = 1
+     | .analysis.filters                = []
     ) as $for_1blk
   |
-    ({} |
-     .node.shutdown_on_block_synced   = 3
+    ({}
+     | .node.shutdown_on_block_synced   = 3
+     | .analysis.filters                = []
     ) as $for_3blk
   |
-    ({} |
-     .node.shutdown_on_block_synced   = 15
+    ({}
+     | .node.shutdown_on_block_synced   = 15
+     | .analysis.filters                = []
     ) as $for_15blk
   |
-    ({} |
-     .node.shutdown_on_block_synced   = 30
+    ({}
+     | .node.shutdown_on_block_synced   = 30
+     | .analysis.filters                = []
     ) as $for_30blk
   |
   ##

--- a/nix/workbench/profiles/variants.jq
+++ b/nix/workbench/profiles/variants.jq
@@ -76,8 +76,11 @@ def all_profile_variants:
   |
     ($current_block_size *
      $current_plutus *
-     $current_dataset
-    ) as $dataset_status_quo
+     { genesis:
+       { utxo:                              0
+       , delegators:                        0
+       }
+     }) as $dataset_empty
   |
     ($current_block_size *
      $current_plutus *
@@ -86,6 +89,11 @@ def all_profile_variants:
        , delegators:                        (0.1 * $M)
        }
      }) as $dataset_miniature
+  |
+    ($current_block_size *
+     $current_plutus *
+     $current_dataset
+    ) as $dataset_status_quo
   |
     { genesis:
       { utxo:                               (30 * $M)
@@ -275,7 +283,7 @@ def all_profile_variants:
   ##
   ### Definition vocabulary:  base variant
   ##
-   ($scenario_fixed_loaded * $doublet * $dataset_miniature * $for_1blk *
+   ($scenario_fixed_loaded * $doublet * $dataset_empty * $for_1blk *
     { desc: "Stop as soon as we've seen a single block"
     }) as $startstop_base
   |

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -34,7 +34,8 @@ case "$op" in
     fixed )
         backend start                "$dir"
 
-        scenario_setup_termination   "$dir"
+        scenario_setup_exit_trap     "$dir"
+        scenario_setup_workload_termination   "$dir"
         backend start-nodes          "$dir"
         backend wait-pools-stopped   "$dir"
         scenario_cleanup_termination
@@ -45,10 +46,11 @@ case "$op" in
     fixed-loaded )
         backend start                "$dir"
 
+        scenario_setup_exit_trap     "$dir"
         backend start-nodes          "$dir"
         backend start-generator      "$dir"
 
-        scenario_setup_termination   "$dir"
+        scenario_setup_workload_termination   "$dir"
         backend wait-pools-stopped   "$dir"
         scenario_cleanup_termination
 
@@ -124,10 +126,8 @@ scenario_watcher() {
     progress "scenario" "now:  $(yellow $(date))"
 }
 
-scenario_setup_termination() {
+scenario_setup_workload_termination() {
     local run_dir=$1
-
-    scenario_setup_exit_trap $run_dir
 
     export __scenario_watcher_self=$BASHPID
     local termination_tolerance_s=40

--- a/nix/workbench/supervisor.sh
+++ b/nix/workbench/supervisor.sh
@@ -197,7 +197,7 @@ EOF
         local usage="USAGE: wb supervisor $op RUN-DIR"
         local dir=${1:?$usage}; shift
 
-        supervisorctl stop all
+        supervisorctl stop all || true
 
         if test -f "${dir}/supervisor/supervisord.pid"
         then kill $(<${dir}/supervisor/supervisord.pid) $(<${dir}/supervisor/child.pids) 2>/dev/null


### PR DESCRIPTION
1. ligther `startstop` profiles (no stuffed UTxO and no extra delegations)
2. better node startup error handling (prevent halfway-started clusters from leaking processes)
3. new tracing has dropped the `Cardano.Node` prefix, so `locli` had to be updated
4. `-autostay` makefile target variants now actually stay after successful runs
5. fix analysis for short-lived profiles, by not filtering out all data (used to drop first two epochs)