### PR TITLE
CAD-4540 Add default LMDB limits to node configuration

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -260,8 +260,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0d19edb5e5fc5644e22a4f3e90ba99d1e3a3d41
-  --sha256: 1bkb7ql295swc17dg4yyv3dhxi2ry7lfpbvrl2xcaw8d20q3xq9q
+  tag: 945f5ac794dac72ae4c3994f3a0ac8d09c122b65
+  --sha256: 04cknb492rq61liml6xsl7z5nl9fkbh71c94dl9896p3s56az84n
   subdir:
     monoidal-synchronisation
     network-mux

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 module Cardano.Node.Configuration.LedgerDB (
     BackingStoreSelectorFlag(..)
+  , defaultLMDBLimits
   ) where
 
 import           Prelude
+
+import           Ouroboros.Consensus.Storage.LedgerDB.HD.LMDB (LMDBLimits (..))
 
 -- | Choose the LedgerDB Backend
 --
@@ -20,3 +25,26 @@ data BackingStoreSelectorFlag =
                      -- default of 12Gi will be used.
   | InMemory
   deriving (Eq, Show)
+
+-- | Recommended settings for the LMDB backing store.
+--
+-- The default @'LMDBLimits'@ uses an @'lmdbMapSize'@ of @16_000_000_000@
+-- bytes, or 16 GigaBytes. @'lmdbMapSize'@ sets the size of the memory map
+-- that is used internally by the LMDB backing store, and is also the
+-- maximum size of the on-disk database. 16 GB should be sufficient for the
+-- medium term, i.e., it is sufficient until a more performant alternative to
+-- the LMDB backing store is implemented, which will probably replace the LMDB
+-- backing store altogether.
+--
+-- Note(jdral): It is recommended not to set the @'lmdbMapSize'@ to a value
+-- that is much smaller than 16 GB through manual configuration: the node will
+-- die with a fatal error as soon as the database size exceeds the
+-- @'lmdbMapSize'@. If this fatal error were to occur, we would expect that
+-- the node can continue normal operation if it is restarted with a higher
+-- @'lmdbMapSize'@ configured. Nonetheless, this situation should be avoided.
+defaultLMDBLimits :: LMDBLimits
+defaultLMDBLimits = LMDBLimits {
+    lmdbMapSize = 16_000_000_000
+  , lmdbMaxDatabases = 10
+  , lmdbMaxReaders = 16
+  }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -391,7 +391,7 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
               onKernel nodeKernel
           , rnEnableP2P      = p2pMode
           , rnBackingStoreSelector = case ncLedgerDBBackend nc of
-                   LMDB newLimit -> LMDBBackingStore $ maybe id (\y x -> x { mapSize = y }) newLimit defaultLMDBLimits
+                   LMDB newLimit -> LMDBBackingStore $ maybe id (\y x -> x { lmdbMapSize = y }) newLimit defaultLMDBLimits
                    InMemory      -> InMemoryBackingStore
           }
     in case p2pMode of


### PR DESCRIPTION
The default LMDB limits are now included in the node configuration. These default limits should be suitable for a node in production. A custom `lmdbMapSize` can still be set through manual configuration, but setting this value is optional.

This PR makes slight changes to the command-line flags that were added by #4011. The options for the JSON config haven't changed.

```
Usage: cardano-node run # ...
                          [ --in-memory-ledger-db-backend
                          | --lmdb-ledger-db-backend [--lmdb-mapsize BIN]
                          ]

  Run the node.

Available options:
  # ...
  --in-memory-ledger-db-backend
                           Use the InMemory ledger DB backend. Incompatible with
                           `--lmdb-ledger-db-backend`.
  --lmdb-ledger-db-backend Use the LMDB ledger DB backend. By default, the
                           mapsize (maximum database size) of the backend is set
                           to 16 Gigabytes. Warning: if the database size
                           exceeds the given mapsize, the node will abort.
                           Therefore, the mapsize should be set to a value high
                           enough to guarantee that the maximum database size
                           will not be reached during the expected node uptime.
                           Incompatible with `--in-memory-ledger-db-backend`.
  --lmdb-mapsize BIN       The maximum database size defined as a binary number.
                           The BIN argument must be a number followed by a unit,
                           for example 10Gi for 10 Gibibytes. Note that BIN must
                           be a multiple of the OS page size (in bytes).
```

EDIT: Updated help text in listing after processing PR reviews.