### PR TITLE
adding a "make check" to the libsodium and secp256k1 install process

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -103,6 +103,7 @@ git checkout 66f017f1
 ./autogen.sh
 ./configure
 make
+make check
 sudo make install
 ```
 
@@ -150,6 +151,7 @@ git checkout ac83be33
 ./autogen.sh
 ./configure --enable-module-schnorrsig --enable-experimental
 make
+make check
 sudo make install
 ```
 


### PR DESCRIPTION
doing a "make check" after a "make" is always a good idea to see if all went well so far