### PR TITLE
Made cardano-node compatible with changes in ShelleyGenesis

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -8,7 +8,7 @@ module Cardano.Benchmarking.GeneratorTx.Genesis
 where
 
 import           Cardano.Prelude hiding (TypeError, filter)
-import qualified Data.Map.Strict as Map
+import qualified Data.ListMap as ListMap
 import           Prelude (error, filter)
 
 import           Cardano.Api
@@ -25,7 +25,7 @@ genesisFunds :: forall era. IsShelleyBasedEra era
   => NetworkId -> ShelleyGenesis StandardShelley -> [(AddressInEra era, Lovelace)]
 genesisFunds networkId g
  = map (castAddr *** fromShelleyLovelace)
-     $ Map.toList
+     . ListMap.unListMap
      $ sgInitialFunds g
  where
   castAddr (Addr _ pcr stref)

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -73,6 +73,7 @@ library
                      , cardano-cli
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
+                     , cardano-data
                      , cardano-git-rev
                      , cardano-ledger-alonzo
                      , cardano-ledger-byron

--- a/cabal.project
+++ b/cabal.project
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: ce3057e0863304ccb3f79d78c77136219dc786c6
-  --sha256: 19ijcy1sl1iqa7diy5nsydnjsn3281kp75i2i42qv0fpn58238s9
+  tag: d6003688a647e8ed32f99171449990be2065f277
+  --sha256: zEpASf6eyxLMNVGcNP54/VL8HCkL3YBFNkoDe3/0SUY=
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -262,9 +262,9 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: a65c29b6a85e90d430c7f58d362b7eb097fd4949
-  --sha256: 1fmab5hmi1y8lss97xh6hhikmyhsx9x31yhvg6zpr2kcq7kc6qkf
+  location: https://github.com/Soupstraw/ouroboros-network
+  tag: 7b6e406dbddc035f235a79f7c93c82530f1d6123
+  --sha256: 3SNP8yLqhAp6gbzOrl9GRSfGfYRRUoZSTxQeag9AgV8=
   subdir:
     monoidal-synchronisation
     network-mux

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -203,6 +203,7 @@ test-suite cardano-api-test
                       , cardano-crypto-class
                       , cardano-crypto-test
                       , cardano-crypto-tests
+                      , cardano-data
                       , cardano-ledger-core
                       , cardano-prelude
                       , cardano-slotting

--- a/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
@@ -65,7 +65,7 @@ shelleyGenesisDefaults =
       -- genesis keys and initial funds
     , sgGenDelegs             = Map.empty
     , sgStaking               = emptyGenesisStaking
-    , sgInitialFunds          = Map.empty
+    , sgInitialFunds          = mempty
     , sgMaxLovelaceSupply     = 0
     }
   where

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -3521,7 +3521,6 @@ toAllegraAuxiliaryData :: forall era ledgerera.
                           ShelleyLedgerEra era ~ ledgerera
                        => Ledger.AuxiliaryData ledgerera ~ Allegra.AuxiliaryData ledgerera
                        => Ledger.AnnotatedData (Ledger.Script ledgerera)
-                       => Ord (Ledger.Script ledgerera)
                        => Map Word64 TxMetadataValue
                        -> [ScriptInEra era]
                        -> Ledger.AuxiliaryData ledgerera

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -11,6 +11,7 @@ import           Cardano.Prelude
 
 import           Cardano.Api.Shelley (ShelleyGenesis (..))
 
+import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
@@ -53,7 +54,7 @@ exampleShelleyGenesis =
                       [( genesisVerKeyHash
                        , GenDelegPair delegVerKeyHash delegVrfKeyHash)
                       ]
-    , sgInitialFunds = Map.fromList [(initialFundedAddress,initialFunds)]
+    , sgInitialFunds = ListMap.ListMap [(initialFundedAddress,initialFunds)]
     , sgStaking = emptyGenesisStaking
     }
  where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -28,6 +28,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Coerce (coerce)
 import qualified Data.List as List
 import qualified Data.List.Split as List
+import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 
 import qualified Data.Sequence.Strict as Seq
@@ -1012,7 +1013,7 @@ updateTemplate (SystemStart start)
           { sgSystemStart = start
           , sgMaxLovelaceSupply = fromIntegral $ nonDelegCoin + delegCoin
           , sgGenDelegs = shelleyDelKeys
-          , sgInitialFunds = Map.fromList
+          , sgInitialFunds = ListMap.ListMap
                               [ (toShelleyAddr addr, toShelleyLovelace v)
                               | (addr, v) <-
                                 distribute (nonDelegCoin - subtractForTreasury) utxoAddrsNonDeleg ++
@@ -1020,10 +1021,10 @@ updateTemplate (SystemStart start)
                                 mkStuffedUtxo stuffedUtxoAddrs ]
           , sgStaking =
             ShelleyGenesisStaking
-              { sgsPools = Map.fromList
+              { sgsPools = ListMap.ListMap
                             [ (Ledger._poolId poolParams, poolParams)
                             | poolParams <- Map.elems poolSpecs ]
-              , sgsStake = Ledger._poolId <$> poolSpecs
+              , sgsStake = ListMap.ListMap . Map.toList $ Ledger._poolId <$> poolSpecs
               }
           , sgProtocolParams = pparamsFromTemplate
           }


### PR DESCRIPTION
The `sgsPools` and `sgsStake` fields in `ShelleyGenesisStaking` were changed to association lists to make them streamable. 
This PR fixes the errors caused by the change.

I also updated the cabal files to point to the commit of `cardano-ledger` that introduces these breaking changes.

https://github.com/input-output-hk/cardano-ledger/pull/2871