### PR TITLE
cardano-node: add docs for NodeState and NodePeers dp.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -355,3 +355,10 @@ allow-newer:
   *:aeson,
   monoidal-containers:aeson,
   size-based:template-haskell
+
+-- Drops an instance breaking our code. Should be released to Hackage eventually.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/moo
+  tag: 8c487714fbfdea66188fcb85053e7e292e0cc348
+  --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -160,6 +160,7 @@ docNodeInfoTraceEvent = Documented [
         \\n _niName_: Name of the node. \
         \\n _niProtocol_: Protocol which this nodes uses. \
         \\n _niVersion_: Software version which this node is using. \
+        \\n _niCommit_: Commit this node is built from. \
         \\n _niStartTime_: Start time of this node. \
         \\n _niSystemStartTime_: How long did the start of the node took."
   ]

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -29,6 +29,8 @@ import           Cardano.Logging.Resources.Types
 import           Cardano.Prelude hiding (trace)
 
 import           Cardano.Node.Tracing.Formatting ()
+import           Cardano.Node.Tracing.Peers
+import           Cardano.Node.Tracing.StateRep
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB
 import           Cardano.Node.Tracing.Tracers.Consensus
@@ -192,6 +194,22 @@ docTracers configFileName outputFileName _ _ _ = do
     configureTracers trConfig docNodeInfoTraceEvent [nodeInfoTr]
     nodeInfoTrDoc <- documentTracer trConfig nodeInfoTr
       (docNodeInfoTraceEvent :: Documented NodeInfo)
+
+    -- NodeState tracer
+    nodeStateTr <- mkDataPointTracer
+                trDataPoint
+                (const ["NodeState"])
+    configureTracers trConfig docNodeState [nodeStateTr]
+    nodeStateTrDoc <- documentTracer trConfig nodeStateTr
+      (docNodeState :: Documented NodeState)
+
+    -- NodeState tracer
+    nodePeersTr <- mkDataPointTracer
+                trDataPoint
+                (const ["NodePeers"])
+    configureTracers trConfig docNodePeers [nodePeersTr]
+    nodePeersTrDoc <- documentTracer trConfig nodePeersTr
+      (docNodePeers :: Documented NodePeers)
 
     -- Resource tracer
     resourcesTr <- mkCardanoTracer
@@ -847,7 +865,9 @@ docTracers configFileName outputFileName _ _ _ = do
     dtAcceptPolicyTrDoc <- documentTracer trConfig dtAcceptPolicyTr
       (docAcceptPolicy :: Documented NtN.AcceptConnectionsPolicyTrace)
 
-    let bl =  nodeInfoTrDoc
+    let bl =   nodeInfoTrDoc
+            <> nodeStateTrDoc
+            <> nodePeersTrDoc
             <> resourcesTrDoc
             <> startupTrDoc
             <> shutdownTrDoc

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -3,6 +3,7 @@
 
 module Cardano.Node.Tracing.Peers
   ( NodePeers (..)
+  , docNodePeers
   , traceNodePeers
   ) where
 
@@ -29,3 +30,9 @@ traceNodePeers
   -> [PeerT blk]
   -> IO ()
 traceNodePeers tr ev = traceWith tr $ NodePeers (map ppPeer ev)
+
+docNodePeers :: Documented NodePeers
+docNodePeers = Documented [
+    DocMsg ["NodePeers"] []
+    "Information about peers of this node. Contains a list of _PeerInfoPP_ messages."
+  ]

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -128,14 +128,17 @@ instance LogFormatting NodeState where
 docNodeState :: Documented NodeState
 docNodeState = addDocumentedNamespace  [] $
   Documented
-  [ DocMsg ["NodeTracingOnlineConfiguring"] [] "Tracing system came online, system configuring now"
-  , DocMsg ["NodeOpeningDbs"]               [] "ChainDB components being opened"
-  , DocMsg ["NodeReplays"]                  [] "Replaying chain"
-  , DocMsg ["NodeInitChainSelection"]       [] "Performing initial chain selection"
-  , DocMsg ["NodeKernelOnline"]             [] "Node kernel online"
-  , DocMsg ["NodeAddBlock"]                 [] "Applying block"
-  , DocMsg ["NodeStartup"]                  [] "Node startup"
-  , DocMsg ["NodeShutdown"]                 [] "Node shutting down"
+  [ DocMsg ["NodeState"] []
+    "State information about this node. It is presented as a sum of the following states\
+    \\n\
+    \\n _NodeTracingOnlineConfiguring_: Tracing system came online, system configuring now. \
+    \\n _NodeOpeningDbs_: ChainDB components being opened. \
+    \\n _NodeReplays_: Replaying chain. \
+    \\n _NodeInitChainSelection_: Performing initial chain selection. \
+    \\n _NodeKernelOnline_: Node kernel online. \
+    \\n _NodeAddBlock_: Applying block. \
+    \\n _NodeStartup_: Node startup. \
+    \\n _NodeShutdown_: Node shutting down."
   ]
 
 namesNodeState :: NodeState -> [Text]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -97,6 +97,7 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     nodeStateDP <- mkDataPointTracer
                 trDataPoint
                 (const ["NodeState"])
+    configureTracers trConfig SR.docNodeState [nodeStateDP]
 
     -- State tracer
     stateTr   <- mkCardanoTracer
@@ -110,6 +111,7 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     nodePeersDP <- mkDataPointTracer
                 trDataPoint
                 (const ["NodePeers"])
+    configureTracers trConfig docNodePeers [nodePeersDP]
 
     -- Peers tracer
     peersTr   <- mkCardanoTracer

--- a/doc/new-tracing/tracers_doc_generated.md
+++ b/doc/new-tracing/tracers_doc_generated.md
@@ -225,18 +225,12 @@
 			1. [RollForward](#chainsyncserialisednodetonodesendrollforward)
 1. __ChainSyncServerBlock__
 	1. __ChainSyncServerEvent__
-		1. __ServerRead__
-			1. [RollBackward](#chainsyncserverblockchainsyncservereventserverreadrollbackward)
-			1. [RollForward](#chainsyncserverblockchainsyncservereventserverreadrollforward)
-			1. [ServerRead](#chainsyncserverblockchainsyncservereventserverreadserverread)
-			1. [ServerReadBlocked](#chainsyncserverblockchainsyncservereventserverreadserverreadblocked)
+		1. __Update__
+			1. [Update](#chainsyncserverblockchainsyncservereventupdateupdate)
 1. __ChainSyncServerHeader__
 	1. __ChainSyncServerEvent__
-		1. __ServerRead__
-			1. [RollBackward](#chainsyncserverheaderchainsyncservereventserverreadrollbackward)
-			1. [RollForward](#chainsyncserverheaderchainsyncservereventserverreadrollforward)
-			1. [ServerRead](#chainsyncserverheaderchainsyncservereventserverreadserverread)
-			1. [ServerReadBlocked](#chainsyncserverheaderchainsyncservereventserverreadserverreadblocked)
+		1. __Update__
+			1. [Update](#chainsyncserverheaderchainsyncservereventupdateupdate)
 1. __ConnectionManager__
 	1. [Connect](#connectionmanagerconnect)
 	1. [ConnectError](#connectionmanagerconnecterror)
@@ -603,7 +597,7 @@
 1. __Shutdown__
 	1. [AbnormalShutdown](#shutdownabnormalshutdown)
 	1. [RequestingShutdown](#shutdownrequestingshutdown)
-	1. [ShutdownArmedAtSlot](#shutdownshutdownarmedatslot)
+	1. [ShutdownArmedAt](#shutdownshutdownarmedat)
 	1. [ShutdownRequested](#shutdownshutdownrequested)
 	1. [ShutdownUnexpectedInput](#shutdownshutdownunexpectedinput)
 1. __Startup__
@@ -751,9 +745,6 @@
 		1. __metrics__
 			1. __served__
 				1. [header](#cardanonodemetricsservedheader)
-				1. [header](#cardanonodemetricsservedheader)
-				1. [header](#cardanonodemetricsservedheader)
-				1. [header](#cardanonodemetricsservedheader)
 		1. [nodeCannotForge](#cardanonodenodecannotforge)
 		1. [nodeIsLeader](#cardanonodenodeisleader)
 		1. [nodeNotLeader](#cardanonodenodenotleader)
@@ -800,6 +791,8 @@
 
 ## [Datapoints](#datapoints)
 1. [NodeInfo](#nodeinfo)
+1. [NodePeers](#nodepeers)
+1. [NodeState](#nodestate)
 
 ## Trace Messages
 ### AcceptPolicy.ConnectionHardLimit
@@ -3691,39 +3684,7 @@ Backends:
 			`Forwarder`
 Filtered  by config value: `Notice`
 
-### ChainSyncServerBlock.ChainSyncServerEvent.ServerRead.RollBackward
-
-
-***
-
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerBlock.ChainSyncServerEvent.ServerRead.RollForward
-
-
-***
-Roll forward to the given point.
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerBlock.ChainSyncServerEvent.ServerRead.ServerRead
+### ChainSyncServerBlock.ChainSyncServerEvent.Update.Update
 
 
 ***
@@ -3739,75 +3700,11 @@ Backends:
 			`Forwarder`
 Filtered  by config value: `Notice`
 
-### ChainSyncServerBlock.ChainSyncServerEvent.ServerRead.ServerReadBlocked
-
-
-***
-A server read has blocked, either for an add block or a rollback
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.RollBackward
-
-
-***
-
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.RollForward
-
-
-***
-Roll forward to the given point.
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.ServerRead
+### ChainSyncServerHeader.ChainSyncServerEvent.Update.Update
 
 
 ***
 A server read has occurred, either for an add block or a rollback
-***
-
-
-From current configuration:
-Details:   `DNormal`
-Backends:
-			`EKGBackend`,
-			`Stdout MachineFormat`,
-			`Forwarder`
-Filtered  by config value: `Notice`
-
-### ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.ServerReadBlocked
-
-
-***
-A server read has blocked, either for an add block or a rollback
 ***
 
 
@@ -9046,7 +8943,7 @@ Backends:
 			`Forwarder`
 Filtered  by config value: `Notice`
 
-### Shutdown.ShutdownArmedAtSlot
+### Shutdown.ShutdownArmedAt
 
 
 ***
@@ -10943,51 +10840,12 @@ Filtered  by config value: `Info`
 ### cardano.node.metrics.served.header
 
 ***
-A counter triggered ony on header event
+A counter triggered only on header event
 ***
 
 
 Dispatched by: 
-ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.RollBackward
-
-From current configuration:
-Filtered  by config value: `Notice`
-
-### cardano.node.metrics.served.header
-
-***
-A counter triggered ony on header event
-***
-
-
-Dispatched by: 
-ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.RollForward
-
-From current configuration:
-Filtered  by config value: `Notice`
-
-### cardano.node.metrics.served.header
-
-***
-A counter triggered ony on header event
-***
-
-
-Dispatched by: 
-ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.ServerRead
-
-From current configuration:
-Filtered  by config value: `Notice`
-
-### cardano.node.metrics.served.header
-
-***
-A counter triggered ony on header event
-***
-
-
-Dispatched by: 
-ChainSyncServerHeader.ChainSyncServerEvent.ServerRead.ServerReadBlocked
+ChainSyncServerHeader.ChainSyncServerEvent.Update.Update
 
 From current configuration:
 Filtered  by config value: `Notice`
@@ -11483,12 +11341,38 @@ Basic information about this node collected at startup
  _niName_: Name of the node. 
  _niProtocol_: Protocol which this nodes uses. 
  _niVersion_: Software version which this node is using. 
+ _niCommit_: Commit this node is built from. 
  _niStartTime_: Start time of this node. 
  _niSystemStartTime_: How long did the start of the node took.
 ***
 
 
-Configuration: TraceConfig {tcOptions = fromList [([],[ConfSeverity {severity = Notice},ConfDetail {detail = DNormal},ConfBackend {backends = [Stdout MachineFormat,EKGBackend,Forwarder]}]),(["AcceptPolicy"],[ConfSeverity {severity = Info}]),(["BlockFetchClient","CompletedBlockFetch"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB"],[ConfSeverity {severity = Info}]),(["ChainDB","AddBlockEvent","AddBlockValidation","ValidCandidate"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","AddBlockEvent","AddedBlockToQueue"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","AddBlockEvent","AddedBlockToVolatileDB"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","CopyToImmutableDBEvent","CopiedBlockToImmutableDB"],[ConfLimiter {maxFrequency = 2.0}]),(["DNSResolver"],[ConfSeverity {severity = Info}]),(["DNSSubscription"],[ConfSeverity {severity = Info}]),(["DiffusionInit"],[ConfSeverity {severity = Info}]),(["ErrorPolicy"],[ConfSeverity {severity = Info}]),(["Forge"],[ConfSeverity {severity = Info}]),(["IpSubscription"],[ConfSeverity {severity = Info}]),(["LocalErrorPolicy"],[ConfSeverity {severity = Info}]),(["Mempool"],[ConfSeverity {severity = Info}]),(["Resources"],[ConfSeverity {severity = Info}])], tcForwarder = TraceOptionForwarder {tofAddress = LocalSocket "/tmp/forwarder.sock", tofMode = Initiator, tofConnQueueSize = 2000, tofDisconnQueueSize = 200000, tofVerbosity = Minimum}, tcNodeName = Nothing, tcPeerFrequency = Just 2000, tcResourceFrequency = Just 5000}
+### NodePeers
 
-677 log messages.
-Generated at 2022-06-03 12:11:02.013173249 CEST.
+
+***
+Information about peers of this node. Contains a list of _PeerInfoPP_ messages.
+***
+
+
+### NodeState
+
+
+***
+State information about this node. It is presented as a sum of the following states
+
+ _NodeTracingOnlineConfiguring_: Tracing system came online, system configuring now. 
+ _NodeOpeningDbs_: ChainDB components being opened. 
+ _NodeReplays_: Replaying chain. 
+ _NodeInitChainSelection_: Performing initial chain selection. 
+ _NodeKernelOnline_: Node kernel online. 
+ _NodeAddBlock_: Applying block. 
+ _NodeStartup_: Node startup. 
+ _NodeShutdown_: Node shutting down.
+***
+
+
+Configuration: TraceConfig {tcOptions = fromList [([],[ConfSeverity {severity = Notice},ConfDetail {detail = DNormal},ConfBackend {backends = [Stdout MachineFormat,EKGBackend,Forwarder]}]),(["AcceptPolicy"],[ConfSeverity {severity = Info}]),(["BlockFetchClient","CompletedBlockFetch"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB"],[ConfSeverity {severity = Info}]),(["ChainDB","AddBlockEvent","AddBlockValidation","ValidCandidate"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","AddBlockEvent","AddedBlockToQueue"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","AddBlockEvent","AddedBlockToVolatileDB"],[ConfLimiter {maxFrequency = 2.0}]),(["ChainDB","CopyToImmutableDBEvent","CopiedBlockToImmutableDB"],[ConfLimiter {maxFrequency = 2.0}]),(["DNSResolver"],[ConfSeverity {severity = Info}]),(["DNSSubscription"],[ConfSeverity {severity = Info}]),(["DiffusionInit"],[ConfSeverity {severity = Info}]),(["ErrorPolicy"],[ConfSeverity {severity = Info}]),(["Forge"],[ConfSeverity {severity = Info}]),(["IpSubscription"],[ConfSeverity {severity = Info}]),(["LocalErrorPolicy"],[ConfSeverity {severity = Info}]),(["Mempool"],[ConfSeverity {severity = Info}]),(["Resources"],[ConfSeverity {severity = Info}])], tcForwarder = TraceOptionForwarder {tofConnQueueSize = 2000, tofDisconnQueueSize = 200000, tofVerbosity = Minimum}, tcNodeName = Nothing, tcPeerFrequency = Just 2000, tcResourceFrequency = Just 5000}
+
+670 log messages.
+Generated at 2022-07-01 14:37:24.670427671 +04.


### PR DESCRIPTION
Add missed documentation for `NodeState` and `NodePeers` datapoints.