### PR TITLE
Update ledger to tip of release/1.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: ce3057e0863304ccb3f79d78c77136219dc786c6
-  --sha256: 19ijcy1sl1iqa7diy5nsydnjsn3281kp75i2i42qv0fpn58238s9
+  tag: 3be8a19083fc13d9261b1640e27dd389b51bb08e
+  --sha256: 0dvm9l43mp1i34bcywmznd0660hhcfxwgawypk9q1hjkml1i41z3
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite


### PR DESCRIPTION
This fixes a bug whereby nodes always re-sync from the start when the last ledger snapshot was in the Babbage era.

See https://github.com/input-output-hk/cardano-ledger/pull/2897 (`release/1.0.0` was branched off of `ce3057e0863304ccb3f79d78c77136219dc786c6` and cherry-picked the commit from the ledger PR 2897).