### PR TITLE
CAD-4728  Change the units for the LMDB `mapsize` option to GB and let the parameter be a number

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,9 @@ The general synopsis is as follows:
                            [--host-ipv6-addr IPV6-ADDRESS]
                            [--port PORT]
                            [--config NODE-CONFIGURATION] [--validate-db]
-                           [ --in-memory-ledger-db-backend | --lmdb-ledger-db-backend [--lmdb-mapsize BIN]]
+                           [ --in-memory-ledger-db-backend
+                           | --lmdb-ledger-db-backend [--lmdb-mapsize NR_GIGABYTES]
+                           ]
 
      Run the node.
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -171,7 +171,6 @@ library
                       , ouroboros-consensus-shelley
                       , ouroboros-network
                       , ouroboros-network-framework
-                      , prefix-units
                       , psqueues
                       , safe-exceptions
                       , scientific

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -3,7 +3,7 @@
 
 module Cardano.Node.Configuration.LedgerDB (
     BackingStoreSelectorFlag(..)
-  , Gigabyte
+  , Gigabytes
   , toBytes
   , defaultLMDBLimits
   ) where
@@ -24,18 +24,20 @@ import qualified Data.Aeson.Types as Aeson (FromJSON)
 --
 -- See 'Ouroboros.Consnesus.Storage.LedgerDB.OnDisk.BackingStoreSelector'.
 data BackingStoreSelectorFlag =
-    LMDB (Maybe Gigabyte) -- ^ A map size can be specified, this is the maximum
+    LMDB (Maybe Gigabytes) -- ^ A map size can be specified, this is the maximum
                           -- disk space the LMDB database can fill. If not
                           -- provided, the default of 16GB will be used.
   | InMemory
   deriving (Eq, Show)
 
-newtype Gigabyte = Gigabyte Int
+-- | A number of gigabytes.
+newtype Gigabytes = Gigabytes Int
   deriving stock (Eq, Show)
   deriving newtype (Read, Aeson.FromJSON)
 
-toBytes :: Gigabyte -> Int
-toBytes (Gigabyte x) = x * 1024 * 1024 * 1024
+-- | Convert a number of Gigabytes to the equivalent number of bytes.
+toBytes :: Gigabytes -> Int
+toBytes (Gigabytes x) = x * 1024 * 1024 * 1024
 
 -- | Recommended settings for the LMDB backing store.
 --

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -30,7 +30,6 @@ import           Data.Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime)
-import           Data.Prefix.Units
 import           Data.Yaml (decodeFileThrow)
 import           Generic.Data (gmappend)
 import           Generic.Data.Orphans ()
@@ -328,12 +327,7 @@ instance FromJSON PartialNodeConfiguration where
         case maybeString of
            Just "InMemory" -> return $ Just InMemory
            Just "LMDB"     -> do
-             maybeMapSize :: Maybe String <- v .:? "LMDBMapSize"
-             mapSize <- case maybeMapSize of
-               Nothing -> return Nothing
-               Just s  -> case parseValue ParseExact s of
-                 Left e      -> fail ("Malformed LMDBMapSize: " <> e)
-                 Right units -> return $ Just units
+             mapSize :: Maybe Gigabyte <- v .:? "LMDBMapSize"
              return . Just . LMDB $ mapSize
            Nothing         -> return Nothing
            Just whatever   -> fail $ "Malformed LedgerDBBackend" <> whatever

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -327,7 +327,7 @@ instance FromJSON PartialNodeConfiguration where
         case maybeString of
            Just "InMemory" -> return $ Just InMemory
            Just "LMDB"     -> do
-             mapSize :: Maybe Gigabyte <- v .:? "LMDBMapSize"
+             mapSize :: Maybe Gigabytes <- v .:? "LMDBMapSize"
              return . Just . LMDB $ mapSize
            Nothing         -> return Nothing
            Just whatever   -> fail $ "Malformed LedgerDBBackend" <> whatever

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -223,7 +223,7 @@ parseLedgerDBBackend = parseInMemory <|> parseLMDB <*> optional parseMapSize
                              \ Incompatible with `--lmdb-ledger-db-backend`."
                      )
 
-    parseLMDB :: Parser (Maybe Gigabyte -> BackingStoreSelectorFlag)
+    parseLMDB :: Parser (Maybe Gigabytes -> BackingStoreSelectorFlag)
     parseLMDB =
       flag' LMDB (  long "lmdb-ledger-db-backend"
                  <> help "Use the LMDB ledger DB backend. By default, the \
@@ -237,7 +237,7 @@ parseLedgerDBBackend = parseInMemory <|> parseLMDB <*> optional parseMapSize
                          \ Incompatible with `--in-memory-ledger-db-backend`."
                 )
 
-    parseMapSize :: Parser Gigabyte
+    parseMapSize :: Parser Gigabytes
     parseMapSize =
       option auto (
            long "lmdb-mapsize"

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -15,7 +15,6 @@ import           Cardano.Prelude hiding (option)
 import           Prelude (String)
 
 import           Data.Time.Clock (secondsToDiffTime)
-import           Data.Prefix.Units
 import           Options.Applicative hiding (str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
@@ -224,7 +223,7 @@ parseLedgerDBBackend = parseInMemory <|> parseLMDB <*> optional parseMapSize
                              \ Incompatible with `--lmdb-ledger-db-backend`."
                      )
 
-    parseLMDB :: Parser (Maybe Int -> BackingStoreSelectorFlag)
+    parseLMDB :: Parser (Maybe Gigabyte -> BackingStoreSelectorFlag)
     parseLMDB =
       flag' LMDB (  long "lmdb-ledger-db-backend"
                  <> help "Use the LMDB ledger DB backend. By default, the \
@@ -238,16 +237,12 @@ parseLedgerDBBackend = parseInMemory <|> parseLMDB <*> optional parseMapSize
                          \ Incompatible with `--in-memory-ledger-db-backend`."
                 )
 
-    parseMapSize :: Parser Int
+    parseMapSize :: Parser Gigabyte
     parseMapSize =
-      option (eitherReader (parseValue ParseExact)) (
+      option auto (
            long "lmdb-mapsize"
-        <> metavar "BIN"
-        <> help "The maximum database size defined as a binary \
-                \ number. The BIN argument must be a number \
-                \ followed by a unit, for example 10Gi for 10 \
-                \ Gibibytes. Note that BIN must be a multiple of \
-                \ the OS page size (in bytes)."
+        <> metavar "NR_GIGABYTES"
+        <> help "The maximum database size defined in number of Gigabytes."
       )
 
 parseDbPath :: Parser FilePath

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -391,8 +391,9 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
               onKernel nodeKernel
           , rnEnableP2P      = p2pMode
           , rnBackingStoreSelector = case ncLedgerDBBackend nc of
-                   LMDB newLimit -> LMDBBackingStore $ maybe id (\y x -> x { lmdbMapSize = y }) newLimit defaultLMDBLimits
-                   InMemory      -> InMemoryBackingStore
+              LMDB newLimit -> LMDBBackingStore $
+                maybe id (\y x -> x { lmdbMapSize = toBytes y }) newLimit defaultLMDBLimits
+              InMemory      -> InMemoryBackingStore
           }
     in case p2pMode of
       EnabledP2PMode -> do

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -366,7 +366,8 @@ The node can be configured to use any of two *backends*:
 (LMDB)](http://www.lmdb.tech/doc/index.html), stores parts of the ledger state
 on disk. Optionally, a configuration can be included that sets the maximum
 database size (mapsize) of the on-disk database that is used to store parts of
-the ledger state. By default, the mapsize is set to 16 Gigabytes. **Warning**:
+the ledger state. The mapsize argument should be defined as a number of Gigabytes.
+By default, the mapsize is set to 16 Gigabytes. **Warning**:
 if the database size exceeds the given mapsize, the node will abort. Therefore,
 the mapsize should be set to a value high enough to guarantee that the maximum
 database size will not be reached during the expected node uptime. The current
@@ -374,7 +375,7 @@ default value is sufficient to offer this guarantee, and setting the mapsize
 to anything less is therefore not recommended.
   ```json
   "LedgerDBBackend": "LMDB",
-  "LMDBMapSize": "16G",
+  "LMDBMapSize": "16",
   ```
 * The *InMemory backend* stores parts of the ledger state in memory.
   ```json


### PR DESCRIPTION
The LMDB `mapsize` option is now set by providing a "number of gigabytes". The parsing of config files, the parsing of command-line options, and relevant documentation has been updated accordingly.