### PR TITLE
tx-generator | reusable API and library

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/FundSet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/FundSet.hs
@@ -1,31 +1,25 @@
 {-# OPTIONS_GHC -Wwarn #-}
-{-# Language DataKinds #-}
-{-# Language FlexibleInstances #-}
-{-# Language GADTs #-}
-{-# Language MultiParamTypeClasses #-}
-{-# Language RankNTypes #-}
-{-# Language TypeApplications #-}
-{-# Language ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Benchmarking.FundSet
-where
+       ( module Cardano.Benchmarking.FundSet
+       , module Cardano.TxGenerator.Fund
+       )
+      where
+
 import           Prelude
 
 import           Cardano.Api as Api
 
-import Cardano.Benchmarking.Fifo as Fifo
+import           Cardano.Benchmarking.Fifo as Fifo
+import           Cardano.TxGenerator.Fund
 
--- Outputs that are available for spending.
--- When building a new TX they provide the TxIn parts.
-
-data FundInEra era = FundInEra {
-    _fundTxIn :: !TxIn
-  , _fundWitness :: Witness WitCtxTxIn era
-  , _fundVal  :: !(TxOutValue era)
-  , _fundSigningKey :: !(Maybe (SigningKey PaymentKey))
-  } deriving (Show)
-
-newtype Fund = Fund {unFund :: InAnyCardanoEra FundInEra}
 
 type FundSet = Fifo Fund
 
@@ -33,43 +27,6 @@ type FundSource m = m (Either String [Fund])
 type FundToStore m = Fund -> m ()
 type FundToStoreList m = [Fund] -> m ()
 
-getFundTxIn :: Fund -> TxIn
-getFundTxIn (Fund (InAnyCardanoEra _ a)) = _fundTxIn a
-
-getFundKey :: Fund -> Maybe (SigningKey PaymentKey)
-getFundKey (Fund (InAnyCardanoEra _ a)) = _fundSigningKey a
-
-getFundLovelace :: Fund -> Lovelace
-getFundLovelace (Fund (InAnyCardanoEra _ a)) = case _fundVal a of
-  TxOutAdaOnly _era l -> l
-  TxOutValue _era v -> selectLovelace v
-
--- This effectively rules out era-transitions for transactions !
--- This is not what we want !!
-getFundWitness :: forall era. IsShelleyBasedEra era => Fund -> Witness WitCtxTxIn era
-getFundWitness fund = case (cardanoEra @ era, fund) of
-  (ByronEra   , Fund (InAnyCardanoEra ByronEra   a)) -> _fundWitness a
-  (ShelleyEra , Fund (InAnyCardanoEra ShelleyEra a)) -> _fundWitness a
-  (AllegraEra , Fund (InAnyCardanoEra AllegraEra a)) -> _fundWitness a
-  (MaryEra    , Fund (InAnyCardanoEra MaryEra    a)) -> _fundWitness a
-  (AlonzoEra  , Fund (InAnyCardanoEra AlonzoEra  a)) -> _fundWitness a
-  (BabbageEra , Fund (InAnyCardanoEra BabbageEra a)) -> _fundWitness a
--- This effectively rules out era-transitions for transactions !
--- This is not what we want !!
--- It should be possible to cast KeyWitnesses from one era to an other !
-  (_ , _) -> error "getFundWitness: era mismatch"
-
-instance Show Fund where
-  show (Fund (InAnyCardanoEra _ f)) = show f
-
--- TxIn/fundTxOut is the primary key.
--- There must be no two entries for the same TxIn !.
-
-instance Eq Fund where
-  (==) a b = getFundTxIn a == getFundTxIn b
-
-instance Ord Fund where
-  compare a b = compare (getFundTxIn a) (getFundTxIn b)
 
 emptyFundSet :: FundSet
 emptyFundSet = Fifo.emptyFifo
@@ -84,7 +41,7 @@ liftAnyEra f x = case x of
   InAnyCardanoEra AllegraEra a ->   InAnyCardanoEra AllegraEra $ f a
   InAnyCardanoEra MaryEra a    ->   InAnyCardanoEra MaryEra $ f a
   InAnyCardanoEra AlonzoEra a  ->   InAnyCardanoEra AlonzoEra $ f a
-  InAnyCardanoEra BabbageEra a  ->  InAnyCardanoEra BabbageEra $ f a  
+  InAnyCardanoEra BabbageEra a  ->  InAnyCardanoEra BabbageEra $ f a
 
 -- Todo: check sufficient funds and minimumValuePerUtxo
 inputsToOutputsWithFee :: Lovelace -> Int -> [Lovelace] -> [Lovelace]

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -39,16 +39,17 @@ import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
 import           Cardano.Api hiding (txFee)
 
-import           Cardano.Benchmarking.GeneratorTx.Error
 import           Cardano.Benchmarking.GeneratorTx.Genesis
 import           Cardano.Benchmarking.GeneratorTx.NodeToNode
 import           Cardano.Benchmarking.GeneratorTx.Submission
 import           Cardano.Benchmarking.GeneratorTx.SubmissionClient
 import           Cardano.Benchmarking.GeneratorTx.Tx
-import           Cardano.Benchmarking.TpsThrottle
 import           Cardano.Benchmarking.LogTypes
+import           Cardano.Benchmarking.TpsThrottle
 import           Cardano.Benchmarking.Types
 import           Cardano.Benchmarking.Wallet (WalletScript)
+import           Cardano.TxGenerator.Types
+
 
 import           Cardano.Ledger.Shelley.API (ShelleyGenesis)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -12,14 +12,17 @@ import qualified Data.ListMap as ListMap
 import           Prelude (error, filter)
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (fromShelleyLovelace, fromShelleyPaymentCredential,
-                   fromShelleyStakeReference, ReferenceScript(..))
+import           Cardano.Api.Shelley (ReferenceScript (..), fromShelleyLovelace,
+                   fromShelleyPaymentCredential, fromShelleyStakeReference)
 import           Control.Arrow ((***))
 
 import           Cardano.Benchmarking.GeneratorTx.Tx
 
 import           Cardano.Ledger.Shelley.API (Addr (..), ShelleyGenesis, sgInitialFunds)
 import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+
+import           Cardano.TxGenerator.Utils (keyAddress)
+
 
 genesisFunds :: forall era. IsShelleyBasedEra era
   => NetworkId -> ShelleyGenesis StandardShelley -> [(AddressInEra era, Lovelace)]

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -8,7 +8,6 @@ module Cardano.Benchmarking.GeneratorTx.Tx
   ( Fund
   , fundTxIn
   , fundAdaValue
-  , keyAddress
   , mkGenesisTransaction
   , mkFund
   , mkFee
@@ -34,13 +33,6 @@ fundTxIn (x,_) = x
 
 fundAdaValue :: Fund -> Lovelace
 fundAdaValue (_, InAnyCardanoEra _ txOut) = txOutValueToLovelace txOut
-
-keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
-keyAddress networkId k
-  = makeShelleyAddressInEra
-      networkId
-      (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
-      NoStakeAddress
 
 --{-# DEPRECATED mkGenesisTransaction "to be removed" #-}
 mkGenesisTransaction :: forall era .

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -13,26 +13,26 @@
 module Cardano.Benchmarking.Script.Env
 where
 
-import           Prelude
-import           Data.Functor.Identity
-import qualified Data.Text as Text
-import           Data.Dependent.Sum (DSum(..))
-import           Data.Dependent.Map (DMap)
-import qualified Data.Dependent.Map as DMap
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.RWS.Strict (RWST)
 import qualified Control.Monad.Trans.RWS.Strict as RWS
 import           "contra-tracer" Control.Tracer (traceWith)
+import           Data.Dependent.Map (DMap)
+import qualified Data.Dependent.Map as DMap
+import           Data.Dependent.Sum (DSum (..))
+import           Data.Functor.Identity
+import qualified Data.Text as Text
+import           Prelude
 
-import qualified Cardano.Node.Types (ConfigError)
 import qualified Cardano.Benchmarking.LogTypes as Tracer
+import qualified Cardano.Node.Types (ConfigError)
 import           Ouroboros.Network.NodeToClient (IOManager)
 
-import           Cardano.TxGenerator.Types (TxGenError)
 import           Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.Script.Store
+import           Cardano.TxGenerator.Types (TxGenError)
 
 type Env = DMap Store Identity
 

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -30,7 +30,7 @@ import qualified Cardano.Node.Types (ConfigError)
 import qualified Cardano.Benchmarking.LogTypes as Tracer
 import           Ouroboros.Network.NodeToClient (IOManager)
 
-import           Cardano.Benchmarking.GeneratorTx.Error (TxGenError)
+import           Cardano.TxGenerator.Types (TxGenError)
 import           Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.Script.Store
 

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -2,41 +2,31 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 module Cardano.Benchmarking.Wallet
 where
 import           Prelude
 
 import           Control.Concurrent.MVar
-import           Data.Maybe
 
 import           Cardano.Api
 
 import           Cardano.TxGenerator.FundQueue as FundQueue
+import           Cardano.TxGenerator.Tx (CreateAndStore, CreateAndStoreList)
 import           Cardano.TxGenerator.Types
+import           Cardano.TxGenerator.Utxo
 
-import           Cardano.Api.Shelley (ProtocolParameters, ReferenceScript (..))
 import           Cardano.Benchmarking.Types (NumberOfTxs (..))
 
 -- All the actual functionality of Wallet / WalletRef has been removed
 -- and WalletRef has been stripped down to MVar FundQueue.
 -- The implementation of Wallet has become trivial.
--- Todo: Remove trivial wrapper functions.
+-- TODO: Remove trivial wrapper functions.
 
 type WalletRef = MVar FundQueue
 
-type TxGenerator era = [Fund] -> [TxOut CtxTx era] -> Either String (Tx era, TxId)
-
-type ToUTxO era = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> Fund)
-type ToUTxOList era split = split -> ([TxOut CtxTx era], TxId -> [Fund])
-
-type CreateAndStore m era = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> m ())
-
-type CreateAndStoreList m era split = split -> ([TxOut CtxTx era], TxId -> m ())
 
 -- 'ToUTxOList era' is more powerful than '[ ToUTxO era ]' but
 -- '[ ToUTxO era ]` is easier to construct.
-
 createAndStore :: ToUTxO era -> (Fund -> m ()) -> CreateAndStore m era
 createAndStore create store lovelace = (utxo, toStore)
   where
@@ -67,18 +57,6 @@ walletSource ref munch = modifyMVar ref $ \fifo -> return $ case FundQueue.remov
   Nothing -> (fifo, Left "WalletSource: out of funds")
   Just (newFifo, funds) -> (newFifo, Right funds)
 
-makeToUTxOList :: [ ToUTxO era ] -> ToUTxOList era [ Lovelace ]
-makeToUTxOList fkts values
-  = (outs, \txId -> map (\f -> f txId) fs)
-  where
-    (outs, fs) =unzip $ map worker $ zip3 fkts values [TxIx 0 ..]
-    worker (toUTxO, value, idx)
-      = let (o, f ) = toUTxO value
-         in  (o, f idx)
-
-data PayWithChange
-  = PayExact [Lovelace]
-  | PayWithChange Lovelace [Lovelace]
 
 mangleWithChange :: Monad m => CreateAndStore m era -> CreateAndStore m era -> CreateAndStoreList m era PayWithChange
 mangleWithChange mkChange mkPayment outs = case outs of
@@ -94,160 +72,6 @@ mangle fkts values
       = let (o, f ) = toUTxO value
          in  (o, f idx)
 
---TODO use Error monad
---TODO need to break this up
-sourceToStoreTransaction ::
-     Monad m
-  => TxGenerator era
-  -> FundSource m
-  -> ([Lovelace] -> split)
-  -> ToUTxOList era split
-  -> FundToStoreList m                --inline to ToUTxOList
-  -> m (Either String (Tx era))
-sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
-  fundSource >>= \case
-    Left err -> return $ Left err
-    Right inputFunds -> work inputFunds
- where
-  work inputFunds = do
-    let
-      outValues = inToOut $ map getFundLovelace inputFunds
-      (outputs, toFunds) = mkTxOut outValues
-    case txGenerator inputFunds outputs of
-        Left err -> return $ Left err
-        Right (tx, txId) -> do
-          fundToStore $ toFunds txId
-          return $ Right tx
-
-sourceToStoreTransactionNew ::
-     Monad m
-  => TxGenerator era
-  -> FundSource m
-  -> ([Lovelace] -> split)
-  -> CreateAndStoreList m era split
-  -> m (Either String (Tx era))
-sourceToStoreTransactionNew txGenerator fundSource valueSplitter toStore = do
-  fundSource >>= \case
-    Left err -> return $ Left err
-    Right inputFunds -> work inputFunds
- where
-  work inputFunds = do
-    let
-      split = valueSplitter $ map getFundLovelace inputFunds
-      (outputs, storeAction) = toStore split
-    case txGenerator inputFunds outputs of
-        Left err -> return $ Left err
-        Right (tx, txId) -> do
-          storeAction txId
-          return $ Right tx
-
-includeChange :: Lovelace -> [Lovelace] -> [Lovelace] -> [Lovelace]
-includeChange fee spend have = case compare changeValue 0 of
-  GT -> changeValue : spend
-  EQ -> spend
-  LT -> error "genTX: Bad transaction: insufficient funds"
-  where changeValue = sum have - sum spend - fee
-
-includeChangeNew :: Lovelace -> [Lovelace] -> [Lovelace] -> PayWithChange
-includeChangeNew fee spend have = case compare changeValue 0 of
-  GT -> PayWithChange changeValue spend
-  EQ -> PayExact spend
-  LT -> error "genTX: Bad transaction: insufficient funds"
-  where changeValue = sum have - sum spend - fee
-
-mkUTxOVariant :: forall era. IsShelleyBasedEra era
-  => NetworkId
-  -> SigningKey PaymentKey
-  -> ToUTxO era
-mkUTxOVariant networkId key value
-  = ( mkTxOut value
-    , mkNewFund value
-    )
- where
-  mkTxOut v = TxOut (keyAddress @ era networkId key) (lovelaceToTxOutValue v) TxOutDatumNone ReferenceScriptNone
-
-  mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
-  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
-      _fundTxIn = TxIn txId txIx
-    , _fundWitness = KeyWitness KeyWitnessForSpending
-    , _fundVal = lovelaceToTxOutValue val
-    , _fundSigningKey = Just key
-    }
-
--- to be merged with mkUTxOVariant
-mkUTxOScript :: forall era.
-     IsShelleyBasedEra era
-  => NetworkId
-  -> (Script PlutusScriptV1, ScriptData)
-  -> Witness WitCtxTxIn era
-  -> ToUTxO era
-mkUTxOScript networkId (script, txOutDatum) witness value
-  = ( mkTxOut value
-    , mkNewFund value
-    )
- where
-  plutusScriptAddr = makeShelleyAddressInEra
-                       networkId
-                       (PaymentCredentialByScript $ hashScript script)
-                       NoStakeAddress
-
-  mkTxOut v = case scriptDataSupportedInEra (cardanoEra @ era) of
-    Nothing -> error " mkUtxOScript scriptDataSupportedInEra==Nothing"
-    Just tag -> TxOut
-                  plutusScriptAddr
-                  (lovelaceToTxOutValue v)
-                  (TxOutDatumHash tag $ hashScriptData txOutDatum)
-                  ReferenceScriptNone
-
-  mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
-  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
-      _fundTxIn = TxIn txId txIx
-    , _fundWitness = witness
-    , _fundVal = lovelaceToTxOutValue val
-    , _fundSigningKey = Nothing
-    }
-
-genTx :: forall era. IsShelleyBasedEra era =>
-     ProtocolParameters
-  -> (TxInsCollateral era, [Fund])
-  -> TxFee era
-  -> TxMetadataInEra era
-  -> TxGenerator era
-genTx protocolParameters (collateral, collFunds) fee metadata inFunds outputs
-  = case makeTransactionBody txBodyContent of
-      Left err -> error $ show err
-      Right b -> Right ( signShelleyTransaction b $ map WitnessPaymentKey allKeys
-                       , getTxId b
-                       )
- where
-  allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
-  txBodyContent = TxBodyContent {
-      txIns = map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds
-    , txInsCollateral = collateral
-    , txInsReference = TxInsReferenceNone
-    , txOuts = outputs
-    , txFee = fee
-    , txValidityRange = (TxValidityNoLowerBound, upperBound)
-    , txMetadata = metadata
-    , txAuxScripts = TxAuxScriptsNone
-    , txExtraKeyWits = TxExtraKeyWitnessesNone
-    , txProtocolParams = BuildTxWith $ Just protocolParameters
-    , txWithdrawals = TxWithdrawalsNone
-    , txCertificates = TxCertificatesNone
-    , txUpdateProposal = TxUpdateProposalNone
-    , txMintValue = TxMintNone
-    , txScriptValidity = TxScriptValidityNone
-    , txReturnCollateral = TxReturnCollateralNone
-    , txTotalCollateral = TxTotalCollateralNone
-    }
-
-  upperBound :: TxValidityUpperBound era
-  upperBound = case shelleyBasedEra @ era of
-    ShelleyBasedEraShelley -> TxValidityUpperBound ValidityUpperBoundInShelleyEra $ SlotNo maxBound
-    ShelleyBasedEraAllegra -> TxValidityNoUpperBound ValidityNoUpperBoundInAllegraEra
-    ShelleyBasedEraMary    -> TxValidityNoUpperBound ValidityNoUpperBoundInMaryEra
-    ShelleyBasedEraAlonzo  -> TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra
-    ShelleyBasedEraBabbage -> TxValidityNoUpperBound ValidityNoUpperBoundInBabbageEra
 
 newtype WalletScript era = WalletScript { runWalletScript :: IO (WalletStep era) }
 
@@ -259,7 +83,6 @@ data WalletStep era
 -- TODO:
 -- Define generator for a single transaction and define combinator for
 -- repeat and sequence.
-
 
 benchmarkWalletScript :: forall era .
      IsShelleyBasedEra era
@@ -279,11 +102,4 @@ limitSteps ::
      NumberOfTxs
   -> WalletScript era
   -> WalletScript era
-limitSteps = undefined
-
-keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
-keyAddress networkId k
-  = makeShelleyAddressInEra
-      networkId
-      (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
-      NoStakeAddress
+limitSteps = undefined          -- FIXME

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -96,12 +96,13 @@ mangle fkts values
 --TODO use Error monad
 --TODO need to break this up
 sourceToStoreTransaction ::
-     TxGenerator era
-  -> FundSource IO         
+     Monad m
+  => TxGenerator era
+  -> FundSource m         
   -> ([Lovelace] -> split)
   -> ToUTxOList era split
-  -> FundToStoreList IO                --inline to ToUTxOList
-  -> IO (Either String (Tx era))
+  -> FundToStoreList m                --inline to ToUTxOList
+  -> m (Either String (Tx era))
 sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
   fundSource >>= \case
     Left err -> return $ Left err
@@ -118,11 +119,12 @@ sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
           return $ Right tx
 
 sourceToStoreTransactionNew ::
-     TxGenerator era
-  -> FundSource IO         
+     Monad m
+  => TxGenerator era
+  -> FundSource m
   -> ([Lovelace] -> split)
-  -> CreateAndStoreList IO era split
-  -> IO (Either String (Tx era))
+  -> CreateAndStoreList m era split
+  -> m (Either String (Tx era))
 sourceToStoreTransactionNew txGenerator fundSource valueSplitter toStore = do
   fundSource >>= \case
     Left err -> return $ Left err

--- a/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.TxGenerator.Fund
+    ( Fund(..)
+    , FundInEra(..)
+    , getFundTxIn
+    , getFundKey
+    , getFundLovelace
+    , getFundWitness
+    )
+    where
+
+-- import           Data.Function (on)
+
+import           Cardano.Api as Api
+
+-- | Outputs that are available for spending.
+-- When building a new transaction, they provide the TxIn parts.
+data FundInEra era = FundInEra {
+    _fundTxIn       :: !TxIn
+  , _fundWitness    :: Witness WitCtxTxIn era
+  , _fundVal        :: !(TxOutValue era)
+  , _fundSigningKey :: !(Maybe (SigningKey PaymentKey))
+  }
+  -- deriving (Show)
+
+newtype Fund = Fund {unFund :: InAnyCardanoEra FundInEra}
+
+{-
+instance Eq Fund where
+    (==) = (==) `on` getFundTxIn
+
+instance Ord Fund where
+    compare = compare `on` getFundTxIn
+
+instance Show Fund where
+  show (Fund (InAnyCardanoEra _ f)) = show f
+-}
+
+getFundTxIn :: Fund -> TxIn
+getFundTxIn (Fund (InAnyCardanoEra _ a)) = _fundTxIn a
+
+getFundKey :: Fund -> Maybe (SigningKey PaymentKey)
+getFundKey (Fund (InAnyCardanoEra _ a)) = _fundSigningKey a
+
+getFundLovelace :: Fund -> Lovelace
+getFundLovelace (Fund (InAnyCardanoEra _ a)) = case _fundVal a of
+  TxOutAdaOnly _era l -> l
+  TxOutValue _era v -> selectLovelace v
+
+-- TODO: facilitate casting KeyWitnesses from one era to an other
+-- background: getFundWitness *must* be partial (e.g. it makes no sense to spend funds in an earlier era that doesn't support a specific feature);
+-- it's implemented here simply by enforcing that both eras are the same. However, that is too constrained.
+-- This approach rules out era transitions for transactions, which is a valid case.
+getFundWitness :: forall era. IsShelleyBasedEra era => Fund -> Witness WitCtxTxIn era
+getFundWitness fund = case (cardanoEra @ era, fund) of
+  (ByronEra   , Fund (InAnyCardanoEra ByronEra   a)) -> _fundWitness a
+  (ShelleyEra , Fund (InAnyCardanoEra ShelleyEra a)) -> _fundWitness a
+  (AllegraEra , Fund (InAnyCardanoEra AllegraEra a)) -> _fundWitness a
+  (MaryEra    , Fund (InAnyCardanoEra MaryEra    a)) -> _fundWitness a
+  (AlonzoEra  , Fund (InAnyCardanoEra AlonzoEra  a)) -> _fundWitness a
+  (BabbageEra , Fund (InAnyCardanoEra BabbageEra a)) -> _fundWitness a
+  _                                                  -> error "getFundWitness: era mismatch"

--- a/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
@@ -50,7 +50,7 @@ getFundLovelace (Fund (InAnyCardanoEra _ a)) = case _fundVal a of
   TxOutAdaOnly _era l -> l
   TxOutValue _era v -> selectLovelace v
 
--- TODO: facilitate casting KeyWitnesses from one era to an other
+-- TODO: facilitate casting KeyWitnesses between eras -- Note [Era transitions]
 getFundWitness :: forall era. IsShelleyBasedEra era => Fund -> Witness WitCtxTxIn era
 getFundWitness fund = case (cardanoEra @ era, fund) of
   (ByronEra   , Fund (InAnyCardanoEra ByronEra   a)) -> _fundWitness a
@@ -60,7 +60,13 @@ getFundWitness fund = case (cardanoEra @ era, fund) of
   (AlonzoEra  , Fund (InAnyCardanoEra AlonzoEra  a)) -> _fundWitness a
   (BabbageEra , Fund (InAnyCardanoEra BabbageEra a)) -> _fundWitness a
   _                                                  -> error "getFundWitness: era mismatch"
--- background: getFundWitness *must* be partial
--- (e.g. it makes no sense to spend funds in an earlier era that doesn't support a specific feature);
--- it's implemented here simply by enforcing that both eras are the same. However, that is too constrained.
--- This approach rules out era transitions for transactions, which is a valid case.
+
+{-
+Note [Era transitions]
+~~~~~~~~~~~~~~~~~~~~~~
+getFundWitness *must* be a partial function since it makes no sense to spend funds in an earlier era that doesn't
+support a specific feature). Currently, it's implemented here simply by enforcing via the type system a fund witness
+only exists in the same era as the fund.
+However, that is too constrained: this approach rules out era transitions for transactions, which is 1) a valid case
+and 2) a potential use case for benchmarking.
+-}

--- a/bench/tx-generator/src/Cardano/TxGenerator/FundQueue.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/FundQueue.hs
@@ -1,0 +1,27 @@
+module Cardano.TxGenerator.FundQueue
+       ( module Cardano.TxGenerator.FundQueue
+       , module Cardano.TxGenerator.Fund
+       )
+      where
+
+import           Cardano.TxGenerator.Fund
+import           Cardano.TxGenerator.Internal.Fifo as Fifo
+
+
+type FundQueue = Fifo Fund
+
+
+emptyFundQueue :: FundQueue
+emptyFundQueue = Fifo.emptyFifo
+
+toList :: FundQueue -> [Fund]
+toList =  Fifo.toList
+
+insertFund :: FundQueue -> Fund -> FundQueue
+insertFund = Fifo.insert
+
+removeFund :: FundQueue -> Maybe (FundQueue, Fund)
+removeFund = Fifo.remove
+
+removeFunds :: Int -> FundQueue -> Maybe (FundQueue, [Fund])
+removeFunds = Fifo.removeN

--- a/bench/tx-generator/src/Cardano/TxGenerator/Internal/Fifo.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Internal/Fifo.hs
@@ -1,10 +1,13 @@
-module Cardano.Benchmarking.Fifo
-where
-import           Prelude
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module  Cardano.TxGenerator.Internal.Fifo
+        (module Cardano.TxGenerator.Internal.Fifo)
+        where
 
 -- This is to be used single threaded behind an MVar.
 
 data Fifo a = Fifo ![a] ![a]
+
 
 emptyFifo :: Fifo a
 emptyFifo = Fifo [] []
@@ -18,11 +21,9 @@ insert (Fifo x y) e = Fifo x $ e:y
 
 remove :: Fifo a -> Maybe (Fifo a, a)
 remove fifo = case fifo of
-  Fifo [] [] -> Nothing
-  Fifo (h:t) y -> Just (Fifo t y, h)
-  Fifo [] y -> case reverse y of
-    (h:t) -> Just (Fifo t [], h)
-    [] -> error "unreachable"
+  Fifo [] []    -> Nothing
+  Fifo (h:t) y  -> Just (Fifo t y, h)
+  Fifo [] y     -> let ~(h:t) = reverse y in Just (Fifo t [], h)
 
 removeN :: Int -> Fifo a -> Maybe (Fifo a, [a])
 removeN 0 f = return (f, [])

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -1,0 +1,117 @@
+module Cardano.TxGenerator.PureExample
+where
+
+import Data.Either (fromRight)
+import Data.String (fromString)
+import Control.Monad (foldM, void)
+import Control.Monad.Trans.State.Strict
+
+import Cardano.Api
+import Cardano.Api.Shelley (ProtocolParameters )
+
+import Cardano.Benchmarking.FundSet (Fund (..), FundInEra (..), inputsToOutputsWithFee)
+import Cardano.Benchmarking.Script.Aeson (readProtocolParametersFile)
+import Cardano.Benchmarking.Script.Core (parseSigningKey)
+import Cardano.Benchmarking.Wallet (TxGenerator, genTx, makeToUTxOList, mkUTxOVariant, sourceToStoreTransaction)
+
+import           Paths_tx_generator
+
+demo :: IO ()
+demo = getDataFileName "data/protocol-parameters.json" >>= demo'
+
+demo' :: FilePath -> IO ()
+demo' parametersFile = do
+  protocolParameters <- readProtocolParametersFile parametersFile
+  void $ foldM (worker $ generateTx protocolParameters) [genesisFund] [1..10]
+  where
+    worker ::
+         Generator (Either String (Tx BabbageEra))
+      -> [Fund]
+      -> Int
+      -> IO [Fund]
+    worker pureGenerator generatorState counter = do
+      putStrLn $ "running tx-generator. Iteration : " ++ show counter
+      let (res, newState) = runState pureGenerator generatorState
+      case res of
+        Right tx -> print tx
+        Left err -> print err
+      return newState
+
+signingKey :: SigningKey PaymentKey
+signingKey = fromRight (error "signingKey: parseError") $ parseSigningKey keyData
+  where
+    keyData = TextEnvelope { teType = TextEnvelopeType "GenesisUTxOSigningKey_ed25519"
+              , teDescription = fromString "Genesis Initial UTxO Signing Key"
+              , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
+
+genesisTxIn :: TxIn
+genesisValue :: TxOutValue BabbageEra
+
+(genesisTxIn, genesisValue) =
+  ( TxIn "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162" (TxIx 0)
+  , lovelaceToTxOutValue $ Lovelace 90000000000000
+  )
+
+genesisFund :: Fund
+genesisFund
+  = Fund $ InAnyCardanoEra BabbageEra fundInEra
+  where
+    fundInEra :: FundInEra BabbageEra
+    fundInEra  = FundInEra {
+        _fundTxIn = genesisTxIn
+      , _fundVal = genesisValue
+      , _fundWitness = KeyWitness KeyWitnessForSpending
+      , _fundSigningKey = Just signingKey
+      }
+
+type Generator = State [Fund]
+
+generateTx ::
+     ProtocolParameters
+  -> Generator (Either String (Tx BabbageEra))
+generateTx protocolParameters
+  = sourceToStoreTransaction
+        generator
+        consumeInputFunds
+        computeOutputValues
+        (makeToUTxOList $ repeat computeUTxO)
+        addNewOutputFunds
+  where
+    -- In the simplest form of the tx-generator
+    -- fees, metadata etc.. are all hardcoded.
+
+    networkId :: NetworkId
+    networkId = Mainnet
+
+    -- hardcoded fees
+    fee :: Lovelace
+    fee = 100000
+
+    babbageFee :: TxFee BabbageEra
+    babbageFee = TxFeeExplicit TxFeesExplicitInBabbageEra fee
+
+    metadata :: TxMetadataInEra BabbageEra
+    metadata = TxMetadataNone
+
+    generator :: TxGenerator BabbageEra
+    generator = genTx protocolParameters collateralFunds babbageFee metadata
+      where
+        -- collateralFunds are needed for Plutus transactions
+        collateralFunds :: (TxInsCollateral BabbageEra, [Fund])
+        collateralFunds = (TxInsCollateralNone, [])
+
+-- Create a transaction that uses all the available funds.
+    consumeInputFunds :: Generator (Either String [Fund])
+    consumeInputFunds = do
+      funds <- get
+      put []
+      return $ Right funds
+
+    addNewOutputFunds :: [Fund] -> Generator ()
+    addNewOutputFunds = put
+
+    computeOutputValues :: [Lovelace] -> [Lovelace]
+    computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
+      where numOfOutputs = 2
+
+    computeUTxO = mkUTxOVariant networkId signingKey

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -1,18 +1,21 @@
-module Cardano.TxGenerator.PureExample
-where
+module  Cardano.TxGenerator.PureExample
+        (demo)
+        where
 
-import Data.Either (fromRight)
-import Data.String (fromString)
-import Control.Monad (foldM, void)
-import Control.Monad.Trans.State.Strict
+import           Control.Monad (foldM, void)
+import           Control.Monad.Trans.State.Strict
+import           Data.Either (fromRight)
+import           Data.String (fromString)
 
-import Cardano.Api
-import Cardano.Api.Shelley (ProtocolParameters )
+import           Cardano.Api
+import           Cardano.Api.Shelley (ProtocolParameters)
 
-import Cardano.Benchmarking.FundSet (Fund (..), FundInEra (..), inputsToOutputsWithFee)
-import Cardano.Benchmarking.Script.Aeson (readProtocolParametersFile)
-import Cardano.Benchmarking.Script.Core (parseSigningKey)
-import Cardano.Benchmarking.Wallet (TxGenerator, genTx, makeToUTxOList, mkUTxOVariant, sourceToStoreTransaction)
+import           Cardano.Benchmarking.Script.Aeson (readProtocolParametersFile)
+import           Cardano.Benchmarking.Script.Core (parseSigningKey)
+import           Cardano.Benchmarking.Wallet (TxGenerator, genTx, makeToUTxOList, mkUTxOVariant,
+                   sourceToStoreTransaction)
+import           Cardano.TxGenerator.Fund (Fund (..), FundInEra (..))
+import           Cardano.TxGenerator.Utils (inputsToOutputsWithFee)
 
 import           Paths_tx_generator
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module  Cardano.TxGenerator.Tx
+        (module Cardano.TxGenerator.Tx)
+        where
+
+import           Data.Maybe (mapMaybe)
+
+import           Cardano.Api
+import           Cardano.Api.Shelley (ProtocolParameters)
+
+import           Cardano.TxGenerator.Fund
+import           Cardano.TxGenerator.Types
+import           Cardano.TxGenerator.Utxo (ToUTxOList)
+
+
+type CreateAndStore m era           = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> m ())
+type CreateAndStoreList m era split = split -> ([TxOut CtxTx era], TxId -> m ())
+
+--TODO: use Error monad
+--TODO: need to break this up
+sourceToStoreTransaction ::
+     Monad m
+  => TxGenerator era
+  -> FundSource m
+  -> ([Lovelace] -> split)
+  -> ToUTxOList era split
+  -> FundToStoreList m                --inline to ToUTxOList
+  -> m (Either String (Tx era))
+sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
+  fundSource >>= \case
+    Left err -> return $ Left err
+    Right inputFunds -> work inputFunds
+ where
+  work inputFunds = do
+    let
+      outValues = inToOut $ map getFundLovelace inputFunds
+      (outputs, toFunds) = mkTxOut outValues
+    case txGenerator inputFunds outputs of
+        Left err -> return $ Left err
+        Right (tx, txId) -> do
+          fundToStore $ toFunds txId
+          return $ Right tx
+
+sourceToStoreTransactionNew ::
+     Monad m
+  => TxGenerator era
+  -> FundSource m
+  -> ([Lovelace] -> split)
+  -> CreateAndStoreList m era split
+  -> m (Either String (Tx era))
+sourceToStoreTransactionNew txGenerator fundSource valueSplitter toStore = do
+  fundSource >>= \case
+    Left err -> return $ Left err
+    Right inputFunds -> work inputFunds
+ where
+  work inputFunds = do
+    let
+      split = valueSplitter $ map getFundLovelace inputFunds
+      (outputs, storeAction) = toStore split
+    case txGenerator inputFunds outputs of
+        Left err -> return $ Left err
+        Right (tx, txId) -> do
+          storeAction txId
+          return $ Right tx
+
+genTx :: forall era. IsShelleyBasedEra era =>
+     ProtocolParameters
+  -> (TxInsCollateral era, [Fund])
+  -> TxFee era
+  -> TxMetadataInEra era
+  -> TxGenerator era
+genTx protocolParameters (collateral, collFunds) fee metadata inFunds outputs
+  = case makeTransactionBody txBodyContent of
+      Left err -> Left $ show err
+      Right b -> Right ( signShelleyTransaction b $ map WitnessPaymentKey allKeys
+                       , getTxId b
+                       )
+ where
+  allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
+  txBodyContent = TxBodyContent {
+      txIns = map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds
+    , txInsCollateral = collateral
+    , txInsReference = TxInsReferenceNone
+    , txOuts = outputs
+    , txFee = fee
+    , txValidityRange = (TxValidityNoLowerBound, upperBound)
+    , txMetadata = metadata
+    , txAuxScripts = TxAuxScriptsNone
+    , txExtraKeyWits = TxExtraKeyWitnessesNone
+    , txProtocolParams = BuildTxWith $ Just protocolParameters
+    , txWithdrawals = TxWithdrawalsNone
+    , txCertificates = TxCertificatesNone
+    , txUpdateProposal = TxUpdateProposalNone
+    , txMintValue = TxMintNone
+    , txScriptValidity = TxScriptValidityNone
+    , txReturnCollateral = TxReturnCollateralNone
+    , txTotalCollateral = TxTotalCollateralNone
+    }
+
+  upperBound :: TxValidityUpperBound era
+  upperBound = case shelleyBasedEra @ era of
+    ShelleyBasedEraShelley -> TxValidityUpperBound ValidityUpperBoundInShelleyEra $ SlotNo maxBound
+    ShelleyBasedEraAllegra -> TxValidityNoUpperBound ValidityNoUpperBoundInAllegraEra
+    ShelleyBasedEraMary    -> TxValidityNoUpperBound ValidityNoUpperBoundInMaryEra
+    ShelleyBasedEraAlonzo  -> TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra
+    ShelleyBasedEraBabbage -> TxValidityNoUpperBound ValidityNoUpperBoundInBabbageEra

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -1,8 +1,16 @@
-module Cardano.TxGenerator.Types (module Cardano.TxGenerator.Types) where
+module  Cardano.TxGenerator.Types
+        (module Cardano.TxGenerator.Types)
+        where
 
 import           Cardano.Api
 import           Cardano.Prelude
 
+import           Cardano.TxGenerator.Fund (Fund)
+
+
+type FundSource m       = m (Either String [Fund])
+type FundToStore m      = Fund -> m ()
+type FundToStoreList m  = [Fund] -> m ()
 
 data TxGenError =
     InsufficientFundsForRecipientTx !Lovelace !Lovelace

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -8,9 +8,15 @@ import           Cardano.Prelude
 import           Cardano.TxGenerator.Fund (Fund)
 
 
+type TxGenerator era = [Fund] -> [TxOut CtxTx era] -> Either String (Tx era, TxId)
+
 type FundSource m       = m (Either String [Fund])
 type FundToStore m      = Fund -> m ()
 type FundToStoreList m  = [Fund] -> m ()
+
+data PayWithChange
+  = PayExact [Lovelace]
+  | PayWithChange Lovelace [Lovelace]
 
 data TxGenError =
     InsufficientFundsForRecipientTx !Lovelace !Lovelace

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -fno-warn-partial-fields #-}
+
 module  Cardano.TxGenerator.Types
         (module Cardano.TxGenerator.Types)
         where
 
 import           Cardano.Api
-import           Cardano.Prelude
+import           Cardano.Prelude (Text)
 
 import           Cardano.TxGenerator.Fund (Fund)
 
@@ -17,6 +20,60 @@ type FundToStoreList m  = [Fund] -> m ()
 data PayWithChange
   = PayExact [Lovelace]
   | PayWithChange Lovelace [Lovelace]
+
+{- TODO:
+data NixServiceOptions = NixServiceOptions {
+    _nix_debugMode        :: Bool
+  , _nix_tx_count         :: NumberOfTxs
+  , _nix_init_cooldown    :: Double
+  , _nix_era              :: AnyCardanoEra
+  , _nix_nodeConfigFile       :: Maybe FilePath
+  , _nix_sigKey               :: SigningKeyFile
+  , _nix_localNodeSocketPath  :: String
+  , _nix_targetNodes          :: NonEmpty NodeIPv4Address
+  } deriving (Show, Eq)
+-}
+
+data TxGenTxParams = TxGenTxParams
+  { txParamFee        :: !Lovelace  -- ^ Transaction fee, in Lovelace
+  , txParamAddTxSize  :: !Int       -- ^ Extra transaction payload, in bytes
+  , txParamInputs     :: !Int       -- ^ Inputs per transaction
+  , txParamOutputs    :: !Int       -- ^ Outputs per transaction
+  }
+  deriving Show
+
+-- defaults taken from: cardano-node/nix/nixos/tx-generator-service.nix
+defaultTxGenTxParams :: TxGenTxParams
+defaultTxGenTxParams = TxGenTxParams
+  { txParamFee        = 10_000_000
+  , txParamAddTxSize  = 100
+  , txParamInputs     = 4
+  , txParamOutputs    = 4
+  }
+
+
+data TxGenConfig = TxGenConfig
+  { confMinUtxoValue  :: !Lovelace  -- ^ Minimum value required per UTxO entry
+  , confTxsPerSecond  :: !Double    -- ^ Strength of generated workload, in transactions per second
+  , confInitCooldown  :: !Double    -- ^ Delay between init and main submissions in seconds
+  }
+  deriving Show
+
+
+data TxGenPlutusParams =
+    PlutusOn                            -- ^ Generate Txs for a Plutus script with explicit settings
+      { plutusScript      :: !FilePath  -- ^ Path to the Plutus script
+      , plutusData        :: !Int       -- ^ Data passed to the Plutus script (for now only an int)
+      , plutusRedeemer    :: !Int       -- ^ Redeemer data passed to the Plutus script (for now only an int)
+      , plutusExecMemory  :: !Int       -- ^ Max. memory available for the Plutus script
+      , plutusExecSteps   :: !Int       -- ^ Max. execution steps available for the Plutus script
+      }
+  | PlutusAuto                          -- ^ Generate Txs for a Plutus script, choosing settings to max out per Tx script budget
+      { plutusScript      :: !FilePath  -- ^ Path to the Plutus script
+      }
+  | PlutusOff                           -- ^ Do not generate Plutus Txs
+  deriving Show
+
 
 data TxGenError =
     InsufficientFundsForRecipientTx !Lovelace !Lovelace

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -1,12 +1,8 @@
-{-# Language DerivingStrategies #-}
-{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
-
-module Cardano.Benchmarking.GeneratorTx.Error
-  ( TxGenError (..)
-  ) where
+module Cardano.TxGenerator.Types (module Cardano.TxGenerator.Types) where
 
 import           Cardano.Api
 import           Cardano.Prelude
+
 
 data TxGenError =
     InsufficientFundsForRecipientTx !Lovelace !Lovelace
@@ -18,4 +14,4 @@ data TxGenError =
   -- ^ The supplied UTxO size (second value) was less than the requested
   --   number of transactions to send (first value).
   | BadPayloadSize !Text
-  deriving stock Show
+  deriving Show

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -7,6 +7,8 @@ module  Cardano.TxGenerator.Utils
 
 import           Cardano.Api as Api
 
+import           Cardano.TxGenerator.Types
+
 
 liftAnyEra :: ( forall era. IsCardanoEra era => f1 era -> f2 era ) -> InAnyCardanoEra f1 -> InAnyCardanoEra f2
 liftAnyEra f x = case x of
@@ -17,10 +19,24 @@ liftAnyEra f x = case x of
   InAnyCardanoEra AlonzoEra a  ->   InAnyCardanoEra AlonzoEra $ f a
   InAnyCardanoEra BabbageEra a  ->  InAnyCardanoEra BabbageEra $ f a
 
--- Todo: check sufficient funds and minimumValuePerUtxo
+keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
+keyAddress networkId k
+  = makeShelleyAddressInEra
+      networkId
+      (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
+      NoStakeAddress
+
+-- TODO: check sufficient funds and minimumValuePerUtxo
 inputsToOutputsWithFee :: Lovelace -> Int -> [Lovelace] -> [Lovelace]
 inputsToOutputsWithFee fee count inputs = map (quantityToLovelace . Quantity) outputs
   where
     (Quantity totalAvailable) = lovelaceToQuantity $ sum inputs - fee
     (out, rest) = divMod totalAvailable (fromIntegral count)
     outputs = (out + rest) : replicate (count-1) out
+
+includeChange :: Lovelace -> [Lovelace] -> [Lovelace] -> PayWithChange
+includeChange fee spend have = case compare changeValue 0 of
+  GT -> PayWithChange changeValue spend
+  EQ -> PayExact spend
+  LT -> error "genTX: Bad transaction: insufficient funds"
+  where changeValue = sum have - sum spend - fee

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -1,38 +1,12 @@
-{-# OPTIONS_GHC -Wwarn #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
-module Cardano.Benchmarking.FundSet
-       ( module Cardano.Benchmarking.FundSet
-       , module Cardano.TxGenerator.Fund
-       )
-      where
-
-import           Prelude
+module  Cardano.TxGenerator.Utils
+        (module Cardano.TxGenerator.Utils)
+        where
 
 import           Cardano.Api as Api
 
-import           Cardano.Benchmarking.Fifo as Fifo
-import           Cardano.TxGenerator.Fund
-
-
-type FundSet = Fifo Fund
-
-type FundSource m = m (Either String [Fund])
-type FundToStore m = Fund -> m ()
-type FundToStoreList m = [Fund] -> m ()
-
-
-emptyFundSet :: FundSet
-emptyFundSet = Fifo.emptyFifo
-
-insertFund :: FundSet -> Fund -> FundSet
-insertFund = Fifo.insert
 
 liftAnyEra :: ( forall era. IsCardanoEra era => f1 era -> f2 era ) -> InAnyCardanoEra f1 -> InAnyCardanoEra f2
 liftAnyEra f x = case x of

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utxo.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utxo.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module  Cardano.TxGenerator.Utxo
+        (module Cardano.TxGenerator.Utxo)
+        where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley (ReferenceScript (..))
+
+import           Cardano.TxGenerator.Fund (Fund (..), FundInEra (..))
+import           Cardano.TxGenerator.Utils (keyAddress)
+
+
+type ToUTxO era = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> Fund)
+type ToUTxOList era split = split -> ([TxOut CtxTx era], TxId -> [Fund])
+
+
+makeToUTxOList :: [ ToUTxO era ] -> ToUTxOList era [ Lovelace ]
+makeToUTxOList fkts values
+  = (outs, \txId -> map (\f -> f txId) fs)
+  where
+    (outs, fs) =unzip $ map worker $ zip3 fkts values [TxIx 0 ..]
+    worker (toUTxO, value, idx)
+      = let (o, f ) = toUTxO value
+         in  (o, f idx)
+
+mkUTxOVariant :: forall era. IsShelleyBasedEra era
+  => NetworkId
+  -> SigningKey PaymentKey
+  -> ToUTxO era
+mkUTxOVariant networkId key value
+  = ( mkTxOut value
+    , mkNewFund value
+    )
+ where
+  mkTxOut v = TxOut (keyAddress @ era networkId key) (lovelaceToTxOutValue v) TxOutDatumNone ReferenceScriptNone
+
+  mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
+  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
+      _fundTxIn = TxIn txId txIx
+    , _fundWitness = KeyWitness KeyWitnessForSpending
+    , _fundVal = lovelaceToTxOutValue val
+    , _fundSigningKey = Just key
+    }
+
+-- to be merged with mkUTxOVariant
+mkUTxOScript :: forall era.
+     IsShelleyBasedEra era
+  => NetworkId
+  -> (Script PlutusScriptV1, ScriptData)
+  -> Witness WitCtxTxIn era
+  -> ToUTxO era
+mkUTxOScript networkId (script, txOutDatum) witness value
+  = ( mkTxOut value
+    , mkNewFund value
+    )
+ where
+  plutusScriptAddr = makeShelleyAddressInEra
+                       networkId
+                       (PaymentCredentialByScript $ hashScript script)
+                       NoStakeAddress
+
+  mkTxOut v = case scriptDataSupportedInEra (cardanoEra @ era) of
+    Nothing -> error " mkUtxOScript scriptDataSupportedInEra==Nothing"
+    Just tag -> TxOut
+                  plutusScriptAddr
+                  (lovelaceToTxOutValue v)
+                  (TxOutDatumHash tag $ hashScriptData txOutDatum)
+                  ReferenceScriptNone
+
+  mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
+  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
+      _fundTxIn = TxIn txId txIx
+    , _fundWitness = witness
+    , _fundVal = lovelaceToTxOutValue val
+    , _fundSigningKey = Nothing
+    }

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -59,7 +59,9 @@ library
                        Cardano.TxGenerator.FundQueue
                        Cardano.TxGenerator.PureExample
                        Cardano.TxGenerator.Types
+                       Cardano.TxGenerator.Tx
                        Cardano.TxGenerator.Utils
+                       Cardano.TxGenerator.Utxo
 
   other-modules:       Cardano.TxGenerator.Internal.Fifo
                        Paths_tx_generator

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -27,8 +27,6 @@ library
   exposed-modules:
                        Cardano.Benchmarking.Command
                        Cardano.Benchmarking.Compiler                       
-                       Cardano.Benchmarking.Fifo
-                       Cardano.Benchmarking.FundSet
                        Cardano.Benchmarking.GeneratorTx
                        Cardano.Benchmarking.GeneratorTx.Genesis
                        Cardano.Benchmarking.GeneratorTx.NodeToNode
@@ -58,10 +56,13 @@ library
                        Cardano.Benchmarking.PlutusExample
                        
                        Cardano.TxGenerator.Fund
+                       Cardano.TxGenerator.FundQueue
                        Cardano.TxGenerator.PureExample
                        Cardano.TxGenerator.Types
+                       Cardano.TxGenerator.Utils
 
-  other-modules:       Paths_tx_generator
+  other-modules:       Cardano.TxGenerator.Internal.Fifo
+                       Paths_tx_generator
 
   autogen-modules:     Paths_tx_generator
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -57,6 +57,7 @@ library
                        Cardano.Benchmarking.Version
                        Cardano.Benchmarking.Wallet
                        Cardano.Benchmarking.PlutusExample
+                       Cardano.TxGenerator.PureExample
 
   other-modules:       Paths_tx_generator
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,5 +1,5 @@
 name:                  tx-generator
-version:               2.3
+version:               2.4
 description:           The transaction generator for cardano node
 author:                IOHK
 maintainer:            operations@iohk.io
@@ -30,7 +30,6 @@ library
                        Cardano.Benchmarking.Fifo
                        Cardano.Benchmarking.FundSet
                        Cardano.Benchmarking.GeneratorTx
-                       Cardano.Benchmarking.GeneratorTx.Error
                        Cardano.Benchmarking.GeneratorTx.Genesis
                        Cardano.Benchmarking.GeneratorTx.NodeToNode
                        Cardano.Benchmarking.GeneratorTx.Tx
@@ -57,7 +56,10 @@ library
                        Cardano.Benchmarking.Version
                        Cardano.Benchmarking.Wallet
                        Cardano.Benchmarking.PlutusExample
+                       
+                       Cardano.TxGenerator.Fund
                        Cardano.TxGenerator.PureExample
+                       Cardano.TxGenerator.Types
 
   other-modules:       Paths_tx_generator
 


### PR DESCRIPTION
The PR adds `Cardano.TxGenerator.PureExample`.
The example shows how to reuses the pure core of the transaction generator.
In the example all configuration options are hard-coded.
