### PR TITLE
Explain how to get utxo address in hex.

### DIFF
--- a/doc/reference/shelley-genesis.md
+++ b/doc/reference/shelley-genesis.md
@@ -498,6 +498,11 @@ And if we compare this with the `initialFunds` from the generated file we see
         "6003662510383a9901958f7a16ceb977917d8102eb2013f4ba5e0b0763": 0
     },
 ```
+The above are hex representations of addresses. To find out hex representations for the address from the output of `cardano-cli genesis initial-addr`
+call 
+```
+cardano-cli address info --address $ADDR
+```
 
 This means we'll start with 0 lovelace in a special genesis UTxO at that
 address.


### PR DESCRIPTION
Documentation mentions `cardano-cli genesis initial-addr` as a command which output to compare with `initialFunds` field in genesis file.
Though as of cardano-cli 1.35.0 the addresses in there are respectively bech32 and hex encoded.

I've added a note on how to get the hex representation of an address. The note should do no harm no matter the version of cardano-cli.