### PR TITLE
Fix `TraceNodeIsLeader` JSON parser

### DIFF
--- a/cardano-testnet/src/Test/Assert.hs
+++ b/cardano-testnet/src/Test/Assert.hs
@@ -10,8 +10,7 @@ module Test.Assert
   , getRelevantLeaderSlots
   ) where
 
-import           Control.Applicative ((<*>))
-import           Control.Monad (Monad (..))
+import           Control.Monad (Monad (..), fail)
 import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Reader (ReaderT)
 import           Control.Monad.Trans.Resource (ResourceT)
@@ -86,10 +85,11 @@ data TraceNodeIsLeader = TraceNodeIsLeader
   } deriving (Eq, Show)
 
 instance FromJSON TraceNodeIsLeader where
-  parseJSON = Aeson.withObject "TraceNodeIsLeader" $ \v ->
-    TraceNodeIsLeader
-      <$> v .: "kind"
-      <*> v .: "slot"
+  parseJSON = Aeson.withObject "TraceNodeIsLeader" $ \v -> do
+    k <- v .: "val" >>= (.: "kind")
+    if k == "TraceNodeIsLeader"
+    then TraceNodeIsLeader k <$> (v .: "val" >>= (.: "slot"))
+    else fail "Not the right kind"
 
 instance FromJSON Kind where
   parseJSON = Aeson.withObject "Kind" $ \v ->


### PR DESCRIPTION
The log messages are formatted slightly different in each case. In particular:
```
{...,"data":{...,"kind":"TraceAddBlockEvent.AddedToCurrentChain","...},...}
```
versus
```
{"...,"data":{...,"val":{"kind":"TraceNodeIsLeader","slot":85}},...}
```

Also the parser was intended to only get the events with the kind `TraceNodeIsLeader`.