### PR TITLE
Use patched aeson from hackage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -330,12 +330,6 @@ source-repository-package
   tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
   --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm
 
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/aeson
-  tag: be4774468e651d1d512edad278cca7276e978034
-  --sha256: 12fr5xnr3ax0r5gzwbf4v49yirppgprmvzlfj1ldx4zhcrdf5j7j
-
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
@@ -360,4 +354,5 @@ package cardano-ledger-alonzo-test
 allow-newer:
   *:aeson,
   monoidal-containers:aeson,
-  size-based:template-haskell
+  size-based:template-haskell,
+  snap-server:attoparsec,

--- a/cardano-node-capi/cardano-node-capi.cabal
+++ b/cardano-node-capi/cardano-node-capi.cabal
@@ -11,7 +11,7 @@ extra-source-files: CHANGELOG.md
 library
     exposed-modules:  Node
     build-depends:    base
-                    , aeson
+                    , aeson                         >= 2.1.0.0
                     , bytestring
                     , cardano-node
                     , optparse-applicative-fork

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -20,7 +20,7 @@ common base                         { build-depends: base                       
 common cardano-api                  { build-depends: cardano-api                                                  }
 common cardano-submit-api           { build-depends: cardano-submit-api                                           }
 
-common aeson                        { build-depends: aeson                            >= 1.5.5.1                  }
+common aeson                        { build-depends: aeson                            >= 2.1.0.0                  }
 common async                        { build-depends: async                            >= 2.2.2                    }
 common bytestring                   { build-depends: bytestring                       >= 0.10.8.2                 }
 common cardano-binary               { build-depends: cardano-binary                   >= 1.5.0                    }

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -109,7 +109,7 @@ test-suite cardano-testnet-tests
   type:                 exitcode-stdio-1.0
 
   build-depends:        cardano-testnet
-                      , aeson
+                      , aeson                         >= 2.1.0.0
                       , cardano-api
                       , cardano-cli
                       , containers

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -35,7 +35,7 @@ library
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
   build-depends:      base >=4.12 && <5
-                      , aeson
+                      , aeson                         >= 2.1.0.0
                       , async
                       , bytestring
                       , cborg
@@ -91,7 +91,7 @@ executable trace-dispatcher-examples
     default-language: Haskell2010
     default-extensions:  OverloadedStrings
     build-depends:    base >=4.12 && <5
-                      , aeson
+                      , aeson                         >= 2.1.0.0
                       , bytestring
                       , containers
                       , ekg
@@ -131,7 +131,7 @@ test-suite trace-dispatcher-test
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
   build-depends:       base >=4.12 && <5
-                      , aeson
+                      , aeson                         >= 2.1.0.0
                       , bytestring
                       , containers
                       , ekg
@@ -173,7 +173,7 @@ benchmark trace-dispatcher-bench
                        Cardano.Logging.Test.Messages
                        Cardano.Logging.Test.Script
   build-depends:       base >=4.12 && <5
-                       , aeson
+                       , aeson                         >= 2.1.0.0
                        , containers
                        , criterion
                        , ekg

--- a/trace-resources/trace-resources.cabal
+++ b/trace-resources/trace-resources.cabal
@@ -22,7 +22,7 @@ library
   build-depends:      base >=4.12 && <5
                       , trace-dispatcher
                       , text
-                      , aeson
+                      , aeson                         >= 2.1.0.0
 
   if os(windows)
      build-depends:    Win32
@@ -60,7 +60,7 @@ test-suite trace-resources-test
   build-depends:       base >=4.12 && <5
                       , trace-dispatcher
                       , text
-                      , aeson
+                      , aeson                         >= 2.1.0.0
                       , QuickCheck
                       , tasty
                       , tasty-quickcheck


### PR DESCRIPTION
Now that the index state has been updated, we can use the patched `aeson-2.1.0.0` from hackage instead of using our fork.

This patch contains a bug fix/memory optimisation.