### PR TITLE
Update node to use ouroboros-network with obsolete node fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -263,8 +263,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
+  tag: d75ca17fc4dc4c9b60c81f8d7a1e362648941378
+  --sha256: 0cyimb0zzskvl5d3sbb3p4hlhzvjza51k0f9ql7vcq22s6mf584s
   subdir:
     monoidal-synchronisation
     network-mux


### PR DESCRIPTION
The PR that relies on this fix https://github.com/input-output-hk/ouroboros-network/pull/3891 hasn't been merged into master yet, thus this is still a draft