### PR TITLE
More memory efficient query ledger-state command

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -174,8 +174,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
-  --sha256: 0p0az3sbkhb7njji8xxdrfb0yx2gc8fmrh872ffm8sfip1w29gg1
+  tag: a3c13fb11bc41fedff7885ca70a3b33f61fef4b5
+  --sha256: 0h492cz9mvzbsl5yzvp3iq40c0z0j5hmrifdrnnqzzk02g9j9c4b
   subdir:
     base-deriving-via
     binary

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -38,6 +41,7 @@ import qualified Cardano.Ledger.Shelley.PoolRank as Shelley
 import           Cardano.Ledger.UnifiedMap (UnifiedMap)
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Cardano.Slotting.Time (SystemStart (..))
+import           Control.State.Transition (STS (State))
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -56,8 +60,8 @@ import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Cardano.Ledger.Shelley.EpochBoundary as ShelleyEpoch
 import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyLedger
 import           Cardano.Ledger.Shelley.PParams (PParamsUpdate)
-import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
 import qualified Cardano.Ledger.Shelley.Rewards as Shelley
+import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
 import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
 
 import           Cardano.Api.Script
@@ -66,11 +70,14 @@ import           Cardano.Api.Script
 -- We will remove/replace these as we provide more API wrapper types
 
 instance ToJSON (Mary.Value era) where
-  toJSON (Mary.Value l ps) =
-    object
-      [ "lovelace" .= toJSON l
-      , "policies" .= toJSON ps
-      ]
+  toJSON = object . toMaryValuePairs
+  toEncoding = Aeson.pairs . mconcat . toMaryValuePairs
+
+toMaryValuePairs :: Aeson.KeyValue a => Mary.Value crypto -> [a]
+toMaryValuePairs (Mary.Value !l !ps) =
+  [ "lovelace" .= l
+  , "policies" .= ps
+  ]
 
 instance ToJSONKey Mary.AssetName where
   toJSONKey = toJSONKeyText render
@@ -89,58 +96,133 @@ instance ToJSON Mary.AssetName where
   toJSON = Aeson.String . Text.decodeLatin1 . B16.encode . Short.fromShort . Mary.assetName
 
 instance ToJSON Shelley.AccountState where
-  toJSON (Shelley.AccountState tr rs) = object [ "treasury" .= tr
-                                               , "reserves" .= rs
-                                               ]
+  toJSON = object . toAccountStatePairs
+  toEncoding = Aeson.pairs . mconcat . toAccountStatePairs
 
-instance ( Consensus.ShelleyBasedEra era
+toAccountStatePairs :: Aeson.KeyValue a => ShelleyLedger.AccountState -> [a]
+toAccountStatePairs (Shelley.AccountState !tr !rs) =
+  [ "treasury" .= tr
+  , "reserves" .= rs
+  ]
+
+instance forall era.
+         ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToJSON (Core.PParams era)
          , ToJSON (Core.PParamsDelta era)
          ) => ToJSON (Shelley.EpochState era) where
-  toJSON eState = object [ "esAccountState" .= Shelley.esAccountState eState
-                         , "esSnapshots" .= Shelley.esSnapshots eState
-                         , "esLState" .= Shelley.esLState eState
-                         , "esPrevPp" .= Shelley.esPrevPp eState
-                         , "esPp" .= Shelley.esPp eState
-                         , "esNonMyopic" .= Shelley.esNonMyopic eState
-                         ]
+  toJSON = object . toEpochStatePairs
+  toEncoding = Aeson.pairs . mconcat . toEpochStatePairs
+
+toEpochStatePairs ::
+  ( Consensus.ShelleyBasedEra era
+  , ToJSON (Core.TxOut era)
+  , ToJSON (Core.PParamsDelta era)
+  , ToJSON (Core.PParams era)
+  , Aeson.KeyValue a
+  )
+  => ShelleyLedger.EpochState era
+  -> [a]
+toEpochStatePairs eState =
+  let !esAccountState = Shelley.esAccountState eState
+      !esSnapshots = Shelley.esSnapshots eState
+      !esLState = Shelley.esLState eState
+      !esPrevPp = Shelley.esPrevPp eState
+      !esPp = Shelley.esPp eState
+      !esNonMyopic = Shelley.esNonMyopic eState
+  in  [ "esAccountState" .= esAccountState
+      , "esSnapshots" .= esSnapshots
+      , "esLState" .= esLState
+      , "esPrevPp" .= esPrevPp
+      , "esPp" .= esPp
+      , "esNonMyopic" .= esNonMyopic
+      ]
+
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToJSON (Core.PParamsDelta era)
          ) => ToJSON (Shelley.LedgerState era) where
-  toJSON lState = object [ "utxoState" .= Shelley.lsUTxOState lState
-                         , "delegationState" .= Shelley.lsDPState lState
-                         ]
+  toJSON = object . toLedgerStatePairs
+  toEncoding = Aeson.pairs . mconcat . toLedgerStatePairs
+
+toLedgerStatePairs ::
+  ( Consensus.ShelleyBasedEra era
+  , ToJSON (Core.TxOut era)
+  , ToJSON (Core.PParamsDelta era)
+  , Aeson.KeyValue a
+  ) => ShelleyLedger.LedgerState era -> [a]
+toLedgerStatePairs lState =
+  let !lsUTxOState = Shelley.lsUTxOState lState
+      !lsDPState = Shelley.lsDPState lState
+  in  [ "utxoState" .= lsUTxOState
+      , "delegationState" .= lsDPState
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.IncrementalStake crypto) where
-  toJSON iStake = object [ "credentials" .= Map.toList (ShelleyLedger.credMap iStake)
-                         , "pointers" .= Map.toList (ShelleyLedger.ptrMap iStake)
-                         ]
+  toJSON = object . toIncrementalStakePairs
+  toEncoding = Aeson.pairs . mconcat . toIncrementalStakePairs
+
+toIncrementalStakePairs ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyLedger.IncrementalStake crypto -> [a]
+toIncrementalStakePairs iStake =
+  let !credentials = Map.toList (ShelleyLedger.credMap iStake)
+      !pointers = Map.toList (ShelleyLedger.ptrMap iStake)
+  in  [ "credentials" .= credentials
+      , "pointers" .= pointers
+      ]
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToJSON (Core.PParamsDelta era)
          ) => ToJSON (Shelley.UTxOState era) where
-  toJSON utxoState = object [ "utxo" .= Shelley._utxo utxoState
-                            , "deposited" .= Shelley._deposited utxoState
-                            , "fees" .= Shelley._fees utxoState
-                            , "ppups" .= Shelley._ppups utxoState
-                            , "stake" .= Shelley._stakeDistro utxoState
-                            ]
+  toJSON = object . toUtxoStatePairs
+  toEncoding = Aeson.pairs . mconcat . toUtxoStatePairs
+
+toUtxoStatePairs ::
+  ( Aeson.KeyValue a
+  , Consensus.ShelleyBasedEra era
+  , ToJSON (Core.TxOut era)
+  , ToJSON (State (Core.EraRule "PPUP" era))
+  ) => ShelleyLedger.UTxOState era -> [a]
+toUtxoStatePairs utxoState =
+  let !utxo = Shelley._utxo utxoState
+      !deposited = Shelley._deposited utxoState
+      !fees = Shelley._fees utxoState
+      !ppups = Shelley._ppups utxoState
+      !stakeDistro = Shelley._stakeDistro utxoState
+  in  [ "utxo" .= utxo
+      , "deposited" .= deposited
+      , "fees" .= fees
+      , "ppups" .= ppups
+      , "stake" .= stakeDistro
+      ]
 
 instance ( ToJSON (Core.PParamsDelta era)
          , Shelley.UsesPParams era
          ) => ToJSON (Shelley.PPUPState era) where
-  toJSON ppUpState = object [ "proposals" .= Shelley.proposals ppUpState
-                            , "futureProposals" .= Shelley.futureProposals ppUpState
-                            ]
+  toJSON = object . toPpupStatePairs
+  toEncoding = Aeson.pairs . mconcat . toPpupStatePairs
+
+toPpupStatePairs ::
+  ( Aeson.KeyValue a
+  , ToJSON (Core.PParamsDelta era)
+  , Shelley.UsesPParams era
+  ) => ShelleyLedger.PPUPState era -> [a]
+toPpupStatePairs ppUpState =
+  let !proposals = Shelley.proposals ppUpState
+      !futureProposals = Shelley.futureProposals ppUpState
+  in  [ "proposals" .= proposals
+      , "futureProposals" .= futureProposals
+      ]
 
 instance ( ToJSON (Core.PParamsDelta era)
          , Shelley.UsesPParams era
          ) => ToJSON (Shelley.ProposedPPUpdates era) where
   toJSON (Shelley.ProposedPPUpdates ppUpdates) = toJSON $ Map.toList ppUpdates
+  toEncoding (Shelley.ProposedPPUpdates ppUpdates) = toEncoding $ Map.toList ppUpdates
 
 instance ToJSON (PParamsUpdate era) where
   toJSON pp =
@@ -224,21 +306,36 @@ instance ( Ledger.Era era
          , ToJSON (Core.Value era)
          , ToJSON (Babbage.Datum era)
          , ToJSON (Core.Script era)
+         , Ledger.Crypto era ~ Consensus.StandardCrypto
          ) => ToJSON (Babbage.TxOut era) where
-  toJSON (Babbage.TxOut addr val dat mRefScript)=
-    object
-      [ "address" .= addr
-      , "value" .= val
-      , "datum" .= dat
-      , "referenceScript" .= mRefScript
-      ]
+  toJSON = object . toBabbageTxOutPairs
+  toEncoding = Aeson.pairs . mconcat . toBabbageTxOutPairs
+
+toBabbageTxOutPairs ::
+  ( Aeson.KeyValue a
+  , Ledger.Era era
+  , ToJSON (Core.Value era)
+  , ToJSON (Core.Script era)
+  , Ledger.Crypto era ~ Consensus.StandardCrypto
+  ) => Babbage.TxOut era -> [a]
+toBabbageTxOutPairs (Babbage.TxOut !addr !val !dat !mRefScript) =
+  [ "address" .= addr
+  , "value" .= val
+  , "datum" .= dat
+  , "referenceScript" .= mRefScript
+  ]
 
 instance ( Ledger.Era era
          , Ledger.Crypto era ~ Consensus.StandardCrypto
          ) => ToJSON (Babbage.Datum era) where
-  toJSON d = case Alonzo.datumDataHash d of
-               SNothing -> Aeson.Null
-               SJust dH -> toJSON $ ScriptDataHash dH
+  toJSON d =
+    case Alonzo.datumDataHash d of
+      SNothing -> Aeson.Null
+      SJust dH -> toJSON $ ScriptDataHash dH
+  toEncoding d =
+    case Alonzo.datumDataHash d of
+      SNothing -> toEncoding Aeson.Null
+      SJust dH -> toEncoding $ ScriptDataHash dH
 
 
 
@@ -246,28 +343,72 @@ instance ToJSON (Alonzo.Script (Babbage.BabbageEra Consensus.StandardCrypto)) wh
   toJSON = Aeson.String . Text.decodeUtf8 . B16.encode . CBOR.serialize'
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.DPState crypto) where
-  toJSON dpState = object [ "dstate" .= Shelley.dpsDState dpState
-                          , "pstate" .= Shelley.dpsPState dpState
-                          ]
+  toJSON = object . toDpStatePairs
+  toEncoding = Aeson.pairs . mconcat . toDpStatePairs
+
+toDpStatePairs ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyLedger.DPState crypto -> [a]
+toDpStatePairs dpState =
+  let !dstate = Shelley.dpsDState dpState
+      !pstate = Shelley.dpsPState dpState
+  in  [ "dstate" .= dstate
+      , "pstate" .= pstate
+      ]
 
 instance (ToJSON coin, ToJSON ptr, ToJSON pool) => ToJSON (Trip coin ptr pool) where
-  toJSON (Triple coin ptr pool) = object
-    [ "coin" .= coin
-    , "ptr" .= ptr
-    , "pool" .= pool
-    ]
+  toJSON = object . toTripPair
+  toEncoding = Aeson.pairs . mconcat . toTripPair
+
+toTripPair ::
+  ( Aeson.KeyValue a
+  , ToJSON coin
+  , ToJSON ptr
+  , ToJSON pool
+  ) => Trip coin ptr pool -> [a]
+toTripPair (Triple !coin !ptr !pool) =
+  [ "coin" .= coin
+  , "ptr" .= ptr
+  , "pool" .= pool
+  ]
+
 instance Crypto.Crypto crypto => ToJSON (UnifiedMap crypto) where
-  toJSON (UnifiedMap m1 m2) = object
-    [ "credentials" .= m1
-    , "pointers" .= m2
-    ]
+  toJSON = object . toUnifiedMapPair
+  toEncoding = Aeson.pairs . mconcat . toUnifiedMapPair
+
+toUnifiedMapPair ::
+  ( Aeson.KeyValue a
+  , ToJSON coin
+  , ToJSON ptr
+  , ToJSON pool
+  , ToJSON cred
+  , ToJSONKey cred
+  , ToJSONKey ptr
+  ) => UMap coin cred pool ptr -> [a]
+toUnifiedMapPair (UnifiedMap !m1 !m2) =
+  [ "credentials" .= m1
+  , "pointers" .= m2
+  ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.DState crypto) where
-  toJSON dState = object [ "unifiedRewards" .= Shelley._unified dState
-                         , "fGenDelegs" .= Map.toList (Shelley._fGenDelegs dState)
-                         , "genDelegs" .= Shelley._genDelegs dState
-                         , "irwd" .= Shelley._irwd dState
-                         ]
+  toJSON = object . toDStatePair
+  toEncoding = Aeson.pairs . mconcat . toDStatePair
+
+toDStatePair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyLedger.DState crypto -> [a]
+toDStatePair dState =
+  let !unifiedRewards = Shelley._unified dState
+      !fGenDelegs = Map.toList (Shelley._fGenDelegs dState)
+      !genDelegs = Shelley._genDelegs dState
+      !irwd = Shelley._irwd dState
+  in  [ "unifiedRewards" .= unifiedRewards
+      , "fGenDelegs" .= fGenDelegs
+      , "genDelegs" .= genDelegs
+      , "irwd" .= irwd
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.FutureGenDeleg crypto) where
   toJSON fGenDeleg =
@@ -277,55 +418,101 @@ instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.FutureGenDeleg crypto) wh
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.GenDelegs crypto) where
   toJSON (Shelley.GenDelegs delegs) = toJSON delegs
+  toEncoding (Shelley.GenDelegs delegs) = toEncoding delegs
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.InstantaneousRewards crypto) where
-  toJSON iRwds = object [ "iRReserves" .= Shelley.iRReserves iRwds
-                        , "iRTreasury" .= Shelley.iRTreasury iRwds
-                        ]
+  toJSON = object . toInstantaneousRewardsPair
+  toEncoding = Aeson.pairs . mconcat . toInstantaneousRewardsPair
+
+toInstantaneousRewardsPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyLedger.InstantaneousRewards crypto -> [a]
+toInstantaneousRewardsPair iRwds =
+  let !iRReserves = Shelley.iRReserves iRwds
+      !iRTreasury = Shelley.iRTreasury iRwds
+  in  [ "iRReserves" .= iRReserves
+      , "iRTreasury" .= iRTreasury
+      ]
 
 instance
   Crypto.Crypto crypto =>
   ToJSON (Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto))
   where
-  toJSON (MkBiMap ptsStakeM stakePtrSetM) =
-    object [ "stakedCreds" .= Map.toList ptsStakeM
-           , "credPtrR" .= toJSON stakePtrSetM
-           ]
+  toJSON = object . toPtrCredentialStakingPair
+  toEncoding = Aeson.pairs . mconcat . toPtrCredentialStakingPair
+
+toPtrCredentialStakingPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto) -> [a]
+toPtrCredentialStakingPair (MkBiMap ptsStakeM stakePtrSetM) =
+  let !stakedCreds = Map.toList ptsStakeM
+      !credPtrR = stakePtrSetM
+  in  [ "stakedCreds" .= stakedCreds
+      , "credPtrR" .= credPtrR
+      ]
 
 deriving newtype instance ToJSON Shelley.CertIx
 deriving newtype instance ToJSON Shelley.TxIx
 
 instance ToJSON Shelley.Ptr where
-  toJSON (Shelley.Ptr slotNo txIndex certIndex) =
-    object [ "slot" .= unSlotNo slotNo
-           , "txIndex" .= txIndex
-           , "certIndex" .= certIndex
-           ]
+  toJSON = object . toPtrPair
+  toEncoding = Aeson.pairs . mconcat . toPtrPair
+
 instance ToJSONKey Shelley.Ptr
+
+toPtrPair :: Aeson.KeyValue a => Shelley.Ptr -> [a]
+toPtrPair (Shelley.Ptr !slotNo !txIndex !certIndex) =
+  [ "slot" .= unSlotNo slotNo
+  , "txIndex" .= txIndex
+  , "certIndex" .= certIndex
+  ]
 
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.PState crypto) where
-  toJSON pState = object [ "pParams pState" .= Shelley._pParams pState
-                         , "fPParams pState" .= Shelley._fPParams pState
-                         , "retiring pState" .= Shelley._retiring pState
-                         ]
+  toJSON = object . toPStatePair
+  toEncoding = Aeson.pairs . mconcat . toPStatePair
+
+toPStatePair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyLedger.PState crypto -> [a]
+toPStatePair pState =
+  let !pParams = Shelley._pParams pState
+      !fPParams = Shelley._fPParams pState
+      !retiring = Shelley._retiring pState
+  in  [ "pParams pState" .= pParams
+      , "fPParams pState" .= fPParams
+      , "retiring pState" .= retiring
+      ]
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          ) => ToJSON (Shelley.UTxO era) where
   toJSON (Shelley.UTxO utxo) = toJSON utxo
+  toEncoding (Shelley.UTxO utxo) = toEncoding utxo
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.Value era)
          ) => ToJSON (Shelley.TxOut era) where
-  toJSON (Shelley.TxOut addr amount) =
-    object
-      [ "address" .= addr
-      , "amount" .= amount
-      ]
+  toJSON = object . toTxOutPair
+  toEncoding = Aeson.pairs . mconcat . toTxOutPair
+
+toTxOutPair ::
+  ( Ledger.Era era
+  , Aeson.KeyValue a
+  , ToJSON (Core.Value era)
+  , Show (Core.Value era))
+  => Shelley.TxOut era -> [a]
+toTxOutPair (Shelley.TxOut !addr !amount) =
+  [ "address" .= addr
+  , "amount" .= amount
+  ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.TxIn crypto) where
   toJSON = toJSON . txInToText
+  toEncoding = toEncoding . txInToText
 
 instance Crypto.Crypto crypto => ToJSONKey (Shelley.TxIn crypto) where
   toJSONKey = toJSONKeyText txInToText
@@ -340,60 +527,134 @@ hashToText :: Crypto.Hash crypto a -> Text
 hashToText = Text.decodeLatin1 . Crypto.hashToBytesAsHex
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.NonMyopic crypto) where
-  toJSON nonMy = object [ "likelihoodsNM" .= Shelley.likelihoodsNM nonMy
-                        , "rewardPotNM" .= Shelley.rewardPotNM nonMy
-                        ]
+  toJSON = object . toNonMyopicPair
+  toEncoding = Aeson.pairs . mconcat . toNonMyopicPair
+
+toNonMyopicPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => Shelley.NonMyopic crypto -> [a]
+toNonMyopicPair nonMy =
+  let !likelihoodsNM = Shelley.likelihoodsNM nonMy
+      !rewardPotNM = Shelley.rewardPotNM nonMy
+  in  [ "likelihoodsNM" .= likelihoodsNM
+      , "rewardPotNM" .= rewardPotNM
+      ]
 
 instance ToJSON Shelley.Likelihood where
   toJSON (Shelley.Likelihood llhd) =
     toJSON $ fmap (\(Shelley.LogWeight f) -> exp $ realToFrac f :: Double) llhd
+  toEncoding (Shelley.Likelihood llhd) =
+    toEncoding $ fmap (\(Shelley.LogWeight f) -> exp $ realToFrac f :: Double) llhd
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShots crypto) where
-  toJSON ss = object [ "pstakeMark" .= Shelley._pstakeMark ss
-                     , "pstakeSet" .= Shelley._pstakeSet ss
-                     , "pstakeGo" .= Shelley._pstakeGo ss
-                     , "feeSS" .= Shelley._feeSS ss
-                     ]
+  toJSON = object . toSnapShotsPair
+  toEncoding = Aeson.pairs . mconcat . toSnapShotsPair
+
+toSnapShotsPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyEpoch.SnapShots crypto -> [a]
+toSnapShotsPair ss =
+  let !pstakeMark = Shelley._pstakeMark ss
+      !pstakeSet = Shelley._pstakeSet ss
+      !pstakeGo = Shelley._pstakeGo ss
+      !feeSS = Shelley._feeSS ss
+  in  [ "pstakeMark" .= pstakeMark
+      , "pstakeSet" .= pstakeSet
+      , "pstakeGo" .= pstakeGo
+      , "feeSS" .= feeSS
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShot crypto) where
-  toJSON ss = object [ "stake" .= Shelley._stake ss
-                     , "delegations" .= ShelleyEpoch._delegations ss
-                     , "poolParams" .= Shelley._poolParams ss
-                     ]
+  toJSON = object . toSnapShotPair
+  toEncoding = Aeson.pairs . mconcat . toSnapShotPair
+
+toSnapShotPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => ShelleyEpoch.SnapShot crypto -> [a]
+toSnapShotPair ss =
+  let !stake = Shelley._stake ss
+      !delegations = ShelleyEpoch._delegations ss
+      !poolParams = Shelley._poolParams ss
+  in  [ "stake" .= stake
+      , "delegations" .= delegations
+      , "poolParams" .= poolParams
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.Stake crypto) where
   toJSON (Shelley.Stake s) = toJSON s
+  toEncoding (Shelley.Stake s) = toEncoding s
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.RewardUpdate crypto) where
-  toJSON rUpdate = object [ "deltaT" .= Shelley.deltaT rUpdate
-                          , "deltaR" .= Shelley.deltaR rUpdate
-                          , "rs" .= Shelley.rs rUpdate
-                          , "deltaF" .= Shelley.deltaF rUpdate
-                          , "nonMyopic" .= Shelley.nonMyopic rUpdate
-                          ]
+  toJSON = object . toRewardUpdatePair
+  toEncoding = Aeson.pairs . mconcat . toRewardUpdatePair
+
+toRewardUpdatePair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => Shelley.RewardUpdate crypto -> [a]
+toRewardUpdatePair rUpdate =
+  let !deltaT = Shelley.deltaT rUpdate
+      !deltaR = Shelley.deltaR rUpdate
+      !rs = Shelley.rs rUpdate
+      !deltaF = Shelley.deltaF rUpdate
+      !nonMyopic = Shelley.nonMyopic rUpdate
+  in  [ "deltaT" .= deltaT
+      , "deltaR" .= deltaR
+      , "rs" .= rs
+      , "deltaF" .= deltaF
+      , "nonMyopic" .= nonMyopic
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.PulsingRewUpdate crypto) where
-  toJSON (Shelley.Pulsing _ _) = Aeson.Null
-  toJSON (Shelley.Complete ru) = toJSON ru
+  toJSON  = \case
+    Shelley.Pulsing _ _ -> Aeson.Null
+    Shelley.Complete ru -> toJSON ru
+  toEncoding  = \case
+    Shelley.Pulsing _ _ -> toEncoding Aeson.Null
+    Shelley.Complete ru -> toEncoding ru
 
 instance ToJSON Shelley.DeltaCoin where
   toJSON (Shelley.DeltaCoin i) = toJSON i
+  toEncoding (Shelley.DeltaCoin i) = toEncoding i
 
 instance Crypto.Crypto crypto => ToJSON (Ledger.PoolDistr crypto) where
   toJSON (Ledger.PoolDistr m) = toJSON m
+  toEncoding (Ledger.PoolDistr m) = toEncoding m
 
 instance Crypto.Crypto crypto => ToJSON (Ledger.IndividualPoolStake crypto) where
-  toJSON indivPoolStake =
-    object [ "individualPoolStake" .= Ledger.individualPoolStake indivPoolStake
-           , "individualPoolStakeVrf" .= Ledger.individualPoolStakeVrf indivPoolStake
-           ]
+  toJSON = object . toIndividualPoolStakePair
+  toEncoding = Aeson.pairs . mconcat . toIndividualPoolStakePair
+
+toIndividualPoolStakePair ::
+  ( Aeson.KeyValue a
+  , Crypto.HashAlgorithm (Crypto.HASH crypto)
+  ) => Ledger.IndividualPoolStake crypto -> [a]
+toIndividualPoolStakePair indivPoolStake =
+  let !individualPoolStake = Ledger.individualPoolStake indivPoolStake
+      !individualPoolStakeVrf = Ledger.individualPoolStakeVrf indivPoolStake
+  in  [ "individualPoolStake" .= individualPoolStake
+      , "individualPoolStakeVrf" .= individualPoolStakeVrf
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.Reward crypto) where
-  toJSON reward =
-     object [ "rewardType" .= Shelley.rewardType reward
-            , "rewardPool" .= Shelley.rewardPool reward
-            , "rewardAmount" .= Shelley.rewardAmount reward
-            ]
+  toJSON = object . toRewardPair
+  toEncoding = Aeson.pairs . mconcat . toRewardPair
+
+toRewardPair ::
+  ( Aeson.KeyValue a
+  , Crypto.Crypto crypto
+  ) => Shelley.Reward crypto -> [a]
+toRewardPair reward =
+  let !rewardType = Shelley.rewardType reward
+      !rewardPool = Shelley.rewardPool reward
+      !rewardAmount = Shelley.rewardAmount reward
+  in  [ "rewardType" .= rewardType
+      , "rewardPool" .= rewardPool
+      , "rewardAmount" .= rewardAmount
+      ]
 
 instance ToJSON Shelley.RewardType where
   toJSON Shelley.MemberReward = "MemberReward"
@@ -401,6 +662,7 @@ instance ToJSON Shelley.RewardType where
 
 instance Crypto.Crypto c => ToJSON (SafeHash.SafeHash c a) where
   toJSON = toJSON . SafeHash.extractHash
+  toEncoding = toEncoding . SafeHash.extractHash
 
 -----
 
@@ -410,9 +672,12 @@ deriving newtype instance FromJSON SystemStart
 
 instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.Credential 'Shelley.Staking crypto) (Shelley.KeyHash 'Shelley.StakePool crypto)) where
   toJSON = toJSON . VMap.toMap
+  toEncoding = toEncoding . VMap.toMap
 
 instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.KeyHash    'Shelley.StakePool crypto) (Shelley.PoolParams crypto)) where
   toJSON = toJSON . VMap.toMap
+  toEncoding = toEncoding . VMap.toMap
 
 instance Crypto.Crypto crypto => ToJSON (VMap VB VP (Shelley.Credential 'Shelley.Staking   crypto) (Shelley.CompactForm Shelley.Coin)) where
   toJSON = toJSON . fmap fromCompact . VMap.toMap
+  toEncoding = toEncoding . fmap fromCompact . VMap.toMap

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -289,6 +290,7 @@ deriving instance Show UTxOInAnyEra
 
 instance IsCardanoEra era => ToJSON (UTxO era) where
   toJSON (UTxO m) = toJSON m
+  toEncoding (UTxO m) = toEncoding m
 
 instance (IsCardanoEra era, IsShelleyBasedEra era, FromJSON (TxOut CtxUTxO era))
   => FromJSON (UTxO era) where
@@ -336,13 +338,32 @@ instance ( IsShelleyBasedEra era
          , ToJSON (Core.TxOut ledgerera)
          , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
          ) => ToJSON (DebugLedgerState era) where
-  toJSON (DebugLedgerState newEpochS) = object [ "lastEpoch" .= Shelley.nesEL newEpochS
-                                          , "blocksBefore" .= Shelley.nesBprev newEpochS
-                                          , "blocksCurrent" .= Shelley.nesBcur newEpochS
-                                          , "stateBefore" .= Shelley.nesEs newEpochS
-                                          , "possibleRewardUpdate" .= Shelley.nesRu newEpochS
-                                          , "stakeDistrib" .= Shelley.nesPd newEpochS
-                                          ]
+  toJSON = object . toDebugLedgerStatePair
+  toEncoding = Aeson.pairs . mconcat . toDebugLedgerStatePair
+
+toDebugLedgerStatePair ::
+  ( ShelleyLedgerEra era ~ ledgerera
+  , Consensus.ShelleyBasedEra ledgerera
+  , ToJSON (Core.PParams ledgerera)
+  , ToJSON (Core.PParamsDelta ledgerera)
+  , ToJSON (Core.TxOut ledgerera)
+  , Aeson.KeyValue a
+  ) => DebugLedgerState era -> [a]
+toDebugLedgerStatePair (DebugLedgerState newEpochS) =
+    let !nesEL = Shelley.nesEL newEpochS
+        !nesBprev = Shelley.nesBprev newEpochS
+        !nesBcur = Shelley.nesBcur newEpochS
+        !nesEs = Shelley.nesEs newEpochS
+        !nesRu = Shelley.nesRu newEpochS
+        !nesPd = Shelley.nesPd newEpochS
+    in  [ "lastEpoch" .= nesEL
+        , "blocksBefore" .= nesBprev
+        , "blocksCurrent" .= nesBcur
+        , "stateBefore" .= nesEs
+        , "possibleRewardUpdate" .= nesRu
+        , "stakeDistrib" .= nesPd
+        ]
+
 newtype ProtocolState era
   = ProtocolState (Serialised (Consensus.ChainDepState (ConsensusProtocol era)))
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -37,6 +37,7 @@ import           Cardano.Api.Shelley
 import           Control.Monad.Trans.Except (except)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
                    hoistMaybe, left, newExceptT)
+import           Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
@@ -55,6 +56,7 @@ import qualified Data.Vector as Vector
 import qualified Data.VMap as VMap
 import           Formatting.Buildable (build)
 import           Numeric (showEFloat)
+import qualified System.IO as IO
 import           Text.Printf (printf)
 
 import           Cardano.Binary (DecoderError)
@@ -102,7 +104,6 @@ import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as LocalStateQuery
-import qualified System.IO as IO
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Use const" -}
@@ -782,9 +783,10 @@ writeLedgerState :: forall era ledgerera.
                  -> ExceptT ShelleyQueryCmdError IO ()
 writeLedgerState mOutFile qState@(SerialisedDebugLedgerState serLedgerState) =
   case mOutFile of
-    Nothing -> case decodeDebugLedgerState qState of
-                 Left bs -> firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
-                 Right ledgerState -> liftIO . LBS.putStrLn $ encodePretty ledgerState
+    Nothing ->
+      case decodeDebugLedgerState qState of
+        Left bs -> firstExceptT ShelleyQueryCmdHelpersError $ pPrintCBOR bs
+        Right ledgerState -> liftIO . LBS.putStrLn $ Aeson.encode ledgerState
     Just (OutputFile fpath) ->
       handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath)
         $ LBS.writeFile fpath $ unSerialised serLedgerState


### PR DESCRIPTION
This implements `toEncoding` of various `ToJSON` instances because it allows for more memory efficient lazy encoding.

As part of the change, the output of the query command will no longer be pretty printed.

Before uses about 16.4G:

```
$ time CARDANO_NODE_SOCKET_PATH=/Users/jky/wrk/iohk/mainnet/cardano-node.socket cardano-cli query ledger-state --mainnet > /tmp/ledger-state.bin

CARDANO_NODE_SOCKET_PATH=/Users/jky/wrk/iohk/mainnet/cardano-node.socket       302.63s user 14.17s system 91% cpu 5:47.89 total
```

After uses about 11.5G:

```
$ time CARDANO_NODE_SOCKET_PATH=/Users/jky/wrk/iohk/mainnet/cardano-node.socket $(./scripts/bin-path.sh cardano-cli) query ledger-state --mainnet > ledger-state.bin

CARDANO_NODE_SOCKET_PATH=/Users/jky/wrk/iohk/mainnet/cardano-node.socket       114.72s user 5.11s system 80% cpu 2:27.96 total
```
