### PR TITLE
bump babbage to report it supports 7.1 in block header

### DIFF
--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -198,7 +198,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Alonzo era. That is, it is the version of protocol
           -- /after/ Alonzo, i.e. Babbage.
-          alonzoProtVer = ProtVer 7 0,
+          alonzoProtVer = ProtVer 7 1,
           alonzoMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }
@@ -207,7 +207,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Babbage era. Since Babbage is currently the last known
           -- protocol version then this is also the Babbage protocol version.
-          Praos.babbageProtVer = ProtVer 7 0,
+          Praos.babbageProtVer = ProtVer 7 1,
           Praos.babbageMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }


### PR DESCRIPTION
Bumping to 7.1 to identify nodes that have updated to 1.35.2