### PR TITLE
tx-generator cleanups

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/ListBufferedSelector.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/ListBufferedSelector.hs
@@ -16,7 +16,7 @@ mkBufferedSource ::
      WalletRef
   -> Int
   -> Lovelace
-  -> Variant
+  -> Maybe Variant
   -> Int
   -> IO (Either String FundSource)
 mkBufferedSource walletRef count minValue variant munch

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -22,7 +22,8 @@ action a = case a of
   Delay t -> delay t
   ImportGenesisFund era wallet submitMode genesisKey fundKey -> importGenesisFund era wallet submitMode genesisKey fundKey
   CreateChange era sourceWallet dstWallet payMode submitMode value count -> createChange era sourceWallet dstWallet payMode submitMode value count
-  RunBenchmark era sourceWallet submitMode spendMode thread auxArgs tps -> runBenchmark era sourceWallet submitMode spendMode thread auxArgs tps
+  RunBenchmark era sourceWallet submitMode thread auxArgs collateralWallet tps
+    -> runBenchmark era sourceWallet submitMode thread auxArgs collateralWallet tps
   WaitBenchmark thread -> waitBenchmark thread
   CancelBenchmark thread -> cancelBenchmark thread
   WaitForEra era -> waitForEra era

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -73,16 +73,16 @@ instance ToJSON PayMode where
 instance FromJSON PayMode where
   parseJSON = genericParseJSON jsonOptionsUnTaggedSum
 
-instance ToJSON SpendMode where
-  toJSON     = genericToJSON jsonOptionsUnTaggedSum
-  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
-instance FromJSON SpendMode where
-  parseJSON = genericParseJSON jsonOptionsUnTaggedSum
-
 instance ToJSON ScriptBudget where
   toJSON     = genericToJSON jsonOptionsUnTaggedSum
   toEncoding = genericToEncoding jsonOptionsUnTaggedSum
 instance FromJSON ScriptBudget where
+  parseJSON = genericParseJSON jsonOptionsUnTaggedSum
+
+instance ToJSON ScriptSpec where
+  toJSON     = genericToJSON jsonOptionsUnTaggedSum
+  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
+instance FromJSON ScriptSpec where
   parseJSON = genericParseJSON jsonOptionsUnTaggedSum
 
 instance ToJSON (DSum Tag Identity) where

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -32,7 +32,9 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult
 
 import           Cardano.Benchmarking.FundSet (FundInEra (..), Validity (..), Variant (..),
                    liftAnyEra)
+
 import qualified Cardano.Benchmarking.FundSet as FundSet
+import           Cardano.Benchmarking.FundSet as FundSet (getFundTxIn)
 import           Cardano.Benchmarking.GeneratorTx as GeneratorTx (AsyncBenchmarkControl, TxGenError)
 import qualified Cardano.Benchmarking.GeneratorTx as GeneratorTx (readSigningKey, secureGenesisFund,
                    waitBenchmark, walletBenchmark)
@@ -42,7 +44,6 @@ import           Cardano.Benchmarking.GeneratorTx.NodeToNode (ConnectClient,
 import           Cardano.Benchmarking.GeneratorTx.SizedMetadata (mkMetadata)
 import           Cardano.Benchmarking.GeneratorTx.Tx as Core (keyAddress, mkFee, txInModeCardano)
 
-import           Cardano.Benchmarking.FundSet as FundSet (getFundTxIn)
 import           Cardano.Benchmarking.ListBufferedSelector
 import           Cardano.Benchmarking.OuroborosImports as Core (LocalSubmitTx, SigningKeyFile,
                    makeLocalConnectInfo, protocolToCodecConfig)
@@ -116,6 +117,7 @@ addFundToWallet wallet txIn outVal skey = do
   where
     mkFund = liftAnyEra $ \value -> FundInEra {
            _fundTxIn = txIn
+         , _fundWitness = KeyWitness KeyWitnessForSpending
          , _fundVal = value
          , _fundSigningKey = Just skey
          , _fundValidity = Confirmed
@@ -240,23 +242,28 @@ makeMetadata = do
     Right m -> return m
     Left err -> throwE $ MetadataError err
 
-runBenchmark :: AnyCardanoEra -> WalletName -> SubmitMode -> SpendMode -> ThreadName -> RunBenchmarkAux -> TPSRate -> ActionM ()
-runBenchmark era sourceWallet submitMode spendMode threadName extraArgs tps
-  = case spendMode of
-      SpendOutput -> withEra era $ runBenchmarkInEra sourceWallet submitMode threadName extraArgs tps
-      SpendScript scriptFile scriptBudget scriptData scriptRedeemer
-        -> withEra era $ runPlutusBenchmark sourceWallet submitMode scriptFile scriptBudget scriptData scriptRedeemer threadName extraArgs tps
-      SpendAutoScript scriptFile -> withEra era $ spendAutoScript sourceWallet submitMode scriptFile threadName extraArgs tps
+runBenchmark ::
+     AnyCardanoEra
+  -> WalletName
+  -> SubmitMode
+  -> ThreadName
+  -> RunBenchmarkAux
+  -> Maybe WalletName
+  -> TPSRate
+  -> ActionM ()
+runBenchmark era sourceWallet submitMode threadName extraArgs collateralWallet tps
+  = withEra era $ runBenchmarkInEra sourceWallet submitMode threadName extraArgs collateralWallet tps
 
 runBenchmarkInEra :: forall era. IsShelleyBasedEra era
   => WalletName
   -> SubmitMode
   -> ThreadName
   -> RunBenchmarkAux
+  -> Maybe WalletName
   -> TPSRate
   -> AsType era
   -> ActionM ()
-runBenchmarkInEra sourceWallet submitMode (ThreadName threadName) shape tps era = do
+runBenchmarkInEra sourceWallet submitMode (ThreadName threadName) shape collateralWallet tps era = do
   tracers  <- get BenchTracers
   networkId <- getUser TNetworkId
   fundKey <- getName $ KeyName "pass-partout" -- should be walletkey
@@ -265,25 +272,26 @@ runBenchmarkInEra sourceWallet submitMode (ThreadName threadName) shape tps era 
   let walletRefDst = walletRefSrc
   metadata <- makeMetadata
 
-
   fundSource <- liftIO (mkBufferedSource walletRefSrc
                    (auxInputs shape)
                    (auxMinValuePerUTxO shape)
-                   PlainOldFund
+                   Nothing
                    (auxInputsPerTx shape)
                    ) >>= \case
     Right a  -> return a
     Left err -> throwE $ WalletError err
 
+  collaterals <- selectCollateralFunds collateralWallet
+
   let
     inToOut :: [Lovelace] -> [Lovelace]
     inToOut = FundSet.inputsToOutputsWithFee (auxFee shape) (auxOutputsPerTx shape)
 
-    txGenerator = genTx protocolParameters (TxInsCollateralNone, []) (mkFee (auxFee shape)) metadata (KeyWitness KeyWitnessForSpending)
+    txGenerator = genTx protocolParameters collaterals (mkFee (auxFee shape)) metadata
 
-    toUTxO :: FundSet.Target -> FundSet.SeqNumber -> ToUTxOList era
-    toUTxO target seqNumber = Wallet.mkUTxOList networkId fundKey (InFlight target seqNumber)
-
+    toUTxO :: FundSet.Target -> FundSet.SeqNumber -> [ToUTxO era]
+    toUTxO target seqNumber = repeat $ Wallet.mkUTxOVariant PlainOldFund networkId fundKey (InFlight target seqNumber)
+  
     fundToStore = mkWalletFundStore walletRefDst
 
     walletScript :: FundSet.Target -> WalletScript era
@@ -302,129 +310,19 @@ runBenchmarkInEra sourceWallet submitMode (ThreadName threadName) shape tps era 
         Right ctl -> setName (ThreadName threadName) ctl
     _otherwise -> runWalletScriptInMode submitMode $ walletScript $ FundSet.Target "alternate-submit-mode"
 
-runPlutusBenchmark :: forall era. IsShelleyBasedEra era
-  => WalletName
-  -> SubmitMode
-  -> FilePath
-  -> ScriptBudget
-  -> ScriptData
-  -> ScriptRedeemer
-  -> ThreadName
-  -> RunBenchmarkAux
-  -> TPSRate
-  -> AsType era
-  -> ActionM ()
-runPlutusBenchmark sourceWallet submitMode scriptFile scriptBudget scriptData scriptRedeemer (ThreadName threadName) extraArgs tps era = do
-  tracers  <- get BenchTracers
-  networkId <- getUser TNetworkId
-  protocolParameters <- getProtocolParameters
-  executionUnitPrices <- case protocolParamPrices protocolParameters of
-    Just x -> return x
-    Nothing -> throwE $ WalletError "unexpected protocolParamPrices == Nothing in runPlutusBenchmark"
-  walletRefSrc <- getName sourceWallet
-  let
-    -- runBenchmark reads and write from the single sourceWallet.
-    walletRefDst = walletRefSrc
-    walletRefCollateral = walletRefSrc
-  fundKey <- getName $ KeyName "pass-partout"
-
-  script <- liftIO $ PlutusExample.readScript scriptFile
-  -- This does not remove the collateral from the wallet, i.e. same collateral is uses for everything.
-  -- This is fine unless a script ever fails.
-  collateralFunds <- liftIO ( askWalletRef walletRefCollateral (FundSet.selectCollateral . walletFunds)) >>= \case
+selectCollateralFunds :: forall era. IsShelleyBasedEra era
+  => Maybe WalletName
+  -> ActionM (TxInsCollateral era, [FundSet.Fund])
+selectCollateralFunds Nothing = return (TxInsCollateralNone, [])
+selectCollateralFunds (Just walletName) = do
+  cw <- getName walletName
+  collateralFunds <- liftIO ( askWalletRef cw (FundSet.selectCollateral . walletFunds)) >>= \case
     Right c -> return c
     Left err -> throwE $ WalletError err
-  baseFee <- getUser TFee
-  metadata <- makeMetadata
-
-  let costsPreRun = preExecuteScript protocolParameters script scriptData scriptRedeemer
-  executionUnits <- case (scriptBudget, costsPreRun) of
-    (_, Left err) -> throwE $ WalletError ("Cannot pre-execute Plutus script." ++ err)
-    (StaticScriptBudget exUnits, _)  -> return exUnits
-    (PreExecuteScript, Right preRun) -> return preRun
-    (CheckScriptBudget want, Right preRun)
-      -> if want == preRun then return preRun
-                           else throwE $ WalletError $ concat [
-        " Stated execution Units do not match result of pre execution. "
-      , " Stated value : ", show want
-      , " PreExecution result : ", show preRun
-      ]
-
-  let msg = mconcat [ "Plutus Benchmark :"
-                  , " Script: ", scriptFile
-                  , ", Datum: ", show scriptData
-                  , ", Redeemer: ", show scriptRedeemer
-                  , ", StatedBudget: ", show executionUnits
-                  ]
-  traceDebug msg
-
-  let
-    -- TODO --    Cardano.Ledger.Alonzo.Scripts.txscriptfee :: Prices -> ExUnits -> Coin
-    scriptFee = quantityToLovelace $ Quantity $ ceiling f
-       where
-         f :: Rational
-         f = (executionSteps e `times` priceExecutionSteps p) + (executionMemory e `times` priceExecutionMemory p)
-         e = executionUnits
-         p = executionUnitPrices
-         times w c = fromIntegral w % 1 * c
-
-    totalFee = baseFee +  fromIntegral (auxInputsPerTx extraArgs) * scriptFee
-    (Quantity minValue) = lovelaceToQuantity $ fromIntegral (auxOutputsPerTx extraArgs) * auxMinValuePerUTxO extraArgs + totalFee
-  -- this is not totally correct:
-  -- beware of rounding errors !
-    minValuePerInput = quantityToLovelace $ fromIntegral (if m==0 then d else d+1)
-      where
-        (d, m) = minValue `divMod` fromIntegral (auxInputsPerTx extraArgs)
-
-  fundSource <- liftIO (mkBufferedSource walletRefSrc
-                   (auxInputs extraArgs)
-                   minValuePerInput
-                   (PlutusScriptFund scriptFile scriptData)
-                   (auxInputsPerTx extraArgs)) >>= \case
-    Right a  -> return a
-    Left err -> throwE $ WalletError err
-
-  let
-    inToOut :: [Lovelace] -> [Lovelace]
-    inToOut = FundSet.inputsToOutputsWithFee totalFee (auxOutputsPerTx extraArgs)
---    inToOut = FundSet.inputsToOutputsWithFee totalFee 1
-
-    PlutusScript PlutusScriptV1 script' = script
-    scriptWitness :: ScriptWitness WitCtxTxIn era
-    scriptWitness = case scriptLanguageSupportedInEra (cardanoEra @ era) (PlutusScriptLanguage PlutusScriptV1) of
-      Nothing -> error $ "runPlutusBenchmark: Plutus V1 scriptlanguage not supported : in era" ++ show (cardanoEra @ era)
-      Just scriptLang -> PlutusScriptWitness
-                          scriptLang
-                          PlutusScriptV1
-                          (PScript script')
-                          (ScriptDatumForTxIn scriptData)
-                          scriptRedeemer
-                          executionUnits
-
-    collateral = case collateralSupportedInEra (cardanoEra @ era) of
-      Nothing -> error $ "runPlutusBenchmark: collateral: era not supported :" ++ show (cardanoEra @ era)
-      Just p -> (TxInsCollateral p $  map getFundTxIn collateralFunds, collateralFunds)
-
-    txGenerator = genTx protocolParameters collateral (mkFee totalFee) metadata (ScriptWitness ScriptWitnessForSpending scriptWitness)
-
-    fundToStore = mkWalletFundStore walletRefDst
-
-    toUTxO :: FundSet.Target -> FundSet.SeqNumber -> ToUTxOList era
-    toUTxO target seqNumber = Wallet.mkUTxOList networkId fundKey (InFlight target seqNumber)
-
-    walletScript :: FundSet.Target -> WalletScript era
-    walletScript = benchmarkWalletScript walletRefSrc txGenerator (NumberOfTxs $ auxTxCount extraArgs) (const fundSource) inToOut toUTxO fundToStore
-
-  case submitMode of
-    NodeToNode targetNodes -> do
-      connectClient <- getConnectClient
-      ret <- liftIO $ runExceptT $ GeneratorTx.walletBenchmark (btTxSubmit_ tracers) (btN2N_ tracers) connectClient
-                               threadName targetNodes tps LogErrors era (NumberOfTxs $ auxTxCount extraArgs) walletScript
-      case ret of
-        Left err -> liftTxGenError err
-        Right ctl -> setName (ThreadName threadName) ctl
-    _otherwise -> runWalletScriptInMode submitMode $ walletScript $ FundSet.Target "alternate-submit-mode"
-
+  case collateralSupportedInEra (cardanoEra @ era) of
+      Nothing -> throwE $ WalletError $ "selectCollateralFunds: collateral: era not supported :" ++ show (cardanoEra @ era)
+      Just p -> return (TxInsCollateral p $  map getFundTxIn collateralFunds, collateralFunds)
+  
 dumpToFile :: FilePath -> TxInMode CardanoMode -> ActionM ()
 dumpToFile filePath tx = liftIO $ dumpToFileIO filePath tx
 
@@ -479,33 +377,37 @@ createChangeInEra :: forall era. IsShelleyBasedEra era
   -> AsType era
   -> ActionM ()
 createChangeInEra sourceWallet dstWallet submitMode payMode value count _era = do
-  networkId <- getUser TNetworkId
   walletRef <- getName dstWallet
   fee <- getUser TFee
   protocolParameters <- getProtocolParameters
-  (toUTxO, addressMsg) <- case payMode of
-    PayToAddr keyName -> do
-      fundKey <- getName keyName
-      return ( Wallet.mkUTxOVariantList PlainOldFund networkId fundKey Confirmed
-             , Text.unpack $ serialiseAddress $ keyAddress @ era networkId fundKey)
-    PayToCollateral keyName -> do
-      fundKey <- getName keyName
-      return ( Wallet.mkUTxOVariantList CollateralFund networkId fundKey Confirmed
-             , Text.unpack $ serialiseAddress $ keyAddress @ era networkId fundKey)
-    PayToScript scriptFile scriptData -> do
-      script <- liftIO $ PlutusExample.readScript scriptFile --TODO: this should throw a file-not-found-error !
-      return ( PlutusExample.mkUTxOScriptList networkId (scriptFile, script, scriptData) Confirmed
-               , Text.unpack $ serialiseAddress $ makeShelleyAddress networkId (PaymentCredentialByScript $ hashScript script) NoStakeAddress )
+  (toUTxO, addressMsg) <- interpretPayMode payMode
   let
     createCoins :: FundSet.FundSource -> [Lovelace] -> ActionM (Either String (TxInMode CardanoMode))
     createCoins fundSource coins = do
       (tx :: Either String (Tx era)) <- liftIO $ sourceToStoreTransaction
                                                   (genTx protocolParameters (TxInsCollateralNone, [])
-                                                   (mkFee fee) TxMetadataNone (KeyWitness KeyWitnessForSpending))
-                                                  fundSource (Wallet.includeChange fee coins) toUTxO (mkWalletFundStore walletRef)
+                                                   (mkFee fee) TxMetadataNone )
+                                                  fundSource (Wallet.includeChange fee coins) (repeat toUTxO) (mkWalletFundStore walletRef)
       return $ fmap txInModeCardano tx
   createChangeGeneric sourceWallet submitMode createCoins addressMsg value count
 
+interpretPayMode :: forall era. IsShelleyBasedEra era => PayMode -> ActionM (ToUTxO era, String)
+interpretPayMode payMode = do
+  networkId <- getUser TNetworkId
+  case payMode of
+    PayToAddr keyName -> do
+      fundKey <- getName keyName
+      return ( Wallet.mkUTxOVariant PlainOldFund networkId fundKey Confirmed
+             , Text.unpack $ serialiseAddress $ keyAddress @ era networkId fundKey)
+    PayToCollateral keyName -> do
+      fundKey <- getName keyName
+      return ( Wallet.mkUTxOVariant CollateralFund networkId fundKey Confirmed
+             , Text.unpack $ serialiseAddress $ keyAddress @ era networkId fundKey)
+    PayToScript scriptSpec -> do
+      (witness, script, scriptData, _scriptFee) <- makePlutusContext scriptSpec
+      return ( mkUTxOScript networkId (script, scriptData) witness Confirmed
+               , Text.unpack $ serialiseAddress $ makeShelleyAddress networkId (PaymentCredentialByScript $ hashScript script) NoStakeAddress )
+  
 createChangeGeneric ::
      WalletName
   -> SubmitMode
@@ -529,7 +431,7 @@ createChangeGeneric sourceWallet submitMode createCoins addressMsg value count =
                   , " address: ", addressMsg
                   ]
   traceDebug msg
-  fundSource <- liftIO (mkBufferedSource walletRef txCount txValue PlainOldFund 1) >>= \case
+  fundSource <- liftIO (mkBufferedSource walletRef txCount txValue (Just PlainOldFund) 1) >>= \case
     Right a  -> return a
     Left err -> throwE $ WalletError err
 
@@ -555,30 +457,23 @@ It is intended to be used with the the loop script from cardano-node/plutus-exam
 loopScriptFile is the FilePath to the Plutus script that implements the delay loop. (for example in /nix/store/).
 spendAutoScript relies on a particular calling convention of the loop script.
 -}
-spendAutoScript :: forall era. IsShelleyBasedEra era
-  => WalletName
-  -> SubmitMode
-  -> FilePath
-  -> ThreadName
-  -> RunBenchmarkAux
-  -> TPSRate
-  -> AsType era
-  -> ActionM ()
-spendAutoScript sourceWallet submitMode loopScriptFile threadName extraArgs tps era = do
-  protocolParameters <- getProtocolParameters
+
+spendAutoScript ::
+     ProtocolParameters
+  -> Script PlutusScriptV1
+  -> ActionM (ScriptData, ScriptRedeemer)
+spendAutoScript protocolParameters script = do
   perTxBudget <- case protocolParamMaxTxExUnits protocolParameters of
     Nothing -> throwE $ ApiError "Cannot determine protocolParamMaxTxExUnits"
     Just b -> return b
   traceDebug $ "Plutus auto mode : Available budget per TX: " ++ show perTxBudget
 
   let
-    numInputs = fromIntegral $ auxInputsPerTx extraArgs
     budget = ExecutionUnits
-                 (executionSteps perTxBudget `div` numInputs)
-                 (executionMemory perTxBudget `div` numInputs)
+                 (executionSteps perTxBudget `div`  2) -- TODO FIX
+                 (executionMemory perTxBudget `div` 2)
   traceDebug $ "Plutus auto mode : Available budget per script run: " ++ show budget
 
-  script <- liftIO $ readScript loopScriptFile
   let
     isInLimits :: Integer -> Either String Bool
     isInLimits n = case preExecuteScript protocolParameters script (ScriptDataNumber 0) (toLoopArgument n) of
@@ -588,7 +483,7 @@ spendAutoScript sourceWallet submitMode loopScriptFile threadName extraArgs tps 
   redeemer <- case startSearch isInLimits 0 searchUpperBound of
     Left err -> throwE $ ApiError $ "cannot find fitting redeemer :" ++ err
     Right n -> return $ toLoopArgument n
-  runPlutusBenchmark sourceWallet submitMode loopScriptFile PreExecuteScript (ScriptDataNumber 0) redeemer threadName extraArgs tps era
+  return (ScriptDataNumber 0, redeemer)
   where
     -- This is the hardcoded calling convention of the loop.plutus script.
     -- To loop n times one has to pass n + 1_000_000 as redeemer.
@@ -604,6 +499,81 @@ spendAutoScript sourceWallet submitMode loopScriptFile threadName extraArgs tps 
              let m = (a + b) `div` 2
              test <- f m
              if test then search f m b else search f a m
+
+makePlutusContext :: forall era. IsShelleyBasedEra era
+  => ScriptSpec
+  -> ActionM (Witness WitCtxTxIn era, Script PlutusScriptV1, ScriptData, Lovelace)
+makePlutusContext scriptSpec = do
+  protocolParameters <- getProtocolParameters
+  script <- liftIO $ PlutusExample.readScript $ scriptSpecFile scriptSpec
+
+  executionUnitPrices <- case protocolParamPrices protocolParameters of
+    Just x -> return x
+    Nothing -> throwE $ WalletError "unexpected protocolParamPrices == Nothing in runPlutusBenchmark"
+
+  perTxBudget <- case protocolParamMaxTxExUnits protocolParameters of
+    Nothing -> throwE $ ApiError "Cannot determine protocolParamMaxTxExUnits"
+    Just b -> return b
+  traceDebug $ "Plutus auto mode : Available budget per TX: " ++ show perTxBudget
+
+  (scriptData, scriptRedeemer, executionUnits) <- case scriptSpecBudget scriptSpec of
+    StaticScriptBudget sdata redeemer units -> return (sdata, redeemer, units)
+    CheckScriptBudget sdata redeemer unitsWant -> do
+      unitsPreRun <- preExecuteScriptAction protocolParameters script sdata redeemer
+      if unitsWant == unitsPreRun
+         then return (sdata, redeemer, unitsWant )
+         else throwE $ WalletError $ concat [
+              " Stated execution Units do not match result of pre execution. "
+            , " Stated value : ", show unitsWant
+            , " PreExecution result : ", show unitsPreRun
+            ]
+    AutoScript -> do
+      (sdata, redeemer) <- spendAutoScript protocolParameters script
+      preRun <- preExecuteScriptAction protocolParameters script sdata redeemer
+      return (sdata, redeemer, preRun)
+
+  let msg = mconcat [ "Plutus Benchmark :"
+                    , " Script: ", scriptSpecFile scriptSpec
+                    , ", Datum: ", show scriptData
+                    , ", Redeemer: ", show scriptRedeemer
+                    , ", StatedBudget: ", show executionUnits
+                    ]
+  traceDebug msg
+
+  let
+    -- TODO --    Cardano.Ledger.Alonzo.Scripts.txscriptfee :: Prices -> ExUnits -> Coin
+    scriptFee = quantityToLovelace $ Quantity $ ceiling f
+       where
+         f :: Rational
+         f = (executionSteps e `times` priceExecutionSteps p) + (executionMemory e `times` priceExecutionMemory p)
+         e = executionUnits
+         p = executionUnitPrices
+         times w c = fromIntegral w % 1 * c
+
+    PlutusScript PlutusScriptV1 script' = script
+    scriptWitness :: ScriptWitness WitCtxTxIn era
+    scriptWitness = case scriptLanguageSupportedInEra (cardanoEra @ era) (PlutusScriptLanguage PlutusScriptV1) of
+      Nothing -> error $ "runPlutusBenchmark: Plutus V1 scriptlanguage not supported : in era" ++ show (cardanoEra @ era)
+      Just scriptLang -> PlutusScriptWitness
+                          scriptLang
+                          PlutusScriptV1
+                          (PScript script')
+                          (ScriptDatumForTxIn scriptData)
+                          scriptRedeemer
+                          executionUnits
+
+  return (ScriptWitness ScriptWitnessForSpending scriptWitness, script, scriptData, scriptFee)
+
+preExecuteScriptAction ::
+     ProtocolParameters
+  -> Script PlutusScriptV1
+  -> ScriptData
+  -> ScriptData
+  -> ActionM ExecutionUnits
+preExecuteScriptAction protocolParameters script scriptData redeemer
+  = case preExecuteScript protocolParameters script scriptData redeemer of
+      Left err -> throwE $ WalletError ( "makePlutusContext preExecuteScript failed : " ++ show err )
+      Right costs -> return costs
 
 traceTxGeneratorVersion :: ActionM ()
 traceTxGeneratorVersion = traceBenchTxSubmit TraceTxGeneratorVersion Version.txGeneratorVersion

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
@@ -60,8 +60,7 @@ testScript protocolFile submitMode =
   , createChange 2300000000 9000
   , RunBenchmark era wallet
     submitMode
-    SpendOutput
-    (ThreadName "walletBasedBenchmark") extraArgs (TPSRate 10.0)
+    (ThreadName "walletBasedBenchmark") extraArgs Nothing (TPSRate 10.0)
   ]
   where
     era = AnyCardanoEra AllegraEra

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -35,7 +35,7 @@ data Action where
   AddFund            :: !AnyCardanoEra -> !WalletName -> !TxIn -> !Lovelace -> !KeyName -> Action
   ImportGenesisFund  :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !KeyName -> !KeyName -> Action
   CreateChange       :: !AnyCardanoEra -> !WalletName -> !WalletName -> !SubmitMode -> !PayMode -> !Lovelace -> !Int -> Action
-  RunBenchmark       :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !SpendMode -> !ThreadName -> !RunBenchmarkAux -> !TPSRate -> Action
+  RunBenchmark       :: !AnyCardanoEra -> !WalletName -> !SubmitMode -> !ThreadName -> !RunBenchmarkAux -> Maybe WalletName -> !TPSRate -> Action
   WaitBenchmark      :: !ThreadName -> Action
   CancelBenchmark    :: !ThreadName -> Action
   Reserved           :: [String] -> Action
@@ -61,23 +61,24 @@ deriving instance Generic SubmitMode
 data PayMode where
   PayToAddr :: !KeyName -> PayMode
   PayToCollateral :: !KeyName  -> PayMode
-  PayToScript :: !FilePath -> !ScriptData -> PayMode
+  PayToScript :: !ScriptSpec -> PayMode
   deriving (Show, Eq)
 deriving instance Generic PayMode
 
-data SpendMode where
-  SpendOutput :: SpendMode
-  SpendScript :: !FilePath -> ScriptBudget -> !ScriptData -> !ScriptRedeemer -> SpendMode
-  SpendAutoScript :: !FilePath -> SpendMode
-  deriving (Show, Eq)
-deriving instance Generic SpendMode
-
 data ScriptBudget where
-  StaticScriptBudget :: !ExecutionUnits -> ScriptBudget
-  PreExecuteScript   :: ScriptBudget
-  CheckScriptBudget  :: !ExecutionUnits -> ScriptBudget
+  StaticScriptBudget :: !ScriptData -> !ScriptRedeemer -> !ExecutionUnits -> ScriptBudget
+  CheckScriptBudget  :: !ScriptData -> !ScriptRedeemer -> !ExecutionUnits -> ScriptBudget
+  AutoScript :: ScriptBudget --todo: add fraction of total available budget to use (==2 with 2 inputs !)
   deriving (Show, Eq)
 deriving instance Generic ScriptBudget
+
+data ScriptSpec = ScriptSpec
+  {
+    scriptSpecFile :: !FilePath
+  , scriptSpecBudget :: !ScriptBudget
+  }
+  deriving (Show, Eq)
+deriving instance Generic ScriptSpec
 
 data RunBenchmarkAux = RunBenchmarkAux {
     auxTxCount :: Int

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -18,6 +18,8 @@ import           Cardano.Api.Shelley (ProtocolParameters, ReferenceScript(..))
 type WalletRef = MVar Wallet
 
 type TxGenerator era = [Fund] -> [TxOut CtxTx era] -> Either String (Tx era, TxId)
+-- Todo: ToUTxO implicitly assumes that all outputs are of the same type (Plutus. normal, collateral).
+-- This is too special
 type ToUTxO era = [Lovelace] -> ([TxOut CtxTx era], TxId -> [Fund])
 
 data Wallet = Wallet {

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -18,7 +18,6 @@ import           Cardano.Api.Shelley (ProtocolParameters, ReferenceScript(..))
 type WalletRef = MVar Wallet
 
 type TxGenerator era = [Fund] -> [TxOut CtxTx era] -> Either String (Tx era, TxId)
-type ToUTxOList era = [Lovelace] -> ([TxOut CtxTx era], TxId -> [Fund])
 
 type ToUTxO era = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> Fund)
 
@@ -80,7 +79,7 @@ sourceToStoreTransaction ::
      TxGenerator era
   -> FundSource
   -> ([Lovelace] -> [Lovelace])
-  -> ToUTxOList era
+  -> [ToUTxO era]
   -> FundToStore
   -> IO (Either String (Tx era))
 sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
@@ -91,11 +90,14 @@ sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore = do
   work inputFunds = do
     let
       outValues = inToOut $ map getFundLovelace inputFunds
-      (outputs, toFunds) = mkTxOut outValues
-    case txGenerator inputFunds outputs of
+      outs = zipWith ($) mkTxOut outValues
+    case txGenerator inputFunds $ map fst outs of
         Left err -> return $ Left err
         Right (tx, txId) -> do
-          fundToStore $ toFunds txId
+          let
+            fkt :: (a, TxIx -> TxId -> Fund) -> TxIx -> Fund
+            fkt a txIx = snd a txIx txId
+          fundToStore $ zipWith fkt outs [TxIx 0 ..]
           return $ Right tx
 
 includeChange :: Lovelace -> [Lovelace] -> [Lovelace] -> [Lovelace]
@@ -104,31 +106,6 @@ includeChange fee spend have = case compare changeValue 0 of
   EQ -> spend
   LT -> error "genTX: Bad transaction: insufficient funds"
   where changeValue = sum have - sum spend - fee
-
-mkUTxOList :: forall era. IsShelleyBasedEra era
-  => NetworkId
-  -> SigningKey PaymentKey
-  -> Validity
-  -> ToUTxOList era
-mkUTxOList = mkUTxOVariantList PlainOldFund
-
-mkUTxOVariantList :: forall era. IsShelleyBasedEra era
-  => Variant
-  -> NetworkId
-  -> SigningKey PaymentKey
-  -> Validity
-  -> ToUTxOList era
-mkUTxOVariantList variant networkId key validity
- = mapToUTxO $ repeat $ mkUTxOVariant variant networkId key validity
-
-mapToUTxO :: [ ToUTxO era ]-> ToUTxOList era
-mapToUTxO fkts values 
-  = (outs, \txId -> map (\f -> f txId) fs)
-  where
-    (outs, fs) =unzip $ map worker $ zip3 fkts values [TxIx 0 ..]
-    worker (toUTxO, value, idx)
-      = let (o, f ) = toUTxO value
-        in  (o, f idx) 
 
 mkUTxOVariant :: forall era. IsShelleyBasedEra era
   => Variant
@@ -146,10 +123,47 @@ mkUTxOVariant variant networkId key validity value
   mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
   mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
       _fundTxIn = TxIn txId txIx
+    , _fundWitness = KeyWitness KeyWitnessForSpending
     , _fundVal = lovelaceToTxOutValue val
     , _fundSigningKey = Just key
     , _fundValidity = validity
     , _fundVariant = variant
+    }
+
+-- to be merged with mkUTxOVariant
+mkUTxOScript :: forall era.
+     IsShelleyBasedEra era
+  => NetworkId
+  -> (Script PlutusScriptV1, ScriptData)
+  -> Witness WitCtxTxIn era
+  -> Validity
+  -> ToUTxO era
+mkUTxOScript networkId (script, txOutDatum) witness validity value
+  = ( mkTxOut value
+    , mkNewFund value
+    )
+ where
+  plutusScriptAddr = makeShelleyAddressInEra
+                       networkId
+                       (PaymentCredentialByScript $ hashScript script)
+                       NoStakeAddress
+
+  mkTxOut v = case scriptDataSupportedInEra (cardanoEra @ era) of
+    Nothing -> error " mkUtxOScript scriptDataSupportedInEra==Nothing"
+    Just tag -> TxOut
+                  plutusScriptAddr
+                  (lovelaceToTxOutValue v)
+                  (TxOutDatumHash tag $ hashScriptData txOutDatum)
+                  ReferenceScriptNone   
+
+  mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
+  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @ era) $ FundInEra {
+      _fundTxIn = TxIn txId txIx
+    , _fundWitness = witness
+    , _fundVal = lovelaceToTxOutValue val
+    , _fundSigningKey = Nothing
+    , _fundValidity = validity
+    , _fundVariant = PlutusScriptFund
     }
 
 genTx :: forall era. IsShelleyBasedEra era =>
@@ -157,9 +171,8 @@ genTx :: forall era. IsShelleyBasedEra era =>
   -> (TxInsCollateral era, [Fund])
   -> TxFee era
   -> TxMetadataInEra era
-  -> Witness WitCtxTxIn era
   -> TxGenerator era
-genTx protocolParameters (collateral, collFunds) fee metadata witness inFunds outputs
+genTx protocolParameters (collateral, collFunds) fee metadata inFunds outputs
   = case makeTransactionBody txBodyContent of
       Left err -> error $ show err
       Right b -> Right ( signShelleyTransaction b $ map WitnessPaymentKey allKeys
@@ -168,7 +181,7 @@ genTx protocolParameters (collateral, collFunds) fee metadata witness inFunds ou
  where
   allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
   txBodyContent = TxBodyContent {
-      txIns = map (\f -> (getFundTxIn f, BuildTxWith witness)) inFunds
+      txIns = map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds
     , txInsCollateral = collateral
     , txInsReference = TxInsReferenceNone
     , txOuts = outputs
@@ -212,7 +225,7 @@ benchmarkWalletScript :: forall era .
   -> NumberOfTxs
   -> (Target -> FundSource)
   -> ([Lovelace] -> [Lovelace])
-  -> (Target -> SeqNumber -> ToUTxOList era)
+  -> ( Target -> SeqNumber -> [ToUTxO era])
   -> FundToStore
   -> Target
   -> WalletScript era


### PR DESCRIPTION
* Merge `createChangeInEra` with `createScriptChange`.
* Make `mkUTxOScript` polymorphic on the era.
* Merge `runBenchmarkInEra` with `runPlutusBenchmark`.
  `runBenchmark` can now create transactions that contain any mix of normal and plutus inputs.
* Change `ToUTxO era = [Lovelace] -> ([TxOut CtxTx era], TxId -> [Fund])` to
  `ToUTxO era = Lovelace -> (TxOut CtxTx era, TxIx -> TxId -> Fund)`
  (Deal with every output of a TX individually. This makes it possible to create TXs with a mix of regular and Plutus outputs). 