### PR TITLE
tx-generator: fix a bug

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/LogTypes.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/LogTypes.hs
@@ -68,16 +68,16 @@ data TraceBenchTxSubmit txid
   | TraceBenchTxSubStart [txid]
   -- ^ The @txid@ has been submitted to `TxSubmission`
   --   protocol peer.
-  | TraceBenchTxSubServAnn [txid]
+  | SubmissionClientReplyTxIds [txid]
   -- ^ Announcing txids in response for server's request.
   | TraceBenchTxSubServReq [txid]
   -- ^ Request for @tx@ received from `TxSubmission` protocol
   --   peer.
-  | TraceBenchTxSubServAck [txid]
+  | SubmissionClientDiscardAcknowledged [txid]
   -- ^ An ack (window moved over) received for these transactions.
   | TraceBenchTxSubServDrop [txid]
   -- ^ Transactions the server implicitly dropped.
-  | TraceBenchTxSubServOuts [txid]
+  | SubmissionClientUnAcked [txid]
   -- ^ Transactions outstanding.
   | TraceBenchTxSubServUnav [txid]
   -- ^ Transactions requested, but unavailable in the outstanding set.
@@ -113,8 +113,8 @@ instance ToJSON SubmissionSummary
 data NodeToNodeSubmissionTrace
   = ReqIdsBlocking  Ack Req
   | IdsListBlocking Int
-  | ReqIdsPrompt    Ack Req
-  | IdsListPrompt   Int
+  | ReqIdsNonBlocking Ack Req
+  | IdsListNonBlocking Int
   | ReqTxs          Int
   | TxList          Int
   | EndOfProtocol

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -276,7 +276,7 @@ runBenchmarkInEra sourceWallet submitMode (ThreadName threadName) shape tps era 
 
   let
     inToOut :: [Lovelace] -> [Lovelace]
-    inToOut = FundSet.inputsToOutputsWithFee (auxFee shape) (auxOutputs shape)
+    inToOut = FundSet.inputsToOutputsWithFee (auxFee shape) (auxOutputsPerTx shape)
 
     txGenerator = genTx protocolParameters (TxInsCollateralNone, []) (mkFee (auxFee shape)) metadata (KeyWitness KeyWitnessForSpending)
 
@@ -642,4 +642,3 @@ and for which the JSON encoding is "reserved".
 reserved :: [String] -> ActionM ()
 reserved _ = do
   throwE $ UserError "no dirty hack is implemented"
-

--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -129,24 +129,24 @@ instance LogFormatting (TraceBenchTxSubmit TxId) where
       mconcat [ "kind"  .= A.String "TraceBenchTxSubStart"
               , "txIds" .= toJSON txIds
               ]
-    TraceBenchTxSubServAnn txIds ->
-      mconcat [ "kind"  .= A.String "TraceBenchTxSubServAnn"
+    SubmissionClientReplyTxIds txIds ->
+      mconcat [ "kind"  .= A.String "SubmissionClientReplyTxIds"
               , "txIds" .= toJSON txIds
               ]
     TraceBenchTxSubServReq txIds ->
       mconcat [ "kind"  .= A.String "TraceBenchTxSubServReq"
               , "txIds" .= toJSON txIds
               ]
-    TraceBenchTxSubServAck txIds ->
-      mconcat [ "kind"  .= A.String "TraceBenchTxSubServAck"
+    SubmissionClientDiscardAcknowledged txIds ->
+      mconcat [ "kind"  .= A.String "SubmissionClientDiscardAcknowledged"
               , "txIds" .= toJSON txIds
               ]
     TraceBenchTxSubServDrop txIds ->
       mconcat [ "kind"  .= A.String "TraceBenchTxSubServDrop"
               , "txIds" .= toJSON txIds
               ]
-    TraceBenchTxSubServOuts txIds ->
-      mconcat [ "kind"  .= A.String "TraceBenchTxSubServOuts"
+    SubmissionClientUnAcked txIds ->
+      mconcat [ "kind"  .= A.String "SubmissionClientUnAcked"
               , "txIds" .= toJSON txIds
               ]
     TraceBenchTxSubServUnav txIds ->
@@ -196,12 +196,12 @@ instance LogFormatting NodeToNodeSubmissionTrace where
     IdsListBlocking sent -> KeyMap.fromList
       [ "kind" .= A.String "IdsListBlocking"
       , "sent" .= A.toJSON sent ]
-    ReqIdsPrompt (Ack ack) (Req req) -> KeyMap.fromList
-      [ "kind" .= A.String "ReqIdsPrompt"
+    ReqIdsNonBlocking (Ack ack) (Req req) -> KeyMap.fromList
+      [ "kind" .= A.String "ReqIdsNonBlocking"
       , "ack"  .= A.toJSON ack
       , "req"  .= A.toJSON req ]
-    IdsListPrompt sent -> KeyMap.fromList
-      [ "kind" .= A.String "IdsListPrompt"
+    IdsListNonBlocking sent -> KeyMap.fromList
+      [ "kind" .= A.String "IdsListNonBlocking"
       , "sent" .= A.toJSON sent ]
     EndOfProtocol -> KeyMap.fromList [ "kind" .= A.String "EndOfProtocol" ]
     ReqTxs req -> KeyMap.fromList


### PR DESCRIPTION
The bug was introduced in :  #3815.
The number of total output transactions of the tx-generator was used for the number of outputs of a single transaction.
It was not found because the tests were only run for Plutus workloads and the bug was in a non-Plutus code-branch.