### PR TITLE
update ledger to the tip of release/1.0.0

### DIFF
--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                  cardano-topology
-version:               1.35.2
+version:               1.35.3
 description:           A cardano topology generator
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cabal.project
+++ b/cabal.project
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: ebcf1a8936dd84de0182d54004473f4ce66c7923
-  --sha256: 1nx07kcjhj39alarr0bxw9viw3m6flfr8d14g2a3crymf6hxwg36
+  tag: c7c63dabdb215ebdaed8b63274965966f2bf408f
+  --sha256: 1cn1z3dh5dy5yy42bwfd8rg25mg8qp3m55gyfsl563wgw4q1nd6d
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -300,8 +300,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: a3fba9f4e776c38bc54cb9a1c1cae82d2338b718
-  --sha256: 1vy4fwrq5jbghwkfgnrd5c22zjv8ym9y2j8g38pq50da4nfyv3dh
+  tag: a56c96598b4b25c9e28215214d25189331087244
+  --sha256: 12d6bndmj0dxl6xlaqmf78326yp5hw093bmybmqfpdkvk4mgz03j
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,6 +1,10 @@
 # Changelog for cardano-api
 
-## 1.35.2 -- July 2022
+## 1.35.3 -- July 2022
+
+None
+
+## 1.35.2 -- July 2022 (not released)
 
 None
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api
-version:                1.35.2
+version:                1.35.3
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,6 +1,10 @@
 # Changelog for cardano-cli
 
-## 1.35.2 -- July 2022
+## 1.35.3 -- July 2022
+
+None
+
+## 1.35.2 -- July 2022 (not released)
 
 None
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-cli
-version:                1.35.2
+version:                1.35.3
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-chairman
-version:                1.35.2
+version:                1.35.3
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,6 +1,24 @@
 # Changelog for cardano-node
 
-## 1.35.2 -- July 2022
+## 1.35.3 -- July 2022
+
+### node changes
+
+- Update ledger and Plutus to the tip of release/1.0.0 (#4242)
+
+### consensus changes
+
+None
+
+### network changes
+
+None
+
+### ledger changes
+
+- Fix the alonzo UTxO rule to use alonzo minfee function (#2938)
+
+## 1.35.2 -- July 2022 (not released)
 
 ### node changes
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                1.35.2
+version:                1.35.3
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-submit-api/CHANGELOG.md
+++ b/cardano-submit-api/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog for Cardano-submit-api
 
-## 1.35.2 -- July 2022
+## 1.35.3 -- July 2022
+
+None
+
+## 1.35.2 -- July 2022 (not released)
 
 None
 

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-testnet
-version:                1.35.2
+version:                1.35.3
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.2}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.3}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -15,7 +15,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.35.2}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.35.3}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:


### PR DESCRIPTION
Update the ledger to the tip of the ledger release branch `release/1.0.0`.

This resolves the minfee bug which we strongly suspect is the root cause of #4228

---

Update the plutus to the tip of the plutus release branch `release/1.0.0`.

This delays the SECP256k1 bultin.