### PR TITLE
Add tx-mempool command to CLI

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -595,6 +595,8 @@ module Cardano.Api (
     MempoolSizeAndCapacity(..),
     queryTxMonitoringLocal,
 
+    TxIdInMode(..),
+
     EraHistory(..),
     getProgress,
 
@@ -718,6 +720,7 @@ import           Cardano.Api.Fees
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.InMode
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad
 import           Cardano.Api.Key

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -2,7 +2,11 @@
 
 ## vNext
 
-Default to the ledger's CDDL format for transaction body creation by removing flags `--cddl-format` and `--cli-format` from `build` and `build-raw` ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303))
+### Features
+
+- Default to the ledger's CDDL format for transaction body creation by removing flags `--cddl-format` and `--cli-format` from `build` and `build-raw` ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303))
+
+- Add `query tx-mempool` ([PR 4276](https://github.com/input-output-hk/cardano-node/pull/4276))
 
 ### Bugs
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -371,6 +371,7 @@ data QueryCmd =
       -- ^ Node operational certificate
       (Maybe OutputFile)
   | QueryPoolState' AnyConsensusModeParams NetworkId [Hash StakePoolKey]
+  | QueryTxMempool AnyConsensusModeParams NetworkId TxMempoolQuery (Maybe OutputFile)
   deriving Show
 
 renderQueryCmd :: QueryCmd -> Text
@@ -388,6 +389,14 @@ renderQueryCmd cmd =
     QueryStakeSnapshot' {} -> "query stake-snapshot"
     QueryKesPeriodInfo {} -> "query kes-period-info"
     QueryPoolState' {} -> "query pool-state"
+    QueryTxMempool _ _ query _ -> "query tx-mempool" <> renderTxMempoolQuery query
+  where
+    renderTxMempoolQuery query =
+      case query of
+        TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
+        TxMempoolQueryNextTx -> "next-tx"
+        TxMempoolQueryInfo -> "info"
+
 
 data GovernanceCmd
   = GovernanceMIRPayStakeAddressesCertificate

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -939,6 +939,8 @@ pQueryCmd =
         (Opt.info pKesPeriodInfo $ Opt.progDesc "Get information about the current KES period and your node's operational certificate.")
     , subParser "pool-state"
         (Opt.info pQueryPoolState $ Opt.progDesc "Dump the pool state")
+    , subParser "tx-mempool"
+        (Opt.info pQueryTxMempool $ Opt.progDesc "Local Mempool info")
     ]
   where
     pQueryProtocolParameters :: Parser QueryCmd
@@ -1008,6 +1010,25 @@ pQueryCmd =
       <*> pNetworkId
       <*> many pStakePoolVerificationKeyHash
 
+    pQueryTxMempool :: Parser QueryCmd
+    pQueryTxMempool = QueryTxMempool
+      <$> pConsensusModeParams
+      <*> pNetworkId
+      <*> pTxMempoolQuery
+      <*> pMaybeOutputFile
+      where
+        pTxMempoolQuery :: Parser TxMempoolQuery
+        pTxMempoolQuery = asum
+          [ subParser "info"
+            (Opt.info (pure TxMempoolQueryInfo) $
+              Opt.progDesc "Ask the node about the current mempool's capacity and sizes")
+          , subParser "next-tx"
+            (Opt.info (pure TxMempoolQueryNextTx) $
+              Opt.progDesc "Requests the next transaction from the mempool's current list")
+          , subParser "tx-exists"
+            (Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID")) $
+              Opt.progDesc "Query if a particular transaction exists in the mempool")
+          ]
     pLeadershipSchedule :: Parser QueryCmd
     pLeadershipSchedule = QueryLeadershipSchedule
       <$> pConsensusModeParams

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -34,6 +34,7 @@ module Cardano.CLI.Types
   , TxOutChangeAddress (..)
   , TxOutDatumAnyEra (..)
   , TxFile (..)
+  , TxMempoolQuery (..)
   , UpdateProposalFile (..)
   , VerificationKeyFile (..)
   , Stakes (..)
@@ -51,8 +52,8 @@ import           Data.Word (Word64)
 import qualified Cardano.Chain.Slotting as Byron
 
 import           Cardano.Api (AddressAny, AnyScriptLanguage, EpochNo, ExecutionUnits, Hash,
-                   InAnyCardanoEra, PaymentKey, PolicyId, ScriptData, SlotNo (SlotNo), Tx, TxIn,
-                   Value, WitCtxMint, WitCtxStake, WitCtxTxIn)
+                   InAnyCardanoEra, PaymentKey, PolicyId, ScriptData, SlotNo (SlotNo), Tx, TxId,
+                   TxIn, Value, WitCtxMint, WitCtxStake, WitCtxTxIn)
 
 import qualified Cardano.Ledger.Crypto as Crypto
 
@@ -383,4 +384,8 @@ newtype TxFile
   = TxFile FilePath
   deriving Show
 
-
+data TxMempoolQuery =
+      TxMempoolQueryTxExists TxId
+    | TxMempoolQueryNextTx
+    | TxMempoolQueryInfo
+  deriving Show

--- a/doc/reference/cardano-node-cli-reference.md
+++ b/doc/reference/cardano-node-cli-reference.md
@@ -78,6 +78,9 @@ The `query` command contains the following subcommands:
 * `pool-params` (advanced): gets the current and future parameters for a stake pool
 * `leadership-schedule`: gets the slots in which the node is slot leader for the current or following epoch
 * `kes-period-info` (advanced): returns diagnostic information about your operational certificate
+* `tx-mempool info`: returns details about a node's mempool's resource usage
+* `tx-mempool next-tx`: returns the next transaction to be processed
+* `tx-mempool tx-exists`: queries whether or not a transaction is in the node's mempool
 
 *cardano-cli governance*
 The `governance` command contains the following subcommands:

--- a/scripts/babbage/example-babbage-script-usage.sh
+++ b/scripts/babbage/example-babbage-script-usage.sh
@@ -21,7 +21,7 @@ ls -al "$CARDANO_NODE_SOCKET_PATH"
 plutusspendingscript="$BASE/scripts/plutus/scripts/v2/required-redeemer.plutus"
 plutusmintingscript="$BASE/scripts/plutus/scripts/v2/minting-script.plutus"
 plutusstakescript="scripts/plutus/scripts/v2/stake-script.plutus"
-mintpolicyid=$(cardano-cli transaction policyid --script-file $plutusmintingscript)
+mintpolicyid=$($CARDANO_CLI transaction policyid --script-file $plutusmintingscript)
 ## This datum hash is the hash of the untyped 42
 scriptdatumhash="9e1199a988ba72ffd6e9c269cadb3b53b5f360ff99f112d9b2ee30c4d74ad88b"
 datumfilepath="$BASE/scripts/plutus/data/42.datum"

--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -31,6 +31,7 @@ case $UNAME in
                 DATE="date";;
 esac
 
+CARDANO_CLI="${CARDANO_CLI:-cardano-cli}"
 NETWORK_MAGIC=42
 SECURITY_PARAM=10
 NUM_SPO_NODES=3
@@ -65,7 +66,7 @@ cat > "${ROOT}/byron.genesis.spec.json" <<EOF
 }
 EOF
 
-cardano-cli byron genesis genesis \
+$CARDANO_CLI byron genesis genesis \
   --protocol-magic ${NETWORK_MAGIC} \
   --start-time "${START_TIME}" \
   --k ${SECURITY_PARAM} \
@@ -107,7 +108,7 @@ $SED -i "${ROOT}/configuration.yaml" \
 # Copy the cost mode
 
 
-cardano-cli genesis create-staked --genesis-dir "${ROOT}" \
+$CARDANO_CLI genesis create-staked --genesis-dir "${ROOT}" \
   --testnet-magic "${NETWORK_MAGIC}" \
   --gen-pools 3 \
   --supply 1000000000000 \


### PR DESCRIPTION
This adds 3 commands

`cardano-cli query tx-mempool info` which prints stats for the transaction mempool for the node
`cardano-cli query tx-mempool next-tx` which returns the ID of the next transaction to be processed
`cardano-cli query tx-mempool tx-exists <txid>` which tells you whether or not a transaction is in the mempool

Closes https://github.com/input-output-hk/cardano-node/issues/3774
Closes https://github.com/input-output-hk/cardano-node/issues/4459