### PR TITLE
Multiple pools support in query stake snapshot 

### DIFF
--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -703,9 +703,11 @@ stakeSnapshotsToPair Consensus.StakeSnapshots
     , Consensus.ssGoTotal
     } =
     [ "pools" .= ssStakeSnapshots
-    , "activeStakeMark" .= ssMarkTotal
-    , "activeStakeSet" .= ssSetTotal
-    , "activeStakeGo" .= ssGoTotal
+    , "total" .= object
+      [ "stakeMark" .= ssMarkTotal
+      , "stakeSet" .= ssSetTotal
+      , "stakeGo" .= ssGoTotal
+      ]
     ]
 
 instance ToJSON (Consensus.StakeSnapshot crypto) where
@@ -718,7 +720,7 @@ stakeSnapshotToPair Consensus.StakeSnapshot
     , Consensus.ssSetPool
     , Consensus.ssGoPool
     } =
-    [ "poolStakeMark" .= ssMarkPool
-    , "poolStakeSet" .= ssSetPool
-    , "poolStakeGo" .= ssGoPool
+    [ "stakeMark" .= ssMarkPool
+    , "stakeSet" .= ssSetPool
+    , "stakeGo" .= ssGoPool
     ]

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -689,8 +689,6 @@ instance Crypto.Crypto crypto => ToJSON (VMap VB VP (Shelley.Credential 'Shelley
   toJSON = toJSON . fmap fromCompact . VMap.toMap
   toEncoding = toEncoding . fmap fromCompact . VMap.toMap
 
------
-
 instance Crypto.Crypto crypto => ToJSON (Consensus.StakeSnapshots crypto) where
   toJSON = object . stakeSnapshotsToPair
   toEncoding = pairs . mconcat . stakeSnapshotsToPair

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -19,7 +19,7 @@ module Cardano.Api.Orphans () where
 
 import           Prelude
 
-import           Data.Aeson (FromJSON (..), ToJSON (..), object, (.=))
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import           Data.BiMap (BiMap (..), Bimap)
@@ -70,6 +70,7 @@ import qualified Cardano.Ledger.Shelley.Rewards as Shelley
 import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
 import           Cardano.Ledger.Val (Val)
 import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Consensus
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
@@ -687,3 +688,37 @@ instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.KeyHash    'Shelley
 instance Crypto.Crypto crypto => ToJSON (VMap VB VP (Shelley.Credential 'Shelley.Staking   crypto) (Shelley.CompactForm Shelley.Coin)) where
   toJSON = toJSON . fmap fromCompact . VMap.toMap
   toEncoding = toEncoding . fmap fromCompact . VMap.toMap
+
+-----
+
+instance Crypto.Crypto crypto => ToJSON (Consensus.StakeSnapshots crypto) where
+  toJSON = object . stakeSnapshotsToPair
+  toEncoding = pairs . mconcat . stakeSnapshotsToPair
+
+stakeSnapshotsToPair :: (Aeson.KeyValue a, Crypto.Crypto crypto) => Consensus.StakeSnapshots crypto -> [a]
+stakeSnapshotsToPair Consensus.StakeSnapshots
+    { Consensus.ssStakeSnapshots
+    , Consensus.ssMarkTotal
+    , Consensus.ssSetTotal
+    , Consensus.ssGoTotal
+    } =
+    [ "pools" .= ssStakeSnapshots
+    , "activeStakeMark" .= ssMarkTotal
+    , "activeStakeSet" .= ssSetTotal
+    , "activeStakeGo" .= ssGoTotal
+    ]
+
+instance ToJSON (Consensus.StakeSnapshot crypto) where
+  toJSON = object . stakeSnapshotToPair
+  toEncoding = pairs . mconcat . stakeSnapshotToPair
+
+stakeSnapshotToPair :: Aeson.KeyValue a => Consensus.StakeSnapshot crypto -> [a]
+stakeSnapshotToPair Consensus.StakeSnapshot
+    { Consensus.ssMarkPool
+    , Consensus.ssSetPool
+    , Consensus.ssGoPool
+    } =
+    [ "poolStakeMark" .= ssMarkPool
+    , "poolStakeSet" .= ssSetPool
+    , "poolStakeGo" .= ssGoPool
+    ]

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -260,7 +260,7 @@ data QueryInShelleyBasedEra era result where
     -> QueryInShelleyBasedEra era (SerialisedPoolDistribution era)
 
   QueryStakeSnapshot
-    :: PoolId
+    :: Maybe (Set PoolId)
     -> QueryInShelleyBasedEra era (SerialisedStakeSnapshots era)
 
 deriving instance Show (QueryInShelleyBasedEra era result)
@@ -631,8 +631,8 @@ toConsensusQueryShelleyBased erainmode QueryCurrentEpochState =
 toConsensusQueryShelleyBased erainmode (QueryPoolState poolIds) =
     Some (consensusQueryInEraInMode erainmode (Consensus.GetCBOR (Consensus.GetPoolState (Set.map unStakePoolKeyHash <$> poolIds))))
 
-toConsensusQueryShelleyBased erainmode (QueryStakeSnapshot poolId) =
-    Some (consensusQueryInEraInMode erainmode (Consensus.GetCBOR (Consensus.GetStakeSnapshots (Just (Set.singleton (unStakePoolKeyHash poolId))))))
+toConsensusQueryShelleyBased erainmode (QueryStakeSnapshot mPoolIds) =
+    Some (consensusQueryInEraInMode erainmode (Consensus.GetCBOR (Consensus.GetStakeSnapshots (fmap (Set.map unStakePoolKeyHash) mPoolIds))))
 
 toConsensusQueryShelleyBased erainmode (QueryPoolDistribution poolIds) =
     Some (consensusQueryInEraInMode erainmode (Consensus.GetCBOR (Consensus.GetPoolDistr (getPoolIds <$> poolIds))))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -365,6 +365,7 @@ data QueryCmd =
       AnyConsensusModeParams
       NetworkId
       (AllOrOnly [Hash StakePoolKey])
+      (Maybe OutputFile)
   | QueryKesPeriodInfo
       AnyConsensusModeParams
       NetworkId
@@ -513,8 +514,9 @@ data MetadataFile = MetadataFileJSON FilePath
 
   deriving Show
 
-newtype OutputFile
-  = OutputFile FilePath
+newtype OutputFile = OutputFile
+  { unOutputFile :: FilePath
+  }
   deriving Show
 
 newtype PoolMetadataFile = PoolMetadataFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -361,7 +361,7 @@ data QueryCmd =
   | QueryUTxO' AnyConsensusModeParams QueryUTxOFilter NetworkId (Maybe OutputFile)
   | QueryDebugLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeSnapshot' AnyConsensusModeParams NetworkId (Hash StakePoolKey)
+  | QueryStakeSnapshot' AnyConsensusModeParams NetworkId [Hash StakePoolKey]
   | QueryKesPeriodInfo
       AnyConsensusModeParams
       NetworkId

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -361,7 +361,10 @@ data QueryCmd =
   | QueryUTxO' AnyConsensusModeParams QueryUTxOFilter NetworkId (Maybe OutputFile)
   | QueryDebugLedgerState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
   | QueryProtocolState' AnyConsensusModeParams NetworkId (Maybe OutputFile)
-  | QueryStakeSnapshot' AnyConsensusModeParams NetworkId [Hash StakePoolKey]
+  | QueryStakeSnapshot'
+      AnyConsensusModeParams
+      NetworkId
+      (AllOrOnly [Hash StakePoolKey])
   | QueryKesPeriodInfo
       AnyConsensusModeParams
       NetworkId

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1005,6 +1005,7 @@ pQueryCmd =
       <$> pConsensusModeParams
       <*> pNetworkId
       <*> pAllStakePoolsOrOnly
+      <*> pMaybeOutputFile
 
     pQueryPoolState :: Parser QueryCmd
     pQueryPoolState = QueryPoolState'

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -994,7 +994,7 @@ pQueryCmd =
     pQueryStakeSnapshot = QueryStakeSnapshot'
       <$> pConsensusModeParams
       <*> pNetworkId
-      <*> pStakePoolVerificationKeyHash
+      <*> many pStakePoolVerificationKeyHash
 
     pQueryPoolState :: Parser QueryCmd
     pQueryPoolState = QueryPoolState'

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -990,11 +990,21 @@ pQueryCmd =
                             <*> pNetworkId
                             <*> pMaybeOutputFile
 
+    pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+    pAllStakePoolsOrOnly = pAll <|> pOnly
+      where pAll :: Parser (AllOrOnly [Hash StakePoolKey])
+            pAll = Opt.flag' All
+              (  Opt.long "all-stake-pools"
+              <> Opt.help "Query for all stake pools"
+              )
+            pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+            pOnly = Only <$> many pStakePoolVerificationKeyHash
+
     pQueryStakeSnapshot :: Parser QueryCmd
     pQueryStakeSnapshot = QueryStakeSnapshot'
       <$> pConsensusModeParams
       <*> pNetworkId
-      <*> many pStakePoolVerificationKeyHash
+      <*> pAllStakePoolsOrOnly
 
     pQueryPoolState :: Parser QueryCmd
     pQueryPoolState = QueryPoolState'
@@ -2572,10 +2582,12 @@ pStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
 pStakePoolVerificationKeyHash =
     Opt.option
       (pBech32StakePoolId <|> pHexStakePoolId)
-        (  Opt.long "stake-pool-id"
-        <> Opt.metavar "STAKE-POOL-ID"
-        <> Opt.help "Stake pool ID/verification key hash (either \
-                    \Bech32-encoded or hex-encoded)."
+        (   Opt.long "stake-pool-id"
+        <>  Opt.metavar "STAKE_POOL_ID"
+        <>  Opt.help
+            (   "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
+            <>  "Zero or more occurences of this option is allowed."
+            )
         )
   where
     pHexStakePoolId :: ReadM (Hash StakePoolKey)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -686,7 +686,9 @@ runQueryStakeSnapshot (AnyConsensusModeParams cModeParams) network mPoolIds = do
   eInMode <- toEraInMode era cMode
     & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-  let qInMode = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakeSnapshot $ Just $ Set.fromList mPoolIds
+  let qInMode = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakeSnapshot $ case mPoolIds of
+        [] -> Nothing
+        _  -> Just $ Set.fromList mPoolIds
   result <- executeQuery era cModeParams localNodeConnInfo qInMode
   obtainLedgerEraClassConstraints sbe writeStakeSnapshots result
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -38,6 +38,7 @@ module Cardano.CLI.Types
   , VerificationKeyFile (..)
   , Params (..)
   , RequiredSigner (..)
+  , AllOrOnly(..)
   ) where
 
 import           Cardano.Prelude hiding (Word64)
@@ -180,6 +181,8 @@ data OutputFormat
   = OutputFormatHex
   | OutputFormatBech32
   deriving (Eq, Show)
+
+data AllOrOnly a = All | Only a deriving (Eq, Show)
 
 -- | This data structure is used to allow nicely formatted output in the query pool-params command.
 -- params are the current pool parameter settings, futureparams are new parameters, retiringEpoch is the

--- a/doc/stake-pool-operations/10_query_stakepool.md
+++ b/doc/stake-pool-operations/10_query_stakepool.md
@@ -29,8 +29,8 @@ Each snapshot is taken at the end of a different era.  The `go` snapshot is the 
 was taken two epochs earlier, `set` was taken one epoch ago, and `mark` was taken immediately
 before the start of the current epoch.
 
-This command is for debugging purposes only and may fail when used in a memory constrained
-environment due to the size of the ledger state.
+The command accepts zero or more occurences of the `--stake-pool-id` option.  Alternatively, to query
+all pools supply the `--all-stake-pools` option instead.
 
 # Querying for pool parameters
 

--- a/doc/stake-pool-operations/10_query_stakepool.md
+++ b/doc/stake-pool-operations/10_query_stakepool.md
@@ -16,12 +16,18 @@ $ cardano-cli query stake-snapshot \
     --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 \
     --mainnet
 {
-    "poolStakeGo": 40278547538358,
-    "activeStakeGo": 22753958467474959,
-    "poolStakeMark": 40424218559492,
-    "activeStakeMark": 22670949084364797,
-    "poolStakeSet": 39898761956772,
-    "activeStakeSet": 22488877070796904
+  "pools": {
+    "00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114": {
+      "stakeGo": 40278547538358,
+      "stakeMark": 40424218559492,
+      "stakeSet": 39898761956772
+    }
+  },
+  "total": {
+    "stakeGo": 22753958467474959,
+    "stakeMark": 22670949084364797,
+    "stakeSet": 22488877070796904
+  }
 }
 ```
 


### PR DESCRIPTION
Add support for querying of multiple pools.  Note, this changes the JSON structure:

Query for no pools:
```
$ time CARDANO_NODE_SOCKET_PATH=example/main.sock cardano-cli query stake-snapshot --testnet-magic 42
{
    "pools": {}
    "total": {
        "stakeGo": 1800000000000,
        "stakeMark": 1800000000000,
        "stakeSet": 1800000000000
    }
}
CARDANO_NODE_SOCKET_PATH=example/main.sock  query stake-snapshot  42  0.01s user 0.00s system 42% cpu 0.029 total
```

Query for two pools:
```
$ time CARDANO_NODE_SOCKET_PATH=example/main.sock cardano-cli query stake-snapshot --testnet-magic 42 --stake-pool-id 0436087e6f0a3d828d4dadaf0fcbccff3a3d5a2fa8f76a015d991613 --stake-pool-id 67086804da63179eb7972e2be856a6fbbd9e3673e50fecc6efbd12f3
{
    "pools": {
        "0436087e6f0a3d828d4dadaf0fcbccff3a3d5a2fa8f76a015d991613": {
            "stakeGo": 300000000000,
            "stakeMark": 300000000000,
            "stakeSet": 300000000000
        },
        "67086804da63179eb7972e2be856a6fbbd9e3673e50fecc6efbd12f3": {
            "stakeGo": 1200000000000,
            "stakeMark": 1200000000000,
            "stakeSet": 1200000000000
        }
    },
    "total": {
        "stakeGo": 1800000000000,
        "stakeMark": 1800000000000,
        "stakeSet": 1800000000000
    }
}
CARDANO_NODE_SOCKET_PATH=example/main.sock  query stake-snapshot  42      0.01s user 0.01s system 45% cpu 0.028 total
```

Query for all pools:

```
$ time CARDANO_NODE_SOCKET_PATH=example/main.sock cardano-cli query stake-snapshot --testnet-magic 42 --all-stake-pools
{
    "pools": {
        "0436087e6f0a3d828d4dadaf0fcbccff3a3d5a2fa8f76a015d991613": {
            "stakeGo": 300000000000,
            "stakeMark": 300000000000,
            "stakeSet": 300000000000
        },
        "2b8126681160daab09f013163df264274aaa77d4a972e4067e2554b2": {
            "stakeGo": 300000000000,
            "stakeMark": 300000000000,
            "stakeSet": 300000000000
        },
        "67086804da63179eb7972e2be856a6fbbd9e3673e50fecc6efbd12f3": {
            "stakeGo": 1200000000000,
            "stakeMark": 1200000000000,
            "stakeSet": 1200000000000
        }
    },
    "total": {
        "stakeGo": 1800000000000,
        "stakeMark": 1800000000000,
        "stakeSet": 1800000000000
    }
}
CARDANO_NODE_SOCKET_PATH=example/main.sock  query stake-snapshot  42   0.01s user 0.01s system 43% cpu 0.029 total
```

Usage:

```
Usage: cardano-cli query stake-snapshot
            [ --shelley-mode
            | --byron-mode [--epoch-slots NATURAL]
            | --cardano-mode [--epoch-slots NATURAL]
            ]
            (--mainnet | --testnet-magic NATURAL)
            [--all-pools | [--stake-pool-id STAKE_POOL_ID]]

  Obtain the three stake snapshots for a pool, plus the total active stake
  (advanced command)

Available options:
  --shelley-mode           For talking to a node running in Shelley-only mode.
  --byron-mode             For talking to a node running in Byron-only mode.
  --epoch-slots NATURAL    The number of slots per epoch for the Byron era.
                           (default: 21600)
  --cardano-mode           For talking to a node running in full Cardano mode
                           (default).
  --epoch-slots NATURAL    The number of slots per epoch for the Byron era.
                           (default: 21600)
  --mainnet                Use the mainnet magic id.
  --testnet-magic NATURAL  Specify a testnet magic id.
  --all-pools              Query for all pools
  --stake-pool-id STAKE_POOL_ID
                           Stake pool ID/verification key hash (either
                           Bech32-encoded or hex-encoded). Zero or more
                           occurences of this option is allowed.
  -h,--help                Show this help text
```

Implements https://github.com/input-output-hk/cardano-node/issues/4570

Depends on:
* https://github.com/input-output-hk/cardano-node/pull/4250