### PR TITLE
cardano-node:  on startup, trace the configuration through the tracing system

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -326,6 +326,8 @@ handleSimpleNode
 handleSimpleNode runP p2pMode tracers nc onKernel = do
   logStartupWarnings
 
+  traceWith (startupTracer tracers) (StartupConfig nc)
+
   traceWith (startupTracer tracers)
     =<< StartupTime <$> getCurrentTime
 

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -45,6 +45,7 @@ import           Ouroboros.Network.Subscription.Ip (IPSubscriptionTarget (..))
 
 import           Cardano.Api.Protocol.Types (BlockType (..), protocolInfo)
 import           Cardano.Logging
+import           Cardano.Node.Configuration.POM (NodeConfiguration)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol.Types (Protocol (..), SomeConsensusProtocol (..))
 
@@ -68,6 +69,8 @@ data StartupTrace blk =
   | StartupP2PInfo DiffusionMode
 
   | StartupTime UTCTime
+
+  | StartupConfig NodeConfiguration
 
   | StartupNetworkMagic NetworkMagic
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -126,6 +126,7 @@ namesStartupInfo = \case
   StartupInfo {}                            -> ["Info"]
   StartupP2PInfo {}                         -> ["P2PInfo"]
   StartupTime {}                            -> ["Time"]
+  StartupConfig {}                          -> ["Config"]
   StartupNetworkMagic {}                    -> ["NetworkMagic"]
   StartupSocketConfigError {}               -> ["SocketConfigError"]
   StartupDBValidation {}                    -> ["DBValidation"]
@@ -186,6 +187,10 @@ instance ( Show (BlockNodeToNodeVersion blk)
                                          . utcTimeToPOSIXSeconds
                                          $ time
                                          )
+               ]
+  forMachine _dtal (StartupConfig nc) =
+      mconcat [ "kind" .= String "StartupConfig"
+               , "config" .= String (showT nc)
                ]
   forMachine _dtal (StartupNetworkMagic networkMagic) =
       mconcat [ "kind" .= String "StartupNetworkMagic"
@@ -294,6 +299,8 @@ ppStartupInfoTrace (StartupTime time) =
        . utcTimeToPOSIXSeconds
        $ time
      )
+ppStartupInfoTrace (StartupConfig nc) =
+  "config: " <> showT nc
 ppStartupInfoTrace (StartupNetworkMagic networkMagic) =
   "network magic: " <> showT (unNetworkMagic networkMagic)
 


### PR DESCRIPTION
cardano-node:  on startup, trace the configuration through the tracing system