### PR TITLE
Append change instead of prepending it

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for cardano-api
 
+## vNext
+
+### Features
+
+- Append, not prepend change output when balancing a transaction ([PR 4343](https://github.com/input-output-hk/cardano-node/pull/4343))
+
 ## 1.33.0 -- December 2021
 ## 1.32.1 -- November 2021
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -1129,7 +1129,9 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
    accountForNoChange change@(TxOut _ balance _ _) rest =
      case txOutValueToLovelace balance of
        Lovelace 0 -> rest
-       _ -> change : rest
+       -- We append change at the end so a client can predict the indexes
+       -- of the outputs
+       _ -> rest ++ [change]
 
    balanceCheck :: TxOutValue era -> Either TxBodyErrorAutoBalance ()
    balanceCheck balance


### PR DESCRIPTION
It's desirable for a client to be able to predict the index of outputs.
As such we append change to the end so that the index of other outputs
doesn't changed based on whether there's change or not.

Resolves https://github.com/input-output-hk/cardano-node/issues/3725