### PR TITLE
Expose module Cardano.Api.Script from cardano-api

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -108,6 +108,7 @@ module Cardano.Api.Shelley
     ProtocolParametersError(..),
 
     -- * Scripts
+    fromShelleyBasedScript,
     toShelleyScript,
     toShelleyMultiSig,
     fromShelleyMultiSig,


### PR DESCRIPTION
I'm writing an indexer for the blockchain from script hash to script https://github.com/input-output-hk/plutus-apps/pull/629 and would like to use the conversion functions from ledger to cardano-api scripts in Cardano.Api.Script, would it be ok to export the module?