### PR TITLE
Update ouroboros-network and cardano-ledger dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: f49879a79098d9372d63baa13b94a941a56eda34
-  --sha256: 0i9x66yqkrvx2w79dy6lzlya82yxc8567rgjj828vc2d46d6nvx6
+  tag: 49613f11e034485c8377945c86c0465726c0860c
+  --sha256: 0gxb9xghsacr0qaljhq3qzvmb2f1wwmly89prwqy4fdm9mvqiq95
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -227,7 +227,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 6ea36cf2247ac0bc33e08c327abec34dfd05bd99
+  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
   --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
   subdir:
     cardano-prelude
@@ -263,14 +263,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
+  tag: 9128bfcc044fc882decb0cf112545abf9bc2d615
+  --sha256: 0a6zq8nfyadd7vdfl2y5l4ixyh0pkgjsw1p0ijj9vlm6x39jhkbc
   subdir:
     monoidal-synchronisation
     network-mux
     ouroboros-consensus
     ouroboros-consensus-byron
     ouroboros-consensus-cardano
+    ouroboros-consensus-cardano-tools
     ouroboros-consensus-protocol
     ouroboros-consensus-shelley
     ouroboros-network
@@ -300,8 +301,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: f680ac6979e069fcc013e4389ee607ff5fa6672f
-  --sha256: 180jq8hd0jlg48ya7b5yw3bnd2d5czy0b1agy9ng3mgnzpyq747i
+  tag: 8ab4c3355c5fdf67dcf6acc1f5a14668d5e6f0a9
+  --sha256: 12d6bndmj0dxl6xlaqmf78326yp5hw093bmybmqfpdkvk4mgz03j
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -127,6 +127,7 @@ library
                       , formatting
                       , iproute
                       , memory
+                      , microlens
                       , network
                       , nothunks
                       , optparse-applicative-fork
@@ -186,6 +187,7 @@ library gen
                       , cardano-prelude
                       , containers
                       , hedgehog
+                      , microlens
                       , plutus-core
                       , cardano-ledger-shelley
                       , text

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -128,8 +128,8 @@ import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Shelley.Spec
 import qualified Cardano.Ledger.Keys as SL
 import qualified Cardano.Ledger.PoolDistr as SL
-import qualified Cardano.Ledger.Shelley.API as ShelleyAPI
 import qualified Cardano.Ledger.Shelley.Genesis as Shelley.Spec
+import           Cardano.Ledger.Shelley.Rules.NewEpoch ()
 import qualified Cardano.Protocol.TPraos.API as TPraos
 import           Cardano.Protocol.TPraos.BHeader (checkLeaderNatValue)
 import qualified Cardano.Protocol.TPraos.BHeader as TPraos
@@ -167,6 +167,8 @@ import qualified Ouroboros.Network.Block
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as CS
 import qualified Ouroboros.Network.Protocol.ChainSync.ClientPipelined as CSP
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+import qualified Cardano.Ledger.Shelley.API as ShelleyAPI
+import Cardano.Ledger.SafeHash (HashAnnotated)
 
 data InitialLedgerStateError
   = ILSEConfigFile Text
@@ -1320,6 +1322,7 @@ nextEpochEligibleLeadershipSlots
   => Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Spec.Credential 'Shelley.Spec.Staking (Cardano.Ledger.Era.Crypto (ShelleyLedgerEra era)))
   => FromCBOR (Consensus.ChainDepState (Api.ConsensusProtocol era))
   => Consensus.PraosProtocolSupportsNode (Api.ConsensusProtocol era)
+  => HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
   => ShelleyBasedEra era
   -> ShelleyGenesis Shelley.StandardShelley
   -> SerialisedCurrentEpochState era
@@ -1502,6 +1505,7 @@ currentEpochEligibleLeadershipSlots :: forall era ledgerera. ()
   => Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Spec.Credential 'Shelley.Spec.Staking (Cardano.Ledger.Era.Crypto (ShelleyLedgerEra era)))
  -- => Ledger.Crypto ledgerera ~ Shelley.StandardCrypto
   => FromCBOR (Consensus.ChainDepState (Api.ConsensusProtocol era))
+  => HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
   -- => Consensus.ChainDepState (ConsensusProtocol era) ~ Consensus.ChainDepState (ConsensusProtocol era)
   => ShelleyBasedEra era
   -> ShelleyGenesis Shelley.StandardShelley

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -10,73 +10,74 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Cardano.Api.Orphans () where
 
-import           Prelude
-
-import           Data.Aeson (FromJSON (..), ToJSON (..), object, (.=))
-import qualified Data.Aeson as Aeson
-import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
-import           Data.BiMap (BiMap (..), Bimap)
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Short as Short
-import qualified Data.Map.Strict as Map
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           Data.UMap (Trip (Triple), UMap (UnifiedMap))
-import           Data.VMap (VB, VMap, VP)
-import qualified Data.VMap as VMap
-
-import qualified Cardano.Ledger.Babbage as Babbage
-import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Compactible (Compactible (fromCompact))
-import qualified Cardano.Ledger.Era as Ledger
-import qualified Cardano.Ledger.Shelley.PoolRank as Shelley
-import           Cardano.Ledger.UnifiedMap (UnifiedMap)
-import           Cardano.Slotting.Slot (SlotNo (..))
-import           Cardano.Slotting.Time (SystemStart (..))
-import           Control.State.Transition (STS (State))
-
+import Cardano.Api.Script
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import Cardano.Ledger.Babbage (BabbageTxOut)
+import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
+import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Coin as Shelley
+import Cardano.Ledger.Compactible (Compactible (fromCompact))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Crypto
+import qualified Cardano.Ledger.Era as Ledger
+import Cardano.Ledger.Mary.Value (MaryValue (..))
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.PoolDistr as Ledger
 import qualified Cardano.Ledger.SafeHash as SafeHash
+import Cardano.Ledger.Shelley.API (ShelleyTxOut (..))
 import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Cardano.Ledger.Shelley.Orphans as Shelley
 import qualified Cardano.Ledger.Shelley.EpochBoundary as ShelleyEpoch
 import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyLedger
-import           Cardano.Ledger.Shelley.PParams (PParamsUpdate)
-import qualified Cardano.Ledger.Shelley.Rewards as Shelley
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
+import qualified Cardano.Ledger.Shelley.PoolRank as Shelley
 import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
+import qualified Cardano.Ledger.Shelley.Rewards as Shelley
+import Cardano.Ledger.UnifiedMap (UnifiedMap)
+import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Time (SystemStart (..))
+import Control.State.Transition (STS (State))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
+import Data.BiMap (BiMap (..), Bimap)
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Short as Short
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.UMap (Trip (Triple), UMap (UnifiedMap))
+import Data.VMap (VB, VMap, VP)
+import qualified Data.VMap as VMap
 import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
-
-import           Cardano.Api.Script
+import Prelude
+import Cardano.Ledger.Core (Era)
+import Cardano.Ledger.Val (Val)
+import Cardano.Ledger.Alonzo (AlonzoScript)
+import Cardano.Ledger.Babbage.PParams (BabbagePParamsUpdate, BabbagePParams)
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
 
-instance ToJSON (Mary.Value era) where
+instance ToJSON (MaryValue era) where
   toJSON = object . toMaryValuePairs
   toEncoding = Aeson.pairs . mconcat . toMaryValuePairs
 
-toMaryValuePairs :: Aeson.KeyValue a => Mary.Value crypto -> [a]
-toMaryValuePairs (Mary.Value !l !ps) =
-  [ "lovelace" .= l
-  , "policies" .= ps
+toMaryValuePairs :: Aeson.KeyValue a => MaryValue crypto -> [a]
+toMaryValuePairs (MaryValue !l !ps) =
+  [ "lovelace" .= l,
+    "policies" .= ps
   ]
 
 instance ToJSONKey Mary.AssetName where
@@ -101,28 +102,31 @@ instance ToJSON Shelley.AccountState where
 
 toAccountStatePairs :: Aeson.KeyValue a => ShelleyLedger.AccountState -> [a]
 toAccountStatePairs (Shelley.AccountState !tr !rs) =
-  [ "treasury" .= tr
-  , "reserves" .= rs
+  [ "treasury" .= tr,
+    "reserves" .= rs
   ]
 
-instance forall era.
-         ( Consensus.ShelleyBasedEra era
-         , ToJSON (Core.TxOut era)
-         , ToJSON (Core.PParams era)
-         , ToJSON (Core.PParamsDelta era)
-         ) => ToJSON (Shelley.EpochState era) where
+instance
+  forall era.
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (Core.PParams era),
+    ToJSON (Core.PParamsUpdate era)
+  ) =>
+  ToJSON (Shelley.EpochState era)
+  where
   toJSON = object . toEpochStatePairs
   toEncoding = Aeson.pairs . mconcat . toEpochStatePairs
 
 toEpochStatePairs ::
-  ( Consensus.ShelleyBasedEra era
-  , ToJSON (Core.TxOut era)
-  , ToJSON (Core.PParamsDelta era)
-  , ToJSON (Core.PParams era)
-  , Aeson.KeyValue a
-  )
-  => ShelleyLedger.EpochState era
-  -> [a]
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (Core.PParamsUpdate era),
+    ToJSON (Core.PParams era),
+    Aeson.KeyValue a
+  ) =>
+  ShelleyLedger.EpochState era ->
+  [a]
 toEpochStatePairs eState =
   let !esAccountState = Shelley.esAccountState eState
       !esSnapshots = Shelley.esSnapshots eState
@@ -130,33 +134,37 @@ toEpochStatePairs eState =
       !esPrevPp = Shelley.esPrevPp eState
       !esPp = Shelley.esPp eState
       !esNonMyopic = Shelley.esNonMyopic eState
-  in  [ "esAccountState" .= esAccountState
-      , "esSnapshots" .= esSnapshots
-      , "esLState" .= esLState
-      , "esPrevPp" .= esPrevPp
-      , "esPp" .= esPp
-      , "esNonMyopic" .= esNonMyopic
+   in [ "esAccountState" .= esAccountState,
+        "esSnapshots" .= esSnapshots,
+        "esLState" .= esLState,
+        "esPrevPp" .= esPrevPp,
+        "esPp" .= esPp,
+        "esNonMyopic" .= esNonMyopic
       ]
 
-
-instance ( Consensus.ShelleyBasedEra era
-         , ToJSON (Core.TxOut era)
-         , ToJSON (Core.PParamsDelta era)
-         ) => ToJSON (Shelley.LedgerState era) where
+instance
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (Core.PParamsUpdate era)
+  ) =>
+  ToJSON (Shelley.LedgerState era)
+  where
   toJSON = object . toLedgerStatePairs
   toEncoding = Aeson.pairs . mconcat . toLedgerStatePairs
 
 toLedgerStatePairs ::
-  ( Consensus.ShelleyBasedEra era
-  , ToJSON (Core.TxOut era)
-  , ToJSON (Core.PParamsDelta era)
-  , Aeson.KeyValue a
-  ) => ShelleyLedger.LedgerState era -> [a]
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (Core.PParamsUpdate era),
+    Aeson.KeyValue a
+  ) =>
+  ShelleyLedger.LedgerState era ->
+  [a]
 toLedgerStatePairs lState =
   let !lsUTxOState = Shelley.lsUTxOState lState
       !lsDPState = Shelley.lsDPState lState
-  in  [ "utxoState" .= lsUTxOState
-      , "delegationState" .= lsDPState
+   in [ "utxoState" .= lsUTxOState,
+        "delegationState" .= lsDPState
       ]
 
 instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.IncrementalStake crypto) where
@@ -164,170 +172,195 @@ instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.IncrementalStake crypto) 
   toEncoding = Aeson.pairs . mconcat . toIncrementalStakePairs
 
 toIncrementalStakePairs ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyLedger.IncrementalStake crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyLedger.IncrementalStake crypto ->
+  [a]
 toIncrementalStakePairs iStake =
   let !credentials = Map.toList (ShelleyLedger.credMap iStake)
       !pointers = Map.toList (ShelleyLedger.ptrMap iStake)
-  in  [ "credentials" .= credentials
-      , "pointers" .= pointers
+   in [ "credentials" .= credentials,
+        "pointers" .= pointers
       ]
 
-instance ( Consensus.ShelleyBasedEra era
-         , ToJSON (Core.TxOut era)
-         , ToJSON (Core.PParamsDelta era)
-         ) => ToJSON (Shelley.UTxOState era) where
+instance
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (Core.PParamsUpdate era)
+  ) =>
+  ToJSON (Shelley.UTxOState era)
+  where
   toJSON = object . toUtxoStatePairs
   toEncoding = Aeson.pairs . mconcat . toUtxoStatePairs
 
 toUtxoStatePairs ::
-  ( Aeson.KeyValue a
-  , Consensus.ShelleyBasedEra era
-  , ToJSON (Core.TxOut era)
-  , ToJSON (State (Core.EraRule "PPUP" era))
-  ) => ShelleyLedger.UTxOState era -> [a]
+  ( Aeson.KeyValue a,
+    Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era),
+    ToJSON (State (Core.EraRule "PPUP" era))
+  ) =>
+  ShelleyLedger.UTxOState era ->
+  [a]
 toUtxoStatePairs utxoState =
   let !utxo = Shelley._utxo utxoState
       !deposited = Shelley._deposited utxoState
       !fees = Shelley._fees utxoState
       !ppups = Shelley._ppups utxoState
       !stakeDistro = Shelley._stakeDistro utxoState
-  in  [ "utxo" .= utxo
-      , "deposited" .= deposited
-      , "fees" .= fees
-      , "ppups" .= ppups
-      , "stake" .= stakeDistro
+   in [ "utxo" .= utxo,
+        "deposited" .= deposited,
+        "fees" .= fees,
+        "ppups" .= ppups,
+        "stake" .= stakeDistro
       ]
 
-instance ( ToJSON (Core.PParamsDelta era)
-         , Shelley.UsesPParams era
-         ) => ToJSON (Shelley.PPUPState era) where
+instance
+  ( ToJSON (Core.PParamsUpdate era)
+  , Era era
+  ) =>
+  ToJSON (Shelley.PPUPState era)
+  where
   toJSON = object . toPpupStatePairs
   toEncoding = Aeson.pairs . mconcat . toPpupStatePairs
 
 toPpupStatePairs ::
-  ( Aeson.KeyValue a
-  , ToJSON (Core.PParamsDelta era)
-  , Shelley.UsesPParams era
-  ) => ShelleyLedger.PPUPState era -> [a]
+  ( Aeson.KeyValue a,
+    ToJSON (Core.PParamsUpdate era),
+    Era era
+  ) =>
+  ShelleyLedger.PPUPState era ->
+  [a]
 toPpupStatePairs ppUpState =
   let !proposals = Shelley.proposals ppUpState
       !futureProposals = Shelley.futureProposals ppUpState
-  in  [ "proposals" .= proposals
-      , "futureProposals" .= futureProposals
+   in [ "proposals" .= proposals,
+        "futureProposals" .= futureProposals
       ]
 
-instance ( ToJSON (Core.PParamsDelta era)
-         , Shelley.UsesPParams era
-         ) => ToJSON (Shelley.ProposedPPUpdates era) where
+instance
+  ( ToJSON (Core.PParamsUpdate era)
+  , Era era
+  ) =>
+  ToJSON (Shelley.ProposedPPUpdates era)
+  where
   toJSON (Shelley.ProposedPPUpdates ppUpdates) = toJSON $ Map.toList ppUpdates
   toEncoding (Shelley.ProposedPPUpdates ppUpdates) = toEncoding $ Map.toList ppUpdates
 
-instance ToJSON (PParamsUpdate era) where
+instance ToJSON (ShelleyPParamsUpdate era) where
   toJSON pp =
     Aeson.object $
-        [ "minFeeA"               .= x | x <- mbfield (Shelley._minfeeA pp) ]
-     ++ [ "minFeeB"               .= x | x <- mbfield (Shelley._minfeeB pp) ]
-     ++ [ "maxBlockBodySize"      .= x | x <- mbfield (Shelley._maxBBSize pp) ]
-     ++ [ "maxTxSize"             .= x | x <- mbfield (Shelley._maxTxSize pp) ]
-     ++ [ "maxBlockHeaderSize"    .= x | x <- mbfield (Shelley._maxBHSize pp) ]
-     ++ [ "keyDeposit"            .= x | x <- mbfield (Shelley._keyDeposit pp) ]
-     ++ [ "poolDeposit"           .= x | x <- mbfield (Shelley._poolDeposit pp) ]
-     ++ [ "eMax"                  .= x | x <- mbfield (Shelley._eMax pp) ]
-     ++ [ "nOpt"                  .= x | x <- mbfield (Shelley._nOpt pp) ]
-     ++ [ "a0"                    .= x | x <- mbfield (Shelley._a0 pp) ]
-     ++ [ "rho"                   .= x | x <- mbfield (Shelley._rho pp) ]
-     ++ [ "tau"                   .= x | x <- mbfield (Shelley._tau pp) ]
-     ++ [ "decentralisationParam" .= x | x <- mbfield (Shelley._d pp) ]
-     ++ [ "extraEntropy"          .= x | x <- mbfield (Shelley._extraEntropy pp) ]
-     ++ [ "protocolVersion"       .= x | x <- mbfield (Shelley._protocolVersion pp) ]
-     ++ [ "minUTxOValue"          .= x | x <- mbfield (Shelley._minUTxOValue pp) ]
-     ++ [ "minPoolCost"           .= x | x <- mbfield (Shelley._minPoolCost pp) ]
+      ["minFeeA" .= x | x <- mbfield (Shelley._minfeeA pp)]
+        ++ ["minFeeB" .= x | x <- mbfield (Shelley._minfeeB pp)]
+        ++ ["maxBlockBodySize" .= x | x <- mbfield (Shelley._maxBBSize pp)]
+        ++ ["maxTxSize" .= x | x <- mbfield (Shelley._maxTxSize pp)]
+        ++ ["maxBlockHeaderSize" .= x | x <- mbfield (Shelley._maxBHSize pp)]
+        ++ ["keyDeposit" .= x | x <- mbfield (Shelley._keyDeposit pp)]
+        ++ ["poolDeposit" .= x | x <- mbfield (Shelley._poolDeposit pp)]
+        ++ ["eMax" .= x | x <- mbfield (Shelley._eMax pp)]
+        ++ ["nOpt" .= x | x <- mbfield (Shelley._nOpt pp)]
+        ++ ["a0" .= x | x <- mbfield (Shelley._a0 pp)]
+        ++ ["rho" .= x | x <- mbfield (Shelley._rho pp)]
+        ++ ["tau" .= x | x <- mbfield (Shelley._tau pp)]
+        ++ ["decentralisationParam" .= x | x <- mbfield (Shelley._d pp)]
+        ++ ["extraEntropy" .= x | x <- mbfield (Shelley._extraEntropy pp)]
+        ++ ["protocolVersion" .= x | x <- mbfield (Shelley._protocolVersion pp)]
+        ++ ["minUTxOValue" .= x | x <- mbfield (Shelley._minUTxOValue pp)]
+        ++ ["minPoolCost" .= x | x <- mbfield (Shelley._minPoolCost pp)]
 
-instance ToJSON (Babbage.PParamsUpdate era) where
+instance ToJSON (BabbagePParamsUpdate era) where
   toJSON pp =
     Aeson.object $
-        [ "minFeeA"               .= x | x <- mbfield (Babbage._minfeeA pp) ]
-     ++ [ "minFeeB"               .= x | x <- mbfield (Babbage._minfeeB pp) ]
-     ++ [ "maxBlockBodySize"      .= x | x <- mbfield (Babbage._maxBBSize pp) ]
-     ++ [ "maxTxSize"             .= x | x <- mbfield (Babbage._maxTxSize pp) ]
-     ++ [ "maxBlockHeaderSize"    .= x | x <- mbfield (Babbage._maxBHSize pp) ]
-     ++ [ "keyDeposit"            .= x | x <- mbfield (Babbage._keyDeposit pp) ]
-     ++ [ "poolDeposit"           .= x | x <- mbfield (Babbage._poolDeposit pp) ]
-     ++ [ "eMax"                  .= x | x <- mbfield (Babbage._eMax pp) ]
-     ++ [ "nOpt"                  .= x | x <- mbfield (Babbage._nOpt pp) ]
-     ++ [ "a0"                    .= x | x <- mbfield (Babbage._a0 pp) ]
-     ++ [ "rho"                   .= x | x <- mbfield (Babbage._rho pp) ]
-     ++ [ "tau"                   .= x | x <- mbfield (Babbage._tau pp) ]
-     ++ [ "protocolVersion"       .= x | x <- mbfield (Babbage._protocolVersion pp) ]
-     ++ [ "minPoolCost"           .= x | x <- mbfield (Babbage._minPoolCost pp) ]
-     ++ [ "coinsPerUTxOByte"      .= x | x <- mbfield (Babbage._coinsPerUTxOByte pp) ]
-     ++ [ "costmdls"              .= x | x <- mbfield (Babbage._costmdls pp) ]
-     ++ [ "prices"                .= x | x <- mbfield (Babbage._prices pp) ]
-     ++ [ "maxTxExUnits"          .= x | x <- mbfield (Babbage._maxTxExUnits pp) ]
-     ++ [ "maxBlockExUnits"       .= x | x <- mbfield (Babbage._maxBlockExUnits pp) ]
-     ++ [ "maxValSize"            .= x | x <- mbfield (Babbage._maxValSize pp) ]
-     ++ [ "collateralPercentage"  .= x | x <- mbfield (Babbage._collateralPercentage pp) ]
-     ++ [ "maxCollateralInputs"   .= x | x <- mbfield (Babbage._maxCollateralInputs pp) ]
+      ["minFeeA" .= x | x <- mbfield (Babbage._minfeeA pp)]
+        ++ ["minFeeB" .= x | x <- mbfield (Babbage._minfeeB pp)]
+        ++ ["maxBlockBodySize" .= x | x <- mbfield (Babbage._maxBBSize pp)]
+        ++ ["maxTxSize" .= x | x <- mbfield (Babbage._maxTxSize pp)]
+        ++ ["maxBlockHeaderSize" .= x | x <- mbfield (Babbage._maxBHSize pp)]
+        ++ ["keyDeposit" .= x | x <- mbfield (Babbage._keyDeposit pp)]
+        ++ ["poolDeposit" .= x | x <- mbfield (Babbage._poolDeposit pp)]
+        ++ ["eMax" .= x | x <- mbfield (Babbage._eMax pp)]
+        ++ ["nOpt" .= x | x <- mbfield (Babbage._nOpt pp)]
+        ++ ["a0" .= x | x <- mbfield (Babbage._a0 pp)]
+        ++ ["rho" .= x | x <- mbfield (Babbage._rho pp)]
+        ++ ["tau" .= x | x <- mbfield (Babbage._tau pp)]
+        ++ ["protocolVersion" .= x | x <- mbfield (Babbage._protocolVersion pp)]
+        ++ ["minPoolCost" .= x | x <- mbfield (Babbage._minPoolCost pp)]
+        ++ ["coinsPerUTxOByte" .= x | x <- mbfield (Babbage._coinsPerUTxOByte pp)]
+        ++ ["costmdls" .= x | x <- mbfield (Babbage._costmdls pp)]
+        ++ ["prices" .= x | x <- mbfield (Babbage._prices pp)]
+        ++ ["maxTxExUnits" .= x | x <- mbfield (Babbage._maxTxExUnits pp)]
+        ++ ["maxBlockExUnits" .= x | x <- mbfield (Babbage._maxBlockExUnits pp)]
+        ++ ["maxValSize" .= x | x <- mbfield (Babbage._maxValSize pp)]
+        ++ ["collateralPercentage" .= x | x <- mbfield (Babbage._collateralPercentage pp)]
+        ++ ["maxCollateralInputs" .= x | x <- mbfield (Babbage._maxCollateralInputs pp)]
 
-instance ToJSON (Babbage.PParams (Babbage.BabbageEra Consensus.StandardCrypto)) where
+instance ToJSON (BabbagePParams (Babbage.BabbageEra Consensus.StandardCrypto)) where
   toJSON pp =
     Aeson.object
-      [ "minFeeA" .= Babbage._minfeeA pp
-      , "minFeeB" .= Babbage._minfeeB pp
-      , "maxBlockBodySize" .= Babbage._maxBBSize pp
-      , "maxTxSize" .= Babbage._maxTxSize pp
-      , "maxBlockHeaderSize" .= Babbage._maxBHSize pp
-      , "keyDeposit" .= Babbage._keyDeposit pp
-      , "poolDeposit" .= Babbage._poolDeposit pp
-      , "eMax" .= Babbage._eMax pp
-      , "nOpt" .= Babbage._nOpt pp
-      , "a0" .= Babbage._a0 pp
-      , "rho" .= Babbage._rho pp
-      , "tau" .= Babbage._tau pp
-      , "protocolVersion" .= Babbage._protocolVersion pp
-      , "minPoolCost" .= Babbage._minPoolCost pp
-      , "coinsPerUTxOByte" .= Babbage._coinsPerUTxOByte pp
-      , "costmdls" .= Babbage._costmdls pp
-      , "prices" .= Babbage._prices pp
-      , "maxTxExUnits" .= Babbage._maxTxExUnits pp
-      , "maxBlockExUnits" .= Babbage._maxBlockExUnits pp
-      , "maxValSize" .= Babbage._maxValSize pp
-      , "collateralPercentage" .= Babbage._collateralPercentage pp
-      , "maxCollateralInputs" .= Babbage._maxCollateralInputs pp
+      [ "minFeeA" .= Babbage._minfeeA pp,
+        "minFeeB" .= Babbage._minfeeB pp,
+        "maxBlockBodySize" .= Babbage._maxBBSize pp,
+        "maxTxSize" .= Babbage._maxTxSize pp,
+        "maxBlockHeaderSize" .= Babbage._maxBHSize pp,
+        "keyDeposit" .= Babbage._keyDeposit pp,
+        "poolDeposit" .= Babbage._poolDeposit pp,
+        "eMax" .= Babbage._eMax pp,
+        "nOpt" .= Babbage._nOpt pp,
+        "a0" .= Babbage._a0 pp,
+        "rho" .= Babbage._rho pp,
+        "tau" .= Babbage._tau pp,
+        "protocolVersion" .= Babbage._protocolVersion pp,
+        "minPoolCost" .= Babbage._minPoolCost pp,
+        "coinsPerUTxOByte" .= Babbage._coinsPerUTxOByte pp,
+        "costmdls" .= Babbage._costmdls pp,
+        "prices" .= Babbage._prices pp,
+        "maxTxExUnits" .= Babbage._maxTxExUnits pp,
+        "maxBlockExUnits" .= Babbage._maxBlockExUnits pp,
+        "maxValSize" .= Babbage._maxValSize pp,
+        "collateralPercentage" .= Babbage._collateralPercentage pp,
+        "maxCollateralInputs" .= Babbage._maxCollateralInputs pp
       ]
 
 mbfield :: StrictMaybe a -> [a]
-mbfield SNothing  = []
+mbfield SNothing = []
 mbfield (SJust x) = [x]
 
-instance ( Ledger.Era era
-         , ToJSON (Core.Value era)
-         , ToJSON (Babbage.Datum era)
-         , ToJSON (Core.Script era)
-         , Ledger.Crypto era ~ Consensus.StandardCrypto
-         ) => ToJSON (Babbage.TxOut era) where
+instance
+  ( Ledger.Era era,
+    ToJSON (Core.Value era),
+    ToJSON (Babbage.Datum era),
+    ToJSON (Core.Script era),
+    Val (Core.Value era),
+    Ledger.Crypto era ~ Consensus.StandardCrypto
+  ) =>
+  ToJSON (BabbageTxOut era)
+  where
   toJSON = object . toBabbageTxOutPairs
   toEncoding = Aeson.pairs . mconcat . toBabbageTxOutPairs
 
 toBabbageTxOutPairs ::
-  ( Aeson.KeyValue a
-  , Ledger.Era era
-  , ToJSON (Core.Value era)
-  , ToJSON (Core.Script era)
-  , Ledger.Crypto era ~ Consensus.StandardCrypto
-  ) => Babbage.TxOut era -> [a]
-toBabbageTxOutPairs (Babbage.TxOut !addr !val !dat !mRefScript) =
-  [ "address" .= addr
-  , "value" .= val
-  , "datum" .= dat
-  , "referenceScript" .= mRefScript
+  ( Aeson.KeyValue a,
+    Ledger.Era era,
+    ToJSON (Core.Value era),
+    ToJSON (Core.Script era),
+    Ledger.Crypto era ~ Consensus.StandardCrypto,
+    Val (Core.Value era)
+  ) =>
+  BabbageTxOut era ->
+  [a]
+toBabbageTxOutPairs (BabbageTxOut !addr !val !dat !mRefScript) =
+  [ "address" .= addr,
+    "value" .= val,
+    "datum" .= dat,
+    "referenceScript" .= mRefScript
   ]
 
-instance ( Ledger.Era era
-         , Ledger.Crypto era ~ Consensus.StandardCrypto
-         ) => ToJSON (Babbage.Datum era) where
+instance
+  ( Ledger.Era era,
+    Ledger.Crypto era ~ Consensus.StandardCrypto
+  ) =>
+  ToJSON (Babbage.Datum era)
+  where
   toJSON d =
     case Alonzo.datumDataHash d of
       SNothing -> Aeson.Null
@@ -337,9 +370,7 @@ instance ( Ledger.Era era
       SNothing -> toEncoding Aeson.Null
       SJust dH -> toEncoding $ ScriptDataHash dH
 
-
-
-instance ToJSON (Alonzo.Script (Babbage.BabbageEra Consensus.StandardCrypto)) where
+instance ToJSON (AlonzoScript (Babbage.BabbageEra Consensus.StandardCrypto)) where
   toJSON = Aeson.String . Text.decodeUtf8 . B16.encode . CBOR.serialize'
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.DPState crypto) where
@@ -347,14 +378,16 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.DPState crypto) where
   toEncoding = Aeson.pairs . mconcat . toDpStatePairs
 
 toDpStatePairs ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyLedger.DPState crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyLedger.DPState crypto ->
+  [a]
 toDpStatePairs dpState =
   let !dstate = Shelley.dpsDState dpState
       !pstate = Shelley.dpsPState dpState
-  in  [ "dstate" .= dstate
-      , "pstate" .= pstate
+   in [ "dstate" .= dstate,
+        "pstate" .= pstate
       ]
 
 instance (ToJSON coin, ToJSON ptr, ToJSON pool) => ToJSON (Trip coin ptr pool) where
@@ -362,15 +395,17 @@ instance (ToJSON coin, ToJSON ptr, ToJSON pool) => ToJSON (Trip coin ptr pool) w
   toEncoding = Aeson.pairs . mconcat . toTripPair
 
 toTripPair ::
-  ( Aeson.KeyValue a
-  , ToJSON coin
-  , ToJSON ptr
-  , ToJSON pool
-  ) => Trip coin ptr pool -> [a]
+  ( Aeson.KeyValue a,
+    ToJSON coin,
+    ToJSON ptr,
+    ToJSON pool
+  ) =>
+  Trip coin ptr pool ->
+  [a]
 toTripPair (Triple !coin !ptr !pool) =
-  [ "coin" .= coin
-  , "ptr" .= ptr
-  , "pool" .= pool
+  [ "coin" .= coin,
+    "ptr" .= ptr,
+    "pool" .= pool
   ]
 
 instance Crypto.Crypto crypto => ToJSON (UnifiedMap crypto) where
@@ -378,17 +413,19 @@ instance Crypto.Crypto crypto => ToJSON (UnifiedMap crypto) where
   toEncoding = Aeson.pairs . mconcat . toUnifiedMapPair
 
 toUnifiedMapPair ::
-  ( Aeson.KeyValue a
-  , ToJSON coin
-  , ToJSON ptr
-  , ToJSON pool
-  , ToJSON cred
-  , ToJSONKey cred
-  , ToJSONKey ptr
-  ) => UMap coin cred pool ptr -> [a]
+  ( Aeson.KeyValue a,
+    ToJSON coin,
+    ToJSON ptr,
+    ToJSON pool,
+    ToJSON cred,
+    ToJSONKey cred,
+    ToJSONKey ptr
+  ) =>
+  UMap coin cred pool ptr ->
+  [a]
 toUnifiedMapPair (UnifiedMap !m1 !m2) =
-  [ "credentials" .= m1
-  , "pointers" .= m2
+  [ "credentials" .= m1,
+    "pointers" .= m2
   ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.DState crypto) where
@@ -396,25 +433,28 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.DState crypto) where
   toEncoding = Aeson.pairs . mconcat . toDStatePair
 
 toDStatePair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyLedger.DState crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyLedger.DState crypto ->
+  [a]
 toDStatePair dState =
   let !unifiedRewards = Shelley._unified dState
       !fGenDelegs = Map.toList (Shelley._fGenDelegs dState)
       !genDelegs = Shelley._genDelegs dState
       !irwd = Shelley._irwd dState
-  in  [ "unifiedRewards" .= unifiedRewards
-      , "fGenDelegs" .= fGenDelegs
-      , "genDelegs" .= genDelegs
-      , "irwd" .= irwd
+   in [ "unifiedRewards" .= unifiedRewards,
+        "fGenDelegs" .= fGenDelegs,
+        "genDelegs" .= genDelegs,
+        "irwd" .= irwd
       ]
 
 instance Crypto.Crypto crypto => ToJSON (ShelleyLedger.FutureGenDeleg crypto) where
   toJSON fGenDeleg =
-    object [ "fGenDelegSlot" .= ShelleyLedger.fGenDelegSlot fGenDeleg
-           , "fGenDelegGenKeyHash" .= ShelleyLedger.fGenDelegGenKeyHash fGenDeleg
-           ]
+    object
+      [ "fGenDelegSlot" .= ShelleyLedger.fGenDelegSlot fGenDeleg,
+        "fGenDelegGenKeyHash" .= ShelleyLedger.fGenDelegGenKeyHash fGenDeleg
+      ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.GenDelegs crypto) where
   toJSON (Shelley.GenDelegs delegs) = toJSON delegs
@@ -425,14 +465,16 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.InstantaneousRewards crypto) wh
   toEncoding = Aeson.pairs . mconcat . toInstantaneousRewardsPair
 
 toInstantaneousRewardsPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyLedger.InstantaneousRewards crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyLedger.InstantaneousRewards crypto ->
+  [a]
 toInstantaneousRewardsPair iRwds =
   let !iRReserves = Shelley.iRReserves iRwds
       !iRTreasury = Shelley.iRTreasury iRwds
-  in  [ "iRReserves" .= iRReserves
-      , "iRTreasury" .= iRTreasury
+   in [ "iRReserves" .= iRReserves,
+        "iRTreasury" .= iRTreasury
       ]
 
 instance
@@ -443,17 +485,20 @@ instance
   toEncoding = Aeson.pairs . mconcat . toPtrCredentialStakingPair
 
 toPtrCredentialStakingPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto) -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  Bimap Shelley.Ptr (Shelley.Credential Shelley.Staking crypto) ->
+  [a]
 toPtrCredentialStakingPair (MkBiMap ptsStakeM stakePtrSetM) =
   let !stakedCreds = Map.toList ptsStakeM
       !credPtrR = stakePtrSetM
-  in  [ "stakedCreds" .= stakedCreds
-      , "credPtrR" .= credPtrR
+   in [ "stakedCreds" .= stakedCreds,
+        "credPtrR" .= credPtrR
       ]
 
 deriving newtype instance ToJSON Shelley.CertIx
+
 deriving newtype instance ToJSON Shelley.TxIx
 
 instance ToJSON Shelley.Ptr where
@@ -464,50 +509,58 @@ instance ToJSONKey Shelley.Ptr
 
 toPtrPair :: Aeson.KeyValue a => Shelley.Ptr -> [a]
 toPtrPair (Shelley.Ptr !slotNo !txIndex !certIndex) =
-  [ "slot" .= unSlotNo slotNo
-  , "txIndex" .= txIndex
-  , "certIndex" .= certIndex
+  [ "slot" .= unSlotNo slotNo,
+    "txIndex" .= txIndex,
+    "certIndex" .= certIndex
   ]
-
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.PState crypto) where
   toJSON = object . toPStatePair
   toEncoding = Aeson.pairs . mconcat . toPStatePair
 
 toPStatePair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyLedger.PState crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyLedger.PState crypto ->
+  [a]
 toPStatePair pState =
   let !pParams = Shelley._pParams pState
       !fPParams = Shelley._fPParams pState
       !retiring = Shelley._retiring pState
-  in  [ "pParams pState" .= pParams
-      , "fPParams pState" .= fPParams
-      , "retiring pState" .= retiring
+   in [ "pParams pState" .= pParams,
+        "fPParams pState" .= fPParams,
+        "retiring pState" .= retiring
       ]
 
-instance ( Consensus.ShelleyBasedEra era
-         , ToJSON (Core.TxOut era)
-         ) => ToJSON (Shelley.UTxO era) where
+instance
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.TxOut era)
+  ) =>
+  ToJSON (Shelley.UTxO era)
+  where
   toJSON (Shelley.UTxO utxo) = toJSON utxo
   toEncoding (Shelley.UTxO utxo) = toEncoding utxo
 
-instance ( Consensus.ShelleyBasedEra era
-         , ToJSON (Core.Value era)
-         ) => ToJSON (Shelley.TxOut era) where
+instance
+  ( Consensus.ShelleyBasedEra era,
+    ToJSON (Core.Value era)
+  ) =>
+  ToJSON (ShelleyTxOut era)
+  where
   toJSON = object . toTxOutPair
   toEncoding = Aeson.pairs . mconcat . toTxOutPair
 
 toTxOutPair ::
-  ( Ledger.Era era
-  , Aeson.KeyValue a
-  , ToJSON (Core.Value era)
-  , Show (Core.Value era))
-  => Shelley.TxOut era -> [a]
-toTxOutPair (Shelley.TxOut !addr !amount) =
-  [ "address" .= addr
-  , "amount" .= amount
+  ( Aeson.KeyValue a,
+    ToJSON (Core.Value era),
+    Core.EraTxOut era
+  ) =>
+  ShelleyTxOut era ->
+  [a]
+toTxOutPair (ShelleyTxOut !addr !amount) =
+  [ "address" .= addr,
+    "amount" .= amount
   ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.TxIn crypto) where
@@ -531,14 +584,16 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.NonMyopic crypto) where
   toEncoding = Aeson.pairs . mconcat . toNonMyopicPair
 
 toNonMyopicPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => Shelley.NonMyopic crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  Shelley.NonMyopic crypto ->
+  [a]
 toNonMyopicPair nonMy =
   let !likelihoodsNM = Shelley.likelihoodsNM nonMy
       !rewardPotNM = Shelley.rewardPotNM nonMy
-  in  [ "likelihoodsNM" .= likelihoodsNM
-      , "rewardPotNM" .= rewardPotNM
+   in [ "likelihoodsNM" .= likelihoodsNM,
+        "rewardPotNM" .= rewardPotNM
       ]
 
 instance ToJSON Shelley.Likelihood where
@@ -552,18 +607,20 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShots crypto) where
   toEncoding = Aeson.pairs . mconcat . toSnapShotsPair
 
 toSnapShotsPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyEpoch.SnapShots crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyEpoch.SnapShots crypto ->
+  [a]
 toSnapShotsPair ss =
   let !pstakeMark = Shelley._pstakeMark ss
       !pstakeSet = Shelley._pstakeSet ss
       !pstakeGo = Shelley._pstakeGo ss
       !feeSS = Shelley._feeSS ss
-  in  [ "pstakeMark" .= pstakeMark
-      , "pstakeSet" .= pstakeSet
-      , "pstakeGo" .= pstakeGo
-      , "feeSS" .= feeSS
+   in [ "pstakeMark" .= pstakeMark,
+        "pstakeSet" .= pstakeSet,
+        "pstakeGo" .= pstakeGo,
+        "feeSS" .= feeSS
       ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShot crypto) where
@@ -571,16 +628,18 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.SnapShot crypto) where
   toEncoding = Aeson.pairs . mconcat . toSnapShotPair
 
 toSnapShotPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => ShelleyEpoch.SnapShot crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  ShelleyEpoch.SnapShot crypto ->
+  [a]
 toSnapShotPair ss =
   let !stake = Shelley._stake ss
       !delegations = ShelleyEpoch._delegations ss
       !poolParams = Shelley._poolParams ss
-  in  [ "stake" .= stake
-      , "delegations" .= delegations
-      , "poolParams" .= poolParams
+   in [ "stake" .= stake,
+        "delegations" .= delegations,
+        "poolParams" .= poolParams
       ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.Stake crypto) where
@@ -592,27 +651,29 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.RewardUpdate crypto) where
   toEncoding = Aeson.pairs . mconcat . toRewardUpdatePair
 
 toRewardUpdatePair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => Shelley.RewardUpdate crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  Shelley.RewardUpdate crypto ->
+  [a]
 toRewardUpdatePair rUpdate =
   let !deltaT = Shelley.deltaT rUpdate
       !deltaR = Shelley.deltaR rUpdate
       !rs = Shelley.rs rUpdate
       !deltaF = Shelley.deltaF rUpdate
       !nonMyopic = Shelley.nonMyopic rUpdate
-  in  [ "deltaT" .= deltaT
-      , "deltaR" .= deltaR
-      , "rs" .= rs
-      , "deltaF" .= deltaF
-      , "nonMyopic" .= nonMyopic
+   in [ "deltaT" .= deltaT,
+        "deltaR" .= deltaR,
+        "rs" .= rs,
+        "deltaF" .= deltaF,
+        "nonMyopic" .= nonMyopic
       ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.PulsingRewUpdate crypto) where
-  toJSON  = \case
+  toJSON = \case
     Shelley.Pulsing _ _ -> Aeson.Null
     Shelley.Complete ru -> toJSON ru
-  toEncoding  = \case
+  toEncoding = \case
     Shelley.Pulsing _ _ -> toEncoding Aeson.Null
     Shelley.Complete ru -> toEncoding ru
 
@@ -629,14 +690,16 @@ instance Crypto.Crypto crypto => ToJSON (Ledger.IndividualPoolStake crypto) wher
   toEncoding = Aeson.pairs . mconcat . toIndividualPoolStakePair
 
 toIndividualPoolStakePair ::
-  ( Aeson.KeyValue a
-  , Crypto.HashAlgorithm (Crypto.HASH crypto)
-  ) => Ledger.IndividualPoolStake crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.HashAlgorithm (Crypto.HASH crypto)
+  ) =>
+  Ledger.IndividualPoolStake crypto ->
+  [a]
 toIndividualPoolStakePair indivPoolStake =
   let !individualPoolStake = Ledger.individualPoolStake indivPoolStake
       !individualPoolStakeVrf = Ledger.individualPoolStakeVrf indivPoolStake
-  in  [ "individualPoolStake" .= individualPoolStake
-      , "individualPoolStakeVrf" .= individualPoolStakeVrf
+   in [ "individualPoolStake" .= individualPoolStake,
+        "individualPoolStakeVrf" .= individualPoolStakeVrf
       ]
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.Reward crypto) where
@@ -644,16 +707,18 @@ instance Crypto.Crypto crypto => ToJSON (Shelley.Reward crypto) where
   toEncoding = Aeson.pairs . mconcat . toRewardPair
 
 toRewardPair ::
-  ( Aeson.KeyValue a
-  , Crypto.Crypto crypto
-  ) => Shelley.Reward crypto -> [a]
+  ( Aeson.KeyValue a,
+    Crypto.Crypto crypto
+  ) =>
+  Shelley.Reward crypto ->
+  [a]
 toRewardPair reward =
   let !rewardType = Shelley.rewardType reward
       !rewardPool = Shelley.rewardPool reward
       !rewardAmount = Shelley.rewardAmount reward
-  in  [ "rewardType" .= rewardType
-      , "rewardPool" .= rewardPool
-      , "rewardAmount" .= rewardAmount
+   in [ "rewardType" .= rewardType,
+        "rewardPool" .= rewardPool,
+        "rewardAmount" .= rewardAmount
       ]
 
 instance ToJSON Shelley.RewardType where
@@ -667,17 +732,17 @@ instance Crypto.Crypto c => ToJSON (SafeHash.SafeHash c a) where
 -----
 
 deriving newtype instance ToJSON SystemStart
-deriving newtype instance FromJSON SystemStart
 
+deriving newtype instance FromJSON SystemStart
 
 instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.Credential 'Shelley.Staking crypto) (Shelley.KeyHash 'Shelley.StakePool crypto)) where
   toJSON = toJSON . VMap.toMap
   toEncoding = toEncoding . VMap.toMap
 
-instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.KeyHash    'Shelley.StakePool crypto) (Shelley.PoolParams crypto)) where
+instance Crypto.Crypto crypto => ToJSON (VMap VB VB (Shelley.KeyHash 'Shelley.StakePool crypto) (Shelley.PoolParams crypto)) where
   toJSON = toJSON . VMap.toMap
   toEncoding = toEncoding . VMap.toMap
 
-instance Crypto.Crypto crypto => ToJSON (VMap VB VP (Shelley.Credential 'Shelley.Staking   crypto) (Shelley.CompactForm Shelley.Coin)) where
+instance Crypto.Crypto crypto => ToJSON (VMap VB VP (Shelley.Credential 'Shelley.Staking crypto) (Shelley.CompactForm Shelley.Coin)) where
   toJSON = toJSON . fmap fromCompact . VMap.toMap
   toEncoding = toEncoding . fmap fromCompact . VMap.toMap

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -56,7 +56,7 @@ import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.PoolDistr as Ledger
 import qualified Cardano.Ledger.SafeHash as SafeHash
 import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Cardano.Ledger.Shelley.Constraints as Shelley
+import qualified Cardano.Ledger.Shelley.Orphans as Shelley
 import qualified Cardano.Ledger.Shelley.EpochBoundary as ShelleyEpoch
 import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyLedger
 import           Cardano.Ledger.Shelley.PParams (PParamsUpdate)

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -88,20 +88,37 @@ import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 
 import qualified Cardano.Ledger.Shelley.PParams as Ledger (ProposedPPUpdates (..), Update (..))
 -- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
 -- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
 -- So we import in twice under different names.
-import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..), PParamsUpdate)
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
+-- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
+-- So we import in twice under different names.
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 
-import qualified Cardano.Ledger.Babbage.PParams as Babbage
 
 import           Text.PrettyBy.Default (display)
 
@@ -121,6 +138,11 @@ import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.TxMetadata
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
+import Cardano.Ledger.Shelley.API (ShelleyPParamsHKD(..), ShelleyPParams)
+import Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD(..), AlonzoPParams)
+import Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD(..), BabbagePParamsUpdate, BabbagePParams)
+import Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
+import Cardano.Ledger.Alonzo (AlonzoPParamsUpdate)
 
 -- | The values of the set of /updatable/ protocol parameters. At any
 -- particular point on the chain there is a current set of parameters in use.
@@ -895,23 +917,23 @@ toLedgerProposedPPUpdates :: forall era ledgerera.
 toLedgerProposedPPUpdates era =
     Ledger.ProposedPPUpdates
   . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
-  . Map.map (toLedgerPParamsDelta era)
+  . Map.map (toLedgerPParamsUpdate era)
 
 
-toLedgerPParamsDelta :: ShelleyBasedEra era
+toLedgerPParamsUpdate :: ShelleyBasedEra era
                      -> ProtocolParametersUpdate
-                     -> Ledger.PParamsDelta (ShelleyLedgerEra era)
-toLedgerPParamsDelta ShelleyBasedEraShelley = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraAllegra = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraMary    = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraAlonzo  = toAlonzoPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraBabbage = toBabbagePParamsUpdate
+                     -> Ledger.PParamsUpdate (ShelleyLedgerEra era)
+toLedgerPParamsUpdate ShelleyBasedEraShelley = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraAllegra = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraMary    = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraAlonzo  = toAlonzoPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraBabbage = toBabbagePParamsUpdate
 
 
 --TODO: we should do validation somewhere, not just silently drop changes that
 -- are not valid. Specifically, see Ledger.boundRational below.
 toShelleyPParamsUpdate :: ProtocolParametersUpdate
-                       -> Shelley.PParamsUpdate ledgerera
+                       -> ShelleyPParamsUpdate ledgerera
 toShelleyPParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -932,39 +954,39 @@ toShelleyPParamsUpdate
     , protocolUpdateMonetaryExpansion
     , protocolUpdateTreasuryCut
     } =
-    Shelley.PParams {
-      Shelley._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Shelley._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Shelley._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Shelley._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Shelley._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Shelley._keyDeposit  = toShelleyLovelace <$>
-                               noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Shelley._poolDeposit = toShelleyLovelace <$>
-                               noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Shelley._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Shelley._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Shelley._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Shelley._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateMonetaryExpansion
-    , Shelley._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateTreasuryCut
-    , Shelley._d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateDecentralization
-    , Shelley._extraEntropy    = toLedgerNonce <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
-    , Shelley._protocolVersion = uncurry Ledger.ProtVer <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Shelley._minUTxOValue    = toShelleyLovelace <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue
-    , Shelley._minPoolCost     = toShelleyLovelace <$>
+    ShelleyPParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                      protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateTreasuryCut
+    , _d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateDecentralization
+    , _extraEntropy    = toLedgerNonce <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minUTxOValue    = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue
+    , _minPoolCost     = toShelleyLovelace <$>
                                    noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
     }
 
 
 toAlonzoPParamsUpdate :: ProtocolParametersUpdate
-                      -> Alonzo.PParamsUpdate ledgerera
+                      -> AlonzoPParamsUpdate ledgerera
 toAlonzoPParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -992,52 +1014,52 @@ toAlonzoPParamsUpdate
     , protocolUpdateCollateralPercent
     , protocolUpdateMaxCollateralInputs
     } =
-    Alonzo.PParams {
-      Alonzo._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Alonzo._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Alonzo._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Alonzo._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Alonzo._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Alonzo._keyDeposit  = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Alonzo._poolDeposit = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Alonzo._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Alonzo._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Alonzo._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Alonzo._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateMonetaryExpansion
-    , Alonzo._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateTreasuryCut
-    , Alonzo._d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateDecentralization
-    , Alonzo._extraEntropy    = toLedgerNonce <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
-    , Alonzo._protocolVersion = uncurry Ledger.ProtVer <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Alonzo._minPoolCost     = toShelleyLovelace <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
-    , Alonzo._coinsPerUTxOWord  = toShelleyLovelace <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerWord
-    , Alonzo._costmdls        = if Map.null protocolUpdateCostModels
-                                  then Ledger.SNothing
-                                  else either (const Ledger.SNothing) Ledger.SJust
-                                         (toAlonzoCostModels protocolUpdateCostModels)
-    , Alonzo._prices          = noInlineMaybeToStrictMaybe $
-                                  toAlonzoPrices =<< protocolUpdatePrices
-    , Alonzo._maxTxExUnits    = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
-    , Alonzo._maxBlockExUnits = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
-    , Alonzo._maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
-    , Alonzo._collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
-    , Alonzo._maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
+    AlonzoPParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateTreasuryCut
+    , _d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateDecentralization
+    , _extraEntropy    = toLedgerNonce <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minPoolCost     = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
+    , _coinsPerUTxOWord  = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerWord
+    , _costmdls        = if Map.null protocolUpdateCostModels
+                           then Ledger.SNothing
+                           else either (const Ledger.SNothing) Ledger.SJust
+                                  (toAlonzoCostModels protocolUpdateCostModels)
+    , _prices          = noInlineMaybeToStrictMaybe $
+                           toAlonzoPrices =<< protocolUpdatePrices
+    , _maxTxExUnits    = toAlonzoExUnits  <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits  <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
+    , _maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
+    , _collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
+    , _maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
     }
 
 -- Decentralization and extra entropy are deprecated in Babbage
 toBabbagePParamsUpdate :: ProtocolParametersUpdate
-                       -> Babbage.PParamsUpdate ledgerera
+                       -> BabbagePParamsUpdate ledgerera
 toBabbagePParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -1063,42 +1085,42 @@ toBabbagePParamsUpdate
     , protocolUpdateMaxCollateralInputs
     , protocolUpdateUTxOCostPerByte
     } =
-    Babbage.PParams {
-      Babbage._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Babbage._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Babbage._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Babbage._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Babbage._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Babbage._keyDeposit  = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Babbage._poolDeposit = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Babbage._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Babbage._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Babbage._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Babbage._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateMonetaryExpansion
-    , Babbage._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateTreasuryCut
-    , Babbage._protocolVersion = uncurry Ledger.ProtVer <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Babbage._minPoolCost     = toShelleyLovelace <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
-    , Babbage._costmdls        = if Map.null protocolUpdateCostModels
-                                  then Ledger.SNothing
-                                  else either (const Ledger.SNothing) Ledger.SJust
-                                         (toAlonzoCostModels protocolUpdateCostModels)
-    , Babbage._prices          = noInlineMaybeToStrictMaybe $
-                                  toAlonzoPrices =<< protocolUpdatePrices
-    , Babbage._maxTxExUnits    = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
-    , Babbage._maxBlockExUnits = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
-    , Babbage._maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
-    , Babbage._collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
-    , Babbage._maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
-    , Babbage._coinsPerUTxOByte = toShelleyLovelace <$>
+    BabbagePParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                      noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                      noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                      protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdateTreasuryCut
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minPoolCost     = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
+    , _costmdls        = if Map.null protocolUpdateCostModels
+                          then Ledger.SNothing
+                          else either (const Ledger.SNothing) Ledger.SJust
+                                 (toAlonzoCostModels protocolUpdateCostModels)
+    , _prices          = noInlineMaybeToStrictMaybe $
+                          toAlonzoPrices =<< protocolUpdatePrices
+    , _maxTxExUnits    = toAlonzoExUnits  <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits  <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
+    , _maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
+    , _collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
+    , _maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
+    , _coinsPerUTxOByte = toShelleyLovelace <$>
                                     noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerByte
     }
 
@@ -1123,42 +1145,42 @@ fromLedgerProposedPPUpdates :: forall era ledgerera.
                             -> Ledger.ProposedPPUpdates ledgerera
                             -> Map (Hash GenesisKey) ProtocolParametersUpdate
 fromLedgerProposedPPUpdates era =
-    Map.map (fromLedgerPParamsDelta era)
+    Map.map (fromLedgerPParamsUpdate era)
   . Map.mapKeysMonotonic GenesisKeyHash
   . (\(Ledger.ProposedPPUpdates ppup) -> ppup)
 
 
-fromLedgerPParamsDelta :: ShelleyBasedEra era
-                       -> Ledger.PParamsDelta (ShelleyLedgerEra era)
+fromLedgerPParamsUpdate :: ShelleyBasedEra era
+                       -> Ledger.PParamsUpdate (ShelleyLedgerEra era)
                        -> ProtocolParametersUpdate
-fromLedgerPParamsDelta ShelleyBasedEraShelley = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraAllegra = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraMary    = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraAlonzo  = fromAlonzoPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraBabbage = fromBabbagePParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraShelley = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraAllegra = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraMary    = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraAlonzo  = fromAlonzoPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraBabbage = fromBabbagePParamsUpdate
 
 
-fromShelleyPParamsUpdate :: Shelley.PParamsUpdate ledgerera
+fromShelleyPParamsUpdate :: ShelleyPParamsUpdate ledgerera
                          -> ProtocolParametersUpdate
 fromShelleyPParamsUpdate
-    Shelley.PParams {
-      Shelley._minfeeA
-    , Shelley._minfeeB
-    , Shelley._maxBBSize
-    , Shelley._maxTxSize
-    , Shelley._maxBHSize
-    , Shelley._keyDeposit
-    , Shelley._poolDeposit
-    , Shelley._eMax
-    , Shelley._nOpt
-    , Shelley._a0
-    , Shelley._rho
-    , Shelley._tau
-    , Shelley._d
-    , Shelley._extraEntropy
-    , Shelley._protocolVersion
-    , Shelley._minUTxOValue
-    , Shelley._minPoolCost
+    ShelleyPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minUTxOValue
+    , _minPoolCost
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1199,34 +1221,34 @@ fromShelleyPParamsUpdate
     , protocolUpdateUTxOCostPerByte     = Nothing
     }
 
-fromAlonzoPParamsUpdate :: Alonzo.PParamsUpdate ledgerera
+fromAlonzoPParamsUpdate :: AlonzoPParamsUpdate ledgerera
                         -> ProtocolParametersUpdate
 fromAlonzoPParamsUpdate
-    Alonzo.PParams {
-      Alonzo._minfeeA
-    , Alonzo._minfeeB
-    , Alonzo._maxBBSize
-    , Alonzo._maxTxSize
-    , Alonzo._maxBHSize
-    , Alonzo._keyDeposit
-    , Alonzo._poolDeposit
-    , Alonzo._eMax
-    , Alonzo._nOpt
-    , Alonzo._a0
-    , Alonzo._rho
-    , Alonzo._tau
-    , Alonzo._d
-    , Alonzo._extraEntropy
-    , Alonzo._protocolVersion
-    , Alonzo._minPoolCost
-    , Alonzo._coinsPerUTxOWord
-    , Alonzo._costmdls
-    , Alonzo._prices
-    , Alonzo._maxTxExUnits
-    , Alonzo._maxBlockExUnits
-    , Alonzo._maxValSize
-    , Alonzo._collateralPercentage
-    , Alonzo._maxCollateralInputs
+    AlonzoPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOWord
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1272,32 +1294,32 @@ fromAlonzoPParamsUpdate
     }
 
 
-fromBabbagePParamsUpdate :: Babbage.PParamsUpdate ledgerera
+fromBabbagePParamsUpdate :: BabbagePParamsUpdate ledgerera
                          -> ProtocolParametersUpdate
 fromBabbagePParamsUpdate
-    Babbage.PParams {
-      Babbage._minfeeA
-    , Babbage._minfeeB
-    , Babbage._maxBBSize
-    , Babbage._maxTxSize
-    , Babbage._maxBHSize
-    , Babbage._keyDeposit
-    , Babbage._poolDeposit
-    , Babbage._eMax
-    , Babbage._nOpt
-    , Babbage._a0
-    , Babbage._rho
-    , Babbage._tau
-    , Babbage._protocolVersion
-    , Babbage._minPoolCost
-    , Babbage._coinsPerUTxOByte
-    , Babbage._costmdls
-    , Babbage._prices
-    , Babbage._maxTxExUnits
-    , Babbage._maxBlockExUnits
-    , Babbage._maxValSize
-    , Babbage._collateralPercentage
-    , Babbage._maxCollateralInputs
+    BabbagePParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOByte
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1358,7 +1380,7 @@ toLedgerPParams ShelleyBasedEraMary    = toShelleyPParams
 toLedgerPParams ShelleyBasedEraAlonzo  = toAlonzoPParams
 toLedgerPParams ShelleyBasedEraBabbage = toBabbagePParams
 
-toShelleyPParams :: ProtocolParameters -> Shelley.PParams ledgerera
+toShelleyPParams :: ProtocolParameters -> ShelleyPParams ledgerera
 toShelleyPParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamDecentralization,
@@ -1378,48 +1400,48 @@ toShelleyPParams ProtocolParameters {
                    protocolParamMonetaryExpansion,
                    protocolParamTreasuryCut
                  } =
-   Shelley.PParams
-     { Shelley._protocolVersion
-                             = let (maj, minor) = protocolParamProtocolVersion
-                                in Ledger.ProtVer maj minor
-     , Shelley._d            = case protocolParamDecentralization of
-                                 -- The decentralization parameter is deprecated in Babbage
-                                 -- so we default to 0 if no dentralization parameter is found
-                                 -- in the api's 'ProtocolParameter' type. If we don't do this
-                                 -- we won't be able to construct an Alonzo tx using the Babbage
-                                 -- era's protocol parameter because our only other option is to
-                                 -- error.
-                                 Nothing -> minBound
-                                 Just pDecentral ->
-                                   fromMaybe
-                                     (error "toShelleyPParams: invalid Decentralization value")
-                                     (Ledger.boundRational pDecentral)
-     , Shelley._extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
-     , Shelley._maxBHSize    = protocolParamMaxBlockHeaderSize
-     , Shelley._maxBBSize    = protocolParamMaxBlockBodySize
-     , Shelley._maxTxSize    = protocolParamMaxTxSize
-     , Shelley._minfeeB      = protocolParamTxFeeFixed
-     , Shelley._minfeeA      = protocolParamTxFeePerByte
-     , Shelley._minUTxOValue = toShelleyLovelace minUTxOValue
-     , Shelley._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-     , Shelley._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-     , Shelley._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-     , Shelley._eMax         = protocolParamPoolRetireMaxEpoch
-     , Shelley._nOpt         = protocolParamStakePoolTargetNum
-     , Shelley._a0           = fromMaybe
-                                 (error "toShelleyPParams: invalid PoolPledgeInfluence value")
-                                 (Ledger.boundRational protocolParamPoolPledgeInfluence)
-     , Shelley._rho          = fromMaybe
-                                 (error "toShelleyPParams: invalid MonetaryExpansion value")
-                                 (Ledger.boundRational protocolParamMonetaryExpansion)
-     , Shelley._tau          = fromMaybe
-                                 (error "toShelleyPParams: invalid TreasuryCut value")
-                                 (Ledger.boundRational protocolParamTreasuryCut)
+   ShelleyPParams
+     { _protocolVersion
+                     = let (maj, minor) = protocolParamProtocolVersion
+                        in Ledger.ProtVer maj minor
+     , _d            = case protocolParamDecentralization of
+                         -- The decentralization parameter is deprecated in Babbage
+                         -- so we default to 0 if no dentralization parameter is found
+                         -- in the api's 'ProtocolParameter' type. If we don't do this
+                         -- we won't be able to construct an Alonzo tx using the Babbage
+                         -- era's protocol parameter because our only other option is to
+                         -- error.
+                         Nothing -> minBound
+                         Just pDecentral ->
+                           fromMaybe
+                             (error "toShelleyPParams: invalid Decentralization value")
+                             (Ledger.boundRational pDecentral)
+     , _extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
+     , _maxBHSize    = protocolParamMaxBlockHeaderSize
+     , _maxBBSize    = protocolParamMaxBlockBodySize
+     , _maxTxSize    = protocolParamMaxTxSize
+     , _minfeeB      = protocolParamTxFeeFixed
+     , _minfeeA      = protocolParamTxFeePerByte
+     , _minUTxOValue = toShelleyLovelace minUTxOValue
+     , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+     , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+     , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+     , _eMax         = protocolParamPoolRetireMaxEpoch
+     , _nOpt         = protocolParamStakePoolTargetNum
+     , _a0           = fromMaybe
+                         (error "toShelleyPParams: invalid PoolPledgeInfluence value")
+                         (Ledger.boundRational protocolParamPoolPledgeInfluence)
+     , _rho          = fromMaybe
+                         (error "toShelleyPParams: invalid MonetaryExpansion value")
+                         (Ledger.boundRational protocolParamMonetaryExpansion)
+     , _tau          = fromMaybe
+                         (error "toShelleyPParams: invalid TreasuryCut value")
+                         (Ledger.boundRational protocolParamTreasuryCut)
      }
 toShelleyPParams ProtocolParameters { protocolParamMinUTxOValue = Nothing } =
   error "toShelleyPParams: must specify protocolParamMinUTxOValue"
 
-toAlonzoPParams :: ProtocolParameters -> Alonzo.PParams ledgerera
+toAlonzoPParams :: ProtocolParameters -> AlonzoPParams ledgerera
 toAlonzoPParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamDecentralization,
@@ -1451,57 +1473,57 @@ toAlonzoPParams ProtocolParameters {
           (error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord or protocolParamUTxOCostPerByte") $
             protocolParamUTxOCostPerWord <|> ((* 8) <$> protocolParamUTxOCostPerByte)
     in
-    Alonzo.PParams {
-      Alonzo._protocolVersion
-                           = let (maj, minor) = protocolParamProtocolVersion
-                              in Ledger.ProtVer maj minor
-    , Alonzo._d            = case protocolParamDecentralization of
-                                 -- The decentralization parameter is deprecated in Babbage
-                                 -- so we default to 0 if no dentralization parameter is found
-                                 -- in the api's 'ProtocolParameter' type. If we don't do this
-                                 -- we won't be able to construct an Alonzo tx using the Babbage
-                                 -- era's protocol parameter because our only other option is to
-                                 -- error.
-                                 Nothing -> minBound
-                                 Just pDecentral ->
-                                   fromMaybe
-                                     (error "toAlonzoPParams: invalid Decentralization value")
-                                     (Ledger.boundRational pDecentral)
-    , Alonzo._extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
-    , Alonzo._maxBHSize    = protocolParamMaxBlockHeaderSize
-    , Alonzo._maxBBSize    = protocolParamMaxBlockBodySize
-    , Alonzo._maxTxSize    = protocolParamMaxTxSize
-    , Alonzo._minfeeB      = protocolParamTxFeeFixed
-    , Alonzo._minfeeA      = protocolParamTxFeePerByte
-    , Alonzo._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-    , Alonzo._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-    , Alonzo._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-    , Alonzo._eMax         = protocolParamPoolRetireMaxEpoch
-    , Alonzo._nOpt         = protocolParamStakePoolTargetNum
-    , Alonzo._a0           = fromMaybe
-                               (error "toAlonzoPParams: invalid PoolPledgeInfluence value")
-                               (Ledger.boundRational protocolParamPoolPledgeInfluence)
-    , Alonzo._rho          = fromMaybe
-                               (error "toAlonzoPParams: invalid MonetaryExpansion value")
-                               (Ledger.boundRational protocolParamMonetaryExpansion)
-    , Alonzo._tau          = fromMaybe
-                               (error "toAlonzoPParams: invalid TreasuryCut value")
-                               (Ledger.boundRational protocolParamTreasuryCut)
+    AlonzoPParams {
+      _protocolVersion
+                    = let (maj, minor) = protocolParamProtocolVersion
+                       in Ledger.ProtVer maj minor
+    , _d            = case protocolParamDecentralization of
+                          -- The decentralization parameter is deprecated in Babbage
+                          -- so we default to 0 if no dentralization parameter is found
+                          -- in the api's 'ProtocolParameter' type. If we don't do this
+                          -- we won't be able to construct an Alonzo tx using the Babbage
+                          -- era's protocol parameter because our only other option is to
+                          -- error.
+                          Nothing -> minBound
+                          Just pDecentral ->
+                            fromMaybe
+                              (error "toAlonzoPParams: invalid Decentralization value")
+                              (Ledger.boundRational pDecentral)
+    , _extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
+    , _maxBHSize    = protocolParamMaxBlockHeaderSize
+    , _maxBBSize    = protocolParamMaxBlockBodySize
+    , _maxTxSize    = protocolParamMaxTxSize
+    , _minfeeB      = protocolParamTxFeeFixed
+    , _minfeeA      = protocolParamTxFeePerByte
+    , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+    , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+    , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+    , _eMax         = protocolParamPoolRetireMaxEpoch
+    , _nOpt         = protocolParamStakePoolTargetNum
+    , _a0           = fromMaybe
+                        (error "toAlonzoPParams: invalid PoolPledgeInfluence value")
+                        (Ledger.boundRational protocolParamPoolPledgeInfluence)
+    , _rho          = fromMaybe
+                        (error "toAlonzoPParams: invalid MonetaryExpansion value")
+                        (Ledger.boundRational protocolParamMonetaryExpansion)
+    , _tau          = fromMaybe
+                        (error "toAlonzoPParams: invalid TreasuryCut value")
+                        (Ledger.boundRational protocolParamTreasuryCut)
 
       -- New params in Alonzo:
-    , Alonzo._coinsPerUTxOWord  = toShelleyLovelace coinsPerUTxOWord
-    , Alonzo._costmdls        = either
-                                  (\e -> error $ "toAlonzoPParams: invalid cost models, error: " <> e)
-                                  id
-                                  (toAlonzoCostModels protocolParamCostModels)
-    , Alonzo._prices          = fromMaybe
-                                  (error "toAlonzoPParams: invalid Price values")
-                                  (toAlonzoPrices prices)
-    , Alonzo._maxTxExUnits    = toAlonzoExUnits maxTxExUnits
-    , Alonzo._maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
-    , Alonzo._maxValSize      = maxValueSize
-    , Alonzo._collateralPercentage = collateralPercentage
-    , Alonzo._maxCollateralInputs  = maxCollateralInputs
+    , _coinsPerUTxOWord  = toShelleyLovelace coinsPerUTxOWord
+    , _costmdls        = either
+                           (\e -> error $ "toAlonzoPParams: invalid cost models, error: " <> e)
+                           id
+                           (toAlonzoCostModels protocolParamCostModels)
+    , _prices          = fromMaybe
+                           (error "toAlonzoPParams: invalid Price values")
+                           (toAlonzoPrices prices)
+    , _maxTxExUnits    = toAlonzoExUnits maxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
+    , _maxValSize      = maxValueSize
+    , _collateralPercentage = collateralPercentage
+    , _maxCollateralInputs  = maxCollateralInputs
     }
 toAlonzoPParams ProtocolParameters { protocolParamUTxOCostPerWord = Nothing } =
   error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord"
@@ -1519,7 +1541,7 @@ toAlonzoPParams ProtocolParameters { protocolParamMaxCollateralInputs = Nothing 
   error "toAlonzoPParams: must specify protocolParamMaxCollateralInputs"
 
 
-toBabbagePParams :: ProtocolParameters -> Babbage.PParams ledgerera
+toBabbagePParams :: ProtocolParameters -> BabbagePParams ledgerera
 toBabbagePParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamMaxBlockHeaderSize,
@@ -1544,45 +1566,45 @@ toBabbagePParams ProtocolParameters {
                    protocolParamCollateralPercent   = Just collateralPercentage,
                    protocolParamMaxCollateralInputs = Just maxCollateralInputs
                  } =
-    Babbage.PParams {
-      Babbage._protocolVersion
-                           = let (maj, minor) = protocolParamProtocolVersion
-                              in Ledger.ProtVer maj minor
-    , Babbage._maxBHSize    = protocolParamMaxBlockHeaderSize
-    , Babbage._maxBBSize    = protocolParamMaxBlockBodySize
-    , Babbage._maxTxSize    = protocolParamMaxTxSize
-    , Babbage._minfeeB      = protocolParamTxFeeFixed
-    , Babbage._minfeeA      = protocolParamTxFeePerByte
-    , Babbage._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-    , Babbage._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-    , Babbage._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-    , Babbage._eMax         = protocolParamPoolRetireMaxEpoch
-    , Babbage._nOpt         = protocolParamStakePoolTargetNum
-    , Babbage._a0           = fromMaybe
-                               (error "toBabbagePParams: invalid PoolPledgeInfluence value")
-                               (Ledger.boundRational protocolParamPoolPledgeInfluence)
-    , Babbage._rho          = fromMaybe
-                               (error "toBabbagePParams: invalid MonetaryExpansion value")
-                               (Ledger.boundRational protocolParamMonetaryExpansion)
-    , Babbage._tau          = fromMaybe
-                               (error "toBabbagePParams: invalid TreasuryCut value")
-                               (Ledger.boundRational protocolParamTreasuryCut)
+    BabbagePParams {
+      _protocolVersion
+                   = let (maj, minor) = protocolParamProtocolVersion
+                      in Ledger.ProtVer maj minor
+    , _maxBHSize    = protocolParamMaxBlockHeaderSize
+    , _maxBBSize    = protocolParamMaxBlockBodySize
+    , _maxTxSize    = protocolParamMaxTxSize
+    , _minfeeB      = protocolParamTxFeeFixed
+    , _minfeeA      = protocolParamTxFeePerByte
+    , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+    , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+    , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+    , _eMax         = protocolParamPoolRetireMaxEpoch
+    , _nOpt         = protocolParamStakePoolTargetNum
+    , _a0           = fromMaybe
+                       (error "toBabbagePParams: invalid PoolPledgeInfluence value")
+                       (Ledger.boundRational protocolParamPoolPledgeInfluence)
+    , _rho          = fromMaybe
+                       (error "toBabbagePParams: invalid MonetaryExpansion value")
+                       (Ledger.boundRational protocolParamMonetaryExpansion)
+    , _tau          = fromMaybe
+                       (error "toBabbagePParams: invalid TreasuryCut value")
+                       (Ledger.boundRational protocolParamTreasuryCut)
 
       -- New params in Babbage.
-    , Babbage._coinsPerUTxOByte = toShelleyLovelace utxoCostPerByte
+    , _coinsPerUTxOByte = toShelleyLovelace utxoCostPerByte
 
-    , Babbage._costmdls        = either
-                                  (\e -> error $ "toBabbagePParams: invalid cost models, error: " <> e)
-                                  id
-                                  (toAlonzoCostModels protocolParamCostModels)
-    , Babbage._prices          = fromMaybe
-                                  (error "toBabbagePParams: invalid Price values")
-                                  (toAlonzoPrices prices)
-    , Babbage._maxTxExUnits    = toAlonzoExUnits maxTxExUnits
-    , Babbage._maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
-    , Babbage._maxValSize      = maxValueSize
-    , Babbage._collateralPercentage = collateralPercentage
-    , Babbage._maxCollateralInputs  = maxCollateralInputs
+    , _costmdls        = either
+                          (\e -> error $ "toBabbagePParams: invalid cost models, error: " <> e)
+                          id
+                          (toAlonzoCostModels protocolParamCostModels)
+    , _prices          = fromMaybe
+                          (error "toBabbagePParams: invalid Price values")
+                          (toAlonzoPrices prices)
+    , _maxTxExUnits    = toAlonzoExUnits maxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
+    , _maxValSize      = maxValueSize
+    , _collateralPercentage = collateralPercentage
+    , _maxCollateralInputs  = maxCollateralInputs
     }
 toBabbagePParams ProtocolParameters { protocolParamUTxOCostPerByte = Nothing } =
   error "toBabbagePParams: must specify protocolParamUTxOCostPerByte"
@@ -1614,27 +1636,27 @@ fromLedgerPParams ShelleyBasedEraAlonzo  = fromAlonzoPParams
 fromLedgerPParams ShelleyBasedEraBabbage = fromBabbagePParams
 
 
-fromShelleyPParams :: Shelley.PParams ledgerera
+fromShelleyPParams :: ShelleyPParams ledgerera
                    -> ProtocolParameters
 fromShelleyPParams
-    Shelley.PParams {
-      Shelley._minfeeA
-    , Shelley._minfeeB
-    , Shelley._maxBBSize
-    , Shelley._maxTxSize
-    , Shelley._maxBHSize
-    , Shelley._keyDeposit
-    , Shelley._poolDeposit
-    , Shelley._eMax
-    , Shelley._nOpt
-    , Shelley._a0
-    , Shelley._rho
-    , Shelley._tau
-    , Shelley._d
-    , Shelley._extraEntropy
-    , Shelley._protocolVersion
-    , Shelley._minUTxOValue
-    , Shelley._minPoolCost
+    ShelleyPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minUTxOValue
+    , _minPoolCost
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))
@@ -1667,33 +1689,33 @@ fromShelleyPParams
     }
 
 
-fromAlonzoPParams :: Alonzo.PParams ledgerera -> ProtocolParameters
+fromAlonzoPParams :: AlonzoPParams ledgerera -> ProtocolParameters
 fromAlonzoPParams
-    Alonzo.PParams {
-      Alonzo._minfeeA
-    , Alonzo._minfeeB
-    , Alonzo._maxBBSize
-    , Alonzo._maxTxSize
-    , Alonzo._maxBHSize
-    , Alonzo._keyDeposit
-    , Alonzo._poolDeposit
-    , Alonzo._eMax
-    , Alonzo._nOpt
-    , Alonzo._a0
-    , Alonzo._rho
-    , Alonzo._tau
-    , Alonzo._d
-    , Alonzo._extraEntropy
-    , Alonzo._protocolVersion
-    , Alonzo._minPoolCost
-    , Alonzo._coinsPerUTxOWord
-    , Alonzo._costmdls
-    , Alonzo._prices
-    , Alonzo._maxTxExUnits
-    , Alonzo._maxBlockExUnits
-    , Alonzo._maxValSize
-    , Alonzo._collateralPercentage
-    , Alonzo._maxCollateralInputs
+    AlonzoPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOWord
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))
@@ -1725,31 +1747,31 @@ fromAlonzoPParams
     , protocolParamUTxOCostPerByte     = Nothing    -- Only from babbage onwards
     }
 
-fromBabbagePParams :: Babbage.PParams ledgerera -> ProtocolParameters
+fromBabbagePParams :: BabbagePParams ledgerera -> ProtocolParameters
 fromBabbagePParams
-    Babbage.PParams {
-      Babbage._minfeeA
-    , Babbage._minfeeB
-    , Babbage._maxBBSize
-    , Babbage._maxTxSize
-    , Babbage._maxBHSize
-    , Babbage._keyDeposit
-    , Babbage._poolDeposit
-    , Babbage._eMax
-    , Babbage._nOpt
-    , Babbage._a0
-    , Babbage._rho
-    , Babbage._tau
-    , Babbage._protocolVersion
-    , Babbage._minPoolCost
-    , Babbage._coinsPerUTxOByte
-    , Babbage._costmdls
-    , Babbage._prices
-    , Babbage._maxTxExUnits
-    , Babbage._maxBlockExUnits
-    , Babbage._maxValSize
-    , Babbage._collateralPercentage
-    , Babbage._maxCollateralInputs
+    BabbagePParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOByte
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -130,6 +130,7 @@ import           Cardano.Api.Value
 import           Data.Word (Word64)
 
 import qualified Data.Aeson.KeyMap as KeyMap
+import Cardano.Ledger.SafeHash (HashAnnotated)
 
 -- ----------------------------------------------------------------------------
 -- Queries
@@ -326,6 +327,7 @@ instance
     , FromCBOR (Ledger.State (Core.EraRule "PPUP" (ShelleyLedgerEra era)))
     , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
     , FromSharedCBOR (Core.TxOut (ShelleyLedgerEra era))
+    , HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
     ) => FromCBOR (DebugLedgerState era) where
   fromCBOR = DebugLedgerState <$> (fromCBOR :: Decoder s (Shelley.NewEpochState (ShelleyLedgerEra era)))
 
@@ -334,7 +336,7 @@ instance ( IsShelleyBasedEra era
          , ShelleyLedgerEra era ~ ledgerera
          , Consensus.ShelleyBasedEra ledgerera
          , ToJSON (Core.PParams ledgerera)
-         , ToJSON (Core.PParamsDelta ledgerera)
+         , ToJSON (Core.PParamsUpdate ledgerera)
          , ToJSON (Core.TxOut ledgerera)
          , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
          ) => ToJSON (DebugLedgerState era) where
@@ -345,7 +347,7 @@ toDebugLedgerStatePair ::
   ( ShelleyLedgerEra era ~ ledgerera
   , Consensus.ShelleyBasedEra ledgerera
   , ToJSON (Core.PParams ledgerera)
-  , ToJSON (Core.PParamsDelta ledgerera)
+  , ToJSON (Core.PParamsUpdate ledgerera)
   , ToJSON (Core.TxOut ledgerera)
   , Aeson.KeyValue a
   ) => DebugLedgerState era -> [a]
@@ -387,6 +389,7 @@ decodeCurrentEpochState
   => FromCBOR (Core.PParams (ShelleyLedgerEra era))
   => FromCBOR (Core.Value (ShelleyLedgerEra era))
   => FromCBOR (Ledger.State (Core.EraRule "PPUP" (ShelleyLedgerEra era)))
+  => HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
   => SerialisedCurrentEpochState era
   -> Either DecoderError (CurrentEpochState era)
 decodeCurrentEpochState (SerialisedCurrentEpochState (Serialised ls)) = CurrentEpochState <$> decodeFull ls

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -142,7 +142,6 @@ import           Cardano.Slotting.Slot (SlotNo)
 
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Era as Ledger
 
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley

--- a/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Shelley/Genesis.hs
@@ -14,7 +14,7 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Time as Time
 
 import           Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Shelley.PParams as Ledger (PParams' (..), emptyPParams)
+import           Cardano.Ledger.Shelley.PParams as Ledger (emptyPParams, ShelleyPParamsHKD (..))
 import           Cardano.Slotting.Slot (EpochSize (..))
 
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..), emptyGenesisStaking)

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -20,19 +20,18 @@
 {- HLINT ignore "Use section" -}
 
 -- | Transaction bodies
---
-module Cardano.Api.TxBody (
-    parseTxId,
-    -- * Transaction bodies
-    TxBody(.., TxBody),
-    makeTransactionBody,
-    TxBodyContent(..),
-    TxBodyError(..),
-    TxBodyScriptData(..),
-    TxScriptValidity(..),
-    TxScriptValiditySupportedInEra(..),
+module Cardano.Api.TxBody
+  ( parseTxId,
 
-    ScriptValidity(..),
+    -- * Transaction bodies
+    TxBody (.., TxBody),
+    makeTransactionBody,
+    TxBodyContent (..),
+    TxBodyError (..),
+    TxBodyScriptData (..),
+    TxScriptValidity (..),
+    TxScriptValiditySupportedInEra (..),
+    ScriptValidity (..),
     scriptValidityToIsValid,
     isValidToScriptValidity,
     scriptValidityToTxScriptValidity,
@@ -40,67 +39,68 @@ module Cardano.Api.TxBody (
     txScriptValidityToScriptValidity,
 
     -- * Transaction Ids
-    TxId(..),
+    TxId (..),
     getTxId,
     getTxIdShelley,
 
     -- * Transaction inputs
-    TxIn(..),
-    TxIx(..),
+    TxIn (..),
+    TxIx (..),
     genesisUTxOPseudoTxIn,
 
     -- * Transaction outputs
-    CtxTx, CtxUTxO,
-    TxOut(..),
-    TxOutValue(..),
-    TxOutDatum(TxOutDatumNone, TxOutDatumHash, TxOutDatumInTx, TxOutDatumInline),
+    CtxTx,
+    CtxUTxO,
+    TxOut (..),
+    TxOutValue (..),
+    TxOutDatum (TxOutDatumNone, TxOutDatumHash, TxOutDatumInTx, TxOutDatumInline),
     toCtxUTxOTxOut,
     lovelaceToTxOutValue,
     prettyRenderTxOut,
     txOutValueToLovelace,
     txOutValueToValue,
     parseHash,
-    TxOutInAnyEra(..),
+    TxOutInAnyEra (..),
     txOutInAnyEra,
 
     -- * Other transaction body types
-    TxInsCollateral(..),
-    TxInsReference(..),
-    TxReturnCollateral(..),
-    TxTotalCollateral(..),
-    TxFee(..),
-    TxValidityLowerBound(..),
-    TxValidityUpperBound(..),
-    TxMetadataInEra(..),
-    TxAuxScripts(..),
-    TxExtraKeyWitnesses(..),
-    TxWithdrawals(..),
-    TxCertificates(..),
-    TxUpdateProposal(..),
-    TxMintValue(..),
+    TxInsCollateral (..),
+    TxInsReference (..),
+    TxReturnCollateral (..),
+    TxTotalCollateral (..),
+    TxFee (..),
+    TxValidityLowerBound (..),
+    TxValidityUpperBound (..),
+    TxMetadataInEra (..),
+    TxAuxScripts (..),
+    TxExtraKeyWitnesses (..),
+    TxWithdrawals (..),
+    TxCertificates (..),
+    TxUpdateProposal (..),
+    TxMintValue (..),
 
     -- ** Building vs viewing transactions
-    BuildTxWith(..),
+    BuildTxWith (..),
     BuildTx,
     ViewTx,
 
     -- * Era-dependent transaction body features
-    CollateralSupportedInEra(..),
-    MultiAssetSupportedInEra(..),
-    OnlyAdaSupportedInEra(..),
-    TxFeesExplicitInEra(..),
-    TxFeesImplicitInEra(..),
-    ValidityUpperBoundSupportedInEra(..),
-    ValidityNoUpperBoundSupportedInEra(..),
-    ValidityLowerBoundSupportedInEra(..),
-    TxMetadataSupportedInEra(..),
-    AuxScriptsSupportedInEra(..),
-    TxExtraKeyWitnessesSupportedInEra(..),
-    ScriptDataSupportedInEra(..),
-    WithdrawalsSupportedInEra(..),
-    CertificatesSupportedInEra(..),
-    UpdateProposalSupportedInEra(..),
-    TxTotalAndReturnCollateralSupportedInEra(..),
+    CollateralSupportedInEra (..),
+    MultiAssetSupportedInEra (..),
+    OnlyAdaSupportedInEra (..),
+    TxFeesExplicitInEra (..),
+    TxFeesImplicitInEra (..),
+    ValidityUpperBoundSupportedInEra (..),
+    ValidityNoUpperBoundSupportedInEra (..),
+    ValidityLowerBoundSupportedInEra (..),
+    TxMetadataSupportedInEra (..),
+    AuxScriptsSupportedInEra (..),
+    TxExtraKeyWitnessesSupportedInEra (..),
+    ScriptDataSupportedInEra (..),
+    WithdrawalsSupportedInEra (..),
+    CertificatesSupportedInEra (..),
+    UpdateProposalSupportedInEra (..),
+    TxTotalAndReturnCollateralSupportedInEra (..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -121,8 +121,8 @@ module Cardano.Api.TxBody (
     totalAndReturnCollateralSupportedInEra,
 
     -- * Inspecting 'ScriptWitness'es
-    AnyScriptWitness(..),
-    ScriptWitnessIndex(..),
+    AnyScriptWitness (..),
+    ScriptWitnessIndex (..),
     renderScriptWitnessIndex,
     collectTxBodyScriptWitnesses,
 
@@ -150,129 +150,130 @@ module Cardano.Api.TxBody (
     orderTxIns,
 
     -- * Data family instances
-    AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
-  ) where
+    AsType (AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
+  )
+where
 
-import           Prelude
-
-import           Control.Applicative (some)
-import           Control.Monad (guard)
-import           Data.Aeson (object, withObject, (.:), (.:?), (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Types as Aeson
-import           Data.Bifunctor (first)
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BSC
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Foldable (for_, toList)
-import           Data.Function (on)
-import           Data.List (intercalate, sortBy)
-import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe, maybeToList)
-import           Data.Scientific (toBoundedInteger)
-import qualified Data.Sequence.Strict as Seq
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Data.String
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
-import           Data.Word (Word16, Word32, Word64)
-import           GHC.Generics
-import           GHC.Records (HasField (..))
-import qualified Text.Parsec as Parsec
-import           Text.Parsec ((<?>))
-import qualified Text.Parsec.String as Parsec
-
-import           Cardano.Binary (Annotated (..), reAnnotate, recoverBytes)
+import Cardano.Api.Address
+import Cardano.Api.Certificate
+import Cardano.Api.EraCast
+import Cardano.Api.Eras
+import Cardano.Api.Error
+import Cardano.Api.HasTypeProxy
+import Cardano.Api.Hash
+import Cardano.Api.KeysByron
+import Cardano.Api.KeysShelley
+import Cardano.Api.NetworkId
+import Cardano.Api.ProtocolParameters
+import Cardano.Api.Script
+import Cardano.Api.ScriptData
+import Cardano.Api.SerialiseCBOR
+import Cardano.Api.SerialiseJSON
+import Cardano.Api.SerialiseRaw
+import Cardano.Api.SerialiseTextEnvelope
+import Cardano.Api.TxIn
+import Cardano.Api.TxMetadata
+import Cardano.Api.Utils
+import Cardano.Api.Value
+import Cardano.Api.ValueParser
+import Cardano.Binary (Annotated (..), reAnnotate, recoverBytes)
 import qualified Cardano.Binary as CBOR
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.Serialization as CBOR (decodeNullMaybe, encodeNullMaybe, mkSized,
-                   sizedValue)
-import           Cardano.Slotting.Slot (SlotNo (..))
-
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Hashing as Byron
-
 import qualified Cardano.Ledger.Address as Shelley
-import qualified Cardano.Ledger.AuxiliaryData as Ledger (hashAuxiliaryData)
-import           Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
-import qualified Cardano.Ledger.Coin as Ledger
-import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Credential as Shelley
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Era as Ledger
-import qualified Cardano.Ledger.Keys as Shelley
-import qualified Cardano.Ledger.SafeHash as SafeHash
-import qualified Cardano.Ledger.Shelley.Constraints as Ledger
-
-import qualified Cardano.Ledger.Shelley.Genesis as Shelley
-import qualified Cardano.Ledger.Shelley.Metadata as Shelley
-import qualified Cardano.Ledger.Shelley.Tx as Shelley
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
-import qualified Cardano.Ledger.TxIn as Ledger
-
-import qualified Cardano.Ledger.Mary.Value as Mary
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary
-import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
-import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
-import           Cardano.Ledger.Val (isZero)
-
-import qualified Cardano.Ledger.Alonzo as Alonzo
+import Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (..))
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
-
-import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..), BabbageTxBody(..), BabbageTxOut(..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
-import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardAlonzo, StandardBabbage,
-                   StandardMary, StandardShelley)
-
-import           Cardano.Api.Address
-import           Cardano.Api.Certificate
-import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
-import           Cardano.Api.Error
-import           Cardano.Api.Hash
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.KeysByron
-import           Cardano.Api.KeysShelley
-import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.Script
-import           Cardano.Api.ScriptData
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseJSON
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseTextEnvelope
-import           Cardano.Api.TxIn
-import           Cardano.Api.TxMetadata
-import           Cardano.Api.Utils
-import           Cardano.Api.Value
-import           Cardano.Api.ValueParser
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Core as Ledger
+import qualified Cardano.Ledger.Credential as Shelley
+import Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Shelley
+import qualified Cardano.Ledger.SafeHash as SafeHash
+import qualified Cardano.Ledger.Serialization as CBOR
+  ( decodeNullMaybe,
+    encodeNullMaybe,
+    mkSized,
+    sizedValue,
+  )
+import Cardano.Ledger.Shelley.API (ShelleyTxOut (..))
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
+import qualified Cardano.Ledger.Shelley.Metadata as Shelley
+import qualified Cardano.Ledger.Shelley.Tx as Shelley
+import Cardano.Ledger.Shelley.TxBody (EraIndependentTxBody)
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
+import Cardano.Ledger.ShelleyMA.TxBody (MATxBody (..))
+import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
+import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
+import qualified Cardano.Ledger.TxIn as Ledger
+import Cardano.Ledger.Val (isZero)
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Applicative (some)
+import Control.Monad (guard)
+import Data.Aeson (object, withObject, (.:), (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Types as Aeson
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (for_, toList)
+import Data.Function (on)
+import Data.List (intercalate, sortBy)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Scientific (toBoundedInteger)
+import qualified Data.Sequence.Strict as Seq
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.String
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Type.Equality (TestEquality (..), (:~:) (Refl))
+import Data.Word (Word16, Word32, Word64)
+import GHC.Generics
+import Lens.Micro ((^.))
+import Ouroboros.Consensus.Shelley.Eras
+  ( StandardAllegra,
+    StandardAlonzo,
+    StandardBabbage,
+    StandardMary,
+    StandardShelley,
+  )
+import Text.Parsec ((<?>))
+import qualified Text.Parsec as Parsec
+import qualified Text.Parsec.String as Parsec
+import Prelude
+import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
 
 -- | Indicates whether a script is expected to fail or pass validation.
 data ScriptValidity
-  = ScriptInvalid -- ^ Script is expected to fail validation.
-                  -- Transactions marked as such can include scripts that fail validation.
-                  -- Such transactions may be submitted to the chain, in which case the
-                  -- collateral will be taken upon on chain script validation failure.
-
-  | ScriptValid   -- ^ Script is expected to pass validation.
-                  -- Transactions marked as such cannot include scripts that fail validation.
-
+  = -- | Script is expected to fail validation.
+    -- Transactions marked as such can include scripts that fail validation.
+    -- Such transactions may be submitted to the chain, in which case the
+    -- collateral will be taken upon on chain script validation failure.
+    ScriptInvalid
+  | -- | Script is expected to pass validation.
+    -- Transactions marked as such cannot include scripts that fail validation.
+    ScriptValid
   deriving (Eq, Show)
 
 instance ToCBOR ScriptValidity where
@@ -292,39 +293,39 @@ isValidToScriptValidity (Alonzo.IsValid True) = ScriptValid
 -- | A representation of whether the era supports tx script validity.
 --
 -- The Alonzo and subsequent eras support script validity.
---
 data TxScriptValidity era where
   TxScriptValidityNone :: TxScriptValidity era
-
   -- | Tx script validity is supported in transactions in the 'Alonzo' era onwards.
-  TxScriptValidity
-    :: TxScriptValiditySupportedInEra era
-    -> ScriptValidity
-    -> TxScriptValidity era
+  TxScriptValidity ::
+    TxScriptValiditySupportedInEra era ->
+    ScriptValidity ->
+    TxScriptValidity era
 
-deriving instance Eq   (TxScriptValiditySupportedInEra era)
+deriving instance Eq (TxScriptValiditySupportedInEra era)
+
 deriving instance Show (TxScriptValiditySupportedInEra era)
 
 data TxScriptValiditySupportedInEra era where
-  TxScriptValiditySupportedInAlonzoEra  :: TxScriptValiditySupportedInEra AlonzoEra
+  TxScriptValiditySupportedInAlonzoEra :: TxScriptValiditySupportedInEra AlonzoEra
   TxScriptValiditySupportedInBabbageEra :: TxScriptValiditySupportedInEra BabbageEra
 
-deriving instance Eq   (TxScriptValidity era)
+deriving instance Eq (TxScriptValidity era)
+
 deriving instance Show (TxScriptValidity era)
 
 txScriptValiditySupportedInCardanoEra :: CardanoEra era -> Maybe (TxScriptValiditySupportedInEra era)
-txScriptValiditySupportedInCardanoEra ByronEra   = Nothing
+txScriptValiditySupportedInCardanoEra ByronEra = Nothing
 txScriptValiditySupportedInCardanoEra ShelleyEra = Nothing
 txScriptValiditySupportedInCardanoEra AllegraEra = Nothing
-txScriptValiditySupportedInCardanoEra MaryEra    = Nothing
-txScriptValiditySupportedInCardanoEra AlonzoEra  = Just TxScriptValiditySupportedInAlonzoEra
+txScriptValiditySupportedInCardanoEra MaryEra = Nothing
+txScriptValiditySupportedInCardanoEra AlonzoEra = Just TxScriptValiditySupportedInAlonzoEra
 txScriptValiditySupportedInCardanoEra BabbageEra = Just TxScriptValiditySupportedInBabbageEra
 
 txScriptValiditySupportedInShelleyBasedEra :: ShelleyBasedEra era -> Maybe (TxScriptValiditySupportedInEra era)
 txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraShelley = Nothing
 txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraAllegra = Nothing
-txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraMary    = Nothing
-txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraAlonzo  = Just TxScriptValiditySupportedInAlonzoEra
+txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraMary = Nothing
+txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraAlonzo = Just TxScriptValiditySupportedInAlonzoEra
 txScriptValiditySupportedInShelleyBasedEra ShelleyBasedEraBabbage = Just TxScriptValiditySupportedInBabbageEra
 
 txScriptValidityToScriptValidity :: TxScriptValidity era -> ScriptValidity
@@ -345,15 +346,19 @@ txScriptValidityToIsValid = scriptValidityToIsValid . txScriptValidityToScriptVa
 
 -- | The context is a transaction body
 data CtxTx
+
 -- | The context is the UTxO
 data CtxUTxO
 
-data TxOut ctx era = TxOut (AddressInEra    era)
-                           (TxOutValue      era)
-                           (TxOutDatum ctx  era)
-                           (ReferenceScript era)
+data TxOut ctx era
+  = TxOut
+      (AddressInEra era)
+      (TxOutValue era)
+      (TxOutDatum ctx era)
+      (ReferenceScript era)
 
-deriving instance Eq   (TxOut ctx era)
+deriving instance Eq (TxOut ctx era)
+
 deriving instance Show (TxOut ctx era)
 
 instance EraCast (TxOut ctx) where
@@ -365,9 +370,10 @@ instance EraCast (TxOut ctx) where
       <*> eraCast toEra referenceScript
 
 data TxOutInAnyEra where
-     TxOutInAnyEra :: CardanoEra era
-                   -> TxOut CtxTx era
-                   -> TxOutInAnyEra
+  TxOutInAnyEra ::
+    CardanoEra era ->
+    TxOut CtxTx era ->
+    TxOutInAnyEra
 
 deriving instance Show TxOutInAnyEra
 
@@ -375,23 +381,23 @@ instance Eq TxOutInAnyEra where
   TxOutInAnyEra era1 out1 == TxOutInAnyEra era2 out2 =
     case testEquality era1 era2 of
       Just Refl -> out1 == out2
-      Nothing   -> False
+      Nothing -> False
 
 -- | Convenience constructor for 'TxOutInAnyEra'
 txOutInAnyEra :: IsCardanoEra era => TxOut CtxTx era -> TxOutInAnyEra
 txOutInAnyEra = TxOutInAnyEra cardanoEra
 
-toCtxUTxOTxOut :: TxOut CtxTx  era -> TxOut CtxUTxO era
+toCtxUTxOTxOut :: TxOut CtxTx era -> TxOut CtxUTxO era
 toCtxUTxOTxOut (TxOut addr val d refS) =
   let dat = case d of
-              TxOutDatumNone -> TxOutDatumNone
-              TxOutDatumHash s h -> TxOutDatumHash s h
-              TxOutDatumInTx' s h _ -> TxOutDatumHash s h
-              TxOutDatumInline s sd -> TxOutDatumInline s sd
-  in TxOut addr val dat refS
+        TxOutDatumNone -> TxOutDatumNone
+        TxOutDatumHash s h -> TxOutDatumHash s h
+        TxOutDatumInTx' s h _ -> TxOutDatumHash s h
+        TxOutDatumInline s sd -> TxOutDatumInline s sd
+   in TxOut addr val dat refS
 
 instance IsCardanoEra era => ToJSON (TxOut ctx era) where
-  toJSON  = txOutToJsonValue cardanoEra
+  toJSON = txOutToJsonValue cardanoEra
 
 txOutToJsonValue :: CardanoEra era -> TxOut ctx era -> Aeson.Value
 txOutToJsonValue era (TxOut addr val dat refScript) =
@@ -400,364 +406,405 @@ txOutToJsonValue era (TxOut addr val dat refScript) =
     ShelleyEra -> object ["address" .= addr, "value" .= val]
     AllegraEra -> object ["address" .= addr, "value" .= val]
     MaryEra -> object ["address" .= addr, "value" .= val]
-    AlonzoEra -> object
-                   [ "address" .= addr
-                   , "value" .= val
-                   , datHashJsonVal dat
-                   , "datum" .= datJsonVal dat
-                   ]
+    AlonzoEra ->
+      object
+        [ "address" .= addr,
+          "value" .= val,
+          datHashJsonVal dat,
+          "datum" .= datJsonVal dat
+        ]
     BabbageEra ->
       object
-        [ "address" .= addr
-        , "value" .= val
-        , datHashJsonVal dat
-        , "datum" .= datJsonVal dat
-        , "inlineDatum" .= inlineDatumJsonVal dat
-        , "referenceScript" .= refScriptJsonVal refScript
+        [ "address" .= addr,
+          "value" .= val,
+          datHashJsonVal dat,
+          "datum" .= datJsonVal dat,
+          "inlineDatum" .= inlineDatumJsonVal dat,
+          "referenceScript" .= refScriptJsonVal refScript
         ]
- where
-   datHashJsonVal :: TxOutDatum ctx era -> Aeson.Pair
-   datHashJsonVal d =
-     case d of
-       TxOutDatumNone ->
-         "datumhash" .= Aeson.Null
-       TxOutDatumHash _ h ->
-         "datumhash" .= toJSON h
-       TxOutDatumInTx' _ h _ ->
-         "datumhash" .= toJSON h
-       TxOutDatumInline _ datum ->
-         "inlineDatumhash"  .= toJSON (hashScriptData datum)
+  where
+    datHashJsonVal :: TxOutDatum ctx era -> Aeson.Pair
+    datHashJsonVal d =
+      case d of
+        TxOutDatumNone ->
+          "datumhash" .= Aeson.Null
+        TxOutDatumHash _ h ->
+          "datumhash" .= toJSON h
+        TxOutDatumInTx' _ h _ ->
+          "datumhash" .= toJSON h
+        TxOutDatumInline _ datum ->
+          "inlineDatumhash" .= toJSON (hashScriptData datum)
 
-   datJsonVal :: TxOutDatum ctx era -> Aeson.Value
-   datJsonVal d =
-     case d of
-       TxOutDatumNone -> Aeson.Null
-       TxOutDatumHash _ _ -> Aeson.Null
-       TxOutDatumInTx' _ _ datum -> scriptDataToJson ScriptDataJsonDetailedSchema datum
-       TxOutDatumInline _ _ -> Aeson.Null
+    datJsonVal :: TxOutDatum ctx era -> Aeson.Value
+    datJsonVal d =
+      case d of
+        TxOutDatumNone -> Aeson.Null
+        TxOutDatumHash _ _ -> Aeson.Null
+        TxOutDatumInTx' _ _ datum -> scriptDataToJson ScriptDataJsonDetailedSchema datum
+        TxOutDatumInline _ _ -> Aeson.Null
 
-   inlineDatumJsonVal :: TxOutDatum ctx era -> Aeson.Value
-   inlineDatumJsonVal d =
-     case d of
-       TxOutDatumNone -> Aeson.Null
-       TxOutDatumHash {} -> Aeson.Null
-       TxOutDatumInTx'{} -> Aeson.Null
-       TxOutDatumInline _ datum -> scriptDataToJson ScriptDataJsonDetailedSchema datum
+    inlineDatumJsonVal :: TxOutDatum ctx era -> Aeson.Value
+    inlineDatumJsonVal d =
+      case d of
+        TxOutDatumNone -> Aeson.Null
+        TxOutDatumHash {} -> Aeson.Null
+        TxOutDatumInTx' {} -> Aeson.Null
+        TxOutDatumInline _ datum -> scriptDataToJson ScriptDataJsonDetailedSchema datum
 
-   refScriptJsonVal :: ReferenceScript era -> Aeson.Value
-   refScriptJsonVal rScript =
-     case rScript of
-       ReferenceScript _ s -> toJSON s
-       ReferenceScriptNone -> Aeson.Null
+    refScriptJsonVal :: ReferenceScript era -> Aeson.Value
+    refScriptJsonVal rScript =
+      case rScript of
+        ReferenceScript _ s -> toJSON s
+        ReferenceScriptNone -> Aeson.Null
 
-instance (IsShelleyBasedEra era, IsCardanoEra era)
-  => FromJSON (TxOut CtxTx era) where
-      parseJSON = withObject "TxOut" $ \o -> do
-        case shelleyBasedEra :: ShelleyBasedEra era of
-          ShelleyBasedEraShelley ->
+instance
+  (IsShelleyBasedEra era, IsCardanoEra era) =>
+  FromJSON (TxOut CtxTx era)
+  where
+  parseJSON = withObject "TxOut" $ \o -> do
+    case shelleyBasedEra :: ShelleyBasedEra era of
+      ShelleyBasedEraShelley ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraMary ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraAllegra ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraAlonzo -> alonzoTxOutParser ScriptDataInAlonzoEra o
+      ShelleyBasedEraBabbage -> do
+        alonzoTxOutInBabbage <- alonzoTxOutParser ScriptDataInBabbageEra o
+
+        -- We check for the existence of inline datums
+        inlineDatumHash <- o .:? "inlineDatumhash"
+        inlineDatum <- o .:? "inlineDatum"
+        mInlineDatum <-
+          case (inlineDatum, inlineDatumHash) of
+            (Just dVal, Just h) ->
+              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
+                Left err ->
+                  fail $ "Error parsing TxOut JSON: " <> displayError err
+                Right sData ->
+                  if hashScriptData sData /= h
+                    then fail "Inline datum not equivalent to inline datum hash"
+                    else return $ TxOutDatumInline ReferenceTxInsScriptsInlineDatumsInBabbageEra sData
+            (Nothing, Nothing) -> return TxOutDatumNone
+            (_, _) -> fail "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+
+        mReferenceScript <- o .:? "referenceScript"
+
+        reconcile alonzoTxOutInBabbage mInlineDatum mReferenceScript
+    where
+      reconcile ::
+        -- | Alonzo era datum in Babbage era
+        TxOut CtxTx BabbageEra ->
+        -- | Babbagae inline datum
+        TxOutDatum CtxTx BabbageEra ->
+        Maybe ScriptInAnyLang ->
+        Aeson.Parser (TxOut CtxTx BabbageEra)
+      reconcile top@(TxOut addr v dat r) babbageDatum mBabRefScript = do
+        -- We check for conflicting datums
+        finalDat <- case (dat, babbageDatum) of
+          (TxOutDatumNone, bDatum) -> return bDatum
+          (anyDat, TxOutDatumNone) -> return anyDat
+          (alonzoDat, babbageDat) ->
+            fail $
+              "Parsed an Alonzo era datum and a Babbage era datum "
+                <> "TxOut: "
+                <> show top
+                <> "Alonzo datum: "
+                <> show alonzoDat
+                <> "Babbage dat: "
+                <> show babbageDat
+        finalRefScript <- case mBabRefScript of
+          Nothing -> return r
+          Just anyScript ->
+            return $ ReferenceScript ReferenceTxInsScriptsInlineDatumsInBabbageEra anyScript
+        return $ TxOut addr v finalDat finalRefScript
+
+      alonzoTxOutParser ::
+        ScriptDataSupportedInEra era -> Aeson.Object -> Aeson.Parser (TxOut CtxTx era)
+      alonzoTxOutParser supp o = do
+        mDatumHash <- o .:? "datumhash"
+        mDatumVal <- o .:? "datum"
+        case (mDatumVal, mDatumHash) of
+          (Nothing, Nothing) ->
             TxOut <$> o .: "address"
+              <*> o .: "value"
+              <*> return TxOutDatumNone
+              <*> return ReferenceScriptNone
+          (Just dVal, Just dHash) ->
+            case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
+              Left err ->
+                fail $ "Error parsing TxOut JSON: " <> displayError err
+              Right sData ->
+                TxOut <$> o .: "address"
                   <*> o .: "value"
-                  <*> return TxOutDatumNone
+                  <*> return (TxOutDatumInTx' supp dHash sData)
                   <*> return ReferenceScriptNone
-          ShelleyBasedEraMary ->
+          (Nothing, Just dHash) ->
             TxOut <$> o .: "address"
-                  <*> o .: "value"
-                  <*> return TxOutDatumNone
-                  <*> return ReferenceScriptNone
-          ShelleyBasedEraAllegra ->
+              <*> o .: "value"
+              <*> return (TxOutDatumHash supp dHash)
+              <*> return ReferenceScriptNone
+          (Just _dVal, Nothing) -> fail "Only datum JSON was found, this should not be possible."
+
+instance
+  (IsShelleyBasedEra era, IsCardanoEra era) =>
+  FromJSON (TxOut CtxUTxO era)
+  where
+  parseJSON = withObject "TxOut" $ \o -> do
+    case shelleyBasedEra :: ShelleyBasedEra era of
+      ShelleyBasedEraShelley ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraMary ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraAllegra ->
+        TxOut <$> o .: "address"
+          <*> o .: "value"
+          <*> return TxOutDatumNone
+          <*> return ReferenceScriptNone
+      ShelleyBasedEraAlonzo -> alonzoTxOutParser ScriptDataInAlonzoEra o
+      ShelleyBasedEraBabbage -> do
+        alonzoTxOutInBabbage <- alonzoTxOutParser ScriptDataInBabbageEra o
+
+        -- We check for the existence of inline datums
+        inlineDatumHash <- o .:? "inlineDatumhash"
+        inlineDatum <- o .:? "inlineDatum"
+        mInlineDatum <-
+          case (inlineDatum, inlineDatumHash) of
+            (Just dVal, Just h) ->
+              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
+                Left err ->
+                  fail $ "Error parsing TxOut JSON: " <> displayError err
+                Right sData ->
+                  if hashScriptData sData /= h
+                    then fail "Inline datum not equivalent to inline datum hash"
+                    else return $ TxOutDatumInline ReferenceTxInsScriptsInlineDatumsInBabbageEra sData
+            (Nothing, Nothing) -> return TxOutDatumNone
+            (_, _) -> fail "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+
+        -- We check for a reference script
+        mReferenceScript <- o .:? "referenceScript"
+
+        reconcile alonzoTxOutInBabbage mInlineDatum mReferenceScript
+    where
+      reconcile ::
+        -- | Alonzo era datum in Babbage era
+        TxOut CtxUTxO BabbageEra ->
+        -- | Babbagae inline datum
+        TxOutDatum CtxUTxO BabbageEra ->
+        Maybe ScriptInAnyLang ->
+        Aeson.Parser (TxOut CtxUTxO BabbageEra)
+      reconcile (TxOut addr v dat r) babbageDatum mBabRefScript = do
+        -- We check for conflicting datums
+        finalDat <- case (dat, babbageDatum) of
+          (TxOutDatumNone, bDatum) -> return bDatum
+          (anyDat, TxOutDatumNone) -> return anyDat
+          (_, _) -> fail "Parsed an Alonzo era datum and a Babbage era datum"
+        finalRefScript <- case mBabRefScript of
+          Nothing -> return r
+          Just anyScript ->
+            return $ ReferenceScript ReferenceTxInsScriptsInlineDatumsInBabbageEra anyScript
+
+        return $ TxOut addr v finalDat finalRefScript
+
+      alonzoTxOutParser :: ScriptDataSupportedInEra era -> Aeson.Object -> Aeson.Parser (TxOut CtxUTxO era)
+      alonzoTxOutParser supp o = do
+        mDatumHash <- o .:? "datumhash"
+        case mDatumHash of
+          Nothing ->
             TxOut <$> o .: "address"
-                  <*> o .: "value"
-                  <*> return TxOutDatumNone
-                  <*> return ReferenceScriptNone
-          ShelleyBasedEraAlonzo -> alonzoTxOutParser ScriptDataInAlonzoEra o
-
-          ShelleyBasedEraBabbage -> do
-            alonzoTxOutInBabbage <- alonzoTxOutParser ScriptDataInBabbageEra o
-
-            -- We check for the existence of inline datums
-            inlineDatumHash <- o .:? "inlineDatumhash"
-            inlineDatum <- o .:? "inlineDatum"
-            mInlineDatum <-
-              case (inlineDatum, inlineDatumHash) of
-                (Just dVal, Just h) ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                    Left err ->
-                      fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData ->
-                      if hashScriptData sData /= h
-                      then fail "Inline datum not equivalent to inline datum hash"
-                      else return $ TxOutDatumInline ReferenceTxInsScriptsInlineDatumsInBabbageEra sData
-                (Nothing, Nothing) -> return TxOutDatumNone
-                (_,_) -> fail "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
-
-            mReferenceScript <- o .:? "referenceScript"
-
-            reconcile alonzoTxOutInBabbage mInlineDatum mReferenceScript
-         where
-           reconcile
-             :: TxOut CtxTx BabbageEra -- ^ Alonzo era datum in Babbage era
-             -> TxOutDatum CtxTx BabbageEra -- ^ Babbagae inline datum
-             -> Maybe ScriptInAnyLang
-             -> Aeson.Parser (TxOut CtxTx BabbageEra)
-           reconcile top@(TxOut addr v dat r) babbageDatum mBabRefScript = do
-             -- We check for conflicting datums
-             finalDat <- case (dat, babbageDatum) of
-                           (TxOutDatumNone, bDatum) -> return bDatum
-                           (anyDat, TxOutDatumNone) -> return anyDat
-                           (alonzoDat, babbageDat) ->
-                             fail $ "Parsed an Alonzo era datum and a Babbage era datum " <>
-                                    "TxOut: " <> show top <>
-                                    "Alonzo datum: " <> show alonzoDat <>
-                                    "Babbage dat: " <> show babbageDat
-             finalRefScript <- case mBabRefScript of
-                                 Nothing -> return r
-                                 Just anyScript ->
-                                   return $ ReferenceScript ReferenceTxInsScriptsInlineDatumsInBabbageEra anyScript
-             return $ TxOut addr v finalDat finalRefScript
-
-           alonzoTxOutParser
-             :: ScriptDataSupportedInEra era -> Aeson.Object -> Aeson.Parser (TxOut CtxTx era)
-           alonzoTxOutParser supp o = do
-            mDatumHash <- o .:? "datumhash"
-            mDatumVal <- o .:? "datum"
-            case (mDatumVal, mDatumHash) of
-               (Nothing,Nothing) -> TxOut <$> o .: "address"
-                                          <*> o .: "value"
-                                          <*> return TxOutDatumNone
-                                          <*> return ReferenceScriptNone
-               (Just dVal, Just dHash) ->
-                 case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                   Left err ->
-                     fail $ "Error parsing TxOut JSON: " <> displayError err
-                   Right sData -> TxOut <$> o .: "address"
-                                        <*> o .: "value"
-                                        <*> return (TxOutDatumInTx' supp dHash sData)
-                                        <*> return ReferenceScriptNone
-               (Nothing, Just dHash) ->
-                 TxOut <$> o .: "address"
-                       <*> o .: "value"
-                       <*> return (TxOutDatumHash supp dHash)
-                       <*> return ReferenceScriptNone
-               (Just _dVal, Nothing) -> fail "Only datum JSON was found, this should not be possible."
-
-instance (IsShelleyBasedEra era, IsCardanoEra era)
-  => FromJSON (TxOut CtxUTxO era) where
-      parseJSON = withObject "TxOut" $ \o -> do
-        case shelleyBasedEra :: ShelleyBasedEra era of
-          ShelleyBasedEraShelley ->
+              <*> o .: "value"
+              <*> return TxOutDatumNone
+              <*> return ReferenceScriptNone
+          Just dHash ->
             TxOut <$> o .: "address"
-                  <*> o .: "value"
-                  <*> return TxOutDatumNone
-                  <*> return ReferenceScriptNone
-          ShelleyBasedEraMary ->
-            TxOut <$> o .: "address"
-                  <*> o .: "value"
-                  <*> return TxOutDatumNone
-                  <*> return ReferenceScriptNone
-          ShelleyBasedEraAllegra ->
-            TxOut <$> o .: "address"
-                  <*> o .: "value"
-                  <*> return TxOutDatumNone
-                  <*> return ReferenceScriptNone
-          ShelleyBasedEraAlonzo -> alonzoTxOutParser ScriptDataInAlonzoEra o
-
-          ShelleyBasedEraBabbage -> do
-            alonzoTxOutInBabbage <- alonzoTxOutParser ScriptDataInBabbageEra o
-
-            -- We check for the existence of inline datums
-            inlineDatumHash <- o .:? "inlineDatumhash"
-            inlineDatum <- o .:? "inlineDatum"
-            mInlineDatum <-
-              case (inlineDatum, inlineDatumHash) of
-                (Just dVal, Just h) ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                    Left err ->
-                      fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData ->
-                      if hashScriptData sData /= h
-                      then fail "Inline datum not equivalent to inline datum hash"
-                      else return $ TxOutDatumInline ReferenceTxInsScriptsInlineDatumsInBabbageEra sData
-                (Nothing, Nothing) -> return TxOutDatumNone
-                (_,_) -> fail "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
-
-            -- We check for a reference script
-            mReferenceScript <- o .:? "referenceScript"
-
-            reconcile alonzoTxOutInBabbage mInlineDatum mReferenceScript
-         where
-           reconcile
-             :: TxOut CtxUTxO BabbageEra -- ^ Alonzo era datum in Babbage era
-             -> TxOutDatum CtxUTxO BabbageEra -- ^ Babbagae inline datum
-             -> Maybe ScriptInAnyLang
-             -> Aeson.Parser (TxOut CtxUTxO BabbageEra)
-           reconcile (TxOut addr v dat r) babbageDatum mBabRefScript = do
-             -- We check for conflicting datums
-             finalDat <- case (dat, babbageDatum) of
-                           (TxOutDatumNone, bDatum) -> return bDatum
-                           (anyDat, TxOutDatumNone) -> return anyDat
-                           (_,_) -> fail "Parsed an Alonzo era datum and a Babbage era datum"
-             finalRefScript <- case mBabRefScript of
-                                 Nothing -> return r
-                                 Just anyScript ->
-                                   return $ ReferenceScript ReferenceTxInsScriptsInlineDatumsInBabbageEra anyScript
-
-             return $ TxOut addr v finalDat finalRefScript
-
-           alonzoTxOutParser :: ScriptDataSupportedInEra era -> Aeson.Object -> Aeson.Parser (TxOut CtxUTxO era)
-           alonzoTxOutParser supp o = do
-            mDatumHash <- o .:? "datumhash"
-            case mDatumHash of
-               Nothing -> TxOut <$> o .: "address"
-                                          <*> o .: "value"
-                                          <*> return TxOutDatumNone
-                                          <*> return ReferenceScriptNone
-               Just dHash ->
-                 TxOut <$> o .: "address"
-                        <*> o .: "value"
-                        <*> return (TxOutDatumHash supp dHash)
-                        <*> return ReferenceScriptNone
+              <*> o .: "value"
+              <*> return (TxOutDatumHash supp dHash)
+              <*> return ReferenceScriptNone
 
 fromByronTxOut :: Byron.TxOut -> TxOut ctx ByronEra
 fromByronTxOut (Byron.TxOut addr value) =
   TxOut
     (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
     (TxOutAdaOnly AdaOnlyInByronEra (fromByronLovelace value))
-     TxOutDatumNone ReferenceScriptNone
-
+    TxOutDatumNone
+    ReferenceScriptNone
 
 toByronTxOut :: TxOut ctx ByronEra -> Maybe Byron.TxOut
-toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
-                    (TxOutAdaOnly AdaOnlyInByronEra value) _ _) =
+toByronTxOut
+  ( TxOut
+      (AddressInEra ByronAddressInAnyEra (ByronAddress addr))
+      (TxOutAdaOnly AdaOnlyInByronEra value)
+      _
+      _
+    ) =
     Byron.TxOut addr <$> toByronLovelace value
+toByronTxOut
+  ( TxOut
+      (AddressInEra ByronAddressInAnyEra (ByronAddress _))
+      (TxOutValue era _)
+      _
+      _
+    ) = case era of
+toByronTxOut
+  ( TxOut
+      (AddressInEra (ShelleyAddressInEra era) ShelleyAddress {})
+      _
+      _
+      _
+    ) = case era of
 
-toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _))
-                    (TxOutValue era _) _ _) = case era of {}
-
-toByronTxOut (TxOut (AddressInEra (ShelleyAddressInEra era) ShelleyAddress{})
-                    _ _ _) = case era of {}
-
-
-toShelleyTxOut :: forall era ledgerera.
-                  ShelleyLedgerEra era ~ ledgerera
-               => ShelleyBasedEra era
-               -> TxOut CtxUTxO era
-               -> Ledger.TxOut ledgerera
+toShelleyTxOut ::
+  forall era ledgerera.
+  ShelleyLedgerEra era ~ ledgerera =>
+  ShelleyBasedEra era ->
+  TxOut CtxUTxO era ->
+  Ledger.TxOut ledgerera
 toShelleyTxOut era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _ _) =
-    case era of {}
-
+  case era of
 toShelleyTxOut _ (TxOut addr (TxOutAdaOnly AdaOnlyInShelleyEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 toShelleyTxOut _ (TxOut addr (TxOutAdaOnly AdaOnlyInAllegraEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 toShelleyTxOut _ (TxOut addr (TxOutValue MultiAssetInMaryEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toMaryValue value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toMaryValue value)
 toShelleyTxOut _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata _) =
-    Alonzo.TxOut (toShelleyAddr addr) (toMaryValue value)
-                 (toAlonzoTxOutDataHash txoutdata)
-
+  AlonzoTxOut
+    (toShelleyAddr addr)
+    (toMaryValue value)
+    (toAlonzoTxOutDataHash txoutdata)
 toShelleyTxOut era (TxOut addr (TxOutValue MultiAssetInBabbageEra value) txoutdata refScript) =
-    let cEra = shelleyBasedToCardanoEra era
-    in Babbage.TxOut (toShelleyAddr addr) (toMaryValue value)
-                     (toBabbageTxOutDatum txoutdata) (refScriptToShelleyScript cEra refScript)
+  let cEra = shelleyBasedToCardanoEra era
+   in BabbageTxOut
+        (toShelleyAddr addr)
+        (toMaryValue value)
+        (toBabbageTxOutDatum txoutdata)
+        (refScriptToShelleyScript cEra refScript)
 
-
-fromShelleyTxOut :: ShelleyLedgerEra era ~ ledgerera
-                 => ShelleyBasedEra era
-                 -> Core.TxOut ledgerera
-                 -> TxOut ctx era
+fromShelleyTxOut ::
+  ShelleyLedgerEra era ~ ledgerera =>
+  ShelleyBasedEra era ->
+  Core.TxOut ledgerera ->
+  TxOut ctx era
 fromShelleyTxOut era ledgerTxOut =
   case era of
     ShelleyBasedEraShelley ->
-        TxOut (fromShelleyAddr era addr)
-              (TxOutAdaOnly AdaOnlyInShelleyEra
-                            (fromShelleyLovelace value))
-               TxOutDatumNone ReferenceScriptNone
+      TxOut
+        (fromShelleyAddr era addr)
+        ( TxOutAdaOnly
+            AdaOnlyInShelleyEra
+            (fromShelleyLovelace value)
+        )
+        TxOutDatumNone
+        ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
-
+        ShelleyTxOut addr value = ledgerTxOut
     ShelleyBasedEraAllegra ->
-        TxOut (fromShelleyAddr era addr)
-              (TxOutAdaOnly AdaOnlyInAllegraEra
-                            (fromShelleyLovelace value))
-               TxOutDatumNone ReferenceScriptNone
+      TxOut
+        (fromShelleyAddr era addr)
+        ( TxOutAdaOnly
+            AdaOnlyInAllegraEra
+            (fromShelleyLovelace value)
+        )
+        TxOutDatumNone
+        ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
-
+        ShelleyTxOut addr value = ledgerTxOut
     ShelleyBasedEraMary ->
-        TxOut (fromShelleyAddr era addr)
-              (TxOutValue MultiAssetInMaryEra
-                          (fromMaryValue value))
-               TxOutDatumNone ReferenceScriptNone
+      TxOut
+        (fromShelleyAddr era addr)
+        ( TxOutValue
+            MultiAssetInMaryEra
+            (fromMaryValue value)
+        )
+        TxOutDatumNone
+        ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
-
+        ShelleyTxOut addr value = ledgerTxOut
     ShelleyBasedEraAlonzo ->
-       TxOut (fromShelleyAddr era addr)
-             (TxOutValue MultiAssetInAlonzoEra
-                         (fromMaryValue value))
-             (fromAlonzoTxOutDataHash ScriptDataInAlonzoEra datahash)
-             ReferenceScriptNone
+      TxOut
+        (fromShelleyAddr era addr)
+        ( TxOutValue
+            MultiAssetInAlonzoEra
+            (fromMaryValue value)
+        )
+        (fromAlonzoTxOutDataHash ScriptDataInAlonzoEra datahash)
+        ReferenceScriptNone
       where
-        Alonzo.TxOut addr value datahash = ledgerTxOut
-
+        AlonzoTxOut addr value datahash = ledgerTxOut
     ShelleyBasedEraBabbage ->
-       TxOut (fromShelleyAddr era addr)
-             (TxOutValue MultiAssetInBabbageEra
-                         (fromMaryValue value))
-             (fromBabbageTxOutDatum
-               ScriptDataInBabbageEra
-               ReferenceTxInsScriptsInlineDatumsInBabbageEra
-               datum)
-             (case mRefScript of
-                SNothing -> ReferenceScriptNone
-                SJust refScript ->
-                  fromShelleyScriptToReferenceScript ShelleyBasedEraBabbage refScript)
+      TxOut
+        (fromShelleyAddr era addr)
+        ( TxOutValue
+            MultiAssetInBabbageEra
+            (fromMaryValue value)
+        )
+        ( fromBabbageTxOutDatum
+            ScriptDataInBabbageEra
+            ReferenceTxInsScriptsInlineDatumsInBabbageEra
+            datum
+        )
+        ( case mRefScript of
+            SNothing -> ReferenceScriptNone
+            SJust refScript ->
+              fromShelleyScriptToReferenceScript ShelleyBasedEraBabbage refScript
+        )
       where
-        Babbage.TxOut addr value datum mRefScript = ledgerTxOut
-
-
+        BabbageTxOut addr value datum mRefScript = ledgerTxOut
 
 -- TODO: If ledger creates an open type family for datums
 -- we can consolidate this function with the Babbage version
-toAlonzoTxOutDataHash
-  :: TxOutDatum CtxUTxO AlonzoEra
-  -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-toAlonzoTxOutDataHash  TxOutDatumNone                        = SNothing
+toAlonzoTxOutDataHash ::
+  TxOutDatum CtxUTxO AlonzoEra ->
+  StrictMaybe (Alonzo.DataHash StandardCrypto)
+toAlonzoTxOutDataHash TxOutDatumNone = SNothing
 toAlonzoTxOutDataHash (TxOutDatumHash _ (ScriptDataHash dh)) = SJust dh
 toAlonzoTxOutDataHash (TxOutDatumInline inlineDatumSupp _sd) =
-  case inlineDatumSupp :: ReferenceTxInsScriptsInlineDatumsSupportedInEra AlonzoEra of {}
+  case inlineDatumSupp :: ReferenceTxInsScriptsInlineDatumsSupportedInEra AlonzoEra of
 
-fromAlonzoTxOutDataHash :: ScriptDataSupportedInEra era
-                        -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-                        -> TxOutDatum ctx era
-fromAlonzoTxOutDataHash _    SNothing  = TxOutDatumNone
-fromAlonzoTxOutDataHash s (SJust dh)   = TxOutDatumHash s (ScriptDataHash dh)
+fromAlonzoTxOutDataHash ::
+  ScriptDataSupportedInEra era ->
+  StrictMaybe (Alonzo.DataHash StandardCrypto) ->
+  TxOutDatum ctx era
+fromAlonzoTxOutDataHash _ SNothing = TxOutDatumNone
+fromAlonzoTxOutDataHash s (SJust dh) = TxOutDatumHash s (ScriptDataHash dh)
 
 -- TODO: If ledger creates an open type family for datums
 -- we can consolidate this function with the Alonzo version
-toBabbageTxOutDatum
-  :: Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => TxOutDatum CtxUTxO era -> Babbage.Datum (ShelleyLedgerEra era)
-toBabbageTxOutDatum  TxOutDatumNone = Babbage.NoDatum
+toBabbageTxOutDatum ::
+  Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto =>
+  TxOutDatum CtxUTxO era ->
+  Babbage.Datum (ShelleyLedgerEra era)
+toBabbageTxOutDatum TxOutDatumNone = Babbage.NoDatum
 toBabbageTxOutDatum (TxOutDatumHash _ (ScriptDataHash dh)) = Babbage.DatumHash dh
 toBabbageTxOutDatum (TxOutDatumInline _ sd) = scriptDataToInlineDatum sd
 
-fromBabbageTxOutDatum
-  :: Ledger.Crypto ledgerera ~ StandardCrypto
-  => ScriptDataSupportedInEra era
-  -> ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-  -> Babbage.Datum ledgerera
-  -> TxOutDatum ctx era
+fromBabbageTxOutDatum ::
+  Ledger.Crypto ledgerera ~ StandardCrypto =>
+  ScriptDataSupportedInEra era ->
+  ReferenceTxInsScriptsInlineDatumsSupportedInEra era ->
+  Babbage.Datum ledgerera ->
+  TxOutDatum ctx era
 fromBabbageTxOutDatum _ _ Babbage.NoDatum = TxOutDatumNone
 fromBabbageTxOutDatum supp _ (Babbage.DatumHash dh) =
   TxOutDatumHash supp $ ScriptDataHash dh
 fromBabbageTxOutDatum _ supp (Babbage.Datum binData) =
   TxOutDatumInline supp $ binaryDataToScriptData supp binData
-
-
 
 -- ----------------------------------------------------------------------------
 -- Era-dependent transaction body features
@@ -767,43 +814,39 @@ fromBabbageTxOutDatum _ supp (Babbage.Datum binData) =
 -- only for collateral for script fees.
 --
 -- The Alonzo and subsequent eras support collateral inputs.
---
 data CollateralSupportedInEra era where
+  CollateralInAlonzoEra :: CollateralSupportedInEra AlonzoEra
+  CollateralInBabbageEra :: CollateralSupportedInEra BabbageEra
 
-     CollateralInAlonzoEra  :: CollateralSupportedInEra AlonzoEra
-     CollateralInBabbageEra :: CollateralSupportedInEra BabbageEra
+deriving instance Eq (CollateralSupportedInEra era)
 
-deriving instance Eq   (CollateralSupportedInEra era)
 deriving instance Show (CollateralSupportedInEra era)
 
-collateralSupportedInEra :: CardanoEra era
-                         -> Maybe (CollateralSupportedInEra era)
-collateralSupportedInEra ByronEra   = Nothing
+collateralSupportedInEra ::
+  CardanoEra era ->
+  Maybe (CollateralSupportedInEra era)
+collateralSupportedInEra ByronEra = Nothing
 collateralSupportedInEra ShelleyEra = Nothing
 collateralSupportedInEra AllegraEra = Nothing
-collateralSupportedInEra MaryEra    = Nothing
-collateralSupportedInEra AlonzoEra  = Just CollateralInAlonzoEra
+collateralSupportedInEra MaryEra = Nothing
+collateralSupportedInEra AlonzoEra = Just CollateralInAlonzoEra
 collateralSupportedInEra BabbageEra = Just CollateralInBabbageEra
-
 
 -- | A representation of whether the era supports multi-asset transactions.
 --
 -- The Mary and subsequent eras support multi-asset transactions.
 --
 -- The negation of this is 'OnlyAdaSupportedInEra'.
---
 data MultiAssetSupportedInEra era where
+  -- | Multi-asset transactions are supported in the 'Mary' era.
+  MultiAssetInMaryEra :: MultiAssetSupportedInEra MaryEra
+  -- | Multi-asset transactions are supported in the 'Alonzo' era.
+  MultiAssetInAlonzoEra :: MultiAssetSupportedInEra AlonzoEra
+  -- | Multi-asset transactions are supported in the 'Babbage' era.
+  MultiAssetInBabbageEra :: MultiAssetSupportedInEra BabbageEra
 
-     -- | Multi-asset transactions are supported in the 'Mary' era.
-     MultiAssetInMaryEra :: MultiAssetSupportedInEra MaryEra
+deriving instance Eq (MultiAssetSupportedInEra era)
 
-     -- | Multi-asset transactions are supported in the 'Alonzo' era.
-     MultiAssetInAlonzoEra :: MultiAssetSupportedInEra AlonzoEra
-
-     -- | Multi-asset transactions are supported in the 'Babbage' era.
-     MultiAssetInBabbageEra :: MultiAssetSupportedInEra BabbageEra
-
-deriving instance Eq   (MultiAssetSupportedInEra era)
 deriving instance Show (MultiAssetSupportedInEra era)
 
 instance ToJSON (MultiAssetSupportedInEra era) where
@@ -816,26 +859,26 @@ instance ToJSON (MultiAssetSupportedInEra era) where
 --
 -- This is the negation of 'MultiAssetSupportedInEra'. It exists since we need
 -- evidence to be positive.
---
 data OnlyAdaSupportedInEra era where
+  AdaOnlyInByronEra :: OnlyAdaSupportedInEra ByronEra
+  AdaOnlyInShelleyEra :: OnlyAdaSupportedInEra ShelleyEra
+  AdaOnlyInAllegraEra :: OnlyAdaSupportedInEra AllegraEra
 
-     AdaOnlyInByronEra   :: OnlyAdaSupportedInEra ByronEra
-     AdaOnlyInShelleyEra :: OnlyAdaSupportedInEra ShelleyEra
-     AdaOnlyInAllegraEra :: OnlyAdaSupportedInEra AllegraEra
+deriving instance Eq (OnlyAdaSupportedInEra era)
 
-deriving instance Eq   (OnlyAdaSupportedInEra era)
 deriving instance Show (OnlyAdaSupportedInEra era)
 
-multiAssetSupportedInEra :: CardanoEra era
-                         -> Either (OnlyAdaSupportedInEra era)
-                                   (MultiAssetSupportedInEra era)
-multiAssetSupportedInEra ByronEra   = Left AdaOnlyInByronEra
+multiAssetSupportedInEra ::
+  CardanoEra era ->
+  Either
+    (OnlyAdaSupportedInEra era)
+    (MultiAssetSupportedInEra era)
+multiAssetSupportedInEra ByronEra = Left AdaOnlyInByronEra
 multiAssetSupportedInEra ShelleyEra = Left AdaOnlyInShelleyEra
 multiAssetSupportedInEra AllegraEra = Left AdaOnlyInAllegraEra
-multiAssetSupportedInEra MaryEra    = Right MultiAssetInMaryEra
-multiAssetSupportedInEra AlonzoEra  = Right MultiAssetInAlonzoEra
+multiAssetSupportedInEra MaryEra = Right MultiAssetInMaryEra
+multiAssetSupportedInEra AlonzoEra = Right MultiAssetInAlonzoEra
 multiAssetSupportedInEra BabbageEra = Right MultiAssetInBabbageEra
-
 
 -- | A representation of whether the era requires explicitly specified fees in
 -- transactions.
@@ -843,39 +886,39 @@ multiAssetSupportedInEra BabbageEra = Right MultiAssetInBabbageEra
 -- The Byron era tx fees are implicit (as the difference bettween the sum of
 -- outputs and sum of inputs), but all later eras the fees are specified in the
 -- transaction explicitly.
---
 data TxFeesExplicitInEra era where
+  TxFeesExplicitInShelleyEra :: TxFeesExplicitInEra ShelleyEra
+  TxFeesExplicitInAllegraEra :: TxFeesExplicitInEra AllegraEra
+  TxFeesExplicitInMaryEra :: TxFeesExplicitInEra MaryEra
+  TxFeesExplicitInAlonzoEra :: TxFeesExplicitInEra AlonzoEra
+  TxFeesExplicitInBabbageEra :: TxFeesExplicitInEra BabbageEra
 
-     TxFeesExplicitInShelleyEra :: TxFeesExplicitInEra ShelleyEra
-     TxFeesExplicitInAllegraEra :: TxFeesExplicitInEra AllegraEra
-     TxFeesExplicitInMaryEra    :: TxFeesExplicitInEra MaryEra
-     TxFeesExplicitInAlonzoEra  :: TxFeesExplicitInEra AlonzoEra
-     TxFeesExplicitInBabbageEra :: TxFeesExplicitInEra BabbageEra
+deriving instance Eq (TxFeesExplicitInEra era)
 
-deriving instance Eq   (TxFeesExplicitInEra era)
 deriving instance Show (TxFeesExplicitInEra era)
 
 -- | A representation of whether the era requires implicitly specified fees in
 -- transactions.
 --
 -- This is the negation of 'TxFeesExplicitInEra'.
---
 data TxFeesImplicitInEra era where
-     TxFeesImplicitInByronEra :: TxFeesImplicitInEra ByronEra
+  TxFeesImplicitInByronEra :: TxFeesImplicitInEra ByronEra
 
-deriving instance Eq   (TxFeesImplicitInEra era)
+deriving instance Eq (TxFeesImplicitInEra era)
+
 deriving instance Show (TxFeesImplicitInEra era)
 
-txFeesExplicitInEra :: CardanoEra era
-                    -> Either (TxFeesImplicitInEra era)
-                              (TxFeesExplicitInEra era)
-txFeesExplicitInEra ByronEra   = Left  TxFeesImplicitInByronEra
+txFeesExplicitInEra ::
+  CardanoEra era ->
+  Either
+    (TxFeesImplicitInEra era)
+    (TxFeesExplicitInEra era)
+txFeesExplicitInEra ByronEra = Left TxFeesImplicitInByronEra
 txFeesExplicitInEra ShelleyEra = Right TxFeesExplicitInShelleyEra
 txFeesExplicitInEra AllegraEra = Right TxFeesExplicitInAllegraEra
-txFeesExplicitInEra MaryEra    = Right TxFeesExplicitInMaryEra
-txFeesExplicitInEra AlonzoEra  = Right TxFeesExplicitInAlonzoEra
+txFeesExplicitInEra MaryEra = Right TxFeesExplicitInMaryEra
+txFeesExplicitInEra AlonzoEra = Right TxFeesExplicitInAlonzoEra
 txFeesExplicitInEra BabbageEra = Right TxFeesExplicitInBabbageEra
-
 
 -- | A representation of whether the era supports transactions with an upper
 -- bound on the range of slots in which they are valid.
@@ -883,27 +926,26 @@ txFeesExplicitInEra BabbageEra = Right TxFeesExplicitInBabbageEra
 -- The Shelley and subsequent eras support an upper bound on the validity
 -- range. In the Shelley era specifically it is actually required. It is
 -- optional in later eras.
---
 data ValidityUpperBoundSupportedInEra era where
+  ValidityUpperBoundInShelleyEra :: ValidityUpperBoundSupportedInEra ShelleyEra
+  ValidityUpperBoundInAllegraEra :: ValidityUpperBoundSupportedInEra AllegraEra
+  ValidityUpperBoundInMaryEra :: ValidityUpperBoundSupportedInEra MaryEra
+  ValidityUpperBoundInAlonzoEra :: ValidityUpperBoundSupportedInEra AlonzoEra
+  ValidityUpperBoundInBabbageEra :: ValidityUpperBoundSupportedInEra BabbageEra
 
-     ValidityUpperBoundInShelleyEra :: ValidityUpperBoundSupportedInEra ShelleyEra
-     ValidityUpperBoundInAllegraEra :: ValidityUpperBoundSupportedInEra AllegraEra
-     ValidityUpperBoundInMaryEra    :: ValidityUpperBoundSupportedInEra MaryEra
-     ValidityUpperBoundInAlonzoEra  :: ValidityUpperBoundSupportedInEra AlonzoEra
-     ValidityUpperBoundInBabbageEra :: ValidityUpperBoundSupportedInEra BabbageEra
+deriving instance Eq (ValidityUpperBoundSupportedInEra era)
 
-deriving instance Eq   (ValidityUpperBoundSupportedInEra era)
 deriving instance Show (ValidityUpperBoundSupportedInEra era)
 
-validityUpperBoundSupportedInEra :: CardanoEra era
-                                 -> Maybe (ValidityUpperBoundSupportedInEra era)
-validityUpperBoundSupportedInEra ByronEra   = Nothing
+validityUpperBoundSupportedInEra ::
+  CardanoEra era ->
+  Maybe (ValidityUpperBoundSupportedInEra era)
+validityUpperBoundSupportedInEra ByronEra = Nothing
 validityUpperBoundSupportedInEra ShelleyEra = Just ValidityUpperBoundInShelleyEra
 validityUpperBoundSupportedInEra AllegraEra = Just ValidityUpperBoundInAllegraEra
-validityUpperBoundSupportedInEra MaryEra    = Just ValidityUpperBoundInMaryEra
-validityUpperBoundSupportedInEra AlonzoEra  = Just ValidityUpperBoundInAlonzoEra
+validityUpperBoundSupportedInEra MaryEra = Just ValidityUpperBoundInMaryEra
+validityUpperBoundSupportedInEra AlonzoEra = Just ValidityUpperBoundInAlonzoEra
 validityUpperBoundSupportedInEra BabbageEra = Just ValidityUpperBoundInBabbageEra
-
 
 -- | A representation of whether the era supports transactions having /no/
 -- upper bound on the range of slots in which they are valid.
@@ -914,27 +956,26 @@ validityUpperBoundSupportedInEra BabbageEra = Just ValidityUpperBoundInBabbageEr
 --
 -- The Byron era supports this by virtue of the fact that it does not support
 -- validity ranges at all.
---
 data ValidityNoUpperBoundSupportedInEra era where
+  ValidityNoUpperBoundInByronEra :: ValidityNoUpperBoundSupportedInEra ByronEra
+  ValidityNoUpperBoundInAllegraEra :: ValidityNoUpperBoundSupportedInEra AllegraEra
+  ValidityNoUpperBoundInMaryEra :: ValidityNoUpperBoundSupportedInEra MaryEra
+  ValidityNoUpperBoundInAlonzoEra :: ValidityNoUpperBoundSupportedInEra AlonzoEra
+  ValidityNoUpperBoundInBabbageEra :: ValidityNoUpperBoundSupportedInEra BabbageEra
 
-     ValidityNoUpperBoundInByronEra   :: ValidityNoUpperBoundSupportedInEra ByronEra
-     ValidityNoUpperBoundInAllegraEra :: ValidityNoUpperBoundSupportedInEra AllegraEra
-     ValidityNoUpperBoundInMaryEra    :: ValidityNoUpperBoundSupportedInEra MaryEra
-     ValidityNoUpperBoundInAlonzoEra  :: ValidityNoUpperBoundSupportedInEra AlonzoEra
-     ValidityNoUpperBoundInBabbageEra :: ValidityNoUpperBoundSupportedInEra BabbageEra
+deriving instance Eq (ValidityNoUpperBoundSupportedInEra era)
 
-deriving instance Eq   (ValidityNoUpperBoundSupportedInEra era)
 deriving instance Show (ValidityNoUpperBoundSupportedInEra era)
 
-validityNoUpperBoundSupportedInEra :: CardanoEra era
-                                   -> Maybe (ValidityNoUpperBoundSupportedInEra era)
-validityNoUpperBoundSupportedInEra ByronEra   = Just ValidityNoUpperBoundInByronEra
+validityNoUpperBoundSupportedInEra ::
+  CardanoEra era ->
+  Maybe (ValidityNoUpperBoundSupportedInEra era)
+validityNoUpperBoundSupportedInEra ByronEra = Just ValidityNoUpperBoundInByronEra
 validityNoUpperBoundSupportedInEra ShelleyEra = Nothing
 validityNoUpperBoundSupportedInEra AllegraEra = Just ValidityNoUpperBoundInAllegraEra
-validityNoUpperBoundSupportedInEra MaryEra    = Just ValidityNoUpperBoundInMaryEra
-validityNoUpperBoundSupportedInEra AlonzoEra  = Just ValidityNoUpperBoundInAlonzoEra
+validityNoUpperBoundSupportedInEra MaryEra = Just ValidityNoUpperBoundInMaryEra
+validityNoUpperBoundSupportedInEra AlonzoEra = Just ValidityNoUpperBoundInAlonzoEra
 validityNoUpperBoundSupportedInEra BabbageEra = Just ValidityNoUpperBoundInBabbageEra
-
 
 -- | A representation of whether the era supports transactions with a lower
 -- bound on the range of slots in which they are valid.
@@ -942,75 +983,73 @@ validityNoUpperBoundSupportedInEra BabbageEra = Just ValidityNoUpperBoundInBabba
 -- The Allegra and subsequent eras support an optional lower bound on the
 -- validity range. No equivalent of 'ValidityNoUpperBoundSupportedInEra' is
 -- needed since all eras support having no lower bound.
---
 data ValidityLowerBoundSupportedInEra era where
+  ValidityLowerBoundInAllegraEra :: ValidityLowerBoundSupportedInEra AllegraEra
+  ValidityLowerBoundInMaryEra :: ValidityLowerBoundSupportedInEra MaryEra
+  ValidityLowerBoundInAlonzoEra :: ValidityLowerBoundSupportedInEra AlonzoEra
+  ValidityLowerBoundInBabbageEra :: ValidityLowerBoundSupportedInEra BabbageEra
 
-     ValidityLowerBoundInAllegraEra :: ValidityLowerBoundSupportedInEra AllegraEra
-     ValidityLowerBoundInMaryEra    :: ValidityLowerBoundSupportedInEra MaryEra
-     ValidityLowerBoundInAlonzoEra  :: ValidityLowerBoundSupportedInEra AlonzoEra
-     ValidityLowerBoundInBabbageEra :: ValidityLowerBoundSupportedInEra BabbageEra
+deriving instance Eq (ValidityLowerBoundSupportedInEra era)
 
-deriving instance Eq   (ValidityLowerBoundSupportedInEra era)
 deriving instance Show (ValidityLowerBoundSupportedInEra era)
 
-validityLowerBoundSupportedInEra :: CardanoEra era
-                                 -> Maybe (ValidityLowerBoundSupportedInEra era)
-validityLowerBoundSupportedInEra ByronEra   = Nothing
+validityLowerBoundSupportedInEra ::
+  CardanoEra era ->
+  Maybe (ValidityLowerBoundSupportedInEra era)
+validityLowerBoundSupportedInEra ByronEra = Nothing
 validityLowerBoundSupportedInEra ShelleyEra = Nothing
 validityLowerBoundSupportedInEra AllegraEra = Just ValidityLowerBoundInAllegraEra
-validityLowerBoundSupportedInEra MaryEra    = Just ValidityLowerBoundInMaryEra
-validityLowerBoundSupportedInEra AlonzoEra  = Just ValidityLowerBoundInAlonzoEra
+validityLowerBoundSupportedInEra MaryEra = Just ValidityLowerBoundInMaryEra
+validityLowerBoundSupportedInEra AlonzoEra = Just ValidityLowerBoundInAlonzoEra
 validityLowerBoundSupportedInEra BabbageEra = Just ValidityLowerBoundInBabbageEra
 
 -- | A representation of whether the era supports transaction metadata.
 --
 -- Transaction metadata is supported from the Shelley era onwards.
---
 data TxMetadataSupportedInEra era where
+  TxMetadataInShelleyEra :: TxMetadataSupportedInEra ShelleyEra
+  TxMetadataInAllegraEra :: TxMetadataSupportedInEra AllegraEra
+  TxMetadataInMaryEra :: TxMetadataSupportedInEra MaryEra
+  TxMetadataInAlonzoEra :: TxMetadataSupportedInEra AlonzoEra
+  TxMetadataInBabbageEra :: TxMetadataSupportedInEra BabbageEra
 
-     TxMetadataInShelleyEra :: TxMetadataSupportedInEra ShelleyEra
-     TxMetadataInAllegraEra :: TxMetadataSupportedInEra AllegraEra
-     TxMetadataInMaryEra    :: TxMetadataSupportedInEra MaryEra
-     TxMetadataInAlonzoEra  :: TxMetadataSupportedInEra AlonzoEra
-     TxMetadataInBabbageEra :: TxMetadataSupportedInEra BabbageEra
+deriving instance Eq (TxMetadataSupportedInEra era)
 
-deriving instance Eq   (TxMetadataSupportedInEra era)
 deriving instance Show (TxMetadataSupportedInEra era)
 
-txMetadataSupportedInEra :: CardanoEra era
-                         -> Maybe (TxMetadataSupportedInEra era)
-txMetadataSupportedInEra ByronEra   = Nothing
+txMetadataSupportedInEra ::
+  CardanoEra era ->
+  Maybe (TxMetadataSupportedInEra era)
+txMetadataSupportedInEra ByronEra = Nothing
 txMetadataSupportedInEra ShelleyEra = Just TxMetadataInShelleyEra
 txMetadataSupportedInEra AllegraEra = Just TxMetadataInAllegraEra
-txMetadataSupportedInEra MaryEra    = Just TxMetadataInMaryEra
-txMetadataSupportedInEra AlonzoEra  = Just TxMetadataInAlonzoEra
+txMetadataSupportedInEra MaryEra = Just TxMetadataInMaryEra
+txMetadataSupportedInEra AlonzoEra = Just TxMetadataInAlonzoEra
 txMetadataSupportedInEra BabbageEra = Just TxMetadataInBabbageEra
-
 
 -- | A representation of whether the era supports auxiliary scripts in
 -- transactions.
 --
 -- Auxiliary scripts are supported from the Allegra era onwards.
---
 data AuxScriptsSupportedInEra era where
+  AuxScriptsInAllegraEra :: AuxScriptsSupportedInEra AllegraEra
+  AuxScriptsInMaryEra :: AuxScriptsSupportedInEra MaryEra
+  AuxScriptsInAlonzoEra :: AuxScriptsSupportedInEra AlonzoEra
+  AuxScriptsInBabbageEra :: AuxScriptsSupportedInEra BabbageEra
 
-     AuxScriptsInAllegraEra :: AuxScriptsSupportedInEra AllegraEra
-     AuxScriptsInMaryEra    :: AuxScriptsSupportedInEra MaryEra
-     AuxScriptsInAlonzoEra  :: AuxScriptsSupportedInEra AlonzoEra
-     AuxScriptsInBabbageEra :: AuxScriptsSupportedInEra BabbageEra
+deriving instance Eq (AuxScriptsSupportedInEra era)
 
-deriving instance Eq   (AuxScriptsSupportedInEra era)
 deriving instance Show (AuxScriptsSupportedInEra era)
 
-auxScriptsSupportedInEra :: CardanoEra era
-                         -> Maybe (AuxScriptsSupportedInEra era)
-auxScriptsSupportedInEra ByronEra   = Nothing
+auxScriptsSupportedInEra ::
+  CardanoEra era ->
+  Maybe (AuxScriptsSupportedInEra era)
+auxScriptsSupportedInEra ByronEra = Nothing
 auxScriptsSupportedInEra ShelleyEra = Nothing
 auxScriptsSupportedInEra AllegraEra = Just AuxScriptsInAllegraEra
-auxScriptsSupportedInEra MaryEra    = Just AuxScriptsInMaryEra
-auxScriptsSupportedInEra AlonzoEra  = Just AuxScriptsInAlonzoEra
+auxScriptsSupportedInEra MaryEra = Just AuxScriptsInMaryEra
+auxScriptsSupportedInEra AlonzoEra = Just AuxScriptsInAlonzoEra
 auxScriptsSupportedInEra BabbageEra = Just AuxScriptsInBabbageEra
-
 
 -- | A representation of whether the era supports transactions that specify
 -- in the body that they need extra key witnesses, and where this fact is
@@ -1018,102 +1057,98 @@ auxScriptsSupportedInEra BabbageEra = Just AuxScriptsInBabbageEra
 --
 -- Extra key witnesses visible to scripts are supported from the Alonzo era
 -- onwards.
---
 data TxExtraKeyWitnessesSupportedInEra era where
+  ExtraKeyWitnessesInAlonzoEra :: TxExtraKeyWitnessesSupportedInEra AlonzoEra
+  ExtraKeyWitnessesInBabbageEra :: TxExtraKeyWitnessesSupportedInEra BabbageEra
 
-     ExtraKeyWitnessesInAlonzoEra  :: TxExtraKeyWitnessesSupportedInEra AlonzoEra
-     ExtraKeyWitnessesInBabbageEra :: TxExtraKeyWitnessesSupportedInEra BabbageEra
+deriving instance Eq (TxExtraKeyWitnessesSupportedInEra era)
 
-deriving instance Eq   (TxExtraKeyWitnessesSupportedInEra era)
 deriving instance Show (TxExtraKeyWitnessesSupportedInEra era)
 
-extraKeyWitnessesSupportedInEra :: CardanoEra era
-                                -> Maybe (TxExtraKeyWitnessesSupportedInEra era)
-extraKeyWitnessesSupportedInEra ByronEra   = Nothing
+extraKeyWitnessesSupportedInEra ::
+  CardanoEra era ->
+  Maybe (TxExtraKeyWitnessesSupportedInEra era)
+extraKeyWitnessesSupportedInEra ByronEra = Nothing
 extraKeyWitnessesSupportedInEra ShelleyEra = Nothing
 extraKeyWitnessesSupportedInEra AllegraEra = Nothing
-extraKeyWitnessesSupportedInEra MaryEra    = Nothing
-extraKeyWitnessesSupportedInEra AlonzoEra  = Just ExtraKeyWitnessesInAlonzoEra
+extraKeyWitnessesSupportedInEra MaryEra = Nothing
+extraKeyWitnessesSupportedInEra AlonzoEra = Just ExtraKeyWitnessesInAlonzoEra
 extraKeyWitnessesSupportedInEra BabbageEra = Just ExtraKeyWitnessesInBabbageEra
-
 
 -- | A representation of whether the era supports multi-asset transactions.
 --
 -- The Mary and subsequent eras support multi-asset transactions.
 --
 -- The negation of this is 'OnlyAdaSupportedInEra'.
---
 data ScriptDataSupportedInEra era where
+  -- | Script data is supported in transactions in the 'Alonzo' era.
+  ScriptDataInAlonzoEra :: ScriptDataSupportedInEra AlonzoEra
+  ScriptDataInBabbageEra :: ScriptDataSupportedInEra BabbageEra
 
-     -- | Script data is supported in transactions in the 'Alonzo' era.
-     ScriptDataInAlonzoEra  :: ScriptDataSupportedInEra AlonzoEra
-     ScriptDataInBabbageEra :: ScriptDataSupportedInEra BabbageEra
+deriving instance Eq (ScriptDataSupportedInEra era)
 
-deriving instance Eq   (ScriptDataSupportedInEra era)
 deriving instance Show (ScriptDataSupportedInEra era)
 
-scriptDataSupportedInEra :: CardanoEra era
-                         -> Maybe (ScriptDataSupportedInEra era)
-scriptDataSupportedInEra ByronEra   = Nothing
+scriptDataSupportedInEra ::
+  CardanoEra era ->
+  Maybe (ScriptDataSupportedInEra era)
+scriptDataSupportedInEra ByronEra = Nothing
 scriptDataSupportedInEra ShelleyEra = Nothing
 scriptDataSupportedInEra AllegraEra = Nothing
-scriptDataSupportedInEra MaryEra    = Nothing
-scriptDataSupportedInEra AlonzoEra  = Just ScriptDataInAlonzoEra
+scriptDataSupportedInEra MaryEra = Nothing
+scriptDataSupportedInEra AlonzoEra = Just ScriptDataInAlonzoEra
 scriptDataSupportedInEra BabbageEra = Just ScriptDataInBabbageEra
-
 
 -- | A representation of whether the era supports withdrawals from reward
 -- accounts.
 --
 -- The Shelley and subsequent eras support stake addresses, their associated
 -- reward accounts and support for withdrawals from them.
---
 data WithdrawalsSupportedInEra era where
+  WithdrawalsInShelleyEra :: WithdrawalsSupportedInEra ShelleyEra
+  WithdrawalsInAllegraEra :: WithdrawalsSupportedInEra AllegraEra
+  WithdrawalsInMaryEra :: WithdrawalsSupportedInEra MaryEra
+  WithdrawalsInAlonzoEra :: WithdrawalsSupportedInEra AlonzoEra
+  WithdrawalsInBabbageEra :: WithdrawalsSupportedInEra BabbageEra
 
-     WithdrawalsInShelleyEra :: WithdrawalsSupportedInEra ShelleyEra
-     WithdrawalsInAllegraEra :: WithdrawalsSupportedInEra AllegraEra
-     WithdrawalsInMaryEra    :: WithdrawalsSupportedInEra MaryEra
-     WithdrawalsInAlonzoEra  :: WithdrawalsSupportedInEra AlonzoEra
-     WithdrawalsInBabbageEra :: WithdrawalsSupportedInEra BabbageEra
+deriving instance Eq (WithdrawalsSupportedInEra era)
 
-deriving instance Eq   (WithdrawalsSupportedInEra era)
 deriving instance Show (WithdrawalsSupportedInEra era)
 
-withdrawalsSupportedInEra :: CardanoEra era
-                          -> Maybe (WithdrawalsSupportedInEra era)
-withdrawalsSupportedInEra ByronEra   = Nothing
+withdrawalsSupportedInEra ::
+  CardanoEra era ->
+  Maybe (WithdrawalsSupportedInEra era)
+withdrawalsSupportedInEra ByronEra = Nothing
 withdrawalsSupportedInEra ShelleyEra = Just WithdrawalsInShelleyEra
 withdrawalsSupportedInEra AllegraEra = Just WithdrawalsInAllegraEra
-withdrawalsSupportedInEra MaryEra    = Just WithdrawalsInMaryEra
-withdrawalsSupportedInEra AlonzoEra  = Just WithdrawalsInAlonzoEra
+withdrawalsSupportedInEra MaryEra = Just WithdrawalsInMaryEra
+withdrawalsSupportedInEra AlonzoEra = Just WithdrawalsInAlonzoEra
 withdrawalsSupportedInEra BabbageEra = Just WithdrawalsInBabbageEra
-
 
 -- | A representation of whether the era supports 'Certificate's embedded in
 -- transactions.
 --
 -- The Shelley and subsequent eras support such certificates.
---
 data CertificatesSupportedInEra era where
+  CertificatesInShelleyEra :: CertificatesSupportedInEra ShelleyEra
+  CertificatesInAllegraEra :: CertificatesSupportedInEra AllegraEra
+  CertificatesInMaryEra :: CertificatesSupportedInEra MaryEra
+  CertificatesInAlonzoEra :: CertificatesSupportedInEra AlonzoEra
+  CertificatesInBabbageEra :: CertificatesSupportedInEra BabbageEra
 
-     CertificatesInShelleyEra :: CertificatesSupportedInEra ShelleyEra
-     CertificatesInAllegraEra :: CertificatesSupportedInEra AllegraEra
-     CertificatesInMaryEra    :: CertificatesSupportedInEra MaryEra
-     CertificatesInAlonzoEra  :: CertificatesSupportedInEra AlonzoEra
-     CertificatesInBabbageEra :: CertificatesSupportedInEra BabbageEra
+deriving instance Eq (CertificatesSupportedInEra era)
 
-deriving instance Eq   (CertificatesSupportedInEra era)
 deriving instance Show (CertificatesSupportedInEra era)
 
-certificatesSupportedInEra :: CardanoEra era
-                           -> Maybe (CertificatesSupportedInEra era)
-certificatesSupportedInEra ByronEra   = Nothing
+certificatesSupportedInEra ::
+  CardanoEra era ->
+  Maybe (CertificatesSupportedInEra era)
+certificatesSupportedInEra ByronEra = Nothing
 certificatesSupportedInEra ShelleyEra = Just CertificatesInShelleyEra
 certificatesSupportedInEra AllegraEra = Just CertificatesInAllegraEra
-certificatesSupportedInEra MaryEra    = Just CertificatesInMaryEra
-certificatesSupportedInEra AlonzoEra  = Just CertificatesInAlonzoEra
+certificatesSupportedInEra MaryEra = Just CertificatesInMaryEra
+certificatesSupportedInEra AlonzoEra = Just CertificatesInAlonzoEra
 certificatesSupportedInEra BabbageEra = Just CertificatesInBabbageEra
-
 
 -- | A representation of whether the era supports 'UpdateProposal's embedded in
 -- transactions.
@@ -1121,41 +1156,41 @@ certificatesSupportedInEra BabbageEra = Just CertificatesInBabbageEra
 -- The Shelley and subsequent eras support such update proposals. They Byron
 -- era has a notion of an update proposal, but it is a standalone chain object
 -- and not embedded in a transaction.
---
 data UpdateProposalSupportedInEra era where
+  UpdateProposalInShelleyEra :: UpdateProposalSupportedInEra ShelleyEra
+  UpdateProposalInAllegraEra :: UpdateProposalSupportedInEra AllegraEra
+  UpdateProposalInMaryEra :: UpdateProposalSupportedInEra MaryEra
+  UpdateProposalInAlonzoEra :: UpdateProposalSupportedInEra AlonzoEra
+  UpdateProposalInBabbageEra :: UpdateProposalSupportedInEra BabbageEra
 
-     UpdateProposalInShelleyEra :: UpdateProposalSupportedInEra ShelleyEra
-     UpdateProposalInAllegraEra :: UpdateProposalSupportedInEra AllegraEra
-     UpdateProposalInMaryEra    :: UpdateProposalSupportedInEra MaryEra
-     UpdateProposalInAlonzoEra  :: UpdateProposalSupportedInEra AlonzoEra
-     UpdateProposalInBabbageEra :: UpdateProposalSupportedInEra BabbageEra
+deriving instance Eq (UpdateProposalSupportedInEra era)
 
-deriving instance Eq   (UpdateProposalSupportedInEra era)
 deriving instance Show (UpdateProposalSupportedInEra era)
 
-updateProposalSupportedInEra :: CardanoEra era
-                             -> Maybe (UpdateProposalSupportedInEra era)
-updateProposalSupportedInEra ByronEra   = Nothing
+updateProposalSupportedInEra ::
+  CardanoEra era ->
+  Maybe (UpdateProposalSupportedInEra era)
+updateProposalSupportedInEra ByronEra = Nothing
 updateProposalSupportedInEra ShelleyEra = Just UpdateProposalInShelleyEra
 updateProposalSupportedInEra AllegraEra = Just UpdateProposalInAllegraEra
-updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
-updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
+updateProposalSupportedInEra MaryEra = Just UpdateProposalInMaryEra
+updateProposalSupportedInEra AlonzoEra = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
-
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions
 --
 
 data BuildTx
+
 data ViewTx
 
 data BuildTxWith build a where
+  ViewTx :: BuildTxWith ViewTx a
+  BuildTxWith :: a -> BuildTxWith BuildTx a
 
-     ViewTx      ::      BuildTxWith ViewTx  a
-     BuildTxWith :: a -> BuildTxWith BuildTx a
+deriving instance Eq a => Eq (BuildTxWith build a)
 
-deriving instance Eq   a => Eq   (BuildTxWith build a)
 deriving instance Show a => Show (BuildTxWith build a)
 
 -- ----------------------------------------------------------------------------
@@ -1165,25 +1200,25 @@ deriving instance Show a => Show (BuildTxWith build a)
 type TxIns build era = [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))]
 
 data TxInsCollateral era where
+  TxInsCollateralNone :: TxInsCollateral era
+  TxInsCollateral ::
+    CollateralSupportedInEra era ->
+    [TxIn] -> -- Only key witnesses, no scripts.
+    TxInsCollateral era
 
-     TxInsCollateralNone :: TxInsCollateral era
+deriving instance Eq (TxInsCollateral era)
 
-     TxInsCollateral     :: CollateralSupportedInEra era
-                         -> [TxIn] -- Only key witnesses, no scripts.
-                         -> TxInsCollateral era
-
-deriving instance Eq   (TxInsCollateral era)
 deriving instance Show (TxInsCollateral era)
 
 data TxInsReference build era where
+  TxInsReferenceNone :: TxInsReference build era
+  TxInsReference ::
+    ReferenceTxInsScriptsInlineDatumsSupportedInEra era ->
+    [TxIn] ->
+    TxInsReference build era
 
-     TxInsReferenceNone :: TxInsReference build era
+deriving instance Eq (TxInsReference build era)
 
-     TxInsReference     :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-                        -> [TxIn]
-                        -> TxInsReference build era
-
-deriving instance Eq   (TxInsReference build era)
 deriving instance Show (TxInsReference build era)
 
 -- ----------------------------------------------------------------------------
@@ -1191,10 +1226,8 @@ deriving instance Show (TxInsReference build era)
 --
 
 data TxOutValue era where
-
-     TxOutAdaOnly :: OnlyAdaSupportedInEra era -> Lovelace -> TxOutValue era
-
-     TxOutValue   :: MultiAssetSupportedInEra era -> Value -> TxOutValue era
+  TxOutAdaOnly :: OnlyAdaSupportedInEra era -> Lovelace -> TxOutValue era
+  TxOutValue :: MultiAssetSupportedInEra era -> Value -> TxOutValue era
 
 instance EraCast TxOutValue where
   eraCast toEra v = case v of
@@ -1202,14 +1235,15 @@ instance EraCast TxOutValue where
       case multiAssetSupportedInEra toEra of
         Left adaOnly -> Right $ TxOutAdaOnly adaOnly lovelace
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp $ lovelaceToValue lovelace
-    TxOutValue  (_ :: MultiAssetSupportedInEra fromEra) value  ->
+    TxOutValue (_ :: MultiAssetSupportedInEra fromEra) value ->
       case multiAssetSupportedInEra toEra of
         Left _adaOnly -> Left $ EraCastError v (cardanoEra @fromEra) toEra
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp value
 
+deriving instance Eq (TxOutValue era)
 
-deriving instance Eq   (TxOutValue era)
 deriving instance Show (TxOutValue era)
+
 deriving instance Generic (TxOutValue era)
 
 instance ToJSON (TxOutValue era) where
@@ -1227,41 +1261,40 @@ instance IsCardanoEra era => FromJSON (TxOutValue era) where
         vals <- mapM decodeAssetId l
         pure $ TxOutValue maSupported $ mconcat vals
     where
-     decodeAssetId :: (Aeson.Key, Aeson.Value) -> Aeson.Parser Value
-     decodeAssetId (polid, Aeson.Object assetNameHm) = do
-       let polId = fromString . Text.unpack $ Aeson.toText polid
-       aNameQuantity <- decodeAssets assetNameHm
-       pure . valueFromList
-         $ map (first $ AssetId polId) aNameQuantity
+      decodeAssetId :: (Aeson.Key, Aeson.Value) -> Aeson.Parser Value
+      decodeAssetId (polid, Aeson.Object assetNameHm) = do
+        let polId = fromString . Text.unpack $ Aeson.toText polid
+        aNameQuantity <- decodeAssets assetNameHm
+        pure . valueFromList $
+          map (first $ AssetId polId) aNameQuantity
+      decodeAssetId ("lovelace", Aeson.Number sci) =
+        case toBoundedInteger sci of
+          Just (ll :: Word64) ->
+            pure $ valueFromList [(AdaAssetId, Quantity $ toInteger ll)]
+          Nothing ->
+            fail $ "Expected a Bounded number but got: " <> show sci
+      decodeAssetId wrong = fail $ "Expected a policy id and a JSON object but got: " <> show wrong
 
-     decodeAssetId ("lovelace", Aeson.Number sci) =
-       case toBoundedInteger sci of
-         Just (ll :: Word64) ->
-           pure $ valueFromList [(AdaAssetId, Quantity $ toInteger ll)]
-         Nothing ->
-           fail $ "Expected a Bounded number but got: " <> show sci
-     decodeAssetId wrong = fail $ "Expected a policy id and a JSON object but got: " <> show wrong
+      decodeAssets :: Aeson.Object -> Aeson.Parser [(AssetName, Quantity)]
+      decodeAssets assetNameHm =
+        let l = KeyMap.toList assetNameHm
+         in mapM (\(aName, q) -> (,) <$> parseAssetName aName <*> decodeQuantity q) l
 
-     decodeAssets :: Aeson.Object -> Aeson.Parser [(AssetName, Quantity)]
-     decodeAssets assetNameHm =
-       let l = KeyMap.toList assetNameHm
-       in mapM (\(aName, q) -> (,) <$> parseAssetName aName <*> decodeQuantity q) l
+      parseAssetName :: Aeson.Key -> Aeson.Parser AssetName
+      parseAssetName aName = runParsecParser assetName (Aeson.toText aName)
 
-     parseAssetName :: Aeson.Key -> Aeson.Parser AssetName
-     parseAssetName aName = runParsecParser assetName (Aeson.toText aName)
-
-     decodeQuantity :: Aeson.Value -> Aeson.Parser Quantity
-     decodeQuantity (Aeson.Number sci) =
-       case toBoundedInteger sci of
-         Just (ll :: Word64) -> return . Quantity $ toInteger ll
-         Nothing -> fail $ "Expected a Bounded number but got: " <> show sci
-     decodeQuantity wrong = fail $ "Expected aeson Number but got: " <> show wrong
+      decodeQuantity :: Aeson.Value -> Aeson.Parser Quantity
+      decodeQuantity (Aeson.Number sci) =
+        case toBoundedInteger sci of
+          Just (ll :: Word64) -> return . Quantity $ toInteger ll
+          Nothing -> fail $ "Expected a Bounded number but got: " <> show sci
+      decodeQuantity wrong = fail $ "Expected aeson Number but got: " <> show wrong
 
 lovelaceToTxOutValue :: IsCardanoEra era => Lovelace -> TxOutValue era
 lovelaceToTxOutValue l =
-    case multiAssetSupportedInEra cardanoEra of
-      Left adaOnly     -> TxOutAdaOnly adaOnly  l
-      Right multiAsset -> TxOutValue multiAsset (lovelaceToValue l)
+  case multiAssetSupportedInEra cardanoEra of
+    Left adaOnly -> TxOutAdaOnly adaOnly l
+    Right multiAsset -> TxOutValue multiAsset (lovelaceToValue l)
 
 txOutValueToLovelace :: TxOutValue era -> Lovelace
 txOutValueToLovelace tv =
@@ -1277,40 +1310,40 @@ txOutValueToValue tv =
 
 prettyRenderTxOut :: TxOutInAnyEra -> Text
 prettyRenderTxOut (TxOutInAnyEra _ (TxOut (AddressInEra _ addr) txOutVal _ _)) =
-     serialiseAddress (toAddressAny addr) <> " + "
-  <> renderValue (txOutValueToValue txOutVal)
+  serialiseAddress (toAddressAny addr) <> " + "
+    <> renderValue (txOutValueToValue txOutVal)
 
 data TxReturnCollateral ctx era where
+  TxReturnCollateralNone :: TxReturnCollateral ctx era
+  TxReturnCollateral ::
+    TxTotalAndReturnCollateralSupportedInEra era ->
+    TxOut ctx era ->
+    TxReturnCollateral ctx era
 
-     TxReturnCollateralNone :: TxReturnCollateral ctx era
+deriving instance Eq (TxReturnCollateral ctx era)
 
-     TxReturnCollateral     :: TxTotalAndReturnCollateralSupportedInEra era
-                            -> TxOut ctx era
-                            -> TxReturnCollateral ctx era
-
-deriving instance Eq   (TxReturnCollateral ctx era)
 deriving instance Show (TxReturnCollateral ctx era)
 
 data TxTotalCollateral era where
+  TxTotalCollateralNone :: TxTotalCollateral era
+  TxTotalCollateral ::
+    TxTotalAndReturnCollateralSupportedInEra era ->
+    Lovelace ->
+    TxTotalCollateral era
 
-     TxTotalCollateralNone :: TxTotalCollateral era
+deriving instance Eq (TxTotalCollateral era)
 
-     TxTotalCollateral     :: TxTotalAndReturnCollateralSupportedInEra era
-                           -> Lovelace
-                           -> TxTotalCollateral era
-
-deriving instance Eq   (TxTotalCollateral era)
 deriving instance Show (TxTotalCollateral era)
 
 data TxTotalAndReturnCollateralSupportedInEra era where
+  TxTotalAndReturnCollateralInBabbageEra :: TxTotalAndReturnCollateralSupportedInEra BabbageEra
 
-     TxTotalAndReturnCollateralInBabbageEra :: TxTotalAndReturnCollateralSupportedInEra BabbageEra
+deriving instance Eq (TxTotalAndReturnCollateralSupportedInEra era)
 
-deriving instance Eq   (TxTotalAndReturnCollateralSupportedInEra era)
 deriving instance Show (TxTotalAndReturnCollateralSupportedInEra era)
 
-totalAndReturnCollateralSupportedInEra
-  :: CardanoEra era -> Maybe (TxTotalAndReturnCollateralSupportedInEra era)
+totalAndReturnCollateralSupportedInEra ::
+  CardanoEra era -> Maybe (TxTotalAndReturnCollateralSupportedInEra era)
 totalAndReturnCollateralSupportedInEra ByronEra = Nothing
 totalAndReturnCollateralSupportedInEra ShelleyEra = Nothing
 totalAndReturnCollateralSupportedInEra AllegraEra = Nothing
@@ -1323,37 +1356,34 @@ totalAndReturnCollateralSupportedInEra BabbageEra = Just TxTotalAndReturnCollate
 --
 
 data TxOutDatum ctx era where
+  TxOutDatumNone :: TxOutDatum ctx era
+  -- | A transaction output that only specifies the hash of the datum, but
+  -- not the full datum value.
+  TxOutDatumHash ::
+    ScriptDataSupportedInEra era ->
+    Hash ScriptData ->
+    TxOutDatum ctx era
+  -- | A transaction output that specifies the whole datum value. This can
+  -- only be used in the context of the transaction body, and does not occur
+  -- in the UTxO. The UTxO only contains the datum hash.
+  TxOutDatumInTx' ::
+    ScriptDataSupportedInEra era ->
+    Hash ScriptData ->
+    ScriptData ->
+    TxOutDatum CtxTx era
+  -- | A transaction output that specifies the whole datum instead of the
+  -- datum hash. Note that the datum map will not be updated with this datum,
+  -- it only exists at the transaction output.
+  TxOutDatumInline ::
+    ReferenceTxInsScriptsInlineDatumsSupportedInEra era ->
+    ScriptData ->
+    TxOutDatum ctx era
 
-     TxOutDatumNone   :: TxOutDatum ctx era
+deriving instance Eq (TxOutDatum ctx era)
 
-     -- | A transaction output that only specifies the hash of the datum, but
-     -- not the full datum value.
-     --
-     TxOutDatumHash   :: ScriptDataSupportedInEra era
-                      -> Hash ScriptData
-                      -> TxOutDatum ctx era
-
-     -- | A transaction output that specifies the whole datum value. This can
-     -- only be used in the context of the transaction body, and does not occur
-     -- in the UTxO. The UTxO only contains the datum hash.
-     --
-     TxOutDatumInTx'  :: ScriptDataSupportedInEra era
-                      -> Hash ScriptData
-                      -> ScriptData
-                      -> TxOutDatum CtxTx era
-
-     -- | A transaction output that specifies the whole datum instead of the
-     -- datum hash. Note that the datum map will not be updated with this datum,
-     -- it only exists at the transaction output.
-     --
-     TxOutDatumInline :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-                      -> ScriptData
-                      -> TxOutDatum ctx era
-
-deriving instance Eq   (TxOutDatum ctx era)
 deriving instance Show (TxOutDatum ctx era)
 
-instance EraCast (TxOutDatum ctx)  where
+instance EraCast (TxOutDatum ctx) where
   eraCast toEra v = case v of
     TxOutDatumNone -> pure TxOutDatumNone
     TxOutDatumHash (_ :: ScriptDataSupportedInEra fromEra) hash ->
@@ -1372,16 +1402,18 @@ instance EraCast (TxOutDatum ctx)  where
         Just refInsAndInlineSupported ->
           Right $ TxOutDatumInline refInsAndInlineSupported scriptData
 
-pattern TxOutDatumInTx
-  :: ScriptDataSupportedInEra era
-  -> ScriptData
-  -> TxOutDatum CtxTx era
-pattern TxOutDatumInTx s d <- TxOutDatumInTx' s _ d
+pattern TxOutDatumInTx ::
+  ScriptDataSupportedInEra era ->
+  ScriptData ->
+  TxOutDatum CtxTx era
+pattern TxOutDatumInTx s d <-
+  TxOutDatumInTx' s _ d
   where
     TxOutDatumInTx s d = TxOutDatumInTx' s (hashScriptData d) d
 
 {-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatumInTx', TxOutDatumInline #-}
-{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatumInTx , TxOutDatumInline #-}
+
+{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatumInTx, TxOutDatumInline #-}
 
 parseHash :: SerialiseAsRawBytes (Hash a) => AsType (Hash a) -> Parsec.Parser (Hash a)
 parseHash asType = do
@@ -1394,75 +1426,70 @@ parseHash asType = do
 --
 
 data TxFee era where
+  TxFeeImplicit :: TxFeesImplicitInEra era -> TxFee era
+  TxFeeExplicit :: TxFeesExplicitInEra era -> Lovelace -> TxFee era
 
-     TxFeeImplicit :: TxFeesImplicitInEra era -> TxFee era
+deriving instance Eq (TxFee era)
 
-     TxFeeExplicit :: TxFeesExplicitInEra era -> Lovelace -> TxFee era
-
-deriving instance Eq   (TxFee era)
 deriving instance Show (TxFee era)
-
 
 -- ----------------------------------------------------------------------------
 -- Transaction validity range
 --
 
 -- | This was formerly known as the TTL.
---
 data TxValidityUpperBound era where
+  TxValidityNoUpperBound ::
+    ValidityNoUpperBoundSupportedInEra era ->
+    TxValidityUpperBound era
+  TxValidityUpperBound ::
+    ValidityUpperBoundSupportedInEra era ->
+    SlotNo ->
+    TxValidityUpperBound era
 
-     TxValidityNoUpperBound :: ValidityNoUpperBoundSupportedInEra era
-                            -> TxValidityUpperBound era
+deriving instance Eq (TxValidityUpperBound era)
 
-     TxValidityUpperBound   :: ValidityUpperBoundSupportedInEra era
-                            -> SlotNo
-                            -> TxValidityUpperBound era
-
-deriving instance Eq   (TxValidityUpperBound era)
 deriving instance Show (TxValidityUpperBound era)
 
-
 data TxValidityLowerBound era where
+  TxValidityNoLowerBound :: TxValidityLowerBound era
+  TxValidityLowerBound ::
+    ValidityLowerBoundSupportedInEra era ->
+    SlotNo ->
+    TxValidityLowerBound era
 
-     TxValidityNoLowerBound :: TxValidityLowerBound era
+deriving instance Eq (TxValidityLowerBound era)
 
-     TxValidityLowerBound   :: ValidityLowerBoundSupportedInEra era
-                            -> SlotNo
-                            -> TxValidityLowerBound era
-
-deriving instance Eq   (TxValidityLowerBound era)
 deriving instance Show (TxValidityLowerBound era)
-
 
 -- ----------------------------------------------------------------------------
 -- Transaction metadata (era-dependent)
 --
 
 data TxMetadataInEra era where
+  TxMetadataNone :: TxMetadataInEra era
+  TxMetadataInEra ::
+    TxMetadataSupportedInEra era ->
+    TxMetadata ->
+    TxMetadataInEra era
 
-     TxMetadataNone  :: TxMetadataInEra era
+deriving instance Eq (TxMetadataInEra era)
 
-     TxMetadataInEra :: TxMetadataSupportedInEra era
-                     -> TxMetadata
-                     -> TxMetadataInEra era
-
-deriving instance Eq   (TxMetadataInEra era)
 deriving instance Show (TxMetadataInEra era)
-
 
 -- ----------------------------------------------------------------------------
 -- Auxiliary scripts (era-dependent)
 --
 
 data TxAuxScripts era where
+  TxAuxScriptsNone :: TxAuxScripts era
+  TxAuxScripts ::
+    AuxScriptsSupportedInEra era ->
+    [ScriptInEra era] ->
+    TxAuxScripts era
 
-     TxAuxScriptsNone :: TxAuxScripts era
+deriving instance Eq (TxAuxScripts era)
 
-     TxAuxScripts     :: AuxScriptsSupportedInEra era
-                      -> [ScriptInEra era]
-                      -> TxAuxScripts era
-
-deriving instance Eq   (TxAuxScripts era)
 deriving instance Show (TxAuxScripts era)
 
 -- ----------------------------------------------------------------------------
@@ -1470,14 +1497,14 @@ deriving instance Show (TxAuxScripts era)
 --
 
 data TxExtraKeyWitnesses era where
-
   TxExtraKeyWitnessesNone :: TxExtraKeyWitnesses era
+  TxExtraKeyWitnesses ::
+    TxExtraKeyWitnessesSupportedInEra era ->
+    [Hash PaymentKey] ->
+    TxExtraKeyWitnesses era
 
-  TxExtraKeyWitnesses     :: TxExtraKeyWitnessesSupportedInEra era
-                          -> [Hash PaymentKey]
-                          -> TxExtraKeyWitnesses era
+deriving instance Eq (TxExtraKeyWitnesses era)
 
-deriving instance Eq   (TxExtraKeyWitnesses era)
 deriving instance Show (TxExtraKeyWitnesses era)
 
 -- ----------------------------------------------------------------------------
@@ -1485,395 +1512,469 @@ deriving instance Show (TxExtraKeyWitnesses era)
 --
 
 data TxWithdrawals build era where
+  TxWithdrawalsNone :: TxWithdrawals build era
+  TxWithdrawals ::
+    WithdrawalsSupportedInEra era ->
+    [ ( StakeAddress,
+        Lovelace,
+        BuildTxWith build (Witness WitCtxStake era)
+      )
+    ] ->
+    TxWithdrawals build era
 
-     TxWithdrawalsNone :: TxWithdrawals build era
+deriving instance Eq (TxWithdrawals build era)
 
-     TxWithdrawals     :: WithdrawalsSupportedInEra era
-                       -> [(StakeAddress, Lovelace,
-                            BuildTxWith build (Witness WitCtxStake era))]
-                       -> TxWithdrawals build era
-
-deriving instance Eq   (TxWithdrawals build era)
 deriving instance Show (TxWithdrawals build era)
-
 
 -- ----------------------------------------------------------------------------
 -- Certificates within transactions (era-dependent)
 --
 
 data TxCertificates build era where
+  TxCertificatesNone :: TxCertificates build era
+  TxCertificates ::
+    CertificatesSupportedInEra era ->
+    [Certificate] ->
+    BuildTxWith
+      build
+      (Map StakeCredential (Witness WitCtxStake era)) ->
+    TxCertificates build era
 
-     TxCertificatesNone :: TxCertificates build era
+deriving instance Eq (TxCertificates build era)
 
-     TxCertificates     :: CertificatesSupportedInEra era
-                        -> [Certificate]
-                        -> BuildTxWith build
-                             (Map StakeCredential (Witness WitCtxStake era))
-                        -> TxCertificates build era
-
-deriving instance Eq   (TxCertificates build era)
 deriving instance Show (TxCertificates build era)
-
 
 -- ----------------------------------------------------------------------------
 -- Transaction update proposal (era-dependent)
 --
 
 data TxUpdateProposal era where
+  TxUpdateProposalNone :: TxUpdateProposal era
+  TxUpdateProposal ::
+    UpdateProposalSupportedInEra era ->
+    UpdateProposal ->
+    TxUpdateProposal era
 
-     TxUpdateProposalNone :: TxUpdateProposal era
+deriving instance Eq (TxUpdateProposal era)
 
-     TxUpdateProposal     :: UpdateProposalSupportedInEra era
-                          -> UpdateProposal
-                          -> TxUpdateProposal era
-
-deriving instance Eq   (TxUpdateProposal era)
 deriving instance Show (TxUpdateProposal era)
-
 
 -- ----------------------------------------------------------------------------
 -- Value minting within transactions (era-dependent)
 --
 
 data TxMintValue build era where
+  TxMintNone :: TxMintValue build era
+  TxMintValue ::
+    MultiAssetSupportedInEra era ->
+    Value ->
+    BuildTxWith
+      build
+      (Map PolicyId (ScriptWitness WitCtxMint era)) ->
+    TxMintValue build era
 
-     TxMintNone  :: TxMintValue build era
+deriving instance Eq (TxMintValue build era)
 
-     TxMintValue :: MultiAssetSupportedInEra era
-                 -> Value
-                 -> BuildTxWith build
-                      (Map PolicyId (ScriptWitness WitCtxMint era))
-                 -> TxMintValue build era
-
-deriving instance Eq   (TxMintValue build era)
 deriving instance Show (TxMintValue build era)
-
 
 -- ----------------------------------------------------------------------------
 -- Transaction body content
 --
 
-data TxBodyContent build era =
-     TxBodyContent {
-       txIns              :: TxIns build era,
-       txInsCollateral    :: TxInsCollateral era,
-       txInsReference     :: TxInsReference build era,
-       txOuts             :: [TxOut CtxTx era],
-       txTotalCollateral  :: TxTotalCollateral era,
-       txReturnCollateral :: TxReturnCollateral CtxTx era,
-       txFee              :: TxFee era,
-       txValidityRange    :: (TxValidityLowerBound era,
-                              TxValidityUpperBound era),
-       txMetadata         :: TxMetadataInEra era,
-       txAuxScripts       :: TxAuxScripts era,
-       txExtraKeyWits     :: TxExtraKeyWitnesses era,
-       txProtocolParams   :: BuildTxWith build (Maybe ProtocolParameters),
-       txWithdrawals      :: TxWithdrawals  build era,
-       txCertificates     :: TxCertificates build era,
-       txUpdateProposal   :: TxUpdateProposal era,
-       txMintValue        :: TxMintValue    build era,
-       txScriptValidity   :: TxScriptValidity era
-     }
-     deriving (Eq, Show)
-
+data TxBodyContent build era = TxBodyContent
+  { txIns :: TxIns build era,
+    txInsCollateral :: TxInsCollateral era,
+    txInsReference :: TxInsReference build era,
+    txOuts :: [TxOut CtxTx era],
+    txTotalCollateral :: TxTotalCollateral era,
+    txReturnCollateral :: TxReturnCollateral CtxTx era,
+    txFee :: TxFee era,
+    txValidityRange ::
+      ( TxValidityLowerBound era,
+        TxValidityUpperBound era
+      ),
+    txMetadata :: TxMetadataInEra era,
+    txAuxScripts :: TxAuxScripts era,
+    txExtraKeyWits :: TxExtraKeyWitnesses era,
+    txProtocolParams :: BuildTxWith build (Maybe ProtocolParameters),
+    txWithdrawals :: TxWithdrawals build era,
+    txCertificates :: TxCertificates build era,
+    txUpdateProposal :: TxUpdateProposal era,
+    txMintValue :: TxMintValue build era,
+    txScriptValidity :: TxScriptValidity era
+  }
+  deriving (Eq, Show)
 
 -- ----------------------------------------------------------------------------
 -- Transaction bodies
 --
 
 data TxBody era where
+  ByronTxBody ::
+    Annotated Byron.Tx ByteString ->
+    TxBody ByronEra
+  ShelleyTxBody ::
+    ShelleyBasedEra era ->
+    Ledger.TxBody (ShelleyLedgerEra era) ->
+    -- We include the scripts along with the tx body, rather than the
+    -- witnesses set, since they need to be known when building the body.
+    [Ledger.Script (ShelleyLedgerEra era)] ->
+    -- The info for each use of each script: the script input data, both
+    -- the UTxO input data (called the "datum") and the supplied input
+    -- data (called the "redeemer") and the execution units.
+    TxBodyScriptData era ->
+    -- The 'Ledger.AuxiliaryData' consists of one or several things,
+    -- depending on era:
+    -- + transaction metadata  (in Shelley and later)
+    -- + auxiliary scripts     (in Allegra and later)
+    -- Note that there is no auxiliary script data as such, because the
+    -- extra script data has to be passed to scripts and hence is needed
+    -- for validation. It is thus part of the witness data, not the
+    -- auxiliary data.
+    Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era)) ->
+    -- | Mark script as expected to pass or fail validation
+    TxScriptValidity era ->
+    TxBody era
 
-     ByronTxBody
-       :: Annotated Byron.Tx ByteString
-       -> TxBody ByronEra
-
-     ShelleyTxBody
-       :: ShelleyBasedEra era
-       -> Ledger.TxBody (ShelleyLedgerEra era)
-
-          -- We include the scripts along with the tx body, rather than the
-          -- witnesses set, since they need to be known when building the body.
-       -> [Ledger.Script (ShelleyLedgerEra era)]
-
-          -- The info for each use of each script: the script input data, both
-          -- the UTxO input data (called the "datum") and the supplied input
-          -- data (called the "redeemer") and the execution units.
-       -> TxBodyScriptData era
-
-          -- The 'Ledger.AuxiliaryData' consists of one or several things,
-          -- depending on era:
-          -- + transaction metadata  (in Shelley and later)
-          -- + auxiliary scripts     (in Allegra and later)
-          -- Note that there is no auxiliary script data as such, because the
-          -- extra script data has to be passed to scripts and hence is needed
-          -- for validation. It is thus part of the witness data, not the
-          -- auxiliary data.
-       -> Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era))
-
-       -> TxScriptValidity era -- ^ Mark script as expected to pass or fail validation
-
-       -> TxBody era
-     -- The 'ShelleyBasedEra' GADT tells us what era we are in.
-     -- The 'ShelleyLedgerEra' type family maps that to the era type from the
-     -- ledger lib. The 'Ledger.TxBody' type family maps that to a specific
-     -- tx body type, which is different for each Shelley-based era.
-
+-- The 'ShelleyBasedEra' GADT tells us what era we are in.
+-- The 'ShelleyLedgerEra' type family maps that to the era type from the
+-- ledger lib. The 'Ledger.TxBody' type family maps that to a specific
+-- tx body type, which is different for each Shelley-based era.
 
 data TxBodyScriptData era where
-     TxBodyNoScriptData :: TxBodyScriptData era
-     TxBodyScriptData   :: ScriptDataSupportedInEra era
-                        -> Alonzo.TxDats (ShelleyLedgerEra era)
-                        -> Alonzo.Redeemers (ShelleyLedgerEra era)
-                        -> TxBodyScriptData era
+  TxBodyNoScriptData :: TxBodyScriptData era
+  TxBodyScriptData ::
+    ScriptDataSupportedInEra era ->
+    Alonzo.TxDats (ShelleyLedgerEra era) ->
+    Alonzo.Redeemers (ShelleyLedgerEra era) ->
+    TxBodyScriptData era
 
-deriving instance Eq   (TxBodyScriptData era)
+deriving instance Eq (TxBodyScriptData era)
+
 deriving instance Show (TxBodyScriptData era)
-
 
 -- The GADT in the ShelleyTxBody case requires a custom instance
 instance Eq (TxBody era) where
-    (==) (ByronTxBody txbodyA)
-         (ByronTxBody txbodyB) = txbodyA == txbodyB
-
-    (==) (ShelleyTxBody era txbodyA txscriptsA redeemersA txmetadataA scriptValidityA)
-         (ShelleyTxBody _   txbodyB txscriptsB redeemersB txmetadataB scriptValidityB) =
-         case era of
-           ShelleyBasedEraShelley -> txbodyA     == txbodyB
-                                  && txscriptsA  == txscriptsB
-                                  && txmetadataA == txmetadataB
-
-           ShelleyBasedEraAllegra -> txbodyA     == txbodyB
-                                  && txscriptsA  == txscriptsB
-                                  && txmetadataA == txmetadataB
-
-           ShelleyBasedEraMary    -> txbodyA     == txbodyB
-                                  && txscriptsA  == txscriptsB
-                                  && txmetadataA == txmetadataB
-
-           ShelleyBasedEraAlonzo  -> txbodyA         == txbodyB
-                                  && txscriptsA      == txscriptsB
-                                  && redeemersA      == redeemersB
-                                  && txmetadataA     == txmetadataB
-                                  && scriptValidityA == scriptValidityB
-
-           ShelleyBasedEraBabbage -> txbodyA         == txbodyB
-                                  && txscriptsA      == txscriptsB
-                                  && redeemersA      == redeemersB
-                                  && txmetadataA     == txmetadataB
-                                  && scriptValidityA == scriptValidityB
-
-    (==) ByronTxBody{} (ShelleyTxBody era _ _ _ _ _) = case era of {}
-
+  (==)
+    (ByronTxBody txbodyA)
+    (ByronTxBody txbodyB) = txbodyA == txbodyB
+  (==)
+    (ShelleyTxBody era txbodyA txscriptsA redeemersA txmetadataA scriptValidityA)
+    (ShelleyTxBody _ txbodyB txscriptsB redeemersB txmetadataB scriptValidityB) =
+      case era of
+        ShelleyBasedEraShelley ->
+          txbodyA == txbodyB
+            && txscriptsA == txscriptsB
+            && txmetadataA == txmetadataB
+        ShelleyBasedEraAllegra ->
+          txbodyA == txbodyB
+            && txscriptsA == txscriptsB
+            && txmetadataA == txmetadataB
+        ShelleyBasedEraMary ->
+          txbodyA == txbodyB
+            && txscriptsA == txscriptsB
+            && txmetadataA == txmetadataB
+        ShelleyBasedEraAlonzo ->
+          txbodyA == txbodyB
+            && txscriptsA == txscriptsB
+            && redeemersA == redeemersB
+            && txmetadataA == txmetadataB
+            && scriptValidityA == scriptValidityB
+        ShelleyBasedEraBabbage ->
+          txbodyA == txbodyB
+            && txscriptsA == txscriptsB
+            && redeemersA == redeemersB
+            && txmetadataA == txmetadataB
+            && scriptValidityA == scriptValidityB
+  (==) ByronTxBody {} (ShelleyTxBody era _ _ _ _ _) = case era of
 
 -- The GADT in the ShelleyTxBody case requires a custom instance
 instance Show (TxBody era) where
-    showsPrec p (ByronTxBody txbody) =
-      showParen (p >= 11)
-        ( showString "ByronTxBody "
-        . showsPrec 11 txbody
-        )
-
-    showsPrec p (ShelleyTxBody ShelleyBasedEraShelley
-                               txbody txscripts redeemers txmetadata scriptValidity) =
-      showParen (p >= 11)
+  showsPrec p (ByronTxBody txbody) =
+    showParen
+      (p >= 11)
+      ( showString "ByronTxBody "
+          . showsPrec 11 txbody
+      )
+  showsPrec
+    p
+    ( ShelleyTxBody
+        ShelleyBasedEraShelley
+        txbody
+        txscripts
+        redeemers
+        txmetadata
+        scriptValidity
+      ) =
+      showParen
+        (p >= 11)
         ( showString "ShelleyTxBody ShelleyBasedEraShelley "
-        . showsPrec 11 txbody
-        . showChar ' '
-        . showsPrec 11 txscripts
-        . showChar ' '
-        . showsPrec 11 redeemers
-        . showChar ' '
-        . showsPrec 11 txmetadata
-        . showChar ' '
-        . showsPrec 11 scriptValidity
+            . showsPrec 11 txbody
+            . showChar ' '
+            . showsPrec 11 txscripts
+            . showChar ' '
+            . showsPrec 11 redeemers
+            . showChar ' '
+            . showsPrec 11 txmetadata
+            . showChar ' '
+            . showsPrec 11 scriptValidity
         )
-
-    showsPrec p (ShelleyTxBody ShelleyBasedEraAllegra
-                               txbody txscripts redeemers txmetadata scriptValidity) =
-      showParen (p >= 11)
+  showsPrec
+    p
+    ( ShelleyTxBody
+        ShelleyBasedEraAllegra
+        txbody
+        txscripts
+        redeemers
+        txmetadata
+        scriptValidity
+      ) =
+      showParen
+        (p >= 11)
         ( showString "ShelleyTxBody ShelleyBasedEraAllegra "
-        . showsPrec 11 txbody
-        . showChar ' '
-        . showsPrec 11 txscripts
-        . showChar ' '
-        . showsPrec 11 redeemers
-        . showChar ' '
-        . showsPrec 11 txmetadata
-        . showChar ' '
-        . showsPrec 11 scriptValidity
+            . showsPrec 11 txbody
+            . showChar ' '
+            . showsPrec 11 txscripts
+            . showChar ' '
+            . showsPrec 11 redeemers
+            . showChar ' '
+            . showsPrec 11 txmetadata
+            . showChar ' '
+            . showsPrec 11 scriptValidity
         )
-
-    showsPrec p (ShelleyTxBody ShelleyBasedEraMary
-                               txbody txscripts redeemers txmetadata scriptValidity) =
-      showParen (p >= 11)
+  showsPrec
+    p
+    ( ShelleyTxBody
+        ShelleyBasedEraMary
+        txbody
+        txscripts
+        redeemers
+        txmetadata
+        scriptValidity
+      ) =
+      showParen
+        (p >= 11)
         ( showString "ShelleyTxBody ShelleyBasedEraMary "
-        . showsPrec 11 txbody
-        . showChar ' '
-        . showsPrec 11 txscripts
-        . showChar ' '
-        . showsPrec 11 redeemers
-        . showChar ' '
-        . showsPrec 11 txmetadata
-        . showChar ' '
-        . showsPrec 11 scriptValidity
+            . showsPrec 11 txbody
+            . showChar ' '
+            . showsPrec 11 txscripts
+            . showChar ' '
+            . showsPrec 11 redeemers
+            . showChar ' '
+            . showsPrec 11 txmetadata
+            . showChar ' '
+            . showsPrec 11 scriptValidity
         )
-
-    showsPrec p (ShelleyTxBody ShelleyBasedEraAlonzo
-                               txbody txscripts redeemers txmetadata scriptValidity) =
-      showParen (p >= 11)
+  showsPrec
+    p
+    ( ShelleyTxBody
+        ShelleyBasedEraAlonzo
+        txbody
+        txscripts
+        redeemers
+        txmetadata
+        scriptValidity
+      ) =
+      showParen
+        (p >= 11)
         ( showString "ShelleyTxBody ShelleyBasedEraAlonzo "
-        . showsPrec 11 txbody
-        . showChar ' '
-        . showsPrec 11 txscripts
-        . showChar ' '
-        . showsPrec 11 redeemers
-        . showChar ' '
-        . showsPrec 11 txmetadata
-        . showChar ' '
-        . showsPrec 11 scriptValidity
+            . showsPrec 11 txbody
+            . showChar ' '
+            . showsPrec 11 txscripts
+            . showChar ' '
+            . showsPrec 11 redeemers
+            . showChar ' '
+            . showsPrec 11 txmetadata
+            . showChar ' '
+            . showsPrec 11 scriptValidity
         )
-
-    showsPrec p (ShelleyTxBody ShelleyBasedEraBabbage
-                               txbody txscripts redeemers txmetadata scriptValidity) =
-      showParen (p >= 11)
+  showsPrec
+    p
+    ( ShelleyTxBody
+        ShelleyBasedEraBabbage
+        txbody
+        txscripts
+        redeemers
+        txmetadata
+        scriptValidity
+      ) =
+      showParen
+        (p >= 11)
         ( showString "ShelleyTxBody ShelleyBasedEraBabbage "
-        . showsPrec 11 txbody
-        . showChar ' '
-        . showsPrec 11 txscripts
-        . showChar ' '
-        . showsPrec 11 redeemers
-        . showChar ' '
-        . showsPrec 11 txmetadata
-        . showChar ' '
-        . showsPrec 11 scriptValidity
+            . showsPrec 11 txbody
+            . showChar ' '
+            . showsPrec 11 txscripts
+            . showChar ' '
+            . showsPrec 11 redeemers
+            . showChar ' '
+            . showsPrec 11 txmetadata
+            . showChar ' '
+            . showsPrec 11 scriptValidity
         )
-
-
 
 instance HasTypeProxy era => HasTypeProxy (TxBody era) where
-    data AsType (TxBody era) = AsTxBody (AsType era)
-    proxyToAsType _ = AsTxBody (proxyToAsType (Proxy :: Proxy era))
+  data AsType (TxBody era) = AsTxBody (AsType era)
+  proxyToAsType _ = AsTxBody (proxyToAsType (Proxy :: Proxy era))
 
 pattern AsByronTxBody :: AsType (TxBody ByronEra)
-pattern AsByronTxBody   = AsTxBody AsByronEra
+pattern AsByronTxBody = AsTxBody AsByronEra
+
 {-# COMPLETE AsByronTxBody #-}
 
 pattern AsShelleyTxBody :: AsType (TxBody ShelleyEra)
 pattern AsShelleyTxBody = AsTxBody AsShelleyEra
+
 {-# COMPLETE AsShelleyTxBody #-}
 
 pattern AsMaryTxBody :: AsType (TxBody MaryEra)
 pattern AsMaryTxBody = AsTxBody AsMaryEra
+
 {-# COMPLETE AsMaryTxBody #-}
 
 instance IsCardanoEra era => SerialiseAsCBOR (TxBody era) where
-
-    serialiseToCBOR (ByronTxBody txbody) =
-      recoverBytes txbody
-
-    serialiseToCBOR (ShelleyTxBody era txbody txscripts redeemers txmetadata scriptValidity) =
-      case era of
-        -- Use the same serialisation impl, but at different types:
-        ShelleyBasedEraShelley -> serialiseShelleyBasedTxBody
-                                    era txbody txscripts redeemers txmetadata scriptValidity
-        ShelleyBasedEraAllegra -> serialiseShelleyBasedTxBody
-                                    era txbody txscripts redeemers txmetadata scriptValidity
-        ShelleyBasedEraMary    -> serialiseShelleyBasedTxBody
-                                    era txbody txscripts redeemers txmetadata scriptValidity
-        ShelleyBasedEraAlonzo  -> serialiseShelleyBasedTxBody
-                                    era txbody txscripts redeemers txmetadata scriptValidity
-
-        ShelleyBasedEraBabbage -> serialiseShelleyBasedTxBody
-                                    era txbody txscripts redeemers txmetadata scriptValidity
-    deserialiseFromCBOR _ bs =
-      case cardanoEra :: CardanoEra era of
-        ByronEra ->
-          ByronTxBody <$>
-            CBOR.decodeFullAnnotatedBytes
-              "Byron TxBody"
-              CBOR.fromCBORAnnotated
-              (LBS.fromStrict bs)
-
-        -- Use the same derialisation impl, but at different types:
-        ShelleyEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraShelley bs
-        AllegraEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraAllegra bs
-        MaryEra    -> deserialiseShelleyBasedTxBody ShelleyBasedEraMary    bs
-        AlonzoEra  -> deserialiseShelleyBasedTxBody ShelleyBasedEraAlonzo  bs
-        BabbageEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraBabbage bs
+  serialiseToCBOR (ByronTxBody txbody) =
+    recoverBytes txbody
+  serialiseToCBOR (ShelleyTxBody era txbody txscripts redeemers txmetadata scriptValidity) =
+    case era of
+      -- Use the same serialisation impl, but at different types:
+      ShelleyBasedEraShelley ->
+        serialiseShelleyBasedTxBody
+          era
+          txbody
+          txscripts
+          redeemers
+          txmetadata
+          scriptValidity
+      ShelleyBasedEraAllegra ->
+        serialiseShelleyBasedTxBody
+          era
+          txbody
+          txscripts
+          redeemers
+          txmetadata
+          scriptValidity
+      ShelleyBasedEraMary ->
+        serialiseShelleyBasedTxBody
+          era
+          txbody
+          txscripts
+          redeemers
+          txmetadata
+          scriptValidity
+      ShelleyBasedEraAlonzo ->
+        serialiseShelleyBasedTxBody
+          era
+          txbody
+          txscripts
+          redeemers
+          txmetadata
+          scriptValidity
+      ShelleyBasedEraBabbage ->
+        serialiseShelleyBasedTxBody
+          era
+          txbody
+          txscripts
+          redeemers
+          txmetadata
+          scriptValidity
+  deserialiseFromCBOR _ bs =
+    case cardanoEra :: CardanoEra era of
+      ByronEra ->
+        ByronTxBody
+          <$> CBOR.decodeFullAnnotatedBytes
+            "Byron TxBody"
+            CBOR.fromCBORAnnotated
+            (LBS.fromStrict bs)
+      -- Use the same derialisation impl, but at different types:
+      ShelleyEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraShelley bs
+      AllegraEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraAllegra bs
+      MaryEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraMary bs
+      AlonzoEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraAlonzo bs
+      BabbageEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraBabbage bs
 
 -- | The serialisation format for the different Shelley-based eras are not the
 -- same, but they can be handled generally with one overloaded implementation.
+serialiseShelleyBasedTxBody ::
+  forall era ledgerera.
+  ShelleyLedgerEra era ~ ledgerera =>
+  ToCBOR (Ledger.TxBody ledgerera) =>
+  ToCBOR (Ledger.Script ledgerera) =>
+  ToCBOR (Alonzo.TxDats ledgerera) =>
+  ToCBOR (Alonzo.Redeemers ledgerera) =>
+  ToCBOR (Ledger.AuxiliaryData ledgerera) =>
+  ShelleyBasedEra era ->
+  Ledger.TxBody ledgerera ->
+  [Ledger.Script ledgerera] ->
+  TxBodyScriptData era ->
+  Maybe (Ledger.AuxiliaryData ledgerera) ->
+  -- | Mark script as expected to pass or fail validation
+  TxScriptValidity era ->
+  ByteString
 serialiseShelleyBasedTxBody
-  :: forall era ledgerera.
-     ShelleyLedgerEra era ~ ledgerera
-  => ToCBOR (Ledger.TxBody ledgerera)
-  => ToCBOR (Ledger.Script ledgerera)
-  => ToCBOR (Alonzo.TxDats ledgerera)
-  => ToCBOR (Alonzo.Redeemers ledgerera)
-  => ToCBOR (Ledger.AuxiliaryData ledgerera)
-  => ShelleyBasedEra era
-  -> Ledger.TxBody ledgerera
-  -> [Ledger.Script ledgerera]
-  -> TxBodyScriptData era
-  -> Maybe (Ledger.AuxiliaryData ledgerera)
-  -> TxScriptValidity era -- ^ Mark script as expected to pass or fail validation
-  -> ByteString
-serialiseShelleyBasedTxBody era txbody txscripts
-                            TxBodyNoScriptData txmetadata scriptValidity =
+  era
+  txbody
+  txscripts
+  TxBodyNoScriptData
+  txmetadata
+  scriptValidity =
     -- Backwards compat for pre-Alonzo era tx body files
     case era of
       ShelleyBasedEraShelley -> preAlonzo
       ShelleyBasedEraAllegra -> preAlonzo
       ShelleyBasedEraMary -> preAlonzo
       ShelleyBasedEraAlonzo ->
-        CBOR.serializeEncoding'
-          $ CBOR.encodeListLen 4
-         <> CBOR.toCBOR txbody
-         <> CBOR.toCBOR txscripts
-         <> CBOR.toCBOR (txScriptValidityToScriptValidity scriptValidity)
-         <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
+        CBOR.serializeEncoding' $
+          CBOR.encodeListLen 4
+            <> CBOR.toCBOR txbody
+            <> CBOR.toCBOR txscripts
+            <> CBOR.toCBOR (txScriptValidityToScriptValidity scriptValidity)
+            <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
       ShelleyBasedEraBabbage ->
-        CBOR.serializeEncoding'
-          $ CBOR.encodeListLen 4
-         <> CBOR.toCBOR txbody
-         <> CBOR.toCBOR txscripts
-         <> CBOR.toCBOR (txScriptValidityToScriptValidity scriptValidity)
-         <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
- where
-   preAlonzo = CBOR.serializeEncoding'
-                 $ CBOR.encodeListLen 3
-                <> CBOR.toCBOR txbody
-                <> CBOR.toCBOR txscripts
-                <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
-
-serialiseShelleyBasedTxBody _era txbody txscripts
-                            (TxBodyScriptData _ datums redeemers)
-                            txmetadata txBodycriptValidity =
+        CBOR.serializeEncoding' $
+          CBOR.encodeListLen 4
+            <> CBOR.toCBOR txbody
+            <> CBOR.toCBOR txscripts
+            <> CBOR.toCBOR (txScriptValidityToScriptValidity scriptValidity)
+            <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
+    where
+      preAlonzo =
+        CBOR.serializeEncoding' $
+          CBOR.encodeListLen 3
+            <> CBOR.toCBOR txbody
+            <> CBOR.toCBOR txscripts
+            <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
+serialiseShelleyBasedTxBody
+  _era
+  txbody
+  txscripts
+  (TxBodyScriptData _ datums redeemers)
+  txmetadata
+  txBodycriptValidity =
     CBOR.serializeEncoding' $
-        CBOR.encodeListLen 6
-     <> CBOR.toCBOR txbody
-     <> CBOR.toCBOR txscripts
-     <> CBOR.toCBOR datums
-     <> CBOR.toCBOR redeemers
-     <> CBOR.toCBOR (txScriptValidityToScriptValidity txBodycriptValidity)
-     <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
+      CBOR.encodeListLen 6
+        <> CBOR.toCBOR txbody
+        <> CBOR.toCBOR txscripts
+        <> CBOR.toCBOR datums
+        <> CBOR.toCBOR redeemers
+        <> CBOR.toCBOR (txScriptValidityToScriptValidity txBodycriptValidity)
+        <> CBOR.encodeNullMaybe CBOR.toCBOR txmetadata
 
-deserialiseShelleyBasedTxBody
-  :: forall era ledgerera.
-     ShelleyLedgerEra era ~ ledgerera
-  => FromCBOR (CBOR.Annotator (Ledger.TxBody ledgerera))
-  => FromCBOR (CBOR.Annotator (Ledger.Script ledgerera))
-  => FromCBOR (CBOR.Annotator (Alonzo.TxDats ledgerera))
-  => FromCBOR (CBOR.Annotator (Alonzo.Redeemers ledgerera))
-  => FromCBOR (CBOR.Annotator (Ledger.AuxiliaryData ledgerera))
-  => ShelleyBasedEra era
-  -> ByteString
-  -> Either CBOR.DecoderError (TxBody era)
+deserialiseShelleyBasedTxBody ::
+  forall era ledgerera.
+  ShelleyLedgerEra era ~ ledgerera =>
+  FromCBOR (CBOR.Annotator (Ledger.TxBody ledgerera)) =>
+  FromCBOR (CBOR.Annotator (Ledger.Script ledgerera)) =>
+  FromCBOR (CBOR.Annotator (Alonzo.TxDats ledgerera)) =>
+  FromCBOR (CBOR.Annotator (Alonzo.Redeemers ledgerera)) =>
+  FromCBOR (CBOR.Annotator (Ledger.AuxiliaryData ledgerera)) =>
+  ShelleyBasedEra era ->
+  ByteString ->
+  Either CBOR.DecoderError (TxBody era)
 deserialiseShelleyBasedTxBody era bs =
-    CBOR.decodeAnnotator
-      "Shelley TxBody"
-      decodeAnnotatedTuple
-      (LBS.fromStrict bs)
+  CBOR.decodeAnnotator
+    "Shelley TxBody"
+    decodeAnnotatedTuple
+    (LBS.fromStrict bs)
   where
     decodeAnnotatedTuple :: CBOR.Decoder s (CBOR.Annotator (TxBody era))
     decodeAnnotatedTuple = do
@@ -1882,305 +1983,350 @@ deserialiseShelleyBasedTxBody era bs =
       case len of
         -- Backwards compat for pre-Alonzo era tx body files
         2 -> do
-          txbody     <- fromCBOR
+          txbody <- fromCBOR
           txmetadata <- CBOR.decodeNullMaybe fromCBOR
-          return $ CBOR.Annotator $ \fbs ->
-            ShelleyTxBody era
-              (flip CBOR.runAnnotator fbs txbody)
-              [] -- scripts
-              (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
-              (fmap (flip CBOR.runAnnotator fbs) txmetadata)
-              (flip CBOR.runAnnotator fbs (return TxScriptValidityNone))
+          return $
+            CBOR.Annotator $ \fbs ->
+              ShelleyTxBody
+                era
+                (flip CBOR.runAnnotator fbs txbody)
+                [] -- scripts
+                (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
+                (fmap (flip CBOR.runAnnotator fbs) txmetadata)
+                (flip CBOR.runAnnotator fbs (return TxScriptValidityNone))
         3 -> do
-          txbody     <- fromCBOR
-          txscripts  <- fromCBOR
+          txbody <- fromCBOR
+          txscripts <- fromCBOR
           txmetadata <- CBOR.decodeNullMaybe fromCBOR
-          return $ CBOR.Annotator $ \fbs ->
-            ShelleyTxBody era
-              (flip CBOR.runAnnotator fbs txbody)
-              (map (flip CBOR.runAnnotator fbs) txscripts)
-              (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
-              (fmap (flip CBOR.runAnnotator fbs) txmetadata)
-              (flip CBOR.runAnnotator fbs (return TxScriptValidityNone))
+          return $
+            CBOR.Annotator $ \fbs ->
+              ShelleyTxBody
+                era
+                (flip CBOR.runAnnotator fbs txbody)
+                (map (flip CBOR.runAnnotator fbs) txscripts)
+                (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
+                (fmap (flip CBOR.runAnnotator fbs) txmetadata)
+                (flip CBOR.runAnnotator fbs (return TxScriptValidityNone))
         4 -> do
           sValiditySupported <-
             case txScriptValiditySupportedInShelleyBasedEra era of
-              Nothing -> fail $ "deserialiseShelleyBasedTxBody: Expected an era that supports the \
-                                \script validity flag but got: "
-                              <> show era
+              Nothing ->
+                fail $
+                  "deserialiseShelleyBasedTxBody: Expected an era that supports the \
+                  \script validity flag but got: "
+                    <> show era
               Just supported -> return supported
 
-          txbody     <- fromCBOR
-          txscripts  <- fromCBOR
+          txbody <- fromCBOR
+          txscripts <- fromCBOR
           scriptValidity <- fromCBOR
           txmetadata <- CBOR.decodeNullMaybe fromCBOR
-          return $ CBOR.Annotator $ \fbs ->
-            ShelleyTxBody era
-              (flip CBOR.runAnnotator fbs txbody)
-              (map (flip CBOR.runAnnotator fbs) txscripts)
-              (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
-              (fmap (flip CBOR.runAnnotator fbs) txmetadata)
-              (flip CBOR.runAnnotator fbs (return $ TxScriptValidity sValiditySupported scriptValidity))
+          return $
+            CBOR.Annotator $ \fbs ->
+              ShelleyTxBody
+                era
+                (flip CBOR.runAnnotator fbs txbody)
+                (map (flip CBOR.runAnnotator fbs) txscripts)
+                (flip CBOR.runAnnotator fbs (return TxBodyNoScriptData))
+                (fmap (flip CBOR.runAnnotator fbs) txmetadata)
+                (flip CBOR.runAnnotator fbs (return $ TxScriptValidity sValiditySupported scriptValidity))
         6 -> do
           sDataSupported <-
             case scriptDataSupportedInEra (shelleyBasedToCardanoEra era) of
-              Nothing -> fail $ "deserialiseShelleyBasedTxBody: Expected an era that supports script\
-                                \ data but got: "
-                             <> show era
+              Nothing ->
+                fail $
+                  "deserialiseShelleyBasedTxBody: Expected an era that supports script\
+                  \ data but got: "
+                    <> show era
               Just supported -> return supported
 
           sValiditySupported <-
             case txScriptValiditySupportedInShelleyBasedEra era of
-              Nothing -> fail $ "deserialiseShelleyBasedTxBody: Expected an era that supports the \
-                                \script validity flag but got: "
-                              <> show era
+              Nothing ->
+                fail $
+                  "deserialiseShelleyBasedTxBody: Expected an era that supports the \
+                  \script validity flag but got: "
+                    <> show era
               Just supported -> return supported
 
-          txbody    <- fromCBOR
+          txbody <- fromCBOR
           txscripts <- fromCBOR
-          datums    <- fromCBOR
+          datums <- fromCBOR
           redeemers <- fromCBOR
           scriptValidity <- fromCBOR
           txmetadata <- CBOR.decodeNullMaybe fromCBOR
 
           let txscriptdata = CBOR.Annotator $ \fbs ->
-                               TxBodyScriptData sDataSupported
-                                 (flip CBOR.runAnnotator fbs datums)
-                                 (flip CBOR.runAnnotator fbs redeemers)
+                TxBodyScriptData
+                  sDataSupported
+                  (flip CBOR.runAnnotator fbs datums)
+                  (flip CBOR.runAnnotator fbs redeemers)
 
-          return $ CBOR.Annotator $ \fbs ->
-            ShelleyTxBody era
-              (flip CBOR.runAnnotator fbs txbody)
-              (map (flip CBOR.runAnnotator fbs) txscripts)
-              (flip CBOR.runAnnotator fbs txscriptdata)
-              (fmap (flip CBOR.runAnnotator fbs) txmetadata)
-              (flip CBOR.runAnnotator fbs (return $ TxScriptValidity sValiditySupported scriptValidity))
+          return $
+            CBOR.Annotator $ \fbs ->
+              ShelleyTxBody
+                era
+                (flip CBOR.runAnnotator fbs txbody)
+                (map (flip CBOR.runAnnotator fbs) txscripts)
+                (flip CBOR.runAnnotator fbs txscriptdata)
+                (fmap (flip CBOR.runAnnotator fbs) txmetadata)
+                (flip CBOR.runAnnotator fbs (return $ TxScriptValidity sValiditySupported scriptValidity))
         _ -> fail $ "expected tx body tuple of size 2, 3, 4 or 6, got " <> show len
 
 instance IsCardanoEra era => HasTextEnvelope (TxBody era) where
-    textEnvelopeType _ =
-      case cardanoEra :: CardanoEra era of
-        ByronEra   -> "TxUnsignedByron"
-        ShelleyEra -> "TxUnsignedShelley"
-        AllegraEra -> "TxBodyAllegra"
-        MaryEra    -> "TxBodyMary"
-        AlonzoEra  -> "TxBodyAlonzo"
-        BabbageEra -> "TxBodyBabbage"
+  textEnvelopeType _ =
+    case cardanoEra :: CardanoEra era of
+      ByronEra -> "TxUnsignedByron"
+      ShelleyEra -> "TxUnsignedShelley"
+      AllegraEra -> "TxBodyAllegra"
+      MaryEra -> "TxBodyMary"
+      AlonzoEra -> "TxBodyAlonzo"
+      BabbageEra -> "TxBodyBabbage"
 
 -- | Calculate the transaction identifier for a 'TxBody'.
---
-getTxId :: forall era. TxBody era -> TxId
+getTxId ::
+  forall era.
+  ( SafeHash.HashAnnotated
+      (Ledger.TxBody (ShelleyLedgerEra era))
+      EraIndependentTxBody
+      StandardCrypto
+  ) =>
+  TxBody era ->
+  TxId
 getTxId (ByronTxBody tx) =
-    TxId
-  . fromMaybe impossible
-  . Crypto.hashFromBytesShort
-  . Byron.abstractHashToShort
-  . Byron.hashDecoded
-  $ tx
+  TxId
+    . fromMaybe impossible
+    . Crypto.hashFromBytesShort
+    . Byron.abstractHashToShort
+    . Byron.hashDecoded
+    $ tx
   where
     impossible =
       error "getTxId: byron and shelley hash sizes do not match"
-
 getTxId (ShelleyTxBody era tx _ _ _ _) =
   obtainConstraints era $ getTxIdShelley era tx
- where
-  obtainConstraints
-    :: ShelleyBasedEra era
-    -> (( Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-        , Ledger.UsesTxBody (ShelleyLedgerEra era)
-        ) => a)
-    -> a
-  obtainConstraints ShelleyBasedEraShelley f = f
-  obtainConstraints ShelleyBasedEraAllegra f = f
-  obtainConstraints ShelleyBasedEraMary    f = f
-  obtainConstraints ShelleyBasedEraAlonzo  f = f
-  obtainConstraints ShelleyBasedEraBabbage f = f
+  where
+    obtainConstraints ::
+      ShelleyBasedEra era ->
+      ( ( Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
+        ) =>
+        a
+      ) ->
+      a
+    obtainConstraints ShelleyBasedEraShelley f = f
+    obtainConstraints ShelleyBasedEraAllegra f = f
+    obtainConstraints ShelleyBasedEraMary f = f
+    obtainConstraints ShelleyBasedEraAlonzo f = f
+    obtainConstraints ShelleyBasedEraBabbage f = f
 
-getTxIdShelley
-  :: Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => Ledger.UsesTxBody (ShelleyLedgerEra era)
-  => ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxId
+getTxIdShelley ::
+  forall era.
+  ( Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto,
+    SafeHash.HashAnnotated (Ledger.TxBody (ShelleyLedgerEra era)) EraIndependentTxBody StandardCrypto
+  ) =>
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxId
 getTxIdShelley _ tx =
-    TxId
-  . Crypto.castHash
-  . (\(Ledger.TxId txhash) -> SafeHash.extractHash txhash)
-  $ Ledger.txid tx
+  TxId
+    . Crypto.castHash
+    . SafeHash.extractHash @(Ledger.Crypto (ShelleyLedgerEra era))
+    $ SafeHash.hashAnnotated tx
 
 -- ----------------------------------------------------------------------------
 -- Constructing transaction bodies
 --
 
-data TxBodyError =
-       TxBodyEmptyTxIns
-     | TxBodyEmptyTxInsCollateral
-     | TxBodyEmptyTxOuts
-     | TxBodyOutputNegative Quantity TxOutInAnyEra
-     | TxBodyOutputOverflow Quantity TxOutInAnyEra
-     | TxBodyMetadataError [(Word64, TxMetadataRangeError)]
-     | TxBodyMintAdaError
-     | TxBodyMissingProtocolParams
-     | TxBodyInIxOverflow TxIn
-     deriving (Eq, Show)
+data TxBodyError
+  = TxBodyEmptyTxIns
+  | TxBodyEmptyTxInsCollateral
+  | TxBodyEmptyTxOuts
+  | TxBodyOutputNegative Quantity TxOutInAnyEra
+  | TxBodyOutputOverflow Quantity TxOutInAnyEra
+  | TxBodyMetadataError [(Word64, TxMetadataRangeError)]
+  | TxBodyMintAdaError
+  | TxBodyMissingProtocolParams
+  | TxBodyInIxOverflow TxIn
+  deriving (Eq, Show)
 
 instance Error TxBodyError where
-    displayError TxBodyEmptyTxIns  = "Transaction body has no inputs"
-    displayError TxBodyEmptyTxInsCollateral =
-      "Transaction body has no collateral inputs, but uses Plutus scripts"
-    displayError TxBodyEmptyTxOuts = "Transaction body has no outputs"
-    displayError (TxBodyOutputNegative (Quantity q) txout) =
-      "Negative quantity (" ++ show q ++ ") in transaction output: " ++
-      show txout
-    displayError (TxBodyOutputOverflow (Quantity q) txout) =
-      "Quantity too large (" ++ show q ++ " >= 2^64) in transaction output: " ++
-      show txout
-    displayError (TxBodyMetadataError [(k, err)]) =
-      "Error in metadata entry " ++ show k ++ ": " ++ displayError err
-    displayError (TxBodyMetadataError errs) =
-      "Error in metadata entries: " ++
-      intercalate "; "
+  displayError TxBodyEmptyTxIns = "Transaction body has no inputs"
+  displayError TxBodyEmptyTxInsCollateral =
+    "Transaction body has no collateral inputs, but uses Plutus scripts"
+  displayError TxBodyEmptyTxOuts = "Transaction body has no outputs"
+  displayError (TxBodyOutputNegative (Quantity q) txout) =
+    "Negative quantity (" ++ show q ++ ") in transaction output: "
+      ++ show txout
+  displayError (TxBodyOutputOverflow (Quantity q) txout) =
+    "Quantity too large (" ++ show q ++ " >= 2^64) in transaction output: "
+      ++ show txout
+  displayError (TxBodyMetadataError [(k, err)]) =
+    "Error in metadata entry " ++ show k ++ ": " ++ displayError err
+  displayError (TxBodyMetadataError errs) =
+    "Error in metadata entries: "
+      ++ intercalate
+        "; "
         [ show k ++ ": " ++ displayError err
-        | (k, err) <- errs ]
-    displayError TxBodyMintAdaError =
-      "Transaction cannot mint ada, only non-ada assets"
-    displayError TxBodyMissingProtocolParams =
-      "Transaction uses Plutus scripts but does not provide the protocol " ++
-      "parameters to hash"
-    displayError (TxBodyInIxOverflow txin) =
-      "Transaction input index is too big, " ++
-      "acceptable value is up to 2^32-1, " ++
-      "in input " ++ show txin
+          | (k, err) <- errs
+        ]
+  displayError TxBodyMintAdaError =
+    "Transaction cannot mint ada, only non-ada assets"
+  displayError TxBodyMissingProtocolParams =
+    "Transaction uses Plutus scripts but does not provide the protocol "
+      ++ "parameters to hash"
+  displayError (TxBodyInIxOverflow txin) =
+    "Transaction input index is too big, "
+      ++ "acceptable value is up to 2^32-1, "
+      ++ "in input "
+      ++ show txin
 
-
-makeTransactionBody :: forall era.
-     IsCardanoEra era
-  => TxBodyContent BuildTx era
-  -> Either TxBodyError (TxBody era)
+makeTransactionBody ::
+  forall era.
+  IsCardanoEra era =>
+  TxBodyContent BuildTx era ->
+  Either TxBodyError (TxBody era)
 makeTransactionBody =
-    case cardanoEraStyle (cardanoEra :: CardanoEra era) of
-      LegacyByronEra      -> makeByronTransactionBody
-      ShelleyBasedEra era -> makeShelleyTransactionBody era
+  case cardanoEraStyle (cardanoEra :: CardanoEra era) of
+    LegacyByronEra -> makeByronTransactionBody
+    ShelleyBasedEra era -> makeShelleyTransactionBody era
 
-
-pattern TxBody :: TxBodyContent ViewTx era -> TxBody era
+pattern TxBody ::
+  ( BabbageEraTxBody (ShelleyLedgerEra era),
+    Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto,
+    Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto,
+    Ledger.TxOut (ShelleyLedgerEra era) ~ BabbageTxOut (ShelleyLedgerEra era)
+  ) =>
+  TxBodyContent ViewTx era ->
+  TxBody era
 pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)
+
 {-# COMPLETE TxBody #-}
 
-getTxBodyContent :: TxBody era -> TxBodyContent ViewTx era
+getTxBodyContent ::
+  BabbageEraTxBody (ShelleyLedgerEra era) =>
+  Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto =>
+  Ledger.TxOut (ShelleyLedgerEra era) ~ BabbageTxOut (ShelleyLedgerEra era) =>
+  TxBody era ->
+  TxBodyContent ViewTx era
 getTxBodyContent (ByronTxBody body) = getByronTxBodyContent body
 getTxBodyContent (ShelleyTxBody era body _scripts scriptdata mAux scriptValidity) =
-    fromLedgerTxBody era scriptValidity body scriptdata mAux
+  fromLedgerTxBody era scriptValidity body scriptdata mAux
 
-fromLedgerTxBody
-  :: ShelleyBasedEra era
-  -> TxScriptValidity era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxBodyScriptData era
-  -> Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era))
-  -> TxBodyContent ViewTx era
+fromLedgerTxBody ::
+  BabbageEraTxBody (ShelleyLedgerEra era) =>
+  Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto =>
+  Ledger.TxOut (ShelleyLedgerEra era) ~ BabbageTxOut (ShelleyLedgerEra era) =>
+  ShelleyBasedEra era ->
+  TxScriptValidity era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxBodyScriptData era ->
+  Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era)) ->
+  TxBodyContent ViewTx era
 fromLedgerTxBody era scriptValidity body scriptdata mAux =
-    TxBodyContent
-      { txIns              = fromLedgerTxIns               era body
-      , txInsCollateral    = fromLedgerTxInsCollateral     era body
-      , txInsReference     = fromLedgerTxInsReference      era body
-      , txOuts             = fromLedgerTxOuts              era body scriptdata
-      , txTotalCollateral  = fromLedgerTxTotalCollateral   era body
-      , txReturnCollateral = fromLedgerTxReturnCollateral  era body
-      , txFee              = fromLedgerTxFee               era body
-      , txValidityRange    = fromLedgerTxValidityRange     era body
-      , txWithdrawals      = fromLedgerTxWithdrawals       era body
-      , txCertificates     = fromLedgerTxCertificates      era body
-      , txUpdateProposal   = fromLedgerTxUpdateProposal    era body
-      , txMintValue        = fromLedgerTxMintValue         era body
-      , txExtraKeyWits     = fromLedgerTxExtraKeyWitnesses era body
-      , txProtocolParams   = ViewTx
-      , txMetadata
-      , txAuxScripts
-      , txScriptValidity   = scriptValidity
-      }
+  TxBodyContent
+    { txIns = fromLedgerTxIns era body,
+      txInsCollateral = fromLedgerTxInsCollateral era body,
+      txInsReference = fromLedgerTxInsReference era body,
+      txOuts = fromLedgerTxOuts era body scriptdata,
+      txTotalCollateral = fromLedgerTxTotalCollateral era body,
+      txReturnCollateral = fromLedgerTxReturnCollateral era body,
+      txFee = fromLedgerTxFee era body,
+      txValidityRange = fromLedgerTxValidityRange era body,
+      txWithdrawals = fromLedgerTxWithdrawals era body,
+      txCertificates = fromLedgerTxCertificates era body,
+      txUpdateProposal = fromLedgerTxUpdateProposal era body,
+      txMintValue = fromLedgerTxMintValue era body,
+      txExtraKeyWits = fromLedgerTxExtraKeyWitnesses era body,
+      txProtocolParams = ViewTx,
+      txMetadata,
+      txAuxScripts,
+      txScriptValidity = scriptValidity
+    }
   where
     (txMetadata, txAuxScripts) = fromLedgerTxAuxiliaryData era mAux
 
-
-fromLedgerTxIns
-  :: forall era.
-     ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> [(TxIn,BuildTxWith ViewTx (Witness WitCtxTxIn era))]
+fromLedgerTxIns ::
+  forall era.
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  [(TxIn, BuildTxWith ViewTx (Witness WitCtxTxIn era))]
 fromLedgerTxIns era body =
-    [ (fromShelleyTxIn input, ViewTx)
-    | input <- Set.toList (inputs era body) ]
+  [ (fromShelleyTxIn input, ViewTx)
+    | input <- Set.toList (inputSet era body)
+  ]
   where
-    inputs :: ShelleyBasedEra era
-           -> Ledger.TxBody (ShelleyLedgerEra era)
-           -> Set (Ledger.TxIn StandardCrypto)
-    inputs ShelleyBasedEraShelley = Shelley._inputs
-    inputs ShelleyBasedEraAllegra = Allegra.inputs'
-    inputs ShelleyBasedEraMary    = Mary.inputs'
-    inputs ShelleyBasedEraAlonzo  = Alonzo.inputs'
-    inputs ShelleyBasedEraBabbage = Babbage.inputs
+    inputSet ::
+      ShelleyBasedEra era ->
+      Ledger.TxBody (ShelleyLedgerEra era) ->
+      Set (Ledger.TxIn StandardCrypto)
+    inputSet ShelleyBasedEraShelley = Shelley._inputs
+    inputSet ShelleyBasedEraAllegra = Allegra.inputs'
+    inputSet ShelleyBasedEraMary = Mary.inputs'
+    inputSet ShelleyBasedEraAlonzo = Alonzo.inputs'
+    inputSet ShelleyBasedEraBabbage = Babbage.inputs
 
-
-fromLedgerTxInsCollateral
-  :: forall era.
-     ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxInsCollateral era
+fromLedgerTxInsCollateral ::
+  forall era.
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxInsCollateral era
 fromLedgerTxInsCollateral era body =
-    case collateralSupportedInEra (shelleyBasedToCardanoEra era) of
-      Nothing        -> TxInsCollateralNone
-      Just supported ->
-        TxInsCollateral supported $ map fromShelleyTxIn collateral
+  case collateralSupportedInEra (shelleyBasedToCardanoEra era) of
+    Nothing -> TxInsCollateralNone
+    Just supported ->
+      TxInsCollateral supported $ map fromShelleyTxIn collaterals
   where
-    collateral :: [Ledger.TxIn StandardCrypto]
-    collateral = case era of
+    collaterals :: [Ledger.TxIn StandardCrypto]
+    collaterals = case era of
       ShelleyBasedEraShelley -> []
       ShelleyBasedEraAllegra -> []
-      ShelleyBasedEraMary    -> []
-      ShelleyBasedEraAlonzo  -> toList $ Alonzo.collateral' body
+      ShelleyBasedEraMary -> []
+      ShelleyBasedEraAlonzo -> toList $ Alonzo.collateral' body
       ShelleyBasedEraBabbage -> toList $ Babbage.collateral body
 
-fromLedgerTxInsReference
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxInsReference ViewTx era
+fromLedgerTxInsReference ::
+  Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto =>
+  BabbageEraTxBody (ShelleyLedgerEra era) =>
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxInsReference ViewTx era
 fromLedgerTxInsReference era txBody =
   case refInsScriptsAndInlineDatsSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxInsReferenceNone
     Just suppInEra ->
-      let ledgerRefInputs = obtainReferenceInputsHasFieldConstraint suppInEra $ getField @"referenceInputs" txBody
-      in TxInsReference suppInEra
-           $ map fromShelleyTxIn . Set.toList $ ledgerRefInputs
- where
-  obtainReferenceInputsHasFieldConstraint
-    :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-    -> (HasField "referenceInputs" (Ledger.TxBody (ShelleyLedgerEra era)) (Set (Ledger.TxIn StandardCrypto)) => a)
-    -> a
-  obtainReferenceInputsHasFieldConstraint ReferenceTxInsScriptsInlineDatumsInBabbageEra f = f
+      let ledgerRefInputs = obtainReferenceInputsHasFieldConstraint suppInEra $ txBody ^. referenceInputsTxBodyL
+       in TxInsReference suppInEra $
+            map fromShelleyTxIn . Set.toList $ ledgerRefInputs
+  where
+    obtainReferenceInputsHasFieldConstraint ::
+      ReferenceTxInsScriptsInlineDatumsSupportedInEra era ->
+      a ->
+      a
+    obtainReferenceInputsHasFieldConstraint ReferenceTxInsScriptsInlineDatumsInBabbageEra f = f
 
-fromLedgerTxOuts
-  :: forall era.
-     ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxBodyScriptData era
-  -> [TxOut CtxTx era]
+fromLedgerTxOuts ::
+  forall era.
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxBodyScriptData era ->
+  [TxOut CtxTx era]
 fromLedgerTxOuts era body scriptdata =
   case era of
     ShelleyBasedEraShelley ->
-      [ fromShelleyTxOut era txout | txout <- toList (Shelley._outputs body) ]
-
+      [fromShelleyTxOut era txout | txout <- toList (Shelley._outputs body)]
     ShelleyBasedEraAllegra ->
-      [ fromShelleyTxOut era txout | txout <- toList (Allegra.outputs' body) ]
-
+      [fromShelleyTxOut era txout | txout <- toList (Allegra.outputs' body)]
     ShelleyBasedEraMary ->
-      [ fromShelleyTxOut era txout | txout <- toList (Mary.outputs' body) ]
-
+      [fromShelleyTxOut era txout | txout <- toList (Mary.outputs' body)]
     ShelleyBasedEraAlonzo ->
       [ fromAlonzoTxOut
           MultiAssetInAlonzoEra
           ScriptDataInAlonzoEra
           txdatums
           txout
-      | let txdatums = selectTxDatums scriptdata
-      , txout <- toList (Alonzo.outputs' body) ]
-
+        | let txdatums = selectTxDatums scriptdata,
+          txout <- toList (Alonzo.outputs' body)
+      ]
     ShelleyBasedEraBabbage ->
       [ fromBabbageTxOut
           MultiAssetInBabbageEra
@@ -2188,1206 +2334,1323 @@ fromLedgerTxOuts era body scriptdata =
           ReferenceTxInsScriptsInlineDatumsInBabbageEra
           txdatums
           (CBOR.sizedValue txouts)
-      | let txdatums = selectTxDatums scriptdata
-      , txouts <- toList (Babbage.outputs body)
+        | let txdatums = selectTxDatums scriptdata,
+          txouts <- toList (Babbage.outputs body)
       ]
   where
-    selectTxDatums  TxBodyNoScriptData                            = Map.empty
+    selectTxDatums TxBodyNoScriptData = Map.empty
     selectTxDatums (TxBodyScriptData _ (Alonzo.TxDats' datums) _) = datums
 
-fromAlonzoTxOut :: forall era ledgerera.
-                   IsShelleyBasedEra era
-                => Ledger.Era ledgerera
-                => Ledger.Crypto ledgerera ~ StandardCrypto
-                => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
-                => MultiAssetSupportedInEra era
-                -> ScriptDataSupportedInEra era
-                -> Map (Alonzo.DataHash StandardCrypto)
-                       (Alonzo.Data ledgerera)
-                -> Alonzo.TxOut ledgerera
-                -> TxOut CtxTx era
-fromAlonzoTxOut multiAssetInEra scriptDataInEra txdatums
-                (Alonzo.TxOut addr value datahash) =
-   TxOut (fromShelleyAddr shelleyBasedEra addr)
-         (TxOutValue multiAssetInEra (fromMaryValue value))
-         (fromAlonzoTxOutDatum scriptDataInEra datahash)
-         ReferenceScriptNone
-  where
-    fromAlonzoTxOutDatum :: ScriptDataSupportedInEra era
-                         -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-                         -> TxOutDatum CtxTx era
-    fromAlonzoTxOutDatum _          SNothing = TxOutDatumNone
-    fromAlonzoTxOutDatum supported (SJust dh)
-      | Just d <- Map.lookup dh txdatums
-                  = TxOutDatumInTx' supported (ScriptDataHash dh)
-                                              (fromAlonzoData d)
-      | otherwise = TxOutDatumHash supported (ScriptDataHash dh)
+fromAlonzoTxOut ::
+  forall era ledgerera.
+  IsShelleyBasedEra era =>
+  Ledger.Era ledgerera =>
+  Ledger.Crypto ledgerera ~ StandardCrypto =>
+  Ledger.Value ledgerera ~ MaryValue StandardCrypto =>
+  MultiAssetSupportedInEra era ->
+  ScriptDataSupportedInEra era ->
+  Map
+    (Alonzo.DataHash StandardCrypto)
+    (Alonzo.Data ledgerera) ->
+  AlonzoTxOut ledgerera ->
+  TxOut CtxTx era
+fromAlonzoTxOut
+  multiAssetInEra
+  scriptDataInEra
+  txdatums
+  (AlonzoTxOut addr value datahash) =
+    TxOut
+      (fromShelleyAddr shelleyBasedEra addr)
+      (TxOutValue multiAssetInEra (fromMaryValue value))
+      (fromAlonzoTxOutDatum scriptDataInEra datahash)
+      ReferenceScriptNone
+    where
+      fromAlonzoTxOutDatum ::
+        ScriptDataSupportedInEra era ->
+        StrictMaybe (Alonzo.DataHash StandardCrypto) ->
+        TxOutDatum CtxTx era
+      fromAlonzoTxOutDatum _ SNothing = TxOutDatumNone
+      fromAlonzoTxOutDatum supported (SJust dh)
+        | Just d <- Map.lookup dh txdatums =
+          TxOutDatumInTx'
+            supported
+            (ScriptDataHash dh)
+            (fromAlonzoData d)
+        | otherwise = TxOutDatumHash supported (ScriptDataHash dh)
 
-fromBabbageTxOut
-  :: forall ledgerera era. Ledger.Era ledgerera
-  => IsShelleyBasedEra era
-  => ShelleyLedgerEra era ~ ledgerera
-  => Ledger.Crypto ledgerera ~ StandardCrypto
-  => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
-  => MultiAssetSupportedInEra era
-  -> ScriptDataSupportedInEra era
-  -> ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-  -> Map (Alonzo.DataHash StandardCrypto)
-         (Alonzo.Data ledgerera)
-  -> Babbage.TxOut ledgerera
-  -> TxOut CtxTx era
+fromBabbageTxOut ::
+  forall ledgerera era.
+  Ledger.Era ledgerera =>
+  IsShelleyBasedEra era =>
+  ShelleyLedgerEra era ~ ledgerera =>
+  Ledger.Crypto ledgerera ~ StandardCrypto =>
+  Ledger.Value ledgerera ~ MaryValue StandardCrypto =>
+  MultiAssetSupportedInEra era ->
+  ScriptDataSupportedInEra era ->
+  ReferenceTxInsScriptsInlineDatumsSupportedInEra era ->
+  Map
+    (Alonzo.DataHash StandardCrypto)
+    (Alonzo.Data ledgerera) ->
+  BabbageTxOut ledgerera ->
+  TxOut CtxTx era
 fromBabbageTxOut multiAssetInEra scriptDataInEra inlineDatumsInEra txdatums txout =
-   TxOut
-     (fromShelleyAddr shelleyBasedEra addr)
-     (TxOutValue multiAssetInEra (fromMaryValue val))
-     babbageTxOutDatum
-     (case mRefScript of
-       SNothing -> ReferenceScriptNone
-       SJust rScript -> fromShelleyScriptToReferenceScript shelleyBasedEra rScript
-     )
- where
-   -- NOTE: This is different to 'fromBabbageTxOutDatum' as it may resolve
-   -- 'DatumHash' values using the datums included in the transaction.
-   babbageTxOutDatum :: TxOutDatum CtxTx era
-   babbageTxOutDatum =
-     case datum of
-       Babbage.NoDatum -> TxOutDatumNone
-       Babbage.DatumHash dh -> resolveDatumInTx dh
-       Babbage.Datum d ->
-         TxOutDatumInline inlineDatumsInEra $
-           binaryDataToScriptData inlineDatumsInEra d
+  TxOut
+    (fromShelleyAddr shelleyBasedEra addr)
+    (TxOutValue multiAssetInEra (fromMaryValue val))
+    babbageTxOutDatum
+    ( case mRefScript of
+        SNothing -> ReferenceScriptNone
+        SJust rScript -> fromShelleyScriptToReferenceScript shelleyBasedEra rScript
+    )
+  where
+    -- NOTE: This is different to 'fromBabbageTxOutDatum' as it may resolve
+    -- 'DatumHash' values using the datums included in the transaction.
+    babbageTxOutDatum :: TxOutDatum CtxTx era
+    babbageTxOutDatum =
+      case datum of
+        Babbage.NoDatum -> TxOutDatumNone
+        Babbage.DatumHash dh -> resolveDatumInTx dh
+        Babbage.Datum d ->
+          TxOutDatumInline inlineDatumsInEra $
+            binaryDataToScriptData inlineDatumsInEra d
 
-   resolveDatumInTx :: Alonzo.DataHash StandardCrypto -> TxOutDatum CtxTx era
-   resolveDatumInTx dh
-      | Just d <- Map.lookup dh txdatums
-                  = TxOutDatumInTx' scriptDataInEra (ScriptDataHash dh) (fromAlonzoData d)
+    resolveDatumInTx :: Alonzo.DataHash StandardCrypto -> TxOutDatum CtxTx era
+    resolveDatumInTx dh
+      | Just d <- Map.lookup dh txdatums =
+        TxOutDatumInTx' scriptDataInEra (ScriptDataHash dh) (fromAlonzoData d)
       | otherwise = TxOutDatumHash scriptDataInEra (ScriptDataHash dh)
 
-   (Babbage.TxOut addr val datum mRefScript) = txout
+    (BabbageTxOut addr val datum mRefScript) = txout
 
-fromLedgerTxTotalCollateral
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxTotalCollateral era
+fromLedgerTxTotalCollateral ::
+  forall era.
+  BabbageEraTxBody (ShelleyLedgerEra era) =>
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxTotalCollateral era
 fromLedgerTxTotalCollateral era txbody =
   case totalAndReturnCollateralSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxTotalCollateralNone
     Just supp ->
-      case obtainTotalCollateralHasFieldConstraint supp $ getField @"totalCollateral" txbody of
+      case obtainTotalCollateralHasFieldConstraint supp $ txbody ^. totalCollateralTxBodyL of
         SNothing -> TxTotalCollateralNone
         SJust totColl -> TxTotalCollateral supp $ fromShelleyLovelace totColl
- where
-  obtainTotalCollateralHasFieldConstraint
-    :: TxTotalAndReturnCollateralSupportedInEra era
-    -> (HasField "totalCollateral" (Ledger.TxBody (ShelleyLedgerEra era)) (StrictMaybe Ledger.Coin) => a)
-    -> a
-  obtainTotalCollateralHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
+  where
+    obtainTotalCollateralHasFieldConstraint ::
+      TxTotalAndReturnCollateralSupportedInEra era ->
+      a ->
+      a
+    obtainTotalCollateralHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
 
-fromLedgerTxReturnCollateral
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxReturnCollateral CtxTx era
+fromLedgerTxReturnCollateral ::
+  BabbageEraTxBody (ShelleyLedgerEra era) =>
+  Ledger.TxOut (ShelleyLedgerEra era) ~ BabbageTxOut (ShelleyLedgerEra era) =>
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxReturnCollateral CtxTx era
 fromLedgerTxReturnCollateral era txbody =
   case totalAndReturnCollateralSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxReturnCollateralNone
     Just supp ->
-      case obtainCollateralReturnHasFieldConstraint supp $ getField @"collateralReturn" txbody of
+      case obtainCollateralReturnHasFieldConstraint supp $ txbody ^. collateralReturnTxBodyL of
         SNothing -> TxReturnCollateralNone
         SJust collReturnOut ->
           TxReturnCollateral supp $ fromShelleyTxOut era collReturnOut
- where
-  obtainCollateralReturnHasFieldConstraint
-    :: TxTotalAndReturnCollateralSupportedInEra era
-    -> (HasField "collateralReturn"
-          (Ledger.TxBody (ShelleyLedgerEra era))
-          (StrictMaybe (Ledger.TxOut (ShelleyLedgerEra era))) => a)
-    -> a
-  obtainCollateralReturnHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
+  where
+    obtainCollateralReturnHasFieldConstraint ::
+      TxTotalAndReturnCollateralSupportedInEra era ->
+      a ->
+      a
+    obtainCollateralReturnHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
 
-
-fromLedgerTxFee
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxFee era
+fromLedgerTxFee ::
+  ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxFee era
 fromLedgerTxFee era body =
   case era of
     ShelleyBasedEraShelley ->
       TxFeeExplicit TxFeesExplicitInShelleyEra $
-      fromShelleyLovelace $ Shelley._txfee body
+        fromShelleyLovelace $ Shelley._txfee body
     ShelleyBasedEraAllegra ->
       TxFeeExplicit TxFeesExplicitInAllegraEra $
-      fromShelleyLovelace $ Allegra.txfee' body
+        fromShelleyLovelace $ Allegra.txfee' body
     ShelleyBasedEraMary ->
       TxFeeExplicit TxFeesExplicitInMaryEra $
-      fromShelleyLovelace $ Mary.txfee' body
+        fromShelleyLovelace $ Mary.txfee' body
     ShelleyBasedEraAlonzo ->
       TxFeeExplicit TxFeesExplicitInAlonzoEra $
-      fromShelleyLovelace $ Alonzo.txfee' body
+        fromShelleyLovelace $ Alonzo.txfee' body
     ShelleyBasedEraBabbage ->
       TxFeeExplicit TxFeesExplicitInBabbageEra $
-      fromShelleyLovelace $ Babbage.txfee body
+        fromShelleyLovelace $ Babbage.txfee body
 
-fromLedgerTxValidityRange
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> (TxValidityLowerBound era, TxValidityUpperBound era)
+fromLedgerTxValidityRange ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  (TxValidityLowerBound era, TxValidityUpperBound era)
 fromLedgerTxValidityRange era body =
   case era of
     ShelleyBasedEraShelley ->
-      ( TxValidityNoLowerBound
-      , TxValidityUpperBound ValidityUpperBoundInShelleyEra $ Shelley._ttl body
+      ( TxValidityNoLowerBound,
+        TxValidityUpperBound ValidityUpperBoundInShelleyEra $ Shelley._ttl body
       )
-
     ShelleyBasedEraAllegra ->
       ( case invalidBefore of
           SNothing -> TxValidityNoLowerBound
-          SJust s  -> TxValidityLowerBound ValidityLowerBoundInAllegraEra s
-      , case invalidHereafter of
+          SJust s -> TxValidityLowerBound ValidityLowerBoundInAllegraEra s,
+        case invalidHereafter of
           SNothing -> TxValidityNoUpperBound ValidityNoUpperBoundInAllegraEra
-          SJust s  -> TxValidityUpperBound   ValidityUpperBoundInAllegraEra s
+          SJust s -> TxValidityUpperBound ValidityUpperBoundInAllegraEra s
       )
       where
-        Allegra.ValidityInterval{invalidBefore, invalidHereafter} =
+        Allegra.ValidityInterval {invalidBefore, invalidHereafter} =
           Allegra.vldt' body
-
     ShelleyBasedEraMary ->
       ( case invalidBefore of
           SNothing -> TxValidityNoLowerBound
-          SJust s  -> TxValidityLowerBound ValidityLowerBoundInMaryEra s
-      , case invalidHereafter of
+          SJust s -> TxValidityLowerBound ValidityLowerBoundInMaryEra s,
+        case invalidHereafter of
           SNothing -> TxValidityNoUpperBound ValidityNoUpperBoundInMaryEra
-          SJust s  -> TxValidityUpperBound   ValidityUpperBoundInMaryEra s
+          SJust s -> TxValidityUpperBound ValidityUpperBoundInMaryEra s
       )
       where
-        Mary.ValidityInterval{invalidBefore, invalidHereafter} = Mary.vldt' body
-
+        Mary.ValidityInterval {invalidBefore, invalidHereafter} = Mary.vldt' body
     ShelleyBasedEraAlonzo ->
       ( case invalidBefore of
           SNothing -> TxValidityNoLowerBound
-          SJust s  -> TxValidityLowerBound ValidityLowerBoundInAlonzoEra s
-      , case invalidHereafter of
+          SJust s -> TxValidityLowerBound ValidityLowerBoundInAlonzoEra s,
+        case invalidHereafter of
           SNothing -> TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra
-          SJust s  -> TxValidityUpperBound   ValidityUpperBoundInAlonzoEra s
+          SJust s -> TxValidityUpperBound ValidityUpperBoundInAlonzoEra s
       )
       where
-        Mary.ValidityInterval{invalidBefore, invalidHereafter} = Alonzo.vldt' body
-
+        Mary.ValidityInterval {invalidBefore, invalidHereafter} = Alonzo.vldt' body
     ShelleyBasedEraBabbage ->
       ( case invalidBefore of
           SNothing -> TxValidityNoLowerBound
-          SJust s  -> TxValidityLowerBound ValidityLowerBoundInBabbageEra s
-      , case invalidHereafter of
+          SJust s -> TxValidityLowerBound ValidityLowerBoundInBabbageEra s,
+        case invalidHereafter of
           SNothing -> TxValidityNoUpperBound ValidityNoUpperBoundInBabbageEra
-          SJust s  -> TxValidityUpperBound   ValidityUpperBoundInBabbageEra s
+          SJust s -> TxValidityUpperBound ValidityUpperBoundInBabbageEra s
       )
       where
-        Mary.ValidityInterval{invalidBefore, invalidHereafter} = Babbage.txvldt body
+        Mary.ValidityInterval {invalidBefore, invalidHereafter} = Babbage.txvldt body
 
-fromLedgerAuxiliaryData
-  :: ShelleyBasedEra era
-  -> Ledger.AuxiliaryData (ShelleyLedgerEra era)
-  -> (Map Word64 TxMetadataValue, [ScriptInEra era])
+fromLedgerAuxiliaryData ::
+  ShelleyBasedEra era ->
+  Ledger.AuxiliaryData (ShelleyLedgerEra era) ->
+  (Map Word64 TxMetadataValue, [ScriptInEra era])
 fromLedgerAuxiliaryData ShelleyBasedEraShelley (Shelley.Metadata metadata) =
   (fromShelleyMetadata metadata, [])
-fromLedgerAuxiliaryData ShelleyBasedEraAllegra (Allegra.AuxiliaryData ms ss) =
-  ( fromShelleyMetadata ms
-  , fromShelleyBasedScript ShelleyBasedEraAllegra <$> toList ss
+fromLedgerAuxiliaryData ShelleyBasedEraAllegra (MAAuxiliaryData ms ss) =
+  ( fromShelleyMetadata ms,
+    fromShelleyBasedScript ShelleyBasedEraAllegra <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraMary (Mary.AuxiliaryData ms ss) =
-  ( fromShelleyMetadata ms
-  , fromShelleyBasedScript ShelleyBasedEraMary <$> toList ss
+fromLedgerAuxiliaryData ShelleyBasedEraMary (MAAuxiliaryData ms ss) =
+  ( fromShelleyMetadata ms,
+    fromShelleyBasedScript ShelleyBasedEraMary <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraAlonzo (Alonzo.AuxiliaryData ms ss) =
-  ( fromShelleyMetadata ms
-  , fromShelleyBasedScript ShelleyBasedEraAlonzo <$> toList ss
+fromLedgerAuxiliaryData ShelleyBasedEraAlonzo (AlonzoAuxiliaryData ms ss) =
+  ( fromShelleyMetadata ms,
+    fromShelleyBasedScript ShelleyBasedEraAlonzo <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraBabbage (Alonzo.AuxiliaryData ms ss) =
-  ( fromShelleyMetadata ms
-  , fromShelleyBasedScript ShelleyBasedEraBabbage <$> toList ss
+fromLedgerAuxiliaryData ShelleyBasedEraBabbage (AlonzoAuxiliaryData ms ss) =
+  ( fromShelleyMetadata ms,
+    fromShelleyBasedScript ShelleyBasedEraBabbage <$> toList ss
   )
 
-fromLedgerTxAuxiliaryData
-  :: ShelleyBasedEra era
-  -> Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era))
-  -> (TxMetadataInEra era, TxAuxScripts era)
+fromLedgerTxAuxiliaryData ::
+  ShelleyBasedEra era ->
+  Maybe (Ledger.AuxiliaryData (ShelleyLedgerEra era)) ->
+  (TxMetadataInEra era, TxAuxScripts era)
 fromLedgerTxAuxiliaryData _ Nothing = (TxMetadataNone, TxAuxScriptsNone)
 fromLedgerTxAuxiliaryData era (Just auxData) =
   case era of
     ShelleyBasedEraShelley ->
-      ( if null ms then
-          TxMetadataNone
-        else
-          TxMetadataInEra TxMetadataInShelleyEra $ TxMetadata ms
-      , TxAuxScriptsNone
+      ( if null ms
+          then TxMetadataNone
+          else TxMetadataInEra TxMetadataInShelleyEra $ TxMetadata ms,
+        TxAuxScriptsNone
       )
     ShelleyBasedEraAllegra ->
-      ( if null ms then
-          TxMetadataNone
-        else
-          TxMetadataInEra TxMetadataInAllegraEra $ TxMetadata ms
-      , case ss of
+      ( if null ms
+          then TxMetadataNone
+          else TxMetadataInEra TxMetadataInAllegraEra $ TxMetadata ms,
+        case ss of
           [] -> TxAuxScriptsNone
-          _  -> TxAuxScripts AuxScriptsInAllegraEra ss
+          _ -> TxAuxScripts AuxScriptsInAllegraEra ss
       )
     ShelleyBasedEraMary ->
-      ( if null ms then
-          TxMetadataNone
-        else
-          TxMetadataInEra TxMetadataInMaryEra $ TxMetadata ms
-      , case ss of
+      ( if null ms
+          then TxMetadataNone
+          else TxMetadataInEra TxMetadataInMaryEra $ TxMetadata ms,
+        case ss of
           [] -> TxAuxScriptsNone
-          _  -> TxAuxScripts AuxScriptsInMaryEra ss
+          _ -> TxAuxScripts AuxScriptsInMaryEra ss
       )
     ShelleyBasedEraAlonzo ->
-      ( if null ms then
-          TxMetadataNone
-        else
-          TxMetadataInEra TxMetadataInAlonzoEra $ TxMetadata ms
-      , case ss of
+      ( if null ms
+          then TxMetadataNone
+          else TxMetadataInEra TxMetadataInAlonzoEra $ TxMetadata ms,
+        case ss of
           [] -> TxAuxScriptsNone
-          _  -> TxAuxScripts AuxScriptsInAlonzoEra ss
+          _ -> TxAuxScripts AuxScriptsInAlonzoEra ss
       )
     ShelleyBasedEraBabbage ->
-      ( if null ms then
-          TxMetadataNone
-        else
-          TxMetadataInEra TxMetadataInBabbageEra $ TxMetadata ms
-      , case ss of
+      ( if null ms
+          then TxMetadataNone
+          else TxMetadataInEra TxMetadataInBabbageEra $ TxMetadata ms,
+        case ss of
           [] -> TxAuxScriptsNone
-          _  -> TxAuxScripts AuxScriptsInBabbageEra ss
+          _ -> TxAuxScripts AuxScriptsInBabbageEra ss
       )
   where
     (ms, ss) = fromLedgerAuxiliaryData era auxData
 
-
-fromLedgerTxExtraKeyWitnesses :: ShelleyBasedEra era
-                              -> Ledger.TxBody (ShelleyLedgerEra era)
-                              -> TxExtraKeyWitnesses era
+fromLedgerTxExtraKeyWitnesses ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxExtraKeyWitnesses era
 fromLedgerTxExtraKeyWitnesses sbe body =
   case sbe of
     ShelleyBasedEraShelley -> TxExtraKeyWitnessesNone
     ShelleyBasedEraAllegra -> TxExtraKeyWitnessesNone
-    ShelleyBasedEraMary    -> TxExtraKeyWitnessesNone
+    ShelleyBasedEraMary -> TxExtraKeyWitnessesNone
     ShelleyBasedEraAlonzo
       | Set.null keyhashes -> TxExtraKeyWitnessesNone
-      | otherwise          -> TxExtraKeyWitnesses
-                                ExtraKeyWitnessesInAlonzoEra
-                                [ PaymentKeyHash (Shelley.coerceKeyRole keyhash)
-                                | keyhash <- Set.toList keyhashes ]
+      | otherwise ->
+        TxExtraKeyWitnesses
+          ExtraKeyWitnessesInAlonzoEra
+          [ PaymentKeyHash (Shelley.coerceKeyRole keyhash)
+            | keyhash <- Set.toList keyhashes
+          ]
       where
         keyhashes = Alonzo.reqSignerHashes body
     ShelleyBasedEraBabbage
       | Set.null keyhashes -> TxExtraKeyWitnessesNone
-      | otherwise          -> TxExtraKeyWitnesses
-                                ExtraKeyWitnessesInBabbageEra
-                                [ PaymentKeyHash (Shelley.coerceKeyRole keyhash)
-                                | keyhash <- Set.toList keyhashes ]
+      | otherwise ->
+        TxExtraKeyWitnesses
+          ExtraKeyWitnessesInBabbageEra
+          [ PaymentKeyHash (Shelley.coerceKeyRole keyhash)
+            | keyhash <- Set.toList keyhashes
+          ]
       where
         keyhashes = Babbage.reqSignerHashes body
 
-fromLedgerTxWithdrawals
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxWithdrawals ViewTx era
+fromLedgerTxWithdrawals ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxWithdrawals ViewTx era
 fromLedgerTxWithdrawals era body =
   case era of
     ShelleyBasedEraShelley
       | null (Shelley.unWdrl withdrawals) -> TxWithdrawalsNone
       | otherwise ->
-          TxWithdrawals WithdrawalsInShelleyEra $
+        TxWithdrawals WithdrawalsInShelleyEra $
           fromShelleyWithdrawal withdrawals
       where
         withdrawals = Shelley._wdrls body
-
     ShelleyBasedEraAllegra
       | null (Shelley.unWdrl withdrawals) -> TxWithdrawalsNone
       | otherwise ->
-          TxWithdrawals WithdrawalsInAllegraEra $
+        TxWithdrawals WithdrawalsInAllegraEra $
           fromShelleyWithdrawal withdrawals
       where
         withdrawals = Allegra.wdrls' body
-
     ShelleyBasedEraMary
       | null (Shelley.unWdrl withdrawals) -> TxWithdrawalsNone
       | otherwise ->
-          TxWithdrawals WithdrawalsInMaryEra $ fromShelleyWithdrawal withdrawals
+        TxWithdrawals WithdrawalsInMaryEra $ fromShelleyWithdrawal withdrawals
       where
         withdrawals = Mary.wdrls' body
-
     ShelleyBasedEraAlonzo
       | null (Shelley.unWdrl withdrawals) -> TxWithdrawalsNone
       | otherwise ->
-          TxWithdrawals WithdrawalsInAlonzoEra $ fromShelleyWithdrawal withdrawals
+        TxWithdrawals WithdrawalsInAlonzoEra $ fromShelleyWithdrawal withdrawals
       where
         withdrawals = Alonzo.wdrls' body
-
     ShelleyBasedEraBabbage
       | null (Shelley.unWdrl withdrawals) -> TxWithdrawalsNone
       | otherwise ->
-          TxWithdrawals WithdrawalsInBabbageEra $ fromShelleyWithdrawal withdrawals
+        TxWithdrawals WithdrawalsInBabbageEra $ fromShelleyWithdrawal withdrawals
       where
         withdrawals = Babbage.wdrls' body
 
-fromLedgerTxCertificates
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxCertificates ViewTx era
+fromLedgerTxCertificates ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxCertificates ViewTx era
 fromLedgerTxCertificates era body =
   case era of
     ShelleyBasedEraShelley
       | null certificates -> TxCertificatesNone
       | otherwise ->
-          TxCertificates
-            CertificatesInShelleyEra
-            (map fromShelleyCertificate $ toList certificates)
-            ViewTx
+        TxCertificates
+          CertificatesInShelleyEra
+          (map fromShelleyCertificate $ toList certificates)
+          ViewTx
       where
         certificates = Shelley._certs body
-
     ShelleyBasedEraAllegra
       | null certificates -> TxCertificatesNone
       | otherwise ->
-          TxCertificates
-            CertificatesInAllegraEra
-            (map fromShelleyCertificate $ toList certificates)
-            ViewTx
+        TxCertificates
+          CertificatesInAllegraEra
+          (map fromShelleyCertificate $ toList certificates)
+          ViewTx
       where
         certificates = Allegra.certs' body
-
     ShelleyBasedEraMary
       | null certificates -> TxCertificatesNone
       | otherwise ->
-          TxCertificates
-            CertificatesInMaryEra
-            (map fromShelleyCertificate $ toList certificates)
-            ViewTx
+        TxCertificates
+          CertificatesInMaryEra
+          (map fromShelleyCertificate $ toList certificates)
+          ViewTx
       where
         certificates = Mary.certs' body
-
     ShelleyBasedEraAlonzo
       | null certificates -> TxCertificatesNone
       | otherwise ->
-          TxCertificates
-            CertificatesInAlonzoEra
-            (map fromShelleyCertificate $ toList certificates)
-            ViewTx
+        TxCertificates
+          CertificatesInAlonzoEra
+          (map fromShelleyCertificate $ toList certificates)
+          ViewTx
       where
         certificates = Alonzo.certs' body
-
     ShelleyBasedEraBabbage
       | null certificates -> TxCertificatesNone
       | otherwise ->
-          TxCertificates
-            CertificatesInBabbageEra
-            (map fromShelleyCertificate $ toList certificates)
-            ViewTx
+        TxCertificates
+          CertificatesInBabbageEra
+          (map fromShelleyCertificate $ toList certificates)
+          ViewTx
       where
         certificates = Babbage.certs' body
 
-fromLedgerTxUpdateProposal
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxUpdateProposal era
+fromLedgerTxUpdateProposal ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxUpdateProposal era
 fromLedgerTxUpdateProposal era body =
   case era of
     ShelleyBasedEraShelley ->
       case Shelley._txUpdate body of
         SNothing -> TxUpdateProposalNone
         SJust p ->
-          TxUpdateProposal UpdateProposalInShelleyEra
-                           (fromLedgerUpdate era p)
-
+          TxUpdateProposal
+            UpdateProposalInShelleyEra
+            (fromLedgerUpdate era p)
     ShelleyBasedEraAllegra ->
       case Allegra.update' body of
         SNothing -> TxUpdateProposalNone
         SJust p ->
-          TxUpdateProposal UpdateProposalInAllegraEra
-                           (fromLedgerUpdate era p)
-
+          TxUpdateProposal
+            UpdateProposalInAllegraEra
+            (fromLedgerUpdate era p)
     ShelleyBasedEraMary ->
       case Mary.update' body of
         SNothing -> TxUpdateProposalNone
         SJust p ->
-          TxUpdateProposal UpdateProposalInMaryEra
-                           (fromLedgerUpdate era p)
-
+          TxUpdateProposal
+            UpdateProposalInMaryEra
+            (fromLedgerUpdate era p)
     ShelleyBasedEraAlonzo ->
       case Alonzo.update' body of
         SNothing -> TxUpdateProposalNone
         SJust p ->
-          TxUpdateProposal UpdateProposalInAlonzoEra
-                           (fromLedgerUpdate era p)
-
+          TxUpdateProposal
+            UpdateProposalInAlonzoEra
+            (fromLedgerUpdate era p)
     ShelleyBasedEraBabbage ->
       case Babbage.update' body of
         SNothing -> TxUpdateProposalNone
         SJust p ->
-          TxUpdateProposal UpdateProposalInBabbageEra
-                           (fromLedgerUpdate era p)
+          TxUpdateProposal
+            UpdateProposalInBabbageEra
+            (fromLedgerUpdate era p)
 
-fromLedgerTxMintValue
-  :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> TxMintValue ViewTx era
+fromLedgerTxMintValue ::
+  ShelleyBasedEra era ->
+  Ledger.TxBody (ShelleyLedgerEra era) ->
+  TxMintValue ViewTx era
 fromLedgerTxMintValue era body =
   case era of
     ShelleyBasedEraShelley -> TxMintNone
     ShelleyBasedEraAllegra -> TxMintNone
     ShelleyBasedEraMary
-      | isZero mint        -> TxMintNone
-      | otherwise          -> TxMintValue MultiAssetInMaryEra
-                                          (fromMaryValue mint) ViewTx
+      | isZero mintVal -> TxMintNone
+      | otherwise ->
+        TxMintValue
+          MultiAssetInMaryEra
+          (fromMaryValue mintVal)
+          ViewTx
       where
-        mint = Mary.mint' body
-
+        mintVal = Mary.mint' body
     ShelleyBasedEraAlonzo
-      | isZero mint         -> TxMintNone
-      | otherwise           -> TxMintValue MultiAssetInAlonzoEra
-                                           (fromMaryValue mint) ViewTx
+      | isZero mintVal -> TxMintNone
+      | otherwise ->
+        TxMintValue
+          MultiAssetInAlonzoEra
+          (fromMaryValue mintVal)
+          ViewTx
       where
-        mint = Alonzo.mint' body
-
+        mintVal = Alonzo.mint' body
     ShelleyBasedEraBabbage
-      | isZero mint         -> TxMintNone
-      | otherwise           -> TxMintValue MultiAssetInBabbageEra
-                                           (fromMaryValue mint) ViewTx
+      | isZero mintVal -> TxMintNone
+      | otherwise ->
+        TxMintValue
+          MultiAssetInBabbageEra
+          (fromMaryValue mintVal)
+          ViewTx
       where
-        mint = Babbage.mint' body
+        mintVal = Babbage.mint' body
 
+makeByronTransactionBody ::
+  TxBodyContent BuildTx ByronEra ->
+  Either TxBodyError (TxBody ByronEra)
+makeByronTransactionBody TxBodyContent {txIns, txOuts} = do
+  ins' <- NonEmpty.nonEmpty (map fst txIns) ?! TxBodyEmptyTxIns
+  for_ ins' $ \txin@(TxIn _ (TxIx txix)) ->
+    guard (fromIntegral txix <= maxByronTxInIx) ?! TxBodyInIxOverflow txin
+  let ins'' = fmap toByronTxIn ins'
 
-makeByronTransactionBody :: TxBodyContent BuildTx ByronEra
-                         -> Either TxBodyError (TxBody ByronEra)
-makeByronTransactionBody TxBodyContent { txIns, txOuts } = do
-    ins' <- NonEmpty.nonEmpty (map fst txIns) ?! TxBodyEmptyTxIns
-    for_ ins' $ \txin@(TxIn _ (TxIx txix)) ->
-      guard (fromIntegral txix <= maxByronTxInIx) ?! TxBodyInIxOverflow txin
-    let ins'' = fmap toByronTxIn ins'
-
-    outs'  <- NonEmpty.nonEmpty txOuts    ?! TxBodyEmptyTxOuts
-    outs'' <- traverse
-                (\out -> toByronTxOut out ?! classifyRangeError out)
-                outs'
-    return $
-      ByronTxBody $
-        reAnnotate $
-          Annotated
-            (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
-            ()
+  outs' <- NonEmpty.nonEmpty txOuts ?! TxBodyEmptyTxOuts
+  outs'' <-
+    traverse
+      (\out -> toByronTxOut out ?! classifyRangeError out)
+      outs'
+  return $
+    ByronTxBody $
+      reAnnotate $
+        Annotated
+          (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
+          ()
   where
     maxByronTxInIx :: Word
     maxByronTxInIx = fromIntegral (maxBound :: Word32)
 
     classifyRangeError :: TxOut CtxTx ByronEra -> TxBodyError
     classifyRangeError
-      txout@(TxOut (AddressInEra ByronAddressInAnyEra ByronAddress{})
-                   (TxOutAdaOnly AdaOnlyInByronEra value) _ _)
-      | value < 0        = TxBodyOutputNegative (lovelaceToQuantity value)
-                                                (txOutInAnyEra txout)
-      | otherwise        = TxBodyOutputOverflow (lovelaceToQuantity value)
-                                                (txOutInAnyEra txout)
-
+      txout@( TxOut
+                (AddressInEra ByronAddressInAnyEra ByronAddress {})
+                (TxOutAdaOnly AdaOnlyInByronEra value)
+                _
+                _
+              )
+        | value < 0 =
+          TxBodyOutputNegative
+            (lovelaceToQuantity value)
+            (txOutInAnyEra txout)
+        | otherwise =
+          TxBodyOutputOverflow
+            (lovelaceToQuantity value)
+            (txOutInAnyEra txout)
     classifyRangeError
-      (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _))
-             (TxOutValue era _) _ _) = case era of {}
-
+      ( TxOut
+          (AddressInEra ByronAddressInAnyEra (ByronAddress _))
+          (TxOutValue era _)
+          _
+          _
+        ) = case era of
     classifyRangeError
-      (TxOut (AddressInEra (ShelleyAddressInEra era) ShelleyAddress{})
-             _ _ _) = case era of {}
+      ( TxOut
+          (AddressInEra (ShelleyAddressInEra era) ShelleyAddress {})
+          _
+          _
+          _
+        ) = case era of
 
-getByronTxBodyContent :: Annotated Byron.Tx ByteString
-                      -> TxBodyContent ViewTx ByronEra
-getByronTxBodyContent (Annotated Byron.UnsafeTx{txInputs, txOutputs} _) =
-    TxBodyContent {
-      txIns              = [ (fromByronTxIn input, ViewTx)
-                           | input <- toList txInputs],
-      txInsCollateral    = TxInsCollateralNone,
-      txInsReference     = TxInsReferenceNone,
-      txOuts             = fromByronTxOut <$> toList txOutputs,
+getByronTxBodyContent ::
+  Annotated Byron.Tx ByteString ->
+  TxBodyContent ViewTx ByronEra
+getByronTxBodyContent (Annotated Byron.UnsafeTx {txInputs, txOutputs} _) =
+  TxBodyContent
+    { txIns =
+        [ (fromByronTxIn input, ViewTx)
+          | input <- toList txInputs
+        ],
+      txInsCollateral = TxInsCollateralNone,
+      txInsReference = TxInsReferenceNone,
+      txOuts = fromByronTxOut <$> toList txOutputs,
       txReturnCollateral = TxReturnCollateralNone,
-      txTotalCollateral  = TxTotalCollateralNone,
-      txFee              = TxFeeImplicit TxFeesImplicitInByronEra,
-      txValidityRange    = (TxValidityNoLowerBound,
-                            TxValidityNoUpperBound
-                              ValidityNoUpperBoundInByronEra),
-      txMetadata         = TxMetadataNone,
-      txAuxScripts       = TxAuxScriptsNone,
-      txExtraKeyWits     = TxExtraKeyWitnessesNone,
-      txProtocolParams   = ViewTx,
-      txWithdrawals      = TxWithdrawalsNone,
-      txCertificates     = TxCertificatesNone,
-      txUpdateProposal   = TxUpdateProposalNone,
-      txMintValue        = TxMintNone,
-      txScriptValidity   = TxScriptValidityNone
+      txTotalCollateral = TxTotalCollateralNone,
+      txFee = TxFeeImplicit TxFeesImplicitInByronEra,
+      txValidityRange =
+        ( TxValidityNoLowerBound,
+          TxValidityNoUpperBound
+            ValidityNoUpperBoundInByronEra
+        ),
+      txMetadata = TxMetadataNone,
+      txAuxScripts = TxAuxScriptsNone,
+      txExtraKeyWits = TxExtraKeyWitnessesNone,
+      txProtocolParams = ViewTx,
+      txWithdrawals = TxWithdrawalsNone,
+      txCertificates = TxCertificatesNone,
+      txUpdateProposal = TxUpdateProposalNone,
+      txMintValue = TxMintNone,
+      txScriptValidity = TxScriptValidityNone
     }
 
+makeShelleyTransactionBody ::
+  ShelleyBasedEra era ->
+  TxBodyContent BuildTx era ->
+  Either TxBodyError (TxBody era)
 makeShelleyTransactionBody
-  :: ShelleyBasedEra era
-  -> TxBodyContent BuildTx era
-  -> Either TxBodyError (TxBody era)
-makeShelleyTransactionBody era@ShelleyBasedEraShelley
-                           txbodycontent@TxBodyContent {
-                             txIns,
-                             txOuts,
-                             txFee,
-                             txValidityRange = (_, upperBound),
-                             txMetadata,
-                             txWithdrawals,
-                             txCertificates,
-                             txUpdateProposal
-                           } = do
-
+  era@ShelleyBasedEraShelley
+  txbodycontent@TxBodyContent
+    { txIns,
+      txOuts,
+      txFee,
+      txValidityRange = (_, upperBound),
+      txMetadata,
+      txWithdrawals,
+      txCertificates,
+      txUpdateProposal
+    } = do
     guard (not (null txIns)) ?! TxBodyEmptyTxIns
     sequence_
-      [ do guard (v >= 0) ?! TxBodyOutputNegative (lovelaceToQuantity v)
-                                                  (txOutInAnyEra txout)
-           guard (v <= maxTxOut) ?! TxBodyOutputOverflow (lovelaceToQuantity v)
-                                                         (txOutInAnyEra txout)
-           for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
-              guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
-      | let maxTxOut = fromIntegral (maxBound :: Word64) :: Lovelace
-      , txout@(TxOut _ (TxOutAdaOnly AdaOnlyInShelleyEra v) _ _) <- txOuts ]
+      [ do
+          guard (v >= 0)
+            ?! TxBodyOutputNegative
+              (lovelaceToQuantity v)
+              (txOutInAnyEra txout)
+          guard (v <= maxTxOut)
+            ?! TxBodyOutputOverflow
+              (lovelaceToQuantity v)
+              (txOutInAnyEra txout)
+          for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
+            guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
+        | let maxTxOut = fromIntegral (maxBound :: Word64) :: Lovelace,
+          txout@(TxOut _ (TxOutAdaOnly AdaOnlyInShelleyEra v) _ _) <- txOuts
+      ]
     case txMetadata of
-      TxMetadataNone      -> return ()
+      TxMetadataNone -> return ()
       TxMetadataInEra _ m -> first TxBodyMetadataError (validateTxMetadata m)
 
     return $
-      ShelleyTxBody era
-        (Shelley.TxBody
-          (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
-          (case txCertificates of
-             TxCertificatesNone    -> Seq.empty
-             TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
-          (case txWithdrawals of
-             TxWithdrawalsNone  -> Shelley.Wdrl Map.empty
-             TxWithdrawals _ ws -> toShelleyWithdrawal ws)
-          (case txFee of
-             TxFeeImplicit era'  -> case era' of {}
-             TxFeeExplicit _ fee -> toShelleyLovelace fee)
-          (case upperBound of
-             TxValidityNoUpperBound era' -> case era' of {}
-             TxValidityUpperBound _ ttl  -> ttl)
-          (case txUpdateProposal of
-             TxUpdateProposalNone -> SNothing
-             TxUpdateProposal _ p -> SJust (toLedgerUpdate era p))
-          (maybeToStrictMaybe
-            (Ledger.hashAuxiliaryData <$> txAuxData)))
-        scripts
+      ShelleyTxBody
+        era
+        ( Shelley.ShelleyTxBody
+            (Set.fromList (map (toShelleyTxIn . fst) txIns))
+            (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
+            ( case txCertificates of
+                TxCertificatesNone -> Seq.empty
+                TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
+            )
+            ( case txWithdrawals of
+                TxWithdrawalsNone -> Shelley.Wdrl Map.empty
+                TxWithdrawals _ ws -> toShelleyWithdrawal ws
+            )
+            ( case txFee of
+                TxFeeImplicit era' -> case era' of
+                TxFeeExplicit _ fee -> toShelleyLovelace fee
+            )
+            ( case upperBound of
+                TxValidityNoUpperBound era' -> case era' of
+                TxValidityUpperBound _ ttl -> ttl
+            )
+            ( case txUpdateProposal of
+                TxUpdateProposalNone -> SNothing
+                TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
+            )
+            ( maybeToStrictMaybe
+                (Ledger.hashAuxiliaryData <$> txAuxData)
+            )
+        )
+        scriptList
         TxBodyNoScriptData
         txAuxData
         TxScriptValidityNone
-  where
+    where
+      maxShelleyTxInIx :: Word
+      maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-    maxShelleyTxInIx :: Word
-    maxShelleyTxInIx = fromIntegral $ maxBound @Word16
+      scriptList :: [Ledger.Script StandardShelley]
+      scriptList =
+        catMaybes
+          [ toShelleyScript <$> scriptWitnessScript scriptwitness
+            | (_, AnyScriptWitness scriptwitness) <-
+                collectTxBodyScriptWitnesses txbodycontent
+          ]
 
-    scripts :: [Ledger.Script StandardShelley]
-    scripts = catMaybes
-      [ toShelleyScript <$> scriptWitnessScript scriptwitness
-      | (_, AnyScriptWitness scriptwitness)
-          <- collectTxBodyScriptWitnesses txbodycontent
-      ]
-
-    txAuxData :: Maybe (Ledger.AuxiliaryData StandardShelley)
-    txAuxData
-      | Map.null ms = Nothing
-      | otherwise   = Just (toShelleyAuxiliaryData ms)
-      where
-        ms = case txMetadata of
-               TxMetadataNone                     -> Map.empty
-               TxMetadataInEra _ (TxMetadata ms') -> ms'
-
-makeShelleyTransactionBody era@ShelleyBasedEraAllegra
-                           txbodycontent@TxBodyContent {
-                             txIns,
-                             txOuts,
-                             txFee,
-                             txValidityRange = (lowerBound, upperBound),
-                             txMetadata,
-                             txAuxScripts,
-                             txWithdrawals,
-                             txCertificates,
-                             txUpdateProposal
-                           } = do
-
+      txAuxData :: Maybe (Ledger.AuxiliaryData StandardShelley)
+      txAuxData
+        | Map.null ms = Nothing
+        | otherwise = Just (toShelleyAuxiliaryData ms)
+        where
+          ms = case txMetadata of
+            TxMetadataNone -> Map.empty
+            TxMetadataInEra _ (TxMetadata ms') -> ms'
+makeShelleyTransactionBody
+  era@ShelleyBasedEraAllegra
+  txbodycontent@TxBodyContent
+    { txIns,
+      txOuts,
+      txFee,
+      txValidityRange = (lowerBound, upperBound),
+      txMetadata,
+      txAuxScripts,
+      txWithdrawals,
+      txCertificates,
+      txUpdateProposal
+    } = do
     guard (not (null txIns)) ?! TxBodyEmptyTxIns
     sequence_
-      [ do guard (v >= 0) ?! TxBodyOutputNegative (lovelaceToQuantity v)
-                                                  (txOutInAnyEra txout)
-           guard (v <= maxTxOut) ?! TxBodyOutputOverflow (lovelaceToQuantity v)
-                                                         (txOutInAnyEra txout)
-           for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
-              guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
-      | let maxTxOut = fromIntegral (maxBound :: Word64) :: Lovelace
-      , txout@(TxOut _ (TxOutAdaOnly AdaOnlyInAllegraEra v) _ _) <- txOuts
+      [ do
+          guard (v >= 0)
+            ?! TxBodyOutputNegative
+              (lovelaceToQuantity v)
+              (txOutInAnyEra txout)
+          guard (v <= maxTxOut)
+            ?! TxBodyOutputOverflow
+              (lovelaceToQuantity v)
+              (txOutInAnyEra txout)
+          for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
+            guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
+        | let maxTxOut = fromIntegral (maxBound :: Word64) :: Lovelace,
+          txout@(TxOut _ (TxOutAdaOnly AdaOnlyInAllegraEra v) _ _) <- txOuts
       ]
     case txMetadata of
-      TxMetadataNone      -> return ()
+      TxMetadataNone -> return ()
       TxMetadataInEra _ m -> validateTxMetadata m ?!. TxBodyMetadataError
 
     return $
-      ShelleyTxBody era
-        (Allegra.TxBody
-          (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
-          (case txCertificates of
-             TxCertificatesNone    -> Seq.empty
-             TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
-          (case txWithdrawals of
-             TxWithdrawalsNone  -> Shelley.Wdrl Map.empty
-             TxWithdrawals _ ws -> toShelleyWithdrawal ws)
-          (case txFee of
-             TxFeeImplicit era'  -> case era' of {}
-             TxFeeExplicit _ fee -> toShelleyLovelace fee)
-          (Allegra.ValidityInterval {
-             invalidBefore    = case lowerBound of
-                                          TxValidityNoLowerBound   -> SNothing
-                                          TxValidityLowerBound _ s -> SJust s,
-             invalidHereafter = case upperBound of
-                                          TxValidityNoUpperBound _ -> SNothing
-                                          TxValidityUpperBound _ s -> SJust s
-           })
-          (case txUpdateProposal of
-             TxUpdateProposalNone -> SNothing
-             TxUpdateProposal _ p -> SJust (toLedgerUpdate era p))
-          (maybeToStrictMaybe
-            (Ledger.hashAuxiliaryData <$> txAuxData))
-          mempty) -- No minting in Allegra, only Mary
-        scripts
+      ShelleyTxBody
+        era
+        ( MATxBody
+            (Set.fromList (map (toShelleyTxIn . fst) txIns))
+            (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
+            ( case txCertificates of
+                TxCertificatesNone -> Seq.empty
+                TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
+            )
+            ( case txWithdrawals of
+                TxWithdrawalsNone -> Shelley.Wdrl Map.empty
+                TxWithdrawals _ ws -> toShelleyWithdrawal ws
+            )
+            ( case txFee of
+                TxFeeImplicit era' -> case era' of
+                TxFeeExplicit _ fee -> toShelleyLovelace fee
+            )
+            ( Allegra.ValidityInterval
+                { invalidBefore = case lowerBound of
+                    TxValidityNoLowerBound -> SNothing
+                    TxValidityLowerBound _ s -> SJust s,
+                  invalidHereafter = case upperBound of
+                    TxValidityNoUpperBound _ -> SNothing
+                    TxValidityUpperBound _ s -> SJust s
+                }
+            )
+            ( case txUpdateProposal of
+                TxUpdateProposalNone -> SNothing
+                TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
+            )
+            ( maybeToStrictMaybe
+                (Ledger.hashAuxiliaryData <$> txAuxData)
+            )
+            mempty -- No minting in Allegra, only Mary
+        )
+        scriptList
         TxBodyNoScriptData
         txAuxData
         TxScriptValidityNone
-  where
+    where
+      maxShelleyTxInIx :: Word
+      maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-    maxShelleyTxInIx :: Word
-    maxShelleyTxInIx = fromIntegral $ maxBound @Word16
+      scriptList :: [Ledger.Script StandardAllegra]
+      scriptList =
+        catMaybes
+          [ toShelleyScript <$> scriptWitnessScript scriptwitness
+            | (_, AnyScriptWitness scriptwitness) <-
+                collectTxBodyScriptWitnesses txbodycontent
+          ]
 
-    scripts :: [Ledger.Script StandardAllegra]
-    scripts = catMaybes
-      [ toShelleyScript <$> scriptWitnessScript scriptwitness
-      | (_, AnyScriptWitness scriptwitness)
-          <- collectTxBodyScriptWitnesses txbodycontent
-      ]
-
-    txAuxData :: Maybe (Ledger.AuxiliaryData StandardAllegra)
-    txAuxData
-      | Map.null ms
-      , null ss   = Nothing
-      | otherwise = Just (toAllegraAuxiliaryData ms ss)
-      where
-        ms = case txMetadata of
-               TxMetadataNone                     -> Map.empty
-               TxMetadataInEra _ (TxMetadata ms') -> ms'
-        ss = case txAuxScripts of
-               TxAuxScriptsNone   -> []
-               TxAuxScripts _ ss' -> ss'
-
-makeShelleyTransactionBody era@ShelleyBasedEraMary
-                           txbodycontent@TxBodyContent {
-                             txIns,
-                             txOuts,
-                             txFee,
-                             txValidityRange = (lowerBound, upperBound),
-                             txMetadata,
-                             txAuxScripts,
-                             txWithdrawals,
-                             txCertificates,
-                             txUpdateProposal,
-                             txMintValue
-                           } = do
-
+      txAuxData :: Maybe (Ledger.AuxiliaryData StandardAllegra)
+      txAuxData
+        | Map.null ms,
+          null ss =
+          Nothing
+        | otherwise = Just (toAllegraAuxiliaryData ms ss)
+        where
+          ms = case txMetadata of
+            TxMetadataNone -> Map.empty
+            TxMetadataInEra _ (TxMetadata ms') -> ms'
+          ss = case txAuxScripts of
+            TxAuxScriptsNone -> []
+            TxAuxScripts _ ss' -> ss'
+makeShelleyTransactionBody
+  era@ShelleyBasedEraMary
+  txbodycontent@TxBodyContent
+    { txIns,
+      txOuts,
+      txFee,
+      txValidityRange = (lowerBound, upperBound),
+      txMetadata,
+      txAuxScripts,
+      txWithdrawals,
+      txCertificates,
+      txUpdateProposal,
+      txMintValue
+    } = do
     guard (not (null txIns)) ?! TxBodyEmptyTxIns
     sequence_
-      [ do allPositive
-           allWithinMaxBound
-           for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
-              guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
-      | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity
-      , txout@(TxOut _ (TxOutValue MultiAssetInMaryEra v) _ _) <- txOuts
-      , let allPositive =
-              case [ q | (_,q) <- valueToList v, q < 0 ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
-            allWithinMaxBound =
-              case [ q | (_,q) <- valueToList v, q > maxTxOut ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
+      [ do
+          allPositive
+          allWithinMaxBound
+          for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
+            guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
+        | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity,
+          txout@(TxOut _ (TxOutValue MultiAssetInMaryEra v) _ _) <- txOuts,
+          let allPositive =
+                case [q | (_, q) <- valueToList v, q < 0] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
+              allWithinMaxBound =
+                case [q | (_, q) <- valueToList v, q > maxTxOut] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
       ]
     case txMetadata of
-      TxMetadataNone      -> return ()
+      TxMetadataNone -> return ()
       TxMetadataInEra _ m -> validateTxMetadata m ?!. TxBodyMetadataError
     case txMintValue of
-      TxMintNone        -> return ()
+      TxMintNone -> return ()
       TxMintValue _ v _ -> guard (selectLovelace v == 0) ?! TxBodyMintAdaError
 
     return $
-      ShelleyTxBody era
-        (Allegra.TxBody
-          (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
-          (case txCertificates of
-             TxCertificatesNone    -> Seq.empty
-             TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
-          (case txWithdrawals of
-             TxWithdrawalsNone  -> Shelley.Wdrl Map.empty
-             TxWithdrawals _ ws -> toShelleyWithdrawal ws)
-          (case txFee of
-             TxFeeImplicit era'  -> case era' of {}
-             TxFeeExplicit _ fee -> toShelleyLovelace fee)
-          (Allegra.ValidityInterval {
-             invalidBefore    = case lowerBound of
-                                          TxValidityNoLowerBound   -> SNothing
-                                          TxValidityLowerBound _ s -> SJust s,
-             invalidHereafter = case upperBound of
-                                          TxValidityNoUpperBound _ -> SNothing
-                                          TxValidityUpperBound _ s -> SJust s
-           })
-          (case txUpdateProposal of
-             TxUpdateProposalNone -> SNothing
-             TxUpdateProposal _ p -> SJust (toLedgerUpdate era p))
-          (maybeToStrictMaybe
-            (Ledger.hashAuxiliaryData <$> txAuxData))
-          (case txMintValue of
-             TxMintNone        -> mempty
-             TxMintValue _ v _ -> toMaryValue v))
-        scripts
+      ShelleyTxBody
+        era
+        ( MATxBody
+            (Set.fromList (map (toShelleyTxIn . fst) txIns))
+            (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
+            ( case txCertificates of
+                TxCertificatesNone -> Seq.empty
+                TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
+            )
+            ( case txWithdrawals of
+                TxWithdrawalsNone -> Shelley.Wdrl Map.empty
+                TxWithdrawals _ ws -> toShelleyWithdrawal ws
+            )
+            ( case txFee of
+                TxFeeImplicit era' -> case era' of
+                TxFeeExplicit _ fee -> toShelleyLovelace fee
+            )
+            ( Allegra.ValidityInterval
+                { invalidBefore = case lowerBound of
+                    TxValidityNoLowerBound -> SNothing
+                    TxValidityLowerBound _ s -> SJust s,
+                  invalidHereafter = case upperBound of
+                    TxValidityNoUpperBound _ -> SNothing
+                    TxValidityUpperBound _ s -> SJust s
+                }
+            )
+            ( case txUpdateProposal of
+                TxUpdateProposalNone -> SNothing
+                TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
+            )
+            ( maybeToStrictMaybe
+                (Ledger.hashAuxiliaryData <$> txAuxData)
+            )
+            ( case txMintValue of
+                TxMintNone -> mempty
+                TxMintValue _ v _ -> toMaryValue v
+            )
+        )
+        scriptList
         TxBodyNoScriptData
         txAuxData
         TxScriptValidityNone
-  where
+    where
+      maxShelleyTxInIx :: Word
+      maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-    maxShelleyTxInIx :: Word
-    maxShelleyTxInIx = fromIntegral $ maxBound @Word16
+      scriptList :: [Ledger.Script StandardMary]
+      scriptList =
+        catMaybes
+          [ toShelleyScript <$> scriptWitnessScript scriptwitness
+            | (_, AnyScriptWitness scriptwitness) <-
+                collectTxBodyScriptWitnesses txbodycontent
+          ]
 
-    scripts :: [Ledger.Script StandardMary]
-    scripts = catMaybes
-      [ toShelleyScript <$> scriptWitnessScript scriptwitness
-      | (_, AnyScriptWitness scriptwitness)
-          <- collectTxBodyScriptWitnesses txbodycontent
-      ]
-
-    txAuxData :: Maybe (Ledger.AuxiliaryData StandardMary)
-    txAuxData
-      | Map.null ms
-      , null ss   = Nothing
-      | otherwise = Just (toAllegraAuxiliaryData ms ss)
-      where
-        ms = case txMetadata of
-               TxMetadataNone                     -> Map.empty
-               TxMetadataInEra _ (TxMetadata ms') -> ms'
-        ss = case txAuxScripts of
-               TxAuxScriptsNone   -> []
-               TxAuxScripts _ ss' -> ss'
-
-makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
-                           txbodycontent@TxBodyContent {
-                             txIns,
-                             txInsCollateral,
-                             txOuts,
-                             txFee,
-                             txValidityRange = (lowerBound, upperBound),
-                             txMetadata,
-                             txAuxScripts,
-                             txExtraKeyWits,
-                             txProtocolParams,
-                             txWithdrawals,
-                             txCertificates,
-                             txUpdateProposal,
-                             txMintValue,
-                             txScriptValidity
-                           } = do
-
+      txAuxData :: Maybe (Ledger.AuxiliaryData StandardMary)
+      txAuxData
+        | Map.null ms,
+          null ss =
+          Nothing
+        | otherwise = Just (toAllegraAuxiliaryData ms ss)
+        where
+          ms = case txMetadata of
+            TxMetadataNone -> Map.empty
+            TxMetadataInEra _ (TxMetadata ms') -> ms'
+          ss = case txAuxScripts of
+            TxAuxScriptsNone -> []
+            TxAuxScripts _ ss' -> ss'
+makeShelleyTransactionBody
+  era@ShelleyBasedEraAlonzo
+  txbodycontent@TxBodyContent
+    { txIns,
+      txInsCollateral,
+      txOuts,
+      txFee,
+      txValidityRange = (lowerBound, upperBound),
+      txMetadata,
+      txAuxScripts,
+      txExtraKeyWits,
+      txProtocolParams,
+      txWithdrawals,
+      txCertificates,
+      txUpdateProposal,
+      txMintValue,
+      txScriptValidity
+    } = do
     guard (not (null txIns)) ?! TxBodyEmptyTxIns
     sequence_
-      [ do allPositive
-           allWithinMaxBound
-           for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
-              guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
-      | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity
-      , txout@(TxOut _ (TxOutValue MultiAssetInAlonzoEra v) _ _) <- txOuts
-      , let allPositive =
-              case [ q | (_,q) <- valueToList v, q < 0 ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
-            allWithinMaxBound =
-              case [ q | (_,q) <- valueToList v, q > maxTxOut ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
+      [ do
+          allPositive
+          allWithinMaxBound
+          for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
+            guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
+        | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity,
+          txout@(TxOut _ (TxOutValue MultiAssetInAlonzoEra v) _ _) <- txOuts,
+          let allPositive =
+                case [q | (_, q) <- valueToList v, q < 0] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
+              allWithinMaxBound =
+                case [q | (_, q) <- valueToList v, q > maxTxOut] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
       ]
     case txMetadata of
-      TxMetadataNone      -> return ()
+      TxMetadataNone -> return ()
       TxMetadataInEra _ m -> validateTxMetadata m ?!. TxBodyMetadataError
     case txMintValue of
-      TxMintNone        -> return ()
+      TxMintNone -> return ()
       TxMintValue _ v _ -> guard (selectLovelace v == 0) ?! TxBodyMintAdaError
     case txInsCollateral of
-      TxInsCollateralNone | not (Set.null languages)
-        -> Left TxBodyEmptyTxInsCollateral
+      TxInsCollateralNone
+        | not (Set.null languages) ->
+          Left TxBodyEmptyTxInsCollateral
       _ -> return ()
     case txProtocolParams of
-      BuildTxWith Nothing | not (Set.null languages)
-        -> Left TxBodyMissingProtocolParams
+      BuildTxWith Nothing
+        | not (Set.null languages) ->
+          Left TxBodyMissingProtocolParams
       _ -> return () --TODO alonzo: validate protocol params for the Alonzo era.
-                     --             All the necessary params must be provided.
-
+      --             All the necessary params must be provided.
     return $
-      ShelleyTxBody era
-        (Alonzo.TxBody
-          (Set.fromList (map (toShelleyTxIn . fst) txIns))
-          (case txInsCollateral of
-             TxInsCollateralNone     -> Set.empty
-             TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins))
-          (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
-          (case txCertificates of
-             TxCertificatesNone    -> Seq.empty
-             TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs))
-          (case txWithdrawals of
-             TxWithdrawalsNone  -> Shelley.Wdrl Map.empty
-             TxWithdrawals _ ws -> toShelleyWithdrawal ws)
-          (case txFee of
-             TxFeeImplicit era'  -> case era' of {}
-             TxFeeExplicit _ fee -> toShelleyLovelace fee)
-          (Allegra.ValidityInterval {
-             invalidBefore    = case lowerBound of
-                                          TxValidityNoLowerBound   -> SNothing
-                                          TxValidityLowerBound _ s -> SJust s,
-             invalidHereafter = case upperBound of
-                                          TxValidityNoUpperBound _ -> SNothing
-                                          TxValidityUpperBound _ s -> SJust s
-           })
-          (case txUpdateProposal of
-             TxUpdateProposalNone -> SNothing
-             TxUpdateProposal _ p -> SJust (toLedgerUpdate era p))
-          (case txExtraKeyWits of
-             TxExtraKeyWitnessesNone   -> Set.empty
-             TxExtraKeyWitnesses _ khs -> Set.fromList
-                                            [ Shelley.coerceKeyRole kh
-                                            | PaymentKeyHash kh <- khs ])
-          (case txMintValue of
-             TxMintNone        -> mempty
-             TxMintValue _ v _ -> toMaryValue v)
-          (case txProtocolParams of
-             BuildTxWith Nothing        -> SNothing
-             BuildTxWith (Just pparams) ->
-               Alonzo.hashScriptIntegrity
-                 (Set.map
-                    (Alonzo.getLanguageView (toLedgerPParams ShelleyBasedEraAlonzo pparams))
-                    languages
-                 )
-                 redeemers
-                 datums)
-          (maybeToStrictMaybe
-            (Ledger.hashAuxiliaryData <$> txAuxData))
-          SNothing) -- TODO alonzo: support optional network id in TxBodyContent
-        scripts
+      ShelleyTxBody
+        era
+        ( AlonzoTxBody
+            (Set.fromList (map (toShelleyTxIn . fst) txIns))
+            ( case txInsCollateral of
+                TxInsCollateralNone -> Set.empty
+                TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins)
+            )
+            (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
+            ( case txCertificates of
+                TxCertificatesNone -> Seq.empty
+                TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
+            )
+            ( case txWithdrawals of
+                TxWithdrawalsNone -> Shelley.Wdrl Map.empty
+                TxWithdrawals _ ws -> toShelleyWithdrawal ws
+            )
+            ( case txFee of
+                TxFeeImplicit era' -> case era' of
+                TxFeeExplicit _ fee -> toShelleyLovelace fee
+            )
+            ( Allegra.ValidityInterval
+                { invalidBefore = case lowerBound of
+                    TxValidityNoLowerBound -> SNothing
+                    TxValidityLowerBound _ s -> SJust s,
+                  invalidHereafter = case upperBound of
+                    TxValidityNoUpperBound _ -> SNothing
+                    TxValidityUpperBound _ s -> SJust s
+                }
+            )
+            ( case txUpdateProposal of
+                TxUpdateProposalNone -> SNothing
+                TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
+            )
+            ( case txExtraKeyWits of
+                TxExtraKeyWitnessesNone -> Set.empty
+                TxExtraKeyWitnesses _ khs ->
+                  Set.fromList
+                    [ Shelley.coerceKeyRole kh
+                      | PaymentKeyHash kh <- khs
+                    ]
+            )
+            ( case txMintValue of
+                TxMintNone -> mempty
+                TxMintValue _ v _ -> toMaryValue v
+            )
+            ( case txProtocolParams of
+                BuildTxWith Nothing -> SNothing
+                BuildTxWith (Just pparams) ->
+                  Alonzo.hashScriptIntegrity
+                    ( Set.map
+                        (Alonzo.getLanguageView (toLedgerPParams ShelleyBasedEraAlonzo pparams))
+                        languages
+                    )
+                    redeemers
+                    datums
+            )
+            ( maybeToStrictMaybe
+                (Ledger.hashAuxiliaryData <$> txAuxData)
+            )
+            SNothing -- TODO alonzo: support optional network id in TxBodyContent
+        )
+        scriptList
         (TxBodyScriptData ScriptDataInAlonzoEra datums redeemers)
         txAuxData
         txScriptValidity
-  where
+    where
+      maxShelleyTxInIx :: Word
+      maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-    maxShelleyTxInIx :: Word
-    maxShelleyTxInIx = fromIntegral $ maxBound @Word16
+      witnesses :: [(ScriptWitnessIndex, AnyScriptWitness AlonzoEra)]
+      witnesses = collectTxBodyScriptWitnesses txbodycontent
 
-    witnesses :: [(ScriptWitnessIndex, AnyScriptWitness AlonzoEra)]
-    witnesses = collectTxBodyScriptWitnesses txbodycontent
-
-    scripts :: [Ledger.Script StandardAlonzo]
-    scripts = catMaybes
-      [ toShelleyScript <$> scriptWitnessScript scriptwitness
-      | (_, AnyScriptWitness scriptwitness) <- witnesses
-      ]
-
-    datums :: Alonzo.TxDats StandardAlonzo
-    datums =
-      Alonzo.TxDats $
-        Map.fromList
-          [ (Alonzo.hashData d', d')
-          | d <- scriptdata
-          , let d' = toAlonzoData d
+      scriptList :: [Ledger.Script StandardAlonzo]
+      scriptList =
+        catMaybes
+          [ toShelleyScript <$> scriptWitnessScript scriptwitness
+            | (_, AnyScriptWitness scriptwitness) <- witnesses
           ]
 
-    scriptdata :: [ScriptData]
-    scriptdata =
-        [ d | TxOut _ _ (TxOutDatumInTx _ d) _ <- txOuts ]
-     ++ [ d | (_, AnyScriptWitness
-                    (PlutusScriptWitness
-                       _ _ _ (ScriptDatumForTxIn d) _ _)) <- witnesses
+      datums :: Alonzo.TxDats StandardAlonzo
+      datums =
+        Alonzo.TxDats $
+          Map.fromList
+            [ (Alonzo.hashData d', d')
+              | d <- scriptdata,
+                let d' = toAlonzoData d
             ]
 
-    redeemers :: Alonzo.Redeemers StandardAlonzo
-    redeemers =
-      Alonzo.Redeemers $
-        Map.fromList
-          [ (toAlonzoRdmrPtr idx, (toAlonzoData d, toAlonzoExUnits e))
-          | (idx, AnyScriptWitness
-                    (PlutusScriptWitness _ _ _ _ d e)) <- witnesses
+      scriptdata :: [ScriptData]
+      scriptdata =
+        [d | TxOut _ _ (TxOutDatumInTx _ d) _ <- txOuts]
+          ++ [ d
+               | ( _,
+                   AnyScriptWitness
+                     ( PlutusScriptWitness
+                         _
+                         _
+                         _
+                         (ScriptDatumForTxIn d)
+                         _
+                         _
+                       )
+                   ) <-
+                   witnesses
+             ]
+
+      redeemers :: Alonzo.Redeemers StandardAlonzo
+      redeemers =
+        Alonzo.Redeemers $
+          Map.fromList
+            [ (toAlonzoRdmrPtr idx, (toAlonzoData d, toAlonzoExUnits e))
+              | ( idx,
+                  AnyScriptWitness
+                    (PlutusScriptWitness _ _ _ _ d e)
+                  ) <-
+                  witnesses
+            ]
+
+      languages :: Set Alonzo.Language
+      languages =
+        Set.fromList
+          [ toAlonzoLanguage (AnyPlutusScriptVersion v)
+            | (_, AnyScriptWitness (PlutusScriptWitness _ v _ _ _ _)) <- witnesses
           ]
 
-    languages :: Set Alonzo.Language
-    languages =
-      Set.fromList
-        [ toAlonzoLanguage (AnyPlutusScriptVersion v)
-        | (_, AnyScriptWitness (PlutusScriptWitness _ v _ _ _ _)) <- witnesses
-        ]
-
-    txAuxData :: Maybe (Ledger.AuxiliaryData StandardAlonzo)
-    txAuxData
-      | Map.null ms
-      , null ss   = Nothing
-      | otherwise = Just (toAlonzoAuxiliaryData ms ss)
-      where
-        ms = case txMetadata of
-               TxMetadataNone                     -> Map.empty
-               TxMetadataInEra _ (TxMetadata ms') -> ms'
-        ss = case txAuxScripts of
-               TxAuxScriptsNone   -> []
-               TxAuxScripts _ ss' -> ss'
-
-makeShelleyTransactionBody era@ShelleyBasedEraBabbage
-                            txbodycontent@TxBodyContent {
-                             txIns,
-                             txInsCollateral,
-                             txInsReference,
-                             txReturnCollateral,
-                             txTotalCollateral,
-                             txOuts,
-                             txFee,
-                             txValidityRange = (lowerBound, upperBound),
-                             txMetadata,
-                             txAuxScripts,
-                             txExtraKeyWits,
-                             txProtocolParams,
-                             txWithdrawals,
-                             txCertificates,
-                             txUpdateProposal,
-                             txMintValue,
-                             txScriptValidity
-                           } = do
+      txAuxData :: Maybe (Ledger.AuxiliaryData StandardAlonzo)
+      txAuxData
+        | Map.null ms,
+          null ss =
+          Nothing
+        | otherwise = Just (toAlonzoAuxiliaryData ms ss)
+        where
+          ms = case txMetadata of
+            TxMetadataNone -> Map.empty
+            TxMetadataInEra _ (TxMetadata ms') -> ms'
+          ss = case txAuxScripts of
+            TxAuxScriptsNone -> []
+            TxAuxScripts _ ss' -> ss'
+makeShelleyTransactionBody
+  era@ShelleyBasedEraBabbage
+  txbodycontent@TxBodyContent
+    { txIns,
+      txInsCollateral,
+      txInsReference,
+      txReturnCollateral,
+      txTotalCollateral,
+      txOuts,
+      txFee,
+      txValidityRange = (lowerBound, upperBound),
+      txMetadata,
+      txAuxScripts,
+      txExtraKeyWits,
+      txProtocolParams,
+      txWithdrawals,
+      txCertificates,
+      txUpdateProposal,
+      txMintValue,
+      txScriptValidity
+    } = do
     guard (not (null txIns)) ?! TxBodyEmptyTxIns
     sequence_
-      [ do allPositive
-           allWithinMaxBound
-           for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
-              guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
-      | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity
-      , txout@(TxOut _ (TxOutValue MultiAssetInBabbageEra v) _ _) <- txOuts
-      , let allPositive =
-              case [ q | (_,q) <- valueToList v, q < 0 ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
-            allWithinMaxBound =
-              case [ q | (_,q) <- valueToList v, q > maxTxOut ] of
-                []  -> Right ()
-                q:_ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
+      [ do
+          allPositive
+          allWithinMaxBound
+          for_ txIns $ \(txin@(TxIn _ (TxIx txix)), _) ->
+            guard (fromIntegral txix <= maxShelleyTxInIx) ?! TxBodyInIxOverflow txin
+        | let maxTxOut = fromIntegral (maxBound :: Word64) :: Quantity,
+          txout@(TxOut _ (TxOutValue MultiAssetInBabbageEra v) _ _) <- txOuts,
+          let allPositive =
+                case [q | (_, q) <- valueToList v, q < 0] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputNegative q (txOutInAnyEra txout))
+              allWithinMaxBound =
+                case [q | (_, q) <- valueToList v, q > maxTxOut] of
+                  [] -> Right ()
+                  q : _ -> Left (TxBodyOutputOverflow q (txOutInAnyEra txout))
       ]
     case txMetadata of
-      TxMetadataNone      -> return ()
+      TxMetadataNone -> return ()
       TxMetadataInEra _ m -> validateTxMetadata m ?!. TxBodyMetadataError
     case txMintValue of
-      TxMintNone        -> return ()
+      TxMintNone -> return ()
       TxMintValue _ v _ -> guard (selectLovelace v == 0) ?! TxBodyMintAdaError
     case txInsCollateral of
-      TxInsCollateralNone | not (Set.null languages)
-        -> Left TxBodyEmptyTxInsCollateral
+      TxInsCollateralNone
+        | not (Set.null languages) ->
+          Left TxBodyEmptyTxInsCollateral
       _ -> return ()
     case txProtocolParams of
-      BuildTxWith Nothing | not (Set.null languages)
-        -> Left TxBodyMissingProtocolParams
+      BuildTxWith Nothing
+        | not (Set.null languages) ->
+          Left TxBodyMissingProtocolParams
       _ -> return () --TODO alonzo: validate protocol params for the Babbage era.
-                     --             All the necessary params must be provided.
-
+      --             All the necessary params must be provided.
     return $
-      ShelleyTxBody era
-        (Babbage.TxBody
-           { Babbage.inputs = Set.fromList $ map (toShelleyTxIn . fst) txIns
-           , Babbage.collateral =
-               case txInsCollateral of
-                TxInsCollateralNone     -> Set.empty
-                TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins)
-           , Babbage.referenceInputs =
-               Set.fromList (map toShelleyTxIn referenceTxIns)
-
-           , Babbage.outputs = Seq.fromList (map (CBOR.mkSized . toShelleyTxOutAny era) txOuts)
-           , Babbage.collateralReturn =
-               case txReturnCollateral of
-                 TxReturnCollateralNone -> SNothing
-                 TxReturnCollateral _ colTxOut -> SJust $ CBOR.mkSized $ toShelleyTxOutAny era colTxOut
-           , Babbage.totalCollateral =
-               case txTotalCollateral of
-                 TxTotalCollateralNone -> SNothing
-                 TxTotalCollateral _ totCollLovelace -> SJust $ toShelleyLovelace totCollLovelace
-           , Babbage.txcerts =
-               case txCertificates of
-                 TxCertificatesNone    -> Seq.empty
-                 TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
-           , Babbage.txwdrls =
-               case txWithdrawals of
-                 TxWithdrawalsNone  -> Shelley.Wdrl Map.empty
-                 TxWithdrawals _ ws -> toShelleyWithdrawal ws
-           , Babbage.txfee =
-               case txFee of
-                 TxFeeImplicit era'  -> case era' of {}
-                 TxFeeExplicit _ fee -> toShelleyLovelace fee
-           , Babbage.txvldt =
-               Allegra.ValidityInterval {
-                 invalidBefore    = case lowerBound of
-                                              TxValidityNoLowerBound   -> SNothing
-                                              TxValidityLowerBound _ s -> SJust s,
-                 invalidHereafter = case upperBound of
-                                              TxValidityNoUpperBound _ -> SNothing
-                                              TxValidityUpperBound _ s -> SJust s}
-           , Babbage.txUpdates =
-               case txUpdateProposal of
-                 TxUpdateProposalNone -> SNothing
-                 TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
-           , Babbage.reqSignerHashes =
-               case txExtraKeyWits of
-                 TxExtraKeyWitnessesNone   -> Set.empty
-                 TxExtraKeyWitnesses _ khs -> Set.fromList
-                                                [ Shelley.coerceKeyRole kh
-                                                | PaymentKeyHash kh <- khs ]
-           , Babbage.mint =
-               case txMintValue of
-                 TxMintNone        -> mempty
-                 TxMintValue _ v _ -> toMaryValue v
-           , Babbage.scriptIntegrityHash =
-               case txProtocolParams of
-                 BuildTxWith Nothing        -> SNothing
-                 BuildTxWith (Just pparams) ->
+      ShelleyTxBody
+        era
+        ( BabbageTxBody
+            { Babbage.inputs = Set.fromList $ map (toShelleyTxIn . fst) txIns,
+              Babbage.collateral =
+                case txInsCollateral of
+                  TxInsCollateralNone -> Set.empty
+                  TxInsCollateral _ txins -> Set.fromList (map toShelleyTxIn txins),
+              Babbage.referenceInputs =
+                Set.fromList (map toShelleyTxIn referenceTxIns),
+              Babbage.outputs = Seq.fromList (map (CBOR.mkSized . toShelleyTxOutAny era) txOuts),
+              Babbage.collateralReturn =
+                case txReturnCollateral of
+                  TxReturnCollateralNone -> SNothing
+                  TxReturnCollateral _ colTxOut -> SJust $ CBOR.mkSized $ toShelleyTxOutAny era colTxOut,
+              Babbage.totalCollateral =
+                case txTotalCollateral of
+                  TxTotalCollateralNone -> SNothing
+                  TxTotalCollateral _ totCollLovelace -> SJust $ toShelleyLovelace totCollLovelace,
+              Babbage.txcerts =
+                case txCertificates of
+                  TxCertificatesNone -> Seq.empty
+                  TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs),
+              Babbage.txwdrls =
+                case txWithdrawals of
+                  TxWithdrawalsNone -> Shelley.Wdrl Map.empty
+                  TxWithdrawals _ ws -> toShelleyWithdrawal ws,
+              Babbage.txfee =
+                case txFee of
+                  TxFeeImplicit era' -> case era' of
+                  TxFeeExplicit _ fee -> toShelleyLovelace fee,
+              Babbage.txvldt =
+                Allegra.ValidityInterval
+                  { invalidBefore = case lowerBound of
+                      TxValidityNoLowerBound -> SNothing
+                      TxValidityLowerBound _ s -> SJust s,
+                    invalidHereafter = case upperBound of
+                      TxValidityNoUpperBound _ -> SNothing
+                      TxValidityUpperBound _ s -> SJust s
+                  },
+              Babbage.txUpdates =
+                case txUpdateProposal of
+                  TxUpdateProposalNone -> SNothing
+                  TxUpdateProposal _ p -> SJust (toLedgerUpdate era p),
+              Babbage.reqSignerHashes =
+                case txExtraKeyWits of
+                  TxExtraKeyWitnessesNone -> Set.empty
+                  TxExtraKeyWitnesses _ khs ->
+                    Set.fromList
+                      [ Shelley.coerceKeyRole kh
+                        | PaymentKeyHash kh <- khs
+                      ],
+              Babbage.mint =
+                case txMintValue of
+                  TxMintNone -> mempty
+                  TxMintValue _ v _ -> toMaryValue v,
+              Babbage.scriptIntegrityHash =
+                case txProtocolParams of
+                  BuildTxWith Nothing -> SNothing
+                  BuildTxWith (Just pparams) ->
                     Alonzo.hashScriptIntegrity
-                      (Set.map
-                         (Alonzo.getLanguageView (toLedgerPParams ShelleyBasedEraBabbage pparams))
-                         languages
+                      ( Set.map
+                          (Alonzo.getLanguageView (toLedgerPParams ShelleyBasedEraBabbage pparams))
+                          languages
                       )
                       redeemers
-                      datums
-           , Babbage.adHash =
-                maybeToStrictMaybe (Ledger.hashAuxiliaryData <$> txAuxData)
-           , Babbage.txnetworkid = SNothing
-           })
-        scripts
-        (TxBodyScriptData ScriptDataInBabbageEra
-          datums redeemers)
+                      datums,
+              Babbage.adHash =
+                maybeToStrictMaybe (Ledger.hashAuxiliaryData <$> txAuxData),
+              Babbage.txnetworkid = SNothing
+            }
+        )
+        scriptList
+        ( TxBodyScriptData
+            ScriptDataInBabbageEra
+            datums
+            redeemers
+        )
         txAuxData
         txScriptValidity
-  where
-    referenceTxIns :: [TxIn]
-    referenceTxIns =
-      case txInsReference of
-        TxInsReferenceNone -> []
-        TxInsReference _ refTxins -> refTxins
+    where
+      referenceTxIns :: [TxIn]
+      referenceTxIns =
+        case txInsReference of
+          TxInsReferenceNone -> []
+          TxInsReference _ refTxins -> refTxins
 
-    maxShelleyTxInIx :: Word
-    maxShelleyTxInIx = fromIntegral $ maxBound @Word16
+      maxShelleyTxInIx :: Word
+      maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-    witnesses :: [(ScriptWitnessIndex, AnyScriptWitness BabbageEra)]
-    witnesses = collectTxBodyScriptWitnesses txbodycontent
+      witnesses :: [(ScriptWitnessIndex, AnyScriptWitness BabbageEra)]
+      witnesses = collectTxBodyScriptWitnesses txbodycontent
 
-    scripts :: [Ledger.Script StandardBabbage]
-    scripts = catMaybes
-      [ toShelleyScript <$> scriptWitnessScript scriptwitness
-      | (_, AnyScriptWitness scriptwitness) <- witnesses
-      ]
-
-    -- Note these do not include inline datums!
-    datums :: Alonzo.TxDats StandardBabbage
-    datums =
-      Alonzo.TxDats $
-        Map.fromList
-          [ (Alonzo.hashData d', d')
-          | d <- scriptdata
-          , let d' = toAlonzoData d
+      scriptList :: [Ledger.Script StandardBabbage]
+      scriptList =
+        catMaybes
+          [ toShelleyScript <$> scriptWitnessScript scriptwitness
+            | (_, AnyScriptWitness scriptwitness) <- witnesses
           ]
 
-    scriptdata :: [ScriptData]
-    scriptdata =
-        [ d | TxOut _ _ (TxOutDatumInTx _ d) _ <- txOuts ]
-     ++ [ d | (_, AnyScriptWitness
-                    (PlutusScriptWitness
-                       _ _ _ (ScriptDatumForTxIn d) _ _)) <- witnesses
+      -- Note these do not include inline datums!
+      datums :: Alonzo.TxDats StandardBabbage
+      datums =
+        Alonzo.TxDats $
+          Map.fromList
+            [ (Alonzo.hashData d', d')
+              | d <- scriptdata,
+                let d' = toAlonzoData d
             ]
 
-    redeemers :: Alonzo.Redeemers StandardBabbage
-    redeemers =
-      Alonzo.Redeemers $
-        Map.fromList
-          [ (toAlonzoRdmrPtr idx, (toAlonzoData d, toAlonzoExUnits e))
-          | (idx, AnyScriptWitness
-                    (PlutusScriptWitness _ _ _ _ d e)) <- witnesses
-          ]
+      scriptdata :: [ScriptData]
+      scriptdata =
+        [d | TxOut _ _ (TxOutDatumInTx _ d) _ <- txOuts]
+          ++ [ d
+               | ( _,
+                   AnyScriptWitness
+                     ( PlutusScriptWitness
+                         _
+                         _
+                         _
+                         (ScriptDatumForTxIn d)
+                         _
+                         _
+                       )
+                   ) <-
+                   witnesses
+             ]
 
-    languages :: Set Alonzo.Language
-    languages =
-      Set.fromList $ catMaybes
-        [ getScriptLanguage sw
-        | (_, AnyScriptWitness sw) <- witnesses
-        ]
+      redeemers :: Alonzo.Redeemers StandardBabbage
+      redeemers =
+        Alonzo.Redeemers $
+          Map.fromList
+            [ (toAlonzoRdmrPtr idx, (toAlonzoData d, toAlonzoExUnits e))
+              | ( idx,
+                  AnyScriptWitness
+                    (PlutusScriptWitness _ _ _ _ d e)
+                  ) <-
+                  witnesses
+            ]
 
-    getScriptLanguage :: ScriptWitness witctx era -> Maybe Alonzo.Language
-    getScriptLanguage (PlutusScriptWitness _ v _ _ _ _) =
-      Just $ toAlonzoLanguage (AnyPlutusScriptVersion v)
-    getScriptLanguage SimpleScriptWitness{} = Nothing
+      languages :: Set Alonzo.Language
+      languages =
+        Set.fromList $
+          catMaybes
+            [ getScriptLanguage sw
+              | (_, AnyScriptWitness sw) <- witnesses
+            ]
 
-    txAuxData :: Maybe (Ledger.AuxiliaryData StandardBabbage)
-    txAuxData
-      | Map.null ms
-      , null ss   = Nothing
-      | otherwise = Just (toAlonzoAuxiliaryData ms ss)
-      where
-        ms = case txMetadata of
-               TxMetadataNone                     -> Map.empty
-               TxMetadataInEra _ (TxMetadata ms') -> ms'
-        ss = case txAuxScripts of
-               TxAuxScriptsNone   -> []
-               TxAuxScripts _ ss' -> ss'
+      getScriptLanguage :: ScriptWitness witctx era -> Maybe Alonzo.Language
+      getScriptLanguage (PlutusScriptWitness _ v _ _ _ _) =
+        Just $ toAlonzoLanguage (AnyPlutusScriptVersion v)
+      getScriptLanguage SimpleScriptWitness {} = Nothing
 
+      txAuxData :: Maybe (Ledger.AuxiliaryData StandardBabbage)
+      txAuxData
+        | Map.null ms,
+          null ss =
+          Nothing
+        | otherwise = Just (toAlonzoAuxiliaryData ms ss)
+        where
+          ms = case txMetadata of
+            TxMetadataNone -> Map.empty
+            TxMetadataInEra _ (TxMetadata ms') -> ms'
+          ss = case txAuxScripts of
+            TxAuxScriptsNone -> []
+            TxAuxScripts _ ss' -> ss'
 
 -- | A variant of 'toShelleyTxOutAny that is used only internally to this module
 -- that works with a 'TxOut' in any context (including CtxTx) by ignoring
 -- embedded datums (taking only their hash).
---
-toShelleyTxOutAny :: forall ctx era ledgerera.
-                   ShelleyLedgerEra era ~ ledgerera
-                => ShelleyBasedEra era
-                -> TxOut ctx era
-                -> Ledger.TxOut ledgerera
+toShelleyTxOutAny ::
+  forall ctx era ledgerera.
+  ShelleyLedgerEra era ~ ledgerera =>
+  ShelleyBasedEra era ->
+  TxOut ctx era ->
+  Ledger.TxOut ledgerera
 toShelleyTxOutAny era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _ _) =
-    case era of {}
-
+  case era of
 toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly AdaOnlyInShelleyEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly AdaOnlyInAllegraEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 toShelleyTxOutAny _ (TxOut addr (TxOutValue MultiAssetInMaryEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toMaryValue value)
-
+  ShelleyTxOut (toShelleyAddr addr) (toMaryValue value)
 toShelleyTxOutAny _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata _) =
-    Alonzo.TxOut (toShelleyAddr addr) (toMaryValue value)
-                 (toAlonzoTxOutDataHash' txoutdata)
-
+  AlonzoTxOut
+    (toShelleyAddr addr)
+    (toMaryValue value)
+    (toAlonzoTxOutDataHash' txoutdata)
 toShelleyTxOutAny era (TxOut addr (TxOutValue MultiAssetInBabbageEra value) txoutdata refScript) =
-    let cEra = shelleyBasedToCardanoEra era
-    in Babbage.TxOut (toShelleyAddr addr) (toMaryValue value)
-                    (toBabbageTxOutDatum' txoutdata) (refScriptToShelleyScript cEra refScript)
+  let cEra = shelleyBasedToCardanoEra era
+   in BabbageTxOut
+        (toShelleyAddr addr)
+        (toMaryValue value)
+        (toBabbageTxOutDatum' txoutdata)
+        (refScriptToShelleyScript cEra refScript)
 
-
-toAlonzoTxOutDataHash' :: TxOutDatum ctx AlonzoEra
-                       -> StrictMaybe (Alonzo.DataHash StandardCrypto)
-toAlonzoTxOutDataHash'  TxOutDatumNone                          = SNothing
-toAlonzoTxOutDataHash' (TxOutDatumHash _ (ScriptDataHash dh))   = SJust dh
+toAlonzoTxOutDataHash' ::
+  TxOutDatum ctx AlonzoEra ->
+  StrictMaybe (Alonzo.DataHash StandardCrypto)
+toAlonzoTxOutDataHash' TxOutDatumNone = SNothing
+toAlonzoTxOutDataHash' (TxOutDatumHash _ (ScriptDataHash dh)) = SJust dh
 toAlonzoTxOutDataHash' (TxOutDatumInTx' _ (ScriptDataHash dh) _) = SJust dh
 toAlonzoTxOutDataHash' (TxOutDatumInline inlineDatumSupp _sd) =
-  case inlineDatumSupp :: ReferenceTxInsScriptsInlineDatumsSupportedInEra AlonzoEra of {}
+  case inlineDatumSupp :: ReferenceTxInsScriptsInlineDatumsSupportedInEra AlonzoEra of
 
 -- TODO: Consolidate with alonzo function and rename
-toBabbageTxOutDatum'
-  :: Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => TxOutDatum ctx era -> Babbage.Datum (ShelleyLedgerEra era)
-toBabbageTxOutDatum'  TxOutDatumNone = Babbage.NoDatum
+toBabbageTxOutDatum' ::
+  Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto =>
+  TxOutDatum ctx era ->
+  Babbage.Datum (ShelleyLedgerEra era)
+toBabbageTxOutDatum' TxOutDatumNone = Babbage.NoDatum
 toBabbageTxOutDatum' (TxOutDatumHash _ (ScriptDataHash dh)) = Babbage.DatumHash dh
 toBabbageTxOutDatum' (TxOutDatumInTx' _ (ScriptDataHash dh) _) = Babbage.DatumHash dh
 toBabbageTxOutDatum' (TxOutDatumInline _ sd) = scriptDataToInlineDatum sd
-
 
 -- ----------------------------------------------------------------------------
 -- Script witnesses within the tx body
@@ -3395,29 +3658,23 @@ toBabbageTxOutDatum' (TxOutDatumInline _ sd) = scriptDataToInlineDatum sd
 
 -- | A 'ScriptWitness' in any 'WitCtx'. This lets us handle heterogeneous
 -- collections of script witnesses from multiple contexts.
---
 data AnyScriptWitness era where
-     AnyScriptWitness :: ScriptWitness witctx era -> AnyScriptWitness era
+  AnyScriptWitness :: ScriptWitness witctx era -> AnyScriptWitness era
 
 -- | Identify the location of a 'ScriptWitness' within the context of a
 -- 'TxBody'. These are indexes of the objects within the transaction that
 -- need or can use script witnesses: inputs, minted assets, withdrawals and
 -- certificates. These are simple numeric indices, enumerated from zero.
 -- Thus the indices are not stable if the transaction body is modified.
---
-data ScriptWitnessIndex =
-
-     -- | The n'th transaction input, in the order of the 'TxId's.
-     ScriptWitnessIndexTxIn !Word
-
-     -- | The n'th minting 'PolicyId', in the order of the 'PolicyId's.
-   | ScriptWitnessIndexMint !Word
-
-     -- | The n'th certificate, in the list order of the certificates.
-   | ScriptWitnessIndexCertificate !Word
-
-     -- | The n'th withdrawal, in the order of the 'StakeAddress's.
-   | ScriptWitnessIndexWithdrawal !Word
+data ScriptWitnessIndex
+  = -- | The n'th transaction input, in the order of the 'TxId's.
+    ScriptWitnessIndexTxIn !Word
+  | -- | The n'th minting 'PolicyId', in the order of the 'PolicyId's.
+    ScriptWitnessIndexMint !Word
+  | -- | The n'th certificate, in the list order of the certificates.
+    ScriptWitnessIndexCertificate !Word
+  | -- | The n'th withdrawal, in the order of the 'StakeAddress's.
+    ScriptWitnessIndexWithdrawal !Word
   deriving (Eq, Ord, Show)
 
 renderScriptWitnessIndex :: ScriptWitnessIndex -> String
@@ -3432,86 +3689,88 @@ renderScriptWitnessIndex (ScriptWitnessIndexWithdrawal index) =
 
 toAlonzoRdmrPtr :: ScriptWitnessIndex -> Alonzo.RdmrPtr
 toAlonzoRdmrPtr widx =
-    case widx of
-      ScriptWitnessIndexTxIn        n -> Alonzo.RdmrPtr Alonzo.Spend (fromIntegral n)
-      ScriptWitnessIndexMint        n -> Alonzo.RdmrPtr Alonzo.Mint  (fromIntegral n)
-      ScriptWitnessIndexCertificate n -> Alonzo.RdmrPtr Alonzo.Cert  (fromIntegral n)
-      ScriptWitnessIndexWithdrawal  n -> Alonzo.RdmrPtr Alonzo.Rewrd (fromIntegral n)
+  case widx of
+    ScriptWitnessIndexTxIn n -> Alonzo.RdmrPtr Alonzo.Spend (fromIntegral n)
+    ScriptWitnessIndexMint n -> Alonzo.RdmrPtr Alonzo.Mint (fromIntegral n)
+    ScriptWitnessIndexCertificate n -> Alonzo.RdmrPtr Alonzo.Cert (fromIntegral n)
+    ScriptWitnessIndexWithdrawal n -> Alonzo.RdmrPtr Alonzo.Rewrd (fromIntegral n)
 
 fromAlonzoRdmrPtr :: Alonzo.RdmrPtr -> ScriptWitnessIndex
 fromAlonzoRdmrPtr (Alonzo.RdmrPtr tag n) =
-    case tag of
-      Alonzo.Spend -> ScriptWitnessIndexTxIn        (fromIntegral n)
-      Alonzo.Mint  -> ScriptWitnessIndexMint        (fromIntegral n)
-      Alonzo.Cert  -> ScriptWitnessIndexCertificate (fromIntegral n)
-      Alonzo.Rewrd -> ScriptWitnessIndexWithdrawal  (fromIntegral n)
+  case tag of
+    Alonzo.Spend -> ScriptWitnessIndexTxIn (fromIntegral n)
+    Alonzo.Mint -> ScriptWitnessIndexMint (fromIntegral n)
+    Alonzo.Cert -> ScriptWitnessIndexCertificate (fromIntegral n)
+    Alonzo.Rewrd -> ScriptWitnessIndexWithdrawal (fromIntegral n)
 
-collectTxBodyScriptWitnesses :: forall era.
-                                TxBodyContent BuildTx era
-                             -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-collectTxBodyScriptWitnesses TxBodyContent {
-                               txIns,
-                               txWithdrawals,
-                               txCertificates,
-                               txMintValue
-                             } =
+collectTxBodyScriptWitnesses ::
+  forall era.
+  TxBodyContent BuildTx era ->
+  [(ScriptWitnessIndex, AnyScriptWitness era)]
+collectTxBodyScriptWitnesses
+  TxBodyContent
+    { txIns,
+      txWithdrawals,
+      txCertificates,
+      txMintValue
+    } =
     concat
-      [ scriptWitnessesTxIns        txIns
-      , scriptWitnessesWithdrawals  txWithdrawals
-      , scriptWitnessesCertificates txCertificates
-      , scriptWitnessesMinting      txMintValue
+      [ scriptWitnessesTxIns txIns,
+        scriptWitnessesWithdrawals txWithdrawals,
+        scriptWitnessesCertificates txCertificates,
+        scriptWitnessesMinting txMintValue
       ]
-  where
-    scriptWitnessesTxIns
-      :: [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
-      -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-    scriptWitnessesTxIns txins =
+    where
+      scriptWitnessesTxIns ::
+        [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))] ->
+        [(ScriptWitnessIndex, AnyScriptWitness era)]
+      scriptWitnessesTxIns txins =
         [ (ScriptWitnessIndexTxIn ix, AnyScriptWitness witness)
-          -- The tx ins are indexed in the map order by txid
-        | (ix, (_, BuildTxWith (ScriptWitness _ witness)))
-            <- zip [0..] (orderTxIns txins)
+          | -- The tx ins are indexed in the map order by txid
+            (ix, (_, BuildTxWith (ScriptWitness _ witness))) <-
+              zip [0 ..] (orderTxIns txins)
         ]
 
-    scriptWitnessesWithdrawals
-      :: TxWithdrawals BuildTx era
-      -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-    scriptWitnessesWithdrawals  TxWithdrawalsNone = []
-    scriptWitnessesWithdrawals (TxWithdrawals _ withdrawals) =
+      scriptWitnessesWithdrawals ::
+        TxWithdrawals BuildTx era ->
+        [(ScriptWitnessIndex, AnyScriptWitness era)]
+      scriptWitnessesWithdrawals TxWithdrawalsNone = []
+      scriptWitnessesWithdrawals (TxWithdrawals _ withdrawals) =
         [ (ScriptWitnessIndexWithdrawal ix, AnyScriptWitness witness)
-          -- The withdrawals are indexed in the map order by stake credential
-        | (ix, (_, _, BuildTxWith (ScriptWitness _ witness)))
-             <- zip [0..] (orderStakeAddrs withdrawals)
+          | -- The withdrawals are indexed in the map order by stake credential
+            (ix, (_, _, BuildTxWith (ScriptWitness _ witness))) <-
+              zip [0 ..] (orderStakeAddrs withdrawals)
         ]
 
-    scriptWitnessesCertificates
-      :: TxCertificates BuildTx era
-      -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-    scriptWitnessesCertificates  TxCertificatesNone = []
-    scriptWitnessesCertificates (TxCertificates _ certs (BuildTxWith witnesses)) =
+      scriptWitnessesCertificates ::
+        TxCertificates BuildTx era ->
+        [(ScriptWitnessIndex, AnyScriptWitness era)]
+      scriptWitnessesCertificates TxCertificatesNone = []
+      scriptWitnessesCertificates (TxCertificates _ certs (BuildTxWith witnesses)) =
         [ (ScriptWitnessIndexCertificate ix, AnyScriptWitness witness)
-          -- The certs are indexed in list order
-        | (ix, cert) <- zip [0..] certs
-        , ScriptWitness _ witness <- maybeToList $ do
-                                       stakecred <- selectStakeCredential cert
-                                       Map.lookup stakecred witnesses
+          | -- The certs are indexed in list order
+            (ix, cert) <- zip [0 ..] certs,
+            ScriptWitness _ witness <- maybeToList $ do
+              stakecred <- selectStakeCredential cert
+              Map.lookup stakecred witnesses
         ]
 
-    selectStakeCredential cert =
-      case cert of
-        StakeAddressDeregistrationCertificate stakecred   -> Just stakecred
-        StakeAddressDelegationCertificate     stakecred _ -> Just stakecred
-        _                                                 -> Nothing
+      selectStakeCredential cert =
+        case cert of
+          StakeAddressDeregistrationCertificate stakecred -> Just stakecred
+          StakeAddressDelegationCertificate stakecred _ -> Just stakecred
+          _ -> Nothing
 
-    scriptWitnessesMinting
-      :: TxMintValue BuildTx era
-      -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-    scriptWitnessesMinting  TxMintNone = []
-    scriptWitnessesMinting (TxMintValue _ value (BuildTxWith witnesses)) =
+      scriptWitnessesMinting ::
+        TxMintValue BuildTx era ->
+        [(ScriptWitnessIndex, AnyScriptWitness era)]
+      scriptWitnessesMinting TxMintNone = []
+      scriptWitnessesMinting (TxMintValue _ value (BuildTxWith witnesses)) =
         [ (ScriptWitnessIndexMint ix, AnyScriptWitness witness)
-          -- The minting policies are indexed in policy id order in the value
-        | let ValueNestedRep bundle = valueToNestedRep value
-        , (ix, ValueNestedBundle policyid _) <- zip [0..] bundle
-        , witness <- maybeToList (Map.lookup policyid witnesses)
+          | -- The minting policies are indexed in policy id order in the value
+            let ValueNestedRep bundle = valueToNestedRep value,
+            (ix, ValueNestedBundle policyid _) <- zip [0 ..] bundle,
+            witness <- maybeToList (Map.lookup policyid witnesses)
         ]
 
 -- This relies on the TxId Ord instance being consistent with the
@@ -3526,64 +3785,58 @@ orderTxIns = sortBy (compare `on` fst)
 orderStakeAddrs :: [(StakeAddress, x, v)] -> [(StakeAddress, x, v)]
 orderStakeAddrs = sortBy (compare `on` (\(k, _, _) -> k))
 
-
 toShelleyWithdrawal :: [(StakeAddress, Lovelace, a)] -> Shelley.Wdrl StandardCrypto
 toShelleyWithdrawal withdrawals =
-    Shelley.Wdrl $
-      Map.fromList
-        [ (toShelleyStakeAddr stakeAddr, toShelleyLovelace value)
-        | (stakeAddr, value, _) <- withdrawals ]
+  Shelley.Wdrl $
+    Map.fromList
+      [ (toShelleyStakeAddr stakeAddr, toShelleyLovelace value)
+        | (stakeAddr, value, _) <- withdrawals
+      ]
 
-
-fromShelleyWithdrawal
-  :: Shelley.Wdrl StandardCrypto
-  -> [(StakeAddress, Lovelace, BuildTxWith ViewTx (Witness WitCtxStake era))]
+fromShelleyWithdrawal ::
+  Shelley.Wdrl StandardCrypto ->
+  [(StakeAddress, Lovelace, BuildTxWith ViewTx (Witness WitCtxStake era))]
 fromShelleyWithdrawal (Shelley.Wdrl withdrawals) =
   [ (fromShelleyStakeAddr stakeAddr, fromShelleyLovelace value, ViewTx)
-  | (stakeAddr, value) <- Map.assocs withdrawals
+    | (stakeAddr, value) <- Map.assocs withdrawals
   ]
 
-
 -- | In the Shelley era the auxiliary data consists only of the tx metadata
-toShelleyAuxiliaryData :: Map Word64 TxMetadataValue
-                       -> Ledger.AuxiliaryData StandardShelley
+toShelleyAuxiliaryData ::
+  Map Word64 TxMetadataValue ->
+  Ledger.AuxiliaryData StandardShelley
 toShelleyAuxiliaryData m =
-    Shelley.Metadata
-      (toShelleyMetadata m)
-
+  Shelley.Metadata
+    (toShelleyMetadata m)
 
 -- | In the Allegra and Mary eras the auxiliary data consists of the tx metadata
 -- and the axiliary scripts.
---
-toAllegraAuxiliaryData :: forall era ledgerera.
-                          ShelleyLedgerEra era ~ ledgerera
-                       => Ledger.AuxiliaryData ledgerera ~ Allegra.AuxiliaryData ledgerera
-                       => Ledger.AnnotatedData (Ledger.Script ledgerera)
-                       => Map Word64 TxMetadataValue
-                       -> [ScriptInEra era]
-                       -> Ledger.AuxiliaryData ledgerera
+toAllegraAuxiliaryData ::
+  forall era ledgerera.
+  (ShelleyLedgerEra era ~ ledgerera, ToCBOR (Ledger.Script ledgerera)) =>
+  Ledger.AuxiliaryData ledgerera ~ MAAuxiliaryData ledgerera =>
+  Map Word64 TxMetadataValue ->
+  [ScriptInEra era] ->
+  Ledger.AuxiliaryData ledgerera
 toAllegraAuxiliaryData m ss =
-    Allegra.AuxiliaryData
-      (toShelleyMetadata m)
-      (Seq.fromList (map toShelleyScript ss))
-
+  MAAuxiliaryData
+    (toShelleyMetadata m)
+    (Seq.fromList (map toShelleyScript ss))
 
 -- | In the Alonzo and later eras the auxiliary data consists of the tx metadata
 -- and the axiliary scripts, and the axiliary script data.
---
-toAlonzoAuxiliaryData :: forall era ledgerera.
-                         ShelleyLedgerEra era ~ ledgerera
-                      => Ledger.AuxiliaryData ledgerera ~ Alonzo.AuxiliaryData ledgerera
-                      => Ledger.Script ledgerera ~ Alonzo.Script ledgerera
-                      => Ledger.Era ledgerera
-                      => Map Word64 TxMetadataValue
-                      -> [ScriptInEra era]
-                      -> Ledger.AuxiliaryData ledgerera
+toAlonzoAuxiliaryData ::
+  forall era ledgerera.
+  ShelleyLedgerEra era ~ ledgerera =>
+  Ledger.Script ledgerera ~ AlonzoScript ledgerera =>
+  Ledger.Era ledgerera =>
+  Map Word64 TxMetadataValue ->
+  [ScriptInEra era] ->
+  AlonzoAuxiliaryData ledgerera
 toAlonzoAuxiliaryData m ss =
-    Alonzo.AuxiliaryData
-      (toShelleyMetadata m)
-      (Seq.fromList (map toShelleyScript ss))
-
+  AlonzoAuxiliaryData
+    (toShelleyMetadata m)
+    (Seq.fromList (map toShelleyScript ss))
 
 -- ----------------------------------------------------------------------------
 -- Other utilities helpful with making transaction bodies
@@ -3598,17 +3851,17 @@ toAlonzoAuxiliaryData m ss =
 -- This gets turned into a UTxO by making a pseudo-transaction for each address,
 -- with the 0th output being the coin value. So to spend from the initial UTxO
 -- we need this same 'TxIn' to use as an input to the spending transaction.
---
 genesisUTxOPseudoTxIn :: NetworkId -> Hash GenesisUTxOKey -> TxIn
 genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
-    --TODO: should handle Byron UTxO case too.
-    fromShelleyTxIn (Shelley.initialFundsPseudoTxIn addr)
+  --TODO: should handle Byron UTxO case too.
+  fromShelleyTxIn (Shelley.initialFundsPseudoTxIn addr)
   where
     addr :: Shelley.Addr StandardCrypto
-    addr = Shelley.Addr
-             (toShelleyNetwork nw)
-             (Shelley.KeyHashObj kh)
-             Shelley.StakeRefNull
+    addr =
+      Shelley.Addr
+        (toShelleyNetwork nw)
+        (Shelley.KeyHashObj kh)
+        Shelley.StakeRefNull
 
 calculateExecutionUnitsLovelace :: ExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
 calculateExecutionUnitsLovelace euPrices eUnits =
@@ -3620,16 +3873,13 @@ calculateExecutionUnitsLovelace euPrices eUnits =
 -- ----------------------------------------------------------------------------
 -- Inline data
 --
+
 -- | Conversion of ScriptData to binary data which allows for the storage of data
 -- onchain within a transaction output.
---
-
 scriptDataToInlineDatum :: ScriptData -> Babbage.Datum ledgerera
 scriptDataToInlineDatum = Babbage.Datum . Alonzo.dataToBinaryData . toAlonzoData
 
-binaryDataToScriptData
-  :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era -> Alonzo.BinaryData ledgerera -> ScriptData
-binaryDataToScriptData ReferenceTxInsScriptsInlineDatumsInBabbageEra  d =
+binaryDataToScriptData ::
+  ReferenceTxInsScriptsInlineDatumsSupportedInEra era -> Alonzo.BinaryData ledgerera -> ScriptData
+binaryDataToScriptData ReferenceTxInsScriptsInlineDatumsInBabbageEra d =
   fromAlonzoData $ Alonzo.binaryDataToData d
-
-

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -78,7 +78,6 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Coin as Shelley
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Mary.Value as Mary
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Shelley
 
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.HasTypeProxy
@@ -87,6 +86,8 @@ import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseUsing
 import           Cardano.Api.Utils (failEitherWith)
+import Cardano.Ledger.Mary.Value (MaryValue(..))
+import Cardano.Ledger.ShelleyMA.Rules (scaledMinDeposit)
 
 -- ----------------------------------------------------------------------------
 -- Lovelace
@@ -263,9 +264,9 @@ valueToLovelace v =
       [(AdaAssetId, q)] -> Just (quantityToLovelace q)
       _                 -> Nothing
 
-toMaryValue :: Value -> Mary.Value StandardCrypto
+toMaryValue :: Value -> MaryValue StandardCrypto
 toMaryValue v =
-    Mary.Value lovelace other
+    MaryValue lovelace other
   where
     Quantity lovelace = selectAsset v AdaAssetId
       --TODO: write QC tests to show it's ok to use Map.fromAscListWith here
@@ -280,8 +281,8 @@ toMaryValue v =
     toMaryAssetName (AssetName n) = Mary.AssetName $ Short.toShort n
 
 
-fromMaryValue :: Mary.Value StandardCrypto -> Value
-fromMaryValue (Mary.Value lovelace other) =
+fromMaryValue :: MaryValue StandardCrypto -> Value
+fromMaryValue (MaryValue lovelace other) =
     Value $
       --TODO: write QC tests to show it's ok to use Map.fromAscList here
       Map.fromList $
@@ -300,7 +301,7 @@ fromMaryValue (Mary.Value lovelace other) =
 -- mininimum UTxO value derived from the 'ProtocolParameters'
 calcMinimumDeposit :: Value -> Lovelace -> Lovelace
 calcMinimumDeposit v minUTxo =
-  fromShelleyLovelace $ Shelley.scaledMinDeposit (toMaryValue v) (toShelleyLovelace minUTxo)
+  fromShelleyLovelace $ scaledMinDeposit (toMaryValue v) (toShelleyLovelace minUTxo)
 
 -- ----------------------------------------------------------------------------
 -- An alternative nested representation

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -765,11 +765,11 @@ severityConnectionManager TrTerminatingConnection {}              = Debug
 severityConnectionManager TrTerminatedConnection {}               = Debug
 severityConnectionManager (TrConnectionHandler _ ev')             =
         case ev' of
-          TrHandshakeSuccess {}     -> Info
-          TrHandshakeClientError {} -> Notice
-          TrHandshakeServerError {} -> Info
-          TrError _ _ ShutdownNode  -> Critical
-          TrError _ _ ShutdownPeer  -> Info
+          TrHandshakeSuccess {}                       -> Info
+          TrHandshakeClientError {}                   -> Notice
+          TrHandshakeServerError {}                   -> Info
+          TrConnectionHandlerError _ _ ShutdownNode   -> Critical
+          TrConnectionHandlerError _ _ ShutdownPeer   -> Info
 
 severityConnectionManager TrShutdown                              = Info
 severityConnectionManager TrConnectionExists {}                   = Info
@@ -961,9 +961,9 @@ instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
       [ "kind" .= String "HandshakeServerError"
       , "reason" .= toJSON err
       ]
-  forMachine _dtal (TrError e err cerr) =
+  forMachine _dtal (TrConnectionHandlerError e err cerr) =
     mconcat
-      [ "kind" .= String "Error"
+      [ "kind" .= String "ConnectionHandlerError"
       , "context" .= show e
       , "reason" .= show err
       , "command" .= show cerr

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -438,12 +438,11 @@ instance HasSeverityAnnotation (ConnectionManagerTrace addr (ConnectionHandlerTr
       TrTerminatedConnection {}               -> Debug
       TrConnectionHandler _ ev'     ->
         case ev' of
-          TrHandshakeSuccess {}               -> Info
-          TrHandshakeClientError {}           -> Notice
-          TrHandshakeServerError {}           -> Info
-          TrError _ _ ShutdownNode            -> Critical
-          TrError _ _ ShutdownPeer            -> Info
-
+          TrHandshakeSuccess {}                     -> Info
+          TrHandshakeClientError {}                 -> Notice
+          TrHandshakeServerError {}                 -> Info
+          TrConnectionHandlerError _ _ ShutdownNode -> Critical
+          TrConnectionHandlerError _ _ ShutdownPeer -> Info
       TrShutdown                              -> Info
       TrConnectionExists {}                   -> Info
       TrForbiddenConnection {}                -> Info
@@ -1770,9 +1769,9 @@ instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
       [ "kind" .= String "HandshakeServerError"
       , "reason" .= toJSON err
       ]
-  toObject _verb (TrError e err cerr) =
+  toObject _verb (TrConnectionHandlerError e err cerr) =
     mconcat
-      [ "kind" .= String "Error"
+      [ "kind" .= String "ConnectionHandlerError"
       , "context" .= show e
       , "reason" .= show err
       , "command" .= show cerr

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -19,7 +19,8 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
 
 * `valency` tells the node how many connections your node should have. It only has an effect for dns addresses. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection; for ip addresses, valency is used as a Boolean value, where `0` means to ignore the address.
 
-Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network. Go to our telegram channel to find out IP addresses and ports of peers.
+Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and
+the relay node should talk to other relay nodes in the network.
 
 #### The P2P topology.json file
 
@@ -101,6 +102,17 @@ You __can__ tell the node that the topology configuration file changed by sendin
 signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
 signal, `cardano-node` will re-read the file and restart all dns resolution. Please
 **note** that this only applies to the topology configuration file!
+
+If you are synchronizing the network for the first time, please connect to IOG
+relays `relays.cardano-node.iohk.io` by adding it to your local root peers and
+set `useLedgerAfterSlot` to `0` (to disable ledger peers).   You can use
+different relays as long as you trust them to provide you the honest chain.
+When the node is synced, you can remove it from the local root peers, you
+should also manually check if other stake pool relays are on the same chain as
+you are.  Once you enabled ledger peers by setting `useLedgerAfterSlot` the
+node will connect to relays registered on the chain, and churn through them by
+randomly picking new peers (weighted by stake distribution) and forgetting 20%
+least performing ones.
 
 #### The genesis.json file
 

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,6 @@
           inherit pinned-workbench;
           projectExes = flatten (haskellLib.collectComponents' "exes" projectPackages) // (with hsPkgsWithPassthru; {
             inherit (ouroboros-consensus-byron.components.exes) db-converter;
-            inherit (ouroboros-consensus-cardano.components.exes) db-analyser;
             inherit (bech32.components.exes) bech32;
           } // lib.optionalAttrs hostPlatform.isUnix {
             inherit (network-mux.components.exes) cardano-ping;
@@ -434,9 +433,6 @@
         cardanoNodeProject = flake.project.${final.system};
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
         inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api bech32 plutus-example;
-
-        # TODO, fix this
-        #db-analyser = ouroboros-network-snapshot.haskellPackages.ouroboros-consensus-cardano.components.exes.db-analyser;
       };
       nixosModules = {
         cardano-node = { pkgs, lib, ... }: {

--- a/nix/workbench/membench-overlay.nix
+++ b/nix/workbench/membench-overlay.nix
@@ -43,7 +43,7 @@ in
   mainnet-chain = cardano-mainnet-mirror.defaultPackage.${self.system};
 
   # TODO, fix this
-  #db-analyser = ouroboros-network-snapshot.haskellPackages.ouroboros-consensus-cardano.components.exes.db-analyser;
+  #db-analyser = ouroboros-network-snapshot.haskellPackages.ouroboros-consensus-cardano-tools.components.exes.db-analyser;
 
   ## 1. Ledger snapshot
   inherit node-snapshot;


### PR DESCRIPTION
The PR is supposed to update `cardano-node` with a newer version of `ouroboros-network` (and `cardano-ledger`).

The networking team decided to [not release P2P](https://github.com/input-output-hk/ouroboros-network/pull/3975) on `NodeToNodeV_10` and to avoid broken `cardano-node` (which would happen if `Conway` was released with incompatible version of `NodeToNodeV_10`).

This PR subsumes #4359.
