### PR TITLE
Allow assembling transactions with no witnesses

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -10,6 +10,7 @@
 
 - Add `query tx-mempool` ([PR 4276](https://github.com/input-output-hk/cardano-node/pull/4276))
 
+- Allow assembling transactions with no witnesses ([PR 4408](https://github.com/input-output-hk/cardano-node/pull/4408))
 
 ### Bugs
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -750,7 +750,7 @@ pTransaction =
 
   pTransactionSign  :: Parser TransactionCmd
   pTransactionSign = TxSign <$> pInputTxOrTxBodyFile
-                            <*> pSomeWitnessSigningData
+                            <*> many pWitnessSigningData
                             <*> optional pNetworkId
                             <*> pTxFile Output
 
@@ -764,7 +764,7 @@ pTransaction =
   pTransactionAssembleTxBodyWit :: Parser TransactionCmd
   pTransactionAssembleTxBodyWit = TxAssembleTxBodyWitness
                                     <$> pTxBodyFile Input
-                                    <*> some pWitnessFile
+                                    <*> many pWitnessFile
                                     <*> pOutputFile
 
   pTransactionSubmit :: Parser TransactionCmd
@@ -1665,9 +1665,8 @@ pWhichLeadershipSchedule = pCurrent <|> pNext
        <> Opt.help "Get the leadership schedule for the following epoch."
        )
 
-pSomeWitnessSigningData :: Parser [WitnessSigningData]
-pSomeWitnessSigningData =
-  some $
+pWitnessSigningData :: Parser WitnessSigningData
+pWitnessSigningData =
       KeyWitnessSigningData
         <$>
           ( SigningKeyFile <$>
@@ -1690,21 +1689,6 @@ pSigningKeyFile fdir =
       <> Opt.help (show fdir ++ " filepath of the signing key.")
       <> Opt.completer (Opt.bashCompleter "file")
       )
-
-pWitnessSigningData :: Parser WitnessSigningData
-pWitnessSigningData =
-    KeyWitnessSigningData
-      <$>
-        ( SigningKeyFile <$>
-            Opt.strOption
-              (  Opt.long "signing-key-file"
-              <> Opt.metavar "FILE"
-              <> Opt.help "Filepath of the signing key to be used in witness construction."
-              <> Opt.completer (Opt.bashCompleter "file")
-              )
-        )
-      <*>
-        optional pByronAddress
 
 pKesPeriod :: Parser KESPeriod
 pKesPeriod =


### PR DESCRIPTION
It's possible to write a script which requires no signatures, for
example

```
{
    "scripts": [
        {
            "keyHash": "df243ee05bbe556970c9f8b48088b90549b8c9e41a3380fdede62d16",
            "type": "sig"
        },
        {
            "keyHash": "452c6cc84a5430b4ff720d5692e0ce7f4d37b1f78a3bea99fdbab240",
            "type": "sig"
        },
        {
            "keyHash": "9b925a6b6462e0c7c48fc69a06d1e72d03da30655fd5af40e988140e",
            "type": "sig"
        }
    ],
    "type": "atLeast",
    "required": 0
}
```

As such, it should be supported by the CLI to assemble a transaction
with no witnesses.

Fixes: https://github.com/input-output-hk/cardano-node/issues/3835
Closes: https://github.com/input-output-hk/cardano-node/issues/4471