### PR TITLE
Infer protocol params in transaction build

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -10,9 +10,12 @@
 
 - Add `query tx-mempool` ([PR 4276](https://github.com/input-output-hk/cardano-node/pull/4276))
 
+
 ### Bugs
 
 - Allow reading signing keys from a pipe ([PR 4342](https://github.com/input-output-hk/cardano-node/pull/4342))
+
+- Query protocol parameters from the node in the `transaction build` command ([PR 4431](https://github.com/input-output-hk/cardano-node/pull/4431))
 
 ## 1.35.3 -- August 2022
 

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -3,6 +3,7 @@
 
 module Cardano.CLI.Helpers
   ( HelpersError(..)
+  , printWarning
   , deprecationWarning
   , ensureNewFile
   , ensureNewFileLBS
@@ -60,12 +61,18 @@ decodeCBOR
 decodeCBOR bs decoder =
   first CBORDecodingError $ deserialiseFromBytes decoder bs
 
-deprecationWarning :: String -> IO ()
-deprecationWarning cmd = do
+printWarning :: String -> IO ()
+printWarning warning = do
   ANSI.hSetSGR IO.stderr [SetColor Foreground Vivid Yellow]
-  IO.hPutStrLn IO.stderr $ "WARNING: This CLI command is deprecated.  Please use "
-                         <> cmd <> " command instead."
+  IO.hPutStrLn IO.stderr $ "WARNING: " <> warning
   ANSI.hSetSGR IO.stderr [Reset]
+    -- We need to flush, or otherwise what's on stdout may have the wrong colour
+    -- since it's likely sharing a console with stderr
+  IO.hFlush IO.stderr
+
+deprecationWarning :: String -> IO ()
+deprecationWarning cmd = printWarning $
+  "This CLI command is deprecated.  Please use " <> cmd <> " command instead."
 
 -- | Checks if a path exists and throws and error if it does.
 ensureNewFile :: (FilePath -> a -> IO ()) -> FilePath -> a -> ExceptT HelpersError IO ()


### PR DESCRIPTION
We now ignore the `--protocol-params-file` in the `transaction build` command. Instead we
fetch it from the node directly. If the user still supplies it, we display a warning, but otherwise
continue.

Fixes https://github.com/input-output-hk/cardano-node/issues/4058