### PR TITLE
Fix incorrect cardano-node versions in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.36.0}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.3-configs}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -15,7 +15,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.36.0}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-1.35.3-configs}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:


### PR DESCRIPTION
`cardano-node` version in `docker-compose.yml`  is incorrectly set to `1.36.0`. Revert back to the current latest release of `1.35.3-configs`.