### PR TITLE
Auto-balance multiasset transactions

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -36,6 +36,8 @@
   New type `BundledProtocolParameters` and new functions `bundleProtocolParams` and `unbundleProtocolParams`.
   ([PR4903](https://github.com/input-output-hk/cardano-node/pull/4903))
 
+- Auto-balance multi asset transactions ([PR 4450](https://github.com/input-output-hk/cardano-node/pull/4450))
+
 ### Bugs
 
 - Allow reading text envelopes from pipes ([PR 4384](https://github.com/input-output-hk/cardano-node/pull/4384))


### PR DESCRIPTION
Previously we gave up when the non-Ada part of a transaction wasn't balanced. We now balance the transaction and correctly update the fee accordingly (since the fee will be higher). We also return an error in the case where the is non-Ada change, but not at least minUTxO change (e.g. in the case where the Ada is already balanced).

Resolves: https://github.com/input-output-hk/cardano-node/issues/3068
Closes: https://github.com/input-output-hk/cardano-node/issues/4453