### PR TITLE
Changed severity of 'DiffusionErrored' log message

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -406,7 +406,7 @@ severityDiffusionInit ND.ListeningServerSocket {}             = Info
 severityDiffusionInit ND.ServerSocketUp {}                    = Info
 severityDiffusionInit ND.UnsupportedLocalSystemdSocket {}     = Info
 severityDiffusionInit ND.UnsupportedReadySocketCase {}        = Info
-severityDiffusionInit ND.DiffusionErrored {}                  = Info
+severityDiffusionInit ND.DiffusionErrored {}                  = Alert
 
 namesForDiffusionInit  :: ND.InitializationTracer rard ladr -> [Text]
 namesForDiffusionInit  ND.RunServer {}                         =

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -114,6 +114,7 @@ import qualified Ouroboros.Network.Diffusion as ND
 
 instance HasPrivacyAnnotation (ND.InitializationTracer ntnAddr ntcAddr)
 instance HasSeverityAnnotation (ND.InitializationTracer ntnAddr ntcAddr) where
+  getSeverityAnnotation ND.DiffusionErrored {} = Alert
   getSeverityAnnotation _ = Info
 
 instance HasPrivacyAnnotation (NtC.HandshakeTr LocalAddress NodeToClientVersion)


### PR DESCRIPTION
It ought to be an `Alert`, these are terminal errors which require
immediate attention from an operator.
