### PR TITLE
Separate validation and creation of transaction bodies

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -85,7 +85,7 @@ mkGenesisTransaction :: forall era .
   -> [TxOut CtxTx era]
   -> Tx era
 mkGenesisTransaction key ttl fee txins txouts
-  = case makeTransactionBody txBodyContent of
+  = case createAndValidateTransactionBody txBodyContent of
     Right b -> signShelleyTransaction b [WitnessGenesisUTxOKey key]
     Left err -> error $ show err
  where

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -101,7 +101,7 @@ metadataSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMeta
 metadataSize p m = dummyTxSize p m - dummyTxSize p Nothing
 
 dummyTxSizeInEra :: forall era . IsShelleyBasedEra era => TxMetadataInEra era -> Int
-dummyTxSizeInEra metadata = case makeTransactionBody dummyTx of
+dummyTxSizeInEra metadata = case createAndValidateTransactionBody dummyTx of
   Right b -> BS.length $ serialiseToCBOR b
   Left err -> error $ "metaDataSize " ++ show err
  where

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -75,7 +75,7 @@ genTx :: forall era. IsShelleyBasedEra era =>
   -> TxMetadataInEra era
   -> TxGenerator era
 genTx protocolParameters (collateral, collFunds) fee metadata inFunds outputs
-  = case makeTransactionBody txBodyContent of
+  = case createAndValidateTransactionBody txBodyContent of
       Left err -> Left $ show err
       Right b -> Right ( signShelleyTransaction b $ map WitnessPaymentKey allKeys
                        , getTxId b

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -609,7 +609,7 @@ genTxFee era =
 
 genTxBody :: IsCardanoEra era => CardanoEra era -> Gen (TxBody era)
 genTxBody era = do
-  res <- makeTransactionBody <$> genTxBodyContent era
+  res <- Api.createAndValidateTransactionBody <$> genTxBodyContent era
   case res of
     Left err -> fail (displayError err)
     Right txBody -> pure txBody

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -155,7 +155,8 @@ module Cardano.Api (
 
     -- ** Transaction bodies
     TxBody(TxBody),
-    makeTransactionBody,
+    createAndValidateTransactionBody,
+    makeTransactionBody, -- TODO: Remove
     TxBodyContent(..),
     TxBodyError(..),
     TxBodyScriptData(..),

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -934,7 +934,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- 3. update tx with fees
     -- 4. balance the transaction and update tx change output
     txbody0 <-
-      first TxBodyError $ makeTransactionBody txbodycontent
+      first TxBodyError $ createAndValidateTransactionBody txbodycontent
         { txOuts =
               TxOut changeaddr (lovelaceToTxOutValue 0) TxOutDatumNone ReferenceScriptNone
             : txOuts txbodycontent
@@ -974,7 +974,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
 
     let (dummyCollRet, dummyTotColl) = maybeDummyTotalCollAndCollReturnOutput txbodycontent changeaddr
     txbody1 <- first TxBodyError $ -- TODO: impossible to fail now
-               makeTransactionBody txbodycontent1 {
+               createAndValidateTransactionBody txbodycontent1 {
                  txFee  = TxFeeExplicit explicitTxFees $ Lovelace (2^(32 :: Integer) - 1),
                  txOuts = TxOut changeaddr
                                 (lovelaceToTxOutValue $ Lovelace (2^(64 :: Integer)) - 1)
@@ -998,7 +998,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- Here we do not want to start with any change output, since that's what
     -- we need to calculate.
     txbody2 <- first TxBodyError $ -- TODO: impossible to fail now
-               makeTransactionBody txbodycontent1 {
+               createAndValidateTransactionBody txbodycontent1 {
                  txFee = TxFeeExplicit explicitTxFees fee,
                  txReturnCollateral = retColl,
                  txTotalCollateral = reqCol
@@ -1027,7 +1027,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- would fit within 2^16-1. That's a possible optimisation.
     txbody3 <-
       first TxBodyError $ -- TODO: impossible to fail now
-        makeTransactionBody txbodycontent1 {
+        createAndValidateTransactionBody txbodycontent1 {
           txFee  = TxFeeExplicit explicitTxFees fee,
           txOuts = accountForNoChange
                      (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone)

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -9,7 +9,7 @@ import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleySc
 import           Cardano.Prelude
 import           Data.Type.Equality (TestEquality (testEquality))
 import           Gen.Cardano.Api.Typed (genTxBodyContent)
-import           Hedgehog (Property, annotateShow, failure, (===), MonadTest)
+import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))
 import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
@@ -24,7 +24,7 @@ prop_roundtrip_txbodycontent_txouts =
   H.property $ do
     content <- H.forAll $ genTxBodyContent BabbageEra
     -- Create the ledger body & auxiliaries
-    body <- case makeTransactionBody content of
+    body <- case createAndValidateTransactionBody content of
       Left err -> annotateShow err >> failure
       Right body -> pure body
     annotateShow body

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -165,7 +165,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             TxUpdateProposalNone
             TxMintNone
             TxScriptValidityNone
-    case makeTransactionBody txBodyCont of
+    case createAndValidateTransactionBody txBodyCont of
       Left err -> error $ "Error occurred while creating a Byron genesis based UTxO transaction: " <> show err
       Right txBody -> let bWit = fromByronWitness sk nId txBody
                       in makeSignedTransaction [bWit] txBody
@@ -207,7 +207,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
                      TxUpdateProposalNone
                      TxMintNone
                      TxScriptValidityNone
-  case makeTransactionBody txBodyCont of
+  case createAndValidateTransactionBody txBodyCont of
     Left err -> error $ "Error occurred while creating a Byron genesis based UTxO transaction: " <> show err
     Right txBody -> let bWit = fromByronWitness sk nId txBody
                     in makeSignedTransaction [bWit] txBody

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -402,7 +402,7 @@ runTxBuildRaw (AnyCardanoEra era)
 
     txBody <-
       firstExceptT ShelleyTxCmdTxBodyError . hoistEither $
-        makeTransactionBody txBodyContent
+        createAndValidateTransactionBody txBodyContent
 
     let noWitTx = makeSignedTransaction [] txBody
     firstExceptT ShelleyTxCmdWriteFileError . newExceptT $


### PR DESCRIPTION
Implement `createTransactionBody` and `createAndValidateTransactionBody`. We want to separate `TxBody` construction and validation to allow the creation of invalid transaction bodies.

Closes #3563 
