### PR TITLE
Separate IO from txBuild and txBuildRaw functions

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -8,6 +8,8 @@
 
 - Expose convenience functions `executeQueryCardanoMode`, `determineEra`, `constructBalancedTx` and `queryStateForBalancedTx` ([PR 4446](https://github.com/input-output-hk/cardano-node/pull/4446))
 
+- Expand `BalancedTxBody` to include `TxBodyContent` ([PR 4491](https://github.com/input-output-hk/cardano-node/pull/4491))
+
 ### Bugs
 
 - Allow reading text envelopes from pipes ([PR 4384](https://github.com/input-output-hk/cardano-node/pull/4384))

--- a/cardano-api/src/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Construction.hs
@@ -53,7 +53,7 @@ constructBalancedTx
   -> Either TxBodyErrorAutoBalance (Tx era)
 constructBalancedTx eInMode txbodcontent changeAddr mOverrideWits utxo pparams
                     eraHistory systemStart stakePools shelleyWitSigningKeys = do
-  BalancedTxBody txbody _txBalanceOutput _fee
+  BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
          eInMode systemStart eraHistory
          pparams stakePools utxo txbodcontent

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -1035,8 +1035,10 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
           txTotalCollateral = reqCol
         }
     txbody3 <-
-      first TxBodyError $ -- TODO: impossible to fail now
-        makeTransactionBody finalTxBodyContent
+      first TxBodyError $ -- TODO: impossible to fail now. We need to implement a function
+                          -- that simply creates a transaction body because we have already
+                          -- validated the transaction body earlier within makeTransactionBodyAutoBalance
+        createAndValidateTransactionBody finalTxBodyContent
     return (BalancedTxBody finalTxBodyContent txbody3 (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone) fee)
  where
    -- Essentially we check for the existence of collateral inputs. If they exist we

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -886,6 +886,7 @@ handleExUnitsErrors ScriptInvalid failuresMap exUnitsMap
 
 data BalancedTxBody era
   = BalancedTxBody
+      (TxBodyContent BuildTx era)
       (TxBody era)
       (TxOut CtxTx era) -- ^ Transaction balance (change output)
       Lovelace    -- ^ Estimated transaction fee
@@ -1025,9 +1026,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- fit within the encoding size we picked above when calculating the fee.
     -- Yes this could be an over-estimate by a few bytes if the fee or change
     -- would fit within 2^16-1. That's a possible optimisation.
-    txbody3 <-
-      first TxBodyError $ -- TODO: impossible to fail now
-        createAndValidateTransactionBody txbodycontent1 {
+    let finalTxBodyContent = txbodycontent1 {
           txFee  = TxFeeExplicit explicitTxFees fee,
           txOuts = accountForNoChange
                      (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone)
@@ -1035,7 +1034,10 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
           txReturnCollateral = retColl,
           txTotalCollateral = reqCol
         }
-    return (BalancedTxBody txbody3 (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone) fee)
+    txbody3 <-
+      first TxBodyError $ -- TODO: impossible to fail now
+        makeTransactionBody finalTxBodyContent
+    return (BalancedTxBody finalTxBodyContent txbody3 (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone) fee)
  where
    -- Essentially we check for the existence of collateral inputs. If they exist we
    -- create a fictitious collateral return output. Why? Because we need to put dummy values


### PR DESCRIPTION
First step towards condensing modules responsible for reading and validating the things required for transaction construction. The end goal is to expose these modules via `cardano-api` so users can implement their own transaction construction and/or validation functions.