### PR TITLE
Export `TextEnvelopeCddl(..)` from `Cardano.Api`

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -490,6 +490,7 @@ module Cardano.Api (
     deserialiseTxLedgerCddl,
     serialiseWitnessLedgerCddl,
     deserialiseWitnessLedgerCddl,
+    TextEnvelopeCddl(..),
     TextEnvelopeCddlError(..),
 
     -- *** Reading one of several key types


### PR DESCRIPTION
This is necessary to be able to refer to results of `deserialiseTxLedgerCddl`