### PR TITLE
remove JaredCorduan from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,8 +7,8 @@ cardano-cli/README.md                                         @Jimbo4350 @newhog
 cabal.project                                                 @Jimbo4350 @newhoggy @LaurenceIO
 
 # General reviewers per PR
-#                        Duncan   Jordan     Erik   John      Jared         Robert        Carlos
-*                        @dcoutts @Jimbo4350 @erikd @newhoggy @JaredCorduan @LudvikGalois @CarlosLopezDeLara
+#                        Duncan   Jordan     Erik   John      Robert        Carlos
+*                        @dcoutts @Jimbo4350 @erikd @newhoggy @LudvikGalois @CarlosLopezDeLara
 
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence


### PR DESCRIPTION
There are now enough members on the node team that can properly review node PRs (better than I can!), so I think it makes sense to remove me from the `CODEOWNERS` file. (Unless folks would prefer I stay on for the occasional PR when folks are on vacation, etc.)