### PR TITLE
trace-dispatcher: optional EKG.Store.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -314,8 +314,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ekg-forward
-  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
-  --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
+  tag: 8a21e6c3fd9b306e07e0e0f39047032c97789b38
+  --sha256: 170vgf94g6fhc2p2cx58gqy9520gs39ddl7q4lkqyr8h33p9wrvq
 
 source-repository-package
   type: git

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -96,7 +96,7 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
           -- TODO: check if this is the correct way to use withIOManager
           (forwardSink, dpStore) <- withIOManager $ \iomgr -> do
             let tracerSocketMode = Just . first unSocketPath =<< ncTraceForwardSocket nc
-            initForwarding iomgr trConfig networkMagic ekgStore tracerSocketMode
+            initForwarding iomgr trConfig networkMagic (Just ekgStore) tracerSocketMode
           pure (forwardTracer forwardSink, dataPointTracer dpStore)
         else
           -- Since 'Forwarder' backend isn't enabled, there is no forwarding.


### PR DESCRIPTION
This PR makes `EKG.Store` optional for `initForwarding`. Uses updated version of `ekg-forward` library.