### PR TITLE
Fix 4493 bug - TxWitness text envelope format does not roundtrip in Shelley era

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -439,7 +439,7 @@ instance IsCardanoEra era => HasTextEnvelope (KeyWitness era) where
     textEnvelopeType _ =
       case cardanoEra :: CardanoEra era of
         ByronEra   -> "TxWitnessByron"
-        ShelleyEra -> "TxWitnessShelley"
+        ShelleyEra -> "TxWitness ShelleyEra"
         AllegraEra -> "TxWitness AllegraEra"
         MaryEra    -> "TxWitness MaryEra"
         AlonzoEra  -> "TxWitness AlonzoEra"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -1759,7 +1759,7 @@ acceptKeyWitnessCDDLSerialisation err =
     firstExceptT (ShelleyTxCmdTextEnvCddlError tEnvErr)
           $ newExceptT $ readFileTextEnvelopeCddlAnyOf teTypes fp
 
-  teTypes = [ FromCDDLWitness "TxWitness Shelley" CddlWitness
+  teTypes = [ FromCDDLWitness "TxWitness ShelleyEra" CddlWitness
             , FromCDDLWitness "TxWitness AllegraEra" CddlWitness
             , FromCDDLWitness "TxWitness MaryEra" CddlWitness
             , FromCDDLWitness "TxWitness AlonzoEra" CddlWitness


### PR DESCRIPTION
Resolves: #4493 