### PR TITLE
de-Generic Env DMap preparation

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
@@ -14,7 +14,6 @@ import           Data.ByteString as BS (ByteString)
 import           Data.ByteString.Base16 as Base16
 import           Data.DList (DList)
 import qualified Data.DList as DL
-import           Data.Dependent.Sum ((==>))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -74,11 +73,8 @@ initConstants = do
   emit $ DefineSigningKey keyNameBenchmarkInputs keyBenchmarkInputs
   emit $ DefineSigningKey keyNameBenchmarkDone keyBenchmarkDone
   where
-    setConst :: Tag v -> v -> Compiler ()
-    setConst key val = emit $ Set $ key ==> val
-
     setN :: Tag v -> (NixServiceOptions -> v) -> Compiler ()
-    setN key s = askNixOption s >>= setConst key
+    setN key s = askNixOption s >>= emit . setConst key
 
 importGenesisFunds :: Compiler WalletName
 importGenesisFunds = do

--- a/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
@@ -19,7 +19,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 
 import           Cardano.Api
-import           Cardano.Benchmarking.Script.Setters
+import           Cardano.Benchmarking.Script.Setters(Tag(..))
 import           Cardano.Benchmarking.Script.Store (KeyName, Name (..), WalletName)
 import           Cardano.Benchmarking.Script.Types
 import           Cardano.TxGenerator.Setup.NixService

--- a/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Compiler.hs
@@ -18,6 +18,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 
 import           Cardano.Api
+import           Cardano.Benchmarking.Script.Action
 import           Cardano.Benchmarking.Script.Setters(Tag(..))
 import           Cardano.Benchmarking.Script.Store (KeyName, Name (..), WalletName)
 import           Cardano.Benchmarking.Script.Types

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -1,14 +1,58 @@
-module Cardano.Benchmarking.Script.Action
-where
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
+module Cardano.Benchmarking.Script.Action(
+          Action(AddFund, CancelBenchmark, DefineSigningKey, Delay,
+                InitWallet, LogMsg, ReadSigningKey, Reserved, Set,
+                SetProtocolParameters, StartProtocol, Submit,
+                WaitBenchmark, WaitForEra)
+        , action
+        , setConst
+) where
+
+import           GHC.Generics
+
+import           Control.Concurrent(threadDelay)
+import           Control.Monad.Trans.Except
 import           Data.Functor.Identity
-import           Data.Dependent.Sum (DSum(..))
-import qualified Data.Text as Text (unpack)
+import           Data.Dependent.Sum (DSum(..), (==>))
+import qualified Data.Text as Text (Text, unpack)
 
-import           Cardano.Benchmarking.Script.Core
+import           Cardano.Api (AnyCardanoEra, AsType(..),
+                   ExecutionUnits, FromSomeType(..), HasTextEnvelope,
+                   Lovelace, ScriptData, ScriptRedeemer, TextEnvelope,
+                   TextEnvelopeError, TxIn, castSigningKey,
+                   deserialiseFromTextEnvelopeAnyOf)
+import           Cardano.Benchmarking.OuroborosImports (PaymentKey, SigningKey, SigningKeyFile)
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.NodeConfig (startProtocol)
+import           qualified Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.Script.Types
+import           Cardano.Benchmarking.Script.Store
+import           Cardano.Benchmarking.Wallet
+import           Cardano.TxGenerator.Types
+
+type SetKeyVal = DSum Setters.Tag Identity
+
+data Action where
+  Set                :: !SetKeyVal -> Action
+--  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
+  InitWallet         :: !WalletName -> Action
+  StartProtocol      :: !FilePath -> !(Maybe FilePath) -> Action
+  Delay              :: !Double -> Action
+  ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
+  DefineSigningKey   :: !KeyName -> !TextEnvelope -> Action
+  AddFund            :: !AnyCardanoEra -> !WalletName -> !TxIn -> !Lovelace -> !KeyName -> Action
+  WaitBenchmark      :: !ThreadName -> Action
+  Submit             :: !AnyCardanoEra -> !SubmitMode -> !TxGenTxParams -> !Generator -> Action
+  CancelBenchmark    :: !ThreadName -> Action
+  Reserved           :: [String] -> Action
+  WaitForEra         :: !AnyCardanoEra -> Action
+  SetProtocolParameters :: ProtocolParametersSource -> Action
+  LogMsg             :: !Text.Text -> Action
+  deriving (Show, Eq)
+deriving instance Generic Action
 
 action :: Action -> ActionM ()
 action a = case a of
@@ -26,3 +70,30 @@ action a = case a of
   WaitForEra era -> waitForEra era
   LogMsg txt -> traceDebug $ Text.unpack txt
   Reserved options -> reserved options
+
+setConst :: Setters.Tag v -> v -> Action
+setConst key val = Set $ key ==> val
+
+{-
+This is for dirty hacking and testing and quick-fixes.
+Its a function that can be called from the JSON scripts
+and for which the JSON encoding is "reserved".
+-}
+reserved :: [String] -> ActionM ()
+reserved _ = do
+  throwE $ UserError "no dirty hack is implemented"
+
+defineSigningKey :: KeyName -> TextEnvelope -> ActionM ()
+defineSigningKey name descr
+  = case parseSigningKey descr of
+    Right key -> setName name key
+    Left err -> liftTxGenError $ ApiError err
+
+parseSigningKey :: TextEnvelope -> Either TextEnvelopeError (SigningKey PaymentKey)
+parseSigningKey = deserialiseFromTextEnvelopeAnyOf types
+  where
+    types :: [FromSomeType HasTextEnvelope (SigningKey PaymentKey)]
+    types =
+      [ FromSomeType (AsSigningKey AsGenesisUTxOKey) castSigningKey
+      , FromSomeType (AsSigningKey AsPaymentKey) id
+      ]

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -8,12 +8,11 @@ import qualified Data.Text as Text (unpack)
 import           Cardano.Benchmarking.Script.Core
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.NodeConfig (startProtocol)
-import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Types
 
 action :: Action -> ActionM ()
 action a = case a of
-  Set (key :=> (Identity val)) -> set (User key) val
+  Set (key :=> (Identity val)) -> setUser key val
   InitWallet name -> initWallet name
   SetProtocolParameters p -> setProtocolParameters p
   StartProtocol configFile cardanoTracerSocket -> startProtocol configFile cardanoTracerSocket

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -29,6 +29,8 @@ import           Cardano.Api.Shelley (ProtocolParameters)
 import           Cardano.CLI.Types (SigningKeyFile (..))
 import qualified Ouroboros.Network.Magic as Ouroboros (NetworkMagic (..))
 
+import           Cardano.Benchmarking.GeneratorTx
+import           Cardano.Benchmarking.Script.Action(Action)
 import           Cardano.Benchmarking.Script.Setters
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Types
@@ -162,6 +164,14 @@ parseScriptFileAeson = parseJSONFile fromJSON
 
 readProtocolParametersFile :: FilePath -> IO ProtocolParameters
 readProtocolParametersFile = parseJSONFile fromJSON
+
+setProtocolParameters :: ProtocolParametersSource -> ActionM ()
+setProtocolParameters s = case s of
+  QueryLocalNode -> do
+    set ProtocolParameterMode ProtocolParameterQuery
+  UseLocalProtocolFile file -> do
+    protocolParameters <- liftIO $ readProtocolParametersFile file
+    set ProtocolParameterMode $ ProtocolParameterLocal protocolParameters
 
 instance ToJSON KeyName         where toJSON (KeyName a) = toJSON a
 instance ToJSON ThreadName      where toJSON (ThreadName a) = toJSON a

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -13,7 +13,6 @@
 module Cardano.Benchmarking.Script.Env (
         ActionM
         , Error(..)
-        , SetKeyVal
         , runActionM
         , runActionMEnv
         , liftTxGenError
@@ -27,12 +26,12 @@ module Cardano.Benchmarking.Script.Env (
         , getName
         , setName
         , getUser
+        , setUser
 ) where
 
 import           Prelude
 import           Data.Functor.Identity
 import qualified Data.Text as Text
-import           Data.Dependent.Sum (DSum(..))
 import           Data.Dependent.Map (DMap)
 import qualified Data.Dependent.Map as DMap
 import           Control.Monad.IO.Class
@@ -62,8 +61,6 @@ runActionM = runActionMEnv emptyEnv
 runActionMEnv :: Env -> ActionM ret -> IOManager -> IO (Either Error ret, Env, ())
 runActionMEnv env action iom = RWS.runRWST (runExceptT action) iom env
 
-type SetKeyVal = DSum Setters.Tag Identity
-
 data Error where
   LookupError :: !(Store v)  -> Error
   TxGenError  :: !TxGenError -> Error
@@ -87,6 +84,9 @@ unSet key = lift $ RWS.modify $ (\e -> e { dmap = DMap.delete key (dmap e)})
 
 setName :: Name v -> v -> ActionM ()
 setName = set . Named
+
+setUser :: Tag v -> v -> ActionM ()
+setUser = set . User
 
 get :: Store v -> ActionM v
 get key = do

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -24,7 +24,7 @@ import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
 
 import           Cardano.TxGenerator.Types
 
-import           Cardano.Benchmarking.Script.Env
+import           Cardano.Benchmarking.Script.Env(SetKeyVal)
 import           Cardano.Benchmarking.Script.Store
 
 data Action where

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -9,11 +9,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Benchmarking.Script.Types (
-          Action(AddFund, CancelBenchmark, DefineSigningKey, Delay,
-                InitWallet, LogMsg, ReadSigningKey, Reserved, Set,
-                SetProtocolParameters, StartProtocol, Submit,
-                WaitBenchmark, WaitForEra)
-        , Generator(Cycle, NtoM, OneOf, RoundRobin, SecureGenesis,
+        Generator(Cycle, NtoM, OneOf, RoundRobin, SecureGenesis,
                 Sequence, Split, SplitN, Take)
         , PayMode(PayToAddr, PayToScript)
         , ProtocolParametersSource(QueryLocalNode, UseLocalProtocolFile)
@@ -22,47 +18,20 @@ module Cardano.Benchmarking.Script.Types (
         , SubmitMode(Benchmark, DiscardTX, DumpToFile, LocalSocket,
                 NodeToNode)
         , TargetNodes
-        , setConst
 ) where
 
 import           GHC.Generics
 import           Prelude
 
-import           Data.Functor.Identity
 import           Data.List.NonEmpty
-import           Data.Text (Text)
-import           Data.Dependent.Sum(DSum(..), (==>))
 
-import           Cardano.Api (AnyCardanoEra, ExecutionUnits, Lovelace, ScriptData, ScriptRedeemer,
-                   TextEnvelope, TxIn)
-import           Cardano.Benchmarking.OuroborosImports (SigningKeyFile)
+import           Cardano.Api (ExecutionUnits, Lovelace,
+                   ScriptData, ScriptRedeemer)
 import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
 
 import           Cardano.TxGenerator.Types
 
-import           qualified Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.Script.Store
-
-type SetKeyVal = DSum Setters.Tag Identity
-
-data Action where
-  Set                :: !SetKeyVal -> Action
---  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
-  InitWallet         :: !WalletName -> Action
-  StartProtocol      :: !FilePath -> !(Maybe FilePath) -> Action
-  Delay              :: !Double -> Action
-  ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
-  DefineSigningKey   :: !KeyName -> !TextEnvelope -> Action
-  AddFund            :: !AnyCardanoEra -> !WalletName -> !TxIn -> !Lovelace -> !KeyName -> Action
-  WaitBenchmark      :: !ThreadName -> Action
-  Submit             :: !AnyCardanoEra -> !SubmitMode -> !TxGenTxParams -> !Generator -> Action
-  CancelBenchmark    :: !ThreadName -> Action
-  Reserved           :: [String] -> Action
-  WaitForEra         :: !AnyCardanoEra -> Action
-  SetProtocolParameters :: ProtocolParametersSource -> Action
-  LogMsg             :: !Text -> Action
-  deriving (Show, Eq)
-deriving instance Generic Action
 
 data Generator where
   SecureGenesis :: !WalletName -> !KeyName -> !KeyName -> Generator -- 0 to N
@@ -116,7 +85,3 @@ data ScriptSpec = ScriptSpec
   }
   deriving (Show, Eq)
 deriving instance Generic ScriptSpec
-
-setConst :: Setters.Tag v -> v -> Action
-setConst key val = Set $ key ==> val
-

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -8,14 +8,30 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Cardano.Benchmarking.Script.Types
-where
+module Cardano.Benchmarking.Script.Types (
+          Action(AddFund, CancelBenchmark, DefineSigningKey, Delay,
+                InitWallet, LogMsg, ReadSigningKey, Reserved, Set,
+                SetProtocolParameters, StartProtocol, Submit,
+                WaitBenchmark, WaitForEra)
+        , Generator(Cycle, NtoM, OneOf, RoundRobin, SecureGenesis,
+                Sequence, Split, SplitN, Take)
+        , PayMode(PayToAddr, PayToScript)
+        , ProtocolParametersSource(QueryLocalNode, UseLocalProtocolFile)
+        , ScriptBudget(AutoScript, CheckScriptBudget, StaticScriptBudget)
+        , ScriptSpec(ScriptSpec, scriptSpecFile, scriptSpecBudget)
+        , SubmitMode(Benchmark, DiscardTX, DumpToFile, LocalSocket,
+                NodeToNode)
+        , TargetNodes
+        , setConst
+) where
 
 import           GHC.Generics
 import           Prelude
 
+import           Data.Functor.Identity
 import           Data.List.NonEmpty
 import           Data.Text (Text)
+import           Data.Dependent.Sum(DSum(..), (==>))
 
 import           Cardano.Api (AnyCardanoEra, ExecutionUnits, Lovelace, ScriptData, ScriptRedeemer,
                    TextEnvelope, TxIn)
@@ -24,8 +40,10 @@ import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
 
 import           Cardano.TxGenerator.Types
 
-import           Cardano.Benchmarking.Script.Env(SetKeyVal)
+import           qualified Cardano.Benchmarking.Script.Setters as Setters
 import           Cardano.Benchmarking.Script.Store
+
+type SetKeyVal = DSum Setters.Tag Identity
 
 data Action where
   Set                :: !SetKeyVal -> Action
@@ -98,3 +116,7 @@ data ScriptSpec = ScriptSpec
   }
   deriving (Show, Eq)
 deriving instance Generic ScriptSpec
+
+setConst :: Setters.Tag v -> v -> Action
+setConst key val = Set $ key ==> val
+


### PR DESCRIPTION
This is some access wrapping & code movement in preparation for switching out the Generic usage in the Env DMap.
It happens along several different points to date, namely Env itself, SetKeyVal, and the Set case of Action.
Separating out different Maps for different key/value types is the eventual hope, though this whole affair is largely to
start the conversation about the code, strategy, etc. and start familiarising myself with the codebase.

I'm going to clean up the hide-skv patch to avoid making spurious changes & moving code unnecessarily & do a different strategy from move-action in an nyc-api-2 branch I'll push shortly.