### PR TITLE
fix nix impurity

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,3 +1,3 @@
 { ... }@args:
 with (import ./flake-compat.nix args);
-defaultNix.legacyPackages.${builtins.currentSystem}
+defaultNix.legacyPackages.${args.system or builtins.currentSystem}

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -183,7 +183,7 @@ in {
 
       cardanoNodePackages = mkOption {
         type = types.attrs;
-        default = pkgs.cardanoNodePackages or (import ../. {}).cardanoNodePackages;
+        default = pkgs.cardanoNodePackages or (import ../. { inherit (pkgs) system; }).cardanoNodePackages;
         defaultText = "cardano-node packages";
         description = ''
           The cardano-node packages and library that should be used.


### PR DESCRIPTION
`builtins.currentSystem` is not available in pure evaluation.

Discovered while working on https://github.com/input-output-hk/cardano-db-sync/pull/1280.