### PR TITLE
cardano-testnet: add single entrypoint for starting testnets

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -11,11 +11,14 @@ import           Data.Maybe
 import           Spec.Chairman.Chairman (chairmanOver)
 import           System.FilePath ((</>))
 
+import           Testnet ( TestnetOptions( CardanoOnlyTestnetOptions),  testnet)
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified Test.Base as H
+import qualified Test.Runtime as H
 import qualified Testnet.Cardano as H
 import qualified Testnet.Conf as H
 
@@ -29,6 +32,6 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing
 
-  allNodes <- fmap H.nodeName . H.allNodes <$> H.testnet H.defaultTestnetOptions conf
+  allNodes <- fmap H.nodeName . H.allNodes <$> testnet (CardanoOnlyTestnetOptions H.defaultTestnetOptions) conf
 
   chairmanOver 120 50 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Shelley.hs
@@ -4,9 +4,7 @@ module Spec.Chairman.Shelley
   ( hprop_chairman
   ) where
 
-import           Control.Monad ((=<<))
-import           Data.Function
-import           Data.Maybe
+import           Prelude
 import           Spec.Chairman.Chairman (chairmanOver)
 import           System.FilePath ((</>))
 
@@ -15,12 +13,9 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified Test.Base as H
+import qualified Test.Runtime as H
 import qualified Testnet.Conf as H
 import qualified Testnet.Shelley as H
-
-{- HLINT ignore "Reduce duplication" -}
-{- HLINT ignore "Redundant <&>" -}
-{- HLINT ignore "Redundant flip" -}
 
 hprop_chairman :: H.Property
 hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
@@ -28,6 +23,6 @@ hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \temp
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing
 
-  allNodes <- H.testnet H.defaultTestnetOptions conf
+  allNodes <- fmap H.nodeName . H.allNodes <$> H.shelleyTestnet H.defaultTestnetOptions conf
 
   chairmanOver 120 21 conf allNodes

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -57,6 +57,7 @@ library
                         Test.Base
                         Test.Process
                         Test.Runtime
+                        Testnet
                         Testnet.Babbage
                         Testnet.Byron
                         Testnet.Cardano

--- a/cardano-testnet/src/Test/Process.hs
+++ b/cardano-testnet/src/Test/Process.hs
@@ -3,6 +3,7 @@ module Test.Process
   , assertByDeadlineMCustom
   , bashPath
   , execCli
+  , execCli_
   , execCli'
   , execCreateScriptContext
   , execCreateScriptContext'
@@ -51,6 +52,13 @@ execCli
   => [String]
   -> m String
 execCli = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI"
+
+-- | Run cardano-cli, discarding return value
+execCli_
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [String]
+  -> m ()
+execCli_ = void . execCli
 
 -- | Run cardano-cli, returning the stdout
 execCli'

--- a/cardano-testnet/src/Test/Runtime.hs
+++ b/cardano-testnet/src/Test/Runtime.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Runtime
   ( LeadershipSlot(..)
@@ -10,30 +9,37 @@ module Test.Runtime
   , PaymentKeyPair(..)
   , StakingKeyPair(..)
   , TestnetRuntime(..)
-  , TestnetNode(..)
+  , NodeRuntime(..)
   , PoolNode(..)
   , PoolNodeKeys(..)
   , Delegator(..)
+  , allNodes
   , bftSprockets
   , poolSprockets
-  , poolNodeToTestnetNode
+  , poolNodeStdout
   , readNodeLoggingFormat
+  , startNode
   ) where
 
+import           Prelude
+
+import           Control.Monad
 import           Data.Aeson (FromJSON)
-import           Data.Either (Either (..))
-import           Data.Eq (Eq)
-import           Data.Function (($), (.))
-import           Data.Functor (fmap)
-import           Data.Int (Int)
-import           Data.Semigroup (Semigroup ((<>)))
-import           Data.String (String)
+import qualified Data.List as L
+
 import           Data.Text (Text)
 import           GHC.Generics (Generic)
+import qualified Hedgehog as H
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
-import           System.IO (FilePath)
-import           Text.Show (Show (..))
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Stock.String as S
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
+import qualified Test.Process as H
 
+import           System.FilePath.Posix ((</>))
+import qualified System.Info as OS
 import qualified System.IO as IO
 import qualified System.Process as IO
 
@@ -43,13 +49,13 @@ data TestnetRuntime = TestnetRuntime
   { configurationFile :: FilePath
   , shelleyGenesisFile :: FilePath
   , testnetMagic :: Int
-  , bftNodes :: [TestnetNode]
+  , bftNodes :: [NodeRuntime]
   , poolNodes :: [PoolNode]
   , wallets :: [PaymentKeyPair]
   , delegators :: [Delegator]
   }
 
-data TestnetNode = TestnetNode
+data NodeRuntime = NodeRuntime
   { nodeName :: String
   , nodeSprocket :: Sprocket
   , nodeStdinHandle :: IO.Handle
@@ -59,13 +65,8 @@ data TestnetNode = TestnetNode
   }
 
 data PoolNode = PoolNode
-  { poolNodeName :: String
-  , poolNodeSprocket :: Sprocket
-  , poolNodeStdinHandle :: IO.Handle
-  , poolNodeStdout :: FilePath
-  , poolNodeStderr :: FilePath
-  , poolNodeProcessHandle :: IO.ProcessHandle
-  , poolNodeKeys :: PoolNodeKeys
+  { poolRuntime :: NodeRuntime
+  , poolKeys :: PoolNodeKeys
   }
 
 data PoolNodeKeys = PoolNodeKeys
@@ -97,31 +98,72 @@ data LeadershipSlot = LeadershipSlot
   , slotTime    :: Text
   } deriving (Eq, Show, Generic, FromJSON)
 
-poolNodeToTestnetNode :: PoolNode -> TestnetNode
-poolNodeToTestnetNode PoolNode
-  { poolNodeName
-  , poolNodeSprocket
-  , poolNodeStdinHandle
-  , poolNodeStdout
-  , poolNodeStderr
-  , poolNodeProcessHandle
-  } = TestnetNode
-  { nodeName = poolNodeName
-  , nodeSprocket = poolNodeSprocket
-  , nodeStdinHandle = poolNodeStdinHandle
-  , nodeStdout = poolNodeStdout
-  , nodeStderr = poolNodeStderr
-  , nodeProcessHandle = poolNodeProcessHandle
-  }
+poolNodeStdout :: PoolNode -> FilePath
+poolNodeStdout = nodeStdout . poolRuntime
 
 bftSprockets :: TestnetRuntime -> [Sprocket]
 bftSprockets = fmap nodeSprocket . bftNodes
 
 poolSprockets :: TestnetRuntime -> [Sprocket]
-poolSprockets = fmap poolNodeSprocket . poolNodes
+poolSprockets = fmap (nodeSprocket . poolRuntime) . poolNodes
 
 readNodeLoggingFormat :: String -> Either String NodeLoggingFormat
 readNodeLoggingFormat = \case
   "json" -> Right NodeLoggingFormatAsJson
   "text" -> Right NodeLoggingFormatAsText
   s -> Left $ "Unrecognised node logging format: " <> show s <> ".  Valid options: \"json\", \"text\""
+
+allNodes :: TestnetRuntime -> [NodeRuntime]
+allNodes tr = bftNodes tr <> fmap poolRuntime (poolNodes tr)
+
+-- | Start a node, creating file handles, sockets and temp-dirs.
+startNode
+  :: String
+  -- ^ The tempBaseAbsPath
+  -> FilePath
+  -- ^ The tempAbsPath
+  -> FilePath
+  -- ^ The log directory
+  -> FilePath
+  -- ^ The directory where the sockets are created
+  -> String
+  -- ^ The name of the node
+  -> [String]
+  -- ^ The command --socket-path and --port will be added automatically.
+  -> H.Integration NodeRuntime
+startNode tempBaseAbsPath tempAbsPath logDir socketDir node nodeCmd = do
+  dbDir <- H.noteShow $ tempAbsPath </> "db/" <> node
+  nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"
+  nodeStderrFile <- H.noteTempFile logDir $ node <> ".stderr.log"
+  sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
+
+  H.createDirectoryIfMissing dbDir
+  H.createDirectoryIfMissing $ tempBaseAbsPath </> socketDir
+
+  hNodeStdout <- H.openFile nodeStdoutFile IO.WriteMode
+  hNodeStderr <- H.openFile nodeStderrFile IO.WriteMode
+
+  H.diff (L.length (IO.sprocketArgumentName sprocket)) (<=) IO.maxSprocketArgumentNameLength
+
+  portString <- fmap S.strip . H.readFile $ tempAbsPath </> node </> "port"
+
+  (Just stdIn, _, _, hProcess, _) <- H.createProcess
+    . (\ cp
+         -> cp
+              {IO.std_in = IO.CreatePipe, IO.std_out = IO.UseHandle hNodeStdout,
+               IO.std_err = IO.UseHandle hNodeStderr,
+               IO.cwd = Just tempBaseAbsPath})
+    =<<
+      H.procNode
+        (nodeCmd
+           <>
+             [ "--socket-path", IO.sprocketArgumentName sprocket
+             , "--port", portString
+             ])
+
+  H.noteShowM_ $ H.getPid hProcess
+
+  when (OS.os `L.elem` ["darwin", "linux"]) $ do
+    H.onFailure . H.noteIO_ $ IO.readProcess "lsof" ["-iTCP:" <> portString, "-sTCP:LISTEN", "-n", "-P"] ""
+
+  return $ NodeRuntime node sprocket stdIn nodeStdoutFile nodeStderrFile hProcess

--- a/cardano-testnet/src/Testnet.hs
+++ b/cardano-testnet/src/Testnet.hs
@@ -1,0 +1,27 @@
+module Testnet
+  ( TestnetOptions(..)
+  , Testnet.testnet
+  ) where
+
+import           Data.Eq (Eq)
+import           Text.Show (Show)
+
+import qualified Hedgehog.Extras.Test.Base as H
+
+import           Testnet.Babbage
+import           Testnet.Cardano
+import           Testnet.Conf
+import           Testnet.Shelley
+
+data TestnetOptions
+  = ShelleyOnlyTestnetOptions ShelleyTestnetOptions
+  | BabbageOnlyTestnetOptions BabbageTestnetOptions
+  | CardanoOnlyTestnetOptions CardanoTestnetOptions
+  deriving (Eq, Show)
+
+testnet :: TestnetOptions -> Conf -> H.Integration TestnetRuntime
+testnet options = case options of
+  ShelleyOnlyTestnetOptions o -> shelleyTestnet o
+  BabbageOnlyTestnetOptions o -> babbageTestnet o
+  CardanoOnlyTestnetOptions o -> cardanoTestnet o
+

--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -82,4 +82,3 @@ queryTip (QueryTipOutput fp) testnetMag execConfig = do
   H.noteShowM $ H.jsonErrorFail $ fromJSON @QueryTipLocalStateOutput tipJSON
 
 newtype QueryTipOutput = QueryTipOutput { unQueryTipOutput :: FilePath}
-

--- a/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
@@ -40,9 +40,10 @@ import qualified System.Info as SYS
 import qualified Test.Base as H
 import qualified Test.Process as H
 import qualified Test.Runtime as TR
+import           Testnet (TestnetOptions( CardanoOnlyTestnetOptions ),  testnet)
 import qualified Testnet.Cardano as TC
-import           Testnet.Cardano (TestnetOptions (..), TestnetRuntime (..),
-                   defaultTestnetNodeOptions, defaultTestnetOptions, testnet)
+
+import           Testnet.Cardano (CardanoTestnetOptions(..), defaultTestnetNodeOptions, defaultTestnetOptions)
 import qualified Testnet.Conf as H
 import           Testnet.Conf (ProjectBase (..), YamlFilePath (..))
 import           Testnet.Utils (waitUntilEpoch)
@@ -60,7 +61,7 @@ hprop_kes_period_info = H.integration . H.runFinallies . H.workspace "chairman" 
     <- H.noteShowM $ H.mkConf (ProjectBase base) (YamlFilePath configurationTemplate)
                               tempAbsBasePath' Nothing
 
-  let fastTestnetOptions = defaultTestnetOptions
+  let fastTestnetOptions = CardanoOnlyTestnetOptions $ defaultTestnetOptions
                              { bftNodeOptions = replicate 1 defaultTestnetNodeOptions
                              , epochLength = 500
                              , slotLength = 0.02

--- a/cardano-testnet/test/Spec/Node/Shutdown.hs
+++ b/cardano-testnet/test/Spec/Node/Shutdown.hs
@@ -36,8 +36,6 @@ import qualified Test.Process as H
 import qualified Testnet.Conf as H
 
 {- HLINT ignore "Redundant <&>" -}
-{- HLINT ignore "Redundant return" -}
-{- HLINT ignore "Use let" -}
 
 hprop_shutdown :: Property
 hprop_shutdown = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/Spec/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Spec/ShutdownOnSlotSynced.hs
@@ -28,9 +28,11 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified Test.Base as H
-import           Testnet.Cardano (TestnetNode (..), TestnetNodeOptions (TestnetNodeOptions),
-                   TestnetOptions (..), TestnetRuntime (..), defaultTestnetNodeOptions,
-                   defaultTestnetOptions, testnet)
+import           Test.Runtime (NodeRuntime (..))
+import           Testnet (TestnetOptions( CardanoOnlyTestnetOptions),  testnet)
+import           Testnet.Cardano (TestnetNodeOptions (TestnetNodeOptions),
+                   CardanoTestnetOptions (..), TestnetRuntime (..), defaultTestnetNodeOptions,
+                   defaultTestnetOptions)
 import qualified Testnet.Cardano as TC
 import qualified Testnet.Conf as H
 
@@ -43,7 +45,7 @@ hprop_shutdownOnSlotSynced = H.integration . H.runFinallies . H.workspace "chair
     H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
   let maxSlot = 1500
       slotLen = 0.01
-  let fastTestnetOptions = defaultTestnetOptions
+  let fastTestnetOptions = CardanoOnlyTestnetOptions $ defaultTestnetOptions
         { epochLength = 300
         , slotLength = slotLen
         , bftNodeOptions =

--- a/cardano-testnet/testnet/Testnet/Commands/Babbage.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Babbage.hs
@@ -12,6 +12,7 @@ import           Data.Semigroup
 import           Options.Applicative
 import           System.IO (IO)
 import           Test.Runtime (readNodeLoggingFormat)
+import           Testnet
 import           Testnet.Babbage
 import           Testnet.Run (runTestnet)
 import           Text.Show
@@ -20,11 +21,11 @@ import qualified Options.Applicative as OA
 
 data BabbageOptions = BabbageOptions
   { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: TestnetOptions
+  , testnetOptions :: BabbageTestnetOptions
   } deriving (Eq, Show)
 
-optsTestnet :: Parser TestnetOptions
-optsTestnet = TestnetOptions
+optsTestnet :: Parser BabbageTestnetOptions
+optsTestnet = BabbageTestnetOptions
   <$> OA.option auto
       (   OA.long "num-spo-nodes"
       <>  OA.help "Number of SPO nodes"
@@ -74,7 +75,7 @@ optsBabbage = BabbageOptions
 
 runBabbageOptions :: BabbageOptions -> IO ()
 runBabbageOptions options = runTestnet (maybeTestnetMagic options) $
-  Testnet.Babbage.testnet (testnetOptions options)
+  Testnet.testnet (BabbageOnlyTestnetOptions $ testnetOptions options)
 
 cmdBabbage :: Mod CommandFields (IO ())
 cmdBabbage = command "babbage"  $ flip info idm $ runBabbageOptions <$> optsBabbage

--- a/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Cardano.hs
@@ -15,6 +15,7 @@ import           GHC.Enum
 import           Options.Applicative
 import           System.IO (IO)
 import           Test.Runtime (readNodeLoggingFormat)
+import           Testnet
 import           Testnet.Cardano
 import           Testnet.Run (runTestnet)
 import           Text.Read
@@ -25,11 +26,11 @@ import qualified Options.Applicative as OA
 
 data CardanoOptions = CardanoOptions
   { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: TestnetOptions
+  , testnetOptions :: CardanoTestnetOptions
   } deriving (Eq, Show)
 
-optsTestnet :: Parser TestnetOptions
-optsTestnet = TestnetOptions
+optsTestnet :: Parser CardanoTestnetOptions
+optsTestnet = CardanoTestnetOptions
   <$> OA.option
       ((`L.replicate` defaultTestnetNodeOptions) <$> auto)
       (   OA.long "num-bft-nodes"
@@ -101,7 +102,7 @@ optsCardano = CardanoOptions
 
 runCardanoOptions :: CardanoOptions -> IO ()
 runCardanoOptions options = runTestnet (maybeTestnetMagic options) $
-  Testnet.Cardano.testnet (testnetOptions options)
+  Testnet.testnet (CardanoOnlyTestnetOptions $ testnetOptions options)
 
 cmdCardano :: Mod CommandFields (IO ())
 cmdCardano = command "cardano"  $ flip info idm $ runCardanoOptions <$> optsCardano

--- a/cardano-testnet/testnet/Testnet/Commands/Shelley.hs
+++ b/cardano-testnet/testnet/Testnet/Commands/Shelley.hs
@@ -13,6 +13,7 @@ import           Data.Semigroup
 import           Options.Applicative
 import           System.IO (IO)
 import           Testnet.Run (runTestnet)
+import           Testnet
 import           Testnet.Shelley
 import           Text.Show
 
@@ -20,11 +21,11 @@ import qualified Options.Applicative as OA
 
 data ShelleyOptions = ShelleyOptions
   { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: TestnetOptions
+  , testnetOptions :: ShelleyTestnetOptions
   } deriving (Eq, Show)
 
-optsTestnet :: Parser TestnetOptions
-optsTestnet = TestnetOptions
+optsTestnet :: Parser ShelleyTestnetOptions
+optsTestnet = ShelleyTestnetOptions
   <$> OA.option auto
       (   OA.long "num-praos-nodes"
       <>  OA.help "Number of PRAOS nodes"
@@ -95,7 +96,7 @@ optsShelley = ShelleyOptions
 
 runShelleyOptions :: ShelleyOptions -> IO ()
 runShelleyOptions options = runTestnet (maybeTestnetMagic options) $
-  Testnet.Shelley.testnet (testnetOptions options)
+  Testnet.testnet (ShelleyOnlyTestnetOptions $ testnetOptions options)
 
 cmdShelley :: Mod CommandFields (IO ())
 cmdShelley = command "shelley"  $ flip info idm $ runShelleyOptions <$> optsShelley


### PR DESCRIPTION
This PR adds a single entry point for starting Shelley, Babbage and Cardano testnets.