### PR TITLE
Fix the workbench manifest

### DIFF
--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -76,6 +76,7 @@ in
             nativeBuildInputs = with cardanoNodePackages; with pkgs; [
               bash
               bech32
+              cabal-install
               coreutils
               gnused
               jq

--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -76,7 +76,7 @@ in
             nativeBuildInputs = with cardanoNodePackages; with pkgs; [
               bash
               bech32
-              cabal-install
+              cabalWrapped
               coreutils
               gnused
               jq

--- a/nix/workbench/cabal-plan-summary.sh
+++ b/nix/workbench/cabal-plan-summary.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+
+# for some reason you can't just put a heredoc in a variable...
+read -r -d '' USAGE << EOF
+cabal-plan-summary.sh DIR 
+  Prints a JSON document giving versions and sources for all the packages (and their components) in the cabal build plan.
+
+  DIR is the directory of the project. The plan.json file must exist, you need to run some cabal command that creates it first (e.g. 'cabal build all --dry-run').
+EOF
+
+if [ "$#" == "0" ]; then
+	echo "$USAGE"
+	exit 1
+fi
+
+PROJECT_DIR=$1
+
+PLAN_FILE=$PROJECT_DIR/dist-newstyle/cache/plan.json
+
+if [[ -f $PLAN_FILE ]]; then
+  CABAL_PLAN=$(cat "$PLAN_FILE")
+else
+  echo "Cabal plan file $PLAN_FILE does not exist, create it (e.g. by running 'cabal build all --dry-run') before starting" >&2
+  exit 1
+fi
+
+# The main jq filter to get stuff out of plan.json
+# - The packages live in `install-plan`
+# - Strip "pkg-" prefixes from a few fields
+# - Process the `src` field:
+#    - If it's a source-repo, then just replace it with the 
+#      description of the repo
+#    - If it's local, strip it out (not interesting)
+#    - Otherwise say "unknown" since it could come from anywhere
+FILTER='."install-plan" 
+  | .[] 
+  | { name: ."pkg-name", version: ."pkg-version", src: ."pkg-src", component: ."component-name" } 
+  | if .src.type == "source-repo" 
+    then .src = .src."source-repo" 
+    else if .src.type == "local" 
+    then empty 
+    else .src = "unknown" 
+    end end'
+
+MANIFEST=$(echo "$CABAL_PLAN" | jq "[$FILTER]")
+
+echo "$MANIFEST"

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -41,7 +41,7 @@ let
       jq
       moreutils
       procps
-      cabal-install
+      cabalWrapped
       cardano-cli
       cardano-topology
     ] ++ lib.optional (!pkgs.stdenv.hostPlatform.isDarwin) db-analyser

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -41,6 +41,7 @@ let
       jq
       moreutils
       procps
+      cabal-install
       cardano-cli
       cardano-topology
     ] ++ lib.optional (!pkgs.stdenv.hostPlatform.isDarwin) db-analyser

--- a/nix/workbench/manifest.sh
+++ b/nix/workbench/manifest.sh
@@ -62,7 +62,7 @@ case "${op}" in
         cabal build all --dry-run --builddir="$temp_builddir" >&2
         popd > /dev/null
 
-        plan_summary=$($(dirname $0)/cabal-plan-summary.sh "$temp_builddir/dist-newstyle/cache/plan.json")
+        plan_summary=$($(dirname $0)/cabal-plan-summary.sh "$temp_builddir/cache/plan.json")
 
         # Construct a filter that filters out entries that aren't in the list of pkgs,
         # and then construct the list of pkgs as a json object to pass to jq


### PR DESCRIPTION
This replaces the old code for generating manifest output in the workbench with a new one based on parsing `plan.json`. This gives us information about all components, including the source-repository they come from if they come from one. That gives us a generic way of listing all the component info.

We do need an explicit list of packages, since otherwise we can't distinguish our packages of interest from, say, random Hackage packages.

This doesn't yet fix the manifest report, but should be a step forwards.