### PR TITLE
Release 1.35.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state: 2022-09-27T00:00:00Z
-index-state: cardano-haskell-packages 2022-10-17T00:00:00Z
+index-state: cardano-haskell-packages 2022-10-21T19:20:00Z
 
 packages:
     cardano-api
@@ -88,20 +88,24 @@ constraints:
   , base-deriving-via == 0.1.0.0
   , cardano-binary  == 1.5.0
   , cardano-binary-test == 1.3.0
-  , cardano-crypto-class  == 2.0.0
+  , cardano-crypto-class  == 2.0.0.0.1
   , cardano-crypto-praos  == 2.0.0
   , cardano-crypto-tests  == 2.0.0
   , cardano-slotting  == 0.1.0.0
   , measures == 0.1.0.0
   , orphans-deriving-via == 0.1.0.0
   , strict-containers == 0.1.0.0
-  , plutus-core == 1.0.0.0
-  , plutus-ledger-api == 1.0.0.0
+  , plutus-core == 1.0.0.1
+  , plutus-ledger-api == 1.0.0.1
   , plutus-tx == 1.0.0.0
   , plutus-tx-plugin == 1.0.0.0
   , prettyprinter-configurable == 0.1.0.0
   , plutus-ghc-stub == 8.6.5
   , word-array == 0.1.0.0
+  , word-array == 0.1.0.0
+
+extra-packages:
+    ouroboros-consensus-cardano-tools == 0.1.0.0
 
 package snap-server
   flags: +openssl

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api
-version:                1.35.3
+version:                1.35.4
 description:            The cardano api
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-cli
-version:                1.35.3
+version:                1.35.4
 description:            The Cardano command-line interface.
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for cardano-node
 
+## 1.35.4 -- October 2022
+
+### node changes
+
+- Update plutus to version 1.0.0.1 to enable SECP at protocol version 8
+- Update cardano-crypto-class to version 2.0.0.0.2 to add SECP crypto primitives
+- Update block header advertised version in babbage to 8.0
+
 ## 1.35.3 -- August 2022
 
 ### node changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                1.35.3
+version:                1.35.4
 description:            The cardano full node
 author:                 IOHK
 maintainer:             operations@iohk.io

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -212,7 +212,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Babbage era. Since Babbage is currently the last known
           -- protocol version then this is also the Babbage protocol version.
-          Praos.babbageProtVer = ProtVer 7 0,
+          Praos.babbageProtVer = ProtVer 8 0,
           Praos.babbageMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }

--- a/flake.lock
+++ b/flake.lock
@@ -3,14 +3,18 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1666380176,
-        "narHash": "sha256-lH1kQsWkV2lGRJaSfrfxVEaq50rMGyBq6NIYG2CHsYA=",
-        "path": "/home/sam/work/iohk/cardano-haskell-packages/_repo",
-        "type": "path"
+        "lastModified": 1666576849,
+        "narHash": "sha256-FDFmN3TzQsUjNxGlKKTFpLOUOnvsQMNI4o3MahJw9zA=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "97aab5bc3f59108d97a6bb0c4d07ae1b79b005ca",
+        "type": "github"
       },
       "original": {
-        "path": "/home/sam/work/iohk/cardano-haskell-packages/_repo",
-        "type": "path"
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
       }
     },
     "HTTP": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,18 +3,14 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1666067814,
-        "narHash": "sha256-2TbQs7HSZRY5G3/jDggaY8ahxY8V5DhQ/+Xg1B9csTY=",
-        "owner": "input-output-hk",
-        "repo": "cardano-haskell-packages",
-        "rev": "e79a09bf6018fa0e5c3196f0ac01e58224caf73d",
-        "type": "github"
+        "lastModified": 1666380176,
+        "narHash": "sha256-lH1kQsWkV2lGRJaSfrfxVEaq50rMGyBq6NIYG2CHsYA=",
+        "path": "/home/sam/work/iohk/cardano-haskell-packages/_repo",
+        "type": "path"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "repo",
-        "repo": "cardano-haskell-packages",
-        "type": "github"
+        "path": "/home/sam/work/iohk/cardano-haskell-packages/_repo",
+        "type": "path"
       }
     },
     "HTTP": {

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
               packages = lib.genAttrs [
                 "ouroboros-consensus"
                 "ouroboros-consensus-cardano"
+                "ouroboros-consensus-cardano-tools"
                 "ouroboros-consensus-byron"
                 "ouroboros-consensus-shelley"
                 "ouroboros-network"
@@ -182,6 +183,7 @@
           projectExes = flatten (haskellLib.collectComponents' "exes" projectPackages) // (with hsPkgsWithPassthru; {
             inherit (ouroboros-consensus-byron.components.exes) db-converter;
             inherit (ouroboros-consensus-cardano.components.exes) db-analyser;
+            inherit (ouroboros-consensus-cardano-tools.components.exes) db-synthesizer;
             inherit (bech32.components.exes) bech32;
           } // lib.optionalAttrs hostPlatform.isUnix {
             inherit (network-mux.components.exes) cardano-ping;


### PR DESCRIPTION
This is initial test of plutus/base bump that this works. Will cut a version of base at 2.0.0.0.1. Will also look at seeing if we can includedb-syhtnesizer from orouboros-network in a minimal change, as well as any CLI improvements that don't require changes to consensus/ledger.