### PR TITLE
Replace usage of QueryGenesisParameters by on that only fetches KES parameters

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,8 +131,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
+  tag: b8d1e10873708fe86e430a24fe635a6125d55938
+  --sha256: 132l9y1hx2cdpimknb5x015k6npks41nrmfwyjj43yvb927irvm9
   subdir:
     monoidal-synchronisation
     network-mux

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -196,6 +196,14 @@ data QueryInEra era result where
 deriving instance Show (QueryInEra era result)
 
 
+fromConsensusKESConfig :: Consensus.KESConfig -> KESConfig
+fromConsensusKESConfig consensusKESConfig = KESConfig {
+    kcSlotsPerKESPeriod = Consensus.kcSlotsPerKESPeriod consensusKESConfig
+  , kcMaxKESEvolutions = Consensus.kcMaxKESEvolutions consensusKESConfig
+  , kcSystemStart = Consensus.kcSystemStart consensusKESConfig
+  }
+
+
 data KESConfig = KESConfig {
     -- | For Ouroboros Praos, the length of a KES period as a number of time
     -- slots. The KES keys get evolved once per KES period.
@@ -550,7 +558,8 @@ toConsensusQueryShelleyBased
 toConsensusQueryShelleyBased erainmode QueryEpoch =
     Some (consensusQueryInEraInMode erainmode Consensus.GetEpochNo)
 
-toConsensusQueryShelleyBased erainmode QueryKESConfig = undefined -- TODO
+toConsensusQueryShelleyBased erainmode QueryKESConfig =
+    Some (consensusQueryInEraInMode erainmode Consensus.GetKESConfig)
 
 toConsensusQueryShelleyBased erainmode QueryProtocolParameters =
     Some (consensusQueryInEraInMode erainmode Consensus.GetCurrentPParams)
@@ -765,7 +774,10 @@ fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryKESConfig q' epoch = undefined -- TODO
+fromConsensusQueryResultShelleyBased _ QueryKESConfig q' consensusKESConfig =
+  case q' of
+    Consensus.GetKESConfig -> fromConsensusKESConfig consensusKESConfig
+    _                      -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased era QueryProtocolParameters q' r' =
     case q' of

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -550,6 +550,8 @@ toConsensusQueryShelleyBased
 toConsensusQueryShelleyBased erainmode QueryEpoch =
     Some (consensusQueryInEraInMode erainmode Consensus.GetEpochNo)
 
+toConsensusQueryShelleyBased erainmode QueryKESConfig = undefined -- TODO
+
 toConsensusQueryShelleyBased erainmode QueryProtocolParameters =
     Some (consensusQueryInEraInMode erainmode Consensus.GetCurrentPParams)
 
@@ -762,6 +764,8 @@ fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
     case q' of
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
+
+fromConsensusQueryResultShelleyBased _ QueryKESConfig q' epoch = undefined -- TODO
 
 fromConsensusQueryResultShelleyBased era QueryProtocolParameters q' r' =
     case q' of

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -19,6 +19,7 @@
 -- | Queries from local clients to the node.
 --
 module Cardano.Api.Query (
+    KESConfig (..),
 
     -- * Queries
     QueryInMode(..),
@@ -83,6 +84,7 @@ import           Data.SOP.Strict (SListI)
 import           Data.Text (Text)
 import           Data.Typeable
 import           Prelude
+import           Data.Time (UTCTime)
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
 
@@ -195,12 +197,35 @@ data QueryInEra era result where
 deriving instance Show (QueryInEra era result)
 
 
+data KESConfig = KESConfig {
+    -- | For Ouroboros Praos, the length of a KES period as a number of time
+    -- slots. The KES keys get evolved once per KES period.
+    --
+    kcSlotsPerKESPeriod :: Int
+
+    -- | The maximum number of times a KES key can be evolved before it is
+    -- no longer considered valid. This can be less than the maximum number
+    -- of times given the KES key size. For example the mainnet KES key size
+    -- would allow 64 evolutions, but the max KES evolutions param is 62.
+    --
+  , kcMaxKESEvolutions :: Int
+
+    -- | The reference time the system started. The time of slot zero.
+    -- The time epoch against which all Ouroboros time slots are measured.
+    --
+  , kcSystemStart :: UTCTime
+}
+
+
 data QueryInShelleyBasedEra era result where
   QueryEpoch
     :: QueryInShelleyBasedEra era EpochNo
 
   QueryGenesisParameters
     :: QueryInShelleyBasedEra era GenesisParameters
+
+  QueryKESConfig
+    :: QueryInShelleyBasedEra era KESConfig
 
   QueryProtocolParameters
     :: QueryInShelleyBasedEra era ProtocolParameters

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -121,7 +121,6 @@ import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
-import           Cardano.Api.GenesisParameters
 import           Cardano.Api.KeysShelley
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
@@ -220,9 +219,6 @@ data KESConfig = KESConfig {
 data QueryInShelleyBasedEra era result where
   QueryEpoch
     :: QueryInShelleyBasedEra era EpochNo
-
-  QueryGenesisParameters
-    :: QueryInShelleyBasedEra era GenesisParameters
 
   QueryKESConfig
     :: QueryInShelleyBasedEra era KESConfig
@@ -554,9 +550,6 @@ toConsensusQueryShelleyBased
 toConsensusQueryShelleyBased erainmode QueryEpoch =
     Some (consensusQueryInEraInMode erainmode Consensus.GetEpochNo)
 
-toConsensusQueryShelleyBased erainmode QueryGenesisParameters =
-    Some (consensusQueryInEraInMode erainmode Consensus.GetGenesisConfig)
-
 toConsensusQueryShelleyBased erainmode QueryProtocolParameters =
     Some (consensusQueryInEraInMode erainmode Consensus.GetCurrentPParams)
 
@@ -769,12 +762,6 @@ fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
     case q' of
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
-
-fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =
-    case q' of
-      Consensus.GetGenesisConfig -> fromShelleyGenesis
-                                      (Consensus.getCompactGenesis r')
-      _                          -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased era QueryProtocolParameters q' r' =
     case q' of


### PR DESCRIPTION
This PR is a proposal to remove usage of the bulky `QueryGenesisParameters` query from ouroboros-network, by a new, lighter query, `GetKESConfig`. As I see it, merging this PR would have the following benefit of reducing the interface between `cardano-node` and `ouroboros-consensus`.

The PR that introduces the `GetKESConfig` query in `ouroboros-consensus` is https://github.com/input-output-hk/ouroboros-network/pull/4156.

Also, there is probably additional cleaning up to do, e.g., removing parts of [Cardano.Api.GenesisParameters](https://github.com/input-output-hk/cardano-node/blob/8832f86728ef6a425452b44f2f269acde149448c/cardano-api/src/Cardano/Api/GenesisParameters.hs#L8). Again, I have postponed doing that until green light.