### PR TITLE
submit-api: add tx_submit_fail_count metric

### DIFF
--- a/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
@@ -7,7 +7,7 @@ module Cardano.TxSubmit.Metrics
   , registerMetricsServer
   ) where
 
-import           Control.Applicative (Applicative (pure), (<$>))
+import           Control.Applicative (Applicative (pure), (<$>), (<*>))
 import           Control.Concurrent.Async (Async, async)
 import           Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
 import           Data.Function (($), (.))
@@ -18,8 +18,9 @@ import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..),
 import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)
 import           System.Metrics.Prometheus.Metric.Gauge (Gauge)
 
-newtype TxSubmitMetrics = TxSubmitMetrics
+data TxSubmitMetrics = TxSubmitMetrics
   { tsmCount :: Gauge
+  , tsmFailCount :: Gauge
   }
 
 registerMetricsServer :: IO (TxSubmitMetrics, Async ())
@@ -31,4 +32,6 @@ registerMetricsServer =
     pure (metrics, server)
 
 makeMetrics :: RegistryT IO TxSubmitMetrics
-makeMetrics = TxSubmitMetrics <$> registerGauge "tx_submit_count" mempty
+makeMetrics = TxSubmitMetrics
+  <$> registerGauge "tx_submit_count" mempty
+  <*> registerGauge "tx_submit_fail_count" mempty

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -181,6 +181,7 @@ txSubmitPost trace metrics (AnyConsensusModeParams cModeParams) networkId (Socke
             liftIO $ logInfo trace $
               "txSubmitPost: failed to submit transaction: "
                 <> renderTxCmdError err
+            liftIO $ Gauge.inc (tsmFailCount metrics)
             errorResponse (TxSubmitFail err)
           Right txid -> do
             liftIO $ logInfo trace $


### PR DESCRIPTION
Similar to `tx_submit_count` for failed submissions.

Closes #3233.

Original PR: https://github.com/input-output-hk/cardano-node/pull/3235