### PR TITLE
Expose txScriptValidityToScriptValidity in Cardano.API

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -266,6 +266,7 @@ module Cardano.Api (
     scriptValidityToTxScriptValidity,
     txScriptValiditySupportedInShelleyBasedEra,
     txScriptValiditySupportedInCardanoEra,
+    txScriptValidityToScriptValidity,
 
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.


### PR DESCRIPTION
The function is needed in Marconi and we had to duplicate it at the moment, it would be great if we could simply import it.