### PR TITLE
Add LedgerStateBabbage patter synonym

### DIFF
--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -274,11 +274,17 @@ pattern LedgerStateAlonzo
   -> LedgerState
 pattern LedgerStateAlonzo st <- LedgerState  (Consensus.LedgerStateAlonzo st)
 
+pattern LedgerStateBabbage
+  :: Ledger.LedgerState (Shelley.ShelleyBlock protocol (Shelley.AlonzoEra Shelley.StandardCrypto))
+  -> LedgerState
+pattern LedgerStateBabbage st <- LedgerState  (Consensus.LedgerStateBabbage st)
+
 {-# COMPLETE LedgerStateByron
            , LedgerStateShelley
            , LedgerStateAllegra
            , LedgerStateMary
-           , LedgerStateAlonzo #-}
+           , LedgerStateAlonzo
+           , LedgerStateBabbage #-}
 
 data FoldBlocksError
   = FoldBlocksInitialLedgerStateError InitialLedgerStateError

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -21,6 +21,7 @@ module Cardano.Api.LedgerState
       , LedgerStateAllegra
       , LedgerStateMary
       , LedgerStateAlonzo
+      , LedgerStateBabbage
       )
   , initialLedgerState
   , applyBlock
@@ -275,7 +276,7 @@ pattern LedgerStateAlonzo
 pattern LedgerStateAlonzo st <- LedgerState  (Consensus.LedgerStateAlonzo st)
 
 pattern LedgerStateBabbage
-  :: Ledger.LedgerState (Shelley.ShelleyBlock protocol (Shelley.AlonzoEra Shelley.StandardCrypto))
+  :: Ledger.LedgerState (Shelley.ShelleyBlock protocol (Shelley.BabbageEra Shelley.StandardCrypto))
   -> LedgerState
 pattern LedgerStateBabbage st <- LedgerState  (Consensus.LedgerStateBabbage st)
 

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -278,6 +278,8 @@ main = do
                        ("mary",    L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
                      LedgerStateAlonzo    (Shelley.ShelleyLedgerState _ ls _) ->
                        ("alonzo",  L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
+                     LedgerStateBabbage  (Shelley.ShelleyLedgerState _ ls _) ->
+                       ("babbage", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
 
              let txBodyComponents = map ( (\(TxBody txbc) -> txbc) . getTxBody ) transactions
 


### PR DESCRIPTION
(Couldn't test the change because when running `cabal build cardano-node` I get:
```
unknown package: cardano-binary (dependency of byron-spec-ledger)
```

`cardano-binary` appears to be a package in the `cardano-base` repository, which is not linked from cardano-node's cabal.project -- is cardano-binary gotten through other means?)