### PR TITLE
Enable stale bot

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.  Remove stale label or comment or this will be closed in 120 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 120 days with no activity.  Remove stale label or comment or this will be closed in 60 days.'
+          close-pr-message: 'This issue was closed because it has been stalled for 60 days with no activity.'
+          days-before-stale: 30
+          days-before-close: 120
+          days-before-pr-stale: 45
+          days-before-pr-close: 60


### PR DESCRIPTION
At `1:30am` each day, run the stale bot.

The stale bot will apply the `Stale` label to:
* any issue that has no activity for more than 30 days
* any pr that has no activity for more than 45 days.

Furthermore:
* `Stale` issues will be closed after 120 days of no activity.
* `Stale` prs will be closed after 60 days of no activity
