### PR TITLE
Update ouroboros-network and cardano-ledger dependencies

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -133,6 +133,7 @@ library
                      , unordered-containers
                      , utf8-string
                      , vector
+                     , cardano-strict-containers == 0.1.0.1
 
 executable locli
   import:              base

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -14,8 +14,8 @@ import           Cardano.Prelude (forever, liftIO)
 import           Prelude
 
 import           Codec.Serialise (DeserialiseFailure)
+import           Control.Concurrent.Class.MonadSTM.Strict (newTVarIO)
 import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
-import           Control.Monad.Class.MonadSTM.Strict (newTVarIO)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
@@ -23,8 +23,8 @@ import           Network.Socket (AddrInfo (..))
 import           System.Random (newStdGen)
 
 import           "contra-tracer" Control.Tracer (Tracer, nullTracer)
-import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx)
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx)
 import qualified Ouroboros.Consensus.Cardano as Consensus (CardanoBlock)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Network.NodeToNode (Codecs (..), defaultCodecs)
@@ -37,19 +37,18 @@ import           Ouroboros.Network.DeltaQ (defaultGSV)
 import           Ouroboros.Network.Driver (runPeerWithLimits)
 import           Ouroboros.Network.KeepAlive
 import           Ouroboros.Network.Magic
-import           Ouroboros.Network.Mux (MuxPeer (..), OuroborosApplication (..),
-                                        OuroborosBundle, RunMiniProtocol (..),
-                                        continueForever)
-import           Ouroboros.Network.NodeToClient (chainSyncPeerNull, IOManager)
+import           Ouroboros.Network.Mux (MuxPeer (..), OuroborosApplication (..), OuroborosBundle,
+                   RunMiniProtocol (..), continueForever)
+import           Ouroboros.Network.NodeToClient (IOManager, chainSyncPeerNull)
 import           Ouroboros.Network.NodeToNode (NetworkConnectTracers (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.Protocol.BlockFetch.Client (BlockFetchClient (..),
-                                                               blockFetchClientPeer)
+                   blockFetchClientPeer)
 import           Ouroboros.Network.Protocol.Handshake.Version (simpleSingletonVersions)
-import           Ouroboros.Network.Protocol.KeepAlive.Codec
 import           Ouroboros.Network.Protocol.KeepAlive.Client
+import           Ouroboros.Network.Protocol.KeepAlive.Codec
 import           Ouroboros.Network.Protocol.TxSubmission2.Client (TxSubmissionClient,
-                                                                  txSubmissionClientPeer)
+                   txSubmissionClientPeer)
 
 import           Ouroboros.Network.Snocket (socketSnocket)
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -103,7 +103,7 @@ library
                      , formatting
                      , generic-monoid
                      , ghc-prim
-                     , io-classes
+                     , io-classes ^>= 0.3
                      , network
                      , network-mux
                      , optparse-applicative-fork

--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for information about these, including some Nix commands 
 -- you need to run if you change them
-index-state: 2022-07-01T00:00:00Z
-index-state: cardano-haskell-packages 2022-10-20T00:00:00Z
+index-state: 2022-11-11T00:00:00Z
+index-state: cardano-haskell-packages 2022-11-12T20:00:00Z
 
 packages:
     cardano-api
@@ -81,30 +81,17 @@ constraints:
     -- that dependency
   , network >= 3.1.1.0
   , HSOpenSSL >= 0.11.7.2
-
-  -- CONSTRAINTS FOR UPSTREAM CARDANO PACKAGES
-  -- These should all be constraints in upstream packages, but are currently missing.
-  -- We should a) fix these upstream and b) revise the constraints  on the released
-  -- version in CHaP. Unfortunately revisions in CHaP don't work yet, revisit this
-  -- when we fix it.
-
-  -- cardano-prelude: newer protolude changes some signatures in a breaking way, fixed
-  -- in newer cardano-prelude which we can't use yet
-  , protolude < 0.3.1
-  -- cardano-crypto-wrapper: broken by cardano-prelude-0.1.0.1 which moves HeapWords out
-  , cardano-prelude < 0.1.0.1
-  -- cardano-ledger-byron: broken by cardano-binary-1.5.0.1 which includes some functions 
-  -- that used to be in cardano-prelude
-  , cardano-binary < 1.5.0.1
-  -- ledger: cardano-crypto-class-2.0.0.1 is missing some instances needed by the ledger
-  , cardano-crypto-class < 2.0.0.1
-  -- cardano-crypto-tests: we required cardano-crypto-class-2.0.0.0 above, which is broken with
-  -- newer cardano-crypto-tests
-  , cardano-crypto-tests < 2.0.0.1
-  -- plutus-core 1.0.0.1 has the fixed SECP primitives which relies on the newer cardano-crypto-class
-  , plutus-core < 1.0.0.1
-  -- plutus-core: needs a constraint here, fixed on plutus master but not in the released version
   , algebraic-graphs < 0.7
+  , protolude >= 0.3.2
+
+  -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
+
+  -- Needed until ouroboros-network gets proper bounds
+  , cardano-binary  == 1.5.0
+
+-- We'll need this once ouroboros has been pushed into CHaP
+-- extra-packages:
+--     ouroboros-consensus-cardano-tools == 0.1.0.0
 
 package snap-server
   flags: +openssl
@@ -113,7 +100,9 @@ package comonad
   flags: -test-doctests
 
 allow-newer:
-  *:aeson,
+  ekg:aeson,
+  ekg-json:aeson,
+  threepenny-gui:aeson,
   monoidal-containers:aeson,
   size-based:template-haskell,
   snap-server:attoparsec,
@@ -128,58 +117,22 @@ source-repository-package
   tag: 4ec92ded05ccf59ba4a874be4b404ac1b6d666b6
   --sha256: 00fvvaf4ir4hskq4a6gggbh2wmdvy8j8kn6s4m1p1vlh8m8mq514
 
+-- And has the adjustments for the ledger refactor
 source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
-  subdir:
-    monoidal-synchronisation
-    network-mux
-    ouroboros-consensus
-    ouroboros-consensus-byron
-    ouroboros-consensus-cardano
-    ouroboros-consensus-protocol
-    ouroboros-consensus-shelley
-    ouroboros-network
-    ouroboros-network-framework
-    ouroboros-network-testing
+   type: git
+   location: https://github.com/input-output-hk/ouroboros-network
+   tag: a6cc54677ad967af24da91e563c360407d41314e
+   --sha256: 0p3xcvqa4vr7aqxx2ds32qha9n28sliixamsp7jp5c9igd1x25h7
+   subdir:
+     monoidal-synchronisation
+     network-mux
+     ouroboros-consensus
+     ouroboros-consensus-byron
+     ouroboros-consensus-cardano
+     ouroboros-consensus-protocol
+     ouroboros-consensus-shelley
+     ouroboros-network
+     ouroboros-network-framework
+     ouroboros-network-testing
+     ouroboros-consensus-cardano-tools     
 
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: f49879a79098d9372d63baa13b94a941a56eda34
-  --sha256: 0i9x66yqkrvx2w79dy6lzlya82yxc8567rgjj828vc2d46d6nvx6
-  subdir:
-    eras/alonzo/impl
-    eras/alonzo/test-suite
-    eras/babbage/impl
-    eras/babbage/test-suite
-    eras/byron/chain/executable-spec
-    eras/byron/crypto
-    eras/byron/crypto/test
-    eras/byron/ledger/executable-spec
-    eras/byron/ledger/impl
-    eras/byron/ledger/impl/test
-    eras/shelley/impl
-    eras/shelley/test-suite
-    eras/shelley-ma/impl
-    eras/shelley-ma/test-suite
-    libs/cardano-ledger-core
-    libs/cardano-ledger-pretty
-    libs/cardano-protocol-tpraos
-    libs/cardano-data
-    libs/vector-map
-    libs/set-algebra
-    libs/small-steps
-    libs/small-steps-test
-    libs/non-integral
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 6ea36cf2247ac0bc33e08c327abec34dfd05bd99
-  --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
-  subdir:
-    cardano-prelude
-    cardano-prelude-test

--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,7 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- See CONTRIBUTING for information about these, including some Nix commands 
+-- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state: 2022-11-11T00:00:00Z
 index-state: cardano-haskell-packages 2022-11-12T20:00:00Z
@@ -121,8 +121,8 @@ source-repository-package
 source-repository-package
    type: git
    location: https://github.com/input-output-hk/ouroboros-network
-   tag: a6cc54677ad967af24da91e563c360407d41314e
-   --sha256: 0p3xcvqa4vr7aqxx2ds32qha9n28sliixamsp7jp5c9igd1x25h7
+   tag: 72863b0fc78abdc2b8e29f0dda96c06da3dd11d0
+   --sha256: 0qwvx04l9q3h7acb0a3b8iarqcn5bkqhwaplbga5pvryqp3lhn00
    subdir:
      monoidal-synchronisation
      network-mux
@@ -134,5 +134,5 @@ source-repository-package
      ouroboros-network
      ouroboros-network-framework
      ouroboros-network-testing
-     ouroboros-consensus-cardano-tools     
+     ouroboros-consensus-cardano-tools
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -112,17 +112,17 @@ library
                       , bytestring
                       , cardano-binary
                       , cardano-crypto
-                      , cardano-crypto-class
-                      , cardano-crypto-wrapper
-                      , cardano-data
-                      , cardano-ledger-alonzo
-                      , cardano-ledger-babbage
-                      , cardano-ledger-byron
-                      , cardano-ledger-core
-                      , cardano-ledger-shelley-ma
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-crypto-wrapper ^>= 1.4
+                      , cardano-data ^>= 0.1
+                      , cardano-ledger-alonzo ^>= 0.1
+                      , cardano-ledger-babbage ^>= 0.1
+                      , cardano-ledger-byron ^>= 0.1
+                      , cardano-ledger-core ^>= 0.1
+                      , cardano-ledger-shelley-ma ^>= 0.1
                       , cardano-prelude
-                      , cardano-protocol-tpraos
-                      , cardano-slotting
+                      , cardano-protocol-tpraos >= 0.1
+                      , cardano-slotting >= 0.1
                       , cborg
                       , contra-tracer
                       , containers
@@ -133,6 +133,7 @@ library
                       , formatting
                       , iproute
                       , memory
+                      , microlens
                       , network
                       , nothunks
                       , optparse-applicative-fork
@@ -144,25 +145,25 @@ library
                       , ouroboros-network
                       , ouroboros-network-framework
                       , parsec
-                      , plutus-ledger-api
+                      , plutus-ledger-api ^>= 1.0
                       , prettyprinter
-                      , prettyprinter-configurable
+                      , prettyprinter-configurable ^>= 0.1
                       , random
                       , scientific
                       , serialise
-                      , small-steps
-                      , cardano-ledger-shelley
-                      , small-steps
+                      , small-steps ^>= 0.1
+                      , cardano-ledger-shelley ^>= 0.1
+                      , small-steps ^>= 0.1
                       , stm
-                      , strict-containers
+                      , cardano-strict-containers ^>= 0.1
                       , text
                       , time
                       , transformers
                       , transformers-except
-                      , typed-protocols
+                      , typed-protocols ^>= 0.1
                       , unordered-containers >= 0.2.11
                       , vector
-                      , vector-map
+                      , vector-map ^>= 0.1
                       , yaml
 
 library gen
@@ -184,16 +185,16 @@ library gen
                       , bytestring
                       , cardano-api
                       , cardano-binary
-                      , cardano-crypto-class
-                      , cardano-crypto-test
-                      , cardano-ledger-alonzo
-                      , cardano-ledger-byron-test
-                      , cardano-ledger-core
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-crypto-test ^>= 1.4
+                      , cardano-ledger-alonzo ^>= 0.1
+                      , cardano-ledger-byron-test ^>= 1.4
+                      , cardano-ledger-core ^>= 0.1
                       , cardano-prelude
                       , containers
                       , hedgehog
-                      , plutus-core
-                      , cardano-ledger-shelley
+                      , plutus-core ^>= 1.0
+                      , cardano-ledger-shelley ^>= 0.1
                       , text
 
 test-suite cardano-api-test
@@ -205,22 +206,22 @@ test-suite cardano-api-test
   build-depends:        aeson             >= 1.5.6.0
                       , cardano-api
                       , cardano-api:gen
-                      , cardano-data
+                      , cardano-data ^>= 0.1
                       , cardano-crypto
-                      , cardano-crypto-class
-                      , cardano-crypto-test
-                      , cardano-crypto-tests
-                      , cardano-ledger-core
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-crypto-test ^>= 1.4
+                      , cardano-crypto-tests ^>= 2.0
+                      , cardano-ledger-core ^>= 0.1
                       , cardano-prelude
-                      , cardano-slotting
+                      , cardano-slotting ^>= 0.1
                       , containers
                       , hedgehog
                       , hedgehog-extras
                       , ouroboros-consensus
                       , ouroboros-consensus-shelley
                       , QuickCheck
-                      , cardano-ledger-shelley
-                      , cardano-ledger-shelley-test
+                      , cardano-ledger-shelley ^>= 0.1
+                      , cardano-ledger-shelley-test ^>= 0.1
                       , tasty
                       , tasty-hedgehog
                       , tasty-quickcheck

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
@@ -52,12 +51,12 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (catMaybes, fromMaybe, maybeToList)
 import           Data.Ratio
-import           Data.Sequence.Strict (StrictSeq (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           GHC.Records (HasField (..))
 import           Numeric.Natural
+import           Lens.Micro ((^.))
 
 import           Control.Monad.Trans.Except
 import qualified Prettyprinter as PP
@@ -70,23 +69,23 @@ import           Cardano.Slotting.EpochInfo (EpochInfo, hoistEpochInfo)
 import qualified Cardano.Chain.Common as Byron
 
 import qualified Cardano.Ledger.Coin as Ledger
+import           Cardano.Ledger.Core (EraTx (sizeTxF))
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Era as Ledger.Era (Crypto)
-import qualified Cardano.Ledger.Hashes as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Shelley.API as Ledger (CLI, DCert, TxIn, Wdrl)
+import qualified Cardano.Ledger.Shelley.API as Ledger (CLI)
 import qualified Cardano.Ledger.Shelley.API.Wallet as Ledger (evaluateTransactionBalance,
                    evaluateTransactionFee)
-
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
-import           Cardano.Ledger.Shelley.PParams (PParams' (..))
+import           Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..))
+import           Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody)
 
-import qualified Cardano.Ledger.Mary.Value as Mary
+import           Cardano.Ledger.Mary.Value (MaryValue)
 
 import qualified Cardano.Ledger.Alonzo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import           Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import           Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tools as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -96,7 +95,7 @@ import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import qualified Plutus.V1.Ledger.Api as Plutus
 
 import qualified Cardano.Ledger.Babbage as Babbage
-import           Cardano.Ledger.Babbage.PParams (PParams' (..))
+import           Cardano.Ledger.Babbage.PParams (BabbagePParamsHKD (..))
 
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
 
@@ -135,16 +134,15 @@ transactionFee txFeeFixed txFeePerByte tx =
   let a = toInteger txFeePerByte
       b = toInteger txFeeFixed
   in case tx of
-       ShelleyTx _ tx' -> let x = obtainHasField shelleyBasedEra $ getField @"txsize" tx'
+       ShelleyTx _ tx' -> let x = obtainHasField shelleyBasedEra $ tx' ^. sizeTxF
                           in Lovelace (a * x + b)
        --TODO: This can be made to work for Byron txs too. Do that: fill in this case
        -- and remove the IsShelleyBasedEra constraint.
        ByronTx _ -> case shelleyBasedEra :: ShelleyBasedEra ByronEra of {}
  where
   obtainHasField
-    :: ShelleyLedgerEra era ~ ledgerera
-    => ShelleyBasedEra era
-    -> ( HasField "txsize" (Ledger.Tx (ShelleyLedgerEra era)) Integer
+    :: ShelleyBasedEra era
+    -> ( EraTx (ShelleyLedgerEra era)
         => a)
     -> a
   obtainHasField ShelleyBasedEraShelley f = f
@@ -538,6 +536,8 @@ evaluateTransactionExecutionUnits _eraInMode systemstart history pparams utxo tx
     evalAlonzo :: forall ledgerera.
                   ShelleyLedgerEra era ~ ledgerera
                => ledgerera ~ Alonzo.AlonzoEra Ledger.StandardCrypto
+               => HasField "_maxTxExUnits" (Ledger.PParams ledgerera) Alonzo.ExUnits
+               => HasField"_protocolVersion" (Ledger.PParams ledgerera) Ledger.ProtVer
                => LedgerEraConstraints ledgerera
                => ShelleyBasedEra era
                -> Ledger.Tx ledgerera
@@ -661,13 +661,28 @@ evaluateTransactionBalance _ _ _ (ByronTxBody _) =
 
 evaluateTransactionBalance pparams poolids utxo
                            (ShelleyTxBody era txbody _ _ _ _) =
-    withLedgerConstraints era evalAdaOnly evalMultiAsset
+    withLedgerConstraints
+      era
+      (getShelleyEraTxBodyConstraint era evalAdaOnly)
+      (getShelleyEraTxBodyConstraint era evalMultiAsset)
   where
+    getShelleyEraTxBodyConstraint
+      :: forall era' a.
+         ShelleyBasedEra era'
+      -> (ShelleyEraTxBody (ShelleyLedgerEra era') => a)
+      -> a
+    getShelleyEraTxBodyConstraint ShelleyBasedEraShelley x = x
+    getShelleyEraTxBodyConstraint ShelleyBasedEraMary x = x
+    getShelleyEraTxBodyConstraint ShelleyBasedEraAllegra x = x
+    getShelleyEraTxBodyConstraint ShelleyBasedEraAlonzo x = x
+    getShelleyEraTxBodyConstraint ShelleyBasedEraBabbage x = x
+
     isNewPool :: Ledger.KeyHash Ledger.StakePool Ledger.StandardCrypto -> Bool
     isNewPool kh = StakePoolKeyHash kh `Set.notMember` poolids
 
     evalMultiAsset :: forall ledgerera.
                       ShelleyLedgerEra era ~ ledgerera
+                   => ShelleyEraTxBody ledgerera
                    => LedgerEraConstraints ledgerera
                    => LedgerMultiAssetConstraints ledgerera
                    => MultiAssetSupportedInEra era
@@ -682,6 +697,7 @@ evaluateTransactionBalance pparams poolids utxo
 
     evalAdaOnly :: forall ledgerera.
                    ShelleyLedgerEra era ~ ledgerera
+                => ShelleyEraTxBody ledgerera
                 => LedgerEraConstraints ledgerera
                 => LedgerAdaOnlyConstraints ledgerera
                 => OnlyAdaSupportedInEra era
@@ -726,8 +742,7 @@ type LedgerAdaOnlyConstraints ledgerera =
          Ledger.Value ledgerera ~ Ledger.Coin
 
 type LedgerMultiAssetConstraints ledgerera =
-       ( Ledger.Value ledgerera ~ Mary.Value Ledger.StandardCrypto
-       , HasField "mint" (Ledger.TxBody ledgerera) (Ledger.Value ledgerera)
+       ( Ledger.Value ledgerera ~ MaryValue Ledger.StandardCrypto
        )
 
 type LedgerPParamsConstraints ledgerera =
@@ -738,11 +753,7 @@ type LedgerPParamsConstraints ledgerera =
        )
 
 type LedgerTxBodyConstraints ledgerera =
-       ( HasField "certs" (Ledger.TxBody ledgerera)
-                          (StrictSeq (Ledger.DCert Ledger.StandardCrypto))
-       , HasField "inputs" (Ledger.TxBody ledgerera)
-                           (Set (Ledger.TxIn Ledger.StandardCrypto))
-       , HasField "wdrls" (Ledger.TxBody ledgerera) (Ledger.Wdrl Ledger.StandardCrypto)
+       ( Ledger.EraTx ledgerera
        )
 
 

--- a/cardano-api/src/Cardano/Api/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Genesis.hs
@@ -14,7 +14,7 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Time as Time
 
 import           Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Shelley.PParams as Ledger (PParams' (..), emptyPParams)
+import           Cardano.Ledger.Shelley.PParams as Ledger (ShelleyPParamsHKD (..), emptyPParams)
 import           Cardano.Slotting.Slot (EpochSize (..))
 
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..), emptyGenesisStaking)

--- a/cardano-api/src/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/src/Cardano/Api/LedgerEvent.hs
@@ -29,21 +29,20 @@ import           Cardano.Ledger.Era (Crypto)
 import qualified Cardano.Ledger.Keys as Ledger
 import           Cardano.Ledger.Shelley.API (InstantaneousRewards (InstantaneousRewards))
 import           Cardano.Ledger.Shelley.Rewards
-import           Cardano.Ledger.Shelley.Rules.Epoch (EpochEvent (PoolReapEvent))
-import           Cardano.Ledger.Shelley.Rules.Mir (MirEvent (..))
-import           Cardano.Ledger.Shelley.Rules.NewEpoch
-                   (NewEpochEvent (DeltaRewardEvent, EpochEvent, MirEvent, TotalRewardEvent))
-import           Cardano.Ledger.Shelley.Rules.PoolReap (PoolreapEvent (RetiredPools))
-import           Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (RupdEvent))
-import           Cardano.Ledger.Shelley.Rules.Tick (TickEvent (NewEpochEvent))
+import           Cardano.Ledger.Shelley.Rules.Epoch (ShelleyEpochEvent (..))
+import           Cardano.Ledger.Shelley.Rules.Mir (ShelleyMirEvent (..))
+import           Cardano.Ledger.Shelley.Rules.NewEpoch (ShelleyNewEpochEvent (..))
+import           Cardano.Ledger.Shelley.Rules.PoolReap (ShelleyPoolreapEvent (..))
+import           Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))
+import           Cardano.Ledger.Shelley.Rules.Tick (ShelleyTickEvent (NewEpochEvent))
 import           Control.State.Transition (Event)
 import           Data.Function (($), (.))
 import           Data.Functor (fmap)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (Maybe (Just, Nothing))
-import           Data.SOP.Strict
 import           Data.Set (Set)
+import           Data.SOP.Strict
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Cardano.Block (HardForkBlock)
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (getOneEraLedgerEvent)
@@ -75,11 +74,11 @@ instance ConvertLedgerEvent ByronBlock where
 
 instance
   ( Crypto ledgerera ~ StandardCrypto,
-    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ TickEvent ledgerera,
-    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ NewEpochEvent ledgerera,
-    Event (Ledger.Core.EraRule "EPOCH" ledgerera) ~ EpochEvent ledgerera,
-    Event (Ledger.Core.EraRule "POOLREAP" ledgerera) ~ PoolreapEvent ledgerera,
-    Event (Ledger.Core.EraRule "MIR" ledgerera) ~ MirEvent ledgerera,
+    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ ShelleyTickEvent ledgerera,
+    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ ShelleyNewEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "EPOCH" ledgerera) ~ ShelleyEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "POOLREAP" ledgerera) ~ ShelleyPoolreapEvent ledgerera,
+    Event (Ledger.Core.EraRule "MIR" ledgerera) ~ ShelleyMirEvent ledgerera,
     Event (Ledger.Core.EraRule "RUPD" ledgerera) ~ RupdEvent (Crypto ledgerera)
   ) =>
   ConvertLedgerEvent (ShelleyBlock protocol ledgerera)
@@ -134,8 +133,8 @@ data PoolReapDetails = PoolReapDetails
 
 pattern LERewardEvent ::
   ( Crypto ledgerera ~ StandardCrypto,
-    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ TickEvent ledgerera,
-    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ NewEpochEvent ledgerera
+    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ ShelleyTickEvent ledgerera,
+    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ ShelleyNewEpochEvent ledgerera
   ) =>
   EpochNo ->
   Map StakeCredential (Set (Reward StandardCrypto)) ->
@@ -146,8 +145,8 @@ pattern LERewardEvent e m <-
 
 pattern LEDeltaRewardEvent ::
   ( Crypto ledgerera ~ StandardCrypto,
-    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ TickEvent ledgerera,
-    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ NewEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ ShelleyTickEvent ledgerera,
+    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ ShelleyNewEpochEvent ledgerera,
     Event (Ledger.Core.EraRule "RUPD" ledgerera) ~ RupdEvent (Crypto ledgerera)
   ) =>
   EpochNo ->
@@ -159,9 +158,9 @@ pattern LEDeltaRewardEvent e m <-
 
 pattern LEMirTransfer ::
   ( Crypto ledgerera ~ StandardCrypto,
-    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ TickEvent ledgerera,
-    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ NewEpochEvent ledgerera,
-    Event (Ledger.Core.EraRule "MIR" ledgerera) ~ MirEvent ledgerera
+    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ ShelleyTickEvent ledgerera,
+    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ ShelleyNewEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "MIR" ledgerera) ~ ShelleyMirEvent ledgerera
   ) =>
   Map StakeCredential Lovelace ->
   Map StakeCredential Lovelace ->
@@ -185,10 +184,10 @@ pattern LEMirTransfer rp tp rtt ttr <-
 
 pattern LERetiredPools ::
   ( Crypto ledgerera ~ StandardCrypto,
-    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ TickEvent ledgerera,
-    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ NewEpochEvent ledgerera,
-    Event (Ledger.Core.EraRule "EPOCH" ledgerera) ~ EpochEvent ledgerera,
-    Event (Ledger.Core.EraRule "POOLREAP" ledgerera) ~ PoolreapEvent ledgerera
+    Event (Ledger.Core.EraRule "TICK" ledgerera) ~ ShelleyTickEvent ledgerera,
+    Event (Ledger.Core.EraRule "NEWEPOCH" ledgerera) ~ ShelleyNewEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "EPOCH" ledgerera) ~ ShelleyEpochEvent ledgerera,
+    Event (Ledger.Core.EraRule "POOLREAP" ledgerera) ~ ShelleyPoolreapEvent ledgerera
   ) =>
   Map StakeCredential (Map (Hash StakePoolKey) Lovelace) ->
   Map StakeCredential (Map (Hash StakePoolKey) Lovelace) ->

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -129,6 +129,7 @@ import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Shelley.Spec
 import qualified Cardano.Ledger.Keys as SL
 import qualified Cardano.Ledger.PoolDistr as SL
+import           Cardano.Ledger.SafeHash (HashAnnotated)
 import qualified Cardano.Ledger.Shelley.API as ShelleyAPI
 import qualified Cardano.Ledger.Shelley.Genesis as Shelley.Spec
 import qualified Cardano.Protocol.TPraos.API as TPraos
@@ -1313,7 +1314,9 @@ instance Error LeadershipError where
 
 nextEpochEligibleLeadershipSlots
   :: forall era.
-     HasField "_d" (Core.PParams (ShelleyLedgerEra era)) UnitInterval
+     ( HasField "_d" (Core.PParams (ShelleyLedgerEra era)) UnitInterval
+     , HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
+     )
   => Ledger.Era (ShelleyLedgerEra era)
   => Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Spec.Credential 'Shelley.Spec.Staking (Cardano.Ledger.Era.Crypto (ShelleyLedgerEra era)))
   => FromCBOR (Consensus.ChainDepState (Api.ConsensusProtocol era))
@@ -1482,6 +1485,10 @@ obtainDecodeEpochStateConstraints
       , FromCBOR (State (Core.EraRule "PPUP" ledgerera))
       , FromCBOR (Core.Value ledgerera)
       , FromSharedCBOR (Core.TxOut ledgerera)
+      , HashAnnotated
+          (Core.TxBody ledgerera)
+          Core.EraIndependentTxBody
+          (Ledger.Crypto (ShelleyLedgerEra era))
       ) => a) -> a
 obtainDecodeEpochStateConstraints ShelleyBasedEraShelley f = f
 obtainDecodeEpochStateConstraints ShelleyBasedEraAllegra f = f

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -43,38 +43,42 @@ import           Cardano.Slotting.Slot (SlotNo (..))
 import           Cardano.Slotting.Time (SystemStart (..))
 import           Control.State.Transition (STS (State))
 
+import           Cardano.Api.Script
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import           Cardano.Ledger.Alonzo.Scripts (AlonzoScript)
+import           Cardano.Ledger.Babbage.PParams (BabbagePParams, BabbagePParamsUpdate)
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import           Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Coin as Shelley
+import           Cardano.Ledger.Core (EraTxOut)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Crypto
+import           Cardano.Ledger.Mary.Value (MaryValue (..))
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.PoolDistr as Ledger
 import qualified Cardano.Ledger.SafeHash as SafeHash
+import           Cardano.Ledger.Shelley.API (ShelleyTxOut (..))
 import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Cardano.Ledger.Shelley.Constraints as Shelley
 import qualified Cardano.Ledger.Shelley.EpochBoundary as ShelleyEpoch
 import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyLedger
-import           Cardano.Ledger.Shelley.PParams (PParamsUpdate)
+import           Cardano.Ledger.Shelley.PParams (ShelleyPParamsUpdate)
 import qualified Cardano.Ledger.Shelley.Rewards as Shelley
 import qualified Cardano.Ledger.Shelley.RewardUpdate as Shelley
+import           Cardano.Ledger.Val (Val)
 import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
-
-import           Cardano.Api.Script
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types
 
-instance ToJSON (Mary.Value era) where
+instance ToJSON (MaryValue era) where
   toJSON = object . toMaryValuePairs
   toEncoding = Aeson.pairs . mconcat . toMaryValuePairs
 
-toMaryValuePairs :: Aeson.KeyValue a => Mary.Value crypto -> [a]
-toMaryValuePairs (Mary.Value !l !ps) =
+toMaryValuePairs :: Aeson.KeyValue a => MaryValue crypto -> [a]
+toMaryValuePairs (MaryValue !l !ps) =
   [ "lovelace" .= l
   , "policies" .= ps
   ]
@@ -109,7 +113,7 @@ instance forall era.
          ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToJSON (Core.PParams era)
-         , ToJSON (Core.PParamsDelta era)
+         , ToJSON (Core.PParamsUpdate era)
          ) => ToJSON (Shelley.EpochState era) where
   toJSON = object . toEpochStatePairs
   toEncoding = Aeson.pairs . mconcat . toEpochStatePairs
@@ -117,7 +121,7 @@ instance forall era.
 toEpochStatePairs ::
   ( Consensus.ShelleyBasedEra era
   , ToJSON (Core.TxOut era)
-  , ToJSON (Core.PParamsDelta era)
+  , ToJSON (Core.PParamsUpdate era)
   , ToJSON (Core.PParams era)
   , Aeson.KeyValue a
   )
@@ -141,7 +145,7 @@ toEpochStatePairs eState =
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
-         , ToJSON (Core.PParamsDelta era)
+         , ToJSON (Core.PParamsUpdate era)
          ) => ToJSON (Shelley.LedgerState era) where
   toJSON = object . toLedgerStatePairs
   toEncoding = Aeson.pairs . mconcat . toLedgerStatePairs
@@ -149,7 +153,7 @@ instance ( Consensus.ShelleyBasedEra era
 toLedgerStatePairs ::
   ( Consensus.ShelleyBasedEra era
   , ToJSON (Core.TxOut era)
-  , ToJSON (Core.PParamsDelta era)
+  , ToJSON (Core.PParamsUpdate era)
   , Aeson.KeyValue a
   ) => ShelleyLedger.LedgerState era -> [a]
 toLedgerStatePairs lState =
@@ -176,7 +180,7 @@ toIncrementalStakePairs iStake =
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
-         , ToJSON (Core.PParamsDelta era)
+         , ToJSON (Core.PParamsUpdate era)
          ) => ToJSON (Shelley.UTxOState era) where
   toJSON = object . toUtxoStatePairs
   toEncoding = Aeson.pairs . mconcat . toUtxoStatePairs
@@ -200,16 +204,16 @@ toUtxoStatePairs utxoState =
       , "stake" .= stakeDistro
       ]
 
-instance ( ToJSON (Core.PParamsDelta era)
-         , Shelley.UsesPParams era
+instance ( ToJSON (Core.PParamsUpdate era)
+         , Core.Era era
          ) => ToJSON (Shelley.PPUPState era) where
   toJSON = object . toPpupStatePairs
   toEncoding = Aeson.pairs . mconcat . toPpupStatePairs
 
 toPpupStatePairs ::
   ( Aeson.KeyValue a
-  , ToJSON (Core.PParamsDelta era)
-  , Shelley.UsesPParams era
+  , ToJSON (Core.PParamsUpdate era)
+  , Core.Era era
   ) => ShelleyLedger.PPUPState era -> [a]
 toPpupStatePairs ppUpState =
   let !proposals = Shelley.proposals ppUpState
@@ -218,13 +222,13 @@ toPpupStatePairs ppUpState =
       , "futureProposals" .= futureProposals
       ]
 
-instance ( ToJSON (Core.PParamsDelta era)
-         , Shelley.UsesPParams era
+instance ( ToJSON (Core.PParamsUpdate era)
+         , Core.Era era
          ) => ToJSON (Shelley.ProposedPPUpdates era) where
   toJSON (Shelley.ProposedPPUpdates ppUpdates) = toJSON $ Map.toList ppUpdates
   toEncoding (Shelley.ProposedPPUpdates ppUpdates) = toEncoding $ Map.toList ppUpdates
 
-instance ToJSON (PParamsUpdate era) where
+instance ToJSON (ShelleyPParamsUpdate era) where
   toJSON pp =
     Aeson.object $
         [ "minFeeA"               .= x | x <- mbfield (Shelley._minfeeA pp) ]
@@ -245,7 +249,7 @@ instance ToJSON (PParamsUpdate era) where
      ++ [ "minUTxOValue"          .= x | x <- mbfield (Shelley._minUTxOValue pp) ]
      ++ [ "minPoolCost"           .= x | x <- mbfield (Shelley._minPoolCost pp) ]
 
-instance ToJSON (Babbage.PParamsUpdate era) where
+instance ToJSON (BabbagePParamsUpdate era) where
   toJSON pp =
     Aeson.object $
         [ "minFeeA"               .= x | x <- mbfield (Babbage._minfeeA pp) ]
@@ -271,7 +275,7 @@ instance ToJSON (Babbage.PParamsUpdate era) where
      ++ [ "collateralPercentage"  .= x | x <- mbfield (Babbage._collateralPercentage pp) ]
      ++ [ "maxCollateralInputs"   .= x | x <- mbfield (Babbage._maxCollateralInputs pp) ]
 
-instance ToJSON (Babbage.PParams (Babbage.BabbageEra Consensus.StandardCrypto)) where
+instance ToJSON (BabbagePParams (Babbage.BabbageEra Consensus.StandardCrypto)) where
   toJSON pp =
     Aeson.object
       [ "minFeeA" .= Babbage._minfeeA pp
@@ -307,7 +311,8 @@ instance ( Ledger.Era era
          , ToJSON (Babbage.Datum era)
          , ToJSON (Core.Script era)
          , Ledger.Crypto era ~ Consensus.StandardCrypto
-         ) => ToJSON (Babbage.TxOut era) where
+         , Val (Core.Value era)
+         ) => ToJSON (BabbageTxOut era) where
   toJSON = object . toBabbageTxOutPairs
   toEncoding = Aeson.pairs . mconcat . toBabbageTxOutPairs
 
@@ -317,8 +322,9 @@ toBabbageTxOutPairs ::
   , ToJSON (Core.Value era)
   , ToJSON (Core.Script era)
   , Ledger.Crypto era ~ Consensus.StandardCrypto
-  ) => Babbage.TxOut era -> [a]
-toBabbageTxOutPairs (Babbage.TxOut !addr !val !dat !mRefScript) =
+  , Val (Core.Value era)
+  ) => BabbageTxOut era -> [a]
+toBabbageTxOutPairs (BabbageTxOut !addr !val !dat !mRefScript) =
   [ "address" .= addr
   , "value" .= val
   , "datum" .= dat
@@ -339,7 +345,7 @@ instance ( Ledger.Era era
 
 
 
-instance ToJSON (Alonzo.Script (Babbage.BabbageEra Consensus.StandardCrypto)) where
+instance ToJSON (AlonzoScript (Babbage.BabbageEra Consensus.StandardCrypto)) where
   toJSON = Aeson.String . Text.decodeUtf8 . B16.encode . CBOR.serialize'
 
 instance Crypto.Crypto crypto => ToJSON (Shelley.DPState crypto) where
@@ -495,17 +501,16 @@ instance ( Consensus.ShelleyBasedEra era
 
 instance ( Consensus.ShelleyBasedEra era
          , ToJSON (Core.Value era)
-         ) => ToJSON (Shelley.TxOut era) where
+         ) => ToJSON (ShelleyTxOut era) where
   toJSON = object . toTxOutPair
   toEncoding = Aeson.pairs . mconcat . toTxOutPair
 
 toTxOutPair ::
-  ( Ledger.Era era
-  , Aeson.KeyValue a
+  ( Aeson.KeyValue a
   , ToJSON (Core.Value era)
-  , Show (Core.Value era))
-  => Shelley.TxOut era -> [a]
-toTxOutPair (Shelley.TxOut !addr !amount) =
+  , EraTxOut era)
+  => ShelleyTxOut era -> [a]
+toTxOutPair (ShelleyTxOut !addr !amount) =
   [ "address" .= addr
   , "amount" .= amount
   ]

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -86,22 +86,24 @@ import           Cardano.Slotting.Slot (EpochNo)
 
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Era as Ledger
+import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 
-import qualified Cardano.Ledger.Shelley.PParams as Ledger (ProposedPPUpdates (..), Update (..))
--- Some of the things from Cardano.Ledger.Shelley.PParams are generic across all
+-- Some of the things from Cardano.Ledger.ShelleyPParams are generic across all
 -- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
 -- So we import in twice under different names.
-import qualified Cardano.Ledger.Shelley.PParams as Shelley (PParams, PParams' (..), PParamsUpdate)
+import qualified Cardano.Ledger.Shelley.API as Ledger hiding (PParams)
+import           Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsHKD (..),
+                   ShelleyPParamsUpdate)
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import           Cardano.Ledger.Alonzo.PParams (AlonzoPParams, AlonzoPParamsHKD (..),
+                   AlonzoPParamsUpdate)
 
-import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import           Cardano.Ledger.Babbage.PParams (BabbagePParams, BabbagePParamsHKD (..),
+                   BabbagePParamsUpdate)
 
 import           Text.PrettyBy.Default (display)
 
@@ -895,23 +897,23 @@ toLedgerProposedPPUpdates :: forall era ledgerera.
 toLedgerProposedPPUpdates era =
     Ledger.ProposedPPUpdates
   . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh)
-  . Map.map (toLedgerPParamsDelta era)
+  . Map.map (toLedgerPParamsUpdate era)
 
 
-toLedgerPParamsDelta :: ShelleyBasedEra era
+toLedgerPParamsUpdate :: ShelleyBasedEra era
                      -> ProtocolParametersUpdate
-                     -> Ledger.PParamsDelta (ShelleyLedgerEra era)
-toLedgerPParamsDelta ShelleyBasedEraShelley = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraAllegra = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraMary    = toShelleyPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraAlonzo  = toAlonzoPParamsUpdate
-toLedgerPParamsDelta ShelleyBasedEraBabbage = toBabbagePParamsUpdate
+                     -> Ledger.PParamsUpdate (ShelleyLedgerEra era)
+toLedgerPParamsUpdate ShelleyBasedEraShelley = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraAllegra = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraMary    = toShelleyPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraAlonzo  = toAlonzoPParamsUpdate
+toLedgerPParamsUpdate ShelleyBasedEraBabbage = toBabbagePParamsUpdate
 
 
 --TODO: we should do validation somewhere, not just silently drop changes that
 -- are not valid. Specifically, see Ledger.boundRational below.
 toShelleyPParamsUpdate :: ProtocolParametersUpdate
-                       -> Shelley.PParamsUpdate ledgerera
+                       -> ShelleyPParamsUpdate ledgerera
 toShelleyPParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -932,39 +934,39 @@ toShelleyPParamsUpdate
     , protocolUpdateMonetaryExpansion
     , protocolUpdateTreasuryCut
     } =
-    Shelley.PParams {
-      Shelley._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Shelley._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Shelley._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Shelley._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Shelley._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Shelley._keyDeposit  = toShelleyLovelace <$>
-                               noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Shelley._poolDeposit = toShelleyLovelace <$>
-                               noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Shelley._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Shelley._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Shelley._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Shelley._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateMonetaryExpansion
-    , Shelley._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateTreasuryCut
-    , Shelley._d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                                protocolUpdateDecentralization
-    , Shelley._extraEntropy    = toLedgerNonce <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
-    , Shelley._protocolVersion = uncurry Ledger.ProtVer <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Shelley._minUTxOValue    = toShelleyLovelace <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue
-    , Shelley._minPoolCost     = toShelleyLovelace <$>
+    ShelleyPParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                      protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateTreasuryCut
+    , _d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateDecentralization
+    , _extraEntropy    = toLedgerNonce <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minUTxOValue    = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue
+    , _minPoolCost     = toShelleyLovelace <$>
                                    noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
     }
 
 
 toAlonzoPParamsUpdate :: ProtocolParametersUpdate
-                      -> Alonzo.PParamsUpdate ledgerera
+                      -> AlonzoPParamsUpdate ledgerera
 toAlonzoPParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -992,52 +994,52 @@ toAlonzoPParamsUpdate
     , protocolUpdateCollateralPercent
     , protocolUpdateMaxCollateralInputs
     } =
-    Alonzo.PParams {
-      Alonzo._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Alonzo._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Alonzo._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Alonzo._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Alonzo._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Alonzo._keyDeposit  = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Alonzo._poolDeposit = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Alonzo._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Alonzo._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Alonzo._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Alonzo._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateMonetaryExpansion
-    , Alonzo._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateTreasuryCut
-    , Alonzo._d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateDecentralization
-    , Alonzo._extraEntropy    = toLedgerNonce <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
-    , Alonzo._protocolVersion = uncurry Ledger.ProtVer <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Alonzo._minPoolCost     = toShelleyLovelace <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
-    , Alonzo._coinsPerUTxOWord  = toShelleyLovelace <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerWord
-    , Alonzo._costmdls        = if Map.null protocolUpdateCostModels
-                                  then Ledger.SNothing
-                                  else either (const Ledger.SNothing) Ledger.SJust
-                                         (toAlonzoCostModels protocolUpdateCostModels)
-    , Alonzo._prices          = noInlineMaybeToStrictMaybe $
-                                  toAlonzoPrices =<< protocolUpdatePrices
-    , Alonzo._maxTxExUnits    = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
-    , Alonzo._maxBlockExUnits = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
-    , Alonzo._maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
-    , Alonzo._collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
-    , Alonzo._maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
+    AlonzoPParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                       noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateTreasuryCut
+    , _d           = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                        protocolUpdateDecentralization
+    , _extraEntropy    = toLedgerNonce <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minPoolCost     = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
+    , _coinsPerUTxOWord  = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerWord
+    , _costmdls        = if Map.null protocolUpdateCostModels
+                           then Ledger.SNothing
+                           else either (const Ledger.SNothing) Ledger.SJust
+                                  (toAlonzoCostModels protocolUpdateCostModels)
+    , _prices          = noInlineMaybeToStrictMaybe $
+                           toAlonzoPrices =<< protocolUpdatePrices
+    , _maxTxExUnits    = toAlonzoExUnits  <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits  <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
+    , _maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
+    , _collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
+    , _maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
     }
 
 -- Decentralization and extra entropy are deprecated in Babbage
 toBabbagePParamsUpdate :: ProtocolParametersUpdate
-                       -> Babbage.PParamsUpdate ledgerera
+                       -> BabbagePParamsUpdate ledgerera
 toBabbagePParamsUpdate
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion
@@ -1063,42 +1065,42 @@ toBabbagePParamsUpdate
     , protocolUpdateMaxCollateralInputs
     , protocolUpdateUTxOCostPerByte
     } =
-    Babbage.PParams {
-      Babbage._minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
-    , Babbage._minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
-    , Babbage._maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
-    , Babbage._maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
-    , Babbage._maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-    , Babbage._keyDeposit  = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
-    , Babbage._poolDeposit = toShelleyLovelace <$>
-                              noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
-    , Babbage._eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
-    , Babbage._nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
-    , Babbage._a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                              protocolUpdatePoolPledgeInfluence
-    , Babbage._rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateMonetaryExpansion
-    , Babbage._tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
-                               protocolUpdateTreasuryCut
-    , Babbage._protocolVersion = uncurry Ledger.ProtVer <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
-    , Babbage._minPoolCost     = toShelleyLovelace <$>
-                                   noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
-    , Babbage._costmdls        = if Map.null protocolUpdateCostModels
-                                  then Ledger.SNothing
-                                  else either (const Ledger.SNothing) Ledger.SJust
-                                         (toAlonzoCostModels protocolUpdateCostModels)
-    , Babbage._prices          = noInlineMaybeToStrictMaybe $
-                                  toAlonzoPrices =<< protocolUpdatePrices
-    , Babbage._maxTxExUnits    = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
-    , Babbage._maxBlockExUnits = toAlonzoExUnits  <$>
-                                  noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
-    , Babbage._maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
-    , Babbage._collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
-    , Babbage._maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
-    , Babbage._coinsPerUTxOByte = toShelleyLovelace <$>
+    BabbagePParams {
+      _minfeeA     = noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+    , _minfeeB     = noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
+    , _maxBBSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
+    , _maxTxSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
+    , _maxBHSize   = noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
+    , _keyDeposit  = toShelleyLovelace <$>
+                      noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+    , _poolDeposit = toShelleyLovelace <$>
+                      noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
+    , _eMax        = noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
+    , _nOpt        = noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
+    , _a0          = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                      protocolUpdatePoolPledgeInfluence
+    , _rho         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdateMonetaryExpansion
+    , _tau         = noInlineMaybeToStrictMaybe $ Ledger.boundRational =<<
+                       protocolUpdateTreasuryCut
+    , _protocolVersion = uncurry Ledger.ProtVer <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateProtocolVersion
+    , _minPoolCost     = toShelleyLovelace <$>
+                           noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
+    , _costmdls        = if Map.null protocolUpdateCostModels
+                          then Ledger.SNothing
+                          else either (const Ledger.SNothing) Ledger.SJust
+                                 (toAlonzoCostModels protocolUpdateCostModels)
+    , _prices          = noInlineMaybeToStrictMaybe $
+                          toAlonzoPrices =<< protocolUpdatePrices
+    , _maxTxExUnits    = toAlonzoExUnits  <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateMaxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits  <$>
+                          noInlineMaybeToStrictMaybe protocolUpdateMaxBlockExUnits
+    , _maxValSize      = noInlineMaybeToStrictMaybe protocolUpdateMaxValueSize
+    , _collateralPercentage = noInlineMaybeToStrictMaybe protocolUpdateCollateralPercent
+    , _maxCollateralInputs  = noInlineMaybeToStrictMaybe protocolUpdateMaxCollateralInputs
+    , _coinsPerUTxOByte = toShelleyLovelace <$>
                                     noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerByte
     }
 
@@ -1123,42 +1125,42 @@ fromLedgerProposedPPUpdates :: forall era ledgerera.
                             -> Ledger.ProposedPPUpdates ledgerera
                             -> Map (Hash GenesisKey) ProtocolParametersUpdate
 fromLedgerProposedPPUpdates era =
-    Map.map (fromLedgerPParamsDelta era)
+    Map.map (fromLedgerPParamsUpdate era)
   . Map.mapKeysMonotonic GenesisKeyHash
   . (\(Ledger.ProposedPPUpdates ppup) -> ppup)
 
 
-fromLedgerPParamsDelta :: ShelleyBasedEra era
-                       -> Ledger.PParamsDelta (ShelleyLedgerEra era)
+fromLedgerPParamsUpdate :: ShelleyBasedEra era
+                       -> Ledger.PParamsUpdate (ShelleyLedgerEra era)
                        -> ProtocolParametersUpdate
-fromLedgerPParamsDelta ShelleyBasedEraShelley = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraAllegra = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraMary    = fromShelleyPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraAlonzo  = fromAlonzoPParamsUpdate
-fromLedgerPParamsDelta ShelleyBasedEraBabbage = fromBabbagePParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraShelley = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraAllegra = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraMary    = fromShelleyPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraAlonzo  = fromAlonzoPParamsUpdate
+fromLedgerPParamsUpdate ShelleyBasedEraBabbage = fromBabbagePParamsUpdate
 
 
-fromShelleyPParamsUpdate :: Shelley.PParamsUpdate ledgerera
+fromShelleyPParamsUpdate :: ShelleyPParamsUpdate ledgerera
                          -> ProtocolParametersUpdate
 fromShelleyPParamsUpdate
-    Shelley.PParams {
-      Shelley._minfeeA
-    , Shelley._minfeeB
-    , Shelley._maxBBSize
-    , Shelley._maxTxSize
-    , Shelley._maxBHSize
-    , Shelley._keyDeposit
-    , Shelley._poolDeposit
-    , Shelley._eMax
-    , Shelley._nOpt
-    , Shelley._a0
-    , Shelley._rho
-    , Shelley._tau
-    , Shelley._d
-    , Shelley._extraEntropy
-    , Shelley._protocolVersion
-    , Shelley._minUTxOValue
-    , Shelley._minPoolCost
+    ShelleyPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minUTxOValue
+    , _minPoolCost
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1199,34 +1201,34 @@ fromShelleyPParamsUpdate
     , protocolUpdateUTxOCostPerByte     = Nothing
     }
 
-fromAlonzoPParamsUpdate :: Alonzo.PParamsUpdate ledgerera
+fromAlonzoPParamsUpdate :: AlonzoPParamsUpdate ledgerera
                         -> ProtocolParametersUpdate
 fromAlonzoPParamsUpdate
-    Alonzo.PParams {
-      Alonzo._minfeeA
-    , Alonzo._minfeeB
-    , Alonzo._maxBBSize
-    , Alonzo._maxTxSize
-    , Alonzo._maxBHSize
-    , Alonzo._keyDeposit
-    , Alonzo._poolDeposit
-    , Alonzo._eMax
-    , Alonzo._nOpt
-    , Alonzo._a0
-    , Alonzo._rho
-    , Alonzo._tau
-    , Alonzo._d
-    , Alonzo._extraEntropy
-    , Alonzo._protocolVersion
-    , Alonzo._minPoolCost
-    , Alonzo._coinsPerUTxOWord
-    , Alonzo._costmdls
-    , Alonzo._prices
-    , Alonzo._maxTxExUnits
-    , Alonzo._maxBlockExUnits
-    , Alonzo._maxValSize
-    , Alonzo._collateralPercentage
-    , Alonzo._maxCollateralInputs
+    AlonzoPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOWord
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1272,32 +1274,32 @@ fromAlonzoPParamsUpdate
     }
 
 
-fromBabbagePParamsUpdate :: Babbage.PParamsUpdate ledgerera
+fromBabbagePParamsUpdate :: BabbagePParamsUpdate ledgerera
                          -> ProtocolParametersUpdate
 fromBabbagePParamsUpdate
-    Babbage.PParams {
-      Babbage._minfeeA
-    , Babbage._minfeeB
-    , Babbage._maxBBSize
-    , Babbage._maxTxSize
-    , Babbage._maxBHSize
-    , Babbage._keyDeposit
-    , Babbage._poolDeposit
-    , Babbage._eMax
-    , Babbage._nOpt
-    , Babbage._a0
-    , Babbage._rho
-    , Babbage._tau
-    , Babbage._protocolVersion
-    , Babbage._minPoolCost
-    , Babbage._coinsPerUTxOByte
-    , Babbage._costmdls
-    , Babbage._prices
-    , Babbage._maxTxExUnits
-    , Babbage._maxBlockExUnits
-    , Babbage._maxValSize
-    , Babbage._collateralPercentage
-    , Babbage._maxCollateralInputs
+    BabbagePParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOByte
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParametersUpdate {
       protocolUpdateProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b)) <$>
@@ -1358,7 +1360,7 @@ toLedgerPParams ShelleyBasedEraMary    = toShelleyPParams
 toLedgerPParams ShelleyBasedEraAlonzo  = toAlonzoPParams
 toLedgerPParams ShelleyBasedEraBabbage = toBabbagePParams
 
-toShelleyPParams :: ProtocolParameters -> Shelley.PParams ledgerera
+toShelleyPParams :: ProtocolParameters -> ShelleyPParams ledgerera
 toShelleyPParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamDecentralization,
@@ -1378,11 +1380,11 @@ toShelleyPParams ProtocolParameters {
                    protocolParamMonetaryExpansion,
                    protocolParamTreasuryCut
                  } =
-   Shelley.PParams
-     { Shelley._protocolVersion
+   ShelleyPParams
+     { _protocolVersion
                              = let (maj, minor) = protocolParamProtocolVersion
                                 in Ledger.ProtVer maj minor
-     , Shelley._d            = case protocolParamDecentralization of
+     , _d            = case protocolParamDecentralization of
                                  -- The decentralization parameter is deprecated in Babbage
                                  -- so we default to 0 if no dentralization parameter is found
                                  -- in the api's 'ProtocolParameter' type. If we don't do this
@@ -1394,32 +1396,32 @@ toShelleyPParams ProtocolParameters {
                                    fromMaybe
                                      (error "toShelleyPParams: invalid Decentralization value")
                                      (Ledger.boundRational pDecentral)
-     , Shelley._extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
-     , Shelley._maxBHSize    = protocolParamMaxBlockHeaderSize
-     , Shelley._maxBBSize    = protocolParamMaxBlockBodySize
-     , Shelley._maxTxSize    = protocolParamMaxTxSize
-     , Shelley._minfeeB      = protocolParamTxFeeFixed
-     , Shelley._minfeeA      = protocolParamTxFeePerByte
-     , Shelley._minUTxOValue = toShelleyLovelace minUTxOValue
-     , Shelley._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-     , Shelley._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-     , Shelley._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-     , Shelley._eMax         = protocolParamPoolRetireMaxEpoch
-     , Shelley._nOpt         = protocolParamStakePoolTargetNum
-     , Shelley._a0           = fromMaybe
+     , _extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
+     , _maxBHSize    = protocolParamMaxBlockHeaderSize
+     , _maxBBSize    = protocolParamMaxBlockBodySize
+     , _maxTxSize    = protocolParamMaxTxSize
+     , _minfeeB      = protocolParamTxFeeFixed
+     , _minfeeA      = protocolParamTxFeePerByte
+     , _minUTxOValue = toShelleyLovelace minUTxOValue
+     , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+     , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+     , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+     , _eMax         = protocolParamPoolRetireMaxEpoch
+     , _nOpt         = protocolParamStakePoolTargetNum
+     , _a0           = fromMaybe
                                  (error "toShelleyPParams: invalid PoolPledgeInfluence value")
                                  (Ledger.boundRational protocolParamPoolPledgeInfluence)
-     , Shelley._rho          = fromMaybe
+     , _rho          = fromMaybe
                                  (error "toShelleyPParams: invalid MonetaryExpansion value")
                                  (Ledger.boundRational protocolParamMonetaryExpansion)
-     , Shelley._tau          = fromMaybe
+     , _tau          = fromMaybe
                                  (error "toShelleyPParams: invalid TreasuryCut value")
                                  (Ledger.boundRational protocolParamTreasuryCut)
      }
 toShelleyPParams ProtocolParameters { protocolParamMinUTxOValue = Nothing } =
   error "toShelleyPParams: must specify protocolParamMinUTxOValue"
 
-toAlonzoPParams :: ProtocolParameters -> Alonzo.PParams ledgerera
+toAlonzoPParams :: ProtocolParameters -> AlonzoPParams ledgerera
 toAlonzoPParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamDecentralization,
@@ -1451,11 +1453,11 @@ toAlonzoPParams ProtocolParameters {
           (error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord or protocolParamUTxOCostPerByte") $
             protocolParamUTxOCostPerWord <|> ((* 8) <$> protocolParamUTxOCostPerByte)
     in
-    Alonzo.PParams {
-      Alonzo._protocolVersion
+    AlonzoPParams {
+      _protocolVersion
                            = let (maj, minor) = protocolParamProtocolVersion
                               in Ledger.ProtVer maj minor
-    , Alonzo._d            = case protocolParamDecentralization of
+    , _d            = case protocolParamDecentralization of
                                  -- The decentralization parameter is deprecated in Babbage
                                  -- so we default to 0 if no dentralization parameter is found
                                  -- in the api's 'ProtocolParameter' type. If we don't do this
@@ -1467,41 +1469,41 @@ toAlonzoPParams ProtocolParameters {
                                    fromMaybe
                                      (error "toAlonzoPParams: invalid Decentralization value")
                                      (Ledger.boundRational pDecentral)
-    , Alonzo._extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
-    , Alonzo._maxBHSize    = protocolParamMaxBlockHeaderSize
-    , Alonzo._maxBBSize    = protocolParamMaxBlockBodySize
-    , Alonzo._maxTxSize    = protocolParamMaxTxSize
-    , Alonzo._minfeeB      = protocolParamTxFeeFixed
-    , Alonzo._minfeeA      = protocolParamTxFeePerByte
-    , Alonzo._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-    , Alonzo._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-    , Alonzo._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-    , Alonzo._eMax         = protocolParamPoolRetireMaxEpoch
-    , Alonzo._nOpt         = protocolParamStakePoolTargetNum
-    , Alonzo._a0           = fromMaybe
+    , _extraEntropy = toLedgerNonce protocolParamExtraPraosEntropy
+    , _maxBHSize    = protocolParamMaxBlockHeaderSize
+    , _maxBBSize    = protocolParamMaxBlockBodySize
+    , _maxTxSize    = protocolParamMaxTxSize
+    , _minfeeB      = protocolParamTxFeeFixed
+    , _minfeeA      = protocolParamTxFeePerByte
+    , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+    , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+    , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+    , _eMax         = protocolParamPoolRetireMaxEpoch
+    , _nOpt         = protocolParamStakePoolTargetNum
+    , _a0           = fromMaybe
                                (error "toAlonzoPParams: invalid PoolPledgeInfluence value")
                                (Ledger.boundRational protocolParamPoolPledgeInfluence)
-    , Alonzo._rho          = fromMaybe
+    , _rho          = fromMaybe
                                (error "toAlonzoPParams: invalid MonetaryExpansion value")
                                (Ledger.boundRational protocolParamMonetaryExpansion)
-    , Alonzo._tau          = fromMaybe
+    , _tau          = fromMaybe
                                (error "toAlonzoPParams: invalid TreasuryCut value")
                                (Ledger.boundRational protocolParamTreasuryCut)
 
       -- New params in Alonzo:
-    , Alonzo._coinsPerUTxOWord  = toShelleyLovelace coinsPerUTxOWord
-    , Alonzo._costmdls        = either
+    , _coinsPerUTxOWord  = toShelleyLovelace coinsPerUTxOWord
+    , _costmdls        = either
                                   (\e -> error $ "toAlonzoPParams: invalid cost models, error: " <> e)
                                   id
                                   (toAlonzoCostModels protocolParamCostModels)
-    , Alonzo._prices          = fromMaybe
+    , _prices          = fromMaybe
                                   (error "toAlonzoPParams: invalid Price values")
                                   (toAlonzoPrices prices)
-    , Alonzo._maxTxExUnits    = toAlonzoExUnits maxTxExUnits
-    , Alonzo._maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
-    , Alonzo._maxValSize      = maxValueSize
-    , Alonzo._collateralPercentage = collateralPercentage
-    , Alonzo._maxCollateralInputs  = maxCollateralInputs
+    , _maxTxExUnits    = toAlonzoExUnits maxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
+    , _maxValSize      = maxValueSize
+    , _collateralPercentage = collateralPercentage
+    , _maxCollateralInputs  = maxCollateralInputs
     }
 toAlonzoPParams ProtocolParameters { protocolParamUTxOCostPerWord = Nothing } =
   error "toAlonzoPParams: must specify protocolParamUTxOCostPerWord"
@@ -1519,7 +1521,7 @@ toAlonzoPParams ProtocolParameters { protocolParamMaxCollateralInputs = Nothing 
   error "toAlonzoPParams: must specify protocolParamMaxCollateralInputs"
 
 
-toBabbagePParams :: ProtocolParameters -> Babbage.PParams ledgerera
+toBabbagePParams :: ProtocolParameters -> BabbagePParams ledgerera
 toBabbagePParams ProtocolParameters {
                    protocolParamProtocolVersion,
                    protocolParamMaxBlockHeaderSize,
@@ -1544,45 +1546,45 @@ toBabbagePParams ProtocolParameters {
                    protocolParamCollateralPercent   = Just collateralPercentage,
                    protocolParamMaxCollateralInputs = Just maxCollateralInputs
                  } =
-    Babbage.PParams {
-      Babbage._protocolVersion
+    BabbagePParams {
+      _protocolVersion
                            = let (maj, minor) = protocolParamProtocolVersion
                               in Ledger.ProtVer maj minor
-    , Babbage._maxBHSize    = protocolParamMaxBlockHeaderSize
-    , Babbage._maxBBSize    = protocolParamMaxBlockBodySize
-    , Babbage._maxTxSize    = protocolParamMaxTxSize
-    , Babbage._minfeeB      = protocolParamTxFeeFixed
-    , Babbage._minfeeA      = protocolParamTxFeePerByte
-    , Babbage._keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
-    , Babbage._poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
-    , Babbage._minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
-    , Babbage._eMax         = protocolParamPoolRetireMaxEpoch
-    , Babbage._nOpt         = protocolParamStakePoolTargetNum
-    , Babbage._a0           = fromMaybe
+    , _maxBHSize    = protocolParamMaxBlockHeaderSize
+    , _maxBBSize    = protocolParamMaxBlockBodySize
+    , _maxTxSize    = protocolParamMaxTxSize
+    , _minfeeB      = protocolParamTxFeeFixed
+    , _minfeeA      = protocolParamTxFeePerByte
+    , _keyDeposit   = toShelleyLovelace protocolParamStakeAddressDeposit
+    , _poolDeposit  = toShelleyLovelace protocolParamStakePoolDeposit
+    , _minPoolCost  = toShelleyLovelace protocolParamMinPoolCost
+    , _eMax         = protocolParamPoolRetireMaxEpoch
+    , _nOpt         = protocolParamStakePoolTargetNum
+    , _a0           = fromMaybe
                                (error "toBabbagePParams: invalid PoolPledgeInfluence value")
                                (Ledger.boundRational protocolParamPoolPledgeInfluence)
-    , Babbage._rho          = fromMaybe
+    , _rho          = fromMaybe
                                (error "toBabbagePParams: invalid MonetaryExpansion value")
                                (Ledger.boundRational protocolParamMonetaryExpansion)
-    , Babbage._tau          = fromMaybe
+    , _tau          = fromMaybe
                                (error "toBabbagePParams: invalid TreasuryCut value")
                                (Ledger.boundRational protocolParamTreasuryCut)
 
       -- New params in Babbage.
-    , Babbage._coinsPerUTxOByte = toShelleyLovelace utxoCostPerByte
+    , _coinsPerUTxOByte = toShelleyLovelace utxoCostPerByte
 
-    , Babbage._costmdls        = either
+    , _costmdls        = either
                                   (\e -> error $ "toBabbagePParams: invalid cost models, error: " <> e)
                                   id
                                   (toAlonzoCostModels protocolParamCostModels)
-    , Babbage._prices          = fromMaybe
+    , _prices          = fromMaybe
                                   (error "toBabbagePParams: invalid Price values")
                                   (toAlonzoPrices prices)
-    , Babbage._maxTxExUnits    = toAlonzoExUnits maxTxExUnits
-    , Babbage._maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
-    , Babbage._maxValSize      = maxValueSize
-    , Babbage._collateralPercentage = collateralPercentage
-    , Babbage._maxCollateralInputs  = maxCollateralInputs
+    , _maxTxExUnits    = toAlonzoExUnits maxTxExUnits
+    , _maxBlockExUnits = toAlonzoExUnits maxBlockExUnits
+    , _maxValSize      = maxValueSize
+    , _collateralPercentage = collateralPercentage
+    , _maxCollateralInputs  = maxCollateralInputs
     }
 toBabbagePParams ProtocolParameters { protocolParamUTxOCostPerByte = Nothing } =
   error "toBabbagePParams: must specify protocolParamUTxOCostPerByte"
@@ -1614,27 +1616,27 @@ fromLedgerPParams ShelleyBasedEraAlonzo  = fromAlonzoPParams
 fromLedgerPParams ShelleyBasedEraBabbage = fromBabbagePParams
 
 
-fromShelleyPParams :: Shelley.PParams ledgerera
+fromShelleyPParams :: ShelleyPParams ledgerera
                    -> ProtocolParameters
 fromShelleyPParams
-    Shelley.PParams {
-      Shelley._minfeeA
-    , Shelley._minfeeB
-    , Shelley._maxBBSize
-    , Shelley._maxTxSize
-    , Shelley._maxBHSize
-    , Shelley._keyDeposit
-    , Shelley._poolDeposit
-    , Shelley._eMax
-    , Shelley._nOpt
-    , Shelley._a0
-    , Shelley._rho
-    , Shelley._tau
-    , Shelley._d
-    , Shelley._extraEntropy
-    , Shelley._protocolVersion
-    , Shelley._minUTxOValue
-    , Shelley._minPoolCost
+    ShelleyPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minUTxOValue
+    , _minPoolCost
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))
@@ -1667,33 +1669,33 @@ fromShelleyPParams
     }
 
 
-fromAlonzoPParams :: Alonzo.PParams ledgerera -> ProtocolParameters
+fromAlonzoPParams :: AlonzoPParams ledgerera -> ProtocolParameters
 fromAlonzoPParams
-    Alonzo.PParams {
-      Alonzo._minfeeA
-    , Alonzo._minfeeB
-    , Alonzo._maxBBSize
-    , Alonzo._maxTxSize
-    , Alonzo._maxBHSize
-    , Alonzo._keyDeposit
-    , Alonzo._poolDeposit
-    , Alonzo._eMax
-    , Alonzo._nOpt
-    , Alonzo._a0
-    , Alonzo._rho
-    , Alonzo._tau
-    , Alonzo._d
-    , Alonzo._extraEntropy
-    , Alonzo._protocolVersion
-    , Alonzo._minPoolCost
-    , Alonzo._coinsPerUTxOWord
-    , Alonzo._costmdls
-    , Alonzo._prices
-    , Alonzo._maxTxExUnits
-    , Alonzo._maxBlockExUnits
-    , Alonzo._maxValSize
-    , Alonzo._collateralPercentage
-    , Alonzo._maxCollateralInputs
+    AlonzoPParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _d
+    , _extraEntropy
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOWord
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))
@@ -1725,31 +1727,31 @@ fromAlonzoPParams
     , protocolParamUTxOCostPerByte     = Nothing    -- Only from babbage onwards
     }
 
-fromBabbagePParams :: Babbage.PParams ledgerera -> ProtocolParameters
+fromBabbagePParams :: BabbagePParams ledgerera -> ProtocolParameters
 fromBabbagePParams
-    Babbage.PParams {
-      Babbage._minfeeA
-    , Babbage._minfeeB
-    , Babbage._maxBBSize
-    , Babbage._maxTxSize
-    , Babbage._maxBHSize
-    , Babbage._keyDeposit
-    , Babbage._poolDeposit
-    , Babbage._eMax
-    , Babbage._nOpt
-    , Babbage._a0
-    , Babbage._rho
-    , Babbage._tau
-    , Babbage._protocolVersion
-    , Babbage._minPoolCost
-    , Babbage._coinsPerUTxOByte
-    , Babbage._costmdls
-    , Babbage._prices
-    , Babbage._maxTxExUnits
-    , Babbage._maxBlockExUnits
-    , Babbage._maxValSize
-    , Babbage._collateralPercentage
-    , Babbage._maxCollateralInputs
+    BabbagePParams {
+      _minfeeA
+    , _minfeeB
+    , _maxBBSize
+    , _maxTxSize
+    , _maxBHSize
+    , _keyDeposit
+    , _poolDeposit
+    , _eMax
+    , _nOpt
+    , _a0
+    , _rho
+    , _tau
+    , _protocolVersion
+    , _minPoolCost
+    , _coinsPerUTxOByte
+    , _costmdls
+    , _prices
+    , _maxTxExUnits
+    , _maxBlockExUnits
+    , _maxValSize
+    , _collateralPercentage
+    , _maxCollateralInputs
     } =
     ProtocolParameters {
       protocolParamProtocolVersion     = (\(Ledger.ProtVer a b) -> (a,b))

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -129,6 +129,7 @@ import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 import           Data.Word (Word64)
 
+import           Cardano.Ledger.SafeHash (HashAnnotated)
 import qualified Data.Aeson.KeyMap as KeyMap
 
 -- ----------------------------------------------------------------------------
@@ -326,6 +327,7 @@ instance
     , FromCBOR (Ledger.State (Core.EraRule "PPUP" (ShelleyLedgerEra era)))
     , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
     , FromSharedCBOR (Core.TxOut (ShelleyLedgerEra era))
+    , HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
     ) => FromCBOR (DebugLedgerState era) where
   fromCBOR = DebugLedgerState <$> (fromCBOR :: Decoder s (Shelley.NewEpochState (ShelleyLedgerEra era)))
 
@@ -334,7 +336,7 @@ instance ( IsShelleyBasedEra era
          , ShelleyLedgerEra era ~ ledgerera
          , Consensus.ShelleyBasedEra ledgerera
          , ToJSON (Core.PParams ledgerera)
-         , ToJSON (Core.PParamsDelta ledgerera)
+         , ToJSON (Core.PParamsUpdate ledgerera)
          , ToJSON (Core.TxOut ledgerera)
          , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
          ) => ToJSON (DebugLedgerState era) where
@@ -345,7 +347,7 @@ toDebugLedgerStatePair ::
   ( ShelleyLedgerEra era ~ ledgerera
   , Consensus.ShelleyBasedEra ledgerera
   , ToJSON (Core.PParams ledgerera)
-  , ToJSON (Core.PParamsDelta ledgerera)
+  , ToJSON (Core.PParamsUpdate ledgerera)
   , ToJSON (Core.TxOut ledgerera)
   , Aeson.KeyValue a
   ) => DebugLedgerState era -> [a]
@@ -380,7 +382,9 @@ newtype SerialisedCurrentEpochState era
 newtype CurrentEpochState era = CurrentEpochState (Shelley.EpochState (ShelleyLedgerEra era))
 
 decodeCurrentEpochState
-  :: forall era. Ledger.Era (ShelleyLedgerEra era)
+  :: forall era. ( Ledger.Era (ShelleyLedgerEra era)
+                 , HashAnnotated (Core.TxBody (ShelleyLedgerEra era)) Core.EraIndependentTxBody (Ledger.Crypto (ShelleyLedgerEra era))
+                 )
   => FromSharedCBOR (Core.TxOut (ShelleyLedgerEra era))
   => Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Shelley.Credential 'Shelley.Staking (Ledger.Crypto (ShelleyLedgerEra era)))
   => FromCBOR (Core.PParams (ShelleyLedgerEra era))

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -143,7 +143,6 @@ import           Cardano.Slotting.Slot (SlotNo)
 
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Era as Ledger
 
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.Shelley.Scripts as Shelley

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -187,6 +187,7 @@ import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Data.Word (Word16, Word32, Word64)
 import           GHC.Generics
 import           GHC.Records (HasField (..))
+import           Lens.Micro hiding (ix)
 import qualified Text.Parsec as Parsec
 import           Text.Parsec ((<?>))
 import qualified Text.Parsec.String as Parsec
@@ -210,35 +211,41 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.SafeHash as SafeHash
-import qualified Cardano.Ledger.Shelley.Constraints as Ledger
-import qualified Cardano.Ledger.Shelley.PParams as Ledger
+import           Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..),
+                   BabbageTxBody (BabbageTxBody), BabbageTxOut (BabbageTxOut))
+import qualified Cardano.Ledger.Block as Ledger
+import           Cardano.Ledger.Core (EraAuxiliaryData)
+import qualified Cardano.Ledger.Era as CC
+import qualified Cardano.Ledger.TxIn as Ledger
+import           Cardano.Ledger.Val (isZero)
 
+import           Cardano.Ledger.Shelley.API (ShelleyTxOut (ShelleyTxOut))
+import qualified Cardano.Ledger.Shelley.API as Ledger hiding (TxBody, TxOut)
 import qualified Cardano.Ledger.Shelley.Genesis as Shelley
 import qualified Cardano.Ledger.Shelley.Metadata as Shelley
 import qualified Cardano.Ledger.Shelley.Tx as Shelley
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
-import qualified Cardano.Ledger.TxIn as Ledger
 
-import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Mary
+import           Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
-import           Cardano.Ledger.Val (isZero)
+import           Cardano.Ledger.ShelleyMA.TxBody (MATxBody (..))
+import           Cardano.Ledger.Mary.Value (MaryValue)
 
-import qualified Cardano.Ledger.Alonzo as Alonzo
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
+import           Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (AlonzoAuxiliaryData))
+import qualified Cardano.Ledger.Alonzo.Data as Alonzo
+import           Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (AlonzoTxBody),
+                   AlonzoTxOut (AlonzoTxOut))
 
-import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import           Ouroboros.Consensus.Shelley.Eras (StandardAllegra, StandardAlonzo, StandardBabbage,
@@ -651,21 +658,21 @@ toShelleyTxOut era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _ _) =
     case era of {}
 
 toShelleyTxOut _ (TxOut addr (TxOutAdaOnly AdaOnlyInShelleyEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+    ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
 toShelleyTxOut _ (TxOut addr (TxOutAdaOnly AdaOnlyInAllegraEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+    ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
 toShelleyTxOut _ (TxOut addr (TxOutValue MultiAssetInMaryEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toMaryValue value)
+    ShelleyTxOut (toShelleyAddr addr) (toMaryValue value)
 
 toShelleyTxOut _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata _) =
-    Alonzo.TxOut (toShelleyAddr addr) (toMaryValue value)
+    AlonzoTxOut (toShelleyAddr addr) (toMaryValue value)
                  (toAlonzoTxOutDataHash txoutdata)
 
 toShelleyTxOut era (TxOut addr (TxOutValue MultiAssetInBabbageEra value) txoutdata refScript) =
     let cEra = shelleyBasedToCardanoEra era
-    in Babbage.TxOut (toShelleyAddr addr) (toMaryValue value)
+    in BabbageTxOut (toShelleyAddr addr) (toMaryValue value)
                      (toBabbageTxOutDatum txoutdata) (refScriptToShelleyScript cEra refScript)
 
 
@@ -681,7 +688,7 @@ fromShelleyTxOut era ledgerTxOut =
                             (fromShelleyLovelace value))
                TxOutDatumNone ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
+        ShelleyTxOut addr value = ledgerTxOut
 
     ShelleyBasedEraAllegra ->
         TxOut (fromShelleyAddr era addr)
@@ -689,7 +696,7 @@ fromShelleyTxOut era ledgerTxOut =
                             (fromShelleyLovelace value))
                TxOutDatumNone ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
+        ShelleyTxOut addr value = ledgerTxOut
 
     ShelleyBasedEraMary ->
         TxOut (fromShelleyAddr era addr)
@@ -697,7 +704,7 @@ fromShelleyTxOut era ledgerTxOut =
                           (fromMaryValue value))
                TxOutDatumNone ReferenceScriptNone
       where
-        Shelley.TxOut addr value = ledgerTxOut
+        ShelleyTxOut addr value = ledgerTxOut
 
     ShelleyBasedEraAlonzo ->
        TxOut (fromShelleyAddr era addr)
@@ -706,7 +713,7 @@ fromShelleyTxOut era ledgerTxOut =
              (fromAlonzoTxOutDataHash ScriptDataInAlonzoEra datahash)
              ReferenceScriptNone
       where
-        Alonzo.TxOut addr value datahash = ledgerTxOut
+        AlonzoTxOut addr value datahash = ledgerTxOut
 
     ShelleyBasedEraBabbage ->
        TxOut (fromShelleyAddr era addr)
@@ -721,7 +728,7 @@ fromShelleyTxOut era ledgerTxOut =
                 SJust refScript ->
                   fromShelleyScriptToReferenceScript ShelleyBasedEraBabbage refScript)
       where
-        Babbage.TxOut addr value datum mRefScript = ledgerTxOut
+        BabbageTxOut addr value datum mRefScript = ledgerTxOut
 
 
 
@@ -1986,9 +1993,7 @@ getTxId (ShelleyTxBody era tx _ _ _ _) =
  where
   obtainConstraints
     :: ShelleyBasedEra era
-    -> (( Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-        , Ledger.UsesTxBody (ShelleyLedgerEra era)
-        ) => a)
+    -> ((Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto, Ledger.EraTxBody (ShelleyLedgerEra era)) => a)
     -> a
   obtainConstraints ShelleyBasedEraShelley f = f
   obtainConstraints ShelleyBasedEraAllegra f = f
@@ -1998,7 +2003,7 @@ getTxId (ShelleyTxBody era tx _ _ _ _) =
 
 getTxIdShelley
   :: Ledger.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => Ledger.UsesTxBody (ShelleyLedgerEra era)
+  => Ledger.EraTxBody (ShelleyLedgerEra era)
   => ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxId
 getTxIdShelley _ tx =
     TxId
@@ -2089,7 +2094,7 @@ createTransactionBody era txBodyContent =
             ttl = case upperBound of
                     TxValidityNoUpperBound era' -> case era' of {}
                     TxValidityUpperBound _ ttl'  -> ttl'
-            ledgerTxBody = Shelley.TxBody
+            ledgerTxBody = Ledger.ShelleyTxBody
                              txins
                              txOuts'
                              certs
@@ -2109,7 +2114,7 @@ createTransactionBody era txBodyContent =
               apiScriptValidity
 
        ShelleyBasedEraAllegra ->
-        let ledgerTxBody = Allegra.TxBody
+        let ledgerTxBody = MATxBody
                              txins
                              txOuts'
                              certs
@@ -2127,7 +2132,7 @@ createTransactionBody era txBodyContent =
               apiScriptValidity
 
        ShelleyBasedEraMary ->
-        let ledgerTxBody = Mary.TxBody
+        let ledgerTxBody = MATxBody
                              txins
                              txOuts'
                              certs
@@ -2156,7 +2161,7 @@ createTransactionBody era txBodyContent =
                     datums
                     languages
 
-            ledgerTxBody = Alonzo.TxBody
+            ledgerTxBody = AlonzoTxBody
                              txins
                              collTxIns
                              txOuts'
@@ -2192,7 +2197,7 @@ createTransactionBody era txBodyContent =
                               datums
                               languages
 
-            ledgerTxBody = Babbage.TxBody
+            ledgerTxBody = BabbageTxBody
                              txins
                              collTxIns
                              refTxIns
@@ -2402,16 +2407,16 @@ fromLedgerTxIns
   -> [(TxIn,BuildTxWith ViewTx (Witness WitCtxTxIn era))]
 fromLedgerTxIns era body =
     [ (fromShelleyTxIn input, ViewTx)
-    | input <- Set.toList (inputs era body) ]
+    | input <- Set.toList (inputs_ era body) ]
   where
-    inputs :: ShelleyBasedEra era
+    inputs_ :: ShelleyBasedEra era
            -> Ledger.TxBody (ShelleyLedgerEra era)
            -> Set (Ledger.TxIn StandardCrypto)
-    inputs ShelleyBasedEraShelley = Shelley._inputs
-    inputs ShelleyBasedEraAllegra = Allegra.inputs'
-    inputs ShelleyBasedEraMary    = Mary.inputs'
-    inputs ShelleyBasedEraAlonzo  = Alonzo.inputs'
-    inputs ShelleyBasedEraBabbage = Babbage.inputs
+    inputs_ ShelleyBasedEraShelley = Shelley._inputs
+    inputs_ ShelleyBasedEraAllegra = Allegra.inputs'
+    inputs_ ShelleyBasedEraMary    = Mary.inputs'
+    inputs_ ShelleyBasedEraAlonzo  = Alonzo.inputs'
+    inputs_ ShelleyBasedEraBabbage = Babbage.inputs
 
 
 fromLedgerTxInsCollateral
@@ -2423,10 +2428,10 @@ fromLedgerTxInsCollateral era body =
     case collateralSupportedInEra (shelleyBasedToCardanoEra era) of
       Nothing        -> TxInsCollateralNone
       Just supported ->
-        TxInsCollateral supported $ map fromShelleyTxIn collateral
+        TxInsCollateral supported $ map fromShelleyTxIn collateral_
   where
-    collateral :: [Ledger.TxIn StandardCrypto]
-    collateral = case era of
+    collateral_ :: [Ledger.TxIn StandardCrypto]
+    collateral_ = case era of
       ShelleyBasedEraShelley -> []
       ShelleyBasedEraAllegra -> []
       ShelleyBasedEraMary    -> []
@@ -2439,13 +2444,13 @@ fromLedgerTxInsReference era txBody =
   case refInsScriptsAndInlineDatsSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxInsReferenceNone
     Just suppInEra ->
-      let ledgerRefInputs = obtainReferenceInputsHasFieldConstraint suppInEra $ getField @"referenceInputs" txBody
+      let ledgerRefInputs = obtainReferenceInputsHasFieldConstraint suppInEra $ txBody ^. referenceInputsTxBodyL
       in TxInsReference suppInEra
            $ map fromShelleyTxIn . Set.toList $ ledgerRefInputs
  where
   obtainReferenceInputsHasFieldConstraint
     :: ReferenceTxInsScriptsInlineDatumsSupportedInEra era
-    -> (HasField "referenceInputs" (Ledger.TxBody (ShelleyLedgerEra era)) (Set (Ledger.TxIn StandardCrypto)) => a)
+    -> ((CC.Crypto (ShelleyLedgerEra era) ~ StandardCrypto, BabbageEraTxBody (ShelleyLedgerEra era)) => a)
     -> a
   obtainReferenceInputsHasFieldConstraint ReferenceTxInsScriptsInlineDatumsInBabbageEra f = f
 
@@ -2493,15 +2498,15 @@ fromAlonzoTxOut :: forall era ledgerera.
                    IsShelleyBasedEra era
                 => Ledger.Era ledgerera
                 => Ledger.Crypto ledgerera ~ StandardCrypto
-                => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
+                => Ledger.Value ledgerera ~ MaryValue StandardCrypto
                 => MultiAssetSupportedInEra era
                 -> ScriptDataSupportedInEra era
                 -> Map (Alonzo.DataHash StandardCrypto)
                        (Alonzo.Data ledgerera)
-                -> Alonzo.TxOut ledgerera
+                -> AlonzoTxOut ledgerera
                 -> TxOut CtxTx era
 fromAlonzoTxOut multiAssetInEra scriptDataInEra txdatums
-                (Alonzo.TxOut addr value datahash) =
+                (AlonzoTxOut addr value datahash) =
    TxOut (fromShelleyAddr shelleyBasedEra addr)
          (TxOutValue multiAssetInEra (fromMaryValue value))
          (fromAlonzoTxOutDatum scriptDataInEra datahash)
@@ -2522,13 +2527,13 @@ fromBabbageTxOut
   => IsShelleyBasedEra era
   => ShelleyLedgerEra era ~ ledgerera
   => Ledger.Crypto ledgerera ~ StandardCrypto
-  => Ledger.Value ledgerera ~ Mary.Value StandardCrypto
+  => Ledger.Value ledgerera ~ MaryValue StandardCrypto
   => MultiAssetSupportedInEra era
   -> ScriptDataSupportedInEra era
   -> ReferenceTxInsScriptsInlineDatumsSupportedInEra era
   -> Map (Alonzo.DataHash StandardCrypto)
          (Alonzo.Data ledgerera)
-  -> Babbage.TxOut ledgerera
+  -> BabbageTxOut ledgerera
   -> TxOut CtxTx era
 fromBabbageTxOut multiAssetInEra scriptDataInEra inlineDatumsInEra txdatums txout =
    TxOut
@@ -2557,7 +2562,7 @@ fromBabbageTxOut multiAssetInEra scriptDataInEra inlineDatumsInEra txdatums txou
                   = TxOutDatumInTx' scriptDataInEra (ScriptDataHash dh) (fromAlonzoData d)
       | otherwise = TxOutDatumHash scriptDataInEra (ScriptDataHash dh)
 
-   (Babbage.TxOut addr val datum mRefScript) = txout
+   (BabbageTxOut addr val datum mRefScript) = txout
 
 fromLedgerTxTotalCollateral
   :: ShelleyBasedEra era
@@ -2567,13 +2572,13 @@ fromLedgerTxTotalCollateral era txbody =
   case totalAndReturnCollateralSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxTotalCollateralNone
     Just supp ->
-      case obtainTotalCollateralHasFieldConstraint supp $ getField @"totalCollateral" txbody of
+      case obtainTotalCollateralHasFieldConstraint supp $ txbody ^. totalCollateralTxBodyL of
         SNothing -> TxTotalCollateralNone
         SJust totColl -> TxTotalCollateral supp $ fromShelleyLovelace totColl
  where
   obtainTotalCollateralHasFieldConstraint
     :: TxTotalAndReturnCollateralSupportedInEra era
-    -> (HasField "totalCollateral" (Ledger.TxBody (ShelleyLedgerEra era)) (StrictMaybe Ledger.Coin) => a)
+    -> (BabbageEraTxBody (ShelleyLedgerEra era) => a)
     -> a
   obtainTotalCollateralHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
 
@@ -2585,16 +2590,17 @@ fromLedgerTxReturnCollateral era txbody =
   case totalAndReturnCollateralSupportedInEra $ shelleyBasedToCardanoEra era of
     Nothing -> TxReturnCollateralNone
     Just supp ->
-      case obtainCollateralReturnHasFieldConstraint supp $ getField @"collateralReturn" txbody of
+      case obtainCollateralReturnHasFieldConstraint supp $ txbody ^. collateralReturnTxBodyL of
         SNothing -> TxReturnCollateralNone
         SJust collReturnOut ->
           TxReturnCollateral supp $ fromShelleyTxOut era collReturnOut
  where
   obtainCollateralReturnHasFieldConstraint
     :: TxTotalAndReturnCollateralSupportedInEra era
-    -> (HasField "collateralReturn"
-          (Ledger.TxBody (ShelleyLedgerEra era))
-          (StrictMaybe (Ledger.TxOut (ShelleyLedgerEra era))) => a)
+    -> (( Ledger.TxOut (ShelleyLedgerEra era) ~ BabbageTxOut (ShelleyLedgerEra era)
+      , CC.Crypto (ShelleyLedgerEra era) ~ StandardCrypto
+      , BabbageEraTxBody (ShelleyLedgerEra era)
+      ) => a)
     -> a
   obtainCollateralReturnHasFieldConstraint TxTotalAndReturnCollateralInBabbageEra f = f
 
@@ -2681,19 +2687,19 @@ fromLedgerAuxiliaryData
   -> (Map Word64 TxMetadataValue, [ScriptInEra era])
 fromLedgerAuxiliaryData ShelleyBasedEraShelley (Shelley.Metadata metadata) =
   (fromShelleyMetadata metadata, [])
-fromLedgerAuxiliaryData ShelleyBasedEraAllegra (Allegra.AuxiliaryData ms ss) =
+fromLedgerAuxiliaryData ShelleyBasedEraAllegra (MAAuxiliaryData ms ss) =
   ( fromShelleyMetadata ms
   , fromShelleyBasedScript ShelleyBasedEraAllegra <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraMary (Mary.AuxiliaryData ms ss) =
+fromLedgerAuxiliaryData ShelleyBasedEraMary (MAAuxiliaryData ms ss) =
   ( fromShelleyMetadata ms
   , fromShelleyBasedScript ShelleyBasedEraMary <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraAlonzo (Alonzo.AuxiliaryData ms ss) =
+fromLedgerAuxiliaryData ShelleyBasedEraAlonzo (AlonzoAuxiliaryData ms ss) =
   ( fromShelleyMetadata ms
   , fromShelleyBasedScript ShelleyBasedEraAlonzo <$> toList ss
   )
-fromLedgerAuxiliaryData ShelleyBasedEraBabbage (Alonzo.AuxiliaryData ms ss) =
+fromLedgerAuxiliaryData ShelleyBasedEraBabbage (AlonzoAuxiliaryData ms ss) =
   ( fromShelleyMetadata ms
   , fromShelleyBasedScript ShelleyBasedEraBabbage <$> toList ss
   )
@@ -3092,7 +3098,7 @@ convTxUpdateProposal era txUpdateProposal =
     TxUpdateProposalNone -> SNothing
     TxUpdateProposal _ p -> SJust (toLedgerUpdate era p)
 
-convMintValue :: TxMintValue build era -> Mary.Value StandardCrypto
+convMintValue :: TxMintValue build era -> MaryValue StandardCrypto
 convMintValue txMintValue =
   case txMintValue of
     TxMintNone        -> mempty
@@ -3119,8 +3125,7 @@ convAuxiliaryData txMetadata
 
 
 convAuxiliaryDataToHash
-  :: Ledger.ValidateAuxiliaryData era c
-  => Maybe (Ledger.AuxiliaryData era) -> StrictMaybe (Ledger.AuxiliaryDataHash c)
+  :: EraAuxiliaryData era => Maybe (Ledger.AuxiliaryData era) -> StrictMaybe (Ledger.AuxiliaryDataHash (CC.Crypto era))
 convAuxiliaryDataToHash txAuxData =
   maybeToStrictMaybe
             (Ledger.hashAuxiliaryData <$> txAuxData)
@@ -3251,7 +3256,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraShelley
 
     return $
       ShelleyTxBody era
-        (Shelley.TxBody
+        (Ledger.ShelleyTxBody
           (convTxIns txIns)
           (convTxOuts era txOuts)
           (convCertificates txCertificates)
@@ -3262,13 +3267,13 @@ makeShelleyTransactionBody era@ShelleyBasedEraShelley
              TxValidityUpperBound _ ttl  -> ttl)
           (convTxUpdateProposal era txUpdateProposal)
           (convAuxiliaryDataToHash txAuxData))
-        scripts
+        scripts_
         TxBodyNoScriptData
         txAuxData
         TxScriptValidityNone
   where
-    scripts :: [Ledger.Script StandardShelley]
-    scripts = catMaybes
+    scripts_ :: [Ledger.Script StandardShelley]
+    scripts_ = catMaybes
       [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness)
           <- collectTxBodyScriptWitnesses txbodycontent
@@ -3300,7 +3305,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAllegra
 
     return $
       ShelleyTxBody era
-        (Allegra.TxBody
+        (MATxBody
           (convTxIns txIns)
           (Seq.fromList (map (toShelleyTxOutAny era) txOuts))
           (convCertificates txCertificates)
@@ -3310,13 +3315,13 @@ makeShelleyTransactionBody era@ShelleyBasedEraAllegra
           (convTxUpdateProposal era txUpdateProposal)
           (convAuxiliaryDataToHash txAuxData)
           mempty) -- No minting in Allegra, only Mary
-        scripts
+        scripts_
         TxBodyNoScriptData
         txAuxData
         TxScriptValidityNone
   where
-    scripts :: [Ledger.Script StandardAllegra]
-    scripts = catMaybes
+    scripts_ :: [Ledger.Script StandardAllegra]
+    scripts_ = catMaybes
       [ toShelleyScript <$> scriptWitnessScript scriptwitness
       | (_, AnyScriptWitness scriptwitness)
           <- collectTxBodyScriptWitnesses txbodycontent
@@ -3353,7 +3358,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraMary
 
     return $
       ShelleyTxBody era
-        (Allegra.TxBody
+        (MATxBody
           (convTxIns txIns)
           (Seq.fromList $ map (toShelleyTxOutAny era) txOuts)
           (convCertificates txCertificates)
@@ -3410,7 +3415,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraAlonzo
 
     return $
       ShelleyTxBody era
-        (Alonzo.TxBody
+        (AlonzoTxBody
           (convTxIns txIns)
           (convCollateralTxIns txInsCollateral)
           (convTxOuts era txOuts)
@@ -3510,7 +3515,7 @@ makeShelleyTransactionBody era@ShelleyBasedEraBabbage
 
     return $
       ShelleyTxBody era
-        (Babbage.TxBody
+        (BabbageTxBody
            { Babbage.inputs = convTxIns txIns
            , Babbage.collateral =
                case txInsCollateral of
@@ -3613,21 +3618,21 @@ toShelleyTxOutAny era (TxOut _ (TxOutAdaOnly AdaOnlyInByronEra _) _ _) =
     case era of {}
 
 toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly AdaOnlyInShelleyEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+    ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
 toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly AdaOnlyInAllegraEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toShelleyLovelace value)
+    ShelleyTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
 toShelleyTxOutAny _ (TxOut addr (TxOutValue MultiAssetInMaryEra value) _ _) =
-    Shelley.TxOut (toShelleyAddr addr) (toMaryValue value)
+    ShelleyTxOut (toShelleyAddr addr) (toMaryValue value)
 
 toShelleyTxOutAny _ (TxOut addr (TxOutValue MultiAssetInAlonzoEra value) txoutdata _) =
-    Alonzo.TxOut (toShelleyAddr addr) (toMaryValue value)
+    AlonzoTxOut (toShelleyAddr addr) (toMaryValue value)
                  (toAlonzoTxOutDataHash' txoutdata)
 
 toShelleyTxOutAny era (TxOut addr (TxOutValue MultiAssetInBabbageEra value) txoutdata refScript) =
     let cEra = shelleyBasedToCardanoEra era
-    in Babbage.TxOut (toShelleyAddr addr) (toMaryValue value)
+    in BabbageTxOut (toShelleyAddr addr) (toMaryValue value)
                     (toBabbageTxOutDatum' txoutdata) (refScriptToShelleyScript cEra refScript)
 
 
@@ -3832,19 +3837,19 @@ toAuxiliaryData sbe txMetadata txAuxScripts =
        ShelleyBasedEraShelley ->
          Shelley.Metadata $ toShelleyMetadata m
        ShelleyBasedEraAllegra ->
-         Allegra.AuxiliaryData
+         Allegra.MAAuxiliaryData
            (toShelleyMetadata m)
            (Seq.fromList (map toShelleyScript ss))
        ShelleyBasedEraMary ->
-         Allegra.AuxiliaryData
+         Allegra.MAAuxiliaryData
            (toShelleyMetadata m)
            (Seq.fromList (map toShelleyScript ss))
        ShelleyBasedEraAlonzo ->
-         Alonzo.AuxiliaryData
+         Alonzo.AlonzoAuxiliaryData
            (toShelleyMetadata m)
            (Seq.fromList (map toShelleyScript ss))
        ShelleyBasedEraBabbage ->
-         Alonzo.AuxiliaryData
+         Alonzo.AlonzoAuxiliaryData
            (toShelleyMetadata m)
            (Seq.fromList (map toShelleyScript ss))
 

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -77,8 +77,9 @@ import qualified Data.Text.Encoding as Text
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Coin as Shelley
 import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Ledger.Mary.Value (MaryValue (..))
 import qualified Cardano.Ledger.Mary.Value as Mary
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Shelley
+import qualified Cardano.Ledger.ShelleyMA.Rules as Shelley
 
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.HasTypeProxy
@@ -263,9 +264,9 @@ valueToLovelace v =
       [(AdaAssetId, q)] -> Just (quantityToLovelace q)
       _                 -> Nothing
 
-toMaryValue :: Value -> Mary.Value StandardCrypto
+toMaryValue :: Value -> MaryValue StandardCrypto
 toMaryValue v =
-    Mary.Value lovelace other
+    MaryValue lovelace other
   where
     Quantity lovelace = selectAsset v AdaAssetId
       --TODO: write QC tests to show it's ok to use Map.fromAscListWith here
@@ -280,8 +281,8 @@ toMaryValue v =
     toMaryAssetName (AssetName n) = Mary.AssetName $ Short.toShort n
 
 
-fromMaryValue :: Mary.Value StandardCrypto -> Value
-fromMaryValue (Mary.Value lovelace other) =
+fromMaryValue :: MaryValue StandardCrypto -> Value
+fromMaryValue (MaryValue lovelace other) =
     Value $
       --TODO: write QC tests to show it's ok to use Map.fromAscList here
       Map.fromList $

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -11,7 +11,7 @@ import           Cardano.Prelude
 
 import           Cardano.Api.Shelley (ShelleyGenesis (..))
 
-import           Data.ListMap (ListMap(ListMap))
+import           Data.ListMap (ListMap (ListMap))
 import qualified Data.Map.Strict as Map
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
@@ -21,13 +21,13 @@ import           Ouroboros.Consensus.Shelley.Node (emptyGenesisStaking)
 import           Ouroboros.Consensus.Util.Time
 
 import           Cardano.Ledger.Address (Addr (..))
-import           Cardano.Ledger.Credential (Credential (..), PaymentCredential,
-                   StakeCredential, StakeReference (..))
 import           Cardano.Ledger.BaseTypes (Network (..))
 import           Cardano.Ledger.Coin (Coin (..))
+import           Cardano.Ledger.Credential (Credential (..), PaymentCredential, StakeCredential,
+                   StakeReference (..))
 import           Cardano.Ledger.Keys (GenDelegPair (..), Hash, KeyHash (..), KeyRole (..),
                    VerKeyVRF)
-import           Cardano.Ledger.Shelley.PParams (PParams' (..), emptyPParams)
+import           Cardano.Ledger.Shelley.PParams (ShelleyPParamsHKD (..), emptyPParams)
 
 import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -107,17 +107,17 @@ library
                       , cardano-binary
                       , cardano-git-rev
                       , cardano-crypto
-                      , cardano-crypto-class
-                      , cardano-crypto-wrapper
-                      , cardano-data
-                      , cardano-ledger-alonzo
-                      , cardano-ledger-byron
-                      , cardano-ledger-core
-                      , cardano-ledger-shelley-ma
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-crypto-wrapper ^>= 1.4
+                      , cardano-data ^>= 0.1
+                      , cardano-ledger-alonzo ^>= 0.1
+                      , cardano-ledger-byron ^>= 0.1
+                      , cardano-ledger-core ^>= 0.1
+                      , cardano-ledger-shelley-ma ^>= 0.1
                       , cardano-prelude
-                      , cardano-protocol-tpraos
-                      , cardano-slotting
-                      , vector-map
+                      , cardano-protocol-tpraos ^>= 0.1
+                      , cardano-slotting ^>= 0.1
+                      , vector-map ^>= 0.1
                       , contra-tracer
                       , cborg >= 0.2.4 && < 0.3
                       , containers
@@ -137,10 +137,10 @@ library
                       , parsec
                       , prettyprinter
                       , random
-                      , cardano-ledger-shelley
-                      , set-algebra
+                      , cardano-ledger-shelley ^>= 0.1
+                      , set-algebra ^>= 0.1
                       , split
-                      , strict-containers
+                      , cardano-strict-containers ^>= 0.1
                       , text
                       , time
                       , transformers
@@ -158,7 +158,7 @@ executable cardano-cli
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
   build-depends:        cardano-cli
-                      , cardano-crypto-class
+                      , cardano-crypto-class ^>= 2.0
                       , cardano-prelude
                       , optparse-applicative-fork
                       , transformers-except
@@ -178,7 +178,7 @@ test-suite cardano-cli-test
                       , cardano-cli
                       , cardano-node
                       , cardano-prelude
-                      , cardano-slotting
+                      , cardano-slotting ^>= 0.1
                       , containers
                       , directory
                       , exceptions
@@ -220,8 +220,8 @@ test-suite cardano-cli-golden
                       , bytestring
                       , cardano-api
                       , cardano-cli
-                      , cardano-crypto-wrapper
-                      , cardano-ledger-byron
+                      , cardano-crypto-wrapper ^>= 1.4
+                      , cardano-ledger-byron ^>= 0.1
                       , cardano-prelude
                       , cborg
                       , containers

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -82,7 +82,7 @@ import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Cardano.Ledger.Era as Era
 import qualified Cardano.Ledger.Era as Ledger
 import           Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import           Cardano.Ledger.Shelley.Constraints
+import           Cardano.Ledger.SafeHash (HashAnnotated)
 import           Cardano.Ledger.Shelley.EpochBoundary
 import           Cardano.Ledger.Shelley.LedgerState (EpochState (esSnapshots),
                    NewEpochState (nesEs), PState (_fPParams, _pParams, _retiring))
@@ -1397,10 +1397,10 @@ toEpochInfo (EraHistory _ interpreter) =
 obtainLedgerEraClassConstraints
   :: ShelleyLedgerEra era ~ ledgerera
   => Api.ShelleyBasedEra era
-  -> (( UsesValue ledgerera
-      , ToJSON (DebugLedgerState era)
+  -> (( ToJSON (DebugLedgerState era)
       , FromCBOR (DebugLedgerState era)
       , Era.Crypto ledgerera ~ StandardCrypto
+      , Ledger.Era (ShelleyLedgerEra era)
       ) => a) -> a
 obtainLedgerEraClassConstraints ShelleyBasedEraShelley f = f
 obtainLedgerEraClassConstraints ShelleyBasedEraAllegra f = f
@@ -1420,7 +1420,11 @@ eligibleLeaderSlotsConstaints
       , HasField "_d" (Core.PParams (ShelleyLedgerEra era)) UnitInterval
       , Crypto.Signable (Crypto.VRF (Ledger.Crypto ledgerera)) Seed
       , Share (Core.TxOut (ShelleyLedgerEra era)) ~ Interns (Ledger.Credential 'Staking StandardCrypto)
-      ,  Crypto.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+      , Crypto.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+      , HashAnnotated
+          (Core.TxBody (ShelleyLedgerEra era))
+          Core.EraIndependentTxBody
+          StandardCrypto
       ) => a
      )
   -> a

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -8,13 +8,13 @@
 import           Cardano.Api
 import           Cardano.Api.Shelley
 import           Cardano.Ledger.Address (getRewardAcnt)
-import           Cardano.Ledger.Alonzo.PParams (PParams' (..))
+import           Cardano.Ledger.Alonzo.PParams (AlonzoPParamsHKD (..))
 import qualified Cardano.Ledger.BaseTypes as L
 import           Cardano.Ledger.Compactible (Compactible (..))
 import qualified Cardano.Ledger.Core as LC
 import qualified Cardano.Ledger.Shelley.API as L
-import qualified Cardano.Ledger.Shelley.RewardUpdate as L
 import qualified Cardano.Ledger.Shelley.Rewards as L
+import qualified Cardano.Ledger.Shelley.RewardUpdate as L
 import qualified Cardano.Ledger.UnifiedMap as UM
 import qualified Codec.Binary.Bech32 as Bech32
 import           Control.Monad.Trans.Except (runExceptT)
@@ -23,7 +23,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Char (ord)
-import qualified Data.VMap as VMap
 import           Data.Foldable (toList)
 import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
@@ -31,6 +30,7 @@ import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Text as T
 import qualified Data.UMap as UM
+import qualified Data.VMap as VMap
 import           GHC.Records (HasField (..))
 import           Options.Applicative (Parser, (<**>), (<|>))
 import qualified Options.Applicative as Opt

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -31,8 +31,8 @@ executable scan-blocks-pipelined
   import:               base, project-config
   main-is:              ScanBlocksPipelined.hs
   build-depends:        cardano-api
-                      , cardano-ledger-byron
-                      , cardano-slotting
+                      , cardano-ledger-byron ^>= 0.1
+                      , cardano-slotting ^>= 0.1
                       , filepath
                       , time
 
@@ -40,8 +40,8 @@ executable chain-sync-client-with-ledger-state
   import:               base, project-config
   main-is:              ChainSyncClientWithLedgerState.hs
   build-depends:        cardano-api
-                      , cardano-ledger-byron
-                      , cardano-slotting
+                      , cardano-ledger-byron ^>= 0.1
+                      , cardano-slotting ^>= 0.1
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano
 

--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -14,8 +14,8 @@ module Cardano.Chairman (chairmanTest) where
 import           Cardano.Prelude hiding (ByteString, STM, atomically, catch, show, throwIO)
 import           Prelude (String, error, show)
 
+import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import           Control.Tracer

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -48,7 +48,7 @@ executable cardano-node-chairman
                       , cardano-prelude
                       , containers
                       , contra-tracer
-                      , io-classes
+                      , io-classes ^>= 0.3
                       , optparse-applicative-fork
                       , ouroboros-consensus
                       , ouroboros-network

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for cardano-node
 
-## vNext
+## 1.35.5 -- November 2022
 
 ### node changes
 
@@ -12,13 +12,41 @@ None
 
 ### network changes
 
-- New P2P topology file format. See [issue #4563][#4563] or the [config
-  files][understanding-config-files] documentation. The old P2P topology
+- Added 'DemoteLocalAsynchronous' warning trace.  It indicates that a remote
+  local root peer was demoted to cold (either due to connection error or
+  misbehaviour).
+
+- New P2P topology file format, see [issue #4563][#4563] or the [config
+  files][understanding-config-files] documentation.  The old p2p topology
   format will be supported for next two major releases of the node (the last
-  supported major version will be `1.37`).
+  major version which will support it is `1.37`).
 
 [#4563]: https://github.com/input-output-hk/cardano-node/issues/4563
 [understanding-config-files]: https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/understanding-config-files.md
+
+### ledger changes
+
+None
+
+## 1.35.4 -- October 2022
+
+### node changes
+
+- Update plutus to version 1.0.0.1 to enable SECP at protocol version 8
+- Update cardano-crypto-class to version 2.0.0.0.2 to add SECP crypto primitives
+- Update block header advertised version in babbage to 8.0
+
+### plutus changes
+
+- enables SECP primitive for plutus smart contracts at protocol version 8 (intra-era hard fork)
+
+### consensus changes
+
+None
+
+### network changes
+
+None
 
 ### ledger changes
 

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,25 @@
 # Changelog for cardano-node
 
+## 1.36.0 -- November 2022
+
+### node changes
+
+ - Bumped cardano-ledger to 0.1
+ - Bumped plutus-core to 1.0
+ - Bumped ouroboros-network to commit 72863b0
+
+### consensus changes
+
+TODO
+
+### network changes
+
+TODO
+
+### ledger changes
+
+TODO
+
 ## 1.35.5 -- November 2022
 
 ### node changes

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -33,7 +33,7 @@ None
 ### node changes
 
 - Update plutus to version 1.0.0.1 to enable SECP at protocol version 8
-- Update cardano-crypto-class to version 2.0.0.0.2 to add SECP crypto primitives
+- Update cardano-crypto-class to version 2.0.0.0.1 to add SECP crypto primitives
 - Update block header advertised version in babbage to 8.0
 
 ### plutus changes

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -95,6 +95,7 @@ library
                        Cardano.Node.Tracing.Tracers.BlockReplayProgress
                        Cardano.Node.Tracing.Tracers.ChainDB
                        Cardano.Node.Tracing.Tracers.Consensus
+                       Cardano.Node.Tracing.Tracers.ConsensusStartupException
                        Cardano.Node.Tracing.Tracers.Diffusion
                        Cardano.Node.Tracing.Tracers.KESInfo
                        Cardano.Node.Tracing.Tracers.StartLeadershipCheck
@@ -130,19 +131,20 @@ library
                       , base16-bytestring
                       , bytestring
                       , cardano-api
-                      , cardano-data
+                      , cardano-data ^>= 0.1
                       , cardano-git-rev
-                      , cardano-crypto-class
-                      , cardano-crypto-wrapper
-                      , cardano-ledger-alonzo
-                      , cardano-ledger-babbage
-                      , cardano-ledger-byron
-                      , cardano-ledger-core
-                      , cardano-ledger-shelley-ma
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-crypto-wrapper ^>= 1.4
+                      , cardano-ledger-core ^>= 0.1
+                      , cardano-ledger-byron ^>= 0.1
+                      , cardano-ledger-shelley ^>= 0.1
+                      , cardano-ledger-shelley-ma ^>= 0.1
+                      , cardano-ledger-alonzo ^>= 0.1
+                      , cardano-ledger-babbage ^>= 0.1
                       , cardano-prelude
-                      , cardano-protocol-tpraos
-                      , cardano-slotting
-                      , cborg >= 0.2.4 && < 0.3
+                      , cardano-protocol-tpraos ^>= 0.1
+                      , cardano-slotting ^>= 0.1
+                      , cborg ^>= 0.2.4
                       , contra-tracer
                       , containers
                       , directory
@@ -153,28 +155,27 @@ library
                       , generic-data
                       , hostname
                       , iproute
-                      , io-classes
+                      , io-classes ^>= 0.3
                       , iohk-monitoring
                       , lobemo-backend-aggregation
                       , lobemo-backend-ekg
                       , lobemo-backend-monitoring
                       , lobemo-backend-trace-forwarder
                       , network
-                      , network-mux
+                      , network-mux ^>= 0.2
                       , nothunks
                       , optparse-applicative-fork
-                      , ouroboros-consensus
+                      , ouroboros-consensus ^>= 0.1.0.2
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano
                       , ouroboros-consensus-protocol
                       , ouroboros-consensus-shelley
-                      , ouroboros-network
-                      , ouroboros-network-framework
+                      , ouroboros-network  ^>= 0.2
+                      , ouroboros-network-framework ^>= 0.2
                       , psqueues
                       , safe-exceptions
                       , scientific
                       , strict-stm
-                      , cardano-ledger-shelley
                       , stm
                       , text
                       , time
@@ -184,7 +185,7 @@ library
                       , trace-resources
                       , transformers
                       , transformers-except
-                      , typed-protocols
+                      , typed-protocols ^>= 0.1
                       , yaml
 
 executable cardano-node
@@ -219,7 +220,7 @@ test-suite cardano-node-test
                       , cardano-api
                       , cardano-node
                       , cardano-prelude
-                      , cardano-slotting
+                      , cardano-slotting ^>= 0.1
                       , directory
                       , hedgehog
                       , hedgehog-corpus

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -211,7 +211,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Babbage era. Since Babbage is currently the last known
           -- protocol version then this is also the Babbage protocol version.
-          Praos.babbageProtVer = ProtVer 7 0,
+          Praos.babbageProtVer = ProtVer 8 0,
           Praos.babbageMaxTxCapacityOverrides =
             TxLimits.mkOverrides TxLimits.noOverridesMeasure
         }

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -23,7 +23,7 @@ import           Cardano.Prelude hiding (ByteString, STM, atomically, show, take
 import           Data.IP (toSockAddr)
 import           Prelude (String, id, show)
 
-import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Trans.Except.Extra (left)
 import           "contra-tracer" Control.Tracer
 import qualified Data.Map.Strict as Map
@@ -624,6 +624,8 @@ mkP2PArguments NodeConfiguration {
       , P2P.daReadUseLedgerAfter
       , P2P.daProtocolIdleTimeout = ncProtocolIdleTimeout
       , P2P.daTimeWaitTimeout     = ncTimeWaitTimeout
+      , P2P.daDeadlineChurnInterval = 3300
+      , P2P.daBulkChurnInterval = 300
       }
   where
     daPeerSelectionTargets = PeerSelectionTargets {

--- a/cardano-node/src/Cardano/Node/Tracing.hs
+++ b/cardano-node/src/Cardano/Node/Tracing.hs
@@ -1,31 +1,32 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PackageImports #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 module Cardano.Node.Tracing
   ( Tracers (..)
+  , ConsensusStartupException (..)
   ) where
 
-import Prelude (IO)
+import           Prelude (IO)
 
-import Codec.CBOR.Read (DeserialiseFailure)
-import "contra-tracer" Control.Tracer (Tracer)
+import           Codec.CBOR.Read (DeserialiseFailure)
+import           "contra-tracer" Control.Tracer (Tracer)
 
-import Ouroboros.Consensus.Network.NodeToClient qualified as NodeToClient
-import Ouroboros.Consensus.Network.NodeToNode   qualified as NodeToNode
-import Ouroboros.Consensus.Node.Tracers         qualified as Consensus
-import Ouroboros.Consensus.Storage.ChainDB      qualified as ChainDB
-import Ouroboros.Network.Diffusion              qualified as Diffusion
+import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
+import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Network.Diffusion as Diffusion
 
-import Ouroboros.Network.NodeToNode   (NodeToNodeVersion, RemoteAddress)
-import Ouroboros.Network.NodeToClient (LocalAddress, NodeToClientVersion)
+import           Ouroboros.Network.NodeToClient (LocalAddress, NodeToClientVersion)
+import           Ouroboros.Network.NodeToNode (NodeToNodeVersion, RemoteAddress)
 
-import Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import Cardano.Node.Startup           (NodeInfo, NodeStartupInfo, StartupTrace)
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
+import           Cardano.Node.Startup (NodeInfo, NodeStartupInfo, StartupTrace)
 
-import Cardano.Logging.Resources
-import Cardano.Node.Tracing.StateRep (NodeState)
-import Cardano.Node.Tracing.Tracers.Peer (PeerT)
+import           Cardano.Logging.Resources
+import           Cardano.Node.Tracing.StateRep (NodeState)
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+import           Cardano.Node.Tracing.Tracers.Peer (PeerT)
 
 data Tracers peer localPeer blk p2p = Tracers
   { -- | Trace the ChainDB

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -35,8 +35,7 @@ import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB
 import           Cardano.Node.Tracing.Tracers.Consensus
 import           Cardano.Node.Tracing.Tracers.Diffusion
-import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (
-                   docForgeStats, forgeThreadStats)
+import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (docForgeStats, forgeThreadStats)
 import           Cardano.Node.Tracing.Tracers.KESInfo
 import           Cardano.Node.Tracing.Tracers.NodeToClient
 import           Cardano.Node.Tracing.Tracers.NodeToNode
@@ -632,7 +631,7 @@ docTracers configFileName outputFileName _ _ _ = do
     configureTracers trConfig docDiffusionInit [dtDiffusionInitializationTr]
     dtDiffusionInitializationTrDoc <- documentTracer trConfig dtDiffusionInitializationTr
       (docDiffusionInit ::
-        Documented (Diffusion.InitializationTracer Socket.SockAddr LocalAddress))
+        Documented (Diffusion.DiffusionTracer Socket.SockAddr LocalAddress))
 
     dtLedgerPeersTr  <- mkCardanoTracer
                 trBase trForward mbTrEKG
@@ -715,7 +714,7 @@ docTracers configFileName outputFileName _ _ _ = do
     configureTracers trConfig docPeerSelectionActions [peerSelectionActionsTr]
     peerSelectionActionsTrDoc <- documentTracer trConfig peerSelectionActionsTr
       (docPeerSelectionActions ::
-        Documented (PeerSelectionActionsTrace Socket.SockAddr))
+        Documented (PeerSelectionActionsTrace Socket.SockAddr LocalAddress))
 
     connectionManagerTr  <-  mkCardanoTracer
       trBase trForward mbTrEKG

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -34,8 +34,6 @@ import           Cardano.Slotting.Block (BlockNo (..))
 import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockNo, blockSlot)
 import           Ouroboros.Network.Point (WithOrigin, withOriginToMaybe)
 
-import qualified Cardano.Ledger.Babbage.Rules.Utxo as Babbage
-import qualified Cardano.Ledger.Babbage.Rules.Utxow as Babbage
 import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as SupportsMempool
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
@@ -54,24 +52,18 @@ import           Cardano.Protocol.TPraos.Rules.Updn (UpdnPredicateFailure)
 
 
 import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
-import           Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail)
-import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
-import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo
-import           Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.AuxiliaryData as Core
 import           Cardano.Ledger.BaseTypes (activeSlotLog, strictMaybeToMaybe)
 import           Cardano.Ledger.Chain
-import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Core as Core hiding (Crypto)
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Crypto as Core
-import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.SafeHash as SafeHash
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
 
 -- TODO: this should be exposed via Cardano.Api
-import           Cardano.Ledger.Shelley.API hiding (ShelleyBasedEra)
+import           Cardano.Ledger.Shelley.API
 
 import           Cardano.Ledger.Shelley.Rules.Bbody
 import           Cardano.Ledger.Shelley.Rules.Deleg
@@ -93,6 +85,13 @@ import           Cardano.Ledger.Shelley.Rules.Upec
 import           Cardano.Ledger.Shelley.Rules.Utxo
 import           Cardano.Ledger.Shelley.Rules.Utxow
 
+import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure, AlonzoUtxoPredFailure,
+                   AlonzoUtxosPredFailure, AlonzoUtxowPredFailure (..))
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
+import           Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
+import           Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
+import qualified Cardano.Ledger.ShelleyMA.Rules as MA
 import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
 import           Cardano.Protocol.TPraos.Rules.Prtcl
@@ -127,8 +126,8 @@ instance ShelleyCompatible protocol era => LogFormatting (Header (ShelleyBlock p
         ]
 
 instance ( ShelleyBasedEra era
-         , LogFormatting (PredicateFailure (UTXO era))
-         , LogFormatting (PredicateFailure (UTXOW era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXOW era))
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => LogFormatting (ApplyTxError era) where
   forMachine dtal (ApplyTxError predicateFailures) =
@@ -232,8 +231,8 @@ instance LogFormatting HotKey.KESEvolutionError where
       ]
 
 instance ( ShelleyBasedEra era
-         , LogFormatting (PredicateFailure (UTXO era))
-         , LogFormatting (PredicateFailure (UTXOW era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXOW era))
          , LogFormatting (PredicateFailure (Core.EraRule "BBODY" era))
          ) => LogFormatting (ShelleyLedgerError era) where
   forMachine dtal (BBodyError (BlockTransitionError fs)) =
@@ -242,21 +241,21 @@ instance ( ShelleyBasedEra era
              ]
 
 instance ( ShelleyBasedEra era
-         , ToJSON (Core.PParamsDelta era)
+         , ToJSON (Core.PParamsUpdate era)
          ) => LogFormatting (ShelleyLedgerUpdate era) where
   forMachine dtal (ShelleyUpdatedProtocolUpdates updates) =
     mconcat [ "kind" .= String "ShelleyUpdatedProtocolUpdates"
              , "updates" .= map (forMachine dtal) updates
              ]
 
-instance (Ledger.Era era, ToJSON (Core.PParamsDelta era))
+instance (Ledger.Era era, ToJSON (Core.PParamsUpdate era))
          => LogFormatting (ProtocolUpdate era) where
   forMachine dtal ProtocolUpdate{protocolUpdateProposal, protocolUpdateState} =
     mconcat [ "proposal" .= forMachine dtal protocolUpdateProposal
              , "state"    .= forMachine dtal protocolUpdateState
              ]
 
-instance ToJSON (Core.PParamsDelta era)
+instance ToJSON (Core.PParamsUpdate era)
          => LogFormatting (UpdateProposal era) where
   forMachine _dtal UpdateProposal{proposalParams, proposalVersion, proposalEpoch} =
     mconcat [ "params"  .= proposalParams
@@ -317,11 +316,11 @@ instance LogFormatting (PrtlSeqFailure crypto) where
              ]
 
 instance ( ShelleyBasedEra era
-         , LogFormatting (PredicateFailure (UTXO era))
-         , LogFormatting (PredicateFailure (UTXOW era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXOW era))
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGER" era))
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGERS" era))
-         ) => LogFormatting (BbodyPredicateFailure era) where
+         ) => LogFormatting (ShelleyBbodyPredFailure era) where
   forMachine _dtal (WrongBlockBodySizeBBODY actualBodySz claimedBodySz) =
     mconcat [ "kind" .= String "WrongBlockBodySizeBBODY"
              , "actualBlockBodySize" .= actualBodySz
@@ -336,20 +335,20 @@ instance ( ShelleyBasedEra era
 
 
 instance ( ShelleyBasedEra era
-         , LogFormatting (PredicateFailure (UTXO era))
-         , LogFormatting (PredicateFailure (UTXOW era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXOW era))
          , LogFormatting (PredicateFailure (Core.EraRule "LEDGER" era))
-         ) => LogFormatting (LedgersPredicateFailure era) where
+         ) => LogFormatting (ShelleyLedgersPredFailure era) where
   forMachine dtal (LedgerFailure f) = forMachine dtal f
 
 
 instance ( ShelleyBasedEra era
          , ToJSON (Core.AuxiliaryDataHash (Ledger.Crypto era))
-         , LogFormatting (PredicateFailure (UTXO era))
-         , LogFormatting (PredicateFailure (UTXOW era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXOW era))
          , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXOW" era))
-         ) => LogFormatting (LedgerPredicateFailure era) where
+         ) => LogFormatting (ShelleyLedgerPredFailure era) where
   forMachine dtal (UtxowFailure f)  = forMachine dtal f
   forMachine dtal (DelegsFailure f) = forMachine dtal f
 
@@ -359,8 +358,8 @@ instance ( ShelleyBasedEra era
          , Ledger.Crypto era ~ StandardCrypto
          , LogFormatting (PredicateFailure (Ledger.EraRule "PPUP" era))
          , LogFormatting (PredicateFailure (Ledger.EraRule "UTXO" era))
-         ) => LogFormatting (UtxowPredicateFail era) where
-  forMachine dtal (WrappedShelleyEraFailure utxoPredFail) =
+         ) => LogFormatting (AlonzoUtxowPredFailure era) where
+  forMachine dtal (ShelleyInAlonzoUtxowPredFailure utxoPredFail) =
     forMachine dtal utxoPredFail
   forMachine _ (MissingRedeemers scripts) =
     mconcat [ "kind" .= String "MissingRedeemers"
@@ -428,9 +427,9 @@ renderScriptPurpose (Alonzo.Certifying cert) =
 instance ( ShelleyBasedEra era
          , Ledger.Crypto era ~ StandardCrypto
          , ToJSON (Core.AuxiliaryDataHash (Ledger.Crypto era))
-         , LogFormatting (PredicateFailure (UTXO era))
+         , LogFormatting (PredicateFailure (ShelleyUTXO era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXO" era))
-         ) => LogFormatting (UtxowPredicateFailure era) where
+         ) => LogFormatting (ShelleyUtxowPredFailure era) where
   forMachine _dtal (InvalidWitnessesUTXOW wits') =
     mconcat [ "kind" .= String "InvalidWitnessesUTXOW"
              , "invalidWitnesses" .= map textShow wits'
@@ -478,7 +477,7 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , LogFormatting (PredicateFailure (Core.EraRule "PPUP" era))
          )
-      => LogFormatting (UtxoPredicateFailure era) where
+      => LogFormatting (ShelleyUtxoPredFailure era) where
   forMachine _dtal (BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -534,7 +533,7 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToJSON MA.ValidityInterval
          , LogFormatting (PredicateFailure (Core.EraRule "PPUP" era))
-         ) => LogFormatting (MA.UtxoPredicateFailure era) where
+         ) => LogFormatting (ShelleyMAUtxoPredFailure era) where
   forMachine _dtal (MA.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -600,7 +599,7 @@ renderValueNotConservedErr :: Show val => val -> val -> Value
 renderValueNotConservedErr consumed produced = String $
     "This transaction consumed " <> show consumed <> " but produced " <> show produced
 
-instance Core.Crypto (Ledger.Crypto era) => LogFormatting (PpupPredicateFailure era) where
+instance Core.Crypto (Ledger.Crypto era) => LogFormatting (ShelleyPpupPredFailure era) where
   forMachine _dtal (NonGenesisUpdatePPUP proposalKeys genesisKeys) =
     mconcat [ "kind" .= String "NonGenesisUpdatePPUP"
              , "keys" .= proposalKeys Set.\\ genesisKeys ]
@@ -618,7 +617,7 @@ instance Core.Crypto (Ledger.Crypto era) => LogFormatting (PpupPredicateFailure 
 
 instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "DELPL" era))
-         ) => LogFormatting (DelegsPredicateFailure era) where
+         ) => LogFormatting (ShelleyDelegsPredFailure era) where
   forMachine _dtal (DelegateeNotRegisteredDELEG targetPool) =
     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
              , "targetPool" .= targetPool
@@ -633,12 +632,12 @@ instance ( ShelleyBasedEra era
 instance ( LogFormatting (PredicateFailure (Core.EraRule "POOL" era))
          , LogFormatting (PredicateFailure (Core.EraRule "DELEG" era))
          , Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
-         ) => LogFormatting (DelplPredicateFailure era) where
+         ) => LogFormatting (ShelleyDelplPredFailure era) where
   forMachine dtal (PoolFailure f)  = forMachine dtal f
   forMachine dtal (DelegFailure f) = forMachine dtal f
 
 instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
-          => LogFormatting (DelegPredicateFailure era) where
+          => LogFormatting (ShelleyDelegPredFailure era) where
   forMachine _dtal (StakeKeyAlreadyRegisteredDELEG alreadyRegistered) =
     mconcat [ "kind" .= String "StakeKeyAlreadyRegisteredDELEG"
              , "credential" .= String (textShow alreadyRegistered)
@@ -717,7 +716,7 @@ instance     Crypto.HashAlgorithm (Core.HASH (Ledger.Crypto era))
              , "coin" .= coin
              ]
 
-instance LogFormatting (PoolPredicateFailure era) where
+instance LogFormatting (ShelleyPoolPredFailure era) where
   forMachine _dtal (StakePoolNotRegisteredOnKeyPOOL (KeyHash unregStakePool)) =
     mconcat [ "kind" .= String "StakePoolNotRegisteredOnKeyPOOL"
              , "unregisteredKeyHash" .= String (textShow unregStakePool)
@@ -770,7 +769,7 @@ instance LogFormatting (PoolPredicateFailure era) where
 
 instance ( LogFormatting (PredicateFailure (Core.EraRule "NEWEPOCH" era))
          , LogFormatting (PredicateFailure (Core.EraRule "RUPD" era))
-         ) => LogFormatting (TickPredicateFailure era) where
+         ) => LogFormatting (ShelleyTickPredFailure era) where
   forMachine dtal (NewEpochFailure f) = forMachine dtal f
   forMachine dtal (RupdFailure f)     = forMachine dtal f
 
@@ -779,7 +778,7 @@ instance LogFormatting TicknPredicateFailure where
 
 instance ( LogFormatting (PredicateFailure (Core.EraRule "EPOCH" era))
          , LogFormatting (PredicateFailure (Core.EraRule "MIR" era))
-         ) => LogFormatting (NewEpochPredicateFailure era) where
+         ) => LogFormatting (ShelleyNewEpochPredFailure era) where
   forMachine dtal (EpochFailure f) = forMachine dtal f
   forMachine dtal (MirFailure f) = forMachine dtal f
   forMachine _dtal (CorruptRewardUpdate update) =
@@ -790,21 +789,21 @@ instance ( LogFormatting (PredicateFailure (Core.EraRule "EPOCH" era))
 instance ( LogFormatting (PredicateFailure (Core.EraRule "POOLREAP" era))
          , LogFormatting (PredicateFailure (Core.EraRule "SNAP" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UPEC" era))
-         ) => LogFormatting (EpochPredicateFailure era) where
+         ) => LogFormatting (ShelleyEpochPredFailure era) where
   forMachine dtal (PoolReapFailure f) = forMachine dtal f
   forMachine dtal (SnapFailure f)     = forMachine dtal f
   forMachine dtal (UpecFailure f)     = forMachine dtal f
 
 
-instance LogFormatting (PoolreapPredicateFailure era) where
+instance LogFormatting (ShelleyPoolreapPredFailure era) where
   forMachine _dtal x = case x of {} -- no constructors
 
 
-instance LogFormatting (SnapPredicateFailure era) where
+instance LogFormatting (ShelleySnapPredFailure era) where
   forMachine _dtal x = case x of {} -- no constructors
 
 -- TODO: Need to elaborate more on this error
-instance LogFormatting (NewppPredicateFailure era) where
+instance LogFormatting (ShelleyNewppPredFailure era) where
   forMachine _dtal (UnexpectedDepositPot outstandingDeposits depositPot) =
     mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "outstandingDeposits" .= String (textShow outstandingDeposits)
@@ -812,11 +811,11 @@ instance LogFormatting (NewppPredicateFailure era) where
              ]
 
 
-instance LogFormatting (MirPredicateFailure era) where
+instance LogFormatting (ShelleyMirPredFailure era) where
   forMachine _dtal x = case x of {} -- no constructors
 
 
-instance LogFormatting (RupdPredicateFailure era) where
+instance LogFormatting (ShelleyRupdPredFailure era) where
   forMachine _dtal x = case x of {} -- no constructors
 
 
@@ -922,7 +921,7 @@ instance LogFormatting (OcertPredicateFailure crypto) where
 instance LogFormatting (UpdnPredicateFailure crypto) where
   forMachine _dtal x = case x of {} -- no constructors
 
-instance LogFormatting (UpecPredicateFailure era) where
+instance LogFormatting (ShelleyUpecPredFailure era) where
   forMachine _dtal (NewPpFailure (UnexpectedDepositPot totalOutstanding depositPot)) =
     mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "totalOutstanding" .=  String (textShow totalOutstanding)
@@ -938,7 +937,7 @@ instance ( Ledger.Era era
          , ToJSON (Ledger.TxOut era)
          , Show (Ledger.Value era)
          , LogFormatting (PredicateFailure (Ledger.EraRule "UTXOS" era))
-         ) => LogFormatting (Alonzo.UtxoPredicateFailure era) where
+         ) => LogFormatting (AlonzoUtxoPredFailure era) where
   forMachine _dtal (Alonzo.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -1034,7 +1033,7 @@ instance ( Ledger.Era era
 
 instance ( ToJSON (Alonzo.CollectError (Ledger.Crypto era))
          , LogFormatting (PredicateFailure (Ledger.EraRule "PPUP" era))
-         ) => LogFormatting (Alonzo.UtxosPredicateFailure era) where
+         ) => LogFormatting (AlonzoUtxosPredFailure era) where
   forMachine _ (Alonzo.ValidationTagMismatch isValidating reason) =
     mconcat [ "kind" .= String "ValidationTagMismatch"
              , "isvalidating" .= isValidating
@@ -1049,7 +1048,7 @@ instance ( ToJSON (Alonzo.CollectError (Ledger.Crypto era))
 
 instance ( Ledger.Era era
          , Show (PredicateFailure (Ledger.EraRule "LEDGERS" era))
-         ) => LogFormatting (AlonzoBbodyPredFail era) where
+         ) => LogFormatting (AlonzoBbodyPredFailure era) where
   forMachine _ err = mconcat [ "kind" .= String "AlonzoBbodyPredFail"
                             , "error" .= String (show err)
                             ]
@@ -1059,12 +1058,12 @@ instance ( Ledger.Era era
 
 
 instance ( Ledger.Era era
-         , LogFormatting (Alonzo.UtxoPredicateFailure era)
+         , LogFormatting (AlonzoUtxoPredFailure era)
          , ToJSON (Ledger.TxOut era)
-         ) => LogFormatting (Babbage.BabbageUtxoPred era) where
+         ) => LogFormatting (BabbageUtxoPredFailure era) where
   forMachine v err =
     case err of
-      Babbage.FromAlonzoUtxoFail alonzoFail ->
+      Babbage.AlonzoInBabbageUtxoPredFailure alonzoFail ->
         forMachine v alonzoFail
 
       Babbage.IncorrectTotalCollateralField provided declared ->
@@ -1083,13 +1082,13 @@ instance ( Ledger.Era era
          , Ledger.Crypto era ~ StandardCrypto
          , ToJSON (Ledger.Value era)
          , ToJSON (Ledger.TxOut era)
-         , LogFormatting (UtxowPredicateFailure era)
+         , LogFormatting (ShelleyUtxowPredFailure era)
          , LogFormatting (PredicateFailure (Ledger.EraRule "PPUP" era))
          , LogFormatting (PredicateFailure (Ledger.EraRule "UTXO" era))
-         ) => LogFormatting (Babbage.BabbageUtxowPred era) where
+         ) => LogFormatting (BabbageUtxowPredFailure era) where
   forMachine v err =
     case err of
-      Babbage.FromAlonzoUtxowFail alonzoFail ->
+      Babbage.AlonzoInBabbageUtxowPredFailure alonzoFail ->
         forMachine v alonzoFail
       Babbage.UtxoFailure utxoFail ->
         forMachine v utxoFail

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -372,6 +372,13 @@ mkConsensusTracers trBase trForward mbTrEKG _trDataPoint trConfig nodeKernel = d
                 severityKeepAliveClient
                 allPublic
     configureTracers trConfig docKeepAliveClient [keepAliveClientTr]
+    consensusStartupErrorTr <- mkCardanoTracer
+                trBase trForward mbTrEKG
+                ["Consensus", "Startup"]
+                namesConsensusStartupError
+                severityConsensusStartupError
+                allPublic
+    configureTracers trConfig docConsensusStartupError [consensusStartupErrorTr]
     pure $ Consensus.Tracers
       { Consensus.chainSyncClientTracer = Tracer $
           traceWith chainSyncClientTr
@@ -405,6 +412,8 @@ mkConsensusTracers trBase trForward mbTrEKG _trDataPoint trConfig nodeKernel = d
           traceWith blockchainTimeTr
       , Consensus.keepAliveClientTracer = Tracer $
           traceWith keepAliveClientTr
+      , Consensus.consensusStartupErrorTracer = Tracer $
+          traceWith consensusStartupErrorTr . ConsensusStartupException
       }
 
 mkNodeToClientTracers :: forall blk.
@@ -577,7 +586,7 @@ mkDiffusionTracers  trBase trForward mbTrEKG _trDataPoint trConfig = do
            traceWith dtLocalMuxTr
        , Diffusion.dtLocalHandshakeTracer          = Tracer $
            traceWith dtLocalHandshakeTr
-       , Diffusion.dtDiffusionInitializationTracer = Tracer $
+       , Diffusion.dtDiffusionTracer               = Tracer $
            traceWith dtDiffusionInitializationTr
        , Diffusion.dtLedgerPeersTracer             = Tracer $
            traceWith dtLedgerPeersTr

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -72,6 +72,10 @@ module Cardano.Node.Tracing.Tracers.Consensus
   , severityKeepAliveClient
   , docKeepAliveClient
 
+  , namesConsensusStartupError
+  , severityConsensusStartupError
+  , docConsensusStartupError
+
   ) where
 
 
@@ -93,8 +97,9 @@ import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.Shelley ()
 import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (ForgingStats)
 import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck
-import           Cardano.Node.Tracing.Tracers.ForgingThreadStats(ForgingStats)
 import           Cardano.Prelude hiding (All, Show, show)
 
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
@@ -130,7 +135,6 @@ import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints, e
 import           Ouroboros.Consensus.Node.Tracers
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Util.Enclose
-
 
 
 instance LogFormatting a => LogFormatting (TraceLabelCreds a) where
@@ -577,7 +581,7 @@ instance (HasHeader header, ConvertRawHash header) =>
     mconcat [ "kind" .= String "AddedFetchRequest" ]
   forMachine _dtal BlockFetch.AcknowledgedFetchRequest {} =
     mconcat [ "kind" .= String "AcknowledgedFetchRequest" ]
-  forMachine _dtal (BlockFetch.SendFetchRequest af) =
+  forMachine _dtal (BlockFetch.SendFetchRequest af _) =
     mconcat [ "kind" .= String "SendFetchRequest"
             , "head" .= String (renderChainHash
                                  (renderHeaderHash (Proxy @header))
@@ -1711,6 +1715,20 @@ instance Show remotePeer => LogFormatting (TraceKeepAliveClient remotePeer) wher
 
 docKeepAliveClient :: Documented (TraceKeepAliveClient peer)
 docKeepAliveClient = Documented [
+    DocMsg
+      []
+      []
+      ""
+  ]
+
+namesConsensusStartupError :: ConsensusStartupException -> [Text]
+namesConsensusStartupError _ = []
+
+severityConsensusStartupError :: ConsensusStartupException -> SeverityS
+severityConsensusStartupError _ = Critical
+
+docConsensusStartupError :: Documented ConsensusStartupException
+docConsensusStartupError = Documented [
     DocMsg
       []
       []

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
@@ -1,0 +1,27 @@
+-- | Consensus startup exception
+--
+-- TODO: once the legacy logging framework is removed it can be moved to
+-- `Cardano.Node.Tracing.Tracers.Consensus`.
+module Cardano.Node.Tracing.Tracers.ConsensusStartupException
+  ( ConsensusStartupException (..)
+  ) where
+
+import           Cardano.Prelude hiding (Show, show)
+
+import           Data.Aeson (Value (String), (.=))
+import qualified Data.Text as Text
+import           Text.Show
+
+import           Cardano.Logging.Types
+
+-- | Exceptions logged when the consensus is initialising.
+--
+newtype ConsensusStartupException = ConsensusStartupException SomeException
+  deriving Show
+
+instance LogFormatting ConsensusStartupException where
+  forMachine _ (ConsensusStartupException err) =
+    mconcat [ "kind" .= String "ConsensusStartupException"
+            , "error" .= String (Text.pack . show $ err)
+            ]
+  forHuman = Text.pack . show

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -46,8 +46,8 @@ import qualified Ouroboros.Network.Diffusion as ND
 import           Ouroboros.Network.Driver.Simple (TraceSendRecv (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 import qualified Ouroboros.Network.NodeToNode as NtN
-import           Ouroboros.Network.PeerSelection.LedgerPeers (NumberOfPeers (..),
-                   PoolStake (..), TraceLedgerPeers (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (NumberOfPeers (..), PoolStake (..),
+                   TraceLedgerPeers (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Type (Message (..))
 import qualified Ouroboros.Network.Protocol.Handshake.Type as HS
 import           Ouroboros.Network.Snocket (LocalAddress (..))
@@ -391,7 +391,7 @@ docLocalHandshake = addDocumentedNamespace  ["Send"] docHandshake'
 -- DiffusionInit Tracer
 --------------------------------------------------------------------------------
 
-severityDiffusionInit :: ND.InitializationTracer rard ladr -> SeverityS
+severityDiffusionInit :: ND.DiffusionTracer rard ladr -> SeverityS
 severityDiffusionInit ND.RunServer {}                         = Info
 severityDiffusionInit ND.RunLocalServer {}                    = Info
 severityDiffusionInit ND.UsingSystemdSocket {}                = Info
@@ -404,11 +404,12 @@ severityDiffusionInit ND.CreatingServerSocket {}              = Info
 severityDiffusionInit ND.ConfiguringServerSocket {}           = Info
 severityDiffusionInit ND.ListeningServerSocket {}             = Info
 severityDiffusionInit ND.ServerSocketUp {}                    = Info
-severityDiffusionInit ND.UnsupportedLocalSystemdSocket {}     = Info
+severityDiffusionInit ND.UnsupportedLocalSystemdSocket {}     = Warning
 severityDiffusionInit ND.UnsupportedReadySocketCase {}        = Info
-severityDiffusionInit ND.DiffusionErrored {}                  = Alert
+severityDiffusionInit ND.DiffusionErrored {}                  = Critical
+severityDiffusionInit ND.SystemdSocketConfiguration {}        = Warning
 
-namesForDiffusionInit  :: ND.InitializationTracer rard ladr -> [Text]
+namesForDiffusionInit  :: ND.DiffusionTracer rard ladr -> [Text]
 namesForDiffusionInit  ND.RunServer {}                         =
   ["RunServer"]
 namesForDiffusionInit  ND.RunLocalServer {}                    =
@@ -439,9 +440,11 @@ namesForDiffusionInit  ND.UnsupportedReadySocketCase {}        =
   ["UnsupportedReadySocketCase"]
 namesForDiffusionInit  ND.DiffusionErrored {}                  =
   ["DiffusionErrored"]
+namesForDiffusionInit  ND.SystemdSocketConfiguration {}        =
+  ["SystemdSocketConfiguration"]
 
 instance (Show ntnAddr, Show ntcAddr) =>
-  LogFormatting (ND.InitializationTracer ntnAddr ntcAddr)  where
+  LogFormatting (ND.DiffusionTracer ntnAddr ntcAddr)  where
   forMachine _dtal (ND.RunServer sockAddr) = mconcat
     [ "kind" .= String "RunServer"
     , "socketAddress" .= String (pack (show sockAddr))
@@ -506,11 +509,15 @@ instance (Show ntnAddr, Show ntcAddr) =>
     [ "kind" .= String "DiffusionErrored"
     , "path" .= String (pack (show exception))
     ]
+  forMachine _dtal (ND.SystemdSocketConfiguration config) = mconcat
+    [ "kind" .= String "SystemdSocketConfiguration"
+    , "path" .= String (pack (show config))
+    ]
 
-docDiffusionInit :: Documented (ND.InitializationTracer Socket.SockAddr NtC.LocalAddress)
+docDiffusionInit :: Documented (ND.DiffusionTracer Socket.SockAddr NtC.LocalAddress)
 docDiffusionInit =  addDocumentedNamespace  [] docDiffusionInit'
 
-docDiffusionInit' :: Documented (ND.InitializationTracer Socket.SockAddr NtC.LocalAddress)
+docDiffusionInit' :: Documented (ND.DiffusionTracer Socket.SockAddr NtC.LocalAddress)
 docDiffusionInit' = Documented [
     DocMsg
       ["RunServer"]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -15,7 +15,7 @@ module Cardano.Node.Tracing.Tracers.Peer
 import           Cardano.Prelude hiding (atomically)
 import           Prelude (String)
 
-import qualified Control.Monad.Class.MonadSTM.Strict as STM
+import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
 import           "contra-tracer" Control.Tracer
 
 import           Data.Aeson (ToJSON (..), Value (..), toJSON, (.=))

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -83,7 +83,7 @@ instance FromJSON TracingVerbosity where
                             <> "Encountered: " <> show invalid
 
 instance FromJSON PortNumber where
-  parseJSON (Number portNum) = case readMaybe . show @Integer $ coefficient portNum of
+  parseJSON (Number portNum) = case readMaybe . show @Integer @Text $ coefficient portNum of
     Just port -> pure port
     Nothing -> fail $ show portNum <> " is not a valid port number."
   parseJSON invalid  = fail $ "Parsing of port number failed due to type mismatch. "

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -32,6 +32,9 @@ import           Cardano.Tracing.Render (renderChainHash, renderChunkNo, renderH
                    renderPointForVerbosity, renderRealPoint, renderRealPointAsPhrase,
                    renderTipBlockNo, renderTipHash, renderWithOrigin)
 
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+                   (ConsensusStartupException (..))
+
 import           Ouroboros.Consensus.Block (BlockProtocol, BlockSupportsProtocol, CannotForge,
                    ConvertRawHash (..), ForgeStateUpdateError, Header, RealPoint, blockNo,
                    blockPoint, blockPrevHash, getHeader, headerPoint, pointHash, realPointHash,
@@ -84,6 +87,20 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 
 {- HLINT ignore "Use const" -}
 {- HLINT ignore "Use record patterns" -}
+
+instance ToObject ConsensusStartupException where
+  toObject _ (ConsensusStartupException err) =
+    mconcat
+      [ "kind" .= String "ConsensusStartupException"
+      , "error" .= String (pack . show $ err)
+      ]
+
+instance HasPrivacyAnnotation ConsensusStartupException where
+instance HasSeverityAnnotation ConsensusStartupException where
+  getSeverityAnnotation _ = Critical
+instance Transformable Text IO ConsensusStartupException where
+  trTransformer = trStructured
+instance HasTextFormatter ConsensusStartupException where
 
 instance ConvertRawHash blk => ConvertRawHash (Header blk) where
   toShortRawHash _ h = toShortRawHash (Proxy @blk) h
@@ -202,7 +219,6 @@ instance HasSeverityAnnotation (LedgerEvent blk) where
 instance HasPrivacyAnnotation (TraceBlockFetchServerEvent blk)
 instance HasSeverityAnnotation (TraceBlockFetchServerEvent blk) where
   getSeverityAnnotation _ = Info
-
 
 instance (ToObject peer, ToObject (TraceChainSyncClientEvent blk))
     => Transformable Text IO (TraceLabelPeer peer (TraceChainSyncClientEvent blk)) where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Network.ConnectionManager.Types (AbstractState (..),
 import qualified Ouroboros.Network.ConnectionManager.Types as ConnMgr
 import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
 import           Ouroboros.Network.Driver.Limits (ProtocolLimitFailure (..))
+import           Ouroboros.Network.ExitPolicy (ReconnectDelay (..))
 import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..), RemoteSt (..))
 import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
@@ -113,9 +114,11 @@ import qualified Ouroboros.Network.Diffusion as ND
 --
 -- NOTE: this list is sorted by the unqualified name of the outermost type.
 
-instance HasPrivacyAnnotation (ND.InitializationTracer ntnAddr ntcAddr)
-instance HasSeverityAnnotation (ND.InitializationTracer ntnAddr ntcAddr) where
-  getSeverityAnnotation ND.DiffusionErrored {} = Alert
+instance HasPrivacyAnnotation (ND.DiffusionTracer ntnAddr ntcAddr)
+instance HasSeverityAnnotation (ND.DiffusionTracer ntnAddr ntcAddr) where
+  getSeverityAnnotation ND.SystemdSocketConfiguration {} = Warning
+  getSeverityAnnotation ND.UnsupportedLocalSystemdSocket {} = Warning
+  getSeverityAnnotation ND.DiffusionErrored {} = Critical
   getSeverityAnnotation _ = Info
 
 instance HasPrivacyAnnotation (NtC.HandshakeTr LocalAddress NodeToClientVersion)
@@ -407,6 +410,7 @@ instance HasSeverityAnnotation (TracePeerSelection addr) where
       TraceDemoteHotFailed       {} -> Info
       TraceDemoteHotDone         {} -> Info
       TraceDemoteAsynchronous    {} -> Info
+      TraceDemoteLocalAsynchronous {} -> Warning
       TraceGovernorWakeup        {} -> Info
       TraceChurnWait             {} -> Info
       TraceChurnMode             {} -> Info
@@ -415,8 +419,8 @@ instance HasPrivacyAnnotation (DebugPeerSelection addr)
 instance HasSeverityAnnotation (DebugPeerSelection addr) where
   getSeverityAnnotation _ = Debug
 
-instance HasPrivacyAnnotation (PeerSelectionActionsTrace SockAddr)
-instance HasSeverityAnnotation (PeerSelectionActionsTrace SockAddr) where
+instance HasPrivacyAnnotation (PeerSelectionActionsTrace SockAddr versionNumber)
+instance HasSeverityAnnotation (PeerSelectionActionsTrace SockAddr versionNumber) where
   getSeverityAnnotation ev =
    case ev of
      PeerStatusChanged {}       -> Info
@@ -443,8 +447,8 @@ instance HasSeverityAnnotation (ConnectionManagerTrace addr (ConnectionHandlerTr
           TrHandshakeSuccess {}               -> Info
           TrHandshakeClientError {}           -> Notice
           TrHandshakeServerError {}           -> Info
-          TrError _ _ ShutdownNode            -> Critical
-          TrError _ _ ShutdownPeer            -> Info
+          TrConnectionHandlerError _ _ ShutdownNode            -> Critical
+          TrConnectionHandlerError _ _ ShutdownPeer            -> Info
 
       TrShutdown                              -> Info
       TrConnectionExists {}                   -> Info
@@ -509,9 +513,9 @@ instance HasSeverityAnnotation (Server.RemoteTransitionTrace addr) where
 --
 -- NOTE: this list is sorted by the unqualified name of the outermost type.
 
-instance Transformable Text IO (ND.InitializationTracer RemoteAddress LocalAddress) where
+instance Transformable Text IO (ND.DiffusionTracer RemoteAddress LocalAddress) where
   trTransformer = trStructuredText
-instance HasTextFormatter (ND.InitializationTracer RemoteAddress LocalAddress) where
+instance HasTextFormatter (ND.DiffusionTracer RemoteAddress LocalAddress) where
   formatText a _ = pack (show a)
 
 instance Transformable Text IO (NtN.HandshakeTr RemoteAddress NodeToNodeVersion) where
@@ -673,9 +677,9 @@ instance HasTextFormatter (DebugPeerSelection SockAddr) where
   -- format.
   formatText _ obj = pack (show obj)
 
-instance Transformable Text IO (PeerSelectionActionsTrace SockAddr) where
+instance Show versionNumber => Transformable Text IO (PeerSelectionActionsTrace SockAddr versionNumber) where
   trTransformer = trStructuredText
-instance HasTextFormatter (PeerSelectionActionsTrace SockAddr) where
+instance Show versionNumber => HasTextFormatter (PeerSelectionActionsTrace SockAddr versionNumber) where
   formatText a _ = pack (show a)
 
 instance Transformable Text IO PeerSelectionCounters where
@@ -972,7 +976,7 @@ instance ToObject (FetchDecision [Point header]) where
              ]
 
 -- TODO: use 'ToJSON' constraints
-instance (Show ntnAddr, Show ntcAddr) => ToObject (ND.InitializationTracer ntnAddr ntcAddr) where
+instance (Show ntnAddr, Show ntcAddr) => ToObject (ND.DiffusionTracer ntnAddr ntcAddr) where
   toObject _verb (ND.RunServer sockAddr) = mconcat
     [ "kind" .= String "RunServer"
     , "socketAddress" .= String (pack (show sockAddr))
@@ -1037,6 +1041,10 @@ instance (Show ntnAddr, Show ntcAddr) => ToObject (ND.InitializationTracer ntnAd
     [ "kind" .= String "DiffusionErrored"
     , "path" .= String (pack (show exception))
     ]
+  toObject _verb (ND.SystemdSocketConfiguration config) = mconcat
+    [ "kind" .= String "SystemdSocketConfiguration"
+    , "message" .= String (pack (show config))
+    ]
 
 instance ToObject (NtC.HandshakeTr LocalAddress NodeToClientVersion) where
   toObject _verb (WithMuxBearer b ev) =
@@ -1096,7 +1104,7 @@ instance (HasHeader header, ConvertRawHash header)
     mconcat [ "kind" .= String "AddedFetchRequest" ]
   toObject _verb BlockFetch.AcknowledgedFetchRequest {} =
     mconcat [ "kind" .= String "AcknowledgedFetchRequest" ]
-  toObject _verb (BlockFetch.SendFetchRequest af) =
+  toObject _verb (BlockFetch.SendFetchRequest af _) =
     mconcat [ "kind" .= String "SendFetchRequest"
              , "head" .= String (renderChainHash
                                   (renderHeaderHash (Proxy @header))
@@ -1408,6 +1416,9 @@ instance ToJSON PeerSelectionTargets where
                  , "targetActivePeers" .= nActivePeers
                  ]
 
+instance ToJSON ReconnectDelay where
+  toJSON = toJSON . reconnectDelay
+
 instance ToObject (TracePeerSelection SockAddr) where
   toObject _verb (TraceLocalRootPeersChanged lrp lrp') =
     mconcat [ "kind" .= String "LocalRootPeersChanged"
@@ -1556,6 +1567,10 @@ instance ToObject (TracePeerSelection SockAddr) where
     mconcat [ "kind" .= String "DemoteAsynchronous"
              , "state" .= toJSON msp
              ]
+  toObject _verb (TraceDemoteLocalAsynchronous msp) =
+    mconcat [ "kind" .= String "DemoteLocalAsynchronous"
+             , "state" .= toJSON msp
+             ]
   toObject _verb TraceGovernorWakeup =
     mconcat [ "kind" .= String "GovernorWakeup"
              ]
@@ -1642,7 +1657,7 @@ instance ToObject (DebugPeerSelection SockAddr) where
 
 -- TODO: Write PeerStatusChangeType ToJSON at ouroboros-network
 -- For that an export is needed at ouroboros-network
-instance ToObject (PeerSelectionActionsTrace SockAddr) where
+instance Show versionNumber => ToObject (PeerSelectionActionsTrace SockAddr versionNumber) where
   toObject _verb (PeerStatusChanged ps) =
     mconcat [ "kind" .= String "PeerStatusChanged"
              , "peerStatusChangeType" .= show ps
@@ -1769,7 +1784,7 @@ instance (Show versionNumber, ToJSON versionNumber, ToJSON agreedOptions)
       [ "kind" .= String "HandshakeServerError"
       , "reason" .= toJSON err
       ]
-  toObject _verb (TrError e err cerr) =
+  toObject _verb (TrConnectionHandlerError e err cerr) =
     mconcat
       [ "kind" .= String "Error"
       , "context" .= show e

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -51,23 +51,15 @@ import qualified Ouroboros.Consensus.Shelley.Protocol.Praos as Praos
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
-import           Cardano.Ledger.Alonzo.Rules.Bbody (AlonzoBbodyPredFail)
-import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
-import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Alonzo
-import           Cardano.Ledger.Alonzo.Rules.Utxow (UtxowPredicateFail (..))
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
 import qualified Cardano.Ledger.AuxiliaryData as Core
-import qualified Cardano.Ledger.Babbage.Rules.Utxo as Babbage
-import qualified Cardano.Ledger.Babbage.Rules.Utxow as Babbage
 import           Cardano.Ledger.BaseTypes (activeSlotLog, strictMaybeToMaybe)
 import           Cardano.Ledger.Chain
-import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Core as Core hiding (Crypto)
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Crypto as Core
-import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.SafeHash as SafeHash
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
 import           Cardano.Protocol.TPraos.BHeader (LastAppliedBlock, labBlockNo)
 import           Cardano.Protocol.TPraos.Rules.OCert
@@ -76,8 +68,13 @@ import           Cardano.Protocol.TPraos.Rules.Tickn
 import           Cardano.Protocol.TPraos.Rules.Updn
 
 -- TODO: this should be exposed via Cardano.Api
-import           Cardano.Ledger.Shelley.API hiding (ShelleyBasedEra)
+import           Cardano.Ledger.Shelley.API
 
+import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure (..), AlonzoUtxoPredFailure,
+                   AlonzoUtxosPredFailure, AlonzoUtxowPredFailure (..))
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
+import           Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import           Cardano.Ledger.Shelley.Rules.Bbody
 import           Cardano.Ledger.Shelley.Rules.Deleg
 import           Cardano.Ledger.Shelley.Rules.Delegs
@@ -97,6 +94,8 @@ import           Cardano.Ledger.Shelley.Rules.Tick
 import           Cardano.Ledger.Shelley.Rules.Upec
 import           Cardano.Ledger.Shelley.Rules.Utxo
 import           Cardano.Ledger.Shelley.Rules.Utxow
+import           Cardano.Ledger.ShelleyMA.Rules (ShelleyMAUtxoPredFailure)
+import qualified Cardano.Ledger.ShelleyMA.Rules as MA
 import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
 import           Cardano.Protocol.TPraos.Rules.Prtcl
@@ -126,8 +125,6 @@ instance ShelleyCompatible protocol era => ToObject (Header (ShelleyBlock protoc
         ]
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
          , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
          ) => ToObject (ApplyTxError era) where
   toObject verb (ApplyTxError predicateFailures) =
@@ -173,9 +170,7 @@ instance ToObject HotKey.KESEvolutionError where
       ]
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
-         , ToObject (PredicateFailure (Core.EraRule "BBODY" era))
+         , ToObject (PredicateFailure (Ledger.EraRule "BBODY" era))
          ) => ToObject (ShelleyLedgerError era) where
   toObject verb (BBodyError (BlockTransitionError fs)) =
     mconcat [ "kind" .= String "BBodyError"
@@ -183,21 +178,21 @@ instance ( ShelleyBasedEra era
              ]
 
 instance ( ShelleyBasedEra era
-         , ToJSON (Ledger.PParamsDelta era)
+         , ToJSON (Ledger.PParamsUpdate era)
          ) => ToObject (ShelleyLedgerUpdate era) where
   toObject verb (ShelleyUpdatedProtocolUpdates updates) =
     mconcat [ "kind" .= String "ShelleyUpdatedProtocolUpdates"
              , "updates" .= map (toObject verb) updates
              ]
 
-instance (Ledger.Era era, ToJSON (Ledger.PParamsDelta era))
+instance (Ledger.Era era, ToJSON (Ledger.PParamsUpdate era))
          => ToObject (ProtocolUpdate era) where
   toObject verb ProtocolUpdate{protocolUpdateProposal, protocolUpdateState} =
     mconcat [ "proposal" .= toObject verb protocolUpdateProposal
              , "state"    .= toObject verb protocolUpdateState
              ]
 
-instance ToJSON (Ledger.PParamsDelta era)
+instance ToJSON (Ledger.PParamsUpdate era)
          => ToObject (UpdateProposal era) where
   toObject _verb UpdateProposal{proposalParams, proposalVersion, proposalEpoch} =
     mconcat [ "params"  .= proposalParams
@@ -258,11 +253,8 @@ instance ToObject (PrtlSeqFailure crypto) where
              ]
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
-         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
-         , ToObject (PredicateFailure (Core.EraRule "LEDGERS" era))
-         ) => ToObject (BbodyPredicateFailure era) where
+         , ToObject (PredicateFailure (Ledger.EraRule "LEDGERS" era))
+         ) => ToObject (ShelleyBbodyPredFailure era) where
   toObject _verb (WrongBlockBodySizeBBODY actualBodySz claimedBodySz) =
     mconcat [ "kind" .= String "WrongBlockBodySizeBBODY"
              , "actualBlockBodySize" .= actualBodySz
@@ -277,19 +269,19 @@ instance ( ShelleyBasedEra era
 
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (ShelleyUTXO era))
+         , ToObject (PredicateFailure (ShelleyUTXOW era))
          , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
-         ) => ToObject (LedgersPredicateFailure era) where
+         ) => ToObject (ShelleyLedgersPredFailure era) where
   toObject verb (LedgerFailure f) = toObject verb f
 
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
-         , ToObject (PredicateFailure (UTXOW era))
+         , ToObject (PredicateFailure (ShelleyUTXO era))
+         , ToObject (PredicateFailure (ShelleyUTXOW era))
          , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
          , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
-         ) => ToObject (LedgerPredicateFailure era) where
+         ) => ToObject (ShelleyLedgerPredFailure era) where
   toObject verb (UtxowFailure f) = toObject verb f
   toObject verb (DelegsFailure f) = toObject verb f
 
@@ -299,8 +291,8 @@ instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (Ledger.EraRule "PPUP" era))
          , ToObject (PredicateFailure (Ledger.EraRule "UTXO" era))
          , Ledger.Crypto era ~ StandardCrypto
-         ) => ToObject (UtxowPredicateFail era) where
-  toObject v (WrappedShelleyEraFailure utxoPredFail) =
+         ) => ToObject (AlonzoUtxowPredFailure era) where
+  toObject v (ShelleyInAlonzoUtxowPredFailure utxoPredFail) =
     toObject v utxoPredFail
   toObject _ (MissingRedeemers scripts) =
     mconcat [ "kind" .= String "MissingRedeemers"
@@ -362,9 +354,9 @@ renderScriptPurpose (Alonzo.Certifying cert) =
   Aeson.object [ "certifying" .= toJSON (Api.textEnvelopeDefaultDescr $ Api.fromShelleyCertificate cert)]
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (UTXO era))
+         , ToObject (PredicateFailure (ShelleyUTXO era))
          , ToObject (PredicateFailure (Core.EraRule "UTXO" era))
-         ) => ToObject (UtxowPredicateFailure era) where
+         ) => ToObject (ShelleyUtxowPredFailure era) where
   toObject _verb (ExtraneousScriptWitnessesUTXOW extraneousScripts) =
     mconcat [ "kind" .= String "InvalidWitnessesUTXOW"
              , "extraneousScripts" .= extraneousScripts
@@ -412,7 +404,7 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.TxOut era)
          , ToObject (PredicateFailure (Core.EraRule "PPUP" era))
          )
-      => ToObject (UtxoPredicateFailure era) where
+      => ToObject (ShelleyUtxoPredFailure era) where
   toObject _verb (BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -477,7 +469,7 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.Value era)
          , ToJSON (Core.TxOut era)
          , ToObject (PredicateFailure (Core.EraRule "PPUP" era))
-         ) => ToObject (MA.UtxoPredicateFailure era) where
+         ) => ToObject (ShelleyMAUtxoPredFailure era) where
   toObject _verb (MA.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -543,7 +535,7 @@ renderValueNotConservedErr :: Show val => val -> val -> Aeson.Value
 renderValueNotConservedErr consumed produced = String $
     "This transaction consumed " <> show consumed <> " but produced " <> show produced
 
-instance Ledger.Era era => ToObject (PpupPredicateFailure era) where
+instance Ledger.Era era => ToObject (ShelleyPpupPredFailure era) where
   toObject _verb (NonGenesisUpdatePPUP proposalKeys genesisKeys) =
     mconcat [ "kind" .= String "NonGenesisUpdatePPUP"
              , "keys" .= proposalKeys Set.\\ genesisKeys ]
@@ -561,7 +553,7 @@ instance Ledger.Era era => ToObject (PpupPredicateFailure era) where
 
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (Core.EraRule "DELPL" era))
-         ) => ToObject (DelegsPredicateFailure era) where
+         ) => ToObject (ShelleyDelegsPredFailure era) where
   toObject _verb (DelegateeNotRegisteredDELEG targetPool) =
     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
              , "targetPool" .= targetPool
@@ -575,11 +567,11 @@ instance ( ShelleyBasedEra era
 
 instance ( ToObject (PredicateFailure (Core.EraRule "POOL" era))
          , ToObject (PredicateFailure (Core.EraRule "DELEG" era))
-         ) => ToObject (DelplPredicateFailure era) where
+         ) => ToObject (ShelleyDelplPredFailure era) where
   toObject verb (PoolFailure f) = toObject verb f
   toObject verb (DelegFailure f) = toObject verb f
 
-instance Ledger.Era era => ToObject (DelegPredicateFailure era) where
+instance Ledger.Era era => ToObject (ShelleyDelegPredFailure era) where
   toObject _verb (StakeKeyAlreadyRegisteredDELEG alreadyRegistered) =
     mconcat [ "kind" .= String "StakeKeyAlreadyRegisteredDELEG"
              , "credential" .= String (textShow alreadyRegistered)
@@ -659,7 +651,7 @@ instance Ledger.Era era => ToObject (DelegPredicateFailure era) where
              , "amount" .= coin
              ]
 
-instance ToObject (PoolPredicateFailure era) where
+instance ToObject (ShelleyPoolPredFailure era) where
   toObject _verb (StakePoolNotRegisteredOnKeyPOOL (KeyHash unregStakePool)) =
     mconcat [ "kind" .= String "StakePoolNotRegisteredOnKeyPOOL"
              , "unregisteredKeyHash" .= String (textShow unregStakePool)
@@ -711,7 +703,7 @@ instance ToObject (PoolPredicateFailure era) where
 
 instance ( ToObject (PredicateFailure (Core.EraRule "NEWEPOCH" era))
          , ToObject (PredicateFailure (Core.EraRule "RUPD" era))
-         ) => ToObject (TickPredicateFailure era) where
+         ) => ToObject (ShelleyTickPredFailure era) where
   toObject verb (NewEpochFailure f) = toObject verb f
   toObject verb (RupdFailure f) = toObject verb f
 
@@ -720,7 +712,7 @@ instance ToObject TicknPredicateFailure where
 
 instance ( ToObject (PredicateFailure (Core.EraRule "EPOCH" era))
          , ToObject (PredicateFailure (Core.EraRule "MIR" era))
-         ) => ToObject (NewEpochPredicateFailure era) where
+         ) => ToObject (ShelleyNewEpochPredFailure era) where
   toObject verb (EpochFailure f) = toObject verb f
   toObject verb (MirFailure f) = toObject verb f
   toObject _verb (CorruptRewardUpdate update) =
@@ -731,21 +723,21 @@ instance ( ToObject (PredicateFailure (Core.EraRule "EPOCH" era))
 instance ( ToObject (PredicateFailure (Core.EraRule "POOLREAP" era))
          , ToObject (PredicateFailure (Core.EraRule "SNAP" era))
          , ToObject (PredicateFailure (Core.EraRule "UPEC" era))
-         ) => ToObject (EpochPredicateFailure era) where
+         ) => ToObject (ShelleyEpochPredFailure era) where
   toObject verb (PoolReapFailure f) = toObject verb f
   toObject verb (SnapFailure f) = toObject verb f
   toObject verb (UpecFailure f) = toObject verb f
 
 
-instance ToObject (PoolreapPredicateFailure era) where
+instance ToObject (ShelleyPoolreapPredFailure era) where
   toObject _verb x = case x of {} -- no constructors
 
 
-instance ToObject (SnapPredicateFailure era) where
+instance ToObject (ShelleySnapPredFailure era) where
   toObject _verb x = case x of {} -- no constructors
 
 -- TODO: Need to elaborate more on this error
-instance ToObject (NewppPredicateFailure era) where
+instance ToObject (ShelleyNewppPredFailure era) where
   toObject _verb (UnexpectedDepositPot outstandingDeposits depositPot) =
     mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "outstandingDeposits" .= String (textShow outstandingDeposits)
@@ -753,11 +745,11 @@ instance ToObject (NewppPredicateFailure era) where
              ]
 
 
-instance ToObject (MirPredicateFailure era) where
+instance ToObject (ShelleyMirPredFailure era) where
   toObject _verb x = case x of {} -- no constructors
 
 
-instance ToObject (RupdPredicateFailure era) where
+instance ToObject (ShelleyRupdPredFailure era) where
   toObject _verb x = case x of {} -- no constructors
 
 
@@ -864,7 +856,7 @@ instance ToObject (OcertPredicateFailure crypto) where
 instance ToObject (UpdnPredicateFailure crypto) where
   toObject _verb x = case x of {} -- no constructors
 
-instance ToObject (UpecPredicateFailure era) where
+instance ToObject (ShelleyUpecPredFailure era) where
   toObject _verb (NewPpFailure (UnexpectedDepositPot totalOutstanding depositPot)) =
     mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "totalOutstanding" .=  String (textShow totalOutstanding)
@@ -882,7 +874,7 @@ instance ( Ledger.Era era
          , ToJSON (Ledger.TxOut era)
          , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" era))
          , ShelleyBasedEra era
-         ) => ToObject (Alonzo.UtxoPredicateFailure era) where
+         ) => ToObject (AlonzoUtxoPredFailure era) where
   toObject _verb (Alonzo.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -978,7 +970,7 @@ instance ( Ledger.Era era
 
 instance ( ToJSON (Alonzo.CollectError (Ledger.Crypto era))
          , ToObject (PredicateFailure (Ledger.EraRule "PPUP" era))
-         ) =>ToObject (Alonzo.UtxosPredicateFailure era) where
+         ) =>ToObject (AlonzoUtxosPredFailure era) where
   toObject _ (Alonzo.ValidationTagMismatch isValidating reason) =
     mconcat [ "kind" .= String "ValidationTagMismatch"
              , "isvalidating" .= isValidating
@@ -1068,7 +1060,7 @@ instance ToJSON Alonzo.FailureDescription where
 
 instance ( Ledger.Era era
          , Show (PredicateFailure (Ledger.EraRule "LEDGERS" era))
-         ) => ToObject (AlonzoBbodyPredFail era) where
+         ) => ToObject (AlonzoBbodyPredFailure era) where
   toObject _ err = mconcat [ "kind" .= String "AlonzoBbodyPredFail"
                             , "error" .= String (show err)
                             ]
@@ -1080,12 +1072,12 @@ instance ( Ledger.Era era
 instance ( ToJSON (Ledger.Value era)
          , ToJSON (Ledger.TxOut era)
          , ShelleyBasedEra era
-         , ToObject (UtxowPredicateFail era)
+         , ToObject (ShelleyUtxowPredFailure era)
          , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" era))
-         ) => ToObject (Babbage.BabbageUtxoPred era) where
+         ) => ToObject (BabbageUtxoPredFailure era) where
   toObject v err =
     case err of
-      Babbage.FromAlonzoUtxoFail alonzoFail ->
+      Babbage.AlonzoInBabbageUtxoPredFailure alonzoFail ->
         toObject v alonzoFail
 
       Babbage.IncorrectTotalCollateralField provided declared ->
@@ -1103,13 +1095,13 @@ instance ( Ledger.Era era
          , Ledger.Crypto era ~ StandardCrypto
          , ToJSON (Ledger.Value era)
          , ToJSON (Ledger.TxOut era)
-         , ToObject (UtxowPredicateFailure era)
+         , ToObject (ShelleyUtxowPredFailure era)
          , ToObject (PredicateFailure (Ledger.EraRule "PPUP" era))
          , ToObject (PredicateFailure (Ledger.EraRule "UTXO" era))
-         ) => ToObject (Babbage.BabbageUtxowPred era) where
+         ) => ToObject (BabbageUtxowPredFailure era) where
   toObject v err =
     case err of
-      Babbage.FromAlonzoUtxowFail alonzoFail ->
+      Babbage.AlonzoInBabbageUtxowPredFailure alonzoFail ->
         toObject v alonzoFail
       Babbage.UtxoFailure utxoFail ->
         toObject v utxoFail

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -13,7 +13,7 @@ module Cardano.Tracing.Peer
 import           Cardano.Prelude hiding (atomically)
 import           Prelude (String)
 
-import qualified Control.Monad.Class.MonadSTM.Strict as STM
+import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
 import           Data.Aeson (ToJSON (..), Value (..), toJSON, (.=))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -79,8 +79,8 @@ import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Util.Enclose
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (BlockNo (..), ChainUpdate (..),
-                   HasHeader (..), Point, StandardHash, blockNo, pointSlot, unBlockNo)
+import           Ouroboros.Network.Block (BlockNo (..), ChainUpdate (..), HasHeader (..), Point,
+                   StandardHash, blockNo, pointSlot, unBlockNo)
 import           Ouroboros.Network.BlockFetch.ClientState (TraceFetchClientState (..),
                    TraceLabelPeer (..))
 import           Ouroboros.Network.BlockFetch.Decision (FetchDecision, FetchDecline (..))
@@ -346,7 +346,7 @@ mkTracers blockConfig tOpts@(TracingOnLegacy trSel) tr nodeKern ekgDirect enable
      , Diffusion.dtHandshakeTracer               = handshakeTracer
      , Diffusion.dtLocalMuxTracer                = localMuxTracer
      , Diffusion.dtLocalHandshakeTracer          = localHandshakeTracer
-     , Diffusion.dtDiffusionInitializationTracer = initializationTracer
+     , Diffusion.dtDiffusionTracer               = initializationTracer
      , Diffusion.dtLedgerPeersTracer             = ledgerPeersTracer
      }
    diffusionTracersExtra' enP2P =
@@ -456,6 +456,7 @@ mkTracers _ _ _ _ _ enableP2P =
       , Consensus.mempoolTracer = nullTracer
       , Consensus.forgeTracer = nullTracer
       , Consensus.blockchainTimeTracer = nullTracer
+      , Consensus.consensusStartupErrorTracer = nullTracer
       }
     , nodeToClientTracers = NodeToClient.Tracers
       { NodeToClient.tChainSyncTracer = nullTracer
@@ -711,6 +712,8 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
     , Consensus.blockchainTimeTracer = tracerOnOff' (traceBlockchainTime trSel) $
         Tracer $ \ev ->
           traceWith (toLogObject tr) (readableTraceBlockchainTimeEvent ev)
+    , Consensus.consensusStartupErrorTracer =
+        Tracer $ \err -> traceWith (toLogObject tr) (ConsensusStartupException err)
     }
  where
    mkForgeTracers :: IO ForgeTracers
@@ -1423,7 +1426,7 @@ tracePeerSelectionCountersMetrics (OnOff False) _                = nullTracer
 tracePeerSelectionCountersMetrics (OnOff True)  (Just ekgDirect) = pscTracer
   where
     pscTracer :: Tracer IO PeerSelectionCounters
-    pscTracer = Tracer $ \(PeerSelectionCounters cold warm hot) -> do
+    pscTracer = Tracer $ \(PeerSelectionCounters cold warm hot _) -> do
       sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.cold" cold
       sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.warm" warm
       sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.hot"  hot

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -66,13 +66,13 @@ common project-config
 
 library
   import:               base, project-config
-                      , aeson
+  build-depends:      , aeson
                       , async
                       , bytestring
                       , cardano-api
                       , cardano-binary
-                      , cardano-crypto-class
-                      , cardano-ledger-byron
+                      , cardano-crypto-class ^>= 2.0
+                      , cardano-ledger-byron ^>= 0.1
                       , formatting
                       , http-media
                       , iohk-monitoring

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -135,7 +135,7 @@ library
                        , directory
                        , ekg
                        , ekg-core
-                       , ekg-forward
+                       , ekg-forward ^>= 0.3
                        , extra
                        , filepath
                        , mime-mail
@@ -200,7 +200,7 @@ library demo-forwarder-lib
                        , contra-tracer
                        , directory
                        , ekg-core
-                       , ekg-forward
+                       , ekg-forward ^>= 0.3
                        , extra
                        , filepath
                        , generic-data
@@ -292,7 +292,7 @@ test-suite cardano-tracer-test
                        , contra-tracer
                        , directory
                        , ekg-core
-                       , ekg-forward
+                       , ekg-forward ^>= 0.3
                        , extra
                        , filepath
                        , generic-data
@@ -346,7 +346,7 @@ test-suite cardano-tracer-test-ext
                        , contra-tracer
                        , directory
                        , ekg-core
-                       , ekg-forward
+                       , ekg-forward ^>= 0.3
                        , extra
                        , filepath
                        , generic-data

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
@@ -12,21 +12,21 @@ import           Data.Word (Word32)
 import           Cardano.Logging (TraceObject)
 import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
                    forwardingCodecCBORTerm, forwardingVersionCodec)
-import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
-                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
-                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.IOManager (withIOManager)
 import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
-                   localAddressFromPath, localSnocket)
-import           Ouroboros.Network.Socket (ConnectionId (..), connectToNode,
-                   nullNetworkConnectTracers)
+import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
+                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
+                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
 import           Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
                    codecHandshake, noTimeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
 import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
                    simpleSingletonVersions)
+import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
+                   localAddressFromPath, localSnocket)
+import           Ouroboros.Network.Socket (ConnectionId (..), connectToNode,
+                   nullNetworkConnectTracers)
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Acceptor (acceptEKGMetricsInit)
 
@@ -89,6 +89,9 @@ doConnectToForwarder
 doConnectToForwarder snocket address netMagic timeLimits app =
   connectToNode
     snocket
+    -- local sockets (e.g. unix sockets or named pipes on Windows), do
+    -- not need any configuration; we only need to configure node-to-node sockets.
+    mempty
     (codecHandshake forwardingVersionCodec)
     timeLimits
     (cborTermVersionDataCodec forwardingCodecCBORTerm)

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
@@ -13,23 +13,23 @@ import           Data.Word (Word32)
 import           Cardano.Logging (TraceObject)
 import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
                    forwardingCodecCBORTerm, forwardingVersionCodec)
-import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
-                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
-                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
 import           Ouroboros.Network.IOManager (withIOManager)
 import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
-                   localAddressFromPath, localSnocket)
-import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..), ConnectionId (..),
-                   SomeResponderApplication (..), cleanNetworkMutableState,
-                   newNetworkMutableState, nullNetworkServerTracers, withServerNode)
+import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
+                   MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
+                   RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
 import           Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
                    codecHandshake, noTimeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
 import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
                    simpleSingletonVersions)
+import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
+                   localAddressFromPath, localSnocket)
+import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..), ConnectionId (..),
+                   SomeResponderApplication (..), cleanNetworkMutableState, newNetworkMutableState,
+                   nullNetworkServerTracers, withServerNode)
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Acceptor (acceptEKGMetricsResp)
 
@@ -94,6 +94,7 @@ doListenToForwarder snocket address netMagic timeLimits app = do
   race_ (cleanNetworkMutableState networkState)
         $ withServerNode
             snocket
+            mempty -- LocalSocket does not need to be configured
             nullNetworkServerTracers
             networkState
             (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -17,15 +17,15 @@ import           Codec.CBOR.Term (Term)
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async
 import           Control.Monad (forever)
-import           "contra-tracer" Control.Tracer (nullTracer, contramap, stdoutTracer)
+import           "contra-tracer" Control.Tracer (contramap, nullTracer, stdoutTracer)
 import           Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Time.Clock (getCurrentTime)
 import           Data.Void (Void)
 import           Data.Word (Word16)
 import           GHC.Generics
-import qualified System.Metrics as EKG
 import           System.Directory
+import qualified System.Metrics as EKG
 
 import           Cardano.Logging (DetailLevel (..), SeverityS (..), TraceObject (..))
 import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
@@ -36,16 +36,16 @@ import           Ouroboros.Network.IOManager (IOManager, withIOManager)
 import           Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolLimits (..),
                    MiniProtocolNum (..), MuxMode (..), OuroborosApplication (..),
                    RunMiniProtocol (..), miniProtocolLimits, miniProtocolNum, miniProtocolRun)
-import           Ouroboros.Network.Protocol.Handshake.Codec (codecHandshake,
-                   cborTermVersionDataCodec, noTimeLimitsHandshake)
+import           Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
+                   codecHandshake, noTimeLimitsHandshake)
 import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
 import           Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
                    simpleSingletonVersions)
 import           Ouroboros.Network.Snocket (Snocket, localAddressFromPath, localSnocket)
 import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..),
-                   SomeResponderApplication (..), cleanNetworkMutableState,
-                   connectToNode, newNetworkMutableState, nullNetworkConnectTracers,
-                   nullNetworkServerTracers, withServerNode)
+                   SomeResponderApplication (..), cleanNetworkMutableState, connectToNode,
+                   newNetworkMutableState, nullNetworkConnectTracers, nullNetworkServerTracers,
+                   withServerNode)
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Forwarder
 
@@ -155,6 +155,7 @@ doConnectToAcceptor TestSetup{..} snocket address timeLimits (ekgConfig, tfConfi
   withAsync (traceObjectsWriter sink) $ \_ -> do
     connectToNode
       snocket
+      mempty
       (codecHandshake forwardingVersionCodec)
       timeLimits
       (cborTermVersionDataCodec forwardingCodecCBORTerm)
@@ -209,6 +210,7 @@ doListenToAcceptor TestSetup{..}
     race_ (cleanNetworkMutableState networkState)
           $ withServerNode
               snocket
+              mempty
               nullNetworkServerTracers
               networkState
               (AcceptedConnectionsLimit maxBound maxBound 0)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1666067814,
-        "narHash": "sha256-2TbQs7HSZRY5G3/jDggaY8ahxY8V5DhQ/+Xg1B9csTY=",
+        "lastModified": 1668127153,
+        "narHash": "sha256-RCd29xb0ZDZj5u9v9+dykv6nWs6pcEBsAyChm9Ut3To=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "e79a09bf6018fa0e5c3196f0ac01e58224caf73d",
+        "rev": "316e0a626fed1a928e659c7fc2577c7773770f7f",
         "type": "github"
       },
       "original": {
@@ -386,6 +386,21 @@
       }
     },
     "blank": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
+    "blank_2": {
       "locked": {
         "lastModified": 1625557891,
         "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
@@ -1509,7 +1524,7 @@
     },
     "cardano-mainnet-mirror_10": {
       "inputs": {
-        "nixpkgs": "nixpkgs_15"
+        "nixpkgs": "nixpkgs_18"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1528,7 +1543,7 @@
     },
     "cardano-mainnet-mirror_11": {
       "inputs": {
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1547,7 +1562,7 @@
     },
     "cardano-mainnet-mirror_12": {
       "inputs": {
-        "nixpkgs": "nixpkgs_17"
+        "nixpkgs": "nixpkgs_20"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1566,7 +1581,7 @@
     },
     "cardano-mainnet-mirror_13": {
       "inputs": {
-        "nixpkgs": "nixpkgs_18"
+        "nixpkgs": "nixpkgs_21"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1585,7 +1600,7 @@
     },
     "cardano-mainnet-mirror_14": {
       "inputs": {
-        "nixpkgs": "nixpkgs_19"
+        "nixpkgs": "nixpkgs_22"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1604,7 +1619,7 @@
     },
     "cardano-mainnet-mirror_15": {
       "inputs": {
-        "nixpkgs": "nixpkgs_20"
+        "nixpkgs": "nixpkgs_23"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1623,7 +1638,7 @@
     },
     "cardano-mainnet-mirror_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1642,7 +1657,7 @@
     },
     "cardano-mainnet-mirror_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1661,7 +1676,7 @@
     },
     "cardano-mainnet-mirror_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1680,7 +1695,7 @@
     },
     "cardano-mainnet-mirror_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1699,7 +1714,7 @@
     },
     "cardano-mainnet-mirror_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1718,7 +1733,7 @@
     },
     "cardano-mainnet-mirror_7": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1737,7 +1752,7 @@
     },
     "cardano-mainnet-mirror_8": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13"
+        "nixpkgs": "nixpkgs_16"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1756,7 +1771,7 @@
     },
     "cardano-mainnet-mirror_9": {
       "inputs": {
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1789,7 +1804,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example",
-        "utils": "utils_6"
+        "utils": "utils_7"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -1823,7 +1838,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_4"
+        "utils": "utils_5"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1856,7 +1871,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_3",
-        "utils": "utils_10"
+        "utils": "utils_11"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -1890,7 +1905,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_8"
+        "utils": "utils_9"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1922,7 +1937,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_12"
+        "utils": "utils_13"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1953,7 +1968,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_16"
+        "utils": "utils_17"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -1983,7 +1998,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_20"
+        "utils": "utils_21"
       },
       "locked": {
         "lastModified": 1644954571,
@@ -2056,7 +2071,7 @@
       "inputs": {
         "cardano-node-workbench": "cardano-node-workbench_4",
         "customConfig": "customConfig_3",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_5",
         "haskellNix": "haskellNix_3",
         "hostNixpkgs": [
           "node-measured",
@@ -2072,7 +2087,7 @@
           "nixpkgs-2105"
         ],
         "plutus-apps": "plutus-apps_2",
-        "utils": "utils_2"
+        "utils": "utils_3"
       },
       "locked": {
         "lastModified": 1647983004,
@@ -2110,7 +2125,7 @@
       "inputs": {
         "cardano-node-workbench": "cardano-node-workbench_6",
         "customConfig": "customConfig_5",
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_7",
         "haskellNix": "haskellNix_5",
         "hostNixpkgs": [
           "node-measured",
@@ -2128,7 +2143,7 @@
           "nixpkgs-2105"
         ],
         "plutus-apps": "plutus-apps_3",
-        "utils": "utils_3"
+        "utils": "utils_4"
       },
       "locked": {
         "lastModified": 1647983004,
@@ -2912,6 +2927,35 @@
     "devshell": {
       "inputs": {
         "flake-utils": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "inputs": {
+        "flake-utils": [
           "tullia",
           "std",
           "flake-utils"
@@ -2937,6 +2981,35 @@
       }
     },
     "dmerge": {
+      "inputs": {
+        "nixlib": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ],
+        "yants": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1659548052,
+        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
+        "owner": "divnix",
+        "repo": "data-merge",
+        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "data-merge",
+        "type": "github"
+      }
+    },
+    "dmerge_2": {
       "inputs": {
         "nixlib": [
           "tullia",
@@ -2980,6 +3053,39 @@
         "type": "github"
       }
     },
+    "flake-compat_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1638445031,
+        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-compat_2": {
       "flake": false,
       "locked": {
@@ -3000,16 +3106,15 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1647532380,
-        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "fixes",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -3017,16 +3122,15 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1647532380,
-        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
-        "owner": "input-output-hk",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "fixes",
+        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -3051,11 +3155,11 @@
     "flake-compat_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1638445031,
-        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
         "type": "github"
       },
       "original": {
@@ -3068,11 +3172,11 @@
     "flake-compat_7": {
       "flake": false,
       "locked": {
-        "lastModified": 1638445031,
-        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
         "type": "github"
       },
       "original": {
@@ -3102,15 +3206,16 @@
     "flake-compat_9": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
+        "lastModified": 1638445031,
+        "narHash": "sha256-dtIZLlf2tfYeLvpZa/jFxP5HvfoXAzr7X76yn6FQAdM=",
+        "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "20f79e3976b76a37090fbeec7b49dc08dac96b8e",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "input-output-hk",
+        "ref": "fixes",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -3372,11 +3477,11 @@
     },
     "flake-utils_25": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -3387,11 +3492,11 @@
     },
     "flake-utils_26": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -3402,11 +3507,41 @@
     },
     "flake-utils_27": {
       "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_28": {
+      "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_29": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -3430,13 +3565,28 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_30": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -3447,11 +3597,11 @@
     },
     "flake-utils_5": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -3462,6 +3612,21 @@
     },
     "flake-utils_6": {
       "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -3475,28 +3640,13 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
-      "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_8": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -3507,11 +3657,11 @@
     },
     "flake-utils_9": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -3913,8 +4063,27 @@
     },
     "gomod2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_21",
-        "utils": "utils_23"
+        "nixpkgs": "nixpkgs_3",
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1655245309,
+        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "gomod2nix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_24",
+        "utils": "utils_24"
       },
       "locked": {
         "lastModified": 1655245309,
@@ -3949,11 +4118,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1656898050,
-        "narHash": "sha256-jemAb/Wm/uT+QhV12GlyeA5euSWxYzr2HOYoK4MZps0=",
+        "lastModified": 1668148097,
+        "narHash": "sha256-AEq57KGTpvuueDcC1R9kBecQ6JFkI6lBXgS5qNBDorM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4f1dd530219ca1165f523ffb2c62213ebede4046",
+        "rev": "0801f3ab96ab5cfaf3e016e87e68be5ed00e7a70",
         "type": "github"
       },
       "original": {
@@ -4341,11 +4510,11 @@
         "cabal-32": "cabal-32_10",
         "cabal-34": "cabal-34_10",
         "cardano-shell": "cardano-shell_10",
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_14",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
         "hackage": "hackage_8",
         "hpc-coveralls": "hpc-coveralls_10",
-        "nix-tools": "nix-tools_10",
+        "nix-tools": "nix-tools_9",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4383,11 +4552,11 @@
         "cabal-34": "cabal-34_11",
         "cabal-36": "cabal-36_10",
         "cardano-shell": "cardano-shell_11",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_15",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_11",
         "hackage": "hackage_9",
         "hpc-coveralls": "hpc-coveralls_11",
-        "nix-tools": "nix-tools_11",
+        "nix-tools": "nix-tools_10",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4422,11 +4591,11 @@
         "cabal-34": "cabal-34_12",
         "cabal-36": "cabal-36_11",
         "cardano-shell": "cardano-shell_12",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_16",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_12",
         "hackage": "hackage_10",
         "hpc-coveralls": "hpc-coveralls_12",
-        "nix-tools": "nix-tools_12",
+        "nix-tools": "nix-tools_11",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4463,11 +4632,11 @@
         "cabal-34": "cabal-34_13",
         "cabal-36": "cabal-36_12",
         "cardano-shell": "cardano-shell_13",
-        "flake-utils": "flake-utils_14",
+        "flake-utils": "flake-utils_17",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_13",
         "hackage": "hackage_11",
         "hpc-coveralls": "hpc-coveralls_13",
-        "nix-tools": "nix-tools_13",
+        "nix-tools": "nix-tools_12",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4505,11 +4674,11 @@
         "cabal-32": "cabal-32_14",
         "cabal-34": "cabal-34_14",
         "cardano-shell": "cardano-shell_14",
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_18",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_14",
         "hackage": "hackage_12",
         "hpc-coveralls": "hpc-coveralls_14",
-        "nix-tools": "nix-tools_14",
+        "nix-tools": "nix-tools_13",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4547,11 +4716,11 @@
         "cabal-34": "cabal-34_15",
         "cabal-36": "cabal-36_13",
         "cardano-shell": "cardano-shell_15",
-        "flake-utils": "flake-utils_16",
+        "flake-utils": "flake-utils_19",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_15",
         "hackage": "hackage_13",
         "hpc-coveralls": "hpc-coveralls_15",
-        "nix-tools": "nix-tools_15",
+        "nix-tools": "nix-tools_14",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4586,11 +4755,11 @@
         "cabal-34": "cabal-34_16",
         "cabal-36": "cabal-36_14",
         "cardano-shell": "cardano-shell_16",
-        "flake-utils": "flake-utils_17",
+        "flake-utils": "flake-utils_20",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_16",
         "hackage": "hackage_14",
         "hpc-coveralls": "hpc-coveralls_16",
-        "nix-tools": "nix-tools_16",
+        "nix-tools": "nix-tools_15",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4626,11 +4795,11 @@
         "cabal-32": "cabal-32_17",
         "cabal-34": "cabal-34_17",
         "cardano-shell": "cardano-shell_17",
-        "flake-utils": "flake-utils_18",
+        "flake-utils": "flake-utils_21",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_17",
         "hackage": "hackage_15",
         "hpc-coveralls": "hpc-coveralls_17",
-        "nix-tools": "nix-tools_17",
+        "nix-tools": "nix-tools_16",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -4666,11 +4835,11 @@
         "cabal-34": "cabal-34_18",
         "cabal-36": "cabal-36_15",
         "cardano-shell": "cardano-shell_18",
-        "flake-utils": "flake-utils_19",
+        "flake-utils": "flake-utils_22",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_18",
         "hackage": "hackage_16",
         "hpc-coveralls": "hpc-coveralls_18",
-        "nix-tools": "nix-tools_18",
+        "nix-tools": "nix-tools_17",
         "nixpkgs": [
           "node-measured",
           "node-snapshot",
@@ -4704,11 +4873,11 @@
         "cabal-34": "cabal-34_19",
         "cabal-36": "cabal-36_16",
         "cardano-shell": "cardano-shell_19",
-        "flake-utils": "flake-utils_20",
+        "flake-utils": "flake-utils_23",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_19",
         "hackage": "hackage_17",
         "hpc-coveralls": "hpc-coveralls_19",
-        "nix-tools": "nix-tools_19",
+        "nix-tools": "nix-tools_18",
         "nixpkgs": [
           "node-measured",
           "node-snapshot",
@@ -4744,6 +4913,7 @@
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": [
@@ -4751,23 +4921,24 @@
         ],
         "hpc-coveralls": "hpc-coveralls_2",
         "hydra": "hydra",
-        "nix-tools": "nix-tools_2",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_2",
         "nixpkgs-2105": "nixpkgs-2105_2",
         "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
-        "stackage": "stackage_2"
+        "stackage": "stackage_2",
+        "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1656898207,
-        "narHash": "sha256-hshNfCnrmhIvM4T+O0/JRZymsHmq9YiIJ4bpzNVTD98=",
+        "lastModified": 1668151131,
+        "narHash": "sha256-zVr+PuM2g7/2JPzEkts0xIGnkimLH9QSuI66IduMKPI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "21230476adfef5fa77fb19fbda396f22006a02bc",
+        "rev": "cfb4563df856057807c3b7b879104701f2740070",
         "type": "github"
       },
       "original": {
@@ -4782,11 +4953,11 @@
         "cabal-32": "cabal-32_20",
         "cabal-34": "cabal-34_20",
         "cardano-shell": "cardano-shell_20",
-        "flake-utils": "flake-utils_21",
+        "flake-utils": "flake-utils_24",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_20",
         "hackage": "hackage_18",
         "hpc-coveralls": "hpc-coveralls_20",
-        "nix-tools": "nix-tools_20",
+        "nix-tools": "nix-tools_19",
         "nixpkgs": [
           "node-measured",
           "node-snapshot",
@@ -4821,11 +4992,11 @@
         "cabal-34": "cabal-34_21",
         "cabal-36": "cabal-36_17",
         "cardano-shell": "cardano-shell_21",
-        "flake-utils": "flake-utils_22",
+        "flake-utils": "flake-utils_25",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_21",
         "hackage": "hackage_19",
         "hpc-coveralls": "hpc-coveralls_21",
-        "nix-tools": "nix-tools_21",
+        "nix-tools": "nix-tools_20",
         "nixpkgs": [
           "node-snapshot",
           "nixpkgs"
@@ -4858,11 +5029,11 @@
         "cabal-34": "cabal-34_22",
         "cabal-36": "cabal-36_18",
         "cardano-shell": "cardano-shell_22",
-        "flake-utils": "flake-utils_23",
+        "flake-utils": "flake-utils_26",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_22",
         "hackage": "hackage_20",
         "hpc-coveralls": "hpc-coveralls_22",
-        "nix-tools": "nix-tools_22",
+        "nix-tools": "nix-tools_21",
         "nixpkgs": [
           "node-snapshot",
           "membench",
@@ -4896,11 +5067,11 @@
         "cabal-32": "cabal-32_23",
         "cabal-34": "cabal-34_23",
         "cardano-shell": "cardano-shell_23",
-        "flake-utils": "flake-utils_24",
+        "flake-utils": "flake-utils_27",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_23",
         "hackage": "hackage_21",
         "hpc-coveralls": "hpc-coveralls_23",
-        "nix-tools": "nix-tools_23",
+        "nix-tools": "nix-tools_22",
         "nixpkgs": [
           "node-snapshot",
           "plutus-example",
@@ -4934,12 +5105,12 @@
         "cabal-34": "cabal-34_3",
         "cabal-36": "cabal-36_3",
         "cardano-shell": "cardano-shell_3",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_7",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_3",
         "hydra": "hydra_2",
-        "nix-tools": "nix-tools_3",
+        "nix-tools": "nix-tools_2",
         "nixpkgs": [
           "node-measured",
           "cardano-node-workbench",
@@ -4973,7 +5144,7 @@
         "cabal-34": "cabal-34_4",
         "cabal-36": "cabal-36_4",
         "cardano-shell": "cardano-shell_4",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_8",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
         "hackage": [
           "node-measured",
@@ -4981,7 +5152,7 @@
         ],
         "hpc-coveralls": "hpc-coveralls_4",
         "hydra": "hydra_3",
-        "nix-tools": "nix-tools_4",
+        "nix-tools": "nix-tools_3",
         "nixpkgs": [
           "node-measured",
           "nixpkgs"
@@ -5014,12 +5185,12 @@
         "cabal-34": "cabal-34_5",
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_5",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_9",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
         "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_5",
         "hydra": "hydra_4",
-        "nix-tools": "nix-tools_5",
+        "nix-tools": "nix-tools_4",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -5054,11 +5225,11 @@
         "cabal-34": "cabal-34_6",
         "cabal-36": "cabal-36_6",
         "cardano-shell": "cardano-shell_6",
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_10",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
         "hackage": "hackage_4",
         "hpc-coveralls": "hpc-coveralls_6",
-        "nix-tools": "nix-tools_6",
+        "nix-tools": "nix-tools_5",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -5092,11 +5263,11 @@
         "cabal-34": "cabal-34_7",
         "cabal-36": "cabal-36_7",
         "cardano-shell": "cardano-shell_7",
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_11",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
         "hackage": "hackage_5",
         "hpc-coveralls": "hpc-coveralls_7",
-        "nix-tools": "nix-tools_7",
+        "nix-tools": "nix-tools_6",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -5131,11 +5302,11 @@
         "cabal-34": "cabal-34_8",
         "cabal-36": "cabal-36_8",
         "cardano-shell": "cardano-shell_8",
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_12",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
         "hackage": "hackage_6",
         "hpc-coveralls": "hpc-coveralls_8",
-        "nix-tools": "nix-tools_8",
+        "nix-tools": "nix-tools_7",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -5172,11 +5343,11 @@
         "cabal-34": "cabal-34_9",
         "cabal-36": "cabal-36_9",
         "cardano-shell": "cardano-shell_9",
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_13",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
         "hackage": "hackage_7",
         "hpc-coveralls": "hpc-coveralls_9",
-        "nix-tools": "nix-tools_9",
+        "nix-tools": "nix-tools_8",
         "nixpkgs": [
           "node-measured",
           "node-measured",
@@ -6292,6 +6463,22 @@
         "type": "github"
       }
     },
+    "mdbook-kroki-preprocessor_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661755005,
+        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
+        "owner": "JoelCourtney",
+        "repo": "mdbook-kroki-preprocessor",
+        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JoelCourtney",
+        "repo": "mdbook-kroki-preprocessor",
+        "type": "github"
+      }
+    },
     "membench": {
       "locked": {
         "lastModified": 1630400035,
@@ -6838,7 +7025,31 @@
     },
     "n2c": {
       "inputs": {
-        "flake-utils": "flake-utils_27",
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665039323,
+        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "n2c_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_30",
         "nixpkgs": [
           "tullia",
           "std",
@@ -6882,13 +7093,48 @@
     },
     "nix-nomad": {
       "inputs": {
-        "flake-compat": "flake-compat_9",
+        "flake-compat": "flake-compat_4",
         "flake-utils": [
+          "haskellNix",
           "tullia",
           "nix2container",
           "flake-utils"
         ],
         "gomod2nix": "gomod2nix",
+        "nixpkgs": [
+          "haskellNix",
+          "tullia",
+          "nixpkgs"
+        ],
+        "nixpkgs-lib": [
+          "haskellNix",
+          "tullia",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1658277770,
+        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tristanpemble",
+        "repo": "nix-nomad",
+        "type": "github"
+      }
+    },
+    "nix-nomad_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_11",
+        "flake-utils": [
+          "tullia",
+          "nix2container",
+          "flake-utils"
+        ],
+        "gomod2nix": "gomod2nix_2",
         "nixpkgs": [
           "tullia",
           "nixpkgs"
@@ -7091,11 +7337,11 @@
     "nix-tools_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1649424170,
-        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -7152,39 +7398,7 @@
         "type": "github"
       }
     },
-    "nix-tools_23": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1636018067,
-        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "type": "github"
-      }
-    },
     "nix-tools_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "type": "github"
-      }
-    },
-    "nix-tools_4": {
       "flake": false,
       "locked": {
         "lastModified": 1649424170,
@@ -7200,7 +7414,7 @@
         "type": "github"
       }
     },
-    "nix-tools_5": {
+    "nix-tools_4": {
       "flake": false,
       "locked": {
         "lastModified": 1644395812,
@@ -7208,6 +7422,22 @@
         "owner": "input-output-hk",
         "repo": "nix-tools",
         "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
         "type": "github"
       },
       "original": {
@@ -7283,14 +7513,14 @@
     "nix2container": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "lastModified": 1658567952,
+        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
         "type": "github"
       },
       "original": {
@@ -7301,8 +7531,27 @@
     },
     "nix2container_2": {
       "inputs": {
-        "flake-utils": "flake-utils_25",
-        "nixpkgs": "nixpkgs_22"
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1668413124,
+        "narHash": "sha256-k0hGnuVjn6pFXmy4yYxpNuRXh/zR1KXB4l1EcAlQMzI=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "f128a164fed3aa97ae8cf15cd7cb15709178dda4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nix2container_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_28",
+        "nixpkgs": "nixpkgs_25"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -7353,7 +7602,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -7374,7 +7623,7 @@
     "nix_3": {
       "inputs": {
         "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
@@ -7395,7 +7644,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_11",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -7414,6 +7663,41 @@
       }
     },
     "nixago": {
+      "inputs": {
+        "flake-utils": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
+        "nixago-exts": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "nixpkgs": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1661824785,
+        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
+        "owner": "nix-community",
+        "repo": "nixago",
+        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixago_2": {
       "inputs": {
         "flake-utils": [
           "tullia",
@@ -8005,11 +8289,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1645296114,
-        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
         "type": "github"
       },
       "original": {
@@ -8373,11 +8657,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1648744337,
-        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
         "type": "github"
       },
       "original": {
@@ -8559,6 +8843,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1663981975,
+        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -8801,11 +9101,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1663905476,
+        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
         "type": "github"
       },
       "original": {
@@ -9007,15 +9307,16 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -9162,6 +9463,48 @@
     },
     "nixpkgs_21": {
       "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_22": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_23": {
+      "locked": {
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_24": {
+      "locked": {
         "lastModified": 1653581809,
         "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "NixOS",
@@ -9176,7 +9519,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_22": {
+    "nixpkgs_25": {
       "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
@@ -9191,7 +9534,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_23": {
+    "nixpkgs_26": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -9209,6 +9552,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
         "owner": "NixOS",
@@ -9222,48 +9581,35 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1654807842,
+        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_7": {
@@ -9297,15 +9643,16 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -9314,7 +9661,7 @@
         "cardano-mainnet-mirror": "cardano-mainnet-mirror_2",
         "cardano-node-workbench": "cardano-node-workbench_3",
         "customConfig": "customConfig_4",
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_6",
         "hackageNix": "hackageNix_2",
         "haskellNix": "haskellNix_4",
         "hostNixpkgs": [
@@ -9332,7 +9679,7 @@
         "node-process": "node-process_2",
         "node-snapshot": "node-snapshot_2",
         "plutus-apps": "plutus-apps_5",
-        "utils": "utils_19"
+        "utils": "utils_20"
       },
       "locked": {
         "lastModified": 1654323094,
@@ -9353,7 +9700,7 @@
         "cardano-mainnet-mirror": "cardano-mainnet-mirror_3",
         "cardano-node-workbench": "cardano-node-workbench_5",
         "customConfig": "customConfig_6",
-        "flake-compat": "flake-compat_6",
+        "flake-compat": "flake-compat_8",
         "haskellNix": "haskellNix_6",
         "hostNixpkgs": [
           "node-measured",
@@ -9371,7 +9718,7 @@
         "node-process": "node-process",
         "node-snapshot": "node-snapshot",
         "plutus-apps": "plutus-apps_4",
-        "utils": "utils_15"
+        "utils": "utils_16"
       },
       "locked": {
         "lastModified": 1648681325,
@@ -9391,7 +9738,7 @@
       "inputs": {
         "cardano-node-workbench": "cardano-node-workbench_7",
         "customConfig": "customConfig_7",
-        "flake-compat": "flake-compat_7",
+        "flake-compat": "flake-compat_9",
         "haskellNix": "haskellNix_7",
         "hostNixpkgs": [
           "node-measured",
@@ -9409,7 +9756,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_2",
-        "utils": "utils_7"
+        "utils": "utils_8"
       },
       "locked": {
         "lastModified": 1647614422,
@@ -9429,7 +9776,7 @@
       "inputs": {
         "cardano-node-workbench": "cardano-node-workbench_8",
         "customConfig": "customConfig_11",
-        "flake-compat": "flake-compat_8",
+        "flake-compat": "flake-compat_10",
         "haskellNix": "haskellNix_11",
         "hostNixpkgs": [
           "node-measured",
@@ -9447,7 +9794,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_4",
-        "utils": "utils_11"
+        "utils": "utils_12"
       },
       "locked": {
         "lastModified": 1647614422,
@@ -9509,7 +9856,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_5",
-        "utils": "utils_14"
+        "utils": "utils_15"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -9539,7 +9886,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_6",
-        "utils": "utils_18"
+        "utils": "utils_19"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -9568,7 +9915,7 @@
           "nixpkgs-2105"
         ],
         "plutus-example": "plutus-example_7",
-        "utils": "utils_22"
+        "utils": "utils_23"
       },
       "locked": {
         "lastModified": 1645120669,
@@ -10279,7 +10626,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_5"
+        "utils": "utils_6"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -10328,7 +10675,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_9"
+        "utils": "utils_10"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -10375,7 +10722,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_13"
+        "utils": "utils_14"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -10404,7 +10751,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_17"
+        "utils": "utils_18"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -10432,7 +10779,7 @@
           "haskellNix",
           "nixpkgs-2105"
         ],
-        "utils": "utils_21"
+        "utils": "utils_22"
       },
       "locked": {
         "lastModified": 1640022647,
@@ -10462,7 +10809,7 @@
           "nixpkgs"
         ],
         "iohkNix": "iohkNix_2",
-        "nix2container": "nix2container",
+        "nix2container": "nix2container_2",
         "nixTools": "nixTools",
         "nixpkgs": [
           "haskellNix",
@@ -10472,8 +10819,8 @@
         "node-process": "node-process_3",
         "node-snapshot": "node-snapshot_3",
         "plutus-apps": "plutus-apps_6",
-        "tullia": "tullia",
-        "utils": "utils_24"
+        "tullia": "tullia_2",
+        "utils": "utils_25"
       }
     },
     "stackage": {
@@ -10655,11 +11002,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1656898145,
-        "narHash": "sha256-EMgMzdANg6r5gEUkMtv5ujDo2/Kx7JJXoXiDKjDVoLw=",
+        "lastModified": 1668149152,
+        "narHash": "sha256-wyZeNL3gYEWaeNvr59fFr8OfHxub1OCWO0F+4bmHujA=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "835a5f2d2a1acafb77add430fc8c2dd47282ef32",
+        "rev": "475c7be36c03470a1749266265431121df9eea3f",
         "type": "github"
       },
       "original": {
@@ -10849,22 +11196,60 @@
         "blank": "blank",
         "devshell": "devshell",
         "dmerge": "dmerge",
-        "flake-utils": "flake-utils_26",
+        "flake-utils": "flake-utils_4",
         "makes": [
+          "haskellNix",
           "tullia",
           "std",
           "blank"
         ],
         "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "microvm": [
+          "haskellNix",
           "tullia",
           "std",
           "blank"
         ],
         "n2c": "n2c",
         "nixago": "nixago",
-        "nixpkgs": "nixpkgs_23",
+        "nixpkgs": "nixpkgs_5",
         "yants": "yants"
+      },
+      "locked": {
+        "lastModified": 1665513321,
+        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
+    "std_2": {
+      "inputs": {
+        "blank": "blank_2",
+        "devshell": "devshell_2",
+        "dmerge": "dmerge_2",
+        "flake-utils": "flake-utils_29",
+        "makes": [
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor_2",
+        "microvm": [
+          "tullia",
+          "std",
+          "blank"
+        ],
+        "n2c": "n2c_2",
+        "nixago": "nixago_2",
+        "nixpkgs": "nixpkgs_26",
+        "yants": "yants_2"
       },
       "locked": {
         "lastModified": 1665513321,
@@ -10883,11 +11268,35 @@
     "tullia": {
       "inputs": {
         "nix-nomad": "nix-nomad",
-        "nix2container": "nix2container_2",
+        "nix2container": "nix2container",
         "nixpkgs": [
+          "haskellNix",
           "nixpkgs"
         ],
         "std": "std"
+      },
+      "locked": {
+        "lastModified": 1666200256,
+        "narHash": "sha256-cJPS8zBu30SMhxMe7I8DWutwqMuhPsEez87y9gxMKc4=",
+        "owner": "input-output-hk",
+        "repo": "tullia",
+        "rev": "575362c2244498e8d2c97f72861510fa72e75d44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "tullia",
+        "type": "github"
+      }
+    },
+    "tullia_2": {
+      "inputs": {
+        "nix-nomad": "nix-nomad_2",
+        "nix2container": "nix2container_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "std": "std_2"
       },
       "locked": {
         "lastModified": 1667307643,
@@ -10920,11 +11329,11 @@
     },
     "utils_10": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -10965,11 +11374,11 @@
     },
     "utils_13": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -10980,11 +11389,11 @@
     },
     "utils_14": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -11025,11 +11434,11 @@
     },
     "utils_17": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -11040,11 +11449,11 @@
     },
     "utils_18": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -11070,11 +11479,11 @@
     },
     "utils_2": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -11100,21 +11509,6 @@
     },
     "utils_21": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_22": {
-      "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
@@ -11128,13 +11522,28 @@
         "type": "github"
       }
     },
-    "utils_23": {
+    "utils_22": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_23": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -11158,7 +11567,37 @@
         "type": "github"
       }
     },
+    "utils_25": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "utils_3": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_4": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -11173,28 +11612,13 @@
         "type": "github"
       }
     },
-    "utils_4": {
+    "utils_5": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_5": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -11205,11 +11629,11 @@
     },
     "utils_6": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -11250,11 +11674,11 @@
     },
     "utils_9": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -11264,6 +11688,29 @@
       }
     },
     "yants": {
+      "inputs": {
+        "nixpkgs": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660507851,
+        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
+      }
+    },
+    "yants_2": {
       "inputs": {
         "nixpkgs": [
           "tullia",

--- a/flake.lock
+++ b/flake.lock
@@ -6118,11 +6118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653579289,
-        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
+        "lastModified": 1667394105,
+        "narHash": "sha256-YhS7zGd6jK/QM/+wWyj0zUBZmE3HOXAL/kpJptGYIWg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
+        "rev": "7fc7625a9ab2ba137bc70ddbc89a13d3fdb78c8b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,7 @@
               packages = lib.genAttrs [
                 "ouroboros-consensus"
                 "ouroboros-consensus-cardano"
+                "ouroboros-consensus-cardano-tools"
                 "ouroboros-consensus-byron"
                 "ouroboros-consensus-shelley"
                 "ouroboros-network"
@@ -195,7 +196,7 @@
           inherit pinned-workbench;
           projectExes = flatten (haskellLib.collectComponents' "exes" projectPackages) // (with hsPkgsWithPassthru; {
             inherit (ouroboros-consensus-byron.components.exes) db-converter;
-            inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser;
+            inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser db-synthesizer;
             inherit (bech32.components.exes) bech32;
           } // lib.optionalAttrs hostPlatform.isUnix {
             inherit (network-mux.components.exes) cardano-ping;
@@ -467,10 +468,7 @@
       overlay = final: prev: {
         cardanoNodeProject = flake.project.${final.system};
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
-        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli plutus-example;
-
-        # TODO, fix this
-        #db-analyser = ouroboros-network-snapshot.haskellPackages.ouroboros-consensus-cardano.components.exes.db-analyser;
+        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli plutus-example db-analyser;
       };
       nixosModules = {
         cardano-node = { pkgs, lib, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -195,7 +195,7 @@
           inherit pinned-workbench;
           projectExes = flatten (haskellLib.collectComponents' "exes" projectPackages) // (with hsPkgsWithPassthru; {
             inherit (ouroboros-consensus-byron.components.exes) db-converter;
-            inherit (ouroboros-consensus-cardano.components.exes) db-analyser;
+            inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser;
             inherit (bech32.components.exes) bech32;
           } // lib.optionalAttrs hostPlatform.isUnix {
             inherit (network-mux.components.exes) cardano-ping;

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -43,7 +43,7 @@ library
                       , contra-tracer
                       , ekg
                       , ekg-core
-                      , ekg-forward >= 0.2.0
+                      , ekg-forward == 0.3.0
                       , hostname
                       , network
                       , optparse-applicative-fork

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -59,12 +59,12 @@ library
                        , containers
                        , contra-tracer
                        , extra
-                       , io-classes
+                       , io-classes ^>= 0.3
                        , ouroboros-network-framework
                        , serialise
                        , stm
                        , text
-                       , typed-protocols
+                       , typed-protocols ^>= 0.1
                        , typed-protocols-cborg
 
 test-suite test
@@ -90,7 +90,7 @@ test-suite test
   build-depends:         aeson
                        , bytestring
                        , contra-tracer
-                       , io-classes
+                       , io-classes ^>= 0.3
                        , io-sim
                        , ouroboros-network-framework
                        , trace-forward
@@ -98,7 +98,7 @@ test-suite test
                        , serialise
                        , tasty
                        , tasty-quickcheck
-                       , typed-protocols
+                       , typed-protocols ^>= 0.1
                        , text
 
   ghc-options:         -rtsopts


### PR DESCRIPTION
This PR updates ouroboros-network and cardano-ledger dependencies. 

This bumps `cardano-ledger` to `0.1.1.1`, which is https://github.com/input-output-hk/cardano-ledger/pull/3080. This in turn is the `release/1.1.x` branch + heapword split compatibility introduced in `cardano-base`, which is in CHaP.

It also bumps ouroboros-network to [a38f898a](https://github.com/input-output-hk/ouroboros-network/commits/a38f898a3740925ccaa0617fa870ca7054a485a6), which is 45 commits ahead of the old [c764553](https://github.com/input-output-hk/ouroboros-network/commits/c764553561bed8978d2c6753d1608dc65449617a) pin.
This is one commit ahead of what https://github.com/input-output-hk/ouroboros-network/pull/3933 (on ouroboros-network/master), that made network compatible with https://github.com/input-output-hk/cardano-ledger/pull/2901