### PR TITLE
Update building-the-node-using-nix.md

### DIFF
--- a/doc/getting-started/building-the-node-using-nix.md
+++ b/doc/getting-started/building-the-node-using-nix.md
@@ -24,15 +24,16 @@ To improve build speed, it is possible to set up a binary cache maintained by IO
 optional**):
 ```
 sudo mkdir -p /etc/nix
-cat <<EOF | sudo tee /etc/nix/nix.conf
-substituters = https://cache.nixos.org https://hydra.iohk.io
-trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+cat <<EOF | sudo tee -a /etc/nix/nix.conf
+substituters = https://cache.nixos.org https://cache.iog.io
+trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 EOF
 ```
 
 ### Building and running with nix
 
-Once Nix is installed, log out and then log back in then:
+Once Nix is installed, log out and then log back in.
+After that you can build the full node package with Mainnet configuration as follows:
 ```
 git clone https://github.com/input-output-hk/cardano-node
 cd cardano-node
@@ -44,6 +45,10 @@ or run in in one go:
 nix run github:input-output-hk/cardano-node#mainnet/node
 ```
 
+If you only want to build just the cardano-node executable, without the configuration bundle:
+```
+nix build .#cardano-node -o cardano-node-build
+```
 To build the cardano-cli executable, follow the steps below:
 ```
 nix build .#cardano-cli -o cardano-cli-build
@@ -54,7 +59,7 @@ Or run directly, eg.:
 nix run .#cardano-cli -- version
 ```
 
-### Developpment environments
+### Development environments
 
 A shell environment with pre-compiled, cached, cabal dependencies is available with:
 ```


### PR DESCRIPTION
Build the cardano-node executable. No default configuration.