### PR TITLE
Restore --cddl-format

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -7,7 +7,9 @@
 - Allow reading and writing text envelope files from pipes([PR4384](https://github.com/input-output-hk/cardano-node/pull/4384))
 - Update cardano transaction view command to render inline datums and reference inputs ([PR4089](https://github.com/input-output-hk/cardano-node/pull/4089))
 - Switch default era in cardano-cli from Alonzo to Babbage ([PR4485](https://github.com/input-output-hk/cardano-node/pull/4485))
-- Default to the ledger's CDDL format for transaction body creation by removing flags `--cddl-format` and `--cli-format` from `build` and `build-raw` ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303))
+- For the `build` and `build-raw` commands, always use ledger's CDDL format for transaction body creation.
+  Remove the `cli-format` flag and make `--cddl-format` deprecated and hidden
+  ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303) [PR 4617](https://github.com/input-output-hk/cardano-node/pull/4617))
 - Allow reading signing keys from a pipe ([PR 4342](https://github.com/input-output-hk/cardano-node/pull/4342))
 
 ## 1.35.3 -- August 2022

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1756,13 +1756,14 @@ pOutputFormat =
     <> Opt.value OutputFormatBech32
     )
 
-pOutputSerialisation :: Parser ()
+pOutputSerialisation :: Parser (Maybe ())
 pOutputSerialisation =
-  Opt.flag () ()
-    (  Opt.long "cddl-format"
-    <> Opt.help "Serialise in the ledger CDDL specified CBOR format."
-    <> Opt.hidden
-    )
+  optional $
+    Opt.flag () ()
+      (  Opt.long "cddl-format"
+      <> Opt.help "Serialise in the ledger CDDL specified CBOR format."
+      <> Opt.hidden
+      )
 
 pMaybeOutputFile :: Parser (Maybe OutputFile)
 pMaybeOutputFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -718,6 +718,7 @@ pTransaction =
             <*> many pMetadataFile
             <*> optional pProtocolParamsSourceSpec
             <*> optional pUpdateProposalFile
+            <*  pOutputSerialisation -- TODO delete in the next release after 1.35.4
             <*> (OutputTxBodyOnly <$> pTxBodyFile Output <|> pCalculatePlutusScriptCost)
 
   pChangeAddress :: Parser TxOutChangeAddress
@@ -754,6 +755,7 @@ pTransaction =
                <*> many pMetadataFile
                <*> optional pProtocolParamsSourceSpec
                <*> optional pUpdateProposalFile
+               <*  pOutputSerialisation -- TODO delete in the next release after 1.35.4
                <*> pTxBodyFile Output
 
   pTransactionSign  :: Parser TransactionCmd
@@ -1752,6 +1754,14 @@ pOutputFormat =
     <> Opt.help "Optional output format. Accepted output formats are \"hex\" \
                 \and \"bech32\" (default is \"bech32\")."
     <> Opt.value OutputFormatBech32
+    )
+
+pOutputSerialisation :: Parser ()
+pOutputSerialisation =
+  Opt.flag () ()
+    (  Opt.long "cddl-format"
+    <> Opt.help "Serialise in the ledger CDDL specified CBOR format."
+    <> Opt.hidden
     )
 
 pMaybeOutputFile :: Parser (Maybe OutputFile)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -35,6 +35,7 @@ golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--tx-out", "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
     , "--tx-out", "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"
     , "--fee", "166777"
+    , "--cddl-format" -- TODO delete in the next release after 1.35.4
     , "--out-file", transactionBodyFile
     ]
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -35,8 +35,22 @@ golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--tx-out", "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
     , "--tx-out", "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"
     , "--fee", "166777"
-    , "--cddl-format" -- TODO delete in the next release after 1.35.4
     , "--out-file", transactionBodyFile
+    ]
+
+  -- TODO delete in the next release after 1.35.4
+  -- Create transaction body in the same manner as the previous command but ensure that the --cddl-format
+  -- option is accepted.  This transaction body file is unused in the test.
+  transactionBodyFile2 <- noteTempFile tempDir "tx-body-file"
+  void $ execCardanoCLI
+    [ "transaction", "build-raw"
+    , "--alonzo-era"
+    , "--tx-in", "f62cd7bc15d8c6d2c8519fb8d13c57c0157ab6bab50af62bc63706feb966393d#0"
+    , "--tx-out", "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
+    , "--tx-out", "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"
+    , "--fee", "166777"
+    , "--cddl-format"
+    , "--out-file", transactionBodyFile2
     ]
 
   -- Sign transaction

--- a/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
@@ -169,6 +169,7 @@ hprop_kes_period_info = H.integration . H.runFinallies . H.workspace "chairman" 
     , "--tx-out", utxoaddrwithstaking <> "+" <> show @Int 5000000
     , "--witness-override", show @Int 3
     , "--certificate-file", work </> "pledger.regcert"
+    , "--cddl-format" -- TODO delete in the next release after 1.35.4
     , "--out-file", work </> "pledge-registration-cert.txbody"
     ]
 

--- a/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Spec/Cli/KesPeriodInfo.hs
@@ -169,6 +169,22 @@ hprop_kes_period_info = H.integration . H.runFinallies . H.workspace "chairman" 
     , "--tx-out", utxoaddrwithstaking <> "+" <> show @Int 5000000
     , "--witness-override", show @Int 3
     , "--certificate-file", work </> "pledger.regcert"
+    , "--out-file", work </> "pledge-registration-cert.txbody"
+    ]
+
+  -- TODO delete in the next release after 1.35.4
+  -- Create transaction body in the same manner as the previous command but ensure that the --cddl-format
+  -- option is accepted.  This transaction body file is unused in the test.
+  void $ H.execCli' execConfig
+    [ "transaction", "build"
+    , "--alonzo-era"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--change-address",  utxoAddr
+    , "--tx-in", T.unpack $ renderTxIn txin
+    , "--tx-out", poolowneraddresswstakecred <> "+" <> show @Int 5000000
+    , "--tx-out", utxoaddrwithstaking <> "+" <> show @Int 5000000
+    , "--witness-override", show @Int 3
+    , "--certificate-file", work </> "pledger.regcert2"
     , "--cddl-format" -- TODO delete in the next release after 1.35.4
     , "--out-file", work </> "pledge-registration-cert.txbody"
     ]


### PR DESCRIPTION
 as a hidden switch to avoid breaking 3rd party tooling.  The restore switch has no effect

Resolves https://github.com/input-output-hk/cardano-node/issues/4597