### PR TITLE
Improved error message for failed asset name decode

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -130,6 +130,7 @@ library
                       , cryptonite
                       , deepseq
                       , directory
+                      , either
                       , filepath
                       , formatting
                       , iproute

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -471,7 +471,7 @@ module Cardano.Api (
     -- | Some types have a natural raw binary format.
     SerialiseAsRawBytes,
     serialiseToRawBytes,
-    deserialiseFromRawBytes,
+    eitherDeserialiseFromRawBytes,
     serialiseToRawBytesHex,
     deserialiseFromRawBytesHex,
     serialiseToRawBytesHexText,

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -293,9 +293,9 @@ newtype instance Hash BlockHeader = HeaderHash SBS.ShortByteString
 instance SerialiseAsRawBytes (Hash BlockHeader) where
     serialiseToRawBytes (HeaderHash bs) = SBS.fromShort bs
 
-    deserialiseFromRawBytes (AsHash AsBlockHeader) bs
-      | BS.length bs == 32 = Just $! HeaderHash (SBS.toShort bs)
-      | otherwise          = Nothing
+    eitherDeserialiseFromRawBytes (AsHash AsBlockHeader) bs
+      | BS.length bs == 32 = Right $! HeaderHash (SBS.toShort bs)
+      | otherwise          = Left (SerialiseAsRawBytesError "Unable to deserialise Hash BlockHeader")
 
 instance HasTypeProxy BlockHeader where
     data AsType BlockHeader = AsBlockHeader

--- a/cardano-api/src/Cardano/Api/Keys/Class.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Class.hs
@@ -77,9 +77,9 @@ generateInsecureSigningKey
   -> IO (SigningKey keyrole, StdGen)
 generateInsecureSigningKey g keytype = do
   let (bs, g') = Random.genByteString (fromIntegral $ deterministicSigningKeySeedSize keytype) g
-  case deserialiseFromRawBytes (AsSigningKey keytype) bs of
-    Just key -> return (key, g')
-    Nothing -> error "generateInsecureSigningKey: Unable to generate insecure key"
+  case eitherDeserialiseFromRawBytes (AsSigningKey keytype) bs of
+    Right key -> return (key, g')
+    Left (SerialiseAsRawBytesError msg) -> error $ "generateInsecureSigningKey: Unable to generate insecure key: " <> msg
 
 instance HasTypeProxy a => HasTypeProxy (VerificationKey a) where
     data AsType (VerificationKey a) = AsVerificationKey (AsType a)

--- a/cardano-api/src/Cardano/Api/Keys/Praos.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Praos.hs
@@ -24,25 +24,25 @@ module Cardano.Api.Keys.Praos (
 
 import           Prelude
 
+import           Data.Either.Combinators (maybeToRight)
 import           Data.String (IsString (..))
 
 import qualified Cardano.Crypto.DSIGN.Class as Crypto
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.KES.Class as Crypto
 import qualified Cardano.Crypto.VRF.Class as Crypto
+import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Crypto as Shelley (KES, VRF)
 import qualified Cardano.Ledger.Keys as Shelley
-import           Cardano.Ledger.Crypto (StandardCrypto)
 
-import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
 import           Cardano.Api.Keys.Class
+import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.SerialiseUsing
-
 
 --
 -- KES keys
@@ -94,16 +94,17 @@ instance SerialiseAsRawBytes (VerificationKey KesKey) where
     serialiseToRawBytes (KesVerificationKey vk) =
       Crypto.rawSerialiseVerKeyKES vk
 
-    deserialiseFromRawBytes (AsVerificationKey AsKesKey) bs =
-      KesVerificationKey <$>
-        Crypto.rawDeserialiseVerKeyKES bs
+    eitherDeserialiseFromRawBytes (AsVerificationKey AsKesKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise VerificationKey KesKey") $
+        KesVerificationKey <$> Crypto.rawDeserialiseVerKeyKES bs
 
 instance SerialiseAsRawBytes (SigningKey KesKey) where
     serialiseToRawBytes (KesSigningKey sk) =
       Crypto.rawSerialiseSignKeyKES sk
 
-    deserialiseFromRawBytes (AsSigningKey AsKesKey) bs =
-      KesSigningKey <$> Crypto.rawDeserialiseSignKeyKES bs
+    eitherDeserialiseFromRawBytes (AsSigningKey AsKesKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise SigningKey KesKey") $
+        KesSigningKey <$> Crypto.rawDeserialiseSignKeyKES bs
 
 instance SerialiseAsBech32 (VerificationKey KesKey) where
     bech32PrefixFor         _ =  "kes_vk"
@@ -126,8 +127,9 @@ instance SerialiseAsRawBytes (Hash KesKey) where
     serialiseToRawBytes (KesKeyHash vkh) =
       Crypto.hashToBytes vkh
 
-    deserialiseFromRawBytes (AsHash AsKesKey) bs =
-      KesKeyHash <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes (AsHash AsKesKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise Hash KesKey") $
+        KesKeyHash <$> Crypto.hashFromBytes bs
 
 instance HasTextEnvelope (VerificationKey KesKey) where
     textEnvelopeType _ = "KesVerificationKey_"
@@ -192,15 +194,17 @@ instance SerialiseAsRawBytes (VerificationKey VrfKey) where
     serialiseToRawBytes (VrfVerificationKey vk) =
       Crypto.rawSerialiseVerKeyVRF vk
 
-    deserialiseFromRawBytes (AsVerificationKey AsVrfKey) bs =
-      VrfVerificationKey <$> Crypto.rawDeserialiseVerKeyVRF bs
+    eitherDeserialiseFromRawBytes (AsVerificationKey AsVrfKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise VerificationKey VrfKey") $
+        VrfVerificationKey <$> Crypto.rawDeserialiseVerKeyVRF bs
 
 instance SerialiseAsRawBytes (SigningKey VrfKey) where
     serialiseToRawBytes (VrfSigningKey sk) =
       Crypto.rawSerialiseSignKeyVRF sk
 
-    deserialiseFromRawBytes (AsSigningKey AsVrfKey) bs =
-      VrfSigningKey <$> Crypto.rawDeserialiseSignKeyVRF bs
+    eitherDeserialiseFromRawBytes (AsSigningKey AsVrfKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise SigningKey VrfKey") $
+        VrfSigningKey <$> Crypto.rawDeserialiseSignKeyVRF bs
 
 instance SerialiseAsBech32 (VerificationKey VrfKey) where
     bech32PrefixFor         _ =  "vrf_vk"
@@ -222,8 +226,9 @@ instance SerialiseAsRawBytes (Hash VrfKey) where
     serialiseToRawBytes (VrfKeyHash vkh) =
       Crypto.hashToBytes vkh
 
-    deserialiseFromRawBytes (AsHash AsVrfKey) bs =
-      VrfKeyHash <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes (AsHash AsVrfKey) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise Hash VrfKey") $
+        VrfKeyHash <$> Crypto.hashFromBytes bs
 
 instance HasTextEnvelope (VerificationKey VrfKey) where
     textEnvelopeType _ = "VrfVerificationKey_" <> fromString (Crypto.algorithmNameVRF proxy)

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -71,6 +71,7 @@ import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!
                    (.=))
 import           Data.Bifunctor (bimap, first)
 import           Data.ByteString (ByteString)
+import           Data.Either.Combinators (maybeToRight)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
@@ -688,8 +689,9 @@ instance SerialiseAsRawBytes PraosNonce where
     serialiseToRawBytes (PraosNonce h) =
       Crypto.hashToBytes h
 
-    deserialiseFromRawBytes AsPraosNonce bs =
-      PraosNonce <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes AsPraosNonce bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise PraosNonce") $
+        PraosNonce <$> Crypto.hashFromBytes bs
 
 
 makePraosNonce :: ByteString -> PraosNonce

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -76,6 +76,7 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (Parser)
 import           Data.Bifunctor (bimap, first)
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Either.Combinators (rightToMaybe)
 import qualified Data.HashMap.Strict as HMS
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -437,7 +438,7 @@ toShelleyAddrSet era =
     -- Ignore any addresses that are not appropriate for the era,
     -- e.g. Shelley addresses in the Byron era, as these would not
     -- appear in the UTxO anyway.
-  . mapMaybe (anyAddressInEra era)
+  . mapMaybe (rightToMaybe . anyAddressInEra era)
   . Set.toList
 
 

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -115,6 +115,7 @@ import           Prelude
 import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as SBS
+import           Data.Either.Combinators (maybeToRight)
 import           Data.Foldable (toList)
 import           Data.Scientific (toBoundedInteger)
 import           Data.String (IsString)
@@ -936,8 +937,9 @@ instance SerialiseAsRawBytes ScriptHash where
     serialiseToRawBytes (ScriptHash (Shelley.ScriptHash h)) =
       Crypto.hashToBytes h
 
-    deserialiseFromRawBytes AsScriptHash bs =
-      ScriptHash . Shelley.ScriptHash <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes AsScriptHash bs =
+      maybeToRight (SerialiseAsRawBytesError "Enable to deserialise ScriptHash") $
+        ScriptHash . Shelley.ScriptHash <$> Crypto.hashFromBytes bs
 
 
 hashScript :: Script lang -> ScriptHash
@@ -1076,9 +1078,9 @@ instance HasTypeProxy lang => HasTypeProxy (PlutusScript lang) where
 instance (HasTypeProxy lang, Typeable lang) => SerialiseAsRawBytes (PlutusScript lang) where
     serialiseToRawBytes (PlutusScriptSerialised sbs) = SBS.fromShort sbs
 
-    deserialiseFromRawBytes (AsPlutusScript _) bs =
+    eitherDeserialiseFromRawBytes (AsPlutusScript _) bs =
       -- TODO alonzo: validate the script syntax and fail decoding if invalid
-      Just (PlutusScriptSerialised (SBS.toShort bs))
+      Right (PlutusScriptSerialised (SBS.toShort bs))
 
 instance (IsPlutusScriptLanguage lang, Typeable lang) =>
          HasTextEnvelope (PlutusScript lang) where

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -43,6 +43,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Char as Char
+import           Data.Either.Combinators
 import qualified Data.List as List
 import           Data.Maybe (fromMaybe)
 import qualified Data.Scientific as Scientific
@@ -70,9 +71,11 @@ import qualified Plutus.V1.Ledger.Api as Plutus
 
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
+
+import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley
+
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
@@ -117,8 +120,9 @@ instance SerialiseAsRawBytes (Hash ScriptData) where
     serialiseToRawBytes (ScriptDataHash dh) =
       Crypto.hashToBytes (Ledger.extractHash dh)
 
-    deserialiseFromRawBytes (AsHash AsScriptData) bs =
-      ScriptDataHash . Ledger.unsafeMakeSafeHash <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes (AsHash AsScriptData) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise Hash ScriptData") $
+        ScriptDataHash . Ledger.unsafeMakeSafeHash <$> Crypto.hashFromBytes bs
 
 instance SerialiseAsCBOR ScriptData where
     serialiseToCBOR = CBOR.serialize'

--- a/cardano-api/src/Cardano/Api/SerialiseBech32.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseBech32.hs
@@ -16,8 +16,8 @@ import           Data.ByteString (ByteString)
 import           Data.Text (Text)
 
 import qualified Data.List as List
-import qualified Data.Set as Set
 import           Data.Set (Set)
+import qualified Data.Set as Set
 
 import           Control.Monad (guard)
 
@@ -68,8 +68,9 @@ deserialiseFromBech32 asType bech32Str = do
     payload <- Bech32.dataPartToBytes dataPart
                  ?! Bech32DataPartToBytesError (Bech32.dataPartToText dataPart)
 
-    value <- deserialiseFromRawBytes asType payload
-               ?! Bech32DeserialiseFromBytesError payload
+    value <- case eitherDeserialiseFromRawBytes asType payload of
+      Right a -> Right a
+      Left _ -> Left $ Bech32DeserialiseFromBytesError payload
 
     let expectedPrefix = bech32PrefixFor value
     guard (actualPrefix == expectedPrefix)
@@ -96,8 +97,9 @@ deserialiseAnyOfFromBech32 types bech32Str = do
     payload <- Bech32.dataPartToBytes dataPart
                  ?! Bech32DataPartToBytesError (Bech32.dataPartToText dataPart)
 
-    value <- deserialiseFromRawBytes actualType payload
-               ?! Bech32DeserialiseFromBytesError payload
+    value <- case eitherDeserialiseFromRawBytes actualType payload of
+      Right a -> Right a
+      Left _ -> Left $ Bech32DeserialiseFromBytesError payload
 
     let expectedPrefix = bech32PrefixFor value
     guard (actualPrefix == expectedPrefix)

--- a/cardano-api/src/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseUsing.hs
@@ -41,9 +41,9 @@ instance (SerialiseAsRawBytes a, Typeable a) => ToCBOR (UsingRawBytes a) where
 instance (SerialiseAsRawBytes a, Typeable a) => FromCBOR (UsingRawBytes a) where
     fromCBOR = do
       bs <- fromCBOR
-      case deserialiseFromRawBytes ttoken bs of
-        Just x  -> return (UsingRawBytes x)
-        Nothing -> fail ("cannot deserialise as a " ++ tname)
+      case eitherDeserialiseFromRawBytes ttoken bs of
+        Right x  -> return (UsingRawBytes x)
+        Left (SerialiseAsRawBytesError msg) -> fail ("cannot deserialise as a " ++ tname ++ ".  The error was: " ++ msg)
       where
         ttoken = proxyToAsType (Proxy :: Proxy a)
         tname  = (tyConName . typeRepTyCon . typeRep) (Proxy :: Proxy a)
@@ -90,9 +90,9 @@ deserialiseFromRawBytesBase16 ::
   SerialiseAsRawBytes a => ByteString -> Either String (UsingRawBytesHex a)
 deserialiseFromRawBytesBase16 str =
   case Base16.decode str of
-    Right raw -> case deserialiseFromRawBytes ttoken raw of
-      Just x  -> Right (UsingRawBytesHex x)
-      Nothing -> Left ("cannot deserialise " ++ show str)
+    Right raw -> case eitherDeserialiseFromRawBytes ttoken raw of
+      Right x  -> Right (UsingRawBytesHex x)
+      Left (SerialiseAsRawBytesError msg) -> Left ("cannot deserialise " ++ show str ++ ".  The error was: " <> msg)
     Left msg  -> Left ("invalid hex " ++ show str ++ ", " ++ msg)
   where
     ttoken = proxyToAsType (Proxy :: Proxy a)

--- a/cardano-api/src/Cardano/Api/SpecialByron.hs
+++ b/cardano-api/src/Cardano/Api/SpecialByron.hs
@@ -32,9 +32,9 @@ import qualified Cardano.Binary as Binary
 import           Cardano.Chain.Common (LovelacePortion, TxFeePolicy)
 import           Cardano.Chain.Slotting
 import           Cardano.Chain.Update (AProposal (aBody, annotation), InstallerHash,
-                     ProposalBody (ProposalBody), ProtocolParametersUpdate (..), ProtocolVersion,
-                     SoftforkRule, SoftwareVersion, SystemTag, UpId, mkVote, recoverUpId,
-                     recoverVoteId, signProposal)
+                   ProposalBody (ProposalBody), ProtocolParametersUpdate (..), ProtocolVersion,
+                   SoftforkRule, SoftwareVersion, SystemTag, UpId, mkVote, recoverUpId,
+                   recoverVoteId, signProposal)
 import qualified Cardano.Chain.Update.Vote as ByronVote
 import           Cardano.Crypto (SafeSigner, noPassSafeSigner)
 
@@ -55,11 +55,11 @@ instance HasTypeProxy ByronUpdateProposal where
 
 instance SerialiseAsRawBytes ByronUpdateProposal where
   serialiseToRawBytes (ByronUpdateProposal proposal) = annotation proposal
-  deserialiseFromRawBytes AsByronUpdateProposal bs =
+  eitherDeserialiseFromRawBytes AsByronUpdateProposal bs =
     let lBs = LB.fromStrict bs
     in case Binary.decodeFull lBs of
-        Left _deserFail -> Nothing
-        Right proposal -> Just (ByronUpdateProposal proposal')
+        Left e -> Left $ SerialiseAsRawBytesError $ "Unable to deserialise ByronUpdateProposal: " <> show e
+        Right proposal -> Right (ByronUpdateProposal proposal')
           where
             proposal' :: AProposal ByteString
             proposal' = Binary.annotationBytes lBs proposal
@@ -168,11 +168,11 @@ instance HasTypeProxy ByronVote where
 
 instance SerialiseAsRawBytes ByronVote where
   serialiseToRawBytes (ByronVote vote) = Binary.serialize' $ fmap (const ()) vote
-  deserialiseFromRawBytes AsByronVote bs =
+  eitherDeserialiseFromRawBytes AsByronVote bs =
     let lBs = LB.fromStrict bs
     in case Binary.decodeFull lBs of
-         Left _deserFail -> Nothing
-         Right vote -> Just . ByronVote $ annotateVote vote lBs
+         Left e -> Left $ SerialiseAsRawBytesError $ "Unable to deserialise ByronVote: " <> show e
+         Right vote -> Right . ByronVote $ annotateVote vote lBs
    where
     annotateVote :: ByronVote.AVote Binary.ByteSpan -> LB.ByteString -> ByronVote.AVote ByteString
     annotateVote vote bs' = Binary.annotationBytes bs' vote

--- a/cardano-api/src/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/src/Cardano/Api/StakePoolMetadata.hs
@@ -19,6 +19,7 @@ import           Prelude
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import           Data.Either.Combinators (maybeToRight)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -79,8 +80,9 @@ instance HasTypeProxy StakePoolMetadata where
 instance SerialiseAsRawBytes (Hash StakePoolMetadata) where
     serialiseToRawBytes (StakePoolMetadataHash h) = Crypto.hashToBytes h
 
-    deserialiseFromRawBytes (AsHash AsStakePoolMetadata) bs =
-      StakePoolMetadataHash <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes (AsHash AsStakePoolMetadata) bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise Hash StakePoolMetadata") $
+        StakePoolMetadataHash <$> Crypto.hashFromBytes bs
 
 --TODO: instance ToJSON StakePoolMetadata where
 

--- a/cardano-api/src/Cardano/Api/TxIn.hs
+++ b/cardano-api/src/Cardano/Api/TxIn.hs
@@ -46,8 +46,8 @@ import qualified Data.ByteString.Char8 as BSC
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Text.Parsec ((<?>))
 import qualified Text.Parsec as Parsec
+import           Text.Parsec ((<?>))
 import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
@@ -92,7 +92,9 @@ instance HasTypeProxy TxId where
 
 instance SerialiseAsRawBytes TxId where
     serialiseToRawBytes (TxId h) = Crypto.hashToBytes h
-    deserialiseFromRawBytes AsTxId bs = TxId <$> Crypto.hashFromBytes bs
+    eitherDeserialiseFromRawBytes AsTxId bs = case Crypto.hashFromBytes bs of
+      Just a -> Right (TxId a)
+      Nothing -> Left $ SerialiseAsRawBytesError "Unable to deserialise TxId"
 
 toByronTxId :: TxId -> Byron.TxId
 toByronTxId (TxId h) =

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -154,8 +154,8 @@ instance HasTypeProxy PolicyId where
 
 instance SerialiseAsRawBytes PolicyId where
     serialiseToRawBytes (PolicyId sh) = serialiseToRawBytes sh
-    deserialiseFromRawBytes AsPolicyId bs =
-      PolicyId <$> deserialiseFromRawBytes AsScriptHash bs
+    eitherDeserialiseFromRawBytes AsPolicyId bs =
+      PolicyId <$> eitherDeserialiseFromRawBytes AsScriptHash bs
 
 scriptPolicyId :: Script lang -> PolicyId
 scriptPolicyId = PolicyId . hashScript
@@ -179,9 +179,11 @@ instance HasTypeProxy AssetName where
 
 instance SerialiseAsRawBytes AssetName where
     serialiseToRawBytes (AssetName bs) = bs
-    deserialiseFromRawBytes AsAssetName bs
-      | BS.length bs <= 32 = Just (AssetName bs)
-      | otherwise          = Nothing
+    eitherDeserialiseFromRawBytes AsAssetName bs
+      | BS.length bs <= 32 = Right (AssetName bs)
+      | otherwise          = Left $ SerialiseAsRawBytesError $
+          "Unable to deserialise AssetName (the bytestring should be no longer than 32 bytes long " <>
+          "which corresponds to a hex representation of 64 characters)"
 
 
 data AssetId = AdaAssetId

--- a/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -80,7 +80,7 @@ roundtrip_raw_bytes
 roundtrip_raw_bytes asType g =
   H.property $ do
     v <- H.forAll g
-    H.tripping v serialiseToRawBytes (deserialiseFromRawBytes asType)
+    H.tripping v serialiseToRawBytes (eitherDeserialiseFromRawBytes asType)
 
 roundtrip_verification_key_hash_raw
   :: (Key keyrole, Eq (Hash keyrole), Show (Hash keyrole))
@@ -89,7 +89,7 @@ roundtrip_verification_key_hash_raw roletoken =
   H.property $ do
     vKey <- H.forAll $ genVerificationKey roletoken
     let vKeyHash = verificationKeyHash vKey
-    H.tripping vKeyHash serialiseToRawBytes (deserialiseFromRawBytes (AsHash roletoken))
+    H.tripping vKeyHash serialiseToRawBytes (eitherDeserialiseFromRawBytes (AsHash roletoken))
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -86,13 +86,13 @@ readByronSigningKey bKeyFormat (SigningKeyFile fp) = do
   sK <- handleIOExceptT (ReadSigningKeyFailure fp . T.pack . displayException) $ SB.readFile fp
   case bKeyFormat of
     LegacyByronKeyFormat ->
-      case deserialiseFromRawBytes (AsSigningKey AsByronKeyLegacy) sK of
-        Just legKey -> right $ AByronSigningKeyLegacy legKey
-        Nothing -> left $ LegacySigningKeyDeserialisationFailed fp
+      case eitherDeserialiseFromRawBytes (AsSigningKey AsByronKeyLegacy) sK of
+        Right legKey -> right $ AByronSigningKeyLegacy legKey
+        Left _ -> left $ LegacySigningKeyDeserialisationFailed fp
     NonLegacyByronKeyFormat ->
-      case deserialiseFromRawBytes (AsSigningKey AsByronKey) sK of
-        Just nonLegSKey -> right $ AByronSigningKey nonLegSKey
-        Nothing -> left $ SigningKeyDeserialisationFailed fp
+      case eitherDeserialiseFromRawBytes (AsSigningKey AsByronKey) sK of
+        Right nonLegSKey -> right $ AByronSigningKey nonLegSKey
+        Left _ -> left $ SigningKeyDeserialisationFailed fp
 
 -- | Read verification key from a file.  Throw an error if the file can't be read
 -- or the key fails to deserialise.

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -77,8 +77,8 @@ readByronUpdateProposal :: FilePath -> ExceptT ByronUpdateProposalError IO Byron
 readByronUpdateProposal fp = do
   proposalBs <- handleIOExceptT (ByronReadUpdateProposalFileFailure fp . toS . displayException)
                   $ BS.readFile fp
-  let mProposal = deserialiseFromRawBytes AsByronUpdateProposal proposalBs
-  hoistEither $ maybe (Left $ UpdateProposalDecodingError fp) Right mProposal
+  let proposalResult = eitherDeserialiseFromRawBytes AsByronUpdateProposal proposalBs
+  hoistEither $ first (const (UpdateProposalDecodingError fp)) proposalResult
 
 submitByronUpdateProposal
   :: NetworkId

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -18,7 +18,7 @@ import qualified Data.Text as Text
 
 import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
-                     readByronUpdateProposal)
+                   readByronUpdateProposal)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
 import           Ouroboros.Consensus.Util.Condense (condense)
 
@@ -83,5 +83,5 @@ submitByronVote network voteFp = do
 readByronVote :: FilePath -> ExceptT ByronVoteError IO ByronVote
 readByronVote fp = do
   voteBs <- liftIO $ BS.readFile fp
-  let mVote = deserialiseFromRawBytes AsByronVote voteBs
-  hoistEither $ maybe (Left $ ByronVoteDecodingError fp) Right mVote
+  let voteResult = eitherDeserialiseFromRawBytes AsByronVote voteBs
+  hoistEither $ first (const (ByronVoteDecodingError fp)) voteResult

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -726,8 +726,8 @@ runTxBuild era (AnyConsensusModeParams cModeParams) networkId mScriptValidity
         . hoistEither $ notScriptLockedTxIns txinsc nodeEraUTxO
 
       let cAddr = case anyAddressInEra era changeAddr of
-                    Just addr -> addr
-                    Nothing -> error $ "runTxBuild: Byron address used: " <> show changeAddr
+                    Right addr -> addr
+                    Left _ -> error $ "runTxBuild: Byron address used: " <> show changeAddr
 
       -- Why do we cast the era? The user can specify an era prior to the era that the node is currently in.
       -- We cannot use the user specified era to construct a query against a node because it may differ

--- a/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
@@ -72,9 +72,9 @@ prop_print_nonLegacy_signing_key_address = propertyOnce $ do
 prop_generate_and_read_nonlegacy_signingkeys :: Property
 prop_generate_and_read_nonlegacy_signingkeys = property $ do
   byronSkey <- liftIO $ generateSigningKey AsByronKey
-  case deserialiseFromRawBytes (AsSigningKey AsByronKey) (serialiseToRawBytes byronSkey ) of
-    Nothing -> failWith Nothing "Failed to deserialise non-legacy Byron signing key."
-    Just _ -> success
+  case eitherDeserialiseFromRawBytes (AsSigningKey AsByronKey) (serialiseToRawBytes byronSkey) of
+    Left _ -> failWith Nothing "Failed to deserialise non-legacy Byron signing key. "
+    Right _ -> success
 
 prop_migrate_legacy_to_nonlegacy_signingkeys :: Property
 prop_migrate_legacy_to_nonlegacy_signingkeys =

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -14,8 +14,7 @@ module Cardano.Node.Protocol.Byron
 
 
 import           Cardano.Prelude
-import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither,
-                   hoistMaybe, left)
+import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither, left)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as Text
 
@@ -157,8 +156,9 @@ readLeaderCredentials genesisConfig
 
          signingKeyFileBytes <- liftIO $ LB.readFile signingKeyFile
          delegCertFileBytes <- liftIO $ LB.readFile delegCertFile
-         ByronSigningKey signingKey <- hoistMaybe (SigningKeyDeserialiseFailure signingKeyFile)
-                         $ deserialiseFromRawBytes (AsSigningKey AsByronKey) $ LB.toStrict signingKeyFileBytes
+         ByronSigningKey signingKey <- firstExceptT (const (SigningKeyDeserialiseFailure signingKeyFile))
+                         . hoistEither
+                         $ eitherDeserialiseFromRawBytes (AsSigningKey AsByronKey) $ LB.toStrict signingKeyFileBytes
          delegCert  <- firstExceptT (CanonicalDecodeFailure delegCertFile)
                          . hoistEither
                          $ canonicalDecodePretty delegCertFileBytes


### PR DESCRIPTION
The new error message can be seen in this output:

```
cardano-cli transaction calculate-min-required-utxo --protocol-params-file ../protocol-params.json --babbage-era --tx-out "addr1q9h2kw7neeh26cmhspye2gyvhca6qaqxakp7qcp3uydzphqu62gur507vnszr24dyt2z6lrmpmrufs6jjdhc2vy04hzqyuuw8z+1 ee659e0a80e8a9815afe8aa3906741c34d234923f4da0543ec1628d4.5468654D616E6472696C6C7A576F726C6443757045646974696F6E233335302337"
option --tx-out:
unexpected end of input
expecting hexadecimal digit
AssetName deserisalisation failed: Failed to deserialise 5468654D616E6472696C6C7A576F726C6443757045646974696F6E233335302337 as AssetName. Unable to deserialise AssetName (the bytestring should be no longer than 32 bytes long which corresponds to a hex representation of 64 characters)

Usage: cardano-cli transaction calculate-min-required-utxo
            [ --byron-era
            | --shelley-era
            | --allegra-era
            | --mary-era
            | --alonzo-era
            | --babbage-era
            ]
            (--genesis FILE | --protocol-params-file FILE)
            --tx-out ADDRESS VALUE
            [ --tx-out-datum-hash HASH
            | --tx-out-datum-hash-cbor-file CBOR FILE
            | --tx-out-datum-hash-file JSON FILE
            | --tx-out-datum-hash-value JSON VALUE
            | --tx-out-datum-embed-cbor-file CBOR FILE
            | --tx-out-datum-embed-file JSON FILE
            | --tx-out-datum-embed-value JSON VALUE
            | --tx-out-inline-datum-cbor-file CBOR FILE
            | --tx-out-inline-datum-file JSON FILE
            | --tx-out-inline-datum-value JSON VALUE
            ]
            [--tx-out-reference-script-file FILE]

  Calculate the minimum required UTxO for a transaction output.
```

Resolves https://github.com/input-output-hk/cardano-node/issues/4619