### PR TITLE
cardano-cli: simplifiy the consumption of 'InputTxBodyOrTxFile`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -8,7 +8,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
-module Cardano.CLI.Run.Friendly (friendlyTxBS, friendlyTxBodyBS) where
+module Cardano.CLI.Run.Friendly
+  ( friendlyTx
+  , friendlyTxBS
+  , friendlyTxBody
+  , friendlyTxBodyBS
+  ) where
 
 import           Cardano.Prelude
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -43,6 +43,7 @@ module Cardano.CLI.Shelley.Commands
   , BlockId (..)
   , WitnessSigningData (..)
   , ColdVerificationKeyOrFile (..)
+  , TxViewFormat(..)
   ) where
 
 import           Prelude
@@ -235,7 +236,7 @@ data TransactionCmd
       TxBuildOutputOptions
   | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
   | TxCreateWitness TxBodyFile WitnessSigningData (Maybe NetworkId) OutputFile
-  | TxAssembleTxBodyWitness TxBodyFile [WitnessFile] OutputFile
+  | TxAssembleTxBodyWitness InputTxBodyOrTxFile [WitnessFile] OutputFile
   | TxSubmit AnyConsensusModeParams NetworkId FilePath
   | TxMintedPolicyId ScriptFile
   | TxCalculateMinFee
@@ -253,7 +254,7 @@ data TransactionCmd
   | TxHashScriptData
       ScriptDataOrFile
   | TxGetTxId InputTxBodyOrTxFile
-  | TxView InputTxBodyOrTxFile
+  | TxView InputTxBodyOrTxFile TxViewFormat (Maybe OutputFile)
 
 data InputTxBodyOrTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
   deriving Show
@@ -542,6 +543,11 @@ data ByronKeyType
   = ByronPaymentKey  ByronKeyFormat
   | ByronGenesisKey  ByronKeyFormat
   | ByronDelegateKey ByronKeyFormat
+  deriving Show
+
+data TxViewFormat
+  = TxViewLegacyYAML
+  | TxViewJSON
   deriving Show
 
 data ByronKeyFormat = NonLegacyByronKeyFormat

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -771,7 +771,7 @@ pTransaction =
 
   pTransactionAssembleTxBodyWit :: Parser TransactionCmd
   pTransactionAssembleTxBodyWit = TxAssembleTxBodyWitness
-                                    <$> pTxBodyFile Input
+                                    <$> pInputTxOrTxBodyFile
                                     <*> some pWitnessFile
                                     <*> pOutputFile
 
@@ -818,8 +818,25 @@ pTransaction =
   pTransactionId  :: Parser TransactionCmd
   pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
 
-  pTransactionView :: Parser TransactionCmd
-  pTransactionView = TxView <$> pInputTxOrTxBodyFile
+  pTransactionView =
+    TxView
+      <$> pInputTxOrTxBodyFile
+      <*> pTxViewFormat
+      <*> pMaybeOutputFile
+
+  pTxViewFormat :: Parser TxViewFormat
+  pTxViewFormat =
+      Opt.flag' TxViewLegacyYAML
+        (  Opt.long "legacy-yaml"
+        <> Opt.help "Use leagay YAML format (default)."
+        )
+    <|>
+      Opt.flag' TxViewJSON
+        (  Opt.long "json"
+        <> Opt.help "Use JSON format."
+        )
+    <|>
+      pure TxViewLegacyYAML
 
 pNodeCmd :: Parser NodeCmd
 pNodeCmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -828,12 +828,12 @@ pTransaction =
   pTxViewFormat =
       Opt.flag' TxViewLegacyYAML
         (  Opt.long "legacy-yaml"
-        <> Opt.help "Use leagay YAML format (default)."
+        <> Opt.help "Use legacy YAML format (default)."
         )
     <|>
       Opt.flag' TxViewJSON
-        (  Opt.long "json"
-        <> Opt.help "Use JSON format."
+        (  Opt.long "legacy-json"
+        <> Opt.help "Use legacy JSON format."
         )
     <|>
       pure TxViewLegacyYAML

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Read.hs
@@ -41,7 +41,6 @@ module Cardano.CLI.Shelley.Run.Read
   , readFileTx
   , readFileTxBody
   , readInputTxBodyOrTxFile
-  , renderCddlError
   , readCddlTx -- For testing purposes
   , viewTxOrTxBody
   , viewInputFormat
@@ -533,13 +532,6 @@ instance Error CddlError where
 
 liftAnyCardanoEra :: (forall era. IsCardanoEra era => thing1 era -> thing2 era) -> InAnyCardanoEra thing1 -> InAnyCardanoEra thing2
 liftAnyCardanoEra f (InAnyCardanoEra era a) = InAnyCardanoEra era $ f a
-
-renderCddlError :: CddlError -> Text
-renderCddlError (CddlErrorTextEnv textEnvErr cddlErr) =
-  "Failed to decode neither the cli's serialisation format nor the ledger's \
-  \CDDL serialisation format. TextEnvelope error: " <> Text.pack (displayError textEnvErr) <> "\n" <>
-  "TextEnvelopeCddl error: " <> Text.pack (displayError cddlErr)
-renderCddlError (CddlIOError e) = Text.pack $ displayError e
 
 acceptTxCDDLSerialisation
   :: FileError TextEnvelopeError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -1201,7 +1201,7 @@ runTxView inputFile format outFile = do
       CompleteTx tx -> friendlyTxBS era tx
       IncompleteTx (UnwitnessedCliFormattedTxBody txBody) -> friendlyTxBodyBS era txBody
       -- In the IncompleteCddlFormattedTx case, the legacy format
-      -- takes the body of the tx  and converts the tx to a tx-body
+      -- takes the body of the tx and converts the tx to a tx-body
       -- and prints that using `friendlyTxBodyBS era body`.
       -- Any preexisting witnesses (that may be there ?!? ) are discarded !!
       -- Would make more sense:
@@ -1243,7 +1243,7 @@ runTxSignWitness
   -> OutputFile
   -> ExceptT ShelleyTxCmdError IO ()
 runTxSignWitness inputTx witnessFiles (OutputFile oFp) = do
-  (InAnyCardanoEra era input) <- readInputTxBodyOrTxFile inputTx `rescue` ShelleyTxCmdCddlError
+  InAnyCardanoEra era input <- readInputTxBodyOrTxFile inputTx `rescue` ShelleyTxCmdCddlError
   let (txBody, existingWitnesses) = case viewTxOrTxBody input of
          OnlyTx tx -> getTxBodyAndWitnesses tx
          OnlyTxBody b -> (b, [])


### PR DESCRIPTION
This PR makes is easier to use CLI arguments of type `InputTxBodyOrTxFile`
* Reorder `IncompleteTx`
* Add `TxOrTxBody`
* Add `readInputTxBodyOrTxFile :: InputTxBodyOrTxFile -> IO (Either CddlError (InAnyCardanoEra CompleteOrIncompleteTx)`