### PR TITLE
Move cardano-ping from ouroboros-network to cardano-node project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -23,6 +23,7 @@ packages:
     cardano-node
     cardano-node-capi
     cardano-node-chairman
+    cardano-ping
     cardano-submit-api
     cardano-testnet
     cardano-tracer

--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for mux
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cardano-ping/LICENSE
+++ b/cardano-ping/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/cardano-ping/NOTICE
+++ b/cardano-ping/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/cardano-ping/README.md
+++ b/cardano-ping/README.md
@@ -1,0 +1,24 @@
+# network-mux
+
+Multiplexing library.  It allows to run multiple network applications over
+a single bearer.  The muliplexer cuts messages in chunks of some maximal size
+and sends them over a bearer channel.  The current version of this library
+relies on reliable and ordered delivery of messages.  The muliplexer should run
+alongside with an incremental decoder.
+
+Example protocol with an incremental
+decoder is implemented in
+[Test.Mux.ReqResp](https://github.com/input-output-hk/ouroboros-network/blob/master/network-mux/test/Test/Mux/ReqResp.hs)
+for other examples of protocols see 'typed-protocols' or 'ouroboros-network'
+packages.
+
+## tests
+
+To run the test suite:
+```
+cabal new-run test-network-mux
+```
+or
+```
+nix-build -A haskellPackages.network-mux.checks
+```

--- a/cardano-ping/app/Main.hs
+++ b/cardano-ping/app/Main.hs
@@ -1,0 +1,534 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import           Control.Exception
+import           Control.Monad (replicateM, unless, when)
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer hiding (timeout)
+import           Control.Tracer (Tracer (..), nullTracer, traceWith)
+import           Data.Aeson hiding (Options, json)
+import           Data.Bits (clearBit, setBit, testBit)
+import qualified Data.ByteString.Char8 as BS.Char
+import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BL.Char (pack, putStr)
+import           Data.List (foldl')
+import           Data.Maybe (fromMaybe, isNothing)
+import           Data.TDigest
+import           Data.Text (unpack)
+import           Data.Word
+import           Network.Socket (AddrInfo, StructLinger (..))
+import qualified Network.Socket as Socket
+import           System.Console.GetOpt
+import           System.Environment (getArgs, getProgName)
+import           System.Exit
+import           System.IO (hFlush, hPrint, stderr, stdout)
+import           Text.Printf
+
+import           Network.Mux.Bearer.Socket
+import           Network.Mux.Timeout
+import           Network.Mux.Types
+
+mainnetMagic :: Word32
+mainnetMagic = 764824073
+
+handshakeNum ::  MiniProtocolNum
+handshakeNum = MiniProtocolNum 0
+
+keepaliveNum :: MiniProtocolNum
+keepaliveNum = MiniProtocolNum 8
+
+nodeToClientVersionBit :: Int
+nodeToClientVersionBit = 15
+
+
+data Flag = CountF String | HelpF | HostF String | PortF String | MagicF String | QuietF | JsonF | UnixF String deriving Show
+
+optionDescriptions :: [OptDescr Flag]
+optionDescriptions = [
+    Option "c" ["count"]  (ReqArg CountF "count")  "number of pings to send",
+    Option "" ["help"]  (NoArg HelpF)  "print help",
+    Option "h" ["host"]  (ReqArg HostF "host")  "hostname/ip, e.g relay.iohk.example",
+    Option "u" ["unixsock"] (ReqArg UnixF "unixsock") "unix socket, e.g file.socket",
+    Option "m" ["magic"] (ReqArg MagicF "magic") ("magic, defaults to " ++ show mainnetMagic),
+    Option "j" ["json"]  (NoArg JsonF ) "json output flag",
+    Option "p" ["port"]  (ReqArg PortF "port") "portnumber, e.g 1234",
+    Option "q" ["quiet"] (NoArg QuietF ) "quiet flag, csv/json only output."
+  ]
+
+data Options = Options {
+      maxCount :: Word32
+    , host     :: Maybe String
+    , unixSock :: Maybe String
+    , port     :: String
+    , magic    :: Word32
+    , json     :: Bool
+    , quiet    :: Bool
+    , help     :: Bool
+    } deriving Show
+
+defaultOpts :: Options
+defaultOpts = Options {
+      maxCount = maxBound
+    , host     = Nothing
+    , unixSock = Nothing
+    , port     = "3001"
+    , json     = False
+    , quiet    = False
+    , magic    = mainnetMagic
+    , help     = False
+    }
+
+buildOptions ::  Flag -> Options -> Options
+buildOptions (CountF c)   opt = opt { maxCount = Prelude.read c }
+buildOptions HelpF        opt = opt { help = True }
+buildOptions (HostF host) opt = opt { host = Just host }
+buildOptions (PortF port) opt = opt { port = port }
+buildOptions (MagicF m)   opt = opt { magic = Prelude.read m }
+buildOptions JsonF        opt = opt { json = True }
+buildOptions QuietF       opt = opt { quiet = True }
+buildOptions (UnixF file) opt = opt { unixSock = Just file }
+
+data LogMsg = LogMsg ByteString
+            | LogEnd
+
+logger :: StrictTMVar IO LogMsg -> Bool -> IO ()
+logger msgQueue json = go True
+  where
+    go first = do
+        msg <- atomically $ takeTMVar  msgQueue
+        case msg of
+             LogMsg bs -> do
+                 let bs' = case (json, first) of
+                                (True, False)  -> BL.Char.pack ",\n" <> bs
+                                (True, True)   -> BL.Char.pack "{ \"pongs\": [ " <> bs
+                                (False, True)  -> BL.Char.pack "   timestamp,                         host,                          cookie,  sample,  median,     p90,    mean,     min,     max,     std\n" <> bs
+                                (False, False) -> bs
+
+                 BL.Char.putStr bs'
+                 go False
+             LogEnd ->
+                 when json $ putStrLn "] }"
+
+supportedNodeToNodeVersions :: Word32 -> [NodeVersion]
+supportedNodeToNodeVersions magic =
+  [ NodeToNodeVersionV7  magic False
+  , NodeToNodeVersionV8  magic False
+  , NodeToNodeVersionV9  magic False
+  , NodeToNodeVersionV10 magic False
+  ]
+
+supportedNodeToClientVersions :: Word32 -> [NodeVersion]
+supportedNodeToClientVersions magic =
+  [ NodeToClientVersionV9  magic
+  , NodeToClientVersionV10 magic
+  , NodeToClientVersionV11 magic
+  , NodeToClientVersionV12 magic
+  , NodeToClientVersionV13 magic
+  , NodeToClientVersionV14 magic
+  ]
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let (flags, _, _ ) = getOpt RequireOrder optionDescriptions args
+        options = foldr buildOptions defaultOpts flags
+        hints = Socket.defaultHints { Socket.addrSocketType = Socket.Stream }
+
+    when (help options) $ do
+        progName <- getProgName
+        putStrLn $ usageInfo progName optionDescriptions
+        exitSuccess
+
+    msgQueue <- newEmptyTMVarIO
+
+    when (isNothing (host options) && isNothing (unixSock options) ) $ do
+        putStrLn "Specify host/ip with '-h <hostname>' or a unix socket with -u <file name>"
+        exitWith (ExitFailure 1)
+
+    (addresses, versions) <- case unixSock options of
+        Nothing -> do
+          addrs <- Socket.getAddrInfo (Just hints) (host options)
+                       (Just $ port options)
+          return (addrs, supportedNodeToNodeVersions $ magic options)
+        Just fname ->
+          return ([ Socket.AddrInfo [] Socket.AF_UNIX Socket.Stream
+                    Socket.defaultProtocol (Socket.SockAddrUnix fname)
+                    Nothing ]
+                 , supportedNodeToClientVersions $ magic options)
+
+    laid <- async $ logger msgQueue $ json options
+    caids <- mapM (async . pingClient (Tracer $ doLog msgQueue) options
+                   versions) addresses
+    res <- zip addresses <$> mapM waitCatch caids
+    doLog msgQueue LogEnd
+    wait laid
+    case foldl' partition ([],[]) res of
+         ([], _) -> do
+             exitSuccess
+         (es, []) -> do
+             mapM_ (hPrint stderr) es
+             exitWith (ExitFailure 1)
+         (es, _) -> do
+             unless (quiet options) $
+               mapM_ (hPrint stderr) es
+             exitSuccess
+
+  where
+
+    partition :: ([(AddrInfo, SomeException)], [AddrInfo])
+              -> (AddrInfo, Either SomeException ())
+              -> ([(AddrInfo, SomeException)], [AddrInfo])
+    partition (es, as) (a, Left e)  = ((a, e) : es, as)
+    partition (es, as) (a, Right _) = (es, a : as)
+
+    doLog :: StrictTMVar IO LogMsg -> LogMsg -> IO ()
+    doLog msgQueue msg = atomically $ putTMVar msgQueue msg
+
+data NodeVersion =       NodeToClientVersionV9  Word32
+                       | NodeToClientVersionV10 Word32
+                       | NodeToClientVersionV11 Word32
+                       | NodeToClientVersionV12 Word32
+                       | NodeToClientVersionV13 Word32
+                       | NodeToClientVersionV14 Word32
+                       | NodeToNodeVersionV1   Word32
+                       | NodeToNodeVersionV2   Word32
+                       | NodeToNodeVersionV3   Word32
+                       | NodeToNodeVersionV4   Word32 Bool
+                       | NodeToNodeVersionV5   Word32 Bool
+                       | NodeToNodeVersionV6   Word32 Bool
+                       | NodeToNodeVersionV7   Word32 Bool
+                       | NodeToNodeVersionV8   Word32 Bool
+                       | NodeToNodeVersionV9   Word32 Bool
+                       | NodeToNodeVersionV10  Word32 Bool
+                       deriving (Eq, Ord, Show)
+
+keepAliveReqEnc :: NodeVersion -> Word16 -> CBOR.Encoding
+keepAliveReqEnc v cookie | v >= NodeToNodeVersionV7 minBound minBound =
+       CBOR.encodeListLen 2
+    <> CBOR.encodeWord 0
+    <> CBOR.encodeWord16 cookie
+keepAliveReqEnc _ cookie =
+       CBOR.encodeWord 0
+    <> CBOR.encodeWord16 cookie
+
+keepAliveReq :: NodeVersion -> Word16 -> ByteString
+keepAliveReq v c = CBOR.toLazyByteString $ keepAliveReqEnc v c
+
+keepAliveDone :: NodeVersion -> ByteString
+keepAliveDone v | v >= NodeToNodeVersionV7 minBound minBound =
+    CBOR.toLazyByteString $
+         CBOR.encodeListLen 1
+      <> CBOR.encodeWord 2
+keepAliveDone _ =
+    CBOR.toLazyByteString $
+      CBOR.encodeWord 2
+
+
+handshakeReqEnc :: [NodeVersion] -> CBOR.Encoding
+handshakeReqEnc [] = error "null version list"
+handshakeReqEnc versions =
+       CBOR.encodeListLen 2
+    <> CBOR.encodeWord 0
+    <> CBOR.encodeMapLen (fromIntegral $ length versions)
+    <> mconcat [ encodeVersion v
+               | v <- versions
+               ]
+  where
+    encodeVersion :: NodeVersion -> CBOR.Encoding
+    encodeVersion (NodeToClientVersionV9 magic) =
+          CBOR.encodeWord (9 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV10 magic) =
+          CBOR.encodeWord (10 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV11 magic) =
+          CBOR.encodeWord (11 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV12 magic) =
+          CBOR.encodeWord (12 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV13 magic) =
+          CBOR.encodeWord (13 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToClientVersionV14 magic) =
+          CBOR.encodeWord (14 `setBit` nodeToClientVersionBit)
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToNodeVersionV1 magic) =
+          CBOR.encodeWord 1
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToNodeVersionV2 magic) =
+          CBOR.encodeWord 2
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToNodeVersionV3 magic) =
+          CBOR.encodeWord 3
+       <> CBOR.encodeInt (fromIntegral magic)
+    encodeVersion (NodeToNodeVersionV4 magic mode) = encodeWithMode 4 magic mode
+    encodeVersion (NodeToNodeVersionV5 magic mode) = encodeWithMode 5 magic mode
+    encodeVersion (NodeToNodeVersionV6 magic mode) = encodeWithMode 6 magic mode
+    encodeVersion (NodeToNodeVersionV7 magic mode) = encodeWithMode 7 magic mode
+    encodeVersion (NodeToNodeVersionV8 magic mode) = encodeWithMode 8 magic mode
+    encodeVersion (NodeToNodeVersionV9 magic mode) = encodeWithMode 9 magic mode
+    encodeVersion (NodeToNodeVersionV10 magic mode) = encodeWithMode 10 magic mode
+
+
+    encodeWithMode :: Word -> Word32 -> Bool -> CBOR.Encoding
+    encodeWithMode vn magic mode =
+          CBOR.encodeWord vn
+       <> CBOR.encodeListLen 2
+       <> CBOR.encodeInt (fromIntegral magic)
+       <> CBOR.encodeBool mode
+
+handshakeReq :: [NodeVersion] -> ByteString
+handshakeReq []       = BL.empty
+handshakeReq versions = CBOR.toLazyByteString $ handshakeReqEnc versions
+
+data HandshakeFailure = UnknownVersionInRsp Word
+                      | UnknownKey Word
+                      | UnknownTag Word
+                      | VersionMissmath [Word]
+                      | DecodeError Word String
+                      | Refused Word String
+                      deriving Show
+
+newtype KeepAliveFailure = KeepAliveFailureKey Word deriving Show
+
+keepAliveRspDec :: NodeVersion
+                -> CBOR.Decoder s (Either KeepAliveFailure Word16)
+keepAliveRspDec v | v >= (NodeToNodeVersionV7 minBound minBound)  = do
+    len <- CBOR.decodeListLen
+    key <- CBOR.decodeWord
+    case (len, key) of
+         (2, 1) -> Right <$> CBOR.decodeWord16
+         (_, k) -> return $ Left $ KeepAliveFailureKey k
+keepAliveRspDec _ = do
+    key <- CBOR.decodeWord
+    case key of
+         1 -> Right <$> CBOR.decodeWord16
+         k -> return $ Left $ KeepAliveFailureKey k
+
+handshakeDec :: CBOR.Decoder s (Either HandshakeFailure NodeVersion)
+handshakeDec = do
+    _ <- CBOR.decodeListLen
+    key <- CBOR.decodeWord
+    case key of
+         1 -> do
+             decodeVersion
+         2 -> do
+             _ <- CBOR.decodeListLen
+             tag <- CBOR.decodeWord
+             case tag of
+                  0 -> do -- VersionMismatch
+                      len <- CBOR.decodeListLen
+                      x <- replicateM len CBOR.decodeWord
+                      return $ Left $ VersionMissmath x
+                  1 -> do -- HandshakeDecodeError
+                      vn <- CBOR.decodeWord
+                      msg <- unpack <$> CBOR.decodeString
+                      return $ Left $ DecodeError vn msg
+                  2 -> do -- Refused
+                      vn <- CBOR.decodeWord
+                      msg <- unpack <$> CBOR.decodeString
+                      return $ Left $ Refused vn msg
+                  _ -> return $ Left $ UnknownTag tag
+
+         k -> return $ Left $ UnknownKey k
+  where
+
+    decodeVersion :: CBOR.Decoder s (Either HandshakeFailure NodeVersion)
+    decodeVersion = do
+        version <- CBOR.decodeWord
+        case ( version `clearBit` nodeToClientVersionBit
+             , version `testBit`  nodeToClientVersionBit ) of
+             (7,  False) -> decodeWithMode NodeToNodeVersionV7
+             (8,  False) -> decodeWithMode NodeToNodeVersionV8
+             (9,  False) -> decodeWithMode NodeToNodeVersionV9
+             (10, False) -> decodeWithMode NodeToNodeVersionV10
+             (9,  True)  -> Right . NodeToClientVersionV9 <$> CBOR.decodeWord32
+             (10, True)  -> Right . NodeToClientVersionV10 <$> CBOR.decodeWord32
+             (11, True)  -> Right . NodeToClientVersionV11 <$> CBOR.decodeWord32
+             (12, True)  -> Right . NodeToClientVersionV12 <$> CBOR.decodeWord32
+             (13, True)  -> Right . NodeToClientVersionV13 <$> CBOR.decodeWord32
+             (14, True)  -> Right . NodeToClientVersionV14 <$> CBOR.decodeWord32
+             _           -> return $ Left $ UnknownVersionInRsp version
+
+    decodeWithMode :: (Word32 -> Bool -> NodeVersion)
+                   -> CBOR.Decoder s (Either HandshakeFailure NodeVersion)
+    decodeWithMode vnFun = do
+        _ <- CBOR.decodeListLen
+        magic <- CBOR.decodeWord32
+        Right . vnFun magic <$> CBOR.decodeBool
+
+wrap :: MiniProtocolNum -> MiniProtocolDir -> BL.ByteString -> MuxSDU
+wrap ptclNum ptclDir blob = MuxSDU {
+      msHeader = MuxSDUHeader {
+                mhTimestamp = RemoteClockModel 0,
+                mhNum       = ptclNum,
+                mhDir       = ptclDir,
+                mhLength    = fromIntegral $ BL.length blob
+              }
+    , msBlob = blob
+    }
+
+
+data StatPoint = StatPoint {
+      spTimestamp :: !UTCTime
+    , spHost      :: !String
+    , spCookie    :: !Word16
+    , spSample    :: !Double
+    , spMedian    :: !Double
+    , spP90       :: !Double
+    , spMean      :: !Double
+    , spMin       :: !Double
+    , spMax       :: !Double
+    , spStd       :: !Double
+    }
+
+instance Show StatPoint where
+    show StatPoint {..} =
+        printf "%36s, %-28s, %7d, %7.3f, %7.3f, %7.3f, %7.3f, %7.3f, %7.3f, %7.3f"
+            (show spTimestamp) spHost spCookie spSample spMedian spP90 spMean spMin spMax spStd
+
+instance ToJSON StatPoint where
+  toJSON StatPoint {..} =
+      object [ "timestamp" .= spTimestamp
+             , "host"      .=  spHost
+             , "cookie"    .= spCookie
+             , "sample"    .= spSample
+             , "median"    .= spMedian
+             , "p90"       .= spP90
+             , "mean"      .= spMean
+             , "min"       .= spMin
+             , "max"       .= spMax
+             ]
+
+toStatPoint :: UTCTime -> String -> Word16 -> Double -> TDigest 5 -> StatPoint
+toStatPoint ts host cookie sample td =
+    StatPoint {
+          spTimestamp = ts
+        , spHost      = host
+        , spCookie    = cookie
+        , spSample    = sample
+        , spMedian    = quantile' 0.5
+        , spP90       = quantile' 0.9
+        , spMean      = mean'
+        , spMin       = minimumValue td
+        , spMax       = maximumValue td
+        , spStd       = stddev'
+        }
+  where
+    quantile' :: Double -> Double
+    quantile' q = fromMaybe 0 (quantile q td)
+
+    mean' :: Double
+    mean' = fromMaybe 0 (mean td)
+
+    stddev' :: Double
+    stddev' = fromMaybe 0 (stddev td)
+
+
+pingClient :: Tracer IO LogMsg -> Options -> [NodeVersion] -> AddrInfo -> IO ()
+pingClient tracer Options{quiet, json, maxCount} versions peer = bracket
+    (Socket.socket (Socket.addrFamily peer) Socket.Stream Socket.defaultProtocol)
+    Socket.close
+    (\sd -> withTimeoutSerial $ \timeoutfn -> do
+        when (Socket.addrFamily peer /= Socket.AF_UNIX) $ do
+            Socket.setSocketOption sd Socket.NoDelay 1
+            Socket.setSockOpt sd Socket.Linger
+                (StructLinger { sl_onoff  = 1
+                              , sl_linger = 0 })
+
+        !t0_s <- getMonotonicTime
+        Socket.connect sd (Socket.addrAddress peer)
+        !t0_e <- getMonotonicTime
+        peerStr <- peerString
+        unless quiet $ printf "%s network rtt: %.3f\n" peerStr $ toSample t0_e t0_s
+        let timeout = 30
+            bearer = socketAsMuxBearer timeout nullTracer sd
+
+        !t1_s <- write bearer timeoutfn $ wrap handshakeNum InitiatorDir
+                    (handshakeReq versions)
+        (msg, !t1_e) <- nextMsg bearer timeoutfn handshakeNum
+        unless quiet $ printf "%s handshake rtt: %s\n" peerStr (show $ diffTime t1_e t1_s)
+        case CBOR.deserialiseFromBytes handshakeDec msg of
+             Left err -> do
+                 eprint $ printf "%s Decoding error %s\n" peerStr (show err)
+             Right (_, Left err) -> do
+                 eprint $ printf "%s Protocol error %s\n" peerStr (show err)
+             Right (_, Right version) -> do
+                unless quiet $ printf "%s Negotiated version %s\n" peerStr (show version)
+                keepAlive bearer timeoutfn peerStr version (tdigest []) 0
+                -- send terminating message
+                _ <- write bearer timeoutfn $
+                        wrap keepaliveNum InitiatorDir (keepAliveDone version)
+                -- protocol idle timeout
+                threadDelay 5
+
+    )
+  where
+
+    peerString :: IO String
+    peerString =
+        case Socket.addrFamily peer of
+             Socket.AF_UNIX -> return $ show $ Socket.addrAddress peer
+             _ -> do
+                  (Just host, Just port) <-
+                    Socket.getNameInfo
+                      [ Socket.NI_NUMERICHOST, Socket.NI_NUMERICSERV ]
+                      True True (Socket.addrAddress peer)
+                  return $ host ++ ":" ++ port
+
+    toSample :: Time -> Time -> Double
+    toSample t_e t_s = realToFrac $ diffTime t_e t_s
+
+    eprint :: String -> IO ()
+    eprint = BS.Char.hPutStr stderr . BS.Char.pack
+
+    nextMsg ::  MuxBearer IO -> TimeoutFn IO -> MiniProtocolNum -> IO (BL.ByteString, Time)
+    nextMsg bearer timeoutfn ptclNum = do
+        (sdu, t_e) <- Network.Mux.Types.read bearer timeoutfn
+        if mhNum (msHeader sdu) == ptclNum
+           then return (msBlob sdu, t_e)
+           else nextMsg bearer timeoutfn ptclNum
+
+    keepAlive :: MuxBearer IO
+              -> TimeoutFn IO
+              -> String
+              -> NodeVersion
+              -> TDigest 5
+              -> Word32
+              -> IO ()
+    keepAlive _ _ _ _ _ cookie | cookie == maxCount = return ()
+    keepAlive bearer timeoutfn peerStr version td !cookie = do
+        let cookie16 = fromIntegral cookie
+        !t_s <- write bearer timeoutfn $ wrap keepaliveNum InitiatorDir (keepAliveReq version cookie16)
+        (!msg, !t_e) <- nextMsg bearer timeoutfn keepaliveNum
+        let rtt = toSample t_e t_s
+            td' = insert rtt td
+        case CBOR.deserialiseFromBytes (keepAliveRspDec version) msg of
+             Left err -> eprint $ printf "%s keepalive decoding error %s\n" peerStr (show err)
+             Right (_, Left err) -> eprint $ printf "%s keepalive protocol error %s\n" peerStr (show err)
+             Right (_, Right cookie') -> do
+                 when (cookie' /= cookie16) $ eprint $ printf "%s cookie missmatch %d /= %d\n"
+                     peerStr cookie' cookie
+
+                 now <- getCurrentTime
+                 let point = toStatPoint now peerStr cookie16 rtt td'
+                 if json
+                    then traceWith tracer $ LogMsg (encode point)
+                    else traceWith tracer $ LogMsg $ BL.Char.pack $ show point <> "\n"
+                 hFlush stdout
+                 threadDelay 1
+                 keepAlive bearer timeoutfn peerStr version td' (cookie + 1)

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -1,0 +1,45 @@
+cabal-version:          2.2
+name:                   cardano-ping
+version:                0.2.0.0
+synopsis:               Cardano Ping
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019 Input Output (Hong Kong) Ltd.
+author:                 Duncan Coutts, Marc Fontaine, Karl Knutsson, Marcin Szamotulski, Alexander Vieth, Neil Davies
+maintainer:             duncan@well-typed.com, marcin.szamotulski@iohk.io, marc.fontaine@iohk.io, karl.knutsson@iohk.io, alex@well-typed.com, neil.davies@pnsol.com
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+common shared-config
+  default-language:     Haskell2010
+  ghc-options:          -threaded
+                        -Wall
+                        -fno-ignore-asserts
+                        -Wcompat
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-record-updates
+                        -Wpartial-fields
+                        -Widentities
+                        -Wredundant-constraints
+
+executable cardano-ping
+  import:               shared-config
+  hs-source-dirs:       app
+  main-is:              Main.hs
+  build-depends:        base,
+                        aeson,
+                        network-mux,
+                        io-classes,
+                        strict-stm,
+                        contra-tracer,
+                        bytestring,
+                        cborg,
+                        network,
+                        tdigest,
+                        text
+  if os(windows)
+    buildable:          False
+  else
+    buildable:          True


### PR DESCRIPTION
This moves `cardano-ping` as is.

This has not been integrated with `cardano-cli` because there is an unresolved question regarding whether this tool will work on Windows.

Depends on:
* https://github.com/input-output-hk/cardano-node/pull/4764
