### PR TITLE
fix pure nix evaluation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,8 +13,9 @@ in
       inherit profileName workbenchDevMode;
     };
   }
+, system ? builtins.currentSystem
 }:
 with (import ./nix/flake-compat.nix customConfig);
-defaultNix // defaultNix.packages.${builtins.currentSystem} // {
-  private.project = defaultNix.legacyPackages.${builtins.currentSystem};
+defaultNix // defaultNix.packages.${system} // {
+  private.project = defaultNix.legacyPackages.${system};
 }


### PR DESCRIPTION
There was access to `builtin.currentSystem` in the nix evaluation for nix-shell so pure evaluation was not possible.

Needed by https://github.com/input-output-hk/hydra/pull/625.