### PR TITLE
Export `fromShelleyBasedScript` from Cardano.Api, backported to 1.35

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -108,6 +108,7 @@ module Cardano.Api.Shelley
     ProtocolParametersError(..),
 
     -- * Scripts
+    fromShelleyBasedScript,
     toShelleyScript,
     toShelleyMultiSig,
     fromShelleyMultiSig,


### PR DESCRIPTION
Backported to release/1.35, original here https://github.com/input-output-hk/cardano-node/pull/4386