### PR TITLE
[cardano-api] Derive Eq instance for AcquiringFailure

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -29,6 +29,8 @@
   
 - **Breaking change** - Remove distinction between multisig and timelock scripts([PR4763](https://github.com/input-output-hk/cardano-node/pull/4763))
 
+- **Breaking change** Change return type of `queryNodeLocalState` to new `AcquiringFailure` type.
+
 ### Bugs
 
 - Allow reading text envelopes from pipes ([PR 4384](https://github.com/input-output-hk/cardano-node/pull/4384))

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -575,7 +575,7 @@ mapLocalTxMonitoringClient convTxid convTx ltxmc =
 
 data AcquiringFailure = AFPointTooOld
                       | AFPointNotOnChain
-                      deriving Show
+                      deriving (Eq, Show)
 
 toAcquiringFailure :: Net.Query.AcquireFailure -> AcquiringFailure
 toAcquiringFailure AcquireFailurePointTooOld = AFPointTooOld


### PR DESCRIPTION
This is often used in tests where we would like to assert that we receive one or the other.