### PR TITLE
Use JSON instances for NodeToNodeVersion & NodeToClientVersion

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -11,6 +11,37 @@
 
 ### network changes
 
+## 1.35.6 -- March 2023
+
+### consensus changes
+
+None
+
+### ledger changes
+
+None
+
+### network changes
+
+- 'EnableP2P' configuration option does not require
+  'TestEnableDevelopmentNetworkProtocols' any more.  We support running at most
+  one p2p relay, if an SPO is running at least two relays.
+
+- Added 'DemoteLocalAsynchronous' warning trace.  It indicates that a remote
+  local root peer was demoted to cold (either due to connection error or
+  misbehaviour). (input-output-hk/ouroboros-network#4127)
+
+- New P2P topology file format, see [issue #4563][#4563] or the [config
+  files][understanding-config-files] documentation.  The old p2p topology
+  format will be supported for next two major releases of the node (the last
+  major version which will support it is `1.37`). (#4563)
+
+- Fixed a tight loop when demoting a peer from hot to warm timeouts
+  (input-output-hk/ouroboros-network#4357).
+
+[#4563]: https://github.com/input-output-hk/cardano-node/issues/4563
+[understanding-config-files]: https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/understanding-config-files.md
+
 ## 1.35.5 -- November 2022
 
 ### node changes

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -514,10 +514,15 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
             (_, Nothing)         -> Map.keys
                                   $ supportedNodeToClientVersions (Proxy @blk)
     when (  ncTestEnableDevelopmentNetworkProtocols nc
-         && (not (null developmentNtnVersions) || not (null developmentNtcVersions)) )
+         && not (null developmentNtnVersions))
        $ traceWith (startupTracer tracers)
-                   (WarningDevelopmentNetworkProtocols
-                     developmentNtnVersions
+                   (WarningDevelopmentNodeToNodeVersions
+                     developmentNtnVersions)
+
+    when (  ncTestEnableDevelopmentNetworkProtocols nc
+         && not (null developmentNtcVersions))
+       $ traceWith (startupTracer tracers)
+                   (WarningDevelopmentNodeToClientVersions
                      developmentNtcVersions)
 
 #ifdef UNIX

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -492,11 +492,7 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
   logStartupWarnings = do
     (case p2pMode of
       DisabledP2PMode -> return ()
-      EnabledP2PMode  -> do
-        traceWith (startupTracer tracers) P2PWarning
-        unless (ncTestEnableDevelopmentNetworkProtocols nc)
-          $ traceWith (startupTracer tracers)
-                      P2PWarningDevelopementNetworkProtocols
+      EnabledP2PMode  -> traceWith (startupTracer tracers) P2PWarning
       ) :: IO () -- annoying, but unavoidable for GADT type inference
 
     let developmentNtnVersions =

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -103,11 +103,6 @@ data StartupTrace blk =
   -- | Warn when 'EnableP2P' is set.
   | P2PWarning
 
-  -- | Warn that peer-to-peer requires
-  -- 'TestEnableDevelopmentNetworkProtocols' to be set.
-  --
-  | P2PWarningDevelopementNetworkProtocols
-
   -- | Warn when 'TestEnableDevelopmentNetworkProtocols' is set and affects
   -- node-to-node protocol.
   --

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -108,9 +108,15 @@ data StartupTrace blk =
   --
   | P2PWarningDevelopementNetworkProtocols
 
-  -- | Warn when 'TestEnableDevelopmentNetworkProtocols' is set.
+  -- | Warn when 'TestEnableDevelopmentNetworkProtocols' is set and affects
+  -- node-to-node protocol.
   --
-  | WarningDevelopmentNetworkProtocols [NodeToNodeVersion] [NodeToClientVersion]
+  | WarningDevelopmentNodeToNodeVersions [NodeToNodeVersion]
+
+  -- | Warn when 'TestEnableDevelopmentNetworkProtocols' is set and affects
+  -- node-to-client protocol.
+  --
+  | WarningDevelopmentNodeToClientVersions [NodeToClientVersion]
 
   | BICommon BasicInfoCommon
   | BIShelley BasicInfoShelleyBased

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -79,7 +79,6 @@ data StartupState
   | NetworkConfigUpdate
   | NetworkConfigUpdateError Text
   | P2PWarning
-  | P2PWarningDevelopementNetworkProtocols
   | WarningDevelopmentNodeToNodeVersions [NPV.NodeToNodeVersion]
   | WarningDevelopmentNodeToClientVersions [NPV.NodeToClientVersion]
   deriving (Generic, FromJSON, ToJSON)

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -73,12 +72,6 @@ type SyncPercentage = Double
 data AddedToCurrentChain
   = AddedToCurrentChain !EpochNo !SlotNo !SyncPercentage
   deriving (Generic, FromJSON, ToJSON)
-
-deriving instance Generic NPV.NodeToClientVersion
-deriving instance Generic NPV.NodeToNodeVersion
-
-instance FromJSON NPV.NodeToClientVersion
-instance FromJSON NPV.NodeToNodeVersion
 
 data StartupState
   = StartupSocketConfigError Text

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -87,7 +87,8 @@ data StartupState
   | NetworkConfigUpdateError Text
   | P2PWarning
   | P2PWarningDevelopementNetworkProtocols
-  | WarningDevelopmentNetworkProtocols [NPV.NodeToNodeVersion] [NPV.NodeToClientVersion]
+  | WarningDevelopmentNodeToNodeVersions [NPV.NodeToNodeVersion]
+  | WarningDevelopmentNodeToClientVersions [NPV.NodeToClientVersion]
   deriving (Generic, FromJSON, ToJSON)
 
 -- | The representation of the current state of node.
@@ -257,10 +258,11 @@ traceNodeStateStartup tr ev =
       traceWith tr $ NodeStartup $ NetworkConfigUpdateError e
     Startup.P2PWarning ->
       traceWith tr $ NodeStartup P2PWarning
-    Startup.P2PWarningDevelopementNetworkProtocols ->
-      traceWith tr $ NodeStartup P2PWarningDevelopementNetworkProtocols
-    Startup.WarningDevelopmentNetworkProtocols n2ns n2cs ->
-      traceWith tr $ NodeStartup $ WarningDevelopmentNetworkProtocols n2ns n2cs
+    Startup.WarningDevelopmentNodeToNodeVersions ntnVersions ->
+      traceWith tr $ NodeStartup (WarningDevelopmentNodeToNodeVersions ntnVersions)
+    Startup.WarningDevelopmentNodeToClientVersions ntcVersions ->
+      traceWith tr $ NodeStartup (WarningDevelopmentNodeToClientVersions ntcVersions)
+    -- TODO: why other constructors are not traced?
     _ -> return ()
 
 traceNodeStateShutdown

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -202,11 +202,15 @@ instance ( Show (BlockNodeToNodeVersion blk)
   forMachine _dtal P2PWarningDevelopementNetworkProtocols =
       mconcat [ "kind" .= String "P2PWarningDevelopementNetworkProtocols"
                , "message" .= String p2pWarningDevelopmentNetworkProtocolsMessage ]
-  forMachine _ver (WarningDevelopmentNetworkProtocols ntnVersions ntcVersions) =
-      mconcat [ "kind" .= String "WarningDevelopmentNetworkProtocols"
+  forMachine _ver (WarningDevelopmentNodeToNodeVersions ntnVersions) =
+      mconcat [ "kind" .= String "WarningDevelopmentNodeToNodeVersions"
                , "message" .= String "enabled development network protocols"
-               , "nodeToNodeDevelopmentVersions" .= String (showT ntnVersions)
-               , "nodeToClientDevelopmentVersions" .= String (showT ntcVersions)
+               , "versions" .= String (showT ntnVersions)
+               ]
+  forMachine _ver (WarningDevelopmentNodeToClientVersions ntcVersions) =
+      mconcat [ "kind" .= String "WarningDevelopmentNodeToClientVersions"
+               , "message" .= String "enabled development network protocols"
+               , "versions" .= String (showT ntcVersions)
                ]
   forMachine _dtal (BINetwork BasicInfoNetwork {..}) =
       mconcat [ "kind" .= String "BasicInfoNetwork"
@@ -266,8 +270,10 @@ instance MetaTrace  (StartupTrace blk) where
     Namespace [] ["P2PWarning"]
   namespaceFor P2PWarningDevelopementNetworkProtocols {}  =
     Namespace [] ["P2PWarningDevelopementNetworkProtocols"]
-  namespaceFor WarningDevelopmentNetworkProtocols {}  =
-    Namespace [] ["WarningDevelopmentNetworkProtocols"]
+  namespaceFor WarningDevelopmentNodeToNodeVersions {}  =
+    Namespace [] ["WarningDevelopmentNodeToNodeVersions"]
+  namespaceFor WarningDevelopmentNodeToClientVersions {}  =
+    Namespace [] ["WarningDevelopmentNodeToClientVersions"]
   namespaceFor BICommon {}  =
     Namespace [] ["Common"]
   namespaceFor BIShelley {}  =
@@ -283,7 +289,8 @@ instance MetaTrace  (StartupTrace blk) where
   severityFor (Namespace _ ["NetworkConfigUpdateUnsupported"]) _ = Just Warning
   severityFor (Namespace _ ["P2PWarning"]) _ = Just Warning
   severityFor (Namespace _ ["P2PWarningDevelopementNetworkProtocols"]) _ = Just Warning
-  severityFor (Namespace _ ["WarningDevelopmentNetworkProtocols"]) _ = Just Warning
+  severityFor (Namespace _ ["WarningDevelopmentNodeToNodeVersions"]) _ = Just Warning
+  severityFor (Namespace _ ["WarningDevelopmentNodeToClientVersions"]) _ = Just Warning
   severityFor _ _ = Just Info
 
   documentFor (Namespace [] ["Info"]) = Just
@@ -312,7 +319,9 @@ instance MetaTrace  (StartupTrace blk) where
     ""
   documentFor (Namespace [] ["P2PWarningDevelopementNetworkProtocols"]) = Just
     ""
-  documentFor (Namespace [] ["WarningDevelopmentNetworkProtocols"]) = Just
+  documentFor (Namespace [] ["WarningDevelopmentNodeToNodeVersions"]) = Just
+    ""
+  documentFor (Namespace [] ["WarningDevelopmentNodeToClientVersions"]) = Just
     ""
   documentFor (Namespace [] ["Common"]) = Just $ mconcat
     [ "_biConfigPath_: is the path to the config in use. "
@@ -359,7 +368,8 @@ instance MetaTrace  (StartupTrace blk) where
     , Namespace [] ["NetworkConfigLegacy"]
     , Namespace [] ["P2PWarning"]
     , Namespace [] ["P2PWarningDevelopementNetworkProtocols"]
-    , Namespace [] ["WarningDevelopmentNetworkProtocols"]
+    , Namespace [] ["WarningDevelopmentNodeToNodeVersions"]
+    , Namespace [] ["WarningDevelopmentNodeToClientVersions"]
     , Namespace [] ["Common"]
     , Namespace [] ["ShelleyBased"]
     , Namespace [] ["Byron"]
@@ -444,10 +454,12 @@ ppStartupInfoTrace P2PWarning = p2pWarningMessage
 ppStartupInfoTrace P2PWarningDevelopementNetworkProtocols =
     p2pWarningDevelopmentNetworkProtocolsMessage
 
-ppStartupInfoTrace (WarningDevelopmentNetworkProtocols ntnVersions ntcVersions) =
-     "enabled development network protocols: "
+ppStartupInfoTrace (WarningDevelopmentNodeToNodeVersions ntnVersions) =
+     "enabled development node-to-node versions: "
   <> showT ntnVersions
-  <> " "
+
+ppStartupInfoTrace (WarningDevelopmentNodeToClientVersions ntcVersions) =
+     "enabled development node-to-client versions: "
   <> showT ntcVersions
 
 ppStartupInfoTrace (BINetwork BasicInfoNetwork {..}) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -222,9 +222,6 @@ instance ( Show (BlockNodeToNodeVersion blk)
   forMachine _dtal P2PWarning =
       mconcat [ "kind" .= String "P2PWarning"
                , "message" .= String p2pWarningMessage ]
-  forMachine _dtal P2PWarningDevelopementNetworkProtocols =
-      mconcat [ "kind" .= String "P2PWarningDevelopementNetworkProtocols"
-               , "message" .= String p2pWarningDevelopmentNetworkProtocolsMessage ]
   forMachine _ver (WarningDevelopmentNodeToNodeVersions ntnVersions) =
       mconcat [ "kind" .= String "WarningDevelopmentNodeToNodeVersions"
                , "message" .= String "enabled development network protocols"
@@ -291,8 +288,6 @@ instance MetaTrace  (StartupTrace blk) where
     Namespace [] ["NetworkConfigLegacy"]
   namespaceFor P2PWarning {}  =
     Namespace [] ["P2PWarning"]
-  namespaceFor P2PWarningDevelopementNetworkProtocols {}  =
-    Namespace [] ["P2PWarningDevelopementNetworkProtocols"]
   namespaceFor WarningDevelopmentNodeToNodeVersions {}  =
     Namespace [] ["WarningDevelopmentNodeToNodeVersions"]
   namespaceFor WarningDevelopmentNodeToClientVersions {}  =
@@ -311,7 +306,6 @@ instance MetaTrace  (StartupTrace blk) where
   severityFor (Namespace _ ["NetworkConfigUpdateError"]) _ = Just Error
   severityFor (Namespace _ ["NetworkConfigUpdateUnsupported"]) _ = Just Warning
   severityFor (Namespace _ ["P2PWarning"]) _ = Just Warning
-  severityFor (Namespace _ ["P2PWarningDevelopementNetworkProtocols"]) _ = Just Warning
   severityFor (Namespace _ ["WarningDevelopmentNodeToNodeVersions"]) _ = Just Warning
   severityFor (Namespace _ ["WarningDevelopmentNodeToClientVersions"]) _ = Just Warning
   severityFor _ _ = Just Info
@@ -339,8 +333,6 @@ instance MetaTrace  (StartupTrace blk) where
   documentFor (Namespace [] ["NetworkConfigLegacy"]) = Just
     ""
   documentFor (Namespace [] ["P2PWarning"]) = Just
-    ""
-  documentFor (Namespace [] ["P2PWarningDevelopementNetworkProtocols"]) = Just
     ""
   documentFor (Namespace [] ["WarningDevelopmentNodeToNodeVersions"]) = Just
     ""
@@ -390,7 +382,6 @@ instance MetaTrace  (StartupTrace blk) where
     , Namespace [] ["NetworkConfig"]
     , Namespace [] ["NetworkConfigLegacy"]
     , Namespace [] ["P2PWarning"]
-    , Namespace [] ["P2PWarningDevelopementNetworkProtocols"]
     , Namespace [] ["WarningDevelopmentNodeToNodeVersions"]
     , Namespace [] ["WarningDevelopmentNodeToClientVersions"]
     , Namespace [] ["Common"]
@@ -474,9 +465,6 @@ ppStartupInfoTrace NetworkConfigLegacy = p2pNetworkConfigLegacyMessage
 
 ppStartupInfoTrace P2PWarning = p2pWarningMessage
 
-ppStartupInfoTrace P2PWarningDevelopementNetworkProtocols =
-    p2pWarningDevelopmentNetworkProtocolsMessage
-
 ppStartupInfoTrace (WarningDevelopmentNodeToNodeVersions ntnVersions) =
      "enabled development node-to-node versions: "
   <> showT ntnVersions
@@ -514,10 +502,6 @@ p2pWarningMessage :: Text
 p2pWarningMessage =
       "unsupported and unverified version of "
    <> "`cardano-node` with peer-to-peer networking capabilities"
-
-p2pWarningDevelopmentNetworkProtocolsMessage :: Text
-p2pWarningDevelopmentNetworkProtocolsMessage =
-    "peer-to-peer requires TestEnableDevelopmentNetworkProtocols to be set to True"
 
 p2pNetworkConfigLegacyMessage :: Text
 p2pNetworkConfigLegacyMessage =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -500,8 +500,8 @@ ppStartupInfoTrace (BICommon BasicInfoCommon {..}) =
 
 p2pWarningMessage :: Text
 p2pWarningMessage =
-      "unsupported and unverified version of "
-   <> "`cardano-node` with peer-to-peer networking capabilities"
+      "You are using an early release of peer-to-peer capabilities, "
+   <> "please report any issues."
 
 p2pNetworkConfigLegacyMessage :: Text
 p2pNetworkConfigLegacyMessage =

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -17,7 +17,7 @@ module Cardano.Tracing.OrphanInstances.Network () where
 
 import           Control.Exception (Exception (..), SomeException (..))
 import           Control.Monad.Class.MonadTime (DiffTime, Time (..))
-import           Data.Aeson (Value (..))
+import           Data.Aeson (Value (..), FromJSON (..))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (listValue)
 import           Data.Bifunctor (Bifunctor (..))
@@ -67,9 +67,9 @@ import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
 import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
 import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.NodeToClient (NodeToClientVersion, NodeToClientVersionData (..))
+import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..), NodeToClientVersionData (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
-import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), NodeToNodeVersion,
+import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), NodeToNodeVersion (..),
                    NodeToNodeVersionData (..), RemoteAddress, TraceSendRecv (..), WithAddr (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
@@ -1756,10 +1756,40 @@ instance Show vNumber => ToJSON (HandshakeException vNumber) where
                  ]
 
 instance ToJSON NodeToNodeVersion where
-  toJSON x = String (pack $ show x)
+  toJSON NodeToNodeV_7  = Number 7
+  toJSON NodeToNodeV_8  = Number 8
+  toJSON NodeToNodeV_9  = Number 9
+  toJSON NodeToNodeV_10 = Number 10
+  toJSON NodeToNodeV_11  = Number 11
+
+instance FromJSON NodeToNodeVersion where
+  parseJSON (Number 7) = return NodeToNodeV_7
+  parseJSON (Number 8) = return NodeToNodeV_8
+  parseJSON (Number 9) = return NodeToNodeV_9
+  parseJSON (Number 10) = return NodeToNodeV_10
+  parseJSON (Number 11) = return NodeToNodeV_11
+  parseJSON (Number x) = fail ("FromJSON.NodeToNodeVersion: unsupported node-to-node protocol version " ++ show x)
+  parseJSON x          = fail ("FromJSON.NodeToNodeVersion: error parsing NodeToNodeVersion: " ++ show x)
 
 instance ToJSON NodeToClientVersion where
-  toJSON x = String (pack $ show x)
+  toJSON NodeToClientV_9  = Number 9
+  toJSON NodeToClientV_10 = Number 10
+  toJSON NodeToClientV_11 = Number 11
+  toJSON NodeToClientV_12 = Number 12
+  toJSON NodeToClientV_13 = Number 13
+  toJSON NodeToClientV_14 = Number 14
+  toJSON NodeToClientV_15 = Number 15
+
+instance FromJSON NodeToClientVersion where
+  parseJSON (Number 9) = return NodeToClientV_9
+  parseJSON (Number 10) = return NodeToClientV_10
+  parseJSON (Number 11) = return NodeToClientV_11
+  parseJSON (Number 12) = return NodeToClientV_12
+  parseJSON (Number 13) = return NodeToClientV_13
+  parseJSON (Number 14) = return NodeToClientV_14
+  parseJSON (Number 15) = return NodeToClientV_15
+  parseJSON (Number x) = fail ("FromJSON.NodeToClientVersion: unsupported node-to-client protocol version " ++ show x)
+  parseJSON x          = fail ("FromJSON.NodeToClientVersion: error parsing NodeToClientVersion: " ++ show x)
 
 instance ToJSON NodeToNodeVersionData where
   toJSON (NodeToNodeVersionData (NetworkMagic m) dm) =

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -30,7 +30,8 @@ instance HasSeverityAnnotation (StartupTrace blk) where
     getSeverityAnnotation NetworkConfigUpdateUnsupported = Warning
     getSeverityAnnotation P2PWarning = Warning
     getSeverityAnnotation P2PWarningDevelopementNetworkProtocols = Warning
-    getSeverityAnnotation WarningDevelopmentNetworkProtocols {} = Warning
+    getSeverityAnnotation WarningDevelopmentNodeToNodeVersions {} = Warning
+    getSeverityAnnotation WarningDevelopmentNodeToClientVersions {} = Warning
     getSeverityAnnotation _ = Info
 
 instance HasPrivacyAnnotation (StartupTrace blk)

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -29,7 +28,6 @@ instance HasSeverityAnnotation (StartupTrace blk) where
     getSeverityAnnotation (NetworkConfigUpdateError _) = Error
     getSeverityAnnotation NetworkConfigUpdateUnsupported = Warning
     getSeverityAnnotation P2PWarning = Warning
-    getSeverityAnnotation P2PWarningDevelopementNetworkProtocols = Warning
     getSeverityAnnotation WarningDevelopmentNodeToNodeVersions {} = Warning
     getSeverityAnnotation WarningDevelopmentNodeToClientVersions {} = Warning
     getSeverityAnnotation _ = Info

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -97,6 +97,17 @@ signal, `cardano-node` will re-read the file and restart all DNS resolution. Ple
 One can disable ledger peers by setting the `useLedgerAfterSlot` to a negative
 value.
 
+If you are synchronizing the network for the first time, please connect to IOG
+relays `relays-new.cardano-mainnet.iohkdev.io` by adding it to your local root
+peers and set `useLedgerAfterSlot` to `0` (to disable ledger peers).  You can
+use different relays as long as you trust them to provide you the honest chain.
+When the node is synced, you can remove it from the local root peers, you
+should also manually check if other stake pool relays are on the same chain as
+you are.  Once you enabled ledger peers by setting `useLedgerAfterSlot` the
+node will connect to relays registered on the chain, and churn through them by
+randomly picking new peers (weighted by stake distribution) and forgetting 20%
+least performing ones.
+
 #### The genesis.json file
 
 The genesis file is generated with the `cardano-cli` by reading a `genesis.spec.json` file, which is out of scope for this document.


### PR DESCRIPTION
- NodeToNodeVersion and NodeToClientVersion JSON instances
- Split WarningDevelopmentNetworkProtocolVersions
