### PR TITLE
remove hydra.iohk.io as substituter

### DIFF
--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -19,7 +19,7 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
-          substituters = https://cache.nixos.org https://hydra.iohk.io
+          substituters = https://cache.nixos.org https://cache.iog.io
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
     - uses: actions/checkout@v2

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Cardano Node";
 
   nixConfig = {
-    extra-substituters = ["https://cache.iog.io" "https://hydra.iohk.io"];
+    extra-substituters = ["https://cache.iog.io"];
     extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
   };
 


### PR DESCRIPTION
Updates binary cache config in flake and GHA to not reference hydra.