### PR TITLE
Remove cardano-cli address build-script

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Remove cardano-cli address build-script ([PR 4700](https://github.com/input-output-hk/cardano-node/pull/4700))
+
 ### Features
 
 - Default to the ledger's CDDL format for transaction body creation by removing flags `--cddl-format` and `--cli-format` from `build` and `build-raw` ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -97,7 +97,6 @@ data AddressCmd
       (Maybe StakeVerifier)
       NetworkId
       (Maybe OutputFile)
-  | AddressBuildMultiSig ScriptFile NetworkId (Maybe OutputFile)
   | AddressInfo Text (Maybe OutputFile)
   deriving Show
 
@@ -108,7 +107,6 @@ renderAddressCmd cmd =
     AddressKeyGen {} -> "address key-gen"
     AddressKeyHash {} -> "address key-hash"
     AddressBuild {} -> "address build"
-    AddressBuildMultiSig {} -> "address build-script"
     AddressInfo {} -> "address info"
 
 data StakeAddressCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -132,8 +132,6 @@ pAddressCmd =
          (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key.")
      , subParser "build"
          (Opt.info pAddressBuild $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address.")
-     , subParser "build-script"
-         (Opt.info pAddressBuildScript $ Opt.progDesc "Build a Shelley script address. (deprecated; use 'build' instead with '--payment-script-file')")
      , subParser "info"
          (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
      ]
@@ -153,12 +151,6 @@ pAddressCmd =
     pAddressBuild = AddressBuild
       <$> pPaymentVerifier
       <*> Opt.optional pStakeVerifier
-      <*> pNetworkId
-      <*> pMaybeOutputFile
-
-    pAddressBuildScript :: Parser AddressCmd
-    pAddressBuildScript = AddressBuildMultiSig
-      <$> pScript
       <*> pNetworkId
       <*> pMaybeOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -22,7 +22,6 @@ import qualified Data.Text.IO as Text
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Helpers
 import           Cardano.CLI.Shelley.Key (PaymentVerifier (..), StakeVerifier (..),
                    VerificationKeyTextOrFile, VerificationKeyTextOrFileError (..), generateKeyPair,
                    readVerificationKeyOrFile, readVerificationKeyTextOrFileAnyOf,
@@ -62,7 +61,6 @@ runAddressCmd cmd =
     AddressKeyGen kt vkf skf -> runAddressKeyGenToFile kt vkf skf
     AddressKeyHash vkf mOFp -> runAddressKeyHash vkf mOFp
     AddressBuild paymentVerifier mbStakeVerifier nw mOutFp -> runAddressBuild paymentVerifier mbStakeVerifier nw mOutFp
-    AddressBuildMultiSig sFp nId mOutFp -> runAddressBuildScript sFp nId mOutFp
     AddressInfo txt mOFp -> firstExceptT ShelleyAddressCmdAddressInfoError $ runAddressInfo txt mOFp
 
 runAddressKeyGenToFile
@@ -202,18 +200,3 @@ foldSomeAddressVerificationKey f (AGenesisExtendedVerificationKey vk) = f vk
 foldSomeAddressVerificationKey f (AVrfVerificationKey             vk) = f vk
 foldSomeAddressVerificationKey f (AStakeVerificationKey           vk) = f vk
 foldSomeAddressVerificationKey f (AStakeExtendedVerificationKey   vk) = f vk
-
-
---
--- Multisig addresses
---
-
-runAddressBuildScript
-  :: ScriptFile
-  -> NetworkId
-  -> Maybe OutputFile
-  -> ExceptT ShelleyAddressCmdError IO ()
-runAddressBuildScript scriptFile networkId mOutputFile = do
-  liftIO $ deprecationWarning "'address build'"
-  runAddressBuild (PaymentVerifierScriptFile scriptFile) Nothing networkId mOutputFile
-

--- a/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
@@ -20,8 +20,8 @@ golden_shelleyAllMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $
   allMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/all"
 
   allMultiSigAddress <- execCardanoCLI
-    [ "address", "build-script"
-    , "--script-file", allMultiSigFp
+    [ "address", "build"
+    , "--payment-script-file", allMultiSigFp
     , "--mainnet"
     ]
 
@@ -36,8 +36,8 @@ golden_shelleyAnyMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $
   anyMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/any"
 
   anyMultiSigAddress <- execCardanoCLI
-    [ "address", "build-script"
-    , "--script-file", anyMultiSigFp
+    [ "address", "build"
+    , "--payment-script-file", anyMultiSigFp
     , "--mainnet"
     ]
 
@@ -52,8 +52,8 @@ golden_shelleyAtLeastMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tm
   atLeastMultiSigFp <- noteInputFile "test/data/golden/shelley/multisig/scripts/atleast"
 
   atLeastMultiSigAddress <- execCardanoCLI
-    [ "address", "build-script"
-    , "--script-file", atLeastMultiSigFp
+    [ "address", "build"
+    , "--payment-script-file", atLeastMultiSigFp
     , "--mainnet"
     ]
 

--- a/doc/reference/cardano-node-cli-reference.md
+++ b/doc/reference/cardano-node-cli-reference.md
@@ -21,7 +21,6 @@ The `address` command contains the following subcommands:
 * `key-gen`: creates a single address key pair
 * `key-hash`: prints the hash of an address to stdout
 * `build`: builds a payment address, with optional delegation to a stake address
-* `build-script`: builds a token locking script
 * `info`: prints details about the address
 
 *cardano-cli stake-address*

--- a/doc/reference/simple-scripts.md
+++ b/doc/reference/simple-scripts.md
@@ -415,8 +415,8 @@ as described above. For this example, we will describe the process using an
 A script address is required in order to use a script. Construct this as follows:
 
 ```
-cardano-cli address build-script
-  --script-file allMultiSigScript
+cardano-cli address
+  --payment-script-file allMultiSigScript
   --testnet-magic 42
   --out-file script.addr
 ```


### PR DESCRIPTION
The `address build-script` command has been deprecated for some time and needs to be removed