### PR TITLE
Use cabal-cache

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -21,27 +21,33 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
     steps:
-    - uses: actions/checkout@v1
+     # this seems to break something. It _must_ come after the pacman setup
+     # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
+     # as such we'd need pacman.exe instead.
+    - name: Setup Haskell
+      run: |
+        # Use GHCUP to manage ghc/cabal
+        ghcup install ghc --set ${{ matrix.ghc }}
+        ghcup install cabal --set 3.8.1.0
 
-    - name: Set cache version
-      run: echo "CACHE_VERSION=UN37rUo" >> $GITHUB_ENV
+        ghc --version
+        cabal --version
+
+    - name: "Setup cabal-store"
+      id: cabal-store
+      shell: bash
+      run: |
+        cabal help user-config
+        cabal_config_file="$(cabal help user-config | grep -A 1 'You can edit the cabal configuration file to set defaults' | tail -n 1 | xargs)"
+
+        echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
+
+    - uses: actions/checkout@v2
 
     - name: Add build script path
       run: echo "$(pwd)/.github/bin" >> $GITHUB_PATH
 
-    - uses: haskell/actions/setup@v1
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.6.2.0
-
-    - name: Haskell versions
-      run: |
-        ghc --version
-        cabal --version
-
     - name: Install build environment
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get -y install libsodium23 libsodium-dev
@@ -49,8 +55,7 @@ jobs:
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
-    - name: "LINUX: Install secp256k1"
-      if: runner.os != 'Windows'
+    - name: "Install secp256k1"
       shell: bash
       env:
         CI_SECP_FLAGS: "--prefix=/usr"
@@ -59,13 +64,6 @@ jobs:
 
     - name: Cabal update
       run: cabal update
-
-    - name: Disable reorder goals on MacOS and Linux
-      # Avoid reorder goals for platforms that don't need it because re-order goals can take up to 10 minutes
-      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
-      run: |
-        cat cabal.project | sed 's|reorder-goals: True|reorder-goals: False|g' > cabal.project.tmp
-        mv cabal.project.tmp cabal.project
 
     - name: combine github-pages, and machine local project files.
       run: |
@@ -79,18 +77,28 @@ jobs:
         mkdir ./haddocks
         DRY_RUN=1 ./scripts/haddocs.sh ./haddocks true
 
-    - name: Record dependencies
-      run: |
-        cat ${{ env.PLAN_JSON }} | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-
-    - uses: actions/cache@v2
-      name: Cache cabal store
+    - name: Cabal cache over S3
+      uses: action-works/cabal-cache-s3@v1
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       with:
-        path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-        restore-keys: |
-          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
+        region: us-west-2
+        dist-dir: dist-newstyle
+        store-path: ${{ steps.cabal-store.outputs.cabal-store }}
+        threads: 16
+        archive-uri: ${{ secrets.BINARY_CACHE_URI }}
+        skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
+
+    - name: Cabal cache over HTTPS
+      uses: action-works/cabal-cache-s3@v1
+      with:
+        dist-dir: dist-newstyle
+        store-path: ${{ steps.cabal-store.outputs.cabal-store }}
+        threads: 16
+        archive-uri: https://iohk.cache.haskellworks.io
+        skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
+        enable-save: false
 
     - name: Install dependencies
       run: cabal build all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -40,12 +40,6 @@ jobs:
       LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
 
     steps:
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
-
     - name: "WIN: Install System Dependencies via pacman (msys2)"
       if: runner.os == 'Windows'
       run: |
@@ -61,15 +55,15 @@ jobs:
             automake `
             libtool `
             make
-  
+
      # this seems to break something. It _must_ come after the pacman setup
      # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
      # as such we'd need pacman.exe instead.
     - name: Setup Haskell
-      run: |        
+      run: |
         # Use GHCUP to manage ghc/cabal
         ghcup install ghc --set ${{ matrix.ghc }}
-        ghcup install cabal --set 3.6.2.0
+        ghcup install cabal --set 3.8.1.0
 
         ghc --version
         cabal --version
@@ -96,19 +90,28 @@ jobs:
                           -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
                           -f init
 
-    - name: "OUTPUT Record cabal-store (Linux)"
-      id: lin-setup-haskell
-      if: runner.os != 'Windows'
-      run: echo "cabal-store=/home/runner/.cabal/store" >> $GITHUB_OUTPUT
-
-    - name: "OUTPUT Record cabal-store (Windows)"
-      id: win-setup-haskell
-      if: runner.os == 'Windows'
+    # Unify the computation of the cabal store directory to a single step. This makes referencing the cabal
+    # store in later steps easier.
+    #
+    # We know on cabal store is located in the following locations by OS:
+    #
+    #   Linux: /home/runner/.cabal/store
+    #   MacOS: /Users/runner/.cabal/store
+    #   Windows: C:\cabal\store
+    #
+    # However, we compute these as best be can from information cabal provides in case this changes in the future.
+    - name: "Setup cabal-store"
+      id: cabal-store
       shell: bash
-      run: echo "cabal-store=C:\\cabal\\store" >> $GITHUB_OUTPUT   
+      run: |
+        cabal help user-config
+        cabal_config_file="$(cabal help user-config | grep -A 1 'You can edit the cabal configuration file to set defaults' | tail -n 1 | xargs)"
 
-    - name: Set cache version
-      run: echo "CACHE_VERSION=grFfw7r" >> $GITHUB_ENV
+        if [[ '${{ runner.os }}' != 'Windows' ]]; then
+          echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo "cabal-store=C:\\cabal\\store" | tee -a "$GITHUB_OUTPUT"
+        fi
 
     - uses: actions/checkout@v2
 
@@ -180,36 +183,65 @@ jobs:
         echo "# cabal.project.local"
         cat cabal.project.local
 
-    - name: Record dependencies
-      id: record-deps
+    - name: List all pkg-config packages
       run: |
+        # The tests call out to msys2 commands. We generally do not want to mix toolchains, so
+        # we are very deliberate about only adding msys64 to the path where absolutely necessary.
+        ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
+        pkg-config --list-all
+
+    - name: Build dry run
+      run: |
+        # The tests call out to msys2 commands. We generally do not want to mix toolchains, so
+        # we are very deliberate about only adding msys64 to the path where absolutely necessary.
+        ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
         cabal build all --dry-run
-        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
-    - name: "OUTPUT Record weeknum"
-      shell: bash
-      run: echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
-
-    - name: Cache Cabal store
-      uses: actions/cache@v2
+    # For users who fork cardano-node and want to define a writable cache, then can set up their own
+    # S3 bucket then define in their forked repository settings the following secrets:
+    #
+    #   AWS_ACCESS_KEY_ID
+    #   AWS_SECRET_ACCESS_KEY
+    #   BINARY_CACHE_URI
+    #   BINARY_CACHE_REGION
+    - name: Cabal cache over S3
+      uses: action-works/cabal-cache-s3@v1
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       with:
-        path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.lin-setup-haskell.outputs.cabal-store }}
-        key: cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}-${{ hashFiles('date.txt') }}
-        restore-keys: |
-          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        region: ${{ secrets.BINARY_CACHE_REGION }}
+        dist-dir: dist-newstyle
+        store-path: ${{ steps.cabal-store.outputs.cabal-store }}
+        threads: 16
+        archive-uri: ${{ secrets.BINARY_CACHE_URI }}
+        skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
 
-    - uses: actions/cache@v2
-      name: "Cache `dist-newstyle`"
+    # It's important to ensure that people who fork this repository can not only successfully build in
+    # CI by default, but also have meaning cabal store caching.
+    #
+    # Because syncing with S3 requires credentials, we cannot rely on S3 for this. For this reason a
+    # https fallback is used. The https server mirrors the content of the S3 bucket. The https cabal
+    # store archive is read-only for security reasons.
+    #
+    # Users who fork this repository who want to have a writable cabal store archive are encouraged
+    # to set up their own S3 bucket.
+    - name: Cabal cache over HTTPS
+      uses: action-works/cabal-cache-s3@v1
       with:
-        path: |
-          dist-newstyle
-          !dist-newstyle/**/.git
-        key: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.record-deps.outputs.weeknum }}
-        restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        dist-dir: dist-newstyle
+        store-path: ${{ steps.cabal-store.outputs.cabal-store }}
+        threads: 16
+        archive-uri: https://iohk.cache.haskellworks.io
+        skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
+        enable-save: false
 
     - name: Build
-      run: cabal build cardano-node cardano-cli cardano-node-chairman cardano-submit-api
+      run: |
+        # The tests call out to msys2 commands. We generally do not want to mix toolchains, so
+        # we are very deliberate about only adding msys64 to the path where absolutely necessary.
+        ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
+        cabal build cardano-node cardano-cli cardano-node-chairman cardano-submit-api
 
     - name: Run tests (all)
       if: github.event.inputs.tests == 'all'
@@ -288,6 +320,8 @@ jobs:
     # - name: Setup tmate session
     #   if: ${{ failure() }}
     #   uses: mxschmitt/action-tmate@v3
+    #   with:
+    #     limit-access-to-actor: true
 
   release:
     needs: [build]


### PR DESCRIPTION
Use `cabal-cache` to cache `cabal` packages.

This is better than using `actions/cache@v2` because `cabal-cache` is a fine grained cache that caches each built cabal package individually.

This means that if any packages were built successfully in CI, even if CI fails, we can still upload those packages that successfully built.  This is far superior to the situation we have now which is if CI fails we cache nothing.

This is especially useful for those occasions where we update the index state or change our package dependencies (including package dependency bounds) because currently for those cases, a failed build means we cache nothing which hurts iteration times very badly.

The change keeps the build time more reliably tight:

![Screenshot 2022-12-21 at 2 12 17 pm](https://user-images.githubusercontent.com/63014/208812063-781fb398-f406-4860-9a12-2acef3936220.png)

Compare this to the old caching method:

![Screenshot 2022-12-21 at 5 17 59 pm](https://user-images.githubusercontent.com/63014/208835215-dfd7c310-626b-4d69-aa79-7fc156785e01.png)

The PR also fixes a bug which mean that MacOS builds weren't cached at all (ie. the `89m` MacOS build time in the old caching method).