### PR TITLE
fix cardano-testnet Babbage genesis.json

### DIFF
--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -186,7 +186,12 @@ babbageTestnet testnetOptions H.Conf {..} = do
     . HM.insert "minFeeB"                (toJSON @Int 155381)
     . HM.insert "minUTxOValue"           (toJSON @Int 1000000)
     . HM.insert "decentralisationParam"  (toJSON @Double 0.7)
-    . HM.insert "major"                  (toJSON @Int 7)
+    . flip HM.adjust "protocolParams"
+      ( J.rewriteObject
+        ( flip HM.adjust "protocolVersion"
+          ( J.rewriteObject ( HM.insert "major" (toJSON @Int 8)))
+        )
+      )
     . HM.insert "rho"                    (toJSON @Double 0.1)
     . HM.insert "tau"                    (toJSON @Double 0.1)
     . HM.insert "updateQuorum"           (toJSON @Int 2)


### PR DESCRIPTION
The problem is if using module `Testnet.Babbage` from `cardano-testnet` the protocol version used is actually `0 0`. This means that a Plutus script doing anything useful, that's anything other than resolving as `()`,  will result in the mysterious `MalformedScriptWitnesses` error.