### PR TITLE
Cache secp256k1

### DIFF
--- a/.github/workflows/build-secp256k1.bash
+++ b/.github/workflows/build-secp256k1.bash
@@ -7,12 +7,18 @@ env | grep CI_
 echo ========
 echo $PATH
 echo ========
-git clone https://github.com/bitcoin-core/secp256k1
-cd secp256k1
-git switch $SECP256K1_REF --detach
-./autogen.sh
-./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
-make
-make check
+
+if [[ ! -d secp256k1/.git ]]; then
+  git clone https://github.com/bitcoin-core/secp256k1
+
+  cd secp256k1
+  git switch $SECP256K1_REF --detach
+  ./autogen.sh
+  ./configure $CI_SECP_FLAGS --enable-module-schnorrsig --enable-experimental
+  make
+  make check
+else
+  cd secp256k1
+fi
+
 $CI_SECP_INSTALL_CMD make install
-cd ..

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,6 +30,9 @@ jobs:
     env:
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+
+      SECP_CACHE_VERSION: 2022-12-23
+
       # OpenSSL is installed in a non-standard location in MacOS. See
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
       PKG_CONFIG_PATH: ${{ (matrix.os == 'macos-latest' && '/usr/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig') || (matrix.os == 'ubuntu-latest' && '/usr/lib/pkgconfig:/usr/local/lib/pkgconfig') || '' }}
@@ -145,6 +148,13 @@ jobs:
     - name: "MAC: Install build environment (for secp256k1)"
       if: runner.os == 'macOS'
       run: brew install autoconf automake libtool
+
+    - uses: actions/cache@v3
+      name: "Cache secp256k1"
+      with:
+        path: secp256k1
+        key: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
+        restore-keys: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
 
     - name: "LINUX: Install secp256k1"
       if: runner.os != 'Windows'


### PR DESCRIPTION
Reduces the installation time of `secp256k1` from this:

![Screenshot 2022-12-23 at 4 48 44 pm](https://user-images.githubusercontent.com/63014/209279065-0d71652b-5ece-4ec4-b418-0525d7612fbd.png)
![Screenshot 2022-12-23 at 4 48 26 pm](https://user-images.githubusercontent.com/63014/209279070-8ad92ac0-b6d5-4605-b26e-f0ac2e213a7d.png)
![Screenshot 2022-12-23 at 4 48 16 pm](https://user-images.githubusercontent.com/63014/209279071-99938df9-1516-485d-8d4a-193ea0537c64.png)

to this:

![Screenshot 2022-12-23 at 4 49 36 pm](https://user-images.githubusercontent.com/63014/209279219-22d5c75e-ec19-4372-8659-8d2fcf790cf5.png)
![Screenshot 2022-12-23 at 4 49 54 pm](https://user-images.githubusercontent.com/63014/209279222-58a8b7b4-d9f3-4c04-b99f-bf567c5ada00.png)
![Screenshot 2022-12-23 at 4 50 02 pm](https://user-images.githubusercontent.com/63014/209279224-9cad2700-2851-40de-8f22-a72f55bc8b6e.png)
