### PR TITLE
Use GITHUB_TOKEN in nix config in Github Actions CI

### DIFF
--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -17,6 +17,7 @@ jobs:
       uses: cachix/install-nix-action@v16
       with:
         extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
           substituters = https://cache.nixos.org https://hydra.iohk.io

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,6 +42,8 @@ jobs:
       # FIXME: this is arguably a bug, and pkg-config should return the right values!
       LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
 
+      CACHE_VERSION: "2022-12-28"
+
     steps:
     - name: "WIN: Install System Dependencies via pacman (msys2)"
       if: runner.os == 'Windows'
@@ -224,7 +226,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: ${{ secrets.BINARY_CACHE_URI }}
+        archive-uri: ${{ secrets.BINARY_CACHE_URI }}/${{ env.CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
 
     # It's important to ensure that people who fork this repository can not only successfully build in
@@ -242,7 +244,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: https://iohk.cache.haskellworks.io
+        archive-uri: https://iohk.cache.haskellworks.io/${{ env.CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
         enable-save: false
 


### PR DESCRIPTION
To fix this:

![Screenshot 2022-12-28 at 1 06 25 pm](https://user-images.githubusercontent.com/63014/209746016-4a35d1c7-e29e-4ce5-a2c6-dd54c3fcc8fb.png)

See https://github.com/marketplace/actions/install-nix
