### PR TITLE
Add cache versioning

### DIFF
--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -14,9 +14,10 @@ jobs:
     steps:
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v18
       with:
         extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
           substituters = https://cache.nixos.org https://hydra.iohk.io

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -26,6 +26,10 @@ jobs:
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
+      # OpenSSL is installed in a non-standard location in MacOS. See
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
+      PKG_CONFIG_PATH: ${{ (matrix.os == 'macos-latest' && '/usr/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig') || (matrix.os == 'ubuntu-latest' && '/usr/lib/pkgconfig:/usr/local/lib/pkgconfig') || '' }}
+
     steps:
      # this seems to break something. It _must_ come after the pacman setup
      # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -17,6 +17,12 @@ jobs:
         os: [ubuntu-latest]
 
     env:
+      # Modify this value to "invalidate" the cabal cache.
+      CABAL_CACHE_VERSION: "2022-12-28"
+
+      # Modify this value to "invalidate" the secp cache.
+      SECP_CACHE_VERSION: "2022-12-23"
+
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
@@ -87,7 +93,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: ${{ secrets.BINARY_CACHE_URI }}
+        archive-uri: ${{ secrets.BINARY_CACHE_URI }}/${{ env.CABAL_CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
 
     - name: Cabal cache over HTTPS
@@ -96,7 +102,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: https://iohk.cache.haskellworks.io
+        archive-uri: https://iohk.cache.haskellworks.io/${{ env.CABAL_CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
         enable-save: false
 

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -30,6 +30,11 @@ jobs:
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
       PKG_CONFIG_PATH: ${{ (matrix.os == 'macos-latest' && '/usr/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig') || (matrix.os == 'ubuntu-latest' && '/usr/lib/pkgconfig:/usr/local/lib/pkgconfig') || '' }}
 
+      # we need the LD_LIBRARY_PATH env var here because we ended up installing libsecp256k1 into /usr/local,
+      # pkg-config, *does* return the proper location, but the library does not appear to be properly referenced.
+      # FIXME: this is arguably a bug, and pkg-config should return the right values!
+      LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
+
     steps:
      # this seems to break something. It _must_ come after the pacman setup
      # above. It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -61,10 +61,17 @@ jobs:
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
+    - uses: actions/cache@v3
+      name: "Cache secp256k1"
+      with:
+        path: secp256k1
+        key: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
+        restore-keys: cache-secp256k1-${{ runner.os }}-${{ env.SECP_CACHE_VERSION }}
+
     - name: "Install secp256k1"
       shell: bash
       env:
-        CI_SECP_FLAGS: "--prefix=/usr"
+        CI_SECP_FLAGS: "--prefix=/usr/local"
         CI_SECP_INSTALL_CMD: sudo
       run: bash .github/workflows/build-secp256k1.bash
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,10 +28,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
+      # Modify this value to "invalidate" the cabal cache.
+      CABAL_CACHE_VERSION: "2022-12-28"
+
+      # Modify this value to "invalidate" the secp cache.
+      SECP_CACHE_VERSION: "2022-12-23"
+
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
-
-      SECP_CACHE_VERSION: 2022-12-23
 
       # OpenSSL is installed in a non-standard location in MacOS. See
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
@@ -224,7 +228,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: ${{ secrets.BINARY_CACHE_URI }}
+        archive-uri: ${{ secrets.BINARY_CACHE_URI }}/${{ env.CABAL_CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
 
     # It's important to ensure that people who fork this repository can not only successfully build in
@@ -242,7 +246,7 @@ jobs:
         dist-dir: dist-newstyle
         store-path: ${{ steps.cabal-store.outputs.cabal-store }}
         threads: 16
-        archive-uri: https://iohk.cache.haskellworks.io
+        archive-uri: https://iohk.cache.haskellworks.io/${{ env.CABAL_CACHE_VERSION }}
         skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
         enable-save: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,6 +46,8 @@ jobs:
       # FIXME: this is arguably a bug, and pkg-config should return the right values!
       LD_LIBRARY_PATH: ${{ (matrix.os != 'windows-latest' && '/usr/local/lib') || '' }}
 
+      CACHE_VERSION: "2022-12-28"
+
     steps:
     - name: "WIN: Install System Dependencies via pacman (msys2)"
       if: runner.os == 'Windows'


### PR DESCRIPTION
`archive-uri` is set more than once, so introduce `CABAL_CACHE_VERSION` which allows cache invalidation to be consistent across both instances.