### PR TITLE
Filter out duplicate collateral inputs in transaction build

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -380,9 +380,11 @@ runTxBuildCmd
 
   txOuts <- mapM (toTxOutInAnyEra cEra) txouts
 
+  -- the same collateral input can be used for several plutus scripts
+  let filteredTxinsc = Set.toList $ Set.fromList txinsc
   -- We need to construct the txBodycontent outside of runTxBuild
   BalancedTxBody txBodycontent balancedTxBody _ _
-    <- runTxBuild cEra consensusModeParams nid mScriptValidity inputsAndMaybeScriptWits readOnlyRefIns txinsc
+    <- runTxBuild cEra consensusModeParams nid mScriptValidity inputsAndMaybeScriptWits readOnlyRefIns filteredTxinsc
                   mReturnCollateral mTotCollateral txOuts changeAddr valuesWithScriptWits mLowBound
                   mUpperBound certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits
                   requiredSigners txAuxScripts txMetadata mpparams mProp mOverrideWits outputOptions
@@ -395,7 +397,7 @@ runTxBuildCmd
                              readOnlyRefIns
 
   let inputsThatRequireWitnessing = [input | (input,_) <- inputsAndMaybeScriptWits]
-      allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ txinsc
+      allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
 
   -- TODO: Calculating the script cost should live as a different command.
   -- Why? Because then we can simply read a txbody and figure out


### PR DESCRIPTION
This fixes #4744 and potential further issues resulting from unfiltered duplicate collateral inputs.