### PR TITLE
workbench:  towards a cloud nomad backend

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -35,7 +35,6 @@ import           Prelude
 import           Cardano.Api
 import           Cardano.Api.Shelley (PlutusScriptOrReferenceInput (..), ProtocolParameters,
                    protocolParamMaxTxExUnits, protocolParamPrices)
-import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))
 
 import           Cardano.TxGenerator.Fund as Fund
 import qualified Cardano.TxGenerator.FundQueue as FundQueue

--- a/nix/workbench/backend/nomad-conf.nix
+++ b/nix/workbench/backend/nomad-conf.nix
@@ -64,8 +64,14 @@ let
                 "${pkgs.coreutils}"/bin/ln -s "${pkgs.python3Packages.supervisor}" "$SUPERVISOR_NIX"
               fi
 
+              # The SUPERVISORD_LOGLEVEL defaults to "info"
+              # The logging level at which supervisor should write to the
+              # activity log. Valid levels are trace, debug, info, warn, error
+              # and critical.
+              LOGLEVEL="''${SUPERVISORD_LOGLEVEL:-info}"
+
               # Start `supervisord` on the foreground.
-              "${pkgs.python3Packages.supervisor}"/bin/supervisord --nodaemon --configuration "$SUPERVISORD_CONFIG"
+              "${pkgs.python3Packages.supervisor}"/bin/supervisord --nodaemon --configuration "$SUPERVISORD_CONFIG" --loglevel="$LOGLEVEL"
             '';
           };
         in

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -1,0 +1,526 @@
+################################################################################
+# A Nomad job description intended to be reused between local/development
+# clusters and SRE infrastructure used for long-running cloud benchmarks. Why?
+# To make it easier to improve and debug the almighty workbench!
+################################################################################
+{ pkgs
+, lib
+, stateDir
+, profileNix
+, clusterImage
+, unixHttpServerPort
+}:
+
+let
+
+  # Container defaults: See ./oci-images.nix
+  container_workdir = "/tmp/cluster";
+  container_supervisor_nix = "${container_workdir}/${stateDir}/supervisor/nix-store";
+  container_supervisord_url = "unix://${unixHttpServerPort}";
+  container_supervisord_conf = "${container_workdir}/${stateDir}/supervisor/supervisord.conf";
+  container_supervisord_loglevel = "info";
+
+  # About the JSON Job Specification and its odd assumptions:
+  #
+  # At least in Nomad version v1.4.3, the CLI command to submit new jobs
+  # (https://developer.hashicorp.com/nomad/docs/commands/job/run) says:
+  # "Job files must conform to the job specification format." With this link:
+  # https://developer.hashicorp.com/nomad/docs/job-specification. This is the
+  # HCL format that is heavily specified in the docs. Nice!
+  #
+  # But note that it starts saying "Nomad HCL is parsed in the command line and
+  # sent to Nomad in JSON format via the HTTP API." and here are the API docs
+  # with "JSON Job Specification" in its title:
+  # https://developer.hashicorp.com/nomad/api-docs/json-jobs
+  # well, this is the format that `nomad job run` expects if you use the `-json`
+  # argument. If you don't provide the `-json` argument it expects HCL or its
+  # JSON representation: https://github.com/hashicorp/hcl/blob/main/json/spec.md
+  #
+  # I finally found this in the HCL overview page:
+  # https://developer.hashicorp.com/nomad/docs/job-specification/hcl2
+  # "Since HCL is a superset of JSON, `nomad job run example.json` will attempt
+  # to parse a JSON job using the HCL parser. However, the JSON format accepted
+  # by the HCL parser is not the same as the API's JSON format. The HCL parser's
+  # JSON format is unspecified, so the API format is preferred. You can use the
+  # API format with the -json command line flag."
+  #
+  # We are using what HashiCorp calls an unespecified format but it the same
+  # format the SRE team is using.
+
+  # The job stanza is the top-most configuration option in the job
+  # specification. A job is a declarative specification of tasks that Nomad
+  # should run. Jobs have one or more task groups, which are themselves
+  # collections of one or more tasks. Job names are unique per region or
+  # namespace.
+  # https://developer.hashicorp.com/nomad/docs/job-specification/job
+  clusterJob = { job."workbench-cluster-job" = jobDefaults // {
+
+    # Specifies the Nomad scheduler to use. Nomad provides the service, system,
+    # batch, and sysbatch (new in Nomad 1.2) schedulers.
+    # https://developer.hashicorp.com/nomad/docs/schedulers
+    type = "service";
+
+    # The namespace in which to execute the job. Prior to Nomad 1.0 namespaces
+    # were Enterprise-only.
+    namespace = "default";
+
+    # The region in which to execute the job.
+    region = "workbench-region";
+
+    #  A list of datacenters in the region which are eligible for task
+    # placement. This must be provided, and does not have a default.
+    datacenters = [ "workbench-datacenter-1" ];
+
+    # The reschedule stanza specifies the group's rescheduling strategy. If
+    # specified at the job level, the configuration will apply to all groups
+    # within the job. If the reschedule stanza is present on both the job and
+    # the group, they are merged with the group stanza taking the highest
+    # precedence and then the job.
+    # To disable rescheduling, set the attempts parameter to zero and unlimited
+    # to false.
+    reschedule = {
+      # Specifies the number of reschedule attempts allowed in the configured
+      # interval. Defaults vary by job type.
+      attempts = 0;
+      # Enables unlimited reschedule attempts. If this is set to true the
+      # attempts and interval fields are not used.
+      unlimited = false;
+    };
+
+    # Specifies a key-value map that annotates with user-defined metadata.
+    meta = null;
+
+    ########################################
+    # Vault / Consul: Not used locally, yet!
+    ########################################
+
+    # Specifies the set of Vault policies required by all tasks in this job.
+    vault = null;
+
+    # Specifies the Vault token that proves the submitter of the job has access
+    # to the specified policies in the vault stanza. This field is only used to
+    # transfer the token and is not stored after job submission.
+    vault_token = "";
+
+    # Specifies the Consul token that proves the submitter of the job has access
+    # to the Service Identity policies associated with the job's Consul Connect
+    # enabled services. This field is only used to transfer the token and is not
+    # stored after job submission.
+    consul_token = "";
+
+    # A group defines a series of tasks that should be co-located
+    # on the same client (host). All tasks within a group will be
+    # placed on the same host.
+    # https://developer.hashicorp.com/nomad/docs/job-specification/group
+    group."workbench-cluster-job-group" = groupDefaults // {
+
+      # Specifies the number of instances that should be running under for this
+      # group. This value must be non-negative. This defaults to the min value
+      # specified in the scaling block, if present; otherwise, this defaults to
+      # 1
+      count = 1;
+
+      # The reschedule stanza specifies the group's rescheduling strategy. If
+      # specified at the job level, the configuration will apply to all groups
+      # within the job. If the reschedule stanza is present on both the job and
+      # the group, they are merged with the group stanza taking the highest
+      # precedence and then the job.
+      # To disable rescheduling, set the attempts parameter to zero and unlimited
+      # to false.
+      reschedule = {
+        # Specifies the number of reschedule attempts allowed in the configured
+        # interval. Defaults vary by job type.
+        attempts = 0;
+        # Enables unlimited reschedule attempts. If this is set to true the
+        # attempts and interval fields are not used.
+        unlimited = false;
+      };
+
+      # Specifies the restart policy for all tasks in this group. If omitted, a
+      # default policy exists for each job type, which can be found in the restart
+      # stanza documentation.
+      restart = {
+        attempts = 0;
+        mode = "fail";
+      };
+
+      # The network stanza specifies the networking requirements for the task
+      # group, including the network mode and port allocations.
+      # https://developer.hashicorp.com/nomad/docs/job-specification/network
+      # TODO: Use "bridge" mode and port allocations ?
+      network = {
+        mode = "host";
+      };
+
+      # Specifies a key-value map that annotates with user-defined metadata.
+      # Used as a "template" to generate the envars passed to the container.
+      # This makes it easier to change them using `jq` inside the workbench!
+      meta = {
+        # Only top level "KEY=STRING" are allowed!
+        SUPERVISOR_NIX = container_supervisor_nix;
+        SUPERVISORD_URL = container_supervisord_url;
+        SUPERVISORD_CONFIG = container_supervisord_conf;
+        SUPERVISORD_LOGLEVEL = container_supervisord_loglevel;
+      };
+
+      # TODO:
+      # Specifies the volumes that are required by tasks within the group.
+      # volume
+
+      ########################################
+      # Vault / Consul: Not used locally, yet!
+      ########################################
+
+      # Specifies Consul configuration options specific to the group.
+      consul = null;
+
+      # Specifies the set of Vault policies required by all tasks in this group.
+      # Overrides a vault block set at the job level.
+      vault = null;
+
+      # The Consul namespace in which group and task-level services within the
+      # group will be registered. Use of template to access Consul KV will read
+      # from the specified Consul namespace. Specifying namespace takes
+      # precedence over the -consul-namespace command line argument in job run.
+      # namespace = "";
+      # Not available as the documentations says: Extraneous JSON object property; No argument or block type is named "namespace".
+
+      # The task stanza creates an individual unit of work, such as a Docker
+      # container, web application, or batch processing.
+      # https://developer.hashicorp.com/nomad/docs/job-specification/task
+      task = let
+        valueF = (name: nodeSpecs: volumes: taskDefaults // {
+
+          driver = "podman";
+
+          # The meta stanza allows for user-defined arbitrary key-value pairs.
+          # It is possible to use the meta stanza at the job, group, or task
+          # level.
+          # Here you can override the meta used at the group level.
+          meta = null;
+
+          # Specifies environment variables that will be passed to the running
+          # process.
+          # `null` because we are using a "template" (see below).
+          env = {
+            #SUPERVISOR_NIX = container_supervisor_nix;
+            #SUPERVISORD_URL = container_supervisord_url;
+            #SUPERVISORD_CONFIG = container_supervisord_conf;
+            #SUPERVISORD_LOGLEVEL = container_supervisord_loglevel;
+          };
+
+          # Specifies the set of templates to render for the task. Templates can
+          # be used to inject both static and dynamic configuration with data
+          # populated from environment variables, Consul and Vault.
+          template = {
+            # podman container input environment variables.
+            env = true;
+            # File name to create inside the allocation directory.
+            destination = "envars";
+            # See runtime for available variables:
+            # https://developer.hashicorp.com/nomad/docs/runtime/environment
+            data = ''
+              SUPERVISOR_NIX="{{ env "NOMAD_META_SUPERVISOR_NIX" }}"
+              SUPERVISORD_URL="{{ env "NOMAD_META_SUPERVISORD_URL" }}"
+              SUPERVISORD_CONFIG="{{ env "NOMAD_META_SUPERVISORD_CONFIG" }}"
+              SUPERVISORD_LOGLEVEL="{{ env "NOMAD_META_SUPERVISORD_LOGLEVEL" }}"
+            '';
+            # Specifies the behavior Nomad should take if the rendered template
+            # changes. Nomad will always write the new contents of the template
+            # to the specified destination. The following possible values
+            # describe Nomad's action after writing the template to disk.
+            change_mode = "noop";
+            error_on_missing_key = true;
+          };
+
+          # Specifies where a group volume should be mounted.
+          volume_mount = null; #TODO
+
+          # Specifies logging configuration for the stdout and stderr of the
+          # task.
+          # TODO: Why not use the stdout and stderr instead of volumes?
+          logs = null;
+
+          # Specifies a configurable kill signal for a task, where the default
+          # is SIGINT (or SIGTERM for docker, or CTRL_BREAK_EVENT for raw_exec
+          # on Windows). Note that this is only supported for drivers sending
+          # signals (currently docker, exec, raw_exec, and java drivers).
+          kill_signal = "SIGINT";
+
+          # Specifies the duration to wait for an application to gracefully quit
+          # before force-killing. Nomad first sends a kill_signal. If the task
+          # does not exit before the configured timeout, SIGKILL is sent to the
+          # task. Note that the value set here is capped at the value set for
+          # "max_kill_timeout" on the agent running the task, which has a
+          # default value of 30 seconds.
+          # Default: (string: "5s").
+          kill_timeout = "5s";
+
+          # Specifies the driver configuration, which is passed directly to the
+          # driver to start the task. The details of configurations are specific
+          # to each driver, so please see specific driver documentation for more
+          # information.
+          # https://github.com/hashicorp/nomad-driver-podman#task-configuration
+          config = {
+
+            # The image to run. Accepted transports are docker (default if
+            # missing), oci-archive and docker-archive. Images reference as
+            # short-names will be treated according to user-configured
+            # preferences.
+            image = "${clusterImage.imageName}:${clusterImage.imageTag}";
+
+            # Always pull the latest image on container start.
+            force_pull = false;
+
+            # Podman redirects its combined stdout/stderr logstream directly
+            # to a Nomad fifo. Benefits of this mode are: zero overhead,
+            # don't have to worry about log rotation at system or Podman
+            # level. Downside: you cannot easily ship the logstream to a log
+            # aggregator plus stdout/stderr is multiplexed into a single
+            # stream.
+            logging = {
+              # The other option is: "journald"
+              driver = "nomad";
+            };
+
+            # The hostname to assign to the container. When launching more
+            # than one of a task (using count) with this option set, every
+            # container the task starts will have the same hostname.
+            hostname = name;
+
+            network_mode = "host";
+
+            # A list of /container_path strings for tmpfs mount points. See
+            # podman run --tmpfs options for details.
+            tmpfs = [
+              "/tmp"
+            ];
+
+            # A list of host_path:container_path:options strings to bind
+            # host paths to container paths. Named volumes are not supported.
+            volumes = volumes;
+
+            # The working directory for the container. Defaults to the
+            # default set in the image.
+            working_dir = container_workdir;
+
+          };
+
+          ########################################
+          # Vault / Consul: Not used locally, yet!
+          ########################################
+
+          # Specifies the set of Vault policies required by the task. This
+          # overrides any vault block set at the group or job level.
+          vault = null;
+
+        });
+      in lib.listToAttrs (
+        [
+          {name = "generator"; value = valueF "generator" null [ stateDir ];}
+        ]
+        ++ lib.optionals profileNix.value.node.tracer [
+          {name = "tracer";    value = valueF "tracer"    null [ stateDir ];}
+        ]
+        ++
+        (lib.mapAttrsToList
+          (_: nodeSpecs: {
+            name = nodeSpecs.name;
+            value = valueF nodeSpecs.name nodeSpecs [];
+          })
+          (profileNix.node-specs.value)
+        )
+      );
+
+    };
+
+  };};
+
+  jobDefaults = {
+    #############################
+    # Job miscellaneous defaults:
+    #############################
+
+    # Controls whether the scheduler can make partial placements if optimistic
+    # scheduling resulted in an oversubscribed node. This does not control
+    # whether all allocations for the job, where all would be the desired count
+    # for each task group, must be placed atomically. This should only be used
+    # for special circumstances.
+    all_at_once = false;
+
+    # This can be provided multiple times to define additional constraints. See
+    # the Nomad constraint reference for more details.
+    # https://developer.hashicorp.com/nomad/docs/job-specification/constraint
+    constraint = null;
+
+    # This can be provided multiple times to define preferred placement
+    # criteria. See the Nomad affinity reference for more details.
+    affinity = null;
+
+    # Specifies the groups strategy for migrating off of draining nodes. If
+    # omitted, a default migration strategy is applied. Only service jobs with a
+    # count greater than 1 support migrate stanzas.
+    migrate = null;
+
+    # The "multiregion" stanza specifies that a job will be deployed to multiple
+    # federated regions. If omitted, the job will be deployed to a single region
+    # - the one specified by the region field or the `-region` command line flag
+    # to `nomad job run`.
+    multiregion = null;
+
+    # Specifies the job as a parameterized job such that it can be dispatched
+    # against.
+    parameterized = null;
+
+    # Allows the job to be scheduled at fixed times, dates or intervals.
+    periodic = null;
+
+    # Specifies the job priority which is used to prioritize scheduling and
+    # access to resources. Must be between 1 and 100 inclusively, with a larger
+    # value corresponding to a higher priority. Priority only has an effect when
+    # job preemption is enabled. It does not have an effect on which of multiple
+    # pending jobs is run first.
+    priority = 50;
+
+    # This can be provided multiple times to define criteria for spreading
+    # allocations across a node attribute or metadata. See the Nomad spread
+    # reference for more details.
+    # https://developer.hashicorp.com/nomad/docs/job-specification/spread
+    spread = null;
+
+    # Specifies the task's update strategy. When omitted, a default update
+    # strategy is applied.
+    update = null;
+  };
+
+  groupDefaults = {
+    ###############################
+    # Group miscellaneous defaults:
+    ###############################
+
+    # This can be provided multiple times to define preferred placement
+    # criteria
+    affinity = null;
+
+    # Specifies user-defined constraints on the task. This can be provided
+    # multiple times to define additional constraints.
+    constraint = null;
+
+    # Specifies the ephemeral disk requirements of the group. Ephemeral disks
+    # can be marked as sticky and support live data migrations.
+    ephemeral_disk = null;
+
+    # Specifies a duration during which a Nomad client will attempt to
+    # reconnect allocations after it fails to heartbeat in the heartbeat_grace
+    # window. See the example code below for more details. This setting cannot
+    # be used with stop_after_client_disconnect.
+    # max_client_disconnect = "";
+    # Error using the documentation default: Unsuitable value type; Unsuitable duration value: time: invalid duration ""
+
+    # Specifies the groups strategy for migrating off of draining nodes. If
+    # omitted, a default migration strategy is applied. Only service jobs with
+    # a count greater than 1 support migrate stanzas.
+    migrate = null;
+
+    # Specifies integrations with Consul for service discovery. Nomad
+    # automatically registers each service when an allocation is started and
+    # de-registers them when the allocation is destroyed.
+    service = null;
+
+    # Specifies the duration to wait when stopping a group's tasks. The delay
+    # occurs between Consul deregistration and sending each task a shutdown
+    # signal. Ideally, services would fail healthchecks once they receive a
+    # shutdown signal. Alternatively shutdown_delay may be set to give
+    # in-flight requests time to complete before shutting down. A group level
+    # shutdown_delay will run regardless if there are any defined group
+    # services. In addition, tasks may have their own shutdown_delay which
+    # waits between deregistering task services and stopping the task.
+    shutdown_delay = "0s";
+
+    # Specifies a duration after which a Nomad client will stop allocations,
+    # if it cannot communicate with the servers. By default, a client will not
+    # stop an allocation until explicitly told to by a server. A client that
+    # fails to heartbeat to a server within the heartbeat_grace window and any
+    # allocations running on it will be marked "lost" and Nomad will schedule
+    # replacement allocations. The replaced allocations will normally continue
+    # to run on the non-responsive client. But you may want them to stop
+    # instead — for example, allocations requiring exclusive access to an
+    # external resource. When specified, the Nomad client will stop them after
+    # this duration. The Nomad client process must be running for this to
+    # occur. This setting cannot be used with max_client_disconnect.
+    # stop_after_client_disconnect = "";
+    # Error using the documentation default: Unsuitable value type; Unsuitable duration value: time: invalid duration ""
+
+    # This can be provided multiple times to define criteria for spreading
+    # allocations across a node attribute or metadata. See the Nomad spread
+    # reference for more details.
+    # https://developer.hashicorp.com/nomad/docs/job-specification/spread
+    spread = null;
+
+    # Specifies the task's update strategy. When omitted, a default update
+    # strategy is applied.
+    update = null;
+  };
+
+  taskDefaults = {
+    ##############################
+    # Task miscellaneous defaults:
+    ##############################
+
+    # This can be provided multiple times to define preferred placement
+    # criteria
+    affinity = null;
+
+    # Defines an artifact to download before running the task. This may be
+    # specified multiple times to download multiple artifacts.
+    artifact = null;
+
+    # Specifies user-defined constraints on the task. This can be provided
+    # multiple times to define additional constraints.
+    constraint = null;
+
+    # Configures the task to have access to dispatch payloads.
+    dispatch_payload = null;
+
+    # Used internally to manage tasks according to the value of this
+    # field. Initial use case is for Consul Connect.
+    # kind = null;
+
+    # Specifies whether the task is the leader task of the task group. If
+    # set to true, when the leader task completes, all other tasks within
+    # the task group will be gracefully shutdown. The shutdown process
+    # starts by applying the shutdown_delay if configured. It then stops
+    # the the leader task first, followed by non-sidecar and non-poststop
+    # tasks, and finally sidecar tasks. Once this process completes,
+    # post-stop tasks are triggered. See the lifecycle documentation for a
+    # complete description of task lifecycle management.
+    leader = false; # Only one task may be marked as leader!
+
+    # Specifies the minimum resource requirements such as RAM, CPU and
+    # devices.
+    resources = null;
+
+    # Specifies integrations with Consul for service discovery. Nomad
+    # automatically registers when a task is started and de-registers it
+    # when the task dies.
+    service = null;
+
+    # Specifies the duration to wait when killing a task between removing
+    # it from Consul and sending it a shutdown signal. Ideally services
+    # would fail healthchecks once they receive a shutdown signal.
+    # Alternatively shutdown_delay may be set to give in flight requests
+    # time to complete before shutting down. In addition, task groups may
+    # have their own shutdown_delay which waits between deregistering
+    # group services and stopping tasks.
+    shutdown_delay = "0s";
+
+    # Specifies the user that will run the task. Defaults to nobody for
+    # the "exec" and "java" drivers. "Docker" and "rkt" images specify
+    # their own default users. This can only be set on Linux platforms,
+    # and clients can restrict which drivers are allowed to run tasks as
+    # certain users.
+    # user = null;
+  };
+
+in pkgs.writeText "nomad-job.json"
+  (lib.generators.toJSON {} clusterJob)

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -77,7 +77,7 @@ let
             };
         supervisorConf =
           import ./supervisor-conf.nix
-            { inherit (profileNix) node-services;
+            { inherit profileNix;
               inherit pkgs lib stateDir;
               unixHttpServerPort = "/tmp/supervisor.sock";
             };

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -87,6 +87,8 @@ let
               inherit profileNix;
               inherit ociImages;
               inherit supervisorConf;
+              # Actually always "false", may evolve to a "cloud" flag!
+              oneTracerPerNode = false;
             };
       in pkgs.runCommand "workbench-backend-output-${profileNix.name}-${name}"
         ({

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -4,20 +4,65 @@
 , ...
 }:
 let
+  #name = builtins.trace (builtins.attrNames pkgs) "nomad";
   name = "nomad";
 
   # Unlike the supervisor backend `useCabalRun` is always false here.
   useCabalRun = false;
 
-  extraShellPkgs = with pkgs; [
-    # https://docs.podman.io/en/latest/markdown/podman.1.html#rootless-mode
-    podman
-    # Was not needed even thou it says so!
-    # https://docs.podman.io/en/latest/markdown/podman.1.html#note-unsupported-file-systems-in-rootless-mode
-    # fuse-overlayfs
-    nomad
-    nomad-driver-podman
-  ];
+  extraShellPkgs =
+    let
+      nomad = (pkgs.buildGo119Module rec {
+        pname = "nomad";
+        version = "1.4.3";
+        subPackages = [ "." ];
+        doCheck = true;
+        src = pkgs.fetchFromGitHub {
+          # fetchFromGit:
+          # - url = "https://github.com/hashicorp/${pname}.git";
+          # - rev = "f464aca721d222ae9c1f3df643b3c3aaa20e2da7";
+          owner = "hashicorp";
+          repo = pname;
+          rev = "v${version}";
+          # nix-prefetch-url --unpack https://github.com/hashicorp/nomad/archive/v1.4.3.tar.gz
+          sha256 = "0j2ik501sg6diyabwwfrqnz1wxx485w5pxry4bfkg5smgyp5y18r";
+        };
+        # error: either `vendorHash` or `vendorSha256` is required
+        # https://discourse.nixos.org/t/buildgomodule-how-to-get-vendorsha256/9317
+        vendorSha256 = "sha256-JQRpsQhq5r/QcgFwtnptmvnjBEhdCFrXFrTKkJioL3A=";
+      });
+      nomad-driver-podman = (pkgs.buildGo119Module rec {
+        pname = "nomad-driver-podman";
+        version = "0.4.1";
+        subPackages = [ "." ];
+        doCheck = false; # some tests require a running podman service
+        src = pkgs.fetchFromGitHub {
+          # fetchFromGit:
+          # - url = "https://github.com/hashicorp/${pname}.git";
+          # - rev = "3f8a8c03d26afe73388546b6235152224bafd6c1";
+          owner = "hashicorp";
+          repo = pname;
+          rev = "v${version}";
+          # nix-prefetch-url --unpack https://github.com/hashicorp/nomad-driver-podman/archive/v0.4.1.tar.gz
+          sha256 = "03856ws02xkqg5374x35zzz5900456rvpsridsjgwvvyqnysn9ls";
+        };
+        # error: either `vendorHash` or `vendorSha256` is required
+        # https://discourse.nixos.org/t/buildgomodule-how-to-get-vendorsha256/9317
+        vendorSha256 = "sha256-AtgxHAkNzzjMQoSqROpuNoSDum/6JR+mLpcHLFL9EIY=";
+      });
+    in
+      [
+        nomad
+        nomad-driver-podman
+      ]
+      ++
+      (with pkgs; [
+        # https://docs.podman.io/en/latest/markdown/podman.1.html#rootless-mode
+        podman
+        # Was not needed even thou it says so!
+        # https://docs.podman.io/en/latest/markdown/podman.1.html#note-unsupported-file-systems-in-rootless-mode
+        # fuse-overlayfs
+      ]);
 
   materialise-profile =
     { stateDir, profileNix }:

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -30,6 +30,14 @@ case "$op" in
         local usage="USAGE: wb nomad $op PROFILE-DIR"
         local profile_dir=${1:?$usage}
 
+        # TODO: stateful nomad ?
+        # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+        # ${XDG_STATE_HOME:-$HOME/.local/state}
+
+        # The one provided by the profile, the one used may suffer changes (jq).
+        setenvjqstr 'nomad_job_file' "$profile_dir"/nomad-job.json
+        # Get the job name from the job's JSON description.
+        setenvjqstr 'nomad_job_name' $(jq -r '.["job"] | keys[0]' "$profile_dir"/nomad-job.json)
         # Look up `supervisord` config file produced by Nix (run profile).
         setenvjqstr 'supervisord_conf' "$profile_dir"/supervisor.conf
         # The `--serverurl` argument is needed in every call to `nomad exec`.
@@ -49,6 +57,10 @@ case "$op" in
         setenvjqstr 'oci_image_tag'  ${WB_OCI_IMAGE_TAG:-$(cat  "$profile_dir/clusterImageTag")}
         # Script that creates the OCI image from nix2container layered output.
         setenvjqstr 'oci_image_skopeo_script' "$profile_dir/clusterImageCopyToPodman"
+        # Can't reside inside $dir, can't use a path longer than 108 characters!
+        # See: https://man7.org/linux/man-pages/man7/unix.7.html
+        # char        sun_path[108];            /* Pathname */
+        setenvjqstr 'podman_socket_path' "/run/user/$UID/workbench-podman.sock"
         # Set cluster's podman container defaults.
         # The workbench is expecting an specific hierarchy of folders and files.
         setenvjqstr 'container_workdir' "/tmp/cluster/"
@@ -96,14 +108,28 @@ case "$op" in
           cp -r "$dir"/genesis/utxo-keys.bak/* "$dir"/genesis/utxo-keys/
         fi
 
-        # Populate the files needed by the `supervisord` instance running inside
-        # the container.
+        # Populate the files needed by each `supervisord` server that will run
+        # for every podman container / nomad task (generator, tracer and nodes).
+        # All these folder are going to be mounted on run/current/supervisor to
+        # keep the supervisor.conf compatible with the supervisor backend.
+        # Previously tried sharing the same folder for every supervisor but
+        # difficult to debug race conditions happened (best guess is PID files).
+        mkdir -p     "$dir"/generator/supervisor
+        mkdir -p     "$dir"/tracer/supervisor
+        for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
+        do
+            mkdir -p "$dir"/"$node"/supervisor
+        done
         local supervisord_conf=$(envjqr 'supervisord_conf')
-        mkdir -p                 "$dir"/supervisor
-        # If $dir is being mounted inside the container the file must be copied
-        # because if it references something outside the container's mounted
-        # volume the container probably won't be able to access it.
-        cp -f "$supervisord_conf" "$dir"/supervisor/supervisord.conf
+        # These files have to be copied, not linked, because folder are going to
+        # be mounted inside the container and the linked file may not be
+        # accesible or may have a different path.
+        cp     "$supervisord_conf" "$dir"/generator/supervisor/supervisord.conf
+        cp     "$supervisord_conf" "$dir"/tracer/supervisor/supervisord.conf
+        for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
+        do
+            cp "$supervisord_conf" "$dir"/"$node"/supervisor/supervisord.conf
+        done
 
         # Create the "cluster" OCI image.
         local oci_image_name=$(         envjqr 'oci_image_name')
@@ -125,72 +151,11 @@ case "$op" in
             msg "OCI image named \"${oci_image_name}:${oci_image_tag}\" created"
         fi
 
-        # Configure `nomad` and the `podman` plugin/task driver.
+        # Create config files for Nomad and the Podman plugin/task driver.
         nomad_create_folders_and_config "$dir"
-        msg "Preparing podman API service for nomad driver \`nomad-driver-podman\` ..."
-        nomad_start_podman_service "$dir"
 
-        # Start `nomad` agent in "-dev-` mode`".
-        msg "Starting nomad agent ..."
-        # The Nomad agent is a long running process which runs on every machine
-        # that is part of the Nomad cluster. The behavior of the agent depends
-        # on if it is running in client or server mode. Clients are responsible
-        # for running tasks, while servers are responsible for managing the
-        # cluster.
-        # -dev: Start the agent in development mode. This enables a
-        # pre-configured dual-role agent (client + server) which is useful for
-        # developing or testing Nomad. No other configuration is required to
-        # start the agent in this mode, but you may pass an optional
-        # comma-separated list of mode configurations
-        nomad agent -config="$dir/nomad/config" -dev -log-level=INFO >> "$dir/nomad/stdout" 2>> "$dir/nomad/stderr" &
-        echo "$!" > "$dir/nomad/nomad.pid"
-        setenvjqstr 'nomad_pid' $(cat $dir/nomad/nomad.pid)
-        msg "Nomad started with PID $(cat $dir/nomad/nomad.pid)"
-
-        # Wait for nomad agent:
-        msg "Waiting for the listening HTTP server ..."
-        local i=0
-        local patience=25
-        until curl -Isf 127.0.0.1:4646 2>&1 | head --lines=1 | grep --quiet "HTTP/1.1"
-        do printf "%3d" $i; sleep 1
-            i=$((i+1))
-            if test $i -ge $patience
-            then echo
-                progress "nomad agent" "$(red FATAL):  workbench:  nomad agent:  patience ran out after ${patience}s, 127.0.0.1:4646"
-                backend_nomad stop-cluster "$dir"
-                fatal "nomad agent startup did not succeed:  check logs"
-            fi
-            echo -ne "\b\b\b"
-        done >&2
-
-        # Create and start the nomad job.
+        # Create the Nomad job file.
         nomad_create_job_file "$dir"
-        msg "Starting nomad job ..."
-        # Upon successful job submission, this command will immediately enter
-        # an interactive monitor. This is useful to watch Nomad's internals make
-        # scheduling decisions and place the submitted work onto nodes. The
-        # monitor will end once job placement is done. It is safe to exit the
-        # monitor early using ctrl+c.
-        # On successful job submission and scheduling, exit code 0 will be
-        # returned. If there are job placement issues encountered (unsatisfiable
-        # constraints, resource exhaustion, etc), then the exit code will be 2.
-        # Any other errors, including client connection issues or internal
-        # errors, are indicated by exit code 1.
-        # FIXME: Timeout for "Deployment "XXX" in progress..."
-        nomad job run -verbose "$dir/nomad/job-cluster.hcl"
-        # Assuming that `nomad` placement is enough wait.
-        local nomad_alloc_id=$(nomad job allocs -json cluster | jq -r '.[0].ID')
-        setenvjqstr 'nomad_alloc_id' "$nomad_alloc_id"
-        msg "Nomad job allocation ID is: $nomad_alloc_id"
-        # Show `--status` of `supervisorctl` inside the container.
-        local supervisord_url=$(envjqr 'supervisord_url')
-        local container_supervisor_nix=$(  envjqr 'container_supervisor_nix')
-        local container_supervisord_conf=$(envjqr 'container_supervisord_conf')
-        msg "Supervisor status inside container ..."
-        # Print the command used for debugging purposes.
-        msg "'nomad alloc exec --task node-0 \"$nomad_alloc_id\" \"$container_supervisor_nix\"/bin/supervisorctl --serverurl \"$supervisord_url\" --configuration \"$container_supervisord_conf\" status'"
-        # Execute the actual command.
-        nomad alloc exec --task node-0 "$nomad_alloc_id" "$container_supervisor_nix"/bin/supervisorctl --serverurl "$supervisord_url" --configuration "$container_supervisord_conf" status || true
         ;;
 
     describe-run )
@@ -309,6 +274,78 @@ case "$op" in
         local usage="USAGE: wb nomad $op RUN-DIR"
         local dir=${1:?$usage}; shift
 
+        msg "Preparing podman API service for nomad driver \`nomad-driver-podman\` ..."
+        nomad_start_podman_service "$dir"
+
+        # Start `nomad` agent".
+        msg "Starting nomad agent ..."
+        # The Nomad agent is a long running process which runs on every machine
+        # that is part of the Nomad cluster. The behavior of the agent depends
+        # on if it is running in client or server mode. Clients are responsible
+        # for running tasks, while servers are responsible for managing the
+        # cluster.
+        #
+        # The Nomad agent supports multiple configuration files, which can be
+        # provided using the -config CLI flag. The flag can accept either a file
+        # or folder. In the case of a folder, any .hcl and .json files in the
+        # folder will be loaded and merged in lexicographical order. Directories
+        # are not loaded recursively.
+        #   -config=<path>
+        # The path to either a single config file or a directory of config files
+        # to use for configuring the Nomad agent. This option may be specified
+        # multiple times. If multiple config files are used, the values from
+        # each will be merged together. During merging, values from files found
+        # later in the list are merged over values from previously parsed file.
+        #
+        # Running a dual-role agent (client + server) but not "-dev" mode.
+        nomad agent -config="$dir/nomad/config" >> "$dir/nomad/stdout" 2>> "$dir/nomad/stderr" &
+        echo "$!" > "$dir/nomad/nomad.pid"
+        setenvjqstr 'nomad_pid' $(cat $dir/nomad/nomad.pid)
+        msg "Nomad started with PID $(cat $dir/nomad/nomad.pid)"
+
+        # Wait for nomad agent:
+        msg "Waiting for the listening HTTP server ..."
+        local i=0
+        local patience=25
+        until curl -Isf 127.0.0.1:4646 2>&1 | head --lines=1 | grep --quiet "HTTP/1.1"
+        do printf "%3d" $i; sleep 1
+            i=$((i+1))
+            if test $i -ge $patience
+            then echo
+                progress "nomad agent" "$(red FATAL):  workbench:  nomad agent:  patience ran out after ${patience}s, 127.0.0.1:4646"
+                cat "$dir/nomad/stderr"
+                backend_nomad stop-cluster "$dir"
+                fatal "nomad agent startup did not succeed:  check logs"
+            fi
+            echo -ne "\b\b\b"
+        done >&2
+
+        msg "Starting nomad job ..."
+        # Upon successful job submission, this command will immediately enter
+        # an interactive monitor. This is useful to watch Nomad's internals make
+        # scheduling decisions and place the submitted work onto nodes. The
+        # monitor will end once job placement is done. It is safe to exit the
+        # monitor early using ctrl+c.
+        # On successful job submission and scheduling, exit code 0 will be
+        # returned. If there are job placement issues encountered (unsatisfiable
+        # constraints, resource exhaustion, etc), then the exit code will be 2.
+        # Any other errors, including client connection issues or internal
+        # errors, are indicated by exit code 1.
+        nomad job run -verbose "$dir/nomad/nomad-job.json" || true
+        # Assuming that `nomad` placement is enough wait.
+        local nomad_alloc_id=$(nomad job allocs -json cluster | jq -r '.[0].ID')
+        setenvjqstr 'nomad_alloc_id' "$nomad_alloc_id"
+        msg "Nomad job allocation ID is: $nomad_alloc_id"
+        # Show `--status` of `supervisorctl` inside the container.
+        local supervisord_url=$(envjqr 'supervisord_url')
+        local container_supervisor_nix=$(  envjqr 'container_supervisor_nix')
+        local container_supervisord_conf=$(envjqr 'container_supervisord_conf')
+        msg "Supervisor status inside container ..."
+        # Print the command used for debugging purposes.
+        msg "'nomad alloc exec --task node-0 \"$nomad_alloc_id\" \"$container_supervisor_nix\"/bin/supervisorctl --serverurl \"$supervisord_url\" --configuration \"$container_supervisord_conf\" status'"
+        # Execute the actual command.
+        nomad alloc exec --task node-0 "$nomad_alloc_id" "$container_supervisor_nix"/bin/supervisorctl --serverurl "$supervisord_url" --configuration "$container_supervisord_conf" status || true
+
         if jqtest ".node.tracer" "$dir"/profile.json
         then
           backend_nomad service-start "$dir" tracer
@@ -398,16 +435,16 @@ case "$op" in
         local nomad_alloc_id=$(envjqr 'nomad_alloc_id')
         local nomad_job_name=$(envjqr 'nomad_job_name')
 
-        msg "Stopping generator ..."
+        msg "Stopping generator inside its container ..."
         backend_nomad nomad-alloc-exec-supervisorctl "$dir" generator stop all || true
-        msg "Stopping tracer ..."
+        msg "Stopping tracer inside its container ..."
         if jqtest ".node.tracer" "$dir"/profile.json
         then
           backend_nomad nomad-alloc-exec-supervisorctl "$dir" tracer stop all || true
         fi
         for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
         do
-            msg "Stopping $node ..."
+            msg "Stopping $node inside its container ..."
             backend_nomad nomad-alloc-exec-supervisorctl "$dir" "$node" stop all || true
         done
 
@@ -416,7 +453,7 @@ case "$op" in
         # ERRO[0087] Unable to get cgroup path of container: cannot get cgroup path unless container b2f4fea15a4a56591231fae10e3c3e55fd485b2c0dfb231c073e2a3c9efa0e42 is running: container is stopped
         # {"@level":"debug","@message":"Could not get container stats, unknown error","@module":"podman.podmanHandle","@timestamp":"2022-12-14T14:34:03.264133Z","driver":"podman","error":"\u0026json.SyntaxError{msg:\"unexpected end of JSON input\", Offset:0}","timestamp":"2022-12-14T14:34:03.264Z"}
         # {"@level":"debug","@message":"Could not get container stats, unknown error","@module":"podman.podmanHandle","@timestamp":"2022-12-14T14:34:16.320494Z","driver":"podman","error":"\u0026url.Error{Op:\"Get\", URL:\"http://u/v1.0.0/libpod/containers/a55f689be4d2898225c76fa12716cfa0c0dedd54a1919e82d44523a35b8d07a4/stats?stream=false\", Err:(*net.OpError)(0xc000ba5220)}","timestamp":"2022-12-14T14:34:16.320Z"}
-        nomad job stop -global -no-shutdown-delay -purge -yes -verbose cluster >> "$dir/nomad/stdout" 2>> "$dir/nomad/stderr"
+        nomad job stop -global -no-shutdown-delay -purge -yes -verbose "$nomad_job_name" >> "$dir/nomad/stdout" 2>> "$dir/nomad/stderr"
 
         local nomad_pid=$(envjqr 'nomad_pid')
         msg "Killing nomad agent (PID $nomad_pid)..."
@@ -436,6 +473,36 @@ case "$op" in
         ;;
 
     * ) usage_docker;; esac
+}
+
+# Start the `podman` API service needed by `nomad`.
+nomad_start_podman_service() {
+    local dir=$1
+    local podman_socket_path=$(envjqr 'podman_socket_path')
+#    if test -S "$socket"
+#    then
+#        msg "Podman API service was already running"
+#    else
+        # The session is kept open waiting for a new connection for 60 seconds.
+        # https://discuss.hashicorp.com/t/nomad-podman-rhel8-driver-difficulties/21877/4
+        # `--time`: Time until the service session expires in seconds. Use 0
+        # to disable the timeout (default 5).
+        podman system service --time 60 "unix://$podman_socket_path" &
+        local i=0
+        local patience=5
+        while test ! -S "$podman_socket_path"
+        do printf "%3d" $i; sleep 1
+            i=$((i+1))
+            if test $i -ge $patience
+            then echo
+                progress "nomad-driver-podman" "$(red FATAL):  workbench:  nomad-driver-podman:  patience ran out after ${patience}s, socket $podman_socket_path"
+                backend_nomad stop-cluster "$dir"
+                fatal "nomad-driver-podman startup did not succeed:  check logs"
+            fi
+            echo -ne "\b\b\b"
+        done >&2
+#    fi
+    msg "Podman API service started"
 }
 
 # Configure `nomad` and its `podman` plugin / task driver
@@ -478,68 +545,281 @@ nomad_create_folders_and_config() {
     # - Specific `nomad` `podman` plugin / task driver configuration docs:
     # - - https://www.nomadproject.io/plugins/drivers/podman#plugin-options
     # - - https://github.com/hashicorp/nomad-driver-podman#driver-configuration
+    local podman_socket_path=$(envjqr 'podman_socket_path')
     cat > "$dir/nomad/config/nomad.hcl" <<- EOF
-        region = "workbench"
-        datacenter = "workbench"
-        name = "workbench"
-        data_dir  = "$dir/nomad/data"
-        plugin_dir  = "$dir/nomad/data/plugins"
-        bind_addr = "127.0.0.1"
-        ports = {
-          http = 4646
-        }
-        log_level = "INFO"
-        log_json = true
-        log_file = "$dir/nomad/"
-        leave_on_interrupt = true
-        leave_on_terminate = true
-        plugin "nomad-driver-podman" {
-          args = []
-          config {
-            # TODO: Use custom socket location!
-            # socket_path = "unix:$dir/nomad/podman.sock"
-            volumes {
-              enabled = true
-            }
-            recover_stopped = false
-            gc {
-              container = false
-            }
-          }
-        }
-EOF
+# Names:
+########
+# Specifies the region the Nomad agent is a member of. A region typically maps
+# to a geographic region, for example us, with potentially multiple zones, which
+# map to datacenters such as us-west and us-east.
+region = "workbench-region"
+# Specifies the data center of the local agent. All members of a datacenter
+# should share a local LAN connection.
+datacenter = "workbench-datacenter-1"
+# Specifies the name of the local node. This value is used to identify
+# individual agents. When specified on a server, the name must be unique within
+# the region.
+name = "workbench-nomad-agent-1"
+
+# Paths:
+########
+# Specifies a local directory used to store agent state. Client nodes use this
+# directory by default to store temporary allocation data as well as cluster
+# information. Server nodes use this directory to store cluster state, including
+# the replicated log and snapshot data. This must be specified as an absolute
+# path.
+data_dir  = "$dir/nomad/data"
+# Specifies the directory to use for looking up plugins. By default, this is the
+# top-level data_dir suffixed with "plugins", like "/opt/nomad/plugins". This
+# must be an absolute path.
+plugin_dir  = "$dir/nomad/data/plugins"
+
+# Network:
+##########
+# Specifies which address the Nomad agent should bind to for network services,
+# including the HTTP interface as well as the internal gossip protocol and RPC
+# mechanism. This should be specified in IP format, and can be used to easily
+# bind all network services to the same address. It is also possible to bind the
+# individual services to different addresses using the "addresses" configuration
+# option. Dev mode (-dev) defaults to localhost.
+bind_addr = "127.0.0.1"
+# Specifies the network ports used for different services required by the Nomad
+# agent.
+ports = {
+  # The port used to run the HTTP server.
+  http = 4646
+  # The port used for internal RPC communication between agents and servers, and
+  # for inter-server traffic for the consensus algorithm (raft).
+  rpc  = 4647
+  # The port used for the gossip protocol for cluster membership. Both TCP and
+  # UDP should be routable between the server nodes on this port.
+  serf = 4648
+}
+# Specifies the advertise address for individual network services. This can be
+# used to advertise a different address to the peers of a server or a client
+# node to support more complex network configurations such as NAT. This
+# configuration is optional, and defaults to the bind address of the specific
+# network service if it is not provided. Any values configured in this stanza
+# take precedence over the default "bind_addr".
+# If the bind address is 0.0.0.0 then the IP address of the default private
+# network interface advertised. The advertise values may include an alternate
+# port, but otherwise default to the port used by the bind address. The values
+# support go-sockaddr/template format.
+# Needed becasue of the below error message:
+# "Defaulting advertise to localhost is unsafe, please set advertise manually"
+advertise {
+  # The address to advertise for the HTTP interface. This should be reachable by
+  # all the nodes from which end users are going to use the Nomad CLI tools.
+  http = "127.0.0.1:4646"
+  # The address used to advertise to Nomad clients for connecting to Nomad
+  # servers for RPC. This allows Nomad clients to connect to Nomad servers from
+  # behind a NAT gateway. This address much be reachable by all Nomad client
+  # nodes. When set, the Nomad servers will use the advertise.serf address for
+  # RPC connections amongst themselves. Setting this value on a Nomad client has
+  # no effect.
+  rpc = "127.0.0.1:4647"
+  # The address advertised for the gossip layer. This address must be reachable
+  # from all server nodes. It is not required that clients can reach this
+  # address. Nomad servers will communicate to each other over RPC using the
+  # advertised Serf IP and advertised RPC Port.
+  serf = "127.0.0.1:4648"
+}
+# The tls stanza configures Nomad's TLS communication via HTTP and RPC to
+# enforce secure cluster communication between servers, clients, and between.
+tls {
+  # Specifies if TLS should be enabled on the HTTP endpoints on the Nomad agent,
+  # including the API.
+  http = false
+  # Specifies if TLS should be enabled on the RPC endpoints and Raft traffic
+  # between the Nomad servers. Enabling this on a Nomad client makes the client
+  # use TLS for making RPC requests to the Nomad servers.
+  rpc  = false
+  # Specifies agents should require client certificates for all incoming HTTPS
+  # requests. The client certificates must be signed by the same CA as Nomad.
+  verify_https_client = false
+  # Specifies if outgoing TLS connections should verify the server's hostname.
+  verify_server_hostname = false
 }
 
-# Start the `podman` API service needed by `nomad`.
-nomad_start_podman_service() {
-    local dir=$1
-    # TODO: Use custom socket location!
-    # podman --url "unix:$dir/nomad/podman.sock" system service --time 60 "unix:$dir/nomad/podman.sock" &
-    local socket="/run/user/$UID/podman/podman.sock"
-#    if test -S "$socket"
-#    then
-#        msg "Podman API service was already running"
-#    else
-        # The session is kept open waiting for a new connection for 60 seconds.
-        # https://discuss.hashicorp.com/t/nomad-podman-rhel8-driver-difficulties/21877/4
-        # `--time`: Time until the service session expires in seconds. Use 0
-        # to disable the timeout (default 5).
-        podman system service --time 60 &
-        local i=0
-        local patience=5
-        while test ! -S "$socket"
-        do printf "%3d" $i; sleep 1
-            i=$((i+1))
-            if test $i -ge $patience
-            then echo
-                progress "nomad-driver-podman" "$(red FATAL):  workbench:  nomad-driver-podman:  patience ran out after ${patience}s, socket $socket"
-                backend_nomad stop-cluster "$dir"
-                fatal "nomad-driver-podman startup did not succeed:  check logs"
-            fi
-            echo -ne "\b\b\b"
-        done >&2
-#    fi
-    msg "Podman API service started"
+# Logging:
+##########
+# Specifies the verbosity of logs the Nomad agent will output. Valid log levels
+# include WARN, INFO, or DEBUG in increasing order of verbosity.
+log_level = "INFO"
+# Output logs in a JSON format.
+log_json = true
+# Specifies the path for logging. If the path does not includes a filename, the
+# filename defaults to nomad.log. This setting can be combined with
+# "log_rotate_bytes" and "log_rotate_duration" for a fine-grained log rotation
+# control.
+log_file = "$dir/nomad/nomad.log"
+# Specifies if the agent should log to syslog. This option only works on Unix
+# based systems.
+enable_syslog = false
+# Specifies if the debugging HTTP endpoints should be enabled. These endpoints
+# can be used with profiling tools to dump diagnostic information about Nomad's
+# internals.
+enable_debug = false
+
+# Termination:
+##############
+# Specifies if the agent should gracefully leave when receiving the interrupt
+# signal. By default, the agent will exit forcefully on any signal. This value
+# should only be set to true on server agents if it is expected that a
+# terminated server instance will never join the cluster again.
+leave_on_interrupt = true
+# Specifies if the agent should gracefully leave when receiving the terminate
+# signal. By default, the agent will exit forcefully on any signal. This value
+# should only be set to true on server agents if it is expected that a
+# terminated server instance will never join the cluster again.
+leave_on_terminate = true
+
+# Server:
+#########
+# https://developer.hashicorp.com/nomad/docs/configuration/server
+server {
+  # Specifies if this agent should run in server mode. All other server options depend on this value being set.
+  enabled = true
+  # Specifies the directory to use for server-specific data, including the
+  # replicated log. By default, this is the top-level "data_dir" suffixed with
+  # "server", like "/opt/nomad/server". The top-level option must be set, even
+  # when setting this value. This must be an absolute path.
+  data_dir = "$dir/nomad/data/server"
+  # Specifies the number of server nodes to wait for before bootstrapping. It is
+  # most common to use the odd-numbered integers 3 or 5 for this value,
+  # depending on the cluster size. A value of 1 does not provide any fault
+  # tolerance and is not recommended for production use cases.
+  bootstrap_expect = 1
+  # Specifies how long a node must be in a terminal state before it is garbage
+  # collected and purged from the system. This is specified using a label suffix
+  # like "30s" or "1h".
+  node_gc_threshold = "60s"
+  # Specifies the interval between the job garbage collections. Only jobs who
+  # have been terminal for at least job_gc_threshold will be collected. Lowering
+  # the interval will perform more frequent but smaller collections. Raising the
+  # interval will perform collections less frequently but collect more jobs at a
+  # time. Reducing this interval is useful if there is a large throughput of
+  # tasks, leading to a large set of dead jobs. This is specified using a label
+  # suffix like "30s" or "3m". job_gc_interval was introduced in Nomad 0.10.0.
+  job_gc_interval = "2s"
+  # Specifies the minimum time a job must be in the terminal state before it is
+  # eligible for garbage collection. This is specified using a label suffix like
+  # "30s" or "1h".
+  job_gc_threshold = "2s"
+  # Specifies the minimum time an evaluation must be in the terminal state
+  # before it is eligible for garbage collection. This is specified using a
+  # label suffix like "30s" or "1h".
+  eval_gc_threshold = "2s"
+  # Specifies the minimum time a deployment must be in the terminal state before
+  # it is eligible for garbage collection. This is specified using a label
+  # suffix like "30s" or "1h".
+  deployment_gc_threshold = "2s"
+  # Specifies if Nomad will ignore a previous leave and attempt to rejoin the
+  # cluster when starting. By default, Nomad treats leave as a permanent intent
+  # and does not attempt to join the cluster again when starting. This flag
+  # allows the previous state to be used to rejoin the cluster.
+  rejoin_after_leave = false
+}
+
+# Client:
+#########
+# https://developer.hashicorp.com/nomad/docs/configuration/client
+client {
+  enabled = true
+  # Specifies the directory to use for allocation data. By default, this is the
+  # top-level data_dir suffixed with "alloc", like "/opt/nomad/alloc". This must
+  # be an absolute path.
+  alloc_dir = "$dir/nomad/data/alloc"
+  # Specifies the directory to use to store client state. By default, this is
+  # the top-level "data_dir" suffixed with "client", like "/opt/nomad/client".
+  # This must be an absolute path.
+  state_dir = "$dir/nomad/data/client"
+  # Specifies an array of addresses to the Nomad servers this client should join.
+  # This list is used to register the client with the server nodes and advertise
+  # the available resources so that the agent can receive work. This may be
+  # specified as an IP address or DNS, with or without the port. If the port is
+  # omitted, the default port of 4647 is used.
+  servers = [ "127.0.0.1:4647" ]
+  # Specifies the maximum amount of time a job is allowed to wait to exit.
+  # Individual jobs may customize their own kill timeout, but it may not exceed
+  # this value.
+  max_kill_timeout = "30s"
+  # Specifies the interval at which Nomad attempts to garbage collect terminal
+  # allocation directories.
+  gc_interval = "2s"
+}
+
+# Plugins:
+##########
+# https://developer.hashicorp.com/nomad/plugins/drivers/podman#plugin-options
+plugin "nomad-driver-podman" {
+  args = []
+  # https://github.com/hashicorp/nomad-driver-podman#driver-configuration
+  config {
+    # Defaults to "unix:///run/podman/podman.sock" when running as root or a
+    # cgroup V1 system, and "unix:///run/user/<USER_ID>/podman/podman.sock" for
+    # rootless cgroup V2 systems.
+    socket_path = "unix://$podman_socket_path"
+    # Allows tasks to bind host paths (volumes) inside their container.
+    volumes {
+      enabled = true
+    }
+    # This option can be used to disable Nomad from removing a container when
+    # the task exits.
+    gc {
+      container = true
+    }
+    # Allows the driver to start and reuse a previously stopped container after
+    # a Nomad client restart. Consider a simple single node system and a
+    # complete reboot. All previously managed containers will be reused instead
+    # of disposed and recreated.
+    recover_stopped = false
+    # Setting this to true will disable Nomad logs collection of Podman tasks.
+    # If you don't rely on nomad log capabilities and exclusively use host based
+    # log aggregation, you may consider this option to disable nomad log
+    # collection overhead. Beware to you also loose automatic log rotation.
+    disable_log_collection = false
+  }
+}
+
+# Misc:
+#######
+# The vault stanza configures Nomad's integration with HashiCorp's Vault. When
+# configured, Nomad can create and distribute Vault tokens to tasks
+# automatically. For more information on the architecture and setup, please see
+# the Nomad and Vault integration documentation.
+vault {
+  # Specifies if the Vault integration should be activated.
+  enabled = false
+}
+# The acl stanza configures the Nomad agent to enable ACLs and tunes various ACL
+# parameters. Learn more about configuring Nomad's ACL system in the Secure
+# Nomad with Access Control guide.
+acl {
+  # Specifies if ACL enforcement is enabled. All other ACL configuration options
+  # depend on this value. Note that the Nomad command line client will send
+  # requests for client endpoints such as alloc exec directly to Nomad clients
+  # whenever they are accessible. In this scenario, the client will enforce
+  # ACLs, so both servers and clients should have ACLs enabled.
+  enabled = false
+}
+# The audit stanza configures the Nomad agent to configure Audit logging
+# behavior. Audit logging is an Enterprise-only feature.
+audit {
+  # Specifies if audit logging should be enabled. When enabled, audit logging
+  # will occur for every request, unless it is filtered by a filter.
+  enabled = true
+}
+# The consul stanza configures the Nomad agent's communication with Consul for
+# service discovery and key-value integration. When configured, tasks can
+# register themselves with Consul, and the Nomad cluster can automatically
+# bootstrap itself.
+consul {
+}
+# Specifies if Nomad should not check for updates and security bulletins. This
+# defaults to true in Nomad Enterprise.
+disable_update_check = true
+EOF
 }
 
 # Need to use HCL instead of JSON. The only workaround is to send commands to
@@ -548,156 +828,104 @@ nomad_start_podman_service() {
 # [https://github.com/hashicorp/nomad/issues/6758#issuecomment-794116722]
 nomad_create_job_file() {
     local dir=$1
-    local container_mountpoint=$(      envjqr 'container_mountpoint')
-    # If CARDANO_MAINNET_MIRROR is present attach it as a volume.
+    local nomad_job_file=$(envjqr 'nomad_job_file')
+    cp $nomad_job_file $dir/nomad/nomad-job.json
+    chmod +w $dir/nomad/nomad-job.json
+    # If CARDANO_MAINNET_MIRROR is present generate a list of needed volumes.
     if test -n "$CARDANO_MAINNET_MIRROR"
     then
       # The nix-store path contains 3 levels of symlinks. This is a hack to
       # avoid creating a container image with all these files.
       local immutable_store=$(readlink -f "$CARDANO_MAINNET_MIRROR"/immutable)
-      local optional_volumes="[
+      local mainnet_mirror_volumes="[
           \"$CARDANO_MAINNET_MIRROR:$CARDANO_MAINNET_MIRROR:ro\"
         , \"$immutable_store:$immutable_store:ro\"
         $(find -L "$immutable_store" -type f -exec realpath {} \; | xargs dirname | sort | uniq | xargs -I "{}" echo ", \"{}:{}:ro\"")
       ]"
     else
-      local optional_volumes="[]"
+      local mainnet_mirror_volumes="[]"
     fi
-    # Volumes
-    local jq_filter="
+    # Hint:
+    # - Working dir is: /tmp/cluster/
+    # - Mount point is: /tmp/cluster/run/current
+    local container_mountpoint=$(      envjqr 'container_mountpoint')
+    # Nodes
+    for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
+    do
+      local task_stanza_name="$node"
+      # Every node needs access to itself, "../tracer/" and "./genesis/"
+      # *1 And remapping its own supervisor to the cluster/upper directory.
+      # *2 And read only access to eveything else so supervisor.conf doesn't
+      # complain about missing files/folders and can be shared unchanged with
+      # the workbench's "supervisor" backend.
+      local jq_filter="
+        [
+            \"${dir}/${node}/supervisor:${container_mountpoint}/supervisor:rw\"
+          , \"${dir}/tracer:${container_mountpoint}/tracer:rw\"
+          , \"${dir}/${node}:${container_mountpoint}/${node}:rw,exec\"
+        ]
+        +
+        [
+          \"${dir}/genesis:${container_mountpoint}/${node}/genesis:ro\"
+        ]
+        +
+        [
+          \"${dir}/generator:${container_mountpoint}/generator:ro\"
+        ]
+        +
+        ( . | keys | map(select(. != \"${node}\")) | map(\"${dir}/\" + . + \":${container_mountpoint}/\" + . + \":ro\") )
+        +
+        \$mainnet_mirror_volumes
+      "
+      local podman_volumes=$(jq "$jq_filter" --argjson mainnet_mirror_volumes "$mainnet_mirror_volumes" "$dir"/profile/node-specs.json)
+      jq ".job[\"workbench-cluster-job\"][\"group\"][\"workbench-cluster-job-group\"][\"task\"][\"$node\"][\"config\"][\"volumes\"] = \$podman_volumes" --argjson podman_volumes "$podman_volumes" $dir/nomad/nomad-job.json | sponge $dir/nomad/nomad-job.json
+    done
+    # Tracer
+    local task_stanza_name_t="tracer"
+    # Tracer only needs access to itself.
+    # *1 And remapping its own supervisor to the cluster/upper directory.
+    # *2 And read only access to eveything else so supervisor.conf doesn't
+    # complain about missing files/folders and can be shared unchanged with
+    # the workbench's "supervisor" backend.
+    local jq_filter_t="
       [
-        \"${dir}:/tmp/cluster/run/current:rw,exec\"
+          \"${dir}/tracer/supervisor:${container_mountpoint}/supervisor:rw\"
+        , \"${dir}/tracer:${container_mountpoint}/tracer:rw\"
       ]
       +
-      ( . | keys | map( \"${dir}/genesis:${container_mountpoint}/\" + . + \"/genesis:ro\" ) )
+      [
+         \"${dir}/generator:${container_mountpoint}/generator:ro\"
+      ]
       +
-      ( . | keys | map( \"${dir}/\" + . + \":${container_mountpoint}/generator/\" + . + \":ro\" ) )
-      +
-      ( . | keys | map( \"${dir}/genesis:${container_mountpoint}/generator/\" + . + \"/genesis:ro\" ) )
+      ( . | keys | map(\"${dir}/\" + . + \":${container_mountpoint}/\" + . + \":ro\") )
+    "
+    local podman_volumes_t=$(jq "$jq_filter_t" "$dir"/profile/node-specs.json)
+    jq ".job[\"workbench-cluster-job\"][\"group\"][\"workbench-cluster-job-group\"][\"task\"][\"tracer\"][\"config\"][\"volumes\"] = \$podman_volumes_t" --argjson podman_volumes_t "$podman_volumes_t" $dir/nomad/nomad-job.json | sponge $dir/nomad/nomad-job.json
+    # Generator
+    local task_stanza_name_g="generator"
+    # Generator needs access to itself, "./genesis", "./genesis/utxo-keys", every node inside its folder (with the genesis of every node).
+    # *1 And remapping its own supervisor to the cluster/upper directory.
+    # *2 And read only access to eveything else so supervisor.conf doesn't
+    # complain about missing files/folders and can be shared unchanged with
+    # the workbench's "supervisor" backend.
+    local jq_filter_g="
+      [
+          \"${dir}/generator/supervisor:${container_mountpoint}/supervisor:rw\"
+        , \"${dir}/tracer:${container_mountpoint}/tracer:rw\"
+        , \"${dir}/generator:${container_mountpoint}/generator:rw\"
+      ]
       +
       [
           \"${dir}/genesis:${container_mountpoint}/generator/genesis:ro\"
         , \"${dir}/genesis/utxo-keys:${container_mountpoint}/generator/genesis/utxo-keys:ro\"
       ]
       +
-      \$optional_volumes
+      ( . | keys | map( \"${dir}/\" + . + \":${container_mountpoint}/generator/\" + . + \":ro\" ) )
+      +
+      ( . | keys | map( \"${dir}/genesis:${container_mountpoint}/generator/\" + . + \"/genesis:ro\" ) )
+      +
+      ( . | keys | map(\"${dir}/\" + . + \":${container_mountpoint}/\" + . + \":ro\") )
     "
-    local podman_volumes=$(jq "$jq_filter" --argjson optional_volumes "$optional_volumes" "$dir"/profile/node-specs.json)
-    # Create the task to run in `nomad` using `podman` driver.
-    # https://www.nomadproject.io/docs/job-specification
-    # https://www.nomadproject.io/docs/job-specification/job
-    # https://github.com/hashicorp/nomad-driver-podman#task-configuration
-cat > "$dir/nomad/job-cluster.hcl" <<- EOF
-job "cluster" {
-  region = "workbench"
-  datacenters = [ "workbench" ]
-  type = "service"
-  reschedule {
-    attempts = 0
-    unlimited = false
-  }
-  # A group defines a series of tasks that should be co-located
-  # on the same client (host). All tasks within a group will be
-  # placed on the same host.
-  group "cluster" {
-    restart {
-      attempts = 0
-      mode = "fail"
-    }
-    # The network stanza specifies the networking requirements for the task
-    # group, including the network mode and port allocations.
-    # https://developer.hashicorp.com/nomad/docs/job-specification/network
-    network {
-      mode = "host"
-    }
-EOF
-    # Cluster
-#    local task_stanza_name_c="cluster"
-#    local task_stanza_file_c="$dir/nomad/job-cluster-task-$task_stanza_name_c.hcl"
-#    nomad_create_task_stanza "$task_stanza_file_c" "$task_stanza_name_c" "$podman_volumes"
-#cat "$task_stanza_file_c" >> "$dir/nomad/job-cluster.hcl"
-    # Nodes
-    for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
-    do
-      local task_stanza_name="$node"
-      local task_stanza_file="$dir/nomad/job-cluster-task-$task_stanza_name.hcl"
-      nomad_create_task_stanza "$task_stanza_file" "$task_stanza_name" "$podman_volumes"
-cat "$task_stanza_file" >> "$dir/nomad/job-cluster.hcl"
-    done
-    # Tracer
-    local task_stanza_name_t="tracer"
-    local task_stanza_file_t="$dir/nomad/job-cluster-task-$task_stanza_name_t.hcl"
-    nomad_create_task_stanza "$task_stanza_file_t" "$task_stanza_name_t" "$podman_volumes"
-cat "$task_stanza_file_t" >> "$dir/nomad/job-cluster.hcl"
-    # Generator
-    local task_stanza_name_g="generator"
-    local task_stanza_file_g="$dir/nomad/job-cluster-task-$task_stanza_name_g.hcl"
-    nomad_create_task_stanza "$task_stanza_file_g" "$task_stanza_name_g" "$podman_volumes"
-cat "$task_stanza_file_g" >> "$dir/nomad/job-cluster.hcl"
-    # The end.
-cat >> "$dir/nomad/job-cluster.hcl" <<- EOF
-  }
-}
-EOF
-}
-
-nomad_create_task_stanza() {
-    local file=$1
-    local name=$2
-    local podman_volumes=$3
-    local oci_image_name=$(                envjqr 'oci_image_name')
-    local oci_image_tag=$(                 envjqr 'oci_image_tag')
-    local container_workdir=$(             envjqr 'container_workdir')
-    local container_supervisor_nix=$(      envjqr 'container_supervisor_nix')
-    local container_supervisord_conf=$(    envjqr 'container_supervisord_conf')
-    local container_supervisord_loglevel=$(envjqr 'container_supervisord_loglevel')
-    cat > "$file" <<- EOF
-# The task stanza creates an individual unit of work, such as a
-# Docker container, web application, or batch processing.
-task "$name" {
-  driver = "podman"
-  # https://github.com/hashicorp/nomad-driver-podman#task-configuration
-  config {
-    # The image to run. Accepted transports are docker (default if missing),
-    # oci-archive and docker-archive. Images reference as short-names will be
-    # treated according to user-configured preferences.
-    image = "${oci_image_name}:${oci_image_tag}"
-    # Always pull the latest image on container start.
-    force_pull = false
-    # Podman redirects its combined stdout/stderr logstream directly to a Nomad
-    # fifo. Benefits of this mode are: zero overhead, don't have to worry about
-    # log rotation at system or Podman level. Downside: you cannot easily ship
-    # the logstream to a log aggregator plus stdout/stderr is multiplexed into a
-    # single stream.
-    logging = {
-      # The other option is: "journald"
-      driver = "nomad"
-    }
-    # The hostname to assign to the container. When launching more than one of a
-    # task (using count) with this option set, every container the task starts
-    # will have the same hostname.
-    hostname = "$name"
-    network_mode = "host"
-    # A list of /container_path strings for tmpfs mount points. See podman run
-    # --tmpfs options for details.
-    tmpfs = [
-      "/tmp"
-    ]
-    # A list of host_path:container_path:options strings to bind host paths to
-    # container paths. Named volumes are not supported.
-    volumes = ${podman_volumes}
-    # The working directory for the container. Defaults to the default set in
-    # the image.
-    working_dir = "${container_workdir}"
-  }
-  env = {
-    SUPERVISOR_NIX = "${container_supervisor_nix}"
-    SUPERVISORD_CONFIG = "${container_supervisord_conf}"
-    SUPERVISORD_LOGLEVEL = "${container_supervisord_loglevel}"
-  }
-  # Avoid: podman WARN[0066] StopSignal SIGTERM failed to stop container
-  # cluster-XX in 5 seconds, resorting to SIGKILL
-  kill_timeout = 15
-}
-EOF
+    local podman_volumes_g=$(jq "$jq_filter_g" "$dir"/profile/node-specs.json)
+    jq ".job[\"workbench-cluster-job\"][\"group\"][\"workbench-cluster-job-group\"][\"task\"][\"generator\"][\"config\"][\"volumes\"] = \$podman_volumes_g" --argjson podman_volumes_g "$podman_volumes_g" $dir/nomad/nomad-job.json | sponge $dir/nomad/nomad-job.json
 }

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -61,6 +61,9 @@ case "$op" in
         # The container need to know where `supervisord` config file is located
         # so it can be started. This is passed as an environment variable.
         setenvjqstr 'container_supervisord_conf' "/tmp/cluster/run/current/supervisor/supervisord.conf"
+        # The logging level at which supervisor should write to the activity
+        # log. Valid levels are trace, debug, info, warn, error and critical.
+        setenvjqstr 'container_supervisord_loglevel' "info"
         ;;
 
     # Man pages for Podman configuration files:
@@ -638,11 +641,12 @@ nomad_create_task_stanza() {
     local file=$1
     local name=$2
     local podman_volumes=$3
-    local oci_image_name=$(            envjqr 'oci_image_name')
-    local oci_image_tag=$(             envjqr 'oci_image_tag')
-    local container_workdir=$(         envjqr 'container_workdir')
-    local container_supervisor_nix=$(  envjqr 'container_supervisor_nix')
-    local container_supervisord_conf=$(envjqr 'container_supervisord_conf')
+    local oci_image_name=$(                envjqr 'oci_image_name')
+    local oci_image_tag=$(                 envjqr 'oci_image_tag')
+    local container_workdir=$(             envjqr 'container_workdir')
+    local container_supervisor_nix=$(      envjqr 'container_supervisor_nix')
+    local container_supervisord_conf=$(    envjqr 'container_supervisord_conf')
+    local container_supervisord_loglevel=$(envjqr 'container_supervisord_loglevel')
     cat > "$file" <<- EOF
 # The task stanza creates an individual unit of work, such as a
 # Docker container, web application, or batch processing.
@@ -668,6 +672,7 @@ task "$name" {
   env = {
     SUPERVISOR_NIX = "${container_supervisor_nix}"
     SUPERVISORD_CONFIG = "${container_supervisord_conf}"
+    SUPERVISORD_LOGLEVEL = "${container_supervisord_loglevel}"
   }
   # Avoid: podman WARN[0066] StopSignal SIGTERM failed to stop container
   # cluster-XX in 5 seconds, resorting to SIGKILL

--- a/nix/workbench/backend/oci-images.nix
+++ b/nix/workbench/backend/oci-images.nix
@@ -1,4 +1,5 @@
 { pkgs
+, lib
 # Cardano packages/executables.
 , cardano-node, cardano-tracer, tx-generator
 # OCI Image builder.
@@ -11,8 +12,8 @@ let
   # - https://discourse.nixos.org/t/nix2container-another-dockertools-buildimage-implementation-based-on-skopeo/21688
   n2c = pkgs.nix2container.outputs.packages.x86_64-linux.nix2container;
 
-  clusterImage = n2c.buildImage {
-    name = "registry.ci.iog.io/workbench-cluster-aio-image";
+  clusterNode = n2c.buildImage {
+    name = "registry.ci.iog.io/workbench-cluster-node";
     # Adds `/etc/protocols` and ``/etc/services` to the root directory.
     # FIXME: Inside the container still can't resolve `localhost` but can
     # resolve WAN domains using public DNS servers.
@@ -79,8 +80,14 @@ let
     };
   };
 
-in {
-
-  inherit clusterImage;
-
-}
+in (rec {
+  value = {
+    clusterNode = {
+      imageName = clusterNode.imageName;
+      imageTag = clusterNode.imageTag;
+      copyToPodman = "${clusterNode.copyToPodman}/bin/copy-to-podman";
+    };
+  };
+  JSON = pkgs.writeText "oci-images.json"
+    (lib.generators.toJSON {} value);
+})

--- a/nix/workbench/backend/oci-images.nix
+++ b/nix/workbench/backend/oci-images.nix
@@ -12,7 +12,7 @@ let
   n2c = pkgs.nix2container.outputs.packages.x86_64-linux.nix2container;
 
   clusterImage = n2c.buildImage {
-    name = "registry.workbench.iog.io/cluster";
+    name = "registry.ci.iog.io/workbench-cluster-aio-image";
     # Adds `/etc/protocols` and ``/etc/services` to the root directory.
     # FIXME: Inside the container still can't resolve `localhost` but can
     # resolve WAN domains using public DNS servers.

--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -47,7 +47,7 @@ in
         --profile      ${profile} \
         --cache-dir    ${cacheDir} \
         --base-port    ${toString basePort} \
-        ${pkgs.lib.optionalString useCabalRun ''--cabal \''}
+        ${pkgs.lib.optionalString useCabalRun ''--cabal''} \
         "$@"
     '';
 

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -49,6 +49,8 @@ let
         command        = "sh start.sh";
         stdout_logfile = "${stateDir}/generator/stdout";
         stderr_logfile = "${stateDir}/generator/stderr";
+        stopasgroup    = false;
+        killasgroup    = false;
         autostart      = false;
         autorestart    = false;
         startretries   = 1;
@@ -62,11 +64,12 @@ let
         command        = "sh start.sh";
         stdout_logfile = "${stateDir}/tracer/stdout";
         stderr_logfile = "${stateDir}/tracer/stderr";
+        stopasgroup    = true;
+        killasgroup    = true;
         autostart      = false;
         autorestart    = false;
         startretries   = 1;
-        stopasgroup    = true;
-        killasgroup    = true;
+        startsecs      = 1;
       };
     };
 
@@ -81,9 +84,12 @@ let
       command        = "sh start.sh";
       stdout_logfile = "${service.value.stateDir 0}/stdout";
       stderr_logfile = "${service.value.stateDir 0}/stderr";
+      stopasgroup    = false;
+      killasgroup    = false;
       autostart      = false;
       autorestart    = false;
       startretries   = 1;
+      startsecs      = 1;
     };
 
 in

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -92,6 +92,7 @@ let
       startsecs      = 1;
     };
 
-in
-  pkgs.writeText "supervisor.conf"
-    (generators.toINI {} supervisorConf)
+in {
+  value = supervisorConf;
+  INI = pkgs.writeText "supervisor.conf" (generators.toINI {} supervisorConf);
+}

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -1,7 +1,7 @@
 { pkgs
 , lib
 , stateDir
-, node-services
+, profileNix
 , unixHttpServerPort ? null
 , inetHttpServerPort ? null
 }:
@@ -41,7 +41,7 @@ let
     }
     //
     listToAttrs
-      (mapAttrsToList (_: nodeSvcSupervisorProgram) node-services)
+      (mapAttrsToList (_: nodeSvcSupervisorProgram) (profileNix.node-services))
     //
     {
       "program:generator" = {
@@ -58,7 +58,7 @@ let
       };
     }
     //
-    {
+    lib.attrsets.optionalAttrs (profileNix.value.node.tracer) {
       "program:tracer" = {
         directory      = "${stateDir}/tracer";
         command        = "sh start.sh";

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -32,7 +32,7 @@ let
   materialise-profile =
     { stateDir, profileNix }:
       let supervisorConf = import ./supervisor-conf.nix
-        { inherit (profileNix) node-services;
+        { inherit profileNix;
           inherit pkgs lib stateDir;
           inetHttpServerPort = "127.0.0.1:9001";
         };

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -28,19 +28,16 @@ let
       tx-generator
     ]);
 
+  # Backend-specific Nix bits:
   materialise-profile =
     { stateDir, profileNix }:
-      pkgs.runCommand "workbench-backend-output-${profileNix.name}-${name}"
-        {
-          ## Backend-specific Nix bits:
-          ## mkBackendConf :: Profile -> SupervisorConf/DockerConf
-          supervisorConfPath =
-            import ./supervisor-conf.nix
-            { inherit (profileNix) node-services;
-              inherit pkgs lib stateDir;
-              inetHttpServerPort = "127.0.0.1:9001";
-            };
-        }
+      let supervisorConf = import ./supervisor-conf.nix
+        { inherit (profileNix) node-services;
+          inherit pkgs lib stateDir;
+          inetHttpServerPort = "127.0.0.1:9001";
+        };
+      in pkgs.runCommand "workbench-backend-output-${profileNix.name}-${name}"
+        {supervisorConfPath = supervisorConf.INI;}
         ''
         mkdir $out
         cp    $supervisorConfPath           $out/supervisor.conf

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -57,6 +57,14 @@ case "$op" in
         cp $(jq '."service-config"' -r $gtor) "$gen_dir"/service-config.json
         cp $(jq '."start"'          -r $gtor) "$gen_dir"/start.sh
 
+        local trac=$dir/profile/tracer-service.json
+        trac_dir="$dir"/tracer
+        mkdir -p                                    "$trac_dir"
+        cp $(jq '."tracer-config"'        -r $trac) "$trac_dir"/tracer-config.json
+        cp $(jq '."nixos-service-config"' -r $trac) "$trac_dir"/nixos-service-config.json
+        cp $(jq '."config"'               -r $trac) "$trac_dir"/config.json
+        cp $(jq '."start"'                -r $trac) "$trac_dir"/start.sh
+
         local supervisor_conf=$(envjqr 'supervisor_conf')
 
         mkdir -p               "$dir"/supervisor

--- a/nix/workbench/profile.nix
+++ b/nix/workbench/profile.nix
@@ -12,7 +12,7 @@
               with svc;
               { inherit name;
                 service-config = serviceConfig.JSON;
-                start          = startupScript;
+                start          = startupScript.JSON;
                 config         = nodeConfig.JSON;
                 topology       = topology.JSON;
               }));
@@ -21,7 +21,7 @@
           __toJSON
           { name           = "generator";
             service-config = serviceConfig.JSON;
-            start          = startupScript;
+            start          = startupScript.JSON;
             run-script     = runScript.JSON;
           };
         tracerService =
@@ -31,7 +31,7 @@
             tracer-config        = tracer-config.JSON;
             nixos-service-config = nixos-service-config.JSON;
             config               = config.JSON;
-            start                = startupScript;
+            start                = startupScript.JSON;
           };
         passAsFile = [ "nodeServices" "generatorService" "tracerService" ];
       }

--- a/nix/workbench/profiles/generator-service.nix
+++ b/nix/workbench/profiles/generator-service.nix
@@ -117,20 +117,23 @@ let
       };
 
       runScript = {
-        value = service.runScript;
+        # TODO / FIXME
+        # the string '...' is not allowed to refer to a store path (such as '')
+        # value = service.decideRunScript service;
         JSON  = runJq "generator-run-script.json"
                   ''--null-input
                     --argjson x '${service.decideRunScript service}'
                   '' "$x";
       };
 
-      startupScript =
-        pkgs.writeScript "startup-generator.sh"
-          ''
+      startupScript = rec {
+        JSON = pkgs.writeScript "startup-generator.sh" value;
+        value = ''
           #!${pkgs.stdenv.shell}
 
           ${service.script}
           '';
+      };
     })
     profile.node-specs.value;
 in

--- a/nix/workbench/profiles/node-services.nix
+++ b/nix/workbench/profiles/node-services.nix
@@ -269,13 +269,14 @@ let
         value = __fromJSON (__readFile JSON);
       };
 
-      startupScript =
-        pkgs.writeScript "startup-${name}.sh"
-          ''
+      startupScript = rec {
+        JSON = pkgs.writeScript "startup-${name}.sh" value;
+        value = ''
           #!${pkgs.stdenv.shell}
 
           ${service.script}
           '';
+      };
     };
 
   ##

--- a/nix/workbench/profiles/services-config.nix
+++ b/nix/workbench/profiles/services-config.nix
@@ -53,9 +53,9 @@ with lib;
             executable = "cardano-node";
             # executable     = ''time -f "${time_fmtstr}" -o kernel-resource-summary.json cabal run exe:cardano-node ''${WB_FLAGS_RTS} -- +RTS -sghc-rts-report.txt -RTS'';
           } // optionalAttrs isProducer {
-            operationalCertificate = "./genesis/node-keys/node${toString i}.opcert";
-            kesKey         = "./genesis/node-keys/node-kes${toString i}.skey";
-            vrfKey         = "./genesis/node-keys/node-vrf${toString i}.skey";
+            operationalCertificate = "../genesis/node-keys/node${toString i}.opcert";
+            kesKey         = "../genesis/node-keys/node-kes${toString i}.skey";
+            vrfKey         = "../genesis/node-keys/node-vrf${toString i}.skey";
           } // optionalAttrs profile.node.tracer {
             tracerSocketPathConnect = "../tracer/tracer.socket";
           });
@@ -64,20 +64,20 @@ with lib;
         { port, ... }: cfg: recursiveUpdate cfg
           (
             {
-              AlonzoGenesisFile    = "./genesis/genesis.alonzo.json";
-              ShelleyGenesisFile   = "./genesis/genesis-shelley.json";
-              ByronGenesisFile     = "./genesis/byron/genesis.json";
+              AlonzoGenesisFile    = "../genesis/genesis.alonzo.json";
+              ShelleyGenesisFile   = "../genesis/genesis-shelley.json";
+              ByronGenesisFile     = "../genesis/byron/genesis.json";
             }
           );
 
       finaliseGeneratorService =
         profile: svc: recursiveUpdate svc
           ({
-            sigKey         = "./genesis/utxo-keys/utxo1.skey";
+            sigKey         = "../genesis/utxo-keys/utxo1.skey";
             runScriptFile  = "run-script.json";
             ## path to the config and socket of the locally running node.
-            nodeConfigFile = "./node-0/config.json";
-            localNodeSocketPath = "./node-0/node.socket";
+            nodeConfigFile = "../node-0/config.json";
+            localNodeSocketPath = "../node-0/node.socket";
           } // optionalAttrs profile.node.tracer {
             tracerSocketPath = "../tracer/tracer.socket";
           } // optionalAttrs useCabalRun {
@@ -87,9 +87,9 @@ with lib;
       finaliseGeneratorConfig =
         cfg: recursiveUpdate cfg
           ({
-            AlonzoGenesisFile    = "./genesis/genesis.alonzo.json";
-            ShelleyGenesisFile   = "./genesis/genesis-shelley.json";
-            ByronGenesisFile     = "./genesis/byron/genesis.json";
+            AlonzoGenesisFile    = "../genesis/genesis.alonzo.json";
+            ShelleyGenesisFile   = "../genesis/genesis-shelley.json";
+            ByronGenesisFile     = "../genesis/byron/genesis.json";
           } // optionalAttrs useCabalRun {
             executable           = "tx-generator";
           });

--- a/nix/workbench/profiles/tracer-service.nix
+++ b/nix/workbench/profiles/tracer-service.nix
@@ -99,13 +99,14 @@ let
                   '' "$x";
       };
 
-      startupScript =
-        pkgs.writeScript "startup-tracer.sh"
-          ''
+      startupScript = rec {
+        JSON = pkgs.writeScript "startup-tracer.sh" value;
+        value = ''
           #!${pkgs.stdenv.shell}
 
           ${nixosServiceConfig.script}
           '';
+      };
     })
     profile.node-specs.value;
 in

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -500,25 +500,10 @@ EOF
         cp "$dir"/genesis/genesis.alonzo.json  "$dir"/genesis.alonzo.json
         echo >&2
 
-        local svcs=$profile/node-services.json
-        for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
-        do local node_dir="$dir"/$node
-           mkdir -p                                          "$node_dir"
-           jq      '."'"$node"'"' "$dir"/node-specs.json   > "$node_dir"/node-spec.json
-           cp $(jq '."'"$node"'"."config"'         -r $svcs) "$node_dir"/config.json
-           cp $(jq '."'"$node"'"."service-config"' -r $svcs) "$node_dir"/service-config.json
-           cp $(jq '."'"$node"'"."start"'          -r $svcs) "$node_dir"/start.sh
-           cp $(jq '."'"$node"'"."topology"'       -r $svcs) "$node_dir"/topology.json
-        done
-
-        local gtor=$profile/generator-service.json
-        gen_dir="$dir"/generator
-        mkdir -p                              "$gen_dir"
-        cp $(jq '."run-script"'     -r $gtor) "$gen_dir"/run-script.json
-        cp $(jq '."service-config"' -r $gtor) "$gen_dir"/service-config.json
-        cp $(jq '."start"'          -r $gtor) "$gen_dir"/start.sh
-
-        local trac=$profile/tracer-service.json
+        # Tracer directory is only task/service that is still mounted as a
+        # volumes for the nomad backend. Generator and nodes folders are
+        # created inside the container.
+        local trac=$dir/profile/tracer-service.json
         trac_dir="$dir"/tracer
         mkdir -p                              "$trac_dir"
         cp $(jq '."tracer-config"'        -r $trac) "$trac_dir"/tracer-config.json

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -500,17 +500,6 @@ EOF
         cp "$dir"/genesis/genesis.alonzo.json  "$dir"/genesis.alonzo.json
         echo >&2
 
-        # Tracer directory is only task/service that is still mounted as a
-        # volumes for the nomad backend. Generator and nodes folders are
-        # created inside the container.
-        local trac=$dir/profile/tracer-service.json
-        trac_dir="$dir"/tracer
-        mkdir -p                              "$trac_dir"
-        cp $(jq '."tracer-config"'        -r $trac) "$trac_dir"/tracer-config.json
-        cp $(jq '."nixos-service-config"' -r $trac) "$trac_dir"/nixos-service-config.json
-        cp $(jq '."config"'               -r $trac) "$trac_dir"/config.json
-        cp $(jq '."start"'                -r $trac) "$trac_dir"/start.sh
-
         backend allocate-run "$dir"
 
         progress "run" "allocated $(with_color white $run) @ $dir"

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -65,6 +65,13 @@ case "$op" in
         ;;
 
     chainsync )
+        # When using the nomad backend `chaindb` must be called after
+        # `backend start` because the node-#, generator and tracer directories
+        # may be created after the nomad job has started (are symlinks to the
+        # containers directories).
+        backend start "$dir"
+
+        # `chaindb` observer:
         local observer=(
             mainnet-chunks-with-snapshot-at-slot
             "$dir"/node-1/run/current/node-1/db-testnet
@@ -73,7 +80,7 @@ case "$op" in
         )
         progress "scenario" "preparing ChainDB for the $(green "observer (fetcher)")"
         chaindb "${observer[@]}"
-
+        # `chaindb` server:
         local chaindb_server=(
             mainnet-chunks-with-snapshot-at-slot
             "$dir"/node-0/run/current/node-0/db-testnet
@@ -83,8 +90,7 @@ case "$op" in
         progress "scenario" "preparing ChainDB for the $(green server node)"
         chaindb "${chaindb_server[@]}"
 
-        backend start "$dir"
-
+        # Nodes must be started AFTER the `chaindb` part!
         progress "scenario" "starting the $(yellow ChainDB server node)"
         backend start-node        "$dir" 'node-0'
 


### PR DESCRIPTION
Multiple enhancements for the workbench's Nomad backend

Moving towards cloud deployments:
- Nix generated JSON Nomad job file (previously bash script and HCL)
- Using Nomad templates instead of mounting volumes when possible
- `node-0` and `generator` in the same container
- Using a pinned nomad/podman version
- WIP: `oneTracerPerNode` flag
- WIP: Stop using Nomad `-dev` mode (Switch to multiple agents)

Misc smaller Nix cleanups/refactorings:
- Shared read-only genesis folder(even if symlinks, multiple were expected)
- Honor the optional tracer flag in `supervisor.conf`
- Verbosity for the stop/kill supervisor flags
- Configurable loglevel for supervisord inside containers

Also: fix `--trace` not working in `cabalRun` mode