### PR TITLE
Remove simple script distinction

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -26,6 +26,8 @@
 
 - **Breaking change** - `queryExpr` to return `IO (Either UnsupportedNtcVersionError a)` instead of `IO a`.
   ([PR4788](https://github.com/input-output-hk/cardano-node/pull/4788))
+  
+- **Breaking change** - Remove distinction between multisig and timelock scripts([PR4763](https://github.com/input-output-hk/cardano-node/pull/4763))
 
 ### Bugs
 

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -125,7 +125,6 @@ import qualified Data.ByteString.Short as SBS
 import           Data.Coerce
 import           Data.Int (Int64)
 import           Data.Map.Strict (Map)
-import           Data.Maybe (maybeToList)
 import           Data.Ratio (Ratio, (%))
 import           Data.String
 import           Data.Word (Word64)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -337,18 +337,15 @@ module Cardano.Api (
     -- | Both 'PaymentCredential's and 'StakeCredential's can use scripts.
 
     -- ** Script languages
-    SimpleScriptV1,
-    SimpleScriptV2,
+    SimpleScript',
     PlutusScriptV1,
     PlutusScriptV2,
     ScriptLanguage(..),
-    SimpleScriptVersion(..),
     PlutusScriptVersion(..),
     AnyScriptLanguage(..),
     AnyPlutusScriptVersion(..),
     IsPlutusScriptLanguage(..),
     IsScriptLanguage(..),
-    IsSimpleScriptLanguage(..),
 
     -- ** Scripts in a specific language
     Script(..),
@@ -389,9 +386,6 @@ module Cardano.Api (
     -- ** Simple scripts
     -- | Making multi-signature and time-lock scripts.
     SimpleScript(..),
-    TimeLocksSupported(..),
-    timeLocksSupported,
-    adjustSimpleScriptVersion,
 
     -- ** Plutus scripts
     PlutusScript,

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -1153,7 +1153,6 @@ instance ToJSON SimpleScript where
 instance FromJSON SimpleScript where
   parseJSON = parseSimpleScript
 
--- TODO: Left off here. You need to comb through cardano-api's property tests concerning simple scripts
 parseSimpleScript :: Value -> Aeson.Parser SimpleScript
 parseSimpleScript v = parseScriptSig v <|>
                       parseScriptBefore v <|>

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -129,13 +129,13 @@ prop_roundtrip_signing_key_kes_CBOR =
 
 prop_roundtrip_script_SimpleScriptV1_CBOR :: Property
 prop_roundtrip_script_SimpleScriptV1_CBOR =
-  roundtrip_CBOR (AsScript AsSimpleScriptV1)
-                 (genScript (SimpleScriptLanguage SimpleScriptV1))
+  roundtrip_CBOR (AsScript AsSimpleScript)
+                 (genScript SimpleScriptLanguage)
 
 prop_roundtrip_script_SimpleScriptV2_CBOR :: Property
 prop_roundtrip_script_SimpleScriptV2_CBOR =
-  roundtrip_CBOR (AsScript AsSimpleScriptV2)
-                 (genScript (SimpleScriptLanguage SimpleScriptV2))
+  roundtrip_CBOR (AsScript AsSimpleScript)
+                 (genScript SimpleScriptLanguage)
 
 prop_roundtrip_script_PlutusScriptV1_CBOR :: Property
 prop_roundtrip_script_PlutusScriptV1_CBOR =

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 
-exampleSimpleScriptV1_All :: SimpleScript SimpleScriptV1
+exampleSimpleScriptV1_All :: SimpleScript
 exampleSimpleScriptV1_All =
   RequireAllOf
     [ RequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
@@ -28,7 +28,7 @@ exampleSimpleScriptV1_All =
     , RequireSignature "6b732c60c267bab894854d6dd57a04a94e603fcc4c36274c9ed75952"
     ]
 
-exampleSimpleScriptV1_Any :: SimpleScript SimpleScriptV1
+exampleSimpleScriptV1_Any :: SimpleScript
 exampleSimpleScriptV1_Any =
   RequireAnyOf
     [ RequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
@@ -39,7 +39,7 @@ exampleSimpleScriptV1_Any =
     , RequireSignature "622be5fab3b5c3f371a50a535e4d3349c942a98cecee93b24e2fd11d"
     ]
 
-exampleSimpleScriptV1_MofN :: SimpleScript SimpleScriptV1
+exampleSimpleScriptV1_MofN :: SimpleScript
 exampleSimpleScriptV1_MofN =
   RequireMOf 2
     [ RequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
@@ -49,26 +49,26 @@ exampleSimpleScriptV1_MofN =
     ]
 
 
-exampleSimpleScriptV2_All :: SimpleScript SimpleScriptV2
+exampleSimpleScriptV2_All :: SimpleScript
 exampleSimpleScriptV2_All =
   RequireAllOf
     [ RequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
-    , RequireTimeBefore TimeLocksInSimpleScriptV2 (SlotNo 42)
+    , RequireTimeBefore (SlotNo 42)
     ]
 
-exampleSimpleScriptV2_Any :: SimpleScript SimpleScriptV2
+exampleSimpleScriptV2_Any :: SimpleScript
 exampleSimpleScriptV2_Any =
   RequireAnyOf
     [ RequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
-    , RequireTimeAfter TimeLocksInSimpleScriptV2 (SlotNo 42)
+    , RequireTimeAfter (SlotNo 42)
     ]
 
-exampleSimpleScriptV2_MofN :: SimpleScript SimpleScriptV2
+exampleSimpleScriptV2_MofN :: SimpleScript
 exampleSimpleScriptV2_MofN =
   RequireMOf 1
     [ RequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
     , RequireSignature "f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614"
-    , RequireTimeBefore TimeLocksInSimpleScriptV2 (SlotNo 42)
+    , RequireTimeBefore (SlotNo 42)
     ]
 
 -- -----------------------------------------------------------------------------
@@ -104,16 +104,10 @@ prop_golden_SimpleScriptV2_MofN =
                             "test/Golden/Script/SimpleV2/atleast"
 
 
-prop_roundtrip_SimpleScriptV1_JSON :: Property
-prop_roundtrip_SimpleScriptV1_JSON =
+prop_roundtrip_SimpleScript_JSON :: Property
+prop_roundtrip_SimpleScript_JSON =
   H.property $ do
-    mss <- H.forAll $ genSimpleScript SimpleScriptV1
-    H.tripping mss encode eitherDecode
-
-prop_roundtrip_SimpleScriptV2_JSON :: Property
-prop_roundtrip_SimpleScriptV2_JSON =
-  H.property $ do
-    mss <- H.forAll $ genSimpleScript SimpleScriptV2
+    mss <- H.forAll genSimpleScript
     H.tripping mss encode eitherDecode
 
 prop_roundtrip_ScriptData :: Property
@@ -132,7 +126,6 @@ tests = testGroup "Test.Cardano.Api.Typed.Script"
   , testPropertyNamed "golden SimpleScriptV2 All"     "golden SimpleScriptV2 All"     prop_golden_SimpleScriptV2_All
   , testPropertyNamed "golden SimpleScriptV2 Any"     "golden SimpleScriptV2 Any"     prop_golden_SimpleScriptV2_Any
   , testPropertyNamed "golden SimpleScriptV2 MofN"    "golden SimpleScriptV2 MofN"    prop_golden_SimpleScriptV2_MofN
-  , testPropertyNamed "roundtrip SimpleScriptV1 JSON" "roundtrip SimpleScriptV1 JSON" prop_roundtrip_SimpleScriptV1_JSON
-  , testPropertyNamed "roundtrip SimpleScriptV2 JSON" "roundtrip SimpleScriptV2 JSON" prop_roundtrip_SimpleScriptV2_JSON
+  , testPropertyNamed "roundtrip SimpleScript JSON"   "roundtrip SimpleScript JSON"   prop_roundtrip_SimpleScript_JSON
   , testPropertyNamed "roundtrip ScriptData"          "roundtrip ScriptData"          prop_roundtrip_ScriptData
   ]

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -58,16 +58,13 @@ prop_roundtrip_txbodycontent_txouts =
   -- because V2 is a superset of V1. So we accept that as a valid conversion.
   matchRefScript :: MonadTest m => (ReferenceScript BabbageEra, ReferenceScript BabbageEra) -> m ()
   matchRefScript (a, b)
-    | isSimpleScriptV1 a && isSimpleScriptV2 b =
+    | isSimpleScriptV2 a && isSimpleScriptV2 b =
       refScriptToShelleyScript BabbageEra a === refScriptToShelleyScript BabbageEra b
     | otherwise =
       a === b
 
-  isSimpleScriptV1 :: ReferenceScript era -> Bool
-  isSimpleScriptV1 = isLang (SimpleScriptLanguage SimpleScriptV1)
-
   isSimpleScriptV2 :: ReferenceScript era -> Bool
-  isSimpleScriptV2 = isLang (SimpleScriptLanguage SimpleScriptV2)
+  isSimpleScriptV2 = isLang SimpleScriptLanguage
 
   isLang :: ScriptLanguage a -> ReferenceScript era -> Bool
   isLang expected = \case

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -2118,7 +2118,7 @@ pTxIn balance =
       :: TxIn
       -> ScriptWitnessFiles WitCtxTxIn
     createSimpleReferenceScriptWitnessFiles refTxIn  =
-      let simpleLang = AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2)
+      let simpleLang = AnyScriptLanguage SimpleScriptLanguage
       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang Nothing
 
   pPlutusReferenceScriptWitness :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxTxIn)
@@ -2331,7 +2331,7 @@ pMintMultiAsset balanceExecUnits =
       -> PolicyId
       -> ScriptWitnessFiles WitCtxMint
     createSimpleMintingReferenceScriptWitnessFiles refTxIn pid =
-      let simpleLang = AnyScriptLanguage (SimpleScriptLanguage SimpleScriptV2)
+      let simpleLang = AnyScriptLanguage SimpleScriptLanguage
       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang (Just pid)
 
   pPlutusMintReferenceScriptWitnessFiles

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -883,8 +883,8 @@ getAllReferenceInputs txins mintWitnesses certFiles withdrawals readOnlyRefIns =
     case sWit of
       PlutusScriptWitness _ _ (PReferenceScript refIn _) _ _ _ -> Just refIn
       PlutusScriptWitness _ _ PScript{} _ _ _ -> Nothing
-      SimpleScriptWitness _ _ (SReferenceScript refIn _)  -> Just refIn
-      SimpleScriptWitness _ _ SScript{}  -> Nothing
+      SimpleScriptWitness _ (SReferenceScript refIn _)  -> Just refIn
+      SimpleScriptWitness _ SScript{}  -> Nothing
 
 toAddressInAnyEra
   :: CardanoEra era
@@ -1037,9 +1037,9 @@ createTxMintValue era (val, scriptWitnesses) =
       witnessesExtra = Set.elems (witnessesProvided Set.\\ witnessesNeeded)
 
 scriptWitnessPolicyId :: ScriptWitness witctx era -> Maybe PolicyId
-scriptWitnessPolicyId (SimpleScriptWitness _ version (SScript script)) =
-   Just . scriptPolicyId $ SimpleScript version script
-scriptWitnessPolicyId (SimpleScriptWitness _ _ (SReferenceScript _ mPid)) =
+scriptWitnessPolicyId (SimpleScriptWitness _ (SScript script)) =
+   Just . scriptPolicyId $ SimpleScript script
+scriptWitnessPolicyId (SimpleScriptWitness _ (SReferenceScript _ mPid)) =
    PolicyId <$> mPid
 scriptWitnessPolicyId (PlutusScriptWitness _ version (PScript script) _ _ _) =
    Just . scriptPolicyId $ PlutusScript version script


### PR DESCRIPTION
Resolves: #4261 
- [Timelock](https://github.com/input-output-hk/cardano-ledger/blob/31c0bb1f5e78e40b83adfd1a916e69f47fdc9835/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs#L105) scripts are a superset of [MultiSig](https://github.com/input-output-hk/cardano-ledger/blob/31c0bb1f5e78e40b83adfd1a916e69f47fdc9835/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs#L70) scripts in that they can also express validation in terms of before or after a particular slot. 

- In `cardano-ledger` the serialization of Timelock and MultiSig scripts are identical. 

Due to these properties, it is not necessary to distinguish between MultiSig and Timelock scripts. We can default to Timelock scripts without issue. 