### PR TITLE
backport to 1.35: add flake outputs that cicero expects

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Store.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Store.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/cardano-node-chairman/test/Spec/Network.hs
+++ b/cardano-node-chairman/test/Spec/Network.hs
@@ -33,7 +33,7 @@ import qualified System.Random as IO
 import qualified UnliftIO.Exception as IO
 
 hprop_isPortOpen_False :: Property
-hprop_isPortOpen_False = H.propertyOnce . H.workspace "temp/network" $ \_ -> do
+hprop_isPortOpen_False = H.propertyOnce $ do
   -- Check multiple random ports and assert that one is closed.
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program
@@ -42,7 +42,7 @@ hprop_isPortOpen_False = H.propertyOnce . H.workspace "temp/network" $ \_ -> do
   H.assert (False `L.elem` results)
 
 hprop_isPortOpen_True :: Property
-hprop_isPortOpen_True = H.propertyOnce . H.workspace "temp/network" $ \_ -> do
+hprop_isPortOpen_True = H.propertyOnce $ do
   -- Check first random port from multiple possible ports to be successfully bound is open
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program

--- a/cardano-testnet/test/Spec/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Spec/Cli/Babbage/LeadershipSchedule.hs
@@ -116,7 +116,7 @@ hprop_leadershipSchedule = H.integration . H.runFinallies . H.workspace "alonzo"
 
     leadershipScheduleDeadline <- H.noteShowM $ DTC.addUTCTime 180 <$> H.noteShowIO DTC.getCurrentTime
 
-    H.byDeadlineM 5 leadershipScheduleDeadline $ do
+    H.byDeadlineM 5 leadershipScheduleDeadline "leadershipSchedule:current:error" $ do
       void $ H.execCli' execConfig
         [ "query", "leadership-schedule"
         , "--testnet-magic", show @Int testnetMagic
@@ -157,7 +157,7 @@ hprop_leadershipSchedule = H.integration . H.runFinallies . H.workspace "alonzo"
 
     leadershipScheduleDeadline <- H.noteShowM $ DTC.addUTCTime 180 <$> H.noteShowIO DTC.getCurrentTime
 
-    H.byDeadlineM 5 leadershipScheduleDeadline $ do
+    H.byDeadlineM 5 leadershipScheduleDeadline "leadershipSchedule:next:error" $ do
       void $ H.execCli' execConfig
         [ "query", "leadership-schedule"
         , "--testnet-magic", show @Int testnetMagic


### PR DESCRIPTION
This is a partial backport of 04c1e174d24377cf7108c1abc21ff16af4966668.