### PR TITLE
Replace `Era` with `AnyCardanoEra` in cardano-testnet

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Shelley.Parsers
 
     -- * Field parser and renderers
   , parseTxIn
+  , pCardanoEra
   ) where
 
 import           Cardano.Prelude hiding (All, Any)
@@ -684,7 +685,7 @@ pTransaction =
 
   pTransactionBuild :: Parser TransactionCmd
   pTransactionBuild =
-    TxBuild <$> pCardanoEra
+    TxBuild <$> pCardanoEra "Specify the"
             <*> pConsensusModeParams
             <*> pNetworkId
             <*> optional pScriptValidity
@@ -723,7 +724,7 @@ pTransaction =
 
   pTransactionBuildRaw :: Parser TransactionCmd
   pTransactionBuildRaw =
-    TxBuildRaw <$> pCardanoEra
+    TxBuildRaw <$> pCardanoEra "Specify the"
                <*> optional pScriptValidity
                <*> some (pTxIn ManualBalance)
                <*> many pReadOnlyReferenceTxIn
@@ -788,7 +789,7 @@ pTransaction =
 
   pTransactionCalculateMinReqUTxO :: Parser TransactionCmd
   pTransactionCalculateMinReqUTxO = TxCalculateMinRequiredUTxO
-    <$> pCardanoEra
+    <$> pCardanoEra "Specify the"
     <*> pProtocolParamsSourceSpec
     <*> pTxOut
 
@@ -2032,31 +2033,31 @@ pTxSubmitFile =
     <> Opt.completer (Opt.bashCompleter "file")
     )
 
-pCardanoEra :: Parser AnyCardanoEra
-pCardanoEra = asum
+pCardanoEra :: String -> Parser AnyCardanoEra
+pCardanoEra h = asum
   [ Opt.flag' (AnyCardanoEra ByronEra)
       (  Opt.long "byron-era"
-      <> Opt.help "Specify the Byron era"
+      <> Opt.help (h ++ " Byron era")
       )
   , Opt.flag' (AnyCardanoEra ShelleyEra)
       (  Opt.long "shelley-era"
-      <> Opt.help "Specify the Shelley era"
+      <> Opt.help (h ++ " Shelley era")
       )
   , Opt.flag' (AnyCardanoEra AllegraEra)
       (  Opt.long "allegra-era"
-      <> Opt.help "Specify the Allegra era"
+      <> Opt.help (h ++ " Allegra era")
       )
   , Opt.flag' (AnyCardanoEra MaryEra)
       (  Opt.long "mary-era"
-      <> Opt.help "Specify the Mary era"
+      <> Opt.help (h ++ " Mary era")
       )
   , Opt.flag' (AnyCardanoEra AlonzoEra)
       (  Opt.long "alonzo-era"
-      <> Opt.help "Specify the Alonzo era"
+      <> Opt.help (h ++ " Alonzo era")
       )
   , Opt.flag' (AnyCardanoEra BabbageEra)
       (  Opt.long "babbage-era"
-      <> Opt.help "Specify the Babbage era (default)"
+      <> Opt.help (h ++ " Babbage era (default)")
       )
     -- Default for now:
   , pure (AnyCardanoEra BabbageEra)

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -108,6 +108,7 @@ test-suite cardano-testnet-tests
 
   other-modules:        Test.Cli.Alonzo.LeadershipSchedule
                         Test.Cli.Babbage.LeadershipSchedule
+                        Test.Cli.Babbage.BabbageTest
                         Test.Cli.KesPeriodInfo
                         Test.FoldBlocks
                         Test.Misc

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -1,22 +1,19 @@
-{-# LANGUAGE TypeApplications #-}
-
 module Parsers.Cardano
   ( CardanoOptions(..)
   , cmdCardano
   , runCardanoOptions
   ) where
 
-import           Prelude
 import qualified Data.List as L
 import           Options.Applicative
 import qualified Options.Applicative as OA
-import           Text.Read
+import           Prelude
 
-import           Testnet.Util.Runtime (readNodeLoggingFormat)
+import           Cardano.CLI.Shelley.Parsers
 import           Testnet
 import           Testnet.Cardano
 import           Testnet.Run (runTestnet)
-
+import           Testnet.Util.Runtime (readNodeLoggingFormat)
 
 data CardanoOptions = CardanoOptions
   { maybeTestnetMagic :: Maybe Int
@@ -40,13 +37,7 @@ optsTestnet = CardanoTestnetOptions
       <>  OA.showDefault
       <>  OA.value (cardanoNumPoolNodes defaultTestnetOptions)
       )
-  <*> OA.option (OA.eitherReader readEither)
-      (   OA.long "era"
-      <>  OA.help ("Era to upgrade to.  " <> show @[Era] [minBound .. maxBound])
-      <>  OA.metavar "ERA"
-      <>  OA.showDefault
-      <>  OA.value (cardanoEra defaultTestnetOptions)
-      )
+  <*> pCardanoEra "Start cluster in the"
   <*> OA.option auto
       (   OA.long "epoch-length"
       <>  OA.help "Epoch length"

--- a/cardano-testnet/src/Testnet/Conf.hs
+++ b/cardano-testnet/src/Testnet/Conf.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Testnet.Conf
   ( ProjectBase(..)
@@ -41,11 +40,20 @@ data Conf = Conf
   } deriving (Eq, Show)
 
 mkConf :: ProjectBase -> YamlFilePath -> FilePath -> Maybe Int -> H.Integration Conf
-mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsPath maybeMagic = do
-  testnetMagic <- H.noteShowIO $ maybe (IO.randomRIO (1000, 2000)) return maybeMagic
-  tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
-  tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath
-  socketDir <- H.noteShow $ tempRelPath </> "socket"
-  logDir <- H.noteTempFile tempAbsPath "logs"
+mkConf (ProjectBase base') (YamlFilePath configurationTemplate') tempAbsPath' maybeMagic = do
+  testnetMagic' <- H.noteShowIO $ maybe (IO.randomRIO (1000, 2000)) return maybeMagic
+  tempBaseAbsPath' <- H.noteShow $ FP.takeDirectory tempAbsPath'
+  tempRelPath' <- H.noteShow $ FP.makeRelative tempBaseAbsPath' tempAbsPath'
+  socketDir' <- H.noteShow $ tempRelPath' </> "socket"
+  logDir' <- H.noteTempFile tempAbsPath' "logs"
 
-  return $ Conf {..}
+  return $ Conf
+            { tempAbsPath = tempAbsPath'
+            , tempRelPath = tempRelPath'
+            , tempBaseAbsPath = tempBaseAbsPath'
+            , logDir = logDir'
+            , base = base'
+            , socketDir = socketDir'
+            , configurationTemplate = configurationTemplate'
+            , testnetMagic = testnetMagic'
+            }

--- a/cardano-testnet/test/Main.hs
+++ b/cardano-testnet/test/Main.hs
@@ -12,14 +12,18 @@ import qualified Test.Tasty as T
 import qualified Test.Tasty.Ingredients as T
 
 --import qualified Test.Cli.Alonzo.LeadershipSchedule
-import qualified Test.Cli.Babbage.LeadershipSchedule
-import qualified Test.Cli.KesPeriodInfo
-import qualified Test.FoldBlocks
-import qualified Test.Node.Shutdown
-import qualified Test.ShutdownOnSlotSynced
+import qualified Test.Cli.Babbage.BabbageTest
+--import qualified Test.Cli.Babbage.LeadershipSchedule
+--import qualified Test.Cli.KesPeriodInfo
+--import qualified Test.FoldBlocks
+--import qualified Test.Node.Shutdown
+--import qualified Test.ShutdownOnSlotSynced
 
 import           Testnet.Util.Ignore as H
 
+tests :: IO TestTree
+tests = pure $ T.testGroup "test/Spec.hs" [H.ignoreOnWindows "Babbage" Test.Cli.Babbage.BabbageTest.hprop_babbageTest]
+{-
 tests :: IO TestTree
 tests = pure $ T.testGroup "test/Spec.hs"
   [ T.testGroup "Spec"
@@ -39,6 +43,7 @@ tests = pure $ T.testGroup "test/Spec.hs"
     ]
   , H.ignoreOnWindows "foldBlocks receives ledger state" Test.FoldBlocks.prop_foldBlocks
   ]
+-}
 
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients

--- a/cardano-testnet/test/Test/Cli/Babbage/BabbageTest.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/BabbageTest.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
+{- HLINT ignore "Redundant return" -}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Use let" -}
+
+module Test.Cli.Babbage.BabbageTest
+  ( hprop_babbageTest
+  ) where
+
+import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Control.Monad (void)
+import           Data.Monoid (Last (..))
+import           GHC.Stack (callStack)
+import           Hedgehog (Property)
+import           Prelude
+import           System.Environment (getEnvironment)
+import           System.FilePath ((</>))
+
+import qualified Data.Aeson as J
+import qualified Data.Time.Clock as DTC
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
+import qualified System.Directory as IO
+import qualified System.Info as SYS
+
+import           Cardano.Testnet
+import           Testnet.Util.Process
+import           Testnet.Util.Runtime
+
+-- TODO: Create a testnet and check the logs to see if indeed it is babbage
+hprop_babbageTest :: Property
+hprop_babbageTest = integration . H.runFinallies . H.workspace "babbage" $ \tempAbsBasePath' -> do
+  H.note_ SYS.os
+  base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
+  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
+  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
+    mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+
+  work <- H.note $ tempAbsPath </> "work"
+  H.createDirectoryIfMissing work
+
+  let
+    testnetOptions = BabbageOnlyTestnetOptions $ babbageDefaultTestnetOptions
+      { babbageNodeLoggingFormat = NodeLoggingFormatAsJson
+      }
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    -- , wallets
+    -- , delegators
+    } <- testnet testnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+
+  env <- H.evalIO getEnvironment
+
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+
+  execConfig <- H.noteShow H.ExecConfig
+    { H.execConfigEnv = Last $ Just $
+      [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName poolSprocket1)
+      ]
+      -- The environment must be passed onto child process on Windows in order to
+      -- successfully start that process.
+      <> env
+    , H.execConfigCwd = Last $ Just tempBaseAbsPath
+    }
+
+  tipDeadline <- H.noteShowM $ DTC.addUTCTime 110 <$> H.noteShowIO DTC.getCurrentTime
+
+  H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
+    void $ execCli' execConfig
+      [ "query", "tip"
+      , "--testnet-magic", show @Int testnetMagic
+      , "--out-file", work </> "current-tip.json"
+      ]
+
+    tipJson <- H.leftFailM . H.readJsonFile $ work </> "current-tip.json"
+    tip <- H.noteShowM $ H.jsonErrorFail $ J.fromJSON @QueryTipLocalStateOutput tipJson
+
+    currEpoch <- case mEpoch tip of
+      Nothing -> H.failMessage callStack "cardano-cli query tip returned Nothing for EpochNo"
+      Just currEpoch -> return currEpoch
+
+    H.note_ $ "Current Epoch: " <> show currEpoch
+    H.assert $ currEpoch > 2
+    H.assert False

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -44,7 +44,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = integration . H.runFinallies . H.workspace "alonzo" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = integration . H.runFinallies . H.workspace "babbage" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"


### PR DESCRIPTION
This will remove the maintenance burden of updating `Era` to match `AnyCardanoEra`