### PR TITLE
Use -Werror by default only in CI

### DIFF
--- a/.github/workflows/cabal.project.local.ci.Darwin
+++ b/.github/workflows/cabal.project.local.ci.Darwin
@@ -1,3 +1,36 @@
+package cardano-api
+  ghc-options: -Werror
+
+package cardano-cli
+  ghc-options: -Werror
+
+package cardano-git-rev
+  ghc-options: -Werror
+
+package cardano-node
+  ghc-options: -Werror
+
+package cardano-node-chairman
+  ghc-options: -Werror
+
+package cardano-testnet
+  ghc-options: -Werror
+
+package tx-generator
+  ghc-options: -Werror
+
+package trace-dispatcher
+  ghc-options: -Werror
+
+package trace-resources
+  ghc-options: -Werror
+
+package cardano-tracer
+  ghc-options: -Werror
+
+package cardano-submit-api
+  ghc-options: -Werror
+
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 

--- a/.github/workflows/cabal.project.local.ci.Linux
+++ b/.github/workflows/cabal.project.local.ci.Linux
@@ -1,3 +1,36 @@
+package cardano-api
+  ghc-options: -Werror
+
+package cardano-cli
+  ghc-options: -Werror
+
+package cardano-git-rev
+  ghc-options: -Werror
+
+package cardano-node
+  ghc-options: -Werror
+
+package cardano-node-chairman
+  ghc-options: -Werror
+
+package cardano-testnet
+  ghc-options: -Werror
+
+package tx-generator
+  ghc-options: -Werror
+
+package trace-dispatcher
+  ghc-options: -Werror
+
+package trace-resources
+  ghc-options: -Werror
+
+package cardano-tracer
+  ghc-options: -Werror
+
+package cardano-submit-api
+  ghc-options: -Werror
+
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 

--- a/.github/workflows/cabal.project.local.ci.MINGW64_NT-10.0-20348
+++ b/.github/workflows/cabal.project.local.ci.MINGW64_NT-10.0-20348
@@ -1,3 +1,36 @@
+package cardano-api
+  ghc-options: -Werror
+
+package cardano-cli
+  ghc-options: -Werror
+
+package cardano-git-rev
+  ghc-options: -Werror
+
+package cardano-node
+  ghc-options: -Werror
+
+package cardano-node-chairman
+  ghc-options: -Werror
+
+package cardano-testnet
+  ghc-options: -Werror
+
+package tx-generator
+  ghc-options: -Werror
+
+package trace-dispatcher
+  ghc-options: -Werror
+
+package trace-resources
+  ghc-options: -Werror
+
+package cardano-tracer
+  ghc-options: -Werror
+
+package cardano-submit-api
+  ghc-options: -Werror
+
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 

--- a/cabal.project
+++ b/cabal.project
@@ -34,39 +34,6 @@ packages:
     trace-resources
     trace-forward
 
-package cardano-api
-  ghc-options: -Werror
-
-package cardano-cli
-  ghc-options: -Werror
-
-package cardano-git-rev
-  ghc-options: -Werror
-
-package cardano-node
-  ghc-options: -Werror
-
-package cardano-node-chairman
-  ghc-options: -Werror
-
-package cardano-testnet
-  ghc-options: -Werror
-
-package tx-generator
-  ghc-options: -Werror
-
-package trace-dispatcher
-  ghc-options: -Werror
-
-package trace-resources
-  ghc-options: -Werror
-
-package cardano-tracer
-  ghc-options: -Werror
-
-package cardano-submit-api
-  ghc-options: -Werror
-
 package cryptonite
   -- Using RDRAND instead of /dev/urandom as an entropy source for key
   -- generation is dubious. Set the flag so we use /dev/urandom by default.

--- a/cabal.project
+++ b/cabal.project
@@ -64,7 +64,7 @@ package trace-resources
 package cardano-tracer
   ghc-options: -Werror
 
-package submit-api
+package cardano-submit-api
   ghc-options: -Werror
 
 package cryptonite


### PR DESCRIPTION
If one wants to use `-Werror` in development, one can always set it in
`cabal.project.local` file.
