### PR TITLE
Markdown links CI check

### DIFF
--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -1,0 +1,12 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: yes


### PR DESCRIPTION
This adds a CI check to make sure Markdown links are valid.

There are currently failures in this CI check, but the idea is to merge the PR as is and then ask the respective teams to fix the invalid links.

Depends on:
* https://github.com/input-output-hk/cicero/issues/67
*  https://github.com/input-output-hk/cardano-ledger/pull/3245
* https://github.com/input-output-hk/cicero/issues/67