### PR TITLE
New NodeToClientVersionOf typeclass

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -72,6 +72,7 @@ library
                         Cardano.Api.IPC
                         Cardano.Api.IPC.Monad
                         Cardano.Api.InMode
+                        Cardano.Api.IPC.Version
                         Cardano.Api.Json
                         Cardano.Api.Keys.Byron
                         Cardano.Api.Keys.Class

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -58,7 +58,6 @@ import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Ouroboros.Consensus.Shelley.Eras as Consensus (StandardAllegra, StandardAlonzo,
                    StandardBabbage, StandardMary, StandardShelley)
 
-
 -- | A type used as a tag to distinguish the Byron era.
 data ByronEra
 

--- a/cardano-api/src/Cardano/Api/IPC/Version.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Version.hs
@@ -1,0 +1,37 @@
+module Cardano.Api.IPC.Version
+  ( NodeToClientVersionOf (..)
+  , MinNodeToClientVersion
+
+  -- *** Error types
+  , UnsupportedNtcVersionError(..)
+  ) where
+
+import           Data.Eq (Eq)
+import           Text.Show (Show)
+
+import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
+
+-- | The query 'a' is a versioned query, which means it requires the Node to support a minimum
+-- Node-to-Client version.
+--
+-- Background: The node to client protocol is such that it will disconnect on any
+-- unrecognised queries.  This means that for a Node-to-Client connection, if a query is sent
+-- that was introduced in a Node-to-Client version that is newer than the Node-To-Client version
+-- of the connection, the node will disconnect the client.  The client will not get any
+-- information about why the disconnect happened.  This is a bad user experience for tools
+-- such as the CLI.
+--
+-- To improve the user experience the API needs to prevent the sending of queries that are
+-- newer than the Node-To-Client version of the connection by checking the version of the
+-- query before sending it.  This affords the ability to return 'UnsupportedNtcVersionError',
+-- informing the caller of a Node-To-Client versioning issue.
+--
+-- For maintaining typeclass instances, see the 'NodeToClientVersion' type documentation for
+-- a list of versions and the queries that were introduced for those versions.
+class NodeToClientVersionOf a where
+  nodeToClientVersionOf :: a -> NodeToClientVersion
+
+type MinNodeToClientVersion = NodeToClientVersion
+
+data UnsupportedNtcVersionError = UnsupportedNtcVersionError !MinNodeToClientVersion !NodeToClientVersion
+  deriving (Eq, Show)


### PR DESCRIPTION
This allows code to check what version of the node to client protocol is needed to use the query.  For example:

```
ntcVersionOf $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolParameters
```

Whilst this function can be called directly, it is intended to be called by `queryExpr` eventually so that only queries that are valid for the current protocol are ever sent.