### PR TITLE
Better error message for query utxo without oops

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,10 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
-index-state: 2022-12-11T00:00:00Z
+index-state: 2023-01-20T05:50:56Z
 
 index-state:
-  , hackage.haskell.org 2022-12-11T00:00:00Z
+  , hackage.haskell.org 2023-01-20T05:50:56Z
   , cardano-haskell-packages 2022-12-14T00:40:15Z
 
 packages:

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -166,7 +166,7 @@ library
                       , text
                       , time
                       , transformers
-                      , transformers-except
+                      , transformers-except ^>= 0.1.3
                       , typed-protocols ^>= 0.1
                       , unordered-containers >= 0.2.11
                       , vector

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -620,6 +620,7 @@ module Cardano.Api (
     UTxO(..),
     queryNodeLocalState,
     executeQueryCardanoMode,
+    UnsupportedNtcVersionError(..),
 
     -- *** Local tx monitoring
     LocalTxMonitorClient(..),

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -77,7 +77,9 @@ module Cardano.Api.IPC (
     consensusModeOnly,
     toAcquiringFailure,
 
-    NodeToClientVersion(..)
+    NodeToClientVersion(..),
+
+    UnsupportedNtcVersionError(..),
   ) where
 
 import           Prelude
@@ -130,6 +132,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 import           Cardano.Api.Block
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.InMode
+import           Cardano.Api.IPC.Version
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.Protocol

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -9,18 +9,15 @@ module Cardano.Api.IPC.Monad
   , determineEraExpr
   ) where
 
-import           Control.Applicative
+import           Prelude
+
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Cont
+import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import           Data.Bifunctor (first)
-import           Data.Either
-import           Data.Function
-import           Data.Maybe
-import           Data.Ord (Ord (..))
-import           System.IO
 
 import           Cardano.Ledger.Shelley.Scripts ()
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
@@ -31,7 +28,6 @@ import           Cardano.Api.Eras
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Version
 import           Cardano.Api.Modes
-import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 
 
 {- HLINT ignore "Use const" -}

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -147,7 +147,7 @@ library
                       , text
                       , time
                       , transformers
-                      , transformers-except
+                      , transformers-except ^>= 0.1.3
                       , unliftio-core
                       , utf8-string
                       , vector


### PR DESCRIPTION
This makes the checking of node to client versions less manual.  It replaces a earlier PRs:

* https://github.com/input-output-hk/cardano-node/pull/2957
* https://github.com/input-output-hk/cardano-node/pull/3390
* https://github.com/input-output-hk/cardano-node/pull/3358
* https://github.com/input-output-hk/cardano-node/pull/2957

This PR improves on the earlier version by making it so that the monadic expressions no longer need to know what version each query requires.  If the node that is connected to does not support the query being made, then the query expression returns `UnsupportedNtcVersionError` which can be handled in a convenient top-level location.

The PR uses the new functions `onLeft` and `onNothing` from `transformers-except-0.1.3` to improve the way we structure code.