### PR TITLE
Consolidate two fields of CardanoTestnetOptions

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -7,15 +7,16 @@ module Parsers.Cardano
   ) where
 
 import           Prelude
+
 import qualified Data.List as L
 import           Options.Applicative
 import qualified Options.Applicative as OA
 import           Text.Read
 
-import           Testnet.Util.Runtime (readNodeLoggingFormat)
 import           Testnet
 import           Testnet.Cardano
 import           Testnet.Run (runTestnet)
+import           Testnet.Util.Runtime (readNodeLoggingFormat)
 
 
 data CardanoOptions = CardanoOptions
@@ -25,21 +26,7 @@ data CardanoOptions = CardanoOptions
 
 optsTestnet :: Parser CardanoTestnetOptions
 optsTestnet = CardanoTestnetOptions
-  <$> OA.option
-      ((`L.replicate` cardanoDefaultTestnetNodeOptions) <$> auto)
-      (   OA.long "num-bft-nodes"
-      <>  OA.help "Number of BFT nodes"
-      <>  OA.metavar "COUNT"
-      <>  OA.showDefault
-      <>  OA.value (cardanoBftNodeOptions defaultTestnetOptions)
-      )
-  <*> OA.option auto
-      (   OA.long "num-pool-nodes"
-      <>  OA.help "Number of pool nodes"
-      <>  OA.metavar "COUNT"
-      <>  OA.showDefault
-      <>  OA.value (cardanoNumPoolNodes defaultTestnetOptions)
-      )
+  <$> pNumBftAndSpoNodes
   <*> OA.option (OA.eitherReader readEither)
       (   OA.long "era"
       <>  OA.help ("Era to upgrade to.  " <> show @[Era] [minBound .. maxBound])
@@ -82,6 +69,26 @@ optsTestnet = CardanoTestnetOptions
       <>  OA.showDefault
       <>  OA.value (cardanoNodeLoggingFormat defaultTestnetOptions)
       )
+
+pNumBftAndSpoNodes :: Parser [TestnetNodeOptions]
+pNumBftAndSpoNodes =
+  (++)
+    <$> OA.option
+          ((`L.replicate` BftTestnetNodeOptions []) <$> auto)
+          (   OA.long "num-bft-nodes"
+          <>  OA.help "Number of BFT nodes"
+          <>  OA.metavar "COUNT"
+          <>  OA.showDefault
+          <>  OA.value (cardanoNodes defaultTestnetOptions)
+          )
+    <*> OA.option
+          ((`L.replicate` SpoTestnetNodeOptions) <$> auto)
+          (   OA.long "num-pool-nodes"
+          <>  OA.help "Number of pool nodes"
+          <>  OA.metavar "COUNT"
+          <>  OA.showDefault
+          <>  OA.value (cardanoNodes defaultTestnetOptions)
+          )
 
 optsCardano :: Parser CardanoOptions
 optsCardano = CardanoOptions

--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -31,12 +31,12 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified System.Info as OS
 
+import qualified Testnet.Conf as H
 import qualified Testnet.Util.Assert as H
 import           Testnet.Util.Process (execCli_)
 import           Testnet.Util.Runtime (Delegator (..), NodeLoggingFormat (..), PaymentKeyPair (..),
-                   PoolNode (PoolNode), PoolNodeKeys (..), StakingKeyPair (..),
-                   TestnetRuntime (..), startNode)
-import qualified Testnet.Conf as H
+                   PoolNode (PoolNode), PoolNodeKeys (..), StakingKeyPair (..), TestnetRuntime (..),
+                   startNode)
 
 
 {- HLINT ignore "Redundant flip" -}

--- a/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
@@ -34,8 +34,8 @@ import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Info as SYS
 
-import           Test.Misc
 import           Cardano.Testnet
+import           Test.Misc
 import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
@@ -51,7 +51,7 @@ hprop_kes_period_info = integration . H.runFinallies . H.workspace "chairman" $ 
                               tempAbsBasePath' Nothing
 
   let fastTestnetOptions = CardanoOnlyTestnetOptions $ cardanoDefaultTestnetOptions
-                             { cardanoBftNodeOptions = replicate 1 cardanoDefaultTestnetNodeOptions
+                             { cardanoNodes = cardanoDefaultTestnetNodeOptions
                              , cardanoEpochLength = 500
                              , cardanoSlotLength = 0.02
                              , cardanoActiveSlotsCoeff = 0.1

--- a/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
@@ -7,15 +7,16 @@ module Test.ShutdownOnSlotSynced
   ) where
 
 import           Prelude
+
 import           Control.Monad
 import           Data.Either (isRight)
 import           Data.List (find, isInfixOf)
 import           Data.Maybe
 import           GHC.IO.Exception (ExitCode (ExitSuccess))
 import           GHC.Stack (callStack)
-import           System.FilePath ((</>))
 import qualified System.Directory as IO
-import           Text.Read (readMaybe) 
+import           System.FilePath ((</>))
+import           Text.Read (readMaybe)
 
 import           Hedgehog (Property, assert, (===))
 import qualified Hedgehog.Extras.Test.Base as H
@@ -23,7 +24,7 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 
 import           Cardano.Testnet
-import           Testnet.Util.Runtime (TestnetRuntime(..))
+import           Testnet.Util.Runtime (TestnetRuntime (..))
 
 hprop_shutdownOnSlotSynced :: Property
 hprop_shutdownOnSlotSynced = integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
@@ -37,12 +38,10 @@ hprop_shutdownOnSlotSynced = integration . H.runFinallies . H.workspace "chairma
   let fastTestnetOptions = CardanoOnlyTestnetOptions $ cardanoDefaultTestnetOptions
         { cardanoEpochLength = 300
         , cardanoSlotLength = slotLen
-        , cardanoBftNodeOptions =
-          [ TestnetNodeOptions
-              { extraNodeCliArgs = ["--shutdown-on-slot-synced", show maxSlot]
-              }
-          , cardanoDefaultTestnetNodeOptions
-          , cardanoDefaultTestnetNodeOptions
+        , cardanoNodes =
+          [ BftTestnetNodeOptions ["--shutdown-on-slot-synced", show maxSlot]
+          , BftTestnetNodeOptions []
+          , SpoTestnetNodeOptions
           ]
         }
   TestnetRuntime { bftNodes = node:_ } <- testnet fastTestnetOptions conf


### PR DESCRIPTION
- Consolidate `cardanoBftNodeOptions` and `cardanoNumPoolNodes` records of `CardanoTestnetOptions`
- Implement `testnetMinimumConfigurationRequirements`