### PR TITLE
Refactor onNothingThrow

### DIFF
--- a/cardano-api/src/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Query.hs
@@ -15,7 +15,7 @@ module Cardano.Api.Convenience.Query (
 
 import           Prelude
 
-import           Control.Monad.Trans.Except (ExceptT(..), except, runExceptT)
+import           Control.Monad.Trans.Except (ExceptT (..), except, runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 import           Data.Bifunctor (first)
 import           Data.Function ((&))
@@ -77,8 +77,8 @@ queryStateForBalancedTx era networkId allTxIns = runExceptT $ do
 
   qSbe <- except $ getSbe $ cardanoEraStyle era
 
-  qeInMode <- toEraInMode era CardanoMode
-    & onNothingThrow (EraConsensusModeMismatch (AnyConsensusMode CardanoMode) (getIsCardanoEraConstraint era $ AnyCardanoEra era))
+  qeInMode <- pure (toEraInMode era CardanoMode)
+    & onNothingThrowA (EraConsensusModeMismatch (AnyConsensusMode CardanoMode) (getIsCardanoEraConstraint era $ AnyCardanoEra era))
 
   -- Queries
   let utxoQuery = QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe


### PR DESCRIPTION
Rename `onNothingThrow` to `onNothingThrowA`, which reads better.

The `A` suffix is the English work "a" as in `onNothingThrowA Banana` reads as "on nothing, throw a banana".

Lift the type of `onNothingThrowA` to into `ExceptT`.  Add `onNothing`, `onLeft` and `onLeftThrowIt` functions.

`onNothingThrowA` has this type signature:

```
onNothingThrowA :: Monad m => e -> Maybe a -> ExceptT e m a
```

And it was used like this:

```
f :: Maybe a

r <- f
    & onNothingThrowA ErrorValue
```

It bothered me that I would have to have another version to accomodate this case:

```
g :: ExceptT ErrorType IO (Maybe a)

onNothingThrowAM :: Monad m => e -> ExceptT e (Maybe a) -> ExceptT e m a

r <- g
    & onNothingThrowAM ErrorValue
```

Then I realised that any pure expression can be lifted so if I delete `onNothingThrowA` and renamed `onNothingThrowAM` to `onNothingThrowA`, I can use the new lifted function by adding `pure`
```
f :: Maybe a

r <- pure f
    & onNothingThrowA ErrorValue
```

This means I don't have to have a pure version and a `ExceptT` version for every possible function.  I can just have the `ExceptT` version and lift into it.