### PR TITLE
Add Cardano RPC command

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -90,7 +90,8 @@ library
                         Cardano.CLI.Shelley.Run.TextView
                         Cardano.CLI.Shelley.Run.Transaction
                         Cardano.CLI.Shelley.Run.Read
-                        Cardano.CLI.Shelley.Run.Validate
+                        Cardano.CLI.Shelley.Run.Rpc
+                        Cardano.CLI.Shelley.Run.Validate                      
 
                         Cardano.CLI.TopHandler
 
@@ -152,6 +153,8 @@ library
                       , utf8-string
                       , vector
                       , yaml
+                      , http-conduit
+                      , case-insensitive
 
 executable cardano-cli
   import:               project-config
@@ -165,6 +168,7 @@ executable cardano-cli
                       , cardano-prelude
                       , optparse-applicative-fork
                       , transformers-except
+
 
 test-suite cardano-cli-test
   import:               project-config

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -10,7 +10,7 @@ import           Cardano.Prelude
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run (ClientCommand (..))
-import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
+import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands, parseRpcCommand)
 import           Options.Applicative
 import           Prelude (String)
 
@@ -45,6 +45,7 @@ parseClientCommand =
     -- so we list it first.
     [ parseShelley
     , parseByron
+    , fmap RPCCommand parseRpcCommand 
     , parseDeprecatedShelleySubcommand
     , backwardsCompatibilityCommands
     , parseDisplayVersion opts

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -18,7 +18,7 @@ import qualified Data.Text.IO as Text
 import           Cardano.CLI.Byron.Commands (ByronCommand)
 import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
                    runByronClientCommand)
-import           Cardano.CLI.Shelley.Commands (ShelleyCommand)
+import           Cardano.CLI.Shelley.Commands (ShelleyCommand, RpcCommand)
 import           Cardano.CLI.Shelley.Run (ShelleyClientCmdError, renderShelleyClientCmdError,
                    runShelleyClientCommand)
 
@@ -34,6 +34,7 @@ import           System.Info (arch, compilerName, compilerVersion, os)
 
 import qualified Data.List as L
 import qualified System.IO as IO
+import Cardano.CLI.Shelley.Run.Rpc (runRpcCmd)
 
 -- | Sub-commands of 'cardano-cli'.
 data ClientCommand =
@@ -43,6 +44,8 @@ data ClientCommand =
 
     -- | Shelley Related Commands
   | ShelleyCommand ShelleyCommand
+
+  | RPCCommand RpcCommand
 
     -- | Shelley-related commands that have been parsed under the
     -- now-deprecated \"shelley\" subcommand.
@@ -58,6 +61,7 @@ data ClientCommandErrors
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()
 runClientCommand (ByronCommand c) = firstExceptT ByronClientError $ runByronClientCommand c
 runClientCommand (ShelleyCommand c) = firstExceptT (ShelleyClientError c) $ runShelleyClientCommand c
+runClientCommand (RPCCommand cmd ) = runRpcCmd cmd
 runClientCommand (DeprecatedShelleySubcommand c) =
   firstExceptT (ShelleyClientError c)
     $ runShelleyClientCommandWithDeprecationWarning

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -15,7 +15,9 @@ module Cardano.CLI.Shelley.Commands
   , GovernanceCmd (..)
   , GenesisCmd (..)
   , TextViewCmd (..)
+  , RpcCommand(..)
   , renderShelleyCommand
+  , renderRpcCommand
 
     -- * CLI flag types
   , AddressKeyType (..)
@@ -57,6 +59,9 @@ import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
 import           Cardano.Ledger.Shelley.TxBody (MIRPot)
+import qualified Data.Text as Text
+import Data.Maybe (isJust)
+import Data.Char (isSpace)
 --
 -- Shelley CLI command data types
 --
@@ -431,6 +436,23 @@ data TextViewCmd
   = TextViewInfo !FilePath (Maybe OutputFile)
   deriving Show
 
+
+data RpcCommand
+  = RpcCommand {
+      rcpUrl:: Text,
+      rpcBasicAuth :: Maybe Text,
+      rpcHeaders :: [Text],
+      rpcMethod :: Text,
+      rpcArgs :: [Text]
+    }
+  deriving Show
+
+renderRpcCommand :: RpcCommand -> Text
+renderRpcCommand (RpcCommand _ _ _  method args) = Text.unwords $ map addQuotes $ method : args
+  where
+    addQuotes txt = if isJust $  Text.findIndex isSpace  txt
+                      then Text.concat ["\"",txt,"\""]
+                      else txt
 
 renderTextViewCmd :: TextViewCmd -> Text
 renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -6,6 +6,7 @@
 module Cardano.CLI.Shelley.Parsers
   ( -- * CLI command parser
     parseShelleyCommands
+  , parseRpcCommand
 
     -- * CLI command and flag types
   , module Cardano.CLI.Shelley.Commands
@@ -99,6 +100,37 @@ parseShelleyCommands =
             )
 
       ]
+
+parseRpcCommand :: Parser RpcCommand
+parseRpcCommand =
+  Opt.hsubparser $ Opt.command  "rpc" (Opt.info pRpcCmd  (Opt.progDesc "Call cardano rpc over network"))
+
+
+pRpcCmd :: Parser RpcCommand
+pRpcCmd =RpcCommand
+      <$> Opt.strOption (
+                Opt.value "http://localhost:3345"
+            <>  Opt.long "url"
+            <> Opt.showDefault
+            <> Opt.help "Rpc Address")
+      <*> optional (Opt.strOption (
+                  Opt.long "user"
+              <>  Opt.short 'u'
+              <>  Opt.help "Basic auth  \"User:Password\""))
+      <*> pHeaders
+      <*> pMethod
+      <*> pArgs
+  where
+    pHeaders = many $  Opt.strOption (Opt.long  "header"
+          <>  Opt.short 'H'
+          <>  Opt.help "Rpc extra HTTP headers \"HeaderName:HeaderValue\"")
+
+    pMethod = Opt.strArgument ( Opt.metavar  "method"
+        <>  Opt.help "Json RPC method"
+      )
+    pArgs = many $ Opt.strArgument ( Opt.metavar  "argument"
+        <>  Opt.help "RPC method arguments"
+      )
 
 pTextViewCmd :: Parser TextViewCmd
 pTextViewCmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Rpc.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Rpc.hs
@@ -1,0 +1,105 @@
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-#LANGUAGE OverloadedStrings#-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Cardano.CLI.Shelley.Run.Rpc
+  ( runRpcCmd
+  ) where
+import Control.Monad.IO.Class
+import Cardano.CLI.Shelley.Parsers (RpcCommand(..))
+import Prelude
+import qualified Data.Text.IO as T
+import qualified Data.Text as T
+import Network.HTTP.Client.Conduit (parseRequest, RequestBody (RequestBodyLBS))
+import Network.HTTP.Simple (httpLBS, setRequestBody, addRequestHeader, setRequestMethod, getResponseStatusCode, getResponseBody, setRequestBasicAuth)
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Char8 as BSL8
+
+import Data.List (foldl')
+import qualified Data.Text.Encoding as T
+import qualified Data.CaseInsensitive as CI
+import Network.HTTP.Conduit (Response(..))
+import Cardano.Api (FromJSON)
+import Data.Aeson ((.:), (.:?))
+import Cardano.Api.Shelley (prettyPrintJSON)
+import qualified Data.ByteString.Char8 as BS8
+import Data.Aeson.Encode.Pretty (encodePretty)
+
+
+data RpcId = RpcIdNumber Integer
+            | RpcIdString T.Text
+            | RpcIdNull
+
+instance FromJSON RpcId where
+  parseJSON (A.Number  n) =  pure $ RpcIdNumber $ round n
+  parseJSON (A.String t) = pure $ RpcIdString t
+  parseJSON A.Null     = pure RpcIdNull
+  parseJSON  _           = fail "Not integer or string or null"
+
+data RpcError = RpcError {
+    rpcErrCode    :: Integer
+  , rpcErrMessage :: T.Text
+}
+instance FromJSON RpcError where
+  parseJSON (A.Object obj) =  RpcError <$> obj .: "code" <*> obj .: "message"
+  parseJSON _              =  fail "RpcError is not object"
+
+data RpcResponse  = RpcErrorResponse{
+        rpcVersion :: String
+      , rpcId :: RpcId
+      , rpcError :: RpcError
+    } |
+    RpcSuccessResponse {
+          rpcVersion :: String
+      , rpcId :: RpcId
+      , rpcResult :: A.Value
+    }
+
+instance FromJSON RpcResponse where
+  parseJSON (A.Object obj) =  do
+    errObj <- obj .:? "error"
+    case errObj of
+      Just err -> RpcErrorResponse
+                  <$> obj .: "jsonrpc"
+                  <*> obj .: "id"
+                  <*> pure err
+      Nothing -> RpcSuccessResponse
+                  <$> obj .: "jsonrpc"
+                  <*> obj .: "id"
+                  <*> obj .: "result"
+
+  parseJSON _              =  fail "RpcError is not object"
+
+runRpcCmd :: MonadIO m => RpcCommand -> m ()
+runRpcCmd (RpcCommand url auth headers method params) =do
+  liftIO $ do
+    baseReq<-parseRequest (T.unpack url)
+    let req = setRequestMethod "POST" 
+                $ flip (foldr (\(k,v) accum->addRequestHeader (CI.mk k) v accum)) headerList
+                $ addRequestHeader "content-type" "application/json" baseReq
+    withBasicAuth <- addAuthIfPresent auth req
+    response <- httpLBS (setRequestBody (RequestBodyLBS  makeBody) withBasicAuth)
+    let status = responseStatus response
+    case getResponseStatusCode response of
+      200 -> do
+        let result=  A.eitherDecode (getResponseBody response)
+        case result of
+          Left s -> fail $ "Invalid response :"  ++ s ++ "\n" ++ BSL8.unpack  (getResponseBody response)
+          Right responseData -> case responseData of
+            RpcErrorResponse _ _ (RpcError code msg) ->   fail (T.unpack msg)
+            RpcSuccessResponse _ _ resultData ->  BSL8.putStrLn $  encodePretty resultData
+      _ -> do
+        putStrLn $  "Rpc Error:" ++ show status
+        BSL8.putStrLn $ responseBody response
+  where
+    addAuthIfPresent mAuth req = do 
+      case mAuth of
+        Nothing -> pure req
+        Just txt -> case T.split  (== ':') txt of 
+            [k,v] ->  pure $ setRequestBasicAuth  (T.encodeUtf8 k) (T.encodeUtf8 v) req
+            _     -> fail $ "Invalid BasicAuth value" ++ T.unpack txt
+    headerList = map (\v -> case T.break (== ':') v of { (key, val) -> ( T.encodeUtf8 key, T.encodeUtf8 val) } ) headers
+    makeBody = BSL.concat  ["{\"jsonrpc\":\"2.0\",\"method\":", A.encode method,",\"params\":",  A.encode params , ",\"id\":1}"]


### PR DESCRIPTION
I have added a JSON-RPC client feature to `cardano-cli` that allows making RPC calls to any backend. The client uses the `network.http.simple` library for sending HTTP requests and `aeson` for parsing JSON responses.

The RPC methods are not yet decided, so the client currently supports any method specified in the request. The standard for the methods can be added later, once the specification for the RPC is created. Additionally, validation of methods can also be added later to ensure they conform to the specified standard.


```
$ cardano-cli rpc --help
Usage: cardano-cli rpc [--url ARG]
            [-u|--user ARG]
            [-H|--header ARG]
            method
            [argument]

  Call cardano rpc over network

Available options:
  --url ARG                Rpc Address (default: "http://localhost:3345")
  -u,--user ARG            Basic auth "User:Password"
  -H,--header ARG          Rpc extra HTTP headers "HeaderName:HeaderValue"
  method                   Json RPC method
  argument                 RPC method arguments
  -h,--help                Show this help text
```



