### PR TITLE
Refactor code using onLeft and onNothing

### DIFF
--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{- HLINT ignore "Monad law, left identity" -}
+
 module Cardano.Logging.Tracer.Composed (
     mkCardanoTracer
   , mkCardanoTracer'


### PR DESCRIPTION
Using `onLeft` and `onNothing` gives more opportunities for straight line code.  Examples of this are marked.

Modifying the code elsewhere as well for general consistency.

This PR is divided into multiple commits to group related changes for easy review.

Note, `throwE` from `Control.Monad.Trans.Except` is the same as `left` from `Control.Monad.Trans.Except.Extra`.