### PR TITLE
Better error message for query utxo without oops 2

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -720,6 +720,7 @@ module Cardano.Api (
     queryNodeLocalState,
     executeQueryCardanoMode,
     UnsupportedNtcVersionError(..),
+    renderUnsupportedNtcVersionError,
 
     -- *** Local tx monitoring
     LocalTxMonitorClient(..),

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -80,6 +80,7 @@ module Cardano.Api.IPC (
     NodeToClientVersion(..),
 
     UnsupportedNtcVersionError(..),
+    renderUnsupportedNtcVersionError,
   ) where
 
 import           Data.Void (Void)

--- a/cardano-api/src/Cardano/Api/IPC/Version.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Version.hs
@@ -1,11 +1,19 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Cardano.Api.IPC.Version
   ( NodeToClientVersionOf (..)
   , MinNodeToClientVersion
 
   -- *** Error types
   , UnsupportedNtcVersionError(..)
+  , renderUnsupportedNtcVersionError
   ) where
 
+import           Prelude
+
+import           Data.Text (Text)
+
+import           Cardano.Api.Utils (textShow)
 import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
 
 -- | The query 'a' is a versioned query, which means it requires the Node to support a minimum
@@ -32,3 +40,10 @@ type MinNodeToClientVersion = NodeToClientVersion
 
 data UnsupportedNtcVersionError = UnsupportedNtcVersionError !MinNodeToClientVersion !NodeToClientVersion
   deriving (Eq, Show)
+
+renderUnsupportedNtcVersionError :: UnsupportedNtcVersionError -> Text
+renderUnsupportedNtcVersionError = \case
+  UnsupportedNtcVersionError minNtcVersion ntcVersion ->
+    "Unsupported feature for the node-to-client protocol version.\n" <>
+    "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>
+    "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -160,10 +160,7 @@ renderShelleyQueryCmdError err =
       "Failed to decode PoolState.  Error: " <> Text.pack (show decoderError)
     ShelleyQueryCmdStakeSnapshotDecodeError decoderError ->
       "Failed to decode StakeSnapshot.  Error: " <> Text.pack (show decoderError)
-    ShelleyQueryCmdUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) ->
-      "Unsupported feature for the node-to-client protocol version.\n" <>
-      "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>
-      "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
+    ShelleyQueryCmdUnsupportedNtcVersion e -> renderUnsupportedNtcVersionError e
 
 runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmd cmd =


### PR DESCRIPTION
Once this is merged, we no longer need `executeQueryCardanoMode` as it is no longer used anywhere.

A subsequent PR will delete this function.