### PR TITLE
Refactor `genesis create` command usage in  cardano testnet

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -81,6 +81,7 @@ library
                         Testnet.Conf
                         Testnet.Commands.Genesis
                         Testnet.Commands.Governance
+                        Testnet.Options
                         Testnet.Run
                         Testnet.Shelley
                         Testnet.Utils

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -79,7 +79,8 @@ library
                         Testnet.Babbage
                         Testnet.Cardano
                         Testnet.Conf
-                        Testnet.Genesis
+                        Testnet.Commands.Genesis
+                        Testnet.Commands.Governance
                         Testnet.Run
                         Testnet.Shelley
                         Testnet.Utils

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -37,9 +37,9 @@ module Cardano.Testnet (
   ) where
 
 import           Testnet
-import           Testnet.Babbage
 import           Testnet.Cardano
 import           Testnet.Conf hiding (base)
+import           Testnet.Options
 import           Testnet.Shelley as Shelley
 import           Testnet.Utils (waitUntilEpoch)
 

--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -4,12 +4,12 @@ module Parsers.Babbage
   , runBabbageOptions
   ) where
 
-import           Prelude
 import           Options.Applicative
 import qualified Options.Applicative as OA
+import           Prelude
 
 import           Testnet
-import           Testnet.Babbage
+import           Testnet.Options
 import           Testnet.Run (runTestnet)
 import           Testnet.Util.Runtime (readNodeLoggingFormat)
 

--- a/cardano-testnet/src/Testnet.hs
+++ b/cardano-testnet/src/Testnet.hs
@@ -16,6 +16,8 @@ import           Hedgehog.Extras.Test.Base (Integration, noteShow_)
 import           Testnet.Babbage as Babbage
 import           Testnet.Cardano as Cardano
 import           Testnet.Conf
+import qualified Testnet.Options as Options
+import           Testnet.Options
 import           Testnet.Shelley as Shelley (ShelleyTestnetOptions, defaultTestnetOptions,
                    shelleyTestnet)
 
@@ -48,7 +50,7 @@ testnet options conf = case options of
     cardanoTestnet o conf
 
 babbageDefaultTestnetOptions :: BabbageTestnetOptions
-babbageDefaultTestnetOptions = Babbage.defaultTestnetOptions
+babbageDefaultTestnetOptions = Options.defaultTestnetOptions
 
 cardanoDefaultTestnetOptions :: CardanoTestnetOptions
 cardanoDefaultTestnetOptions = Cardano.defaultTestnetOptions

--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -31,8 +31,8 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified System.Info as OS
 
+import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
-import           Testnet.Genesis
 import qualified Testnet.Util.Assert as H
 import           Testnet.Util.Process (execCli_)
 import           Testnet.Util.Runtime (Delegator (..), NodeLoggingFormat (..), PaymentKeyPair (..),
@@ -53,7 +53,7 @@ data BabbageTestnetOptions = BabbageTestnetOptions
 defaultTestnetOptions :: BabbageTestnetOptions
 defaultTestnetOptions = BabbageTestnetOptions
   { babbageNumSpoNodes = 3
-  , babbageSlotDuration = 1000
+  , babbageSlotDuration = 200
   , babbageSecurityParam = 10
   , babbageTotalBalance = 10020000000
   , babbageNodeLoggingFormat = NodeLoggingFormatAsJson

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -355,14 +355,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     1
 
   forM_ bftNodesN $ \n -> do
-    execCli_
-      [ "byron", "governance", "create-proposal-vote"
-      , "--proposal-filepath", tempAbsPath </> "update-proposal"
-      , "--testnet-magic", show @Int testnetMagic
-      , "--signing-key", tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
-      , "--vote-yes"
-      , "--output-filepath", tempAbsPath </> "update-vote.00" <> show @Int (n - 1)
-      ]
+    createByronUpdateProposalVote
+      testnetMagic
+      (tempAbsPath </> "update-proposal")
+      (tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
+      (tempAbsPath </> "update-vote.00" <> show @Int (n - 1))
 
   createByronUpdateProposal
     testnetMagic
@@ -371,14 +368,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     2
 
   forM_ bftNodesN $ \n ->
-    execCli_
-      [ "byron", "governance", "create-proposal-vote"
-      , "--proposal-filepath", tempAbsPath </> "update-proposal-1"
-      , "--testnet-magic", show @Int testnetMagic
-      , "--signing-key", tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
-      , "--vote-yes"
-      , "--output-filepath", tempAbsPath </> "update-vote-1.00" <> show @Int (n - 1)
-      ]
+    createByronUpdateProposalVote
+      testnetMagic
+      (tempAbsPath </> "update-proposal-1")
+      (tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
+      (tempAbsPath </> "update-vote-1.00" <> show @Int (n - 1))
 
   -- Generated genesis keys and genesis files
   H.noteEachM_ . H.listDirectory $ tempAbsPath </> "byron"

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -63,8 +63,9 @@ import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Network as H
 
+import           Testnet.Commands.Genesis
+import           Testnet.Commands.Governance
 import qualified Testnet.Conf as H
-import           Testnet.Genesis
 import qualified Testnet.Util.Assert as H
 import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process (execCli_)
@@ -347,19 +348,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
       ]
 
   -- Update Proposal and votes
-  execCli_
-    [ "byron", "governance", "create-update-proposal"
-    , "--filepath", tempAbsPath </> "update-proposal"
-    , "--testnet-magic", show @Int testnetMagic
-    , "--signing-key", tempAbsPath </> "byron/delegate-keys.000.key"
-    , "--protocol-version-major", "1"
-    , "--protocol-version-minor", "0"
-    , "--protocol-version-alt", "0"
-    , "--application-name", "cardano-sl"
-    , "--software-version-num", "1"
-    , "--system-tag", "linux"
-    , "--installer-hash", "0"
-    ]
+  createByronUpdateProposal
+    testnetMagic
+    (tempAbsPath </> "byron/delegate-keys.000.key")
+    (tempAbsPath </> "update-proposal")
+    1
 
   forM_ bftNodesN $ \n -> do
     execCli_
@@ -371,19 +364,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
       , "--output-filepath", tempAbsPath </> "update-vote.00" <> show @Int (n - 1)
       ]
 
-  execCli_
-    [ "byron", "governance", "create-update-proposal"
-    , "--filepath", tempAbsPath </> "update-proposal-1"
-    , "--testnet-magic", show @Int testnetMagic
-    , "--signing-key", tempAbsPath </> "byron/delegate-keys.000.key"
-    , "--protocol-version-major", "2"
-    , "--protocol-version-minor", "0"
-    , "--protocol-version-alt", "0"
-    , "--application-name", "cardano-sl"
-    , "--software-version-num", "1"
-    , "--system-tag", "linux"
-    , "--installer-hash", "0"
-    ]
+  createByronUpdateProposal
+    testnetMagic
+    (tempAbsPath </> "byron/delegate-keys.000.key")
+    (tempAbsPath </> "update-proposal-1")
+    2
 
   forM_ bftNodesN $ \n ->
     execCli_

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -644,11 +644,7 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     --  2. register the stake pool 1
     --  3. register the user1 stake address
     --  4. delegate from the user1 stake address to the stake pool
-    txIn <- H.noteShow . S.strip =<< H.execCli
-      [ "genesis", "initial-txin"
-      , "--testnet-magic", show @Int testnetMagic
-      , "--verification-key-file", tempAbsPath </> "shelley/utxo-keys/utxo1.vkey"
-      ]
+    txIn <- H.noteShow . S.strip =<< createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath </> "shelley/utxo-keys/utxo1.vkey")
 
     H.note_ txIn
 

--- a/cardano-testnet/src/Testnet/Commands/Genesis.hs
+++ b/cardano-testnet/src/Testnet/Commands/Genesis.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 -- | All Byron and Shelley Genesis related functionality
-module Testnet.Genesis
+module Testnet.Commands.Genesis
   ( defaultByronGenesisJsonValue
   , createShelleyGenesisInitialTxIn
   ) where

--- a/cardano-testnet/src/Testnet/Commands/Governance.hs
+++ b/cardano-testnet/src/Testnet/Commands/Governance.hs
@@ -1,0 +1,33 @@
+
+
+module Testnet.Commands.Governance
+  ( createByronUpdateProposal
+  ) where
+
+import           Prelude
+
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class
+
+import           Testnet.Util.Process (execCli_)
+
+import           Hedgehog.Internal.Property
+
+
+createByronUpdateProposal
+  :: (MonadTest m, MonadCatch m, MonadIO m)
+  => Int -> String -> String -> Int -> m ()
+createByronUpdateProposal testnetMagic signingKeyFp updateProposalFp ptclMajorVersion =
+  execCli_
+    [ "byron", "governance", "create-update-proposal"
+    , "--filepath", updateProposalFp
+    , "--testnet-magic", show testnetMagic
+    , "--signing-key", signingKeyFp
+    , "--protocol-version-major", show ptclMajorVersion
+    , "--protocol-version-minor", "0"
+    , "--protocol-version-alt", "0"
+    , "--application-name", "cardano-sl"
+    , "--software-version-num", "1"
+    , "--system-tag", "linux"
+    , "--installer-hash", "0"
+    ]

--- a/cardano-testnet/src/Testnet/Commands/Governance.hs
+++ b/cardano-testnet/src/Testnet/Commands/Governance.hs
@@ -2,6 +2,7 @@
 
 module Testnet.Commands.Governance
   ( createByronUpdateProposal
+  , createByronUpdateProposalVote
   ) where
 
 import           Prelude
@@ -31,3 +32,16 @@ createByronUpdateProposal testnetMagic signingKeyFp updateProposalFp ptclMajorVe
     , "--system-tag", "linux"
     , "--installer-hash", "0"
     ]
+
+createByronUpdateProposalVote
+  :: (MonadTest m, MonadCatch m, MonadIO m)
+  => Int -> String -> String -> String -> m ()
+createByronUpdateProposalVote testnetMagic updateProposalFp signingKey outputFp =
+    execCli_
+      [ "byron", "governance", "create-proposal-vote"
+      , "--proposal-filepath", updateProposalFp
+      , "--testnet-magic", show testnetMagic
+      , "--signing-key", signingKey
+      , "--vote-yes"
+      , "--output-filepath", outputFp
+      ]

--- a/cardano-testnet/src/Testnet/Commands/Governance.hs
+++ b/cardano-testnet/src/Testnet/Commands/Governance.hs
@@ -1,5 +1,3 @@
-
-
 module Testnet.Commands.Governance
   ( createByronUpdateProposal
   , createByronUpdateProposalVote
@@ -9,6 +7,7 @@ import           Prelude
 
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
+import           GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import           Testnet.Util.Process (execCli_)
 
@@ -16,10 +15,10 @@ import           Hedgehog.Internal.Property
 
 
 createByronUpdateProposal
-  :: (MonadTest m, MonadCatch m, MonadIO m)
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => Int -> String -> String -> Int -> m ()
 createByronUpdateProposal testnetMagic signingKeyFp updateProposalFp ptclMajorVersion =
-  execCli_
+  withFrozenCallStack $ execCli_
     [ "byron", "governance", "create-update-proposal"
     , "--filepath", updateProposalFp
     , "--testnet-magic", show testnetMagic
@@ -34,10 +33,10 @@ createByronUpdateProposal testnetMagic signingKeyFp updateProposalFp ptclMajorVe
     ]
 
 createByronUpdateProposalVote
-  :: (MonadTest m, MonadCatch m, MonadIO m)
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => Int -> String -> String -> String -> m ()
 createByronUpdateProposalVote testnetMagic updateProposalFp signingKey outputFp =
-    execCli_
+    withFrozenCallStack $ execCli_
       [ "byron", "governance", "create-proposal-vote"
       , "--proposal-filepath", updateProposalFp
       , "--testnet-magic", show testnetMagic

--- a/cardano-testnet/src/Testnet/Options.hs
+++ b/cardano-testnet/src/Testnet/Options.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-unused-local-binds -Wno-unused-matches #-}
+
+module Testnet.Options
+  ( BabbageTestnetOptions(..)
+  , defaultTestnetOptions
+  ) where
+
+import           Prelude
+
+import           Testnet.Util.Runtime (NodeLoggingFormat (..))
+
+{- HLINT ignore "Redundant flip" -}
+
+data BabbageTestnetOptions = BabbageTestnetOptions
+  { babbageNumSpoNodes :: Int
+  , babbageSlotDuration :: Int
+  , babbageSecurityParam :: Int
+  , babbageTotalBalance :: Int
+  , babbageNodeLoggingFormat :: NodeLoggingFormat
+  } deriving (Eq, Show)
+
+defaultTestnetOptions :: BabbageTestnetOptions
+defaultTestnetOptions = BabbageTestnetOptions
+  { babbageNumSpoNodes = 3
+  , babbageSlotDuration = 200
+  , babbageSecurityParam = 10
+  , babbageTotalBalance = 10020000000
+  , babbageNodeLoggingFormat = NodeLoggingFormatAsJson
+  }

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -53,7 +53,9 @@ import qualified Hedgehog.Extras.Test.Network as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Info as OS
+
 import qualified Testnet.Conf as H
+import           Testnet.Genesis
 import qualified Testnet.Util.Base as H
 import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process (execCli_)
@@ -352,11 +354,9 @@ shelleyTestnet testnetOptions H.Conf {..} = do
     --  2. register the stake pool n
     --  3. register the usern stake address
     --  4. delegate from the usern stake address to the stake pool
-    genesisTxinResult <- H.noteShowM $ S.strip <$> H.execCli
-      [ "genesis", "initial-txin"
-      , "--testnet-magic", show @Int testnetMagic
-      , "--verification-key-file", tempAbsPath </> "utxo-keys/utxo" <> n <> ".vkey"
-      ]
+    genesisTxinResult
+      <- H.noteShowM $ S.strip <$> createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath </> "utxo-keys/utxo" <> n <> ".vkey")
+
 
     userNAddr <- H.readFile $ tempAbsPath </> "addresses/user" <> n <> ".addr"
 

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -54,8 +54,8 @@ import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Info as OS
 
+import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
-import           Testnet.Genesis
 import qualified Testnet.Util.Base as H
 import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process (execCli_)


### PR DESCRIPTION
Implement the following three modules:
1. Testnet.Commands.Genesis - Houses the refactoring of cli commands concerning genesis generation

2. Testnet.Commands.Governance - Houses the refactoring of cli commands concerning governance 

3. Testnet.Options - Module that will house all the different `TestnetOptions` types. The aim is to only have one `TestnetOptions` type in the future.