### PR TITLE
Remove NoImplicitPrelude from cardano-api

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -17,8 +17,7 @@ extra-source-files:     README.md, ChangeLog.md
 
 common project-config
   default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
-                        OverloadedStrings
+  default-extensions:   OverloadedStrings
   build-depends:        base >= 4.14 && < 4.15
 
   ghc-options:          -Wall
@@ -211,6 +210,7 @@ test-suite cardano-api-test
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson             >= 1.5.6.0
+                      , bytestring
                       , cardano-api
                       , cardano-api:gen
                       , cardano-data ^>= 0.1
@@ -219,7 +219,6 @@ test-suite cardano-api-test
                       , cardano-crypto-test ^>= 1.4
                       , cardano-crypto-tests ^>= 2.0
                       , cardano-ledger-core ^>= 0.1
-                      , cardano-prelude
                       , cardano-slotting ^>= 0.1
                       , containers
                       , hedgehog

--- a/cardano-api/gen/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Gen/Cardano/Api.hs
@@ -8,13 +8,13 @@ module Gen.Cardano.Api
   , genAlonzoGenesis
   ) where
 
-import           Cardano.Prelude
+import           Cardano.Prelude (panic)
 
 import           Cardano.Api.Shelley as Api
 
-import           Control.Monad (MonadFail (fail))
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
+import           Data.Word (Word64)
 
 --TODO: why do we have this odd split? We can get rid of the old name "typed"
 import           Gen.Cardano.Api.Typed (genCostModel, genRational)
@@ -25,7 +25,6 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Coin as Ledger
 import           Cardano.Ledger.Shelley.Metadata (Metadata (..), Metadatum (..))
-
 
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
@@ -97,7 +96,7 @@ genCostModels = do
     Right alonzoCostModel ->
       Alonzo.CostModels . conv <$> Gen.list (Range.linear 1 3) (return alonzoCostModel)
  where
-  conv :: [Alonzo.CostModel] -> Map Alonzo.Language Alonzo.CostModel
+  conv :: [Alonzo.CostModel] -> Map.Map Alonzo.Language Alonzo.CostModel
   conv [] = mempty
   conv (c : rest) = Map.singleton (Alonzo.getCostModelLanguage c) c <> conv rest
 

--- a/cardano-api/gen/Gen/Cardano/Api/Metadata.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Metadata.hs
@@ -7,8 +7,10 @@ module Gen.Cardano.Api.Metadata
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 import           Data.Aeson (ToJSON (..))
+import           Data.ByteString (ByteString)
+import           Data.Text (Text)
+import           Data.Word (Word64)
 import           Hedgehog (Gen)
 
 import qualified Data.Aeson as Aeson

--- a/cardano-api/gen/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Gen/Cardano/Api/Typed.hs
@@ -105,6 +105,8 @@ module Gen.Cardano.Api.Typed
   , genRational
   ) where
 
+import           Cardano.Prelude (panic)
+
 import           Cardano.Api hiding (txIns)
 import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
@@ -116,14 +118,18 @@ import           Cardano.Api.Shelley (Hash (ScriptDataHash), KESPeriod (KESPerio
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
                    refInsScriptsAndInlineDatsSupportedInEra)
 
-import           Cardano.Prelude
-
-import           Control.Monad.Fail (fail)
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import           Data.Coerce
+import           Data.Int (Int64)
+import           Data.Map.Strict (Map)
+import           Data.Maybe (maybeToList)
+import           Data.Ratio (Ratio, (%))
 import           Data.String
 import qualified Data.Text as Text
+import           Data.Word (Word64)
+import           Numeric.Natural (Natural)
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto

--- a/cardano-api/gen/Gen/Cardano/Crypto/Seed.hs
+++ b/cardano-api/gen/Gen/Cardano/Crypto/Seed.hs
@@ -5,10 +5,7 @@ module Gen.Cardano.Crypto.Seed
 
 import           Cardano.Api (AsType, Key)
 import           Cardano.Crypto.Seed (Seed)
-import           Data.Functor ((<$>))
-import           Data.Int (Int)
 import           Hedgehog (MonadGen, Range)
-import           Prelude (fromIntegral)
 
 import qualified Cardano.Api as API
 import qualified Cardano.Crypto.Seed as C

--- a/cardano-api/gen/Gen/Hedgehog/Roundtrip/Bech32.hs
+++ b/cardano-api/gen/Gen/Hedgehog/Roundtrip/Bech32.hs
@@ -3,7 +3,6 @@ module Gen.Hedgehog.Roundtrip.Bech32
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 import           Hedgehog (Gen, Property)
 
 import qualified Hedgehog as H

--- a/cardano-api/gen/Gen/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Gen/Hedgehog/Roundtrip/CBOR.hs
@@ -6,7 +6,6 @@ module Gen.Hedgehog.Roundtrip.CBOR
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 import           Hedgehog (Gen, Property)
 
 import qualified Hedgehog as H

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -76,8 +76,6 @@ module Cardano.Api.Address (
     isKeyAddress
   ) where
 
-import           Prelude
-
 import           Control.Applicative ((<|>))
 import           Data.Aeson (FromJSON (..), ToJSON (..), withText, (.=))
 import qualified Data.Aeson as Aeson
@@ -104,7 +102,6 @@ import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.NetworkId

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -48,8 +48,6 @@ module Cardano.Api.Block (
     makeChainTip,
   ) where
 
-import           Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -36,8 +36,6 @@ module Cardano.Api.Certificate (
     AsType(..)
   ) where
 
-import           Prelude
-
 import           Data.ByteString (ByteString)
 import qualified Data.Foldable as Foldable
 import qualified Data.Map.Strict as Map
@@ -62,8 +60,8 @@ import           Cardano.Ledger.Shelley.TxBody (MIRPot (..))
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 import           Cardano.Api.Address
-import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/src/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Construction.hs
@@ -13,8 +13,6 @@ module Cardano.Api.Convenience.Construction (
 
   ) where
 
-import           Prelude
-
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)

--- a/cardano-api/src/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Query.hs
@@ -13,8 +13,6 @@ module Cardano.Api.Convenience.Query (
     renderQueryConvenienceError,
   ) where
 
-import           Prelude
-
 import           Control.Monad.Trans.Except (ExceptT (..), except, runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistMaybe)
 import           Data.Bifunctor (first)

--- a/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
+++ b/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
@@ -18,11 +18,11 @@ module Cardano.Api.Crypto.Ed25519Bip32
   )
 where
 
-import           Cardano.Prelude hiding (show)
-import           Prelude (show)
-
+import           Control.DeepSeq (NFData)
 import           Data.ByteArray as BA (ByteArrayAccess, ScrubbedBytes, convert)
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import           GHC.Generics (Generic)
 import           NoThunks.Class (InspectHeap (..), NoThunks)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))

--- a/cardano-api/src/Cardano/Api/DeserialiseAnyOf.hs
+++ b/cardano-api/src/Cardano/Api/DeserialiseAnyOf.hs
@@ -18,8 +18,6 @@ module Cardano.Api.DeserialiseAnyOf
   , renderSomeAddressVerificationKey
   ) where
 
-import           Prelude
-
 import qualified Data.Aeson as Aeson
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
@@ -42,8 +40,8 @@ import           Cardano.Api.SerialiseTextEnvelope
 
 -- TODO: Think about if these belong
 import           Cardano.Api.Address
-import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Keys.Shelley
 

--- a/cardano-api/src/Cardano/Api/Environment.hs
+++ b/cardano-api/src/Cardano/Api/Environment.hs
@@ -8,8 +8,6 @@ module Cardano.Api.Environment
   , renderEnvSocketError
   ) where
 
-import           Prelude
-
 import           Data.Aeson
 import           Data.Text (Text)
 import qualified Data.Text as Text

--- a/cardano-api/src/Cardano/Api/EraCast.hs
+++ b/cardano-api/src/Cardano/Api/EraCast.hs
@@ -7,9 +7,7 @@ module Cardano.Api.EraCast
   ) where
 
 import           Cardano.Api.Eras (CardanoEra (..), IsCardanoEra)
-import           Data.Either (Either)
 import           Data.Kind (Type)
-import           Text.Show (Show (..))
 
 data EraCastError = forall fromEra toEra value.
   ( IsCardanoEra fromEra

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -46,8 +46,6 @@ module Cardano.Api.Eras
            AsByron,    AsShelley,    AsAllegra,    AsMary,    AsAlonzo,    AsBabbage)
   ) where
 
-import           Prelude
-
 import           Cardano.Api.HasTypeProxy
 
 import           Control.DeepSeq

--- a/cardano-api/src/Cardano/Api/Error.hs
+++ b/cardano-api/src/Cardano/Api/Error.hs
@@ -10,8 +10,6 @@ module Cardano.Api.Error
   , FileError(..)
   ) where
 
-import           Prelude
-
 import           Control.Exception (Exception (..), IOException, throwIO)
 import           System.IO (Handle)
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -41,8 +41,6 @@ module Cardano.Api.Fees (
     toLedgerEpochInfo,
   ) where
 
-import           Prelude
-
 import qualified Data.Array as Array
 import           Data.Bifunctor (bimap, first)
 import qualified Data.ByteString as BS
@@ -55,8 +53,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           GHC.Records (HasField (..))
-import           Numeric.Natural
 import           Lens.Micro ((^.))
+import           Numeric.Natural
 
 import           Control.Monad.Trans.Except
 import qualified Prettyprinter as PP
@@ -947,7 +945,7 @@ makeTransactionBodyAutoBalance eraInMode systemstart history pparams
     -- 4. balance the transaction and update tx change output
     txbody0 <-
       first TxBodyError $ createAndValidateTransactionBody txbodycontent
-        { txOuts = txOuts txbodycontent ++ 
+        { txOuts = txOuts txbodycontent ++
                    [TxOut changeaddr (lovelaceToTxOutValue 0) TxOutDatumNone ReferenceScriptNone]
             --TODO: think about the size of the change output
             -- 1,2,4 or 8 bytes?

--- a/cardano-api/src/Cardano/Api/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Genesis.hs
@@ -6,8 +6,6 @@ module Cardano.Api.Genesis
   , shelleyGenesisDefaults
   ) where
 
-import           Prelude
-
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)

--- a/cardano-api/src/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/src/Cardano/Api/GenesisParameters.hs
@@ -16,8 +16,6 @@ module Cardano.Api.GenesisParameters (
 
   ) where
 
-import           Prelude
-
 import           Data.Time (NominalDiffTime, UTCTime)
 
 import           Cardano.Slotting.Slot (EpochSize (..))

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -82,8 +82,6 @@ module Cardano.Api.IPC (
     UnsupportedNtcVersionError(..),
   ) where
 
-import           Prelude
-
 import           Data.Void (Void)
 
 import           Data.Aeson (ToJSON, object, toJSON, (.=))

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -9,8 +9,6 @@ module Cardano.Api.IPC.Monad
   , determineEraExpr
   ) where
 
-import           Prelude
-
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.IO.Class

--- a/cardano-api/src/Cardano/Api/IPC/Version.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Version.hs
@@ -6,9 +6,6 @@ module Cardano.Api.IPC.Version
   , UnsupportedNtcVersionError(..)
   ) where
 
-import           Data.Eq (Eq)
-import           Text.Show (Show)
-
 import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
 
 -- | The query 'a' is a versioned query, which means it requires the Node to support a minimum

--- a/cardano-api/src/Cardano/Api/InMode.hs
+++ b/cardano-api/src/Cardano/Api/InMode.hs
@@ -24,8 +24,6 @@ module Cardano.Api.InMode (
     fromConsensusApplyTxErr,
   ) where
 
-import           Prelude
-
 import           Data.SOP.Strict (NS (S, Z))
 
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus

--- a/cardano-api/src/Cardano/Api/Json.hs
+++ b/cardano-api/src/Cardano/Api/Json.hs
@@ -3,10 +3,7 @@ module Cardano.Api.Json
   ) where
 
 import           Data.Aeson
-import           Data.Either
-import           Data.Maybe
 import           Data.Scientific
-import           GHC.Real
 
 -- Rationals and JSON are an awkward mix. We cannot convert rationals
 -- like @1/3@ to JSON numbers. But _most_ of the numbers we want to use

--- a/cardano-api/src/Cardano/Api/Keys/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Byron.hs
@@ -30,14 +30,14 @@ module Cardano.Api.Keys.Byron (
     toByronSigningKey
   ) where
 
-import           Cardano.Prelude (cborError, toCborError)
-import           Prelude
+import qualified Cardano.Prelude as CBOR (toCborError)
 
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import           Control.Monad
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as LB
+import           Data.Coders (cborError)
 import           Data.Either.Combinators
 import           Data.String (IsString)
 import           Data.Text (Text)
@@ -55,9 +55,9 @@ import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Wallet
 
 import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
@@ -272,7 +272,7 @@ instance SerialiseAsRawBytes (SigningKey ByronKeyLegacy) where
                     )
 
       decodeXPrv :: CBOR.Decoder s Wallet.XPrv
-      decodeXPrv = CBOR.decodeBytesCanonical >>= toCborError . Wallet.xprv
+      decodeXPrv = CBOR.decodeBytesCanonical >>= CBOR.toCborError . Wallet.xprv
 
 
       -- | Decoder for a Byron/Classic signing key.

--- a/cardano-api/src/Cardano/Api/Keys/Class.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Class.hs
@@ -11,8 +11,6 @@ module Cardano.Api.Keys.Class
   , AsType(AsVerificationKey, AsSigningKey)
   ) where
 
-import           Prelude
-
 import           Data.Kind (Type)
 
 import qualified Cardano.Crypto.DSIGN.Class as Crypto

--- a/cardano-api/src/Cardano/Api/Keys/Praos.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Praos.hs
@@ -26,8 +26,6 @@ module Cardano.Api.Keys.Praos (
     signArbitraryBytesKes,
   ) where
 
-import           Prelude
-
 import           Data.ByteString (ByteString)
 import           Data.Either.Combinators (maybeToRight)
 import           Data.String (IsString (..))

--- a/cardano-api/src/Cardano/Api/Keys/Read.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Read.hs
@@ -9,8 +9,6 @@ module Cardano.Api.Keys.Read
   , readKeyFileAnyOf
   ) where
 
-import           Prelude
-
 import           Control.Exception
 import           Data.Bifunctor
 import           Data.ByteString as BS

--- a/cardano-api/src/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Shelley.hs
@@ -35,8 +35,6 @@ module Cardano.Api.Keys.Shelley (
     Hash(..),
   ) where
 
-import           Prelude
-
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText, withText)
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)

--- a/cardano-api/src/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/src/Cardano/Api/LedgerEvent.hs
@@ -36,11 +36,8 @@ import           Cardano.Ledger.Shelley.Rules.PoolReap (ShelleyPoolreapEvent (..
 import           Cardano.Ledger.Shelley.Rules.Rupd (RupdEvent (..))
 import           Cardano.Ledger.Shelley.Rules.Tick (ShelleyTickEvent (NewEpochEvent))
 import           Control.State.Transition (Event)
-import           Data.Function (($), (.))
-import           Data.Functor (fmap)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (Maybe (Just, Nothing))
 import           Data.Set (Set)
 import           Data.SOP.Strict
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -50,8 +50,6 @@ module Cardano.Api.LedgerState
   )
   where
 
-import           Prelude
-
 import           Control.Exception
 import           Control.Monad (when)
 import           Control.Monad.Trans.Class
@@ -105,8 +103,8 @@ import           Cardano.Api.Modes (CardanoMode, EpochSlots (..))
 import qualified Cardano.Api.Modes as Api
 import           Cardano.Api.NetworkId (NetworkId (..), NetworkMagic (NetworkMagic))
 import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (unPoolDistr), ProtocolState,
-                   SerialisedCurrentEpochState (..), SerialisedPoolDistribution,
+import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (unPoolDistr),
+                   ProtocolState, SerialisedCurrentEpochState (..), SerialisedPoolDistribution,
                    decodeCurrentEpochState, decodePoolDistribution, decodeProtocolState)
 import           Cardano.Api.Utils (textShow)
 import           Cardano.Binary (DecoderError, FromCBOR)

--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -43,8 +43,6 @@ module Cardano.Api.Modes (
     fromConsensusEraIndex,
   ) where
 
-import           Prelude
-
 import           Cardano.Api.Eras
 import           Cardano.Ledger.Crypto (StandardCrypto)
 

--- a/cardano-api/src/Cardano/Api/NetworkId.hs
+++ b/cardano-api/src/Cardano/Api/NetworkId.hs
@@ -16,8 +16,6 @@ module Cardano.Api.NetworkId (
     fromShelleyNetwork,
   ) where
 
-import           Prelude
-
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 import qualified Cardano.Chain.Common as Byron (NetworkMagic (..))

--- a/cardano-api/src/Cardano/Api/OperationalCertificate.hs
+++ b/cardano-api/src/Cardano/Api/OperationalCertificate.hs
@@ -18,8 +18,6 @@ module Cardano.Api.OperationalCertificate (
     AsType(..)
   ) where
 
-import           Prelude
-
 import           Data.Word
 
 import           Cardano.Ledger.Crypto (StandardCrypto)
@@ -30,8 +28,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.ProtocolParameters

--- a/cardano-api/src/Cardano/Api/Orphans.hs
+++ b/cardano-api/src/Cardano/Api/Orphans.hs
@@ -17,8 +17,6 @@
 
 module Cardano.Api.Orphans () where
 
-import           Prelude
-
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)

--- a/cardano-api/src/Cardano/Api/Protocol.hs
+++ b/cardano-api/src/Cardano/Api/Protocol.hs
@@ -15,8 +15,6 @@ module Cardano.Api.Protocol
   , ProtocolClientInfoArgs(..)
   ) where
 
-import           Cardano.Prelude
-
 import           Ouroboros.Consensus.Cardano
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -63,8 +63,6 @@ module Cardano.Api.ProtocolParameters (
     AsType(..)
   ) where
 
-import           Prelude
-
 import           Control.Applicative ((<|>))
 import           Control.Monad
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?),
@@ -87,8 +85,8 @@ import           Cardano.Slotting.Slot (EpochNo)
 
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Core as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Keys as Ledger
 
 -- Some of the things from Cardano.Ledger.ShelleyPParams are generic across all
@@ -99,9 +97,9 @@ import           Cardano.Ledger.Shelley.PParams (ShelleyPParams, ShelleyPParamsH
                    ShelleyPParamsUpdate)
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import           Cardano.Ledger.Alonzo.PParams (AlonzoPParams, AlonzoPParamsHKD (..),
                    AlonzoPParamsUpdate)
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 
 import           Cardano.Ledger.Babbage.PParams (BabbagePParams, BabbagePParamsHKD (..),
                    BabbagePParamsUpdate)

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -91,7 +91,6 @@ import           Data.Sharing (FromSharedCBOR, Interns, Share)
 import           Data.SOP.Strict (SListI)
 import           Data.Text (Text)
 import           Data.Typeable
-import           Prelude
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
 

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -110,8 +110,6 @@ module Cardano.Api.Script (
     Hash(..),
   ) where
 
-import           Prelude
-
 import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as SBS

--- a/cardano-api/src/Cardano/Api/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/ScriptData.hs
@@ -35,8 +35,6 @@ module Cardano.Api.ScriptData (
     Hash(..),
   ) where
 
-import           Prelude
-
 import           Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16

--- a/cardano-api/src/Cardano/Api/SerialiseBech32.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseBech32.hs
@@ -10,8 +10,6 @@ module Cardano.Api.SerialiseBech32
   , deserialiseAnyOfFromBech32
   ) where
 
-import           Prelude
-
 import           Data.ByteString (ByteString)
 import           Data.Text (Text)
 

--- a/cardano-api/src/Cardano/Api/SerialiseCBOR.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseCBOR.hs
@@ -8,8 +8,6 @@ module Cardano.Api.SerialiseCBOR
   , ToCBOR(..)
   ) where
 
-import           Prelude
-
 import           Data.ByteString (ByteString)
 
 import           Cardano.Binary (FromCBOR, ToCBOR)

--- a/cardano-api/src/Cardano/Api/SerialiseJSON.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseJSON.hs
@@ -14,11 +14,9 @@ module Cardano.Api.SerialiseJSON
   , writeFileJSON
   ) where
 
-import           Prelude
-
 import           Control.Monad.Trans.Except (runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
-import           Data.Aeson (FromJSON (..), ToJSON (..), ToJSONKey, FromJSONKey)
+import           Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey)
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.ByteString (ByteString)

--- a/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseLedgerCddl.hs
@@ -27,8 +27,6 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
-import           Prelude
-
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
                    newExceptT, runExceptT)
 import           Data.Aeson

--- a/cardano-api/src/Cardano/Api/SerialiseRaw.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseRaw.hs
@@ -12,12 +12,15 @@ module Cardano.Api.SerialiseRaw
   , serialiseToRawBytesHexText
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
-
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
+import           Data.Data (typeRep)
+import           Data.Either.Combinators (rightToMaybe)
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import           Data.Typeable (TypeRep, Typeable)
 
 import           Cardano.Api.Error (Error, displayError)
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseTextEnvelope.hs
@@ -37,8 +37,6 @@ module Cardano.Api.SerialiseTextEnvelope
   , AsType(..)
   ) where
 
-import           Prelude
-
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
@@ -68,10 +66,10 @@ import           Cardano.Api.Utils (readFileBlocking)
 #ifdef UNIX
 import           Control.Exception (IOException, bracket, bracketOnError, try)
 import           System.Directory ()
-import           System.Posix.Files (ownerModes, setFdOwnerAndGroup)
-import           System.Posix.IO (OpenMode (..), closeFd, openFd, fdToHandle, defaultFileFlags)
-import           System.Posix.User (getRealUserID)
 import           System.IO (hClose)
+import           System.Posix.Files (ownerModes, setFdOwnerAndGroup)
+import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
+import           System.Posix.User (getRealUserID)
 #else
 import           Control.Exception (bracketOnError)
 import           System.Directory (removeFile, renameFile)

--- a/cardano-api/src/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/SerialiseUsing.hs
@@ -8,8 +8,6 @@ module Cardano.Api.SerialiseUsing
   , UsingBech32(..)
   ) where
 
-import           Prelude
-
 import qualified Data.Aeson.Types as Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16

--- a/cardano-api/src/Cardano/Api/SpecialByron.hs
+++ b/cardano-api/src/Cardano/Api/SpecialByron.hs
@@ -15,8 +15,6 @@ module Cardano.Api.SpecialByron
     toByronLedgertoByronVote,
   ) where
 
-import           Prelude
-
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Map.Strict as M

--- a/cardano-api/src/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/src/Cardano/Api/StakePoolMetadata.hs
@@ -14,8 +14,6 @@ module Cardano.Api.StakePoolMetadata (
     Hash(..),
   ) where
 
-import           Prelude
-
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -33,7 +31,6 @@ import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Script

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -47,8 +47,6 @@ module Cardano.Api.Tx (
            AsKeyWitness, AsByronWitness, AsShelleyWitness),
   ) where
 
-import           Prelude
-
 import           Data.Maybe
 
 import           Data.ByteString (ByteString)
@@ -95,8 +93,8 @@ import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.Keys.Bootstrap as Shelley
 import qualified Cardano.Ledger.SafeHash as Ledger
 
-import qualified Cardano.Ledger.Shelley.Tx as Shelley
 import qualified Cardano.Ledger.Shelley.API as Ledger (ShelleyTx (..))
+import qualified Cardano.Ledger.Shelley.Tx as Shelley
 
 import           Cardano.Ledger.Alonzo (AlonzoScript)
 import qualified Cardano.Ledger.Alonzo as Alonzo
@@ -109,8 +107,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.NetworkId
 import           Cardano.Api.SerialiseCBOR

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -156,8 +156,6 @@ module Cardano.Api.TxBody (
     AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
   ) where
 
-import           Prelude
-
 import           Control.Applicative (some)
 import           Control.Monad (guard)
 import           Data.Aeson (object, withObject, (.:), (.:?), (.=))
@@ -205,19 +203,19 @@ import qualified Cardano.Crypto.Hashing as Byron
 
 import qualified Cardano.Ledger.Address as Shelley
 import qualified Cardano.Ledger.AuxiliaryData as Ledger
+import           Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..),
+                   BabbageTxBody (BabbageTxBody), BabbageTxOut (BabbageTxOut))
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
+import qualified Cardano.Ledger.Block as Ledger
 import qualified Cardano.Ledger.Coin as Ledger
+import           Cardano.Ledger.Core (EraAuxiliaryData)
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Era as CC
 import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Ledger.SafeHash as SafeHash
-import           Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..),
-                   BabbageTxBody (BabbageTxBody), BabbageTxOut (BabbageTxOut))
-import qualified Cardano.Ledger.Block as Ledger
-import           Cardano.Ledger.Core (EraAuxiliaryData)
-import qualified Cardano.Ledger.Era as CC
 import qualified Cardano.Ledger.TxIn as Ledger
 import           Cardano.Ledger.Val (isZero)
 
@@ -228,23 +226,23 @@ import qualified Cardano.Ledger.Shelley.Metadata as Shelley
 import qualified Cardano.Ledger.Shelley.Tx as Shelley
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
+import           Cardano.Ledger.Mary.Value (MaryValue)
 import           Cardano.Ledger.ShelleyMA.AuxiliaryData (MAAuxiliaryData (..))
+import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Allegra
+import           Cardano.Ledger.ShelleyMA.TxBody (MATxBody (..))
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Allegra
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Mary
-import           Cardano.Ledger.ShelleyMA.TxBody (MATxBody (..))
-import           Cardano.Ledger.Mary.Value (MaryValue)
 
+import           Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (AlonzoAuxiliaryData))
+import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
-import           Cardano.Ledger.Alonzo.Data (AlonzoAuxiliaryData (AlonzoAuxiliaryData))
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import           Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (AlonzoTxBody),
                    AlonzoTxOut (AlonzoTxOut))
+import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage

--- a/cardano-api/src/Cardano/Api/TxIn.hs
+++ b/cardano-api/src/Cardano/Api/TxIn.hs
@@ -35,8 +35,6 @@ module Cardano.Api.TxIn (
     renderTxIn,
   ) where
 
-import           Prelude
-
 import           Control.Applicative (some)
 import           Data.Aeson (withText)
 import qualified Data.Aeson as Aeson

--- a/cardano-api/src/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/src/Cardano/Api/TxMetadata.hs
@@ -40,8 +40,6 @@ module Cardano.Api.TxMetadata (
     AsType(..)
   ) where
 
-import           Prelude
-
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/Utils.hs
+++ b/cardano-api/src/Cardano/Api/Utils.hs
@@ -24,8 +24,6 @@ module Cardano.Api.Utils
   , writeSecrets
   ) where
 
-import           Prelude
-
 import           Control.Exception (bracket)
 import           Control.Monad (forM_)
 import qualified Data.Aeson.Types as Aeson

--- a/cardano-api/src/Cardano/Api/Value.hs
+++ b/cardano-api/src/Cardano/Api/Value.hs
@@ -55,8 +55,6 @@ module Cardano.Api.Value
   , AsType(..)
   ) where
 
-import           Prelude
-
 import           Data.Aeson (FromJSON, FromJSONKey, ToJSON, object, parseJSON, toJSON, withObject)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson

--- a/cardano-api/src/Cardano/Api/ValueParser.hs
+++ b/cardano-api/src/Cardano/Api/ValueParser.hs
@@ -4,8 +4,6 @@ module Cardano.Api.ValueParser
   , policyId
   ) where
 
-import           Prelude
-
 import           Control.Applicative (many, some, (<|>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Char as Char

--- a/cardano-api/test/Test/Cardano/Api/Crypto.hs
+++ b/cardano-api/test/Test/Cardano/Api/Crypto.hs
@@ -12,8 +12,7 @@ module Test.Cardano.Api.Crypto
   )
 where
 
-import           Cardano.Prelude
-import           Prelude (String)
+import           Data.Proxy (Proxy (..))
 
 import           Cardano.Api.Crypto.Ed25519Bip32 (Ed25519Bip32DSIGN, SignKeyDSIGN (..))
 

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -7,8 +7,6 @@ module Test.Cardano.Api.Genesis
   ( exampleShelleyGenesis
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Shelley (ShelleyGenesis (..))
 
 import           Data.ListMap (ListMap (ListMap))

--- a/cardano-api/test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/Test/Cardano/Api/Json.hs
@@ -8,7 +8,6 @@ module Test.Cardano.Api.Json
 
 import           Cardano.Api.Orphans ()
 import           Cardano.Api.Shelley
-import           Cardano.Prelude
 import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), eitherDecode, encode)
 import           Data.Aeson.Types (Parser, parseEither)
 import           Gen.Cardano.Api (genAlonzoGenesis)

--- a/cardano-api/test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/Test/Cardano/Api/KeysByron.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Api.KeysByron
   ) where
 
 import           Cardano.Api (AsType (AsByronKey, AsSigningKey), Key (deterministicSigningKey))
-import           Cardano.Prelude ((<$>))
 import           Gen.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR)
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()

--- a/cardano-api/test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/Test/Cardano/Api/Ledger.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Api.Ledger
   ) where
 
 import           Cardano.Ledger.Address (deserialiseAddr, serialiseAddr)
-import           Cardano.Prelude (($))
 import           Hedgehog (Property)
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 import           Test.Cardano.Api.Genesis (exampleShelleyGenesis)

--- a/cardano-api/test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/Test/Cardano/Api/Metadata.hs
@@ -7,8 +7,11 @@ module Test.Cardano.Api.Metadata
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
+
 import           Gen.Cardano.Api.Metadata
+
+import           Data.ByteString (ByteString)
+import           Data.Word (Word64)
 import           Hedgehog (Property, property, (===))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)

--- a/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Api.Typed.Address
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude (($), Eq, Show)
 import           Gen.Cardano.Api.Typed (genAddressByron, genAddressShelley)
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
@@ -59,5 +58,5 @@ tests = testGroup "Test.Cardano.Api.Typed.Address"
   [ testPropertyNamed "roundtrip shelley address" "roundtrip shelley address" prop_roundtrip_shelley_address
   , testPropertyNamed "roundtrip byron address"   "roundtrip byron address" prop_roundtrip_byron_address
   , testPropertyNamed "roundtrip byron address JSON"   "roundtrip byron address JSON" prop_roundtrip_byron_address_JSON
-  , testPropertyNamed "roundtrip shelley address JSON"   "roundtrip shelley address JSON" prop_roundtrip_shelley_address_JSON  
+  , testPropertyNamed "roundtrip shelley address JSON"   "roundtrip shelley address JSON" prop_roundtrip_shelley_address_JSON
   ]

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -7,7 +7,8 @@ module Test.Cardano.Api.Typed.CBOR
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
+
+import           Data.Proxy (Proxy (..))
 import           Data.String (IsString (..))
 import           Gen.Cardano.Api.Typed
 import           Gen.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR, roundtrip_CDDL_Tx)

--- a/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Api.Typed.Envelope
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -8,13 +8,12 @@ module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
-import           Cardano.Prelude
 import           Data.Aeson (eitherDecode, encode)
+import           Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
 import           Hedgehog (Property, forAll, tripping)
+import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-import           Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
-import           Test.Cardano.Api.Typed.Orphans ()
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen

--- a/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
@@ -4,9 +4,9 @@ module Test.Cardano.Api.Typed.Ord
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
+
 import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property, (===))
-import           Prelude
 import           Test.Cardano.Api.Metadata (genTxMetadataValue)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)

--- a/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
@@ -7,8 +7,6 @@
 
 module Test.Cardano.Api.Typed.Orphans () where
 
-import           Cardano.Prelude
-
 import           Cardano.Api.Shelley
 import           Cardano.Crypto.Hash hiding (Hash)
 import           Cardano.Crypto.KES

--- a/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -5,7 +5,6 @@ module Test.Cardano.Api.Typed.RawBytes
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -4,7 +4,6 @@ module Test.Cardano.Api.Typed.Script
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
-import           Cardano.Prelude
 import           Data.Aeson
 import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property, (===))

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -6,7 +6,7 @@ module Test.Cardano.Api.Typed.TxBody
 
 import           Cardano.Api
 import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleyScript)
-import           Cardano.Prelude
+import           Data.Maybe (isJust)
 import           Data.Type.Equality (TestEquality (testEquality))
 import           Gen.Cardano.Api.Typed (genTxBodyContent)
 import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))

--- a/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
@@ -2,12 +2,12 @@ module Test.Cardano.Api.Typed.Value
   ( tests
   ) where
 
-import           Cardano.Api (ValueNestedBundle(..), ValueNestedRep (..), valueFromNestedRep, valueToNestedRep)
+import           Cardano.Api (ValueNestedBundle (..), ValueNestedRep (..), valueFromNestedRep,
+                   valueToNestedRep)
 import           Data.Aeson (eitherDecode, encode)
 import           Data.List (groupBy, sort)
 import           Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genValueNestedRep)
 import           Hedgehog (Property, forAll, property, tripping, (===))
-import           Prelude
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -1,6 +1,5 @@
 
 import           Cardano.Crypto.Libsodium (sodiumInit)
-import           Cardano.Prelude
 
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 


### PR DESCRIPTION
We import Prelude explicitly from the majority of `cardano-api` modules.  Removing this language extension makes this unnecessary and removes confusion about the status of `cardano-prelude`.