### PR TITLE
Implement ADR-2: Restructure modules for generators

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -179,12 +179,12 @@ library gen
 
   hs-source-dirs:       gen
 
-  exposed-modules:      Gen.Cardano.Api
-                        Gen.Cardano.Api.Metadata
-                        Gen.Cardano.Api.Typed
-                        Gen.Cardano.Crypto.Seed
-                        Gen.Hedgehog.Roundtrip.Bech32
-                        Gen.Hedgehog.Roundtrip.CBOR
+  exposed-modules:      Test.Gen.Cardano.Api
+                        Test.Gen.Cardano.Api.Metadata
+                        Test.Gen.Cardano.Api.Typed
+                        Test.Gen.Cardano.Crypto.Seed
+                        Test.Hedgehog.Roundtrip.Bech32
+                        Test.Hedgehog.Roundtrip.CBOR
 
   build-depends:        aeson             >= 1.5.6.0
                       , base16-bytestring

--- a/cardano-api/gen/Test/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Gen.Cardano.Api
+module Test.Gen.Cardano.Api
   ( genMetadata
   , genAlonzoGenesis
   ) where
@@ -17,7 +17,7 @@ import qualified Data.Text as Text
 import           Data.Word (Word64)
 
 --TODO: why do we have this odd split? We can get rid of the old name "typed"
-import           Gen.Cardano.Api.Typed (genCostModel, genRational)
+import           Test.Gen.Cardano.Api.Typed (genCostModel, genRational)
 
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Gen.Cardano.Api.Metadata
+module Test.Gen.Cardano.Api.Metadata
   ( genTxMetadata
   , genTxMetadataValue
   , genJsonForTxMetadata

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Gen.Cardano.Api.Typed
+module Test.Gen.Cardano.Api.Typed
   ( genAddressByron
   , genAddressInEra
   , genAddressShelley
@@ -146,9 +146,9 @@ import           Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import           Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 
-import           Gen.Cardano.Api.Metadata (genTxMetadata)
 import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
+import           Test.Gen.Cardano.Api.Metadata (genTxMetadata)
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-api/gen/Test/Gen/Cardano/Crypto/Seed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Crypto/Seed.hs
@@ -1,4 +1,4 @@
-module Gen.Cardano.Crypto.Seed
+module Test.Gen.Cardano.Crypto.Seed
   ( genSeed
   , genSeedForKey
   ) where

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
@@ -1,4 +1,4 @@
-module Gen.Hedgehog.Roundtrip.Bech32
+module Test.Hedgehog.Roundtrip.Bech32
   ( roundtrip_Bech32
   ) where
 

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module Gen.Hedgehog.Roundtrip.CBOR
+module Test.Hedgehog.Roundtrip.CBOR
   ( roundtrip_CBOR
   , roundtrip_CDDL_Tx
   ) where

--- a/cardano-api/test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/Test/Cardano/Api/Json.hs
@@ -10,9 +10,9 @@ import           Cardano.Api.Orphans ()
 import           Cardano.Api.Shelley
 import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), eitherDecode, encode)
 import           Data.Aeson.Types (Parser, parseEither)
-import           Gen.Cardano.Api (genAlonzoGenesis)
-import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property, forAll, tripping)
+import           Test.Gen.Cardano.Api (genAlonzoGenesis)
+import           Test.Gen.Cardano.Api.Typed
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/Test/Cardano/Api/KeysByron.hs
@@ -5,13 +5,14 @@ module Test.Cardano.Api.KeysByron
   ) where
 
 import           Cardano.Api (AsType (AsByronKey, AsSigningKey), Key (deterministicSigningKey))
-import           Gen.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR)
+
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 
-import qualified Gen.Cardano.Crypto.Seed as Gen
+import qualified Test.Gen.Cardano.Crypto.Seed as Gen
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/Test/Cardano/Api/Metadata.hs
@@ -8,11 +8,10 @@ module Test.Cardano.Api.Metadata
 
 import           Cardano.Api
 
-import           Gen.Cardano.Api.Metadata
-
 import           Data.ByteString (ByteString)
 import           Data.Word (Word64)
 import           Hedgehog (Property, property, (===))
+import           Test.Gen.Cardano.Api.Metadata
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
@@ -5,9 +5,10 @@ module Test.Cardano.Api.Typed.Address
   ) where
 
 import           Cardano.Api
-import           Gen.Cardano.Api.Typed (genAddressByron, genAddressShelley)
+
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed (genAddressByron, genAddressShelley)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
@@ -2,10 +2,10 @@ module Test.Cardano.Api.Typed.Bech32
   ( tests
   ) where
 
-import           Cardano.Api (AsType(AsStakeAddress, AsShelleyAddress))
-import           Gen.Cardano.Api.Typed( genAddressShelley, genStakeAddress)
-import           Gen.Hedgehog.Roundtrip.Bech32 (roundtrip_Bech32)
+import           Cardano.Api (AsType (AsShelleyAddress, AsStakeAddress))
 import           Hedgehog (Property)
+import           Test.Gen.Cardano.Api.Typed (genAddressShelley, genStakeAddress)
+import           Test.Hedgehog.Roundtrip.Bech32 (roundtrip_Bech32)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -10,10 +10,10 @@ import           Cardano.Api
 
 import           Data.Proxy (Proxy (..))
 import           Data.String (IsString (..))
-import           Gen.Cardano.Api.Typed
-import           Gen.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR, roundtrip_CDDL_Tx)
 import           Hedgehog (Property, forAll, property, success, tripping)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed
+import           Test.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR, roundtrip_CDDL_Tx)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
@@ -5,9 +5,10 @@ module Test.Cardano.Api.Typed.Envelope
   ) where
 
 import           Cardano.Api
-import           Gen.Cardano.Api.Typed
+
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -9,9 +9,10 @@ module Test.Cardano.Api.Typed.JSON
   ) where
 
 import           Data.Aeson (eitherDecode, encode)
-import           Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
+
 import           Hedgehog (Property, forAll, tripping)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
@@ -5,9 +5,9 @@ module Test.Cardano.Api.Typed.Ord
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property, (===))
 import           Test.Cardano.Api.Metadata (genTxMetadataValue)
+import           Test.Gen.Cardano.Api.Typed
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -5,9 +5,10 @@ module Test.Cardano.Api.Typed.RawBytes
   ) where
 
 import           Cardano.Api
-import           Gen.Cardano.Api.Typed
+
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -5,9 +5,9 @@ module Test.Cardano.Api.Typed.Script
 import           Cardano.Api
 import           Cardano.Api.Shelley
 import           Data.Aeson
-import           Gen.Cardano.Api.Typed
 import           Hedgehog (Property, (===))
 import           Hedgehog.Extras.Aeson
+import           Test.Gen.Cardano.Api.Typed
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -8,9 +8,9 @@ import           Cardano.Api
 import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleyScript)
 import           Data.Maybe (isJust)
 import           Data.Type.Equality (TestEquality (testEquality))
-import           Gen.Cardano.Api.Typed (genTxBodyContent)
 import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))
 import           Test.Cardano.Api.Typed.Orphans ()
+import           Test.Gen.Cardano.Api.Typed (genTxBodyContent)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
@@ -2,16 +2,19 @@ module Test.Cardano.Api.Typed.Value
   ( tests
   ) where
 
+import           Prelude
+
 import           Cardano.Api (ValueNestedBundle (..), ValueNestedRep (..), valueFromNestedRep,
                    valueToNestedRep)
+
 import           Data.Aeson (eitherDecode, encode)
 import           Data.List (groupBy, sort)
-import           Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genValueNestedRep)
+import qualified Data.Map.Strict as Map
+
 import           Hedgehog (Property, forAll, property, tripping, (===))
+import           Test.Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genValueNestedRep)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Data.Map.Strict as Map
 
 prop_roundtrip_Value_JSON :: Property
 prop_roundtrip_Value_JSON =

--- a/cardano-cli/test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/Test/Cli/JSON.hs
@@ -6,7 +6,7 @@ module Test.Cli.JSON where
 import           Cardano.Prelude hiding (filter)
 
 import           Cardano.Api.Shelley
-import           Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
+import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
                    genVerificationKeyHash)
 
 import           Data.Aeson

--- a/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
@@ -13,7 +13,7 @@ import           Hedgehog.Gen (filter)
 
 import           Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
 
-import           Gen.Cardano.Api.Typed (genValueDefault)
+import           Test.Gen.Cardano.Api.Typed (genValueDefault)
 
 prop_roundtrip_Value_parse_render :: Property
 prop_roundtrip_Value_parse_render =


### PR DESCRIPTION
Rename:

* `Gen.Cardano.*` -> `Test.Gen.Cardano.*`
* `Hedgehog.*` -> `Test.Hedgehog.*`

See https://github.com/input-output-hk/cardano-node/wiki/ADR-2-Module-structure-for-generators