### PR TITLE
bump install-nix-action to v18. fix nix and channel to nixos-22.11. fix cache

### DIFF
--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -14,15 +14,18 @@ jobs:
     steps:
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v18
       with:
+        # Use last stable nixos channel and the same nix as in channel:
+        install_url: https://releases.nixos.org/nix/nix-2.11.1/install
+        nix_path: nixpkgs=channel:nixos-22.11
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
           substituters = https://cache.nixos.org https://cache.iog.io
-          trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -16,13 +16,16 @@ jobs:
     - name: Install Nix
       uses: cachix/install-nix-action@v18
       with:
+        # Use last stable nixos channel and the same nix as in channel:
+        install_url: https://releases.nixos.org/nix/nix-2.11.1/install
+        nix_path: nixpkgs=channel:nixos-22.11
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
-          substituters = https://cache.nixos.org https://hydra.iohk.io
-          trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://cache.nixos.org https://cache.iog.io
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
nix 2.13 seems to fails very often with core dumps (https://github.com/NixOS/nix/issues/7644).
This PR use 2.11.1 to be in sync with nixos 22.11 channel, but nix 2.12 would also work.