### PR TITLE
tullia jobs: use generic gitrev for PRs

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  "ci/push/required",
+  "ci/pr/required",
 ]
 timeout_sec = 7200
 required_approvals = 1

--- a/flake.lock
+++ b/flake.lock
@@ -12334,16 +12334,16 @@
     },
     "nixpkgs_37": {
       "locked": {
-        "lastModified": 1653920503,
-        "narHash": "sha256-BBeCZwZImtjP3oYy4WogkQYy5OxNyfNciVSc1AfZgLQ=",
+        "lastModified": 1674407282,
+        "narHash": "sha256-2qwc8mrPINSFdWffPK+ji6nQ9aGnnZyHSItVcYDZDlk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a634c8f6c1fbf9b9730e01764999666f3436f10a",
+        "rev": "ab1254087f4cdf4af74b552d7fc95175d9bdbb49",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -14608,11 +14608,11 @@
         "std": "std_4"
       },
       "locked": {
-        "lastModified": 1673956445,
-        "narHash": "sha256-v5SrnJ2LLihxv5HyXoQEm5z1UCiir2Q9NUKg1zzDPdo=",
+        "lastModified": 1674645024,
+        "narHash": "sha256-HMd6pnBlV2eSqB5Cy+KHmhNiLu2oybsoWHqDDXIErKo=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "0fc4c13d6981b08ba1e7aff1725c6a1f997222cd",
+        "rev": "68201331f733c82a5598e39ec8e455db0d40594a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3982,15 +3982,16 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1635892615,
-        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -6194,11 +6195,11 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1672275074,
-        "narHash": "sha256-1Ja+EjMYL/1Ah+jNcmMyFa3Qx8qIZ6jizU5HcISbfVk=",
+        "lastModified": 1674694244,
+        "narHash": "sha256-WiRjhSOxIqBwAP39VPf4ZrCqPK2Jf58up2xyk3tYyxI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "bb590a281666aba5266b3dd7c23f6854529066ea",
+        "rev": "418612f2f2b814ae6161682fb3770c3c86c41b44",
         "type": "github"
       },
       "original": {
@@ -8105,17 +8106,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1639165170,
-        "narHash": "sha256-QsWL/sBDL5GM8IXd/dE/ORiL4RvteEN+aok23tXgAoc=",
-        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
-        "revCount": 7,
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
         "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
       "original": {
-        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
+        "ref": "hkm/remote-iserv",
         "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       }
     },
     "lowdown-src": {
@@ -14100,11 +14102,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1672099824,
-        "narHash": "sha256-L2c4kjqJlZIOmesW7+8pHRbskoYwaKLy79gWO0/tNEI=",
+        "lastModified": 1674605441,
+        "narHash": "sha256-GX5OHXYP6jRSlDq0KOpb4AXgeEU70zVTRQ/ogKg7vR4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "b94478487c1223d80ecfd227d7394f96a1ed8099",
+        "rev": "17e090ed82bc8aedaf251a8becb7ba2455db816a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "Cardano Node";
 
   nixConfig = {
-    extra-substituters = ["https://cache.iog.io"];
-    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
 
   inputs = {
@@ -15,9 +15,9 @@
       flake = false;
     };
     nixTools = {
-        url = "github:input-output-hk/nix-tools";
-        flake = false;
-      };
+      url = "github:input-output-hk/nix-tools";
+      flake = false;
+    };
     haskellNix = {
       url = "github:input-output-hk/haskell.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -143,181 +143,172 @@
             inherit (project.pkgs) system;
           }).plutus-apps.haskell.packages.plutus-example.components.exes) plutus-example;
 
-        in project.exes // (with project.hsPkgs; {
-            inherit (ouroboros-consensus-byron.components.exes) db-converter;
-            inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser db-synthesizer;
-            inherit (bech32.components.exes) bech32;
-          } // lib.optionalAttrs hostPlatform.isUnix {
-            inherit (network-mux.components.exes) cardano-ping;
-            inherit plutus-example;
-          });
+        in
+        project.exes // (with project.hsPkgs; {
+          inherit (ouroboros-consensus-byron.components.exes) db-converter;
+          inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser db-synthesizer;
+          inherit (bech32.components.exes) bech32;
+        } // lib.optionalAttrs hostPlatform.isUnix {
+          inherit (network-mux.components.exes) cardano-ping;
+          inherit plutus-example;
+        });
 
       mkCardanoNodePackages = project: (collectExes project) // {
         inherit (project.pkgs) cardanoLib;
       };
 
-      flake = eachSystem supportedSystems (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system overlays;
-            inherit (haskellNix) config;
+      mkFlakeAttrs = pkgs: rec {
+        inherit (pkgs) system;
+        inherit (pkgs.haskell-nix) haskellLib;
+        inherit (haskellLib) collectChecks' collectComponents';
+        inherit (pkgs.commonLib) eachEnv environments mkSupervisordCluster;
+        inherit (pkgs.stdenv) hostPlatform;
+        project = pkgs.cardanoNodeProject;
+
+        # This is used by `nix develop .` to open a devShell
+        devShells = let shell = import ./shell.nix { inherit pkgs customConfig cardano-mainnet-mirror; }; in {
+          inherit (shell) devops workbench-shell;
+          default = shell.dev;
+          cluster = shell;
+          profiled = project.profiled.shell;
+        };
+
+        # NixOS tests run a node and submit-api and validate it listens
+        nixosTests = import ./nix/nixos/tests {
+          inherit pkgs;
+        };
+
+        checks = flattenTree project.checks //
+          # Linux only checks:
+          (optionalAttrs hostPlatform.isLinux (
+            prefixNamesWith "nixosTests/" (mapAttrs (_: v: v.${system} or v) nixosTests)
+          ))
+          # checks run on default system only;
+          // (optionalAttrs (system == defaultSystem) {
+          hlint = pkgs.callPackage pkgs.hlintCheck {
+            inherit (project.args) src;
           };
-          inherit (pkgs.haskell-nix) haskellLib;
-          inherit (haskellLib) collectChecks' collectComponents';
-          inherit (pkgs.commonLib) eachEnv environments mkSupervisordCluster;
-          inherit (project.pkgs.stdenv) hostPlatform;
+        });
 
-          project = (import ./nix/haskell.nix {
-            inherit (pkgs) haskell-nix gitrev;
-            inherit (std) incl;
-            inputMap = {
-              "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP;
-            };
-          }).appendModule customConfig.haskellNix;
-
-          pinned-workbench = cardano-node-workbench.workbench.${system};
-
-          shell = import ./shell.nix { inherit pkgs customConfig cardano-mainnet-mirror; };
-          devShells = {
-            inherit (shell) devops workbench-shell;
-            default = shell.dev;
-            cluster = shell;
-            profiled = project.profiled.shell;
+        exes = (collectExes project) // {
+          inherit (pkgs) cabalProjectRegenerate checkCabalProject;
+          "dockerImages/push" = import ./.buildkite/docker-build-push.nix {
+            hostPkgs = import hostNixpkgs { inherit system; };
+            inherit (pkgs) dockerImage submitApiDockerImage;
           };
+          "dockerImage/node/load" = pkgs.writeShellScript "load-docker-image" ''
+            docker load -i ${pkgs.dockerImage} $@
+          '';
+          "dockerImage/submit-api/load" = pkgs.writeShellScript "load-submit-docker-image" ''
+            docker load -i ${pkgs.submitApiDockerImage} $@
+          '';
+        } // flattenTree (pkgs.scripts // {
+          # `tests` are the test suites which have been built.
+          inherit (project) tests;
+          # `benchmarks` (only built, not run).
+          inherit (project) benchmarks;
+        });
 
-          # NixOS tests run a node and submit-api and validate it listens
-          nixosTests = import ./nix/nixos/tests {
-            inherit pkgs;
-          };
+        # The parametrisable workbench.
+        inherit (pkgs) workbench;
 
-          checks = flattenTree project.checks //
-            # Linux only checks:
-            (optionalAttrs hostPlatform.isLinux (
-              prefixNamesWith "nixosTests/" (mapAttrs (_: v: v.${system} or v) nixosTests)
-            ))
-            # checks run on default system only;
-            // (optionalAttrs (system == defaultSystem) {
-            hlint = pkgs.callPackage pkgs.hlintCheck {
-              inherit (project.args) src;
-            };
-          });
+        packages =
+          exes
+          # Linux only packages:
+          // optionalAttrs (system == "x86_64-linux") rec {
+            "dockerImage/node" = pkgs.dockerImage;
+            "dockerImage/submit-api" = pkgs.submitApiDockerImage;
 
-          exes = (collectExes project) // {
-            inherit (pkgs) cabalProjectRegenerate checkCabalProject;
-            "dockerImages/push" = import ./.buildkite/docker-build-push.nix {
-              hostPkgs = import hostNixpkgs { inherit system; };
-              inherit (pkgs) dockerImage submitApiDockerImage;
-            };
-            "dockerImage/node/load" = pkgs.writeShellScript "load-docker-image" ''
-              docker load -i ${pkgs.dockerImage} $@
-            '';
-            "dockerImage/submit-api/load" = pkgs.writeShellScript "load-submit-docker-image" ''
-              docker load -i ${pkgs.submitApiDockerImage} $@
-            '';
-          } // flattenTree (pkgs.scripts // {
-            # `tests` are the test suites which have been built.
-            inherit (project) tests;
-            # `benchmarks` (only built, not run).
-            inherit (project) benchmarks;
-          });
+            ## This is a very light profile, no caching&pinning needed.
+            workbench-ci-test =
+              (pkgs.workbench-runner
+                {
+                  profileName = "ci-test-bage";
+                  backendName = "supervisor";
+                  cardano-node-rev =
+                    if __hasAttr "rev" self
+                    then pkgs.gitrev
+                    else throw "Cannot get git revision of 'cardano-node', unclean checkout?";
+                }).profile-run { };
 
-          inherit (pkgs) workbench all-profiles-json workbench-runner;
+            inherit (pkgs) all-profiles-json;
+          }
+          # Add checks to be able to build them individually
+          // (prefixNamesWith "checks/" checks);
 
-          packages =
-            exes
-            # Linux only packages:
-            // optionalAttrs (system == "x86_64-linux") rec {
-              "dockerImage/node" = pkgs.dockerImage;
-              "dockerImage/submit-api" = pkgs.submitApiDockerImage;
+        apps = lib.mapAttrs (n: p: { type = "app"; program = p.exePath or (if (p.executable or false) then "${p}" else "${p}/bin/${p.name or n}"); }) exes;
 
-              ## This is a very light profile, no caching&pinning needed.
-              workbench-ci-test =
-                (pkgs.workbench-runner
-                  {
-                    profileName = "ci-test-bage";
-                    backendName = "supervisor";
-                    ## Not required, as long as it's fast.
-                    # workbench = pinned-workbench;
-                    cardano-node-rev =
-                      if __hasAttr "rev" self
-                      then self.rev
-                      else throw "Cannot get git revision of 'cardano-node', unclean checkout?";
-                  }).profile-run {};
-
-              all-profiles-json = pkgs.all-profiles-json;
-            }
-            # Add checks to be able to build them individually
-            // (prefixNamesWith "checks/" checks);
-
-          apps = lib.mapAttrs (n: p: { type = "app"; program = p.exePath or (if (p.executable or false) then "${p}" else "${p}/bin/${p.name or n}"); }) exes;
-
-          ciJobs = let ciJobs = {
-            cardano-deployment = pkgs.cardanoLib.mkConfigHtml { inherit (pkgs.cardanoLib.environments) mainnet testnet; };
-          } // optionalAttrs (system == "x86_64-linux") {
-            native = packages // {
-              shells = devShells;
-              internal = {
-                roots.project = project.roots;
-                plan-nix.project = project.plan-nix;
+        ciJobs =
+          let
+            ciJobs = {
+              cardano-deployment = pkgs.cardanoLib.mkConfigHtml { inherit (pkgs.cardanoLib.environments) mainnet testnet; };
+            } // optionalAttrs (system == "x86_64-linux") {
+              native = packages // {
+                shells = devShells;
+                internal = {
+                  roots.project = project.roots;
+                  plan-nix.project = project.plan-nix;
+                };
+                profiled = lib.genAttrs [ "cardano-node" "tx-generator" "locli" ] (n:
+                  packages.${n}.passthru.profiled
+                );
+                asserted = lib.genAttrs [ "cardano-node" ] (n:
+                  packages.${n}.passthru.asserted
+                );
               };
-              profiled = lib.genAttrs [ "cardano-node" "tx-generator" "locli" ] (n:
-                packages.${n}.passthru.profiled
-              );
-              asserted = lib.genAttrs [ "cardano-node" ] (n:
-                packages.${n}.passthru.asserted
-              );
-            };
-            musl =
-              let
-                muslProject = project.projectCross.musl64;
-                projectExes = collectExes muslProject;
-              in
-              projectExes // {
-                cardano-node-linux = import ./nix/binary-release.nix {
+              musl =
+                let
+                  muslProject = project.projectCross.musl64;
+                  projectExes = collectExes muslProject;
+                in
+                projectExes // {
+                  cardano-node-linux = import ./nix/binary-release.nix {
+                    inherit pkgs;
+                    inherit (exes.cardano-node.identifier) version;
+                    platform = "linux";
+                    exes = lib.collect lib.isDerivation projectExes;
+                  };
+                  internal.roots.project = muslProject.roots;
+                };
+              windows =
+                let
+                  windowsProject = project.projectCross.mingwW64;
+                  projectExes = collectExes windowsProject;
+                in
+                projectExes
+                  // (removeRecurse {
+                  inherit (windowsProject) checks tests benchmarks;
+                  cardano-node-win64 = import ./nix/binary-release.nix {
+                    inherit pkgs;
+                    inherit (exes.cardano-node.identifier) version;
+                    platform = "win64";
+                    exes = lib.collect lib.isDerivation (
+                      # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
+                      removeAttrs projectExes [ "tx-generator" ]
+                    );
+                  };
+                  internal.roots.project = windowsProject.roots;
+                });
+            } // optionalAttrs (system == "x86_64-darwin") {
+              native = lib.filterAttrs
+                (n: _:
+                  # only build docker images once on linux:
+                  !(lib.hasPrefix "dockerImage" n))
+                packages // {
+                cardano-node-macos = import ./nix/binary-release.nix {
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
-                  platform = "linux";
-                  exes = lib.collect lib.isDerivation projectExes;
+                  platform = "macos";
+                  exes = lib.collect lib.isDerivation (collectExes project);
                 };
-                internal.roots.project = muslProject.roots;
-              };
-            windows =
-              let
-                windowsProject = project.projectCross.mingwW64;
-                projectExes = collectExes windowsProject;
-              in
-              projectExes
-                // (removeRecurse {
-                inherit (windowsProject) checks tests benchmarks;
-                cardano-node-win64 = import ./nix/binary-release.nix {
-                  inherit pkgs;
-                  inherit (exes.cardano-node.identifier) version;
-                  platform = "win64";
-                  exes = lib.collect lib.isDerivation (
-                    # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
-                    removeAttrs projectExes ["tx-generator"]
-                  );
+                shells = removeAttrs devShells [ "profiled" ];
+                internal = {
+                  roots.project = project.roots;
+                  plan-nix.project = project.plan-nix;
                 };
-                internal.roots.project = windowsProject.roots;
-              });
-          } // optionalAttrs (system == "x86_64-darwin") {
-            native = lib.filterAttrs (n: _:
-              # only build docker images once on linux:
-              !(lib.hasPrefix "dockerImage" n)) packages // {
-              cardano-node-macos = import ./nix/binary-release.nix {
-                inherit pkgs;
-                inherit (exes.cardano-node.identifier) version;
-                platform = "macos";
-                exes = lib.collect lib.isDerivation (collectExes project);
-              };
-              shells = removeAttrs devShells [ "profiled" ];
-              internal = {
-                roots.project = project.roots;
-                plan-nix.project = project.plan-nix;
               };
             };
-          };
-          defaultNonRequiredPaths = [
+            nonRequiredPaths = [
               # hlint required status is controled via the github action:
               "native.checks/hlint"
               #FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
@@ -328,71 +319,77 @@
               "windows.tests.tx-generator.tx-generator-apitest"
               "windows.checks.tx-generator.tx-generator-apitest"
               "windows.tests.tx-generator.tx-generator-test"
-              "windows.checks.tx-generator.tx-generator-test"] ++
+              "windows.checks.tx-generator.tx-generator-test"
+            ] ++
             lib.optionals (system == "x86_64-darwin") [
               #FIXME:  ExceptionInLinkedThread (ThreadId 253) pokeSockAddr: path is too long
               "native.checks/cardano-testnet/cardano-testnet-tests"
             ];
-          in pkgs.callPackages iohkNix.utils.ciJobsAggregates {
-            inherit ciJobs;
-            nonRequiredPaths = map lib.hasPrefix defaultNonRequiredPaths;
-          } // {
-            pr = pkgs.callPackages iohkNix.utils.ciJobsAggregates {
+          in
+          pkgs.callPackages iohkNix.utils.ciJobsAggregates
+            {
               inherit ciJobs;
-              nonRequiredPaths = map lib.hasPrefix (defaultNonRequiredPaths ++ [
-                "native.membenches"
-              ]);
+              nonRequiredPaths = map lib.hasPrefix nonRequiredPaths;
+            } // ciJobs // {
+            pr = {
+              # We use a generic gitrev for PR CI to avoid unecessary rebuilds:
+              inherit ((mkFlakeAttrs (pkgs.extend (prev: final: { gitrev = "0000000000000000000000000000000000000000"; }))).ciJobs)
+                required nonrequired;
             };
-          } // ciJobs;
+          };
+      };
 
+      flake = eachSystem supportedSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system overlays;
+            inherit (haskellNix) config;
+          };
+          inherit (mkFlakeAttrs pkgs) environments packages checks apps project ciJobs devShells workbench;
         in
         {
 
-          inherit environments packages checks apps project ciJobs;
+          inherit environments checks project ciJobs devShells workbench;
 
           legacyPackages = pkgs // {
-            # allows access to hydraJobs with specifying <arch>:
+            # allows access to hydraJobs without specifying <arch>:
             hydraJobs = ciJobs;
           };
 
-          # Built by `nix build .`
-          defaultPackage = packages.cardano-node;
+          packages = packages // {
+            # Built by `nix build .`
+            default = packages.cardano-node;
+          };
 
           # Run by `nix run .`
-          defaultApp = apps.cardano-node;
-
-          # This is used by `nix develop .` to open a devShell
-          inherit devShells;
-
-          # The parametrisable workbench.
-          inherit workbench;
+          apps = apps // {
+            default = apps.cardano-node;
+          };
 
         } //
         tullia.fromSimple system (import ./nix/tullia.nix)
       );
 
-      hydraJobs = flake.ciJobs // {
-        # TODO: remove nex 3 lines once tullia config reference architecture directly:
-        inherit (flake.ciJobs.${defaultSystem}) cardano-deployment;
-        linux.required = flake.ciJobs.x86_64-linux.required or {};
-        macos.required = flake.ciJobs.x86_64-darwin.required or {};
-      };
-      # TODO: also hydraJobsPr remove once tullia config reference hydraJobs.<arch>.pr:
-      hydraJobsPr = {
-        inherit (flake.ciJobs.${defaultSystem}) cardano-deployment;
-        linux.required = flake.ciJobs.x86_64-linux.pr.required or {};
-        macos.required = flake.ciJobs.x86_64-darwin.pr.required or {};
-      };
+    in
+    removeAttrs flake [ "ciJobs" ] // {
 
-    in removeAttrs flake ["ciJobs"] // {
-
-      inherit hydraJobs hydraJobsPr;
+      hydraJobs = flake.ciJobs;
 
       # allows precise paths (avoid fallbacks) with nix build/eval:
       outputs = self;
 
       overlay = final: prev: {
-        cardanoNodeProject = flake.project.${final.system};
+        cardanoNodeProject = (import ./nix/haskell.nix {
+          inherit (final) haskell-nix;
+          inherit (std) incl;
+        }).appendModule [
+          {
+            inputMap = {
+              "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP;
+            };
+          }
+          customConfig.haskellNix
+        ];
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
         inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli plutus-example db-analyser;
       };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -2,9 +2,6 @@
 # Builds Haskell packages with Haskell.nix
 ############################################################################
 { haskell-nix
-, # Version info (git revision)
-  gitrev
-, inputMap
 , incl
 }:
 let
@@ -20,8 +17,6 @@ let
                                        , ...
                                        }:
     {
-      inherit inputMap;
-      # We clean-up src to avoid rebuild for unrelated changes for tests that use $CARDANO_NODE_SRC:
       src = ../.;
       name = "cardano-node";
       compiler-nix-name = "ghc8107";
@@ -230,7 +225,7 @@ in
 project.appendOverlays (with haskellLib.projectOverlays; [
   projectComponents
   (final: prev:
-    let inherit (final.pkgs) lib; in {
+    let inherit (final.pkgs) lib gitrev; in {
       profiled = final.appendModule {
         modules = [{
           enableLibraryProfiling = true;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -13,23 +13,23 @@ final: prev: with final; {
 
   hlint = haskell-nix.tool compiler-nix-name "hlint" {
     version = "3.2.7";
-    index-state = "2022-12-11T00:00:00Z";
+    index-state = "2023-01-20T05:50:56Z";
   };
 
   ghcid = haskell-nix.tool compiler-nix-name "ghcid" {
     version = "0.8.7";
-    index-state = "2022-12-11T00:00:00Z";
+    index-state = "2023-01-20T05:50:56Z";
   };
 
-  haskell-language-server = haskell-nix.tool "ghc8107" "haskell-language-server" {
+  haskell-language-server = haskell-nix.tool compiler-nix-name "haskell-language-server" {
     # ghcide 1.9.0.0 does not compile on ghc 8.10.7
     version = {ghc8107 = "1.8.0.0";}.${compiler-nix-name} or "1.9.0.0";
-    index-state = {ghc8107 = "2022-12-11T00:00:00Z";}.${compiler-nix-name} or "2023-01-11T00:00:00Z";
+    index-state = "2023-01-20T05:50:56Z";
   };
 
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit compiler-nix-name;
-    index-state = "2022-12-11T00:00:00Z";
+    index-state = "2023-01-20T05:50:56Z";
   };
 
   cardanolib-py = callPackage ./cardanolib-py { };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -3,12 +3,6 @@ final: prev: with final; {
 
   inherit (cardanoNodeProject.args) compiler-nix-name;
 
-  # The is used by nix/regenerate.sh to pre-compute package list to avoid double evaluation.
-  genProjectPackages = lib.genAttrs
-    (lib.attrNames (haskell-nix.haskellLib.selectProjectPackages
-      cardanoNodeProject.hsPkgs))
-    (name: lib.attrNames cardanoNodeProject.pkg-set.options.packages.value.${name}.components.exes);
-
   cabal = haskell-nix.cabal-install.${compiler-nix-name};
 
   hlint = haskell-nix.tool compiler-nix-name "hlint" {

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -70,7 +70,7 @@ rec {
     in
     {
       "ci/pr/required" = mkBulkJobsTask "pr.required";
-      "ci/pr/nonrequired" = mkBulkJobsTask "pr.nonrequired";
+      "ci/pr/nonrequired" = mkBulkJobsTask "pr.nonrequired --keep-going";
       "ci/push/required" = mkBulkJobsTask "required";
 
       "ci/cardano-deployment" = { lib, ... } @ args: {

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -104,7 +104,7 @@ rec {
         #lib.io.github_push
         #input: "${ciInputName}"
         #repo: "${repository}"
-        #branch: "master|staging|trying"
+        #branch: "master|release/.*"
       '';
     in
     {
@@ -117,10 +117,23 @@ rec {
         task = "ci/cardano-deployment";
         io = pushIo;
       };
-
+      # This one is used for both PR status and bors:
       "cardano-node/ci/pr/required" = {
         task = "ci/pr/required";
-        io = prIo;
+        io = ''
+          let github = {
+            #input: "${ciInputName}"
+            #repo: "${repository}"
+          }
+          let borsBranches = {
+            #branch: "staging|trying"
+          }
+          #lib.merge
+          #ios: [
+            #lib.io.github_pr & github,
+            #lib.io.github_push & borsBranches & github,
+          ]
+        '';
       };
       "cardano-node/ci/pr/nonrequired" = {
         task = "ci/pr/nonrequired";


### PR DESCRIPTION
 to avoid unnecessary builds of big artifact, like dockerImages.
 Goal: bors ci build should not build anything if branch is up-to-date
 and ci pass.

 Some other minor clean-ups.