### PR TITLE
Use Haskell variables for passing values.

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -67,6 +67,7 @@ library
                         Testnet.Byron
                         Testnet.Util.Assert
                         Testnet.Util.Base
+                        Testnet.Util.Cli
                         Testnet.Util.Ignore
                         Testnet.Util.Process
                         Testnet.Util.Runtime

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -21,6 +21,11 @@ module Cardano.Testnet (
   Conf(..),
   ProjectBase(..),
   YamlFilePath(..),
+  TmpPath(..),
+  getTmpBaseAbsPath,
+  getSocketDir,
+  getLogDir,
+
   mkConf,
 
   -- * Processes

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -17,7 +17,7 @@ import           Testnet
 import           Testnet.Cardano
 import           Testnet.Run (runTestnet)
 import           Testnet.Util.Runtime (readNodeLoggingFormat)
-import           Testnet.Utils
+import           Testnet.Utils (pMaxLovelaceSupply)
 
 data CardanoOptions = CardanoOptions
   { maybeTestnetMagic :: Maybe Int

--- a/cardano-testnet/src/Parsers/Shelley.hs
+++ b/cardano-testnet/src/Parsers/Shelley.hs
@@ -4,15 +4,13 @@ module Parsers.Shelley
   , runShelleyOptions
   ) where
 
-import           Prelude
-
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
 import           Testnet
 import           Testnet.Run (runTestnet)
 import           Testnet.Shelley
-import           Testnet.Utils
+import           Testnet.Utils (pMaxLovelaceSupply)
 
 
 data ShelleyOptions = ShelleyOptions

--- a/cardano-testnet/src/Testnet.hs
+++ b/cardano-testnet/src/Testnet.hs
@@ -7,9 +7,6 @@ module Testnet
   ) where
 
 import           Control.Monad
-import           Prelude
-
-
 
 import           Hedgehog
 import           Hedgehog.Extras.Test.Base (Integration, noteShow_)

--- a/cardano-testnet/src/Testnet/Byron.hs
+++ b/cardano-testnet/src/Testnet/Byron.hs
@@ -43,6 +43,7 @@ import qualified System.IO as IO
 import qualified System.Process as IO
 import qualified Testnet.Conf as H
 import qualified Testnet.Util.Process as H
+import           Testnet.Util.Runtime (TmpPath(..), getLogDir, getSocketDir, getTmpBaseAbsPath, makeSprocket)
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
@@ -165,6 +166,11 @@ testnet testnetOptions H.Conf {..} = do
   let nodeIndexes = [0..numBftNodes testnetOptions - 1]
   let allNodes = fmap (\i -> "node-" <> show @Int i) nodeIndexes
 
+  let
+    logDir = getLogDir (TmpPath tempAbsPath)
+    socketDir = getSocketDir (TmpPath tempAbsPath)
+    tempBaseAbsPath = getTmpBaseAbsPath (TmpPath tempAbsPath)
+
   H.createDirectoryIfMissing logDir
 
   -- Launch cluster of three nodes in P2P Mode
@@ -173,7 +179,7 @@ testnet testnetOptions H.Conf {..} = do
     dbDir <- H.noteShow $ tempAbsPath </> "db/node-" <> si
     nodeStdoutFile <- H.noteTempFile tempAbsPath $ "cardano-node-" <> si <> ".stdout.log"
     nodeStderrFile <- H.noteTempFile tempAbsPath $ "cardano-node-" <> si <> ".stderr.log"
-    sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> "node-" <> si)
+    sprocket <- H.noteShow $ makeSprocket (TmpPath tempAbsPath) ("node-" <> si)
     portString <- H.note $ show @Int (allPorts L.!! i)
     topologyFile <- H.noteShow $ tempAbsPath </> "topology-node-" <> si <> ".json"
     configFile <- H.noteShow $ tempAbsPath </> "config-" <> si <> ".yaml"

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -277,8 +277,8 @@ cardanoTestnetByronGenesis
     , [File ByronDelegationKey]
     )
 cardanoTestnetByronGenesis tp testnetMagic testnetOptions configurationTemplate startTime = do
-  let (TmpPath tmpDir) = tp
-  let numBftNodes = cardanoNumBftNodes $ cardanoNodes testnetOptions
+  let TmpPath tmpDir = tp
+      numBftNodes = cardanoNumBftNodes $ cardanoNodes testnetOptions
       bftNodesN = [1 .. numBftNodes]
       poolNodesN = [1 .. cardanoNumPoolNodes $ cardanoNodes testnetOptions]
       bftNodeNames = ("node-bft" <>) . show @Int <$> bftNodesN
@@ -364,6 +364,7 @@ cardanoTestnetByronGenesis tp testnetMagic testnetOptions configurationTemplate 
 
 
     H.writeFile (tmpDir </> node </> "port") (show port)
+
   H.lbsWriteFile (tmpDir </> "byron.genesis.spec.json")
     . J.encode $ defaultByronGenesisJsonValue
 
@@ -396,16 +397,16 @@ cardanoTestnetByronGenesis tp testnetMagic testnetOptions configurationTemplate 
   let
     forallBftNodesMkFile x = forM [1..numBftNodes] (fakeItH . x)
 
-  (genesisKeys :: [File ByronKey])<- forallBftNodesMkFile $ \n -> "byron/genesis-keys.00" <> show @Int (n - 1) <> ".json"
-  (delegationCerts :: [File ByronDelegationCert]) <- forallBftNodesMkFile $ \n -> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
-  (delegationKeys :: [File ByronDelegationKey]) <- forallBftNodesMkFile $ \n -> "byron/delegation-cert.00" <> show @Int (n - 1) <> ".json"
+  genesisKeys <- forallBftNodesMkFile $ \n -> "byron/genesis-keys.00" <> show @Int (n - 1) <> ".json"
+  delegationCerts <- forallBftNodesMkFile $ \n -> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key"
+  delegationKeys <- forallBftNodesMkFile $ \n -> "byron/delegation-cert.00" <> show @Int (n - 1) <> ".json"
 
   return (genesisKeys, delegationCerts, delegationKeys)
 
 
 {-
 cardanoTestnetByronGenesisExpenditure creates an transaction `tx0.tx'
-which however is never used anywhere ??
+TODO: a test that transmits tx0.tx and checks that it gets accepted.
 -}
 cardanoTestnetByronGenesisExpenditure
   :: CardanoTestnetOptions
@@ -447,7 +448,8 @@ cardanoTestnetByronGenesisExpenditure testnetOptions H.Conf {..} genesisKeys = d
 
 {-
 cardanoTestnetByronGovernance creates two update-proposals and two update-votes.
-However they are never transmitted to the chain ?!
+TODO: There should be a test that transmits thoese proposals and checks
+that they get activated.
 -}
 cardanoTestnetByronGovernance
   :: Int

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Testnet.Cardano
   ( ForkPoint(..)

--- a/cardano-testnet/src/Testnet/Conf.hs
+++ b/cardano-testnet/src/Testnet/Conf.hs
@@ -2,43 +2,33 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Testnet.Conf
-  ( ProjectBase(..)
-  , YamlFilePath(..)
-  , Conf(..)
-  , mkConf
+  ( ProjectBase(..)  -- Todo remove inline
+  , YamlFilePath(..) -- Todo remove inline
+  , Conf(..) -- Todo remove inline
+  , mkConf -- Todo remove inline
   ) where
 
-import           System.FilePath.Posix ((</>))
-
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified System.FilePath.Posix as FP
 import qualified System.Random as IO
 
-newtype ProjectBase = ProjectBase
+newtype ProjectBase = ProjectBase  -- from the project that surounds the cabal package
   { projectBase :: FilePath
   } deriving (Eq, Show)
 
-newtype YamlFilePath = YamlFilePath
+newtype YamlFilePath = YamlFilePath   -- from the project that surounds the cabal package
   { projectBase :: FilePath
   } deriving (Eq, Show)
 
 data Conf = Conf
   { tempAbsPath :: FilePath
-  , tempRelPath :: FilePath
-  , tempBaseAbsPath :: FilePath
-  , logDir :: FilePath
-  , base :: FilePath
-  , socketDir :: FilePath
-  , configurationTemplate :: FilePath
+  , base :: FilePath -- -- from the project that surounds the cabal package
+  , configurationTemplate :: FilePath -- from the project that surounds the cabal package
   , testnetMagic :: Int
   } deriving (Eq, Show)
 
 mkConf :: ProjectBase -> YamlFilePath -> FilePath -> Maybe Int -> H.Integration Conf
-mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsPath maybeMagic = do
-  testnetMagic <- H.noteShowIO $ maybe (IO.randomRIO (1000, 2000)) return maybeMagic
-  tempBaseAbsPath <- H.noteShow $ FP.takeDirectory tempAbsPath
-  tempRelPath <- H.noteShow $ FP.makeRelative tempBaseAbsPath tempAbsPath
-  socketDir <- H.noteShow $ tempRelPath </> "socket"
-  logDir <- H.noteTempFile tempAbsPath "logs"
-
+mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tmpPath maybeMagic = do
+  testnetMagic <- maybe (IO.randomRIO (1000, 2000)) return maybeMagic
+  let tempAbsPath = tmpPath
+  H.noteShow_ testnetMagic
   return $ Conf {..}

--- a/cardano-testnet/src/Testnet/Util/Cli.hs
+++ b/cardano-testnet/src/Testnet/Util/Cli.hs
@@ -1,0 +1,186 @@
+module Testnet.Util.Cli
+  ( cliAddressKeyGen
+  , cliNodeKeyGen
+  , cliNodeKeyGenVrf
+  , cliNodeKeyGenKes
+  , cliStakeAddressKeyGen
+  , Comment (..)
+  , KeyNames (..)
+
+  , fakeItH
+  , fakeIt
+  , TmpDir
+  , TestnetMagic
+  , File (..)
+  , Address
+  , Operator -- == Cold Keys
+  , Kes
+  , StakeAddress
+  , Vrf
+
+  , VKey
+  , SKey
+
+  , OperatorCounter
+  , ByronKey
+  , ByronAddress
+
+  , ByronDelegationKey
+  , ByronDelegationCert
+
+  , getVKeyPath
+  , getSKeyPath
+
+  , makeFilePath
+  , cliKeyGen
+
+  , cliSigningKeyAddress
+  ) where
+
+import           Prelude
+
+import           Data.String
+import           Control.Monad
+import           System.FilePath.Posix
+
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H (writeFile)
+import           Hedgehog
+import           Hedgehog.Gen
+
+import           Testnet.Util.Process
+
+-- TODO: check no whitespace , slash etc allowed
+-- TODO: use Comment instead of Filepath
+newtype Comment = Comment { unComment :: String}
+  deriving (Show, Eq, Ord )
+
+instance IsString Comment where fromString a = Comment a
+
+instance Semigroup Comment where
+  (Comment a) <> (Comment b) = Comment $ a <> "-" <> b
+
+-- Could also use IO (timestamp).
+makeFilePath :: MonadGen m => FilePath -> Comment -> FilePath -> m FilePath
+makeFilePath path comment suffix = do
+  almostUnique <- Comment <$> replicateM 4 hexit
+  return $ path </> unComment ( comment <> almostUnique) <.> suffix
+
+data KeyNames = KeyNames
+  { verificationKeyFile :: FilePath
+  , signingKeyFile :: FilePath
+  }
+
+type KeyGen a = H.Integration (File (a VKey), File (a SKey))
+
+-- cliAddressKeyGen :: FilePath -> Comment -> KeyGen
+cliAddressKeyGen :: TmpDir -> KeyNames -> KeyGen Address
+cliAddressKeyGen = shelleyKeyGen "address" "key-gen"
+
+cliStakeAddressKeyGen :: TmpDir -> KeyNames -> KeyGen StakeAddress
+cliStakeAddressKeyGen = shelleyKeyGen "stake-address" "key-gen"
+
+cliNodeKeyGenVrf :: TmpDir -> KeyNames -> KeyGen Vrf
+cliNodeKeyGenVrf = shelleyKeyGen "node" "key-gen-VRF"
+
+cliNodeKeyGenKes :: TmpDir -> KeyNames -> KeyGen Kes
+cliNodeKeyGenKes = shelleyKeyGen "node" "key-gen-KES"
+
+shelleyKeyGen :: String -> String -> TmpDir -> KeyNames -> KeyGen x
+shelleyKeyGen command subCommand tmpDir keyNames = do
+  let
+    vKeyPath = tmpDir </> verificationKeyFile keyNames
+    sKeyPath = tmpDir </> signingKeyFile keyNames
+  execCli_
+      [ command, subCommand
+      , "--verification-key-file", vKeyPath
+      , "--signing-key-file", sKeyPath
+      ]
+  return (File vKeyPath, File sKeyPath)
+
+cliNodeKeyGen
+  :: TmpDir
+  -> FilePath
+  -> FilePath
+  -> FilePath
+  -> H.Integration (File (Operator VKey), File (Operator SKey), File OperatorCounter)
+cliNodeKeyGen tmpDir vkey skey counter = do
+  let
+    vkPath = tmpDir </> vkey
+    skPath = tmpDir </> skey
+    counterPath = tmpDir </> counter
+  execCli_
+    [ "node", "key-gen"
+    , "--cold-verification-key-file", vkPath
+    , "--cold-signing-key-file", skPath
+    , "--operational-certificate-issue-counter-file", counterPath
+    ]
+  return (File vkPath, File skPath, File counterPath)
+
+data Address key
+data Kes key
+data Operator key
+data StakeAddress key
+data Vrf key
+
+data VKey
+data SKey
+
+data OperatorCounter
+data ByronKey
+data ByronAddress
+data ByronDelegationKey
+data ByronDelegationCert
+
+type TmpDir = FilePath
+type TestnetMagic = Int
+newtype File a = File {unFile :: FilePath}
+  deriving (Show, Eq)
+
+-- This is the back-door for creating File resources in parts of
+-- code that have not been refactored.
+-- When all uses of fakeItH are removed the cleanup is done.
+fakeItH :: FilePath -> H.Integration (File a)
+fakeItH filePath = do
+  return $ File filePath
+  {-
+  exists <- liftIO $ fileExists filePath
+  if exists
+    then return $ File filePath
+    else error (filePath <> " does not exist.")
+-}
+
+fakeIt :: FilePath -> File a
+fakeIt = File
+
+getVKeyPath ::  (File (a VKey), File (a SKey)) -> FilePath
+getVKeyPath (File a, _ ) = a
+
+getSKeyPath ::  (File (a VKey), File (a SKey)) -> FilePath
+getSKeyPath (_, File a) = a
+
+-- Byron
+cliKeyGen :: TmpDir -> FilePath -> H.Integration (File ByronKey)
+cliKeyGen tmp key = do
+  let keyPath = tmp </> key
+  execCli_
+      [ "keygen"
+      , "--secret", keyPath
+      ]
+  return $ File keyPath
+
+cliSigningKeyAddress
+  :: TmpDir
+  -> Int
+  -> File ByronKey
+  -> FilePath
+  -> H.Integration (File ByronAddress)
+cliSigningKeyAddress tmp testnetMagic (File key) destPath = do
+  let addrPath = tmp </> destPath
+  addr <- execCli
+      [ "signing-key-address"
+      , "--testnet-magic", show testnetMagic
+      , "--secret", tmp </> key
+      ]
+  H.writeFile addrPath addr
+  return $ File addrPath

--- a/cardano-testnet/src/Testnet/Util/Cli.hs
+++ b/cardano-testnet/src/Testnet/Util/Cli.hs
@@ -58,7 +58,7 @@ newtype Comment = Comment { unComment :: String}
 instance IsString Comment where fromString a = Comment a
 
 instance Semigroup Comment where
-  (Comment a) <> (Comment b) = Comment $ a <> "-" <> b
+  Comment a <> Comment b = Comment $ a <> "-" <> b
 
 -- Could also use IO (timestamp).
 makeFilePath :: MonadGen m => FilePath -> Comment -> FilePath -> m FilePath
@@ -134,6 +134,7 @@ data ByronDelegationCert
 
 type TmpDir = FilePath
 type TestnetMagic = Int
+
 newtype File a = File {unFile :: FilePath}
   deriving (Show, Eq)
 
@@ -143,21 +144,19 @@ newtype File a = File {unFile :: FilePath}
 fakeItH :: FilePath -> H.Integration (File a)
 fakeItH filePath = do
   return $ File filePath
-  {-
-  exists <- liftIO $ fileExists filePath
-  if exists
-    then return $ File filePath
-    else error (filePath <> " does not exist.")
+{-
+  TODO: check that the file actually exists.
+  TODO: Is there a simple function in the test framework for that ?
 -}
 
 fakeIt :: FilePath -> File a
 fakeIt = File
 
 getVKeyPath ::  (File (a VKey), File (a SKey)) -> FilePath
-getVKeyPath (File a, _ ) = a
+getVKeyPath = unFile . fst
 
 getSKeyPath ::  (File (a VKey), File (a SKey)) -> FilePath
-getSKeyPath (_, File a) = a
+getSKeyPath = unFile . snd
 
 -- Byron
 cliKeyGen :: TmpDir -> FilePath -> H.Integration (File ByronKey)

--- a/cardano-testnet/src/Testnet/Util/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Util/Runtime.hs
@@ -26,12 +26,11 @@ module Testnet.Util.Runtime
   , getTmpBaseAbsPath    -- used for Testnet.Byron
   ) where
 
-
 import           Control.Monad
 import           Data.Aeson (FromJSON)
 import qualified Data.List as L
-
 import           Data.Text (Text)
+
 import           GHC.Generics (Generic)
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
@@ -48,6 +47,7 @@ import qualified System.Process as IO
 
 import           Testnet.Util.Cli
 import qualified Testnet.Util.Process as H
+
 
 data NodeLoggingFormat = NodeLoggingFormatAsJson | NodeLoggingFormatAsText deriving (Eq, Show)
 
@@ -127,18 +127,24 @@ makeSprocket
   -> String
   -> Sprocket
 makeSprocket tmpPath node
-  = Sprocket (getTmpBaseAbsPath tmpPath)  (getSocketDir tmpPath </> node)
+  = Sprocket (getTmpBaseAbsPath tmpPath) (getSocketDir tmpPath </> node)
+
 newtype TmpPath = TmpPath
   { unTmpPath :: FilePath
   } deriving (Eq, Show)
+
 getTmpRelPath :: TmpPath -> FilePath
 getTmpRelPath (TmpPath fp) = FP.makeRelative (getTmpBaseAbsPath (TmpPath fp)) fp
+
 getSocketDir :: TmpPath -> FilePath
 getSocketDir fp = getTmpRelPath fp </> "socket"
+
 getTmpBaseAbsPath :: TmpPath -> FilePath
 getTmpBaseAbsPath (TmpPath fp) = FP.takeDirectory fp
+
 getLogDir :: TmpPath -> FilePath
 getLogDir (TmpPath fp) = fp </> "logs"
+
 -- | Start a node, creating file handles, sockets and temp-dirs.
 startNode
   :: TmpPath
@@ -154,6 +160,7 @@ startNode tp@(TmpPath tempAbsPath) node nodeCmd = do
     logDir = getLogDir tp
 
   H.createDirectoryIfMissing logDir
+
   dbDir <- H.noteShow $ tempAbsPath </> "db/" <> node
   nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"
   nodeStderrFile <- H.noteTempFile logDir $ node <> ".stderr.log"

--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -18,16 +18,16 @@ import           Control.Concurrent (threadDelay)
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Data.Aeson
+import           Data.Aeson (fromJSON)
 import           Data.Word
 import           GHC.Stack
 import           Options.Applicative
+import           Hedgehog.Extras.Test.Process (ExecConfig)
+import           Hedgehog.Internal.Property (MonadTest)
 import           System.Directory (doesFileExist, removeFile)
 
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Hedgehog.Extras.Test.Process (ExecConfig)
-import           Hedgehog.Internal.Property (MonadTest)
 
 import           Testnet.Cardano (CardanoTestnetOptions (..), defaultTestnetOptions)
 import qualified Testnet.Util.Process as H
@@ -87,7 +87,6 @@ queryTip (QueryTipOutput fp) testnetMag execConfig = do
   H.noteShowM $ H.jsonErrorFail $ fromJSON @QueryTipLocalStateOutput tipJSON
 
 newtype QueryTipOutput = QueryTipOutput { unQueryTipOutput :: FilePath}
-
 
 -- Parsers
 

--- a/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -56,9 +56,10 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo-leadership-schedu
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
+  conf@Conf { tempAbsPath } <- H.noteShowM $
     mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
   let
+    tempBaseAbsPath = getTmpBaseAbsPath (TmpPath tempAbsPath)
     fastTestnetOptions = CardanoOnlyTestnetOptions cardanoDefaultTestnetOptions
       { cardanoEpochLength = 500
       , cardanoSlotLength = 0.01

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -49,13 +49,14 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
+  conf@Conf { tempAbsPath } <- H.noteShowM $
     mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
 
   work <- H.note $ tempAbsPath </> "work"
   H.createDirectoryIfMissing work
 
   let
+    tempBaseAbsPath = getTmpBaseAbsPath (TmpPath tempAbsPath)
     testnetOptions = BabbageOnlyTestnetOptions $ babbageDefaultTestnetOptions
       { babbageNodeLoggingFormat = NodeLoggingFormatAsJson
       }

--- a/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -49,7 +49,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
+  conf@Conf { tempAbsPath } <- H.noteShowM $
     mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
 
   work <- H.note $ tempAbsPath </> "work"
@@ -78,7 +78,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
       -- The environment must be passed onto child process on Windows in order to
       -- successfully start that process.
       <> env
-    , H.execConfigCwd = Last $ Just tempBaseAbsPath
+    , H.execConfigCwd = Last $ Just $ getTmpBaseAbsPath $ TmpPath tempAbsPath
     }
 
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime

--- a/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
@@ -47,7 +47,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   configurationTemplate
     <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
 
-  conf@Conf { tempBaseAbsPath, tempAbsPath }
+  conf@Conf { tempAbsPath }
     <- H.noteShowM $ mkConf (ProjectBase base) (YamlFilePath configurationTemplate)
                               tempAbsBasePath' Nothing
 
@@ -68,7 +68,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
           -- The environment must be passed onto child process on Windows in order to
           -- successfully start that process.
           <> env
-        , H.execConfigCwd = Last $ Just tempBaseAbsPath
+        , H.execConfigCwd = Last $ Just $ getTmpBaseAbsPath $ TmpPath tempAbsPath
         }
 
   -- First we note all the relevant files

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -35,13 +35,12 @@ instance Show FoldBlocksException where
 -- that main thread blocks on.
 prop_foldBlocks :: H.Property
 prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath' -> do
-
   -- Start testnet
   base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase
-  configTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
+  configTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml" --- outside of the package directory !!
   conf <- HE.noteShowM $
     TN.mkConf (TN.ProjectBase base) (TN.YamlFilePath configTemplate)
-      (tempAbsBasePath' <> "/")
+      (tempAbsBasePath' <> "/") --  '<> "/")'  is needed otherwise test fails !
       Nothing
 
   let options = CardanoOnlyTestnetOptions $ cardanoDefaultTestnetOptions

--- a/cardano-testnet/test/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/Test/Node/Shutdown.hs
@@ -38,8 +38,11 @@ hprop_shutdown :: Property
 hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  Conf { tempBaseAbsPath, tempAbsPath, logDir, socketDir } <- H.noteShowM $
+  Conf { tempAbsPath } <- H.noteShowM $
     mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+  let logDir = getLogDir (TmpPath tempAbsPath) 
+      tempBaseAbsPath = getTmpBaseAbsPath (TmpPath tempAbsPath)
+      socketDir = getSocketDir (TmpPath tempAbsPath)
 
   [port] <- H.noteShowIO $ IO.allocateRandomPorts 1
 

--- a/cardano-testnet/test/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/Test/Node/Shutdown.hs
@@ -40,7 +40,7 @@ hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' ->
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   Conf { tempAbsPath } <- H.noteShowM $
     mkConf (ProjectBase base) (YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
-  let logDir = getLogDir (TmpPath tempAbsPath) 
+  let logDir = getLogDir (TmpPath tempAbsPath)
       tempBaseAbsPath = getTmpBaseAbsPath (TmpPath tempAbsPath)
       socketDir = getSocketDir (TmpPath tempAbsPath)
 


### PR DESCRIPTION
This is a combination of several commits. (They were squashed into one big commit during an elaborate re-base).
Most changes are related to the way filenames work in `cardano-testnet`.

Currently the `cardano-testnet` uses filenames (Strings) to reference objects like keys, certs etc.
Two locations in the code refer to the same object by "magically" using the same filename.
This means that the data flow is implicit and hard to follow.
Old scheme:
```
do
cli_call_1 "filenameX" "filenameY"
cli_call_2 "filenameX" "filenameZ"
cli_call_3 "filenameA" "filenameB"
```
This PR changes the design as follows:
* File names are stored in an opaque `File` datatype (which wraps the file path).
* A wrapper is used for CLI calls. When a CLI call creates a file the wrapper returns the corresponding `File` resource.
* While CLI calls have type `IO ()` the wrapper has type `IO (File,..,File).
* CLI calls don't construct magic Filenames, but instead use the `File` resource that was created earlier.
The new scheme is
```
do
(file1, file2) <- cli_call1 arg1 arg2     -- cli_call1 creates file resources file1 and file2
(fileX, fileY) <- cli_call2 file1 file2    -- cli_call2 uses file resourcs file1 and file2
```
Full transformation to new scheme for filenames is still WIP.
