### PR TITLE
Fix how changed files are selected in stylish-haskell CI check

### DIFF
--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -1,4 +1,4 @@
-name: Stylish Haskell
+name: Check Stylish Haskell
 
 on:
   push:
@@ -128,8 +128,8 @@ jobs:
       run: |
         git add .
         git stash
-        git fetch origin master --unshallow
-        for x in $(git diff --name-only HEAD origin/master ${{ env.STYLISH_HASKELL_PATHS }}); do
+        git fetch origin ${{ github.base_ref }} --unshallow
+        for x in $(git diff --name-only ${{ github.base_ref }} HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
             stylish-haskell -i $x
           fi


### PR DESCRIPTION
The `stylish-haskell` CI had `git diff --name-only HEAD origin/master`, which is wrong because that means added files are not check, but removed files are, which causes `stylish-haskell` to fail because removed files can't be found.  The order needed to be swapped around to `git diff --name-only origin/master HEAD`