### PR TITLE
Remove NoImplicitPrelude

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -124,7 +124,6 @@ library
                       , cardano-ledger-byron ^>= 0.1
                       , cardano-ledger-core ^>= 0.1
                       , cardano-ledger-shelley-ma ^>= 0.1
-                      , cardano-prelude
                       , cardano-protocol-tpraos >= 0.1
                       , cardano-slotting >= 0.1
                       , cborg
@@ -197,7 +196,6 @@ library gen
                       , cardano-ledger-alonzo-test
                       , cardano-ledger-byron-test ^>= 1.4
                       , cardano-ledger-core ^>= 0.1
-                      , cardano-prelude
                       , containers
                       , hedgehog
                       , cardano-ledger-shelley ^>= 0.1

--- a/cardano-api/gen/Test/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api.hs
@@ -8,12 +8,9 @@ module Test.Gen.Cardano.Api
   , genAlonzoGenesis
   ) where
 
-import           Cardano.Prelude (panic)
-
 import           Cardano.Api.Shelley as Api
 
 import qualified Data.Map.Strict as Map
-import qualified Data.Text as Text
 import           Data.Word (Word64)
 
 --TODO: why do we have this odd split? We can get rid of the old name "typed"
@@ -92,7 +89,7 @@ genCostModels = do
   CostModel cModel <- genCostModel
   lang <- genLanguage
   case Alonzo.mkCostModel lang cModel of
-    Left err -> panic . Text.pack $ "genCostModels: " <> show err
+    Left err -> error $ "genCostModels: " <> show err
     Right alonzoCostModel ->
       Alonzo.CostModels . conv <$> Gen.list (Range.linear 1 3) (return alonzoCostModel)
  where

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -105,8 +105,6 @@ module Test.Gen.Cardano.Api.Typed
   , genRational
   ) where
 
-import           Cardano.Prelude (panic)
-
 import           Cardano.Api hiding (txIns)
 import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
@@ -127,7 +125,6 @@ import           Data.Map.Strict (Map)
 import           Data.Maybe (maybeToList)
 import           Data.Ratio (Ratio, (%))
 import           Data.String
-import qualified Data.Text as Text
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 
@@ -498,7 +495,7 @@ genTxValidityUpperBound era =
       pure (TxValidityNoUpperBound supported)
 
     (Nothing, Nothing) ->
-      panic "genTxValidityUpperBound: unexpected era support combination"
+      error "genTxValidityUpperBound: unexpected era support combination"
 
 genTxValidityRange
   :: CardanoEra era
@@ -863,7 +860,7 @@ genCostModel = do
   eCostModel <- Alonzo.mkCostModel <$> genPlutusLanguage
                                    <*> mapM (const $ Gen.integral (Range.linear 0 5000)) costModelParams
   case eCostModel of
-    Left err -> panic $ Text.pack $ "genCostModel: " <> show err
+    Left err -> error $ "genCostModel: " <> show err
     Right cModel -> return . CostModel $ Alonzo.getCostModelParams cModel
 
 genPlutusLanguage :: Gen Language

--- a/cardano-api/src/Cardano/Api/Keys/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Byron.hs
@@ -30,8 +30,6 @@ module Cardano.Api.Keys.Byron (
     toByronSigningKey
   ) where
 
-import qualified Cardano.Prelude as CBOR (toCborError)
-
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import           Control.Monad
@@ -42,6 +40,7 @@ import           Data.Either.Combinators
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import           Formatting (build, formatToString)
 
 import qualified Cardano.Crypto.DSIGN.Class as Crypto
 import qualified Cardano.Crypto.Seed as Crypto
@@ -272,8 +271,7 @@ instance SerialiseAsRawBytes (SigningKey ByronKeyLegacy) where
                     )
 
       decodeXPrv :: CBOR.Decoder s Wallet.XPrv
-      decodeXPrv = CBOR.decodeBytesCanonical >>= CBOR.toCborError . Wallet.xprv
-
+      decodeXPrv = CBOR.decodeBytesCanonical >>= either (fail . formatToString build) pure . Wallet.xprv
 
       -- | Decoder for a Byron/Classic signing key.
       --   Lifted from cardano-sl legacy codebase.

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -58,6 +58,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import qualified Data.Vector as Vector
+import           Formatting (build, formatToString)
 
 --
 -- Common types, consensus, network
@@ -431,7 +432,7 @@ decodeShelleyBasedWitness era =
       case t of
         0 -> fmap (fmap (ShelleyKeyWitness era)) fromCBOR
         1 -> fmap (fmap (ShelleyBootstrapWitness era)) fromCBOR
-        _ -> CBOR.cborError $ CBOR.DecoderErrorUnknownTag
+        _ -> fail . formatToString build $ CBOR.DecoderErrorUnknownTag
                                 "Shelley Witness" (fromIntegral t)
 
 

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -5,8 +5,6 @@
 #define UNIX
 #endif
 
-import           Cardano.Prelude
-
 import           Control.Monad.Trans.Except.Exit (orDie)
 import qualified Options.Applicative as Opt
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -119,10 +119,12 @@ library
                       , cborg >= 0.2.4 && < 0.3
                       , containers
                       , cryptonite
+                      , deepseq
                       , directory
                       , filepath
                       , formatting
                       , iproute
+                      , mtl
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus
@@ -174,7 +176,6 @@ test-suite cardano-cli-test
                       , cardano-api:gen
                       , cardano-cli
                       , cardano-node
-                      , cardano-prelude
                       , cardano-slotting ^>= 0.1
                       , containers
                       , directory

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -22,8 +22,7 @@ Flag unexpected_thunks
 common project-config
   default-language:     Haskell2010
 
-  default-extensions:   NoImplicitPrelude
-                        OverloadedStrings
+  default-extensions:   OverloadedStrings
   build-depends:        base >= 4.14 && < 4.17
 
   ghc-options:          -Wall
@@ -157,7 +156,6 @@ executable cardano-cli
 
   build-depends:        cardano-cli
                       , cardano-crypto-class ^>= 2.0
-                      , cardano-prelude
                       , optparse-applicative-fork
                       , transformers-except
 
@@ -171,6 +169,7 @@ test-suite cardano-cli-test
   build-depends:        aeson
                       , bech32            >= 1.1.0
                       , base16-bytestring
+                      , bytestring
                       , cardano-api
                       , cardano-api:gen
                       , cardano-cli
@@ -231,6 +230,7 @@ test-suite cardano-cli-golden
                       , hedgehog-extras
                       , text
                       , time
+                      , transformers
                       , unordered-containers
   build-tool-depends:   cardano-cli:cardano-cli
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -9,12 +9,12 @@ module Cardano.CLI.Byron.Commands
   , NewCertificateFile (..)
   ) where
 
-import           Cardano.Prelude
+import           Data.String (IsString)
 
 import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
-                     SoftwareVersion (..), SystemTag (..))
+                   SoftwareVersion (..), SystemTag (..))
 
-import           Cardano.Api       hiding (GenesisParameters)
+import           Cardano.Api hiding (GenesisParameters)
 import           Cardano.Api.Byron hiding (GenesisParameters)
 
 import           Cardano.CLI.Byron.Genesis

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -12,8 +12,9 @@ module Cardano.CLI.Byron.Delegation
   )
 where
 
-import           Cardano.Prelude hiding (show, trace)
+import           Prelude hiding ((.))
 
+import           Control.Category
 import           Control.Monad.Trans.Except.Extra (left)
 import qualified Data.ByteString.Lazy as LB
 import           Formatting (Format, sformat)
@@ -28,6 +29,12 @@ import qualified Cardano.Crypto as Crypto
 
 import           Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
 import           Cardano.CLI.Types (CertificateFile (..))
+import           Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
+import           Control.Monad (unless)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.ByteString (ByteString)
+import           Data.Text (Text)
 
 data ByronDelegationError
   = CertificateValidationErrors !FilePath ![Text]

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -14,14 +14,14 @@ module Cardano.CLI.Byron.Key
   )
 where
 
-import           Cardano.Prelude hiding (show, trace, (%))
-import           Prelude (show)
-
+import           Control.Exception (Exception (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
                    right)
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.UTF8 as UTF8
-import           Data.String (fromString)
+import           Data.String (IsString, fromString)
+import           Data.Text (Text)
 import qualified Data.Text as T
 import           Formatting (build, sformat, (%))
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -21,19 +21,22 @@ module Cardano.CLI.Byron.Parsers
   , parseUpdateVoteThd
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
+import           Cardano.Prelude (ConvertText (..))
 
-import           Control.Monad (fail)
+import           Control.Monad (when)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import           Data.Attoparsec.Combinator ((<?>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
-import qualified Data.Text as Text
+import           Data.Foldable
+import           Data.Text (Text)
 import           Data.Time (UTCTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import           Data.Word (Word16, Word64)
 import           Formatting (build, sformat)
+import           GHC.Natural (Natural)
+import           GHC.Word (Word8)
 
 import           Options.Applicative
 import qualified Options.Applicative as Opt
@@ -301,13 +304,13 @@ parseTxOut =
   pAddressInEra :: Text -> AddressInEra ByronEra
   pAddressInEra t =
     case decodeAddressBase58 t of
-      Left err -> panic $ "Bad Base58 address: " <> Text.pack (show err)
+      Left err -> error $ "Bad Base58 address: " <> show err
       Right byronAddress -> AddressInEra ByronAddressInAnyEra $ ByronAddress byronAddress
 
   pLovelaceTxOut :: Word64 -> TxOutValue ByronEra
   pLovelaceTxOut l =
     if l > (maxBound :: Word64)
-    then panic $ show l <> " lovelace exceeds the Word64 upper bound"
+    then error $ show l <> " lovelace exceeds the Word64 upper bound"
     else TxOutAdaOnly AdaOnlyInByronEra . Lovelace $ toInteger l
 
 readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
@@ -706,7 +709,7 @@ parseUTCTime optname desc =
 cliParseBase58Address :: Text -> Address ByronAddr
 cliParseBase58Address t =
   case decodeAddressBase58 t of
-    Left err -> panic $ "Bad Base58 address: " <> Text.pack (show err)
+    Left err -> error $ "Bad Base58 address: " <> show err
     Right byronAddress -> ByronAddress byronAddress
 
 parseFraction :: String -> String -> Parser Rational
@@ -735,7 +738,7 @@ parseLovelace optname desc =
     then fail $ show i <> " lovelace exceeds the Word64 upper bound"
     else case toByronLovelace (Lovelace i) of
            Just byronLovelace -> return byronLovelace
-           Nothing -> panic $ "Error converting lovelace: " <> Text.pack (show i)
+           Nothing -> error $ "Error converting lovelace: " <> show i
 
 readDouble :: ReadM Double
 readDouble = do

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -10,12 +10,15 @@ module Cardano.CLI.Byron.Query
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 
+import           Control.Monad.IO.Unlift (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as LB
+import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
 
 
 {- HLINT ignore "Reduce duplication" -}
@@ -44,6 +47,6 @@ runGetLocalNodeTip networkId = do
           }
 
     tip <- liftIO $ getLocalChainTip connctInfo
-    liftIO . putTextLn . Text.decodeUtf8 . LB.toStrict $ encodePretty tip
+    liftIO . Text.putStrLn . Text.decodeUtf8 . LB.toStrict $ encodePretty tip
 
 

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -8,11 +8,15 @@ module Cardano.CLI.Byron.UpdateProposal
   , submitByronUpdateProposal
   ) where
 
-import           Cardano.Prelude
+import           Cardano.Prelude (ConvertText (..))
 
+import           Control.Exception (Exception (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
 import           Control.Tracer (stdoutTracer, traceWith)
+import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
+import           Data.Text (Text)
 
 import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
                    SoftwareVersion (..), SystemTag (..))

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -8,13 +8,12 @@ module Cardano.CLI.Byron.Vote
   , submitByronVote
   ) where
 
-import           Cardano.Prelude
-
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
 import           Control.Tracer (stdoutTracer, traceWith)
 import qualified Data.ByteString as BS
+import           Data.Text (Text)
 import qualified Data.Text as Text
-
 
 import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
@@ -30,6 +29,8 @@ import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
 import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS)
 import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
 import           Cardano.CLI.Types
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.Bifunctor (first)
 
 
 data ByronVoteError

--- a/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
@@ -10,12 +10,8 @@ module Cardano.CLI.IO.Lazy
   , forStateM
   ) where
 
-import Control.Applicative (Applicative((<*>), pure), (<$>))
-import Control.Monad (Monad(..))
-import Control.Monad.IO.Unlift (MonadIO(liftIO), MonadUnliftIO, askUnliftIO, UnliftIO(unliftIO))
-import Data.Function (($), (.), flip)
-import Data.Int (Int)
-import System.IO (IO)
+import           Control.Monad.IO.Unlift (MonadIO (liftIO), MonadUnliftIO, UnliftIO (unliftIO),
+                   askUnliftIO)
 
 import qualified Data.List as L
 import qualified System.IO.Unsafe as IO

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -12,9 +12,9 @@ import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, pars
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run (ClientCommand (..))
 import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
-import           Cardano.Prelude
+
+import           Data.Foldable
 import           Options.Applicative
-import           Prelude (String)
 
 import qualified Options.Applicative as Opt
 

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -4,18 +4,18 @@ module Cardano.CLI.Render
   ( customRenderHelp
   ) where
 
-import           Cardano.Prelude
-import           Data.Function (id)
+import           Data.Text (Text)
 import           Options.Applicative
 import           Options.Applicative.Help.Ann
 import           Options.Applicative.Help.Types (helpText, renderHelp)
-import           Prelude (String)
 import           Prettyprinter
 import           Prettyprinter.Render.Util.SimpleDocTree
 
 import qualified Data.Text as T
 import qualified System.Environment as IO
 import qualified System.IO.Unsafe as IO
+
+import           Cardano.Api (textShow)
 
 cliHelpTraceEnabled :: Bool
 cliHelpTraceEnabled = IO.unsafePerformIO $ do
@@ -44,7 +44,7 @@ customRenderHelpAsHtml cols
     renderElement :: Ann -> Text -> Text
     renderElement ann x = if cliHelpTraceEnabled
       then case ann of
-        AnnTrace _ name -> "<span name=" <> show name <> ">" <> x <> "</span>"
+        AnnTrace _ name -> "<span name=" <> textShow name <> ">" <> x <> "</span>"
         AnnStyle _ -> x
       else x
     wrapper = if cliHelpTraceEnabled

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -10,18 +10,24 @@
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
 module Cardano.CLI.Run.Friendly (friendlyTxBS, friendlyTxBodyBS) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (Value (..), object, toJSON, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.Types as Aeson
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BSC
+import           Data.Char (isAscii)
+import           Data.Function ((&))
+import           Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes, isJust)
+import           Data.Ratio (numerator)
 import qualified Data.Text as Text
 import           Data.Yaml (array)
 import           Data.Yaml.Pretty (setConfCompare)
 import qualified Data.Yaml.Pretty as Yaml
+import           GHC.Real (denominator)
+import           GHC.Unicode (isAlphaNum)
 
 import           Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
@@ -200,7 +206,7 @@ friendlyTxOut (TxOut addr amount mdatum script) =
 friendlyStakeReference :: StakeAddressReference -> Aeson.Value
 friendlyStakeReference = \case
   NoStakeAddress -> Null
-  StakeAddressByPointer ptr -> String (show ptr)
+  StakeAddressByPointer ptr -> String (textShow ptr)
   StakeAddressByValue cred -> object [friendlyStakeCredential cred]
 
 friendlyUpdateProposal :: TxUpdateProposal era -> Aeson.Value

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -26,10 +26,12 @@ module Cardano.CLI.Shelley.Key
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
 
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -23,14 +23,13 @@ import qualified Cardano.Ledger.PoolDistr as Ledger
 import qualified Cardano.Ledger.Shelley.EpochBoundary as Ledger
 import qualified Cardano.Ledger.Shelley.PoolRank as Ledger
 import           Cardano.Ledger.TxIn (TxId (..))
-import           Cardano.Prelude (Bool(True), Category((.)))
 import qualified Cardano.Protocol.TPraos.API as Ledger
 import           Cardano.Protocol.TPraos.BHeader (HashHeader (..))
 import qualified Cardano.Protocol.TPraos.Rules.Prtcl as Ledger
 import qualified Cardano.Protocol.TPraos.Rules.Tickn as Ledger
 import qualified Cardano.Slotting.Slot as Cardano
 import qualified Control.SetAlgebra as SetAlgebra (BiMap, forwards)
-import           Data.Aeson (FromJSON(..), KeyValue((.=)), ToJSON(..), ToJSONKey)
+import           Data.Aeson (FromJSON (..), KeyValue ((.=)), ToJSON (..), ToJSONKey)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Short as SBS

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -14,22 +14,30 @@ module Cardano.CLI.Shelley.Parsers
   , parseTxIn
   ) where
 
-import           Cardano.Prelude hiding (All, Any)
-import           Prelude (String)
+import           Cardano.Prelude (ConvertText (..))
 
-import           Control.Monad.Fail (fail)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Parser as Aeson.Parser
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
+import           Data.Bifunctor
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
+import           Data.Foldable
+import           Data.Functor (($>))
 import qualified Data.IP as IP
+import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (fromMaybe)
+import           Data.Ratio ((%))
 import qualified Data.Set as Set
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Time.Clock (UTCTime)
 import           Data.Time.Format (defaultTimeLocale, parseTimeOrError)
+import           Data.Word (Word64)
+import           GHC.Natural (Natural)
 import           Network.Socket (PortNumber)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
@@ -41,6 +49,7 @@ import qualified Text.Parsec.Error as Parsec
 import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
+import           Text.Read (readEither, readMaybe)
 
 import qualified Cardano.Ledger.BaseTypes as Shelley
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
@@ -2799,7 +2808,7 @@ pSingleHostAddress = singleHostAddress
   singleHostAddress ipv4 ipv6 port =
     case (ipv4, ipv6) of
       (Nothing, Nothing) ->
-        panic "Please enter either an IPv4 or IPv6 address for the pool relay"
+        error "Please enter either an IPv4 or IPv6 address for the pool relay"
       (Just i4, Nothing) ->
         StakePoolRelayIp (Just i4) Nothing (Just port)
       (Nothing, Just i6) ->

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -4,8 +4,6 @@ module Cardano.CLI.Shelley.Run
   , runShelleyClientCommand
   ) where
 
-import           Cardano.Prelude
-
 import           Cardano.Api
 
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
@@ -24,6 +22,8 @@ import           Cardano.CLI.Shelley.Run.Transaction
                                          -- Block, System, DevOps
 import           Cardano.CLI.Shelley.Run.Genesis
 import           Cardano.CLI.Shelley.Run.TextView
+import           Cardano.Prelude (ExceptT)
+import           Data.Text (Text)
 
 data ShelleyClientCmdError
   = ShelleyCmdAddressError !ShelleyAddressCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -4,6 +4,9 @@ module Cardano.CLI.Shelley.Run
   , runShelleyClientCommand
   ) where
 
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Text (Text)
+
 import           Cardano.Api
 
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
@@ -22,8 +25,6 @@ import           Cardano.CLI.Shelley.Run.Transaction
                                          -- Block, System, DevOps
 import           Cardano.CLI.Shelley.Run.Genesis
 import           Cardano.CLI.Shelley.Run.TextView
-import           Cardano.Prelude (ExceptT)
-import           Data.Text (Text)
 
 data ShelleyClientCmdError
   = ShelleyCmdAddressError !ShelleyAddressCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -11,9 +11,6 @@ module Cardano.CLI.Shelley.Run.Address
   , makeStakeAddressRef
   ) where
 
-import           Cardano.Prelude hiding (putStrLn)
-
-
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as Text
@@ -30,6 +27,9 @@ import           Cardano.CLI.Shelley.Parsers (AddressCmd (..), AddressKeyType (.
 import           Cardano.CLI.Shelley.Run.Address.Info (ShelleyAddressInfoError, runAddressInfo)
 import           Cardano.CLI.Shelley.Run.Read
 import           Cardano.CLI.Types
+import           Cardano.Prelude (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Text (Text)
 
 data ShelleyAddressCmdError
   = ShelleyAddressCmdAddressInfoError !ShelleyAddressInfoError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -11,8 +11,11 @@ module Cardano.CLI.Shelley.Run.Address
   , makeStakeAddressRef
   ) where
 
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
 import qualified Data.ByteString.Char8 as BS
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 
@@ -27,9 +30,6 @@ import           Cardano.CLI.Shelley.Parsers (AddressCmd (..), AddressKeyType (.
 import           Cardano.CLI.Shelley.Run.Address.Info (ShelleyAddressInfoError, runAddressInfo)
 import           Cardano.CLI.Shelley.Run.Read
 import           Cardano.CLI.Types
-import           Cardano.Prelude (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Data.Text (Text)
 
 data ShelleyAddressCmdError
   = ShelleyAddressCmdAddressInfoError !ShelleyAddressInfoError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
@@ -6,12 +6,15 @@ module Cardano.CLI.Shelley.Run.Address.Info
 
 import           Cardano.Api
 import           Cardano.CLI.Shelley.Parsers (OutputFile (..))
-import           Cardano.Prelude
+
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (left)
 import           Data.Aeson (ToJSON (..), object, (.=))
 import           Data.Aeson.Encode.Pretty (encodePretty)
-
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Text (Text)
+import           Options.Applicative (Alternative (..))
 
 newtype ShelleyAddressInfoError = ShelleyAddressInvalid Text
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -4,13 +4,13 @@ module Cardano.CLI.Shelley.Run.Governance
   , runGovernanceCmd
   ) where
 
-import           Cardano.Prelude
-
-import           Data.Aeson
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Text as Text
-
+import           Control.Monad (unless, when)
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, left, newExceptT)
+import           Data.Aeson (eitherDecode)
+import qualified Data.ByteString.Lazy as LB
+import           Data.Text (Text)
+import qualified Data.Text as Text
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
@@ -170,7 +170,7 @@ runGovernanceUpdateProposal (OutputFile upFile) eNo genVerKeyFiles upPprams mCos
                         (AsVerificationKey AsGenesisKey)
                         vkeyFile
                   | VerificationKeyFile vkeyFile <- genVerKeyFiles ]
-    let genKeyHashes = map verificationKeyHash genVKeys
+    let genKeyHashes = fmap verificationKeyHash genVKeys
         upProp = makeShelleyUpdateProposal finalUpPprams genKeyHashes eNo
     firstExceptT ShelleyGovernanceCmdTextEnvWriteError . newExceptT $
       writeFileTextEnvelope upFile Nothing upProp

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -12,9 +12,17 @@ module Cardano.CLI.Shelley.Run.Key
   , decodeBech32
   ) where
 
+import           Control.Exception (Exception (..), IOException)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           System.Exit (exitFailure)
 
 import qualified Control.Exception as Exception
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left, newExceptT)
@@ -39,14 +47,6 @@ import           Cardano.CLI.Shelley.Key (VerificationKeyTextOrFile (..),
                    VerificationKeyTextOrFileError, readVerificationKeyTextOrFileAnyOf,
                    renderVerificationKeyTextOrFileError)
 import           Cardano.CLI.Types (SigningKeyFile (..), VerificationKeyFile (..))
-import           Cardano.Prelude (MonadIO (..))
-import           Control.Exception (Exception (..), IOException)
-import           Control.Monad.Trans.Except (ExceptT)
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.ByteString (ByteString)
-import           Data.Text (Text)
-import qualified Data.Text.Encoding as Text
-import           System.Exit (exitFailure)
 
 
 data ShelleyKeyCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -9,14 +9,14 @@ module Cardano.CLI.Shelley.Run.Node
   , readColdVerificationKeyOrFile
   ) where
 
-import           Cardano.Prelude hiding ((<.>))
-import           Prelude (id)
-
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
 import qualified Data.ByteString.Char8 as BS
 import           Data.String (fromString)
+import           Data.Text (Text)
 import qualified Data.Text as Text
-
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
+import           Data.Word (Word64)
 
 import           Cardano.Api
 import           Cardano.Api.Shelley

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -4,15 +4,11 @@ module Cardano.CLI.Shelley.Run.Pool
   , runPoolCmd
   ) where
 
-import           Cardano.Prelude
-
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
                    newExceptT)
-
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
@@ -21,6 +17,9 @@ import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificatio
 import           Cardano.CLI.Types (OutputFormat (..))
 
 import qualified Cardano.Ledger.Slot as Shelley
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Text (Text)
 
 data ShelleyPoolCmdError
   = ShelleyPoolCmdReadFileError !(FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -5,13 +5,13 @@ module Cardano.CLI.Shelley.Run.StakeAddress
   , runStakeAddressKeyGenToFile
   ) where
 
-import           Cardano.Prelude
-
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Char8 as BS
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-
-import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 
 import           Cardano.Api
 import           Cardano.Api.Shelley

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
@@ -4,8 +4,9 @@ module Cardano.CLI.Shelley.Run.TextView
   , runTextViewCmd
   ) where
 
-import           Cardano.Prelude
-
+import           Control.Monad.Trans.Except (ExceptT)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Text (Text)
 import qualified Data.Text as Text
 
 import           Cardano.CLI.Helpers (HelpersError, pPrintCBOR, renderHelpersError)
@@ -13,9 +14,8 @@ import           Cardano.CLI.Shelley.Parsers
 
 import           Cardano.Api
 
+import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
-
-import qualified Data.ByteString.Lazy.Char8 as LBS
 
 data ShelleyTextViewFileError
   = TextViewReadFileError (FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -41,10 +41,9 @@ module Cardano.CLI.Types
   , AllOrOnly(..)
   ) where
 
-import           Cardano.Prelude hiding (Word64)
-
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
+import           Data.String (IsString)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
 
@@ -173,8 +172,8 @@ data OpCertIntervalInformation
 
 instance FromJSON GenesisFile where
   parseJSON (Aeson.String genFp) = pure . GenesisFile $ Text.unpack genFp
-  parseJSON invalid = panic $ "Parsing of GenesisFile failed due to type mismatch. "
-                           <> "Encountered: " <> Text.pack (show invalid)
+  parseJSON invalid = error $ "Parsing of GenesisFile failed due to type mismatch. "
+                           <> "Encountered: " <> show invalid
 
 -- | The desired output format.
 data OutputFormat

--- a/cardano-cli/test/Test/Cli/CliIntermediateFormat.hs
+++ b/cardano-cli/test/Test/Cli/CliIntermediateFormat.hs
@@ -5,7 +5,8 @@ module Test.Cli.CliIntermediateFormat
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+
 import           Hedgehog (Property, discover)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/Test/Cli/FilePermissions.hs
@@ -5,15 +5,16 @@ module Test.Cli.FilePermissions
   ( tests
   ) where
 
-import           Cardano.Prelude
-
-
 import           Cardano.Node.Run (checkVRFFilePermissions)
+
 import           Hedgehog (Property, discover, success)
 import qualified Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
 import           Hedgehog.Internal.Property (failWith)
 
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (runExceptT)
 import           Test.OptParse (execCardanoCLI)
 
 -- | This property ensures that the VRF signing key file is created only with owner permissions

--- a/cardano-cli/test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/Test/Cli/ITN.hs
@@ -5,15 +5,19 @@ module Test.Cli.ITN
   ) where
 
 import           Cardano.CLI.Shelley.Run.Key (decodeBech32)
-import           Cardano.Prelude
-import           Hedgehog (Property, (===))
-import           Test.OptParse
 
 import qualified Codec.Binary.Bech32 as Bech32
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
+import           Data.Text (Text)
+import qualified Data.Text.IO as Text
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
+import           Test.OptParse
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -38,8 +42,8 @@ prop_convertITNKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   outputHaskellSignKeyFp <- noteTempFile tempDir "haskell-signing-key.key"
 
   -- Write ITN keys to disk
-  liftIO $ writeFile itnVerKeyFp itnVerKey
-  liftIO $ writeFile itnSignKeyFp itnSignKey
+  liftIO $ Text.writeFile itnVerKeyFp itnVerKey
+  liftIO $ Text.writeFile itnSignKeyFp itnSignKey
   H.assertFilesExist [itnVerKeyFp, itnSignKeyFp]
 
   -- Generate haskell stake verification key

--- a/cardano-cli/test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/Test/Cli/JSON.hs
@@ -3,8 +3,6 @@
 
 module Test.Cli.JSON where
 
-import           Cardano.Prelude hiding (filter)
-
 import           Cardano.Api.Shelley
 import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
                    genVerificationKeyHash)
@@ -13,6 +11,7 @@ import           Data.Aeson
 import qualified Data.Map.Strict as Map
 import           Data.Time
 import           Data.Time.Clock.System
+import           Data.Word (Word64)
 
 import           Cardano.CLI.Shelley.Output (QueryKesPeriodInfoOutput (..),
                    createOpCertIntervalInfo)
@@ -38,7 +37,7 @@ genDelegationsAndRewards = do
   let delegMapAmt = Map.fromList $ zip sAddrs sLovelace
   poolIDs <- Gen.list r genPoolId
   let delegMapPool = Map.fromList $ zip sAddrs poolIDs
-  return $ DelegationsAndRewards (delegMapAmt,delegMapPool)
+  return $ DelegationsAndRewards (delegMapAmt, delegMapPool)
 
 genOpCertIntervalInformation :: Gen OpCertIntervalInformation
 genOpCertIntervalInformation = do

--- a/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/Test/Cli/MultiAssetParsing.hs
@@ -3,13 +3,11 @@
 
 module Test.Cli.MultiAssetParsing where
 
-import           Cardano.Prelude hiding (filter)
-
 import qualified Data.Text as Text
 import qualified Text.Parsec as Parsec (parse)
 
 import           Hedgehog (Property, checkSequential, discover, forAll, property, tripping)
-import           Hedgehog.Gen (filter)
+import qualified Hedgehog.Gen as Gen
 
 import           Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
 
@@ -18,7 +16,7 @@ import           Test.Gen.Cardano.Api.Typed (genValueDefault)
 prop_roundtrip_Value_parse_render :: Property
 prop_roundtrip_Value_parse_render =
   property $ do
-    value <- forAll $ filter (not . null . valueToList) genValueDefault
+    value <- forAll $ Gen.filter (not . null . valueToList) genValueDefault
     tripping
       value
       renderValue
@@ -27,7 +25,7 @@ prop_roundtrip_Value_parse_render =
 prop_roundtrip_Value_parse_renderPretty :: Property
 prop_roundtrip_Value_parse_renderPretty =
   property $ do
-    value <- forAll $ filter (not . null . valueToList) genValueDefault
+    value <- forAll $ Gen.filter (not . null . valueToList) genValueDefault
     tripping
       value
       renderValuePretty

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise1.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise1
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise2.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise2
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise3.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise3
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise4.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise4
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise5.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise5.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise5
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Pioneers/Exercise6.hs
+++ b/cardano-cli/test/Test/Cli/Pioneers/Exercise6.hs
@@ -4,7 +4,7 @@ module Test.Cli.Pioneers.Exercise6
   ( tests
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Cli/Shelley/Run/Query.hs
+++ b/cardano-cli/test/Test/Cli/Shelley/Run/Query.hs
@@ -2,15 +2,11 @@ module Test.Cli.Shelley.Run.Query
   ( tests
   ) where
 
-import           Cardano.Slotting.Time (RelativeTime(..))
-import           Control.Monad (return)
-import           Data.Bool
-import           Data.Function
+import           Cardano.Slotting.Time (RelativeTime (..))
 import           Hedgehog (Property, (===))
-import           System.IO as IO
 
 import qualified Cardano.CLI.Shelley.Run.Query as Q
-import qualified Hedgehog as H 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 
 unit_percentage :: Property

--- a/cardano-cli/test/Test/Config/Mainnet.hs
+++ b/cardano-cli/test/Test/Config/Mainnet.hs
@@ -7,16 +7,9 @@ module Test.Config.Mainnet
   ) where
 
 import           Cardano.Api (initialLedgerState, renderInitialLedgerStateError)
-import           Control.Monad
 import           Control.Monad.Trans.Except
-import           Data.Bool (Bool(..))
-import           Data.Either (Either(..))
-import           Data.Function
-import           Data.Maybe
 import           Hedgehog (Property, (===))
 import           System.FilePath ((</>))
-import           System.IO (IO)
-import           Text.Show
 
 import qualified Data.Aeson as J
 import qualified Data.Text as T

--- a/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
@@ -4,9 +4,10 @@ module Test.Golden.Byron.SigningKeys
   ( tests
   ) where
 
-import           Cardano.Prelude
-
 import           Codec.CBOR.Read (deserialiseFromBytes)
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.ByteString.Lazy as LB
 
 import qualified Cardano.Crypto.Signing as Crypto

--- a/cardano-cli/test/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Byron/Tx.hs
@@ -4,12 +4,14 @@ module Test.Golden.Byron.Tx
   ( txTests
   ) where
 
-import           Cardano.CLI.Byron.Tx
-import           Cardano.Prelude
-import qualified Data.Text as Text
-
 import           Cardano.Chain.UTxO (ATxAux)
+import           Cardano.CLI.Byron.Tx
 
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Except (runExceptT)
+import           Data.ByteString (ByteString)
+import qualified Data.Text as Text
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H

--- a/cardano-cli/test/Test/Golden/Byron/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Byron/TxBody.hs
@@ -4,10 +4,9 @@ module Test.Golden.Byron.TxBody
   ( golden_byronTxBody
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_byronTxBody :: Property
-golden_byronTxBody = panic "TODO"
+golden_byronTxBody = error "TODO"

--- a/cardano-cli/test/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/Test/Golden/Byron/UpdateProposal.hs
@@ -4,7 +4,9 @@ module Test.Golden.Byron.UpdateProposal
   ( updateProposalTest
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
 
 import           Cardano.CLI.Byron.UpdateProposal

--- a/cardano-cli/test/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/Test/Golden/Byron/Vote.hs
@@ -5,15 +5,17 @@ module Test.Golden.Byron.Vote
   ) where
 
 import           Cardano.CLI.Byron.Vote
-import           Cardano.Prelude
+
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
+import qualified Hedgehog.Extras.Test.Base as H
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import           Hedgehog.Internal.Property (failWith)
 import           Test.OptParse
-
-import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/Test/Golden/Byron/Witness.hs
+++ b/cardano-cli/test/Test/Golden/Byron/Witness.hs
@@ -4,10 +4,9 @@ module Test.Golden.Byron.Witness
   ( golden_byronWitness
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_byronWitness :: Property
-golden_byronWitness = panic "TODO"
+golden_byronWitness = error "TODO"

--- a/cardano-cli/test/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/Test/Golden/Shelley.hs
@@ -9,8 +9,6 @@ module Test.Golden.Shelley
   , txTests
   ) where
 
-import           Cardano.Prelude
-
 import           Test.Golden.Shelley.Address.Build (golden_shelleyAddressBuild)
 import           Test.Golden.Shelley.Address.Info (golden_shelleyAddressInfo)
 import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressKeyGen)

--- a/cardano-cli/test/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/Build.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Address.Build
   ( golden_shelleyAddressBuild
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 

--- a/cardano-cli/test/Test/Golden/Shelley/Address/Info.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/Info.hs
@@ -4,7 +4,8 @@ module Test.Golden.Shelley.Address.Info
   ( golden_shelleyAddressInfo
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (when)
+
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Address/KeyGen.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Address.KeyGen
   ( golden_shelleyAddressKeyGen
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -5,9 +5,12 @@ module Test.Golden.Shelley.Genesis.Create
   ( golden_shelleyGenesisCreate
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Foldable (for_)
+
 import           Hedgehog (Property, forAll, (===))
-import           Prelude (String)
 import           Test.OptParse as OP
 
 import qualified Data.Aeson as J

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -4,7 +4,6 @@ module Test.Golden.Shelley.Genesis.InitialTxIn
   ( golden_shelleyGenesisInitialTxIn
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Genesis.KeyGenDelegate
   ( golden_shelleyGenesisKeyGenDelegate
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Genesis.KeyGenGenesis
   ( golden_shelleyGenesisKeyGenGenesis
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Genesis.KeyGenUtxo
   ( golden_shelleyGenesisKeyGenUtxo
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -4,7 +4,6 @@ module Test.Golden.Shelley.Genesis.KeyHash
   ( golden_shelleyGenesisKeyHash
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property, (===))
 import           Test.OptParse as OP
 

--- a/cardano-cli/test/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -7,7 +7,8 @@ module Test.Golden.Shelley.Key.ConvertCardanoAddressKey
   , golden_convertCardanoAddressShelleyStakeSigningKey
   ) where
 
-import           Cardano.Prelude hiding (readFile)
+import           Control.Monad (void)
+import           Data.Text (Text)
 import           Hedgehog (Property, (===))
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -4,7 +4,10 @@ module Test.Golden.Shelley.Metadata.StakePoolMetadata
   ( golden_stakePoolMetadataHash
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.Text (Text)
+import qualified Data.Text.IO as Text
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
@@ -21,7 +24,7 @@ golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
   outputStakePoolMetadataHashFp <- noteTempFile tempDir "stake-pool-metadata-hash.txt"
 
   -- Write the example stake pool metadata to disk
-  liftIO $ writeFile stakePoolMetadataFile exampleStakePoolMetadata
+  liftIO $ Text.writeFile stakePoolMetadataFile exampleStakePoolMetadata
 
   -- Hash the stake pool metadata
   void $ execCardanoCLI

--- a/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/MultiSig/Address.hs
@@ -6,7 +6,6 @@ module Test.Golden.Shelley.MultiSig.Address
   , golden_shelleyAtLeastMultiSigAddressBuild
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 

--- a/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -4,7 +4,8 @@ module Test.Golden.Shelley.Node.IssueOpCert
   ( golden_shelleyNodeIssueOpCert
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGen.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Node.KeyGen
   ( golden_shelleyNodeKeyGen
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Node.KeyGenKes
   ( golden_shelleyNodeKeyGenKes
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Node.KeyGenVrf
   ( golden_shelleyNodeKeyGenVrf
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -4,7 +4,6 @@ module Test.Golden.Shelley.StakeAddress.Build
   ( golden_shelleyStakeAddressBuild
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.StakeAddress.DeregistrationCertificate
   ( golden_shelleyStakeAddressDeregistrationCertificate
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           System.FilePath ((</>))
 import           Test.OptParse

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -4,10 +4,10 @@ module Test.Golden.Shelley.StakeAddress.KeyGen
   ( golden_shelleyStakeAddressKeyGen
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import           Control.Monad (void)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.StakeAddress.RegistrationCertificate
   ( golden_shelleyStakeAddressRegistrationCertificate
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           System.FilePath ((</>))
 import           Test.OptParse

--- a/cardano-cli/test/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -4,10 +4,10 @@ module Test.Golden.Shelley.StakePool.RegistrationCertificate
   ( golden_shelleyStakePoolRegistrationCertificate
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import           Control.Monad (void)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertifi
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.MIRCertificate
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.OperationalCertificate
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddressCertificates
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.StakePoolCertificates
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -5,7 +5,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -4,8 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Tx.Tx
   ( golden_shelleyTx
   ) where
 
-import           Cardano.Prelude
-
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -4,11 +4,10 @@ module Test.Golden.Shelley.TextEnvelope.Tx.TxBody
   ( golden_shelleyTxBody
   ) where
 
-import           Cardano.Prelude
-
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import           Control.Monad (void)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
@@ -4,10 +4,9 @@ module Test.Golden.Shelley.TextEnvelope.Tx.Witness
   ( golden_shelleyWitness
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 
 {- HLINT ignore "Use camelCase" -}
 
 golden_shelleyWitness :: Property
-golden_shelleyWitness = panic "TODO"
+golden_shelleyWitness = error "TODO"

--- a/cardano-cli/test/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -4,7 +4,6 @@ module Test.Golden.Shelley.TextView.DecodeCbor
   ( golden_shelleyTextViewDecodeCbor
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Assemble.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Assemble.hs
@@ -4,7 +4,8 @@ module Test.Golden.Shelley.Transaction.Assemble
   ( golden_shelleyTransactionAssembleWitness_SigningKey
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Build.hs
@@ -8,8 +8,7 @@ module Test.Golden.Shelley.Transaction.Build
   , golden_shelleyTransactionBuild_WithdrawalScriptWitnessed
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
+import           Control.Monad (void)
 
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BSC

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -4,7 +4,6 @@ module Test.Golden.Shelley.Transaction.CalculateMinFee
   ( golden_shelleyTransactionCalculateMinFee
   ) where
 
-import           Cardano.Prelude
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -4,9 +4,7 @@ module Test.Golden.Shelley.Transaction.CreateWitness
   ( golden_shelleyTransactionSigningKeyWitness
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
-
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Transaction/Sign.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.Transaction.Sign
   ( golden_shelleyTransactionSign
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Golden/TxView.hs
+++ b/cardano-cli/test/Test/Golden/TxView.hs
@@ -2,7 +2,7 @@
 
 module Test.Golden.TxView (txViewTests) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
 
 import           Hedgehog (Group (..), Property, checkSequential)
 import           Hedgehog.Extras (Integration, moduleWorkspace, note_, propertyOnce)

--- a/cardano-cli/test/Test/Golden/Version.hs
+++ b/cardano-cli/test/Test/Golden/Version.hs
@@ -4,7 +4,8 @@ module Test.Golden.Version
   ( golden_version
   ) where
 
-import           Cardano.Prelude
+import           Control.Monad (void)
+
 import           Hedgehog (Property)
 import           Test.OptParse
 

--- a/cardano-cli/test/Test/Utilities.hs
+++ b/cardano-cli/test/Test/Utilities.hs
@@ -1,11 +1,11 @@
 module Test.Utilities (diffVsGoldenFile) where
 
-import           Cardano.Prelude
-import           Prelude (String)
-import qualified Prelude
+import           Cardano.Prelude (ConvertText (..))
 
+import           Control.Monad.IO.Class (MonadIO (liftIO))
 import           Data.Algorithm.Diff (PolyDiff (Both), getGroupedDiff)
 import           Data.Algorithm.DiffOutput (ppDiff)
+import           GHC.Stack (callStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Extras.Test.Base (failMessage)
 

--- a/cardano-cli/test/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden.hs
@@ -1,5 +1,3 @@
-import           Cardano.Prelude
-
 import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Golden.Byron.SigningKeys

--- a/cardano-cli/test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test.hs
@@ -1,4 +1,3 @@
-import           Cardano.Prelude
 
 import           Hedgehog.Main (defaultMain)
 

--- a/cardano-git-rev/cardano-git-rev.cabal
+++ b/cardano-git-rev/cardano-git-rev.cabal
@@ -17,7 +17,6 @@ extra-source-files:     README.md
 
 common project-config
   default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
   build-depends:        base >= 4.14 && < 4.17
 
   ghc-options:          -Wall
@@ -36,8 +35,7 @@ library
   exposed-modules:      Cardano.Git.Rev
                         Cardano.Git.RevFromGit
 
-  build-depends:        cardano-prelude
-                      , file-embed
+  build-depends:        file-embed
                       , process
                       , template-haskell
                       , text

--- a/cardano-git-rev/src/Cardano/Git/Rev.hs
+++ b/cardano-git-rev/src/Cardano/Git/Rev.hs
@@ -6,10 +6,10 @@ module Cardano.Git.Rev
   ( gitRev
   ) where
 
-import           Cardano.Prelude
-
 import           Data.FileEmbed (dummySpaceWith)
+import           Data.Text (Text)
 import qualified Data.Text as T
+import           Data.Text.Encoding (decodeUtf8)
 
 import           Cardano.Git.RevFromGit (gitRevFromGit)
 

--- a/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
+++ b/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
@@ -2,10 +2,9 @@ module Cardano.Git.RevFromGit
   ( gitRevFromGit
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
-
+import           Control.Exception (catch)
 import qualified Language.Haskell.TH as TH
+import           System.Exit (ExitCode (..))
 import qualified System.IO as IO
 import           System.IO.Error (isDoesNotExistError)
 import           System.Process (readProcessWithExitCode)

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
@@ -2,10 +2,7 @@ module Cardano.Chairman.Commands where
 
 import           Cardano.Chairman.Commands.Run
 import           Cardano.Chairman.Commands.Version
-import           Data.Function
-import           Data.Monoid
 import           Options.Applicative
-import           System.IO (IO)
 
 {- HLINT ignore "Monoid law, left identity" -}
 

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -7,15 +7,20 @@ module Cardano.Chairman.Commands.Run
   ( cmdRun
   ) where
 
+import           Cardano.Prelude (ConvertText (..))
+
 import qualified Cardano.Api as Api
-import           Cardano.Prelude
 
 import           Control.Monad.Class.MonadTime (DiffTime)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (runExceptT)
 import           Control.Tracer (Tracer (..), stdoutTracer)
-import qualified Data.Text as Text
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
 import qualified Data.Time.Clock as DTC
 import           Options.Applicative
 import qualified Options.Applicative as Opt
+import           System.Exit (exitFailure)
 import qualified System.IO as IO
 
 import           Cardano.Node.Configuration.NodeAddress
@@ -102,8 +107,8 @@ run RunOpts
 
   ptclConfig <- case getProtocolConfiguration configYamlPc of
                   Nothing ->
-                    panic $ "Node protocol configuration was not specified "<>
-                            "in Config yaml filepath: " <> Text.pack (unConfigPath caConfigYaml)
+                    error $ "Node protocol configuration was not specified "<>
+                            "in Config yaml filepath: " <> unConfigPath caConfigYaml
                   Just ptclConfig -> return ptclConfig
 
   eitherSomeProtocol <- runExceptT $ mkConsensusProtocol ptclConfig Nothing

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
@@ -5,15 +5,10 @@ module Cardano.Chairman.Commands.Version
   ) where
 
 import           Cardano.Git.Rev (gitRev)
-import           Data.Eq
-import           Data.Function
-import           Data.Monoid
 import           Data.Version (showVersion)
 import           Options.Applicative
 import           Paths_cardano_node_chairman (version)
-import           System.IO (IO)
 import           System.Info (arch, compilerName, compilerVersion, os)
-import           Text.Show
 
 import qualified Data.Text as T
 import qualified System.IO as IO

--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -2,10 +2,7 @@ module Main where
 
 import           Cardano.Chairman.Commands
 import           Control.Monad
-import           Data.Function
-import           Data.Semigroup
 import           Options.Applicative
-import           System.IO (IO)
 
 main :: IO ()
 main = join

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -16,7 +16,6 @@ build-type:             Simple
 
 common project-config
   default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
   build-depends:        base >= 4.14 && < 4.17
 
   ghc-options:          -Wall
@@ -55,6 +54,7 @@ executable cardano-node-chairman
                       , strict-stm
                       , text
                       , time
+                      , transformers
 
 test-suite chairman-tests
   import:               project-config

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -4,10 +4,6 @@ module Spec.Chairman.Cardano
   ( hprop_chairman
   ) where
 
-import           Control.Monad ((=<<))
-import           Data.Function
-import           Data.Functor
-import           Data.Maybe
 import           Spec.Chairman.Chairman (chairmanOver)
 import           System.FilePath ((</>))
 

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -6,22 +6,12 @@ module Spec.Chairman.Chairman
   ( chairmanOver
   ) where
 
-import           Control.Monad
-import           Data.Either
-import           Data.Eq
-import           Data.Function
-import           Data.Functor
-import           Data.Int
-import           Data.Maybe
-import           Data.Semigroup
-import           Data.String
-import           GHC.Num
+import           Control.Monad (when)
+import           Data.Functor ((<&>))
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           Hedgehog.Extras.Test.Base (Integration)
 import           System.Exit (ExitCode (..))
 import           System.FilePath.Posix ((</>))
-import           System.IO (FilePath)
-import           Text.Show
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
-import           Cardano.Prelude
-import qualified Data.Text as Text
-import           Prelude (String)
-
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 import           Options.Applicative.Help ((<$$>))
 
 import           Cardano.Git.Rev (gitRev)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import           Data.Version (showVersion)
 import           Paths_cardano_node (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
@@ -84,7 +82,7 @@ parseVersionCmd =
 
 runVersionCommand :: IO ()
 runVersionCommand =
-    putTextLn $ mconcat
+    Text.putStrLn $ mconcat
       [ "cardano-node ", renderVersion version
       , " - ", Text.pack os, "-", Text.pack arch
       , " - ", Text.pack compilerName, "-", renderVersion compilerVersion

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -27,8 +27,7 @@ flag systemd
 common project-config
   default-language:     Haskell2010
 
-  default-extensions:   NoImplicitPrelude
-                        OverloadedStrings
+  default-extensions:   OverloadedStrings
   build-depends:        base >= 4.14 && < 4.17
 
   ghc-options:          -Wall
@@ -166,6 +165,7 @@ library
                       , lobemo-backend-ekg
                       , lobemo-backend-monitoring
                       , lobemo-backend-trace-forwarder
+                      , mtl
                       , network
                       , network-mux ^>= 0.2
                       , nothunks
@@ -233,10 +233,13 @@ test-suite cardano-node-test
                       , hedgehog
                       , hedgehog-corpus
                       , iproute
+                      , mtl
                       , ouroboros-consensus
                       , ouroboros-network
                       , mtl
+                      , text
                       , time
+                      , transformers
                       , vector
 
   other-modules:        Test.Cardano.Node.FilePermissions

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -151,6 +151,7 @@ library
                       , cborg ^>= 0.2.4
                       , contra-tracer
                       , containers
+                      , deepseq
                       , directory
                       , dns
                       , ekg
@@ -211,7 +212,6 @@ executable cardano-node
   build-depends:        base >= 4.14 && < 4.17
                       , cardano-git-rev
                       , cardano-node
-                      , cardano-prelude
                       , optparse-applicative-fork
                       , text
 
@@ -227,7 +227,6 @@ test-suite cardano-node-test
                       , bytestring
                       , cardano-api
                       , cardano-node
-                      , cardano-prelude
                       , cardano-slotting ^>= 0.1
                       , directory
                       , hedgehog
@@ -239,7 +238,6 @@ test-suite cardano-node-test
                       , mtl
                       , text
                       , time
-                      , transformers
                       , vector
 
   other-modules:        Test.Cardano.Node.FilePermissions

--- a/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
@@ -30,16 +30,16 @@ module Cardano.Node.Configuration.NodeAddress
   ) where
 
 import           Cardano.Api
-import           Cardano.Prelude
-import           Prelude (fail)
 
 import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
 import           Data.IP (IP (..), IPv4, IPv6)
 import qualified Data.IP as IP
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.DNS as DNS (Domain)
 import           Network.Socket (PortNumber, SockAddr (..))
+import           Text.Read (readMaybe)
 
 import           Ouroboros.Network.PeerSelection.RootPeersDNS (DomainAccessPoint (..))
 

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -21,18 +21,17 @@ module Cardano.Node.Configuration.POM
   )
 where
 
-import           Cardano.Prelude
-import qualified GHC.Show as Show
-import           Prelude (String)
-
-import           Control.Monad (fail)
 import           Data.Aeson
 import qualified Data.Aeson.Types as Aeson
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime)
 import           Data.Yaml (decodeFileThrow)
 import           Generic.Data (gmappend)
 import           Generic.Data.Orphans ()
+import           GHC.Generics (Generic)
 import           Options.Applicative
 import           System.FilePath (takeDirectory, (</>))
 

--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -15,14 +15,17 @@ module Cardano.Node.Configuration.Topology
   )
 where
 
-import           Cardano.Prelude
-import           Prelude (String)
-
+import           Control.Exception (Exception (..), IOException)
 import qualified Control.Exception as Exception
 import           Data.Aeson
+import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Foldable
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import           Data.Word (Word64)
+import           Text.Read (readMaybe)
 
 import           Cardano.Node.Configuration.NodeAddress
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
@@ -152,6 +155,6 @@ readTopologyFile nc = do
 readTopologyFileOrError :: NodeConfiguration -> IO NetworkTopology
 readTopologyFileOrError nc =
       readTopologyFile nc
-  >>= either (\err -> panic $ "Cardano.Node.Configuration.Topology.readTopologyFile: "
-                           <> err)
+  >>= either (\err -> error $ "Cardano.Node.Configuration.Topology.readTopologyFile: "
+                           <> Text.unpack err)
              pure

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -24,14 +24,17 @@ module Cardano.Node.Configuration.TopologyP2P
   )
 where
 
-import           Cardano.Prelude hiding (ap)
-import           Prelude (String)
-
+import           Control.Exception (IOException)
 import qualified Control.Exception as Exception
+import           Control.Exception.Base (Exception (..))
+import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
+import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import           Data.Word (Word64)
 
 import           "contra-tracer" Control.Tracer (Tracer, traceWith)
 
@@ -268,6 +271,6 @@ readTopologyFileOrError :: Tracer IO (StartupTrace blk)
                         -> NodeConfiguration -> IO NetworkTopology
 readTopologyFileOrError tr nc =
       readTopologyFile tr nc
-  >>= either (\err -> panic $ "Cardano.Node.Configuration.TopologyP2P.readTopologyFile: "
-                           <> err)
+  >>= either (\err -> error $ "Cardano.Node.Configuration.TopologyP2P.readTopologyFile: "
+                           <> Text.unpack err)
              pure

--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -26,13 +26,18 @@ module Cardano.Node.Handlers.Shutdown
   )
 where
 
-import           Cardano.Prelude
+import           Control.Applicative (Alternative (..))
+import           Control.Concurrent.Async (race_)
+import           Control.Exception (try)
+import           Control.Exception.Base (throwIO)
+import           Control.Monad (void, when)
 import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Text (Text, pack)
 import           Generic.Data.Orphans ()
-
-import           Data.Text (pack)
+import           GHC.Generics (Generic)
 import qualified GHC.IO.Handle.FD as IO (fdToHandle)
 import qualified Options.Applicative as Opt
+import           System.Exit (ExitCode (..))
 import qualified System.IO as IO
 import qualified System.IO.Error as IO
 import           System.Posix.Types (Fd (Fd))
@@ -148,7 +153,7 @@ maybeSpawnOnSlotSyncedShutdownHandler sc tr registry chaindb =
   spawnLimitTerminator :: ShutdownOn -> IO ()
   spawnLimitTerminator limit =
     void $ forkLinkedWatcher registry "slotLimitTerminator" Watcher {
-        wFingerprint = identity
+        wFingerprint = id
       , wInitial     = Nothing
       , wReader      =
           case limit of

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -1,13 +1,10 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Node.Orphans () where
-
-import           Cardano.Prelude
-import           Prelude (fail)
 
 import           Cardano.Api.Orphans ()
 
@@ -16,8 +13,8 @@ import qualified Data.Text as Text
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
 import qualified Cardano.Chain.Update as Update
-import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.CompactAddress as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..))
 
 instance FromJSON TracingVerbosity where

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -11,14 +11,18 @@ module Cardano.Node.Parsers
   , renderHelpDoc
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
+import           Cardano.Prelude (ConvertText (..))
 
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
 import           Data.Time.Clock (secondsToDiffTime)
+import           Data.Word (Word32)
 import           Options.Applicative hiding (str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
 import           System.Posix.Types (Fd (..))
+import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Mempool.API (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -4,8 +4,7 @@ module Cardano.Node.Protocol
   , ProtocolInstantiationError(..)
   ) where
 
-import           Cardano.Prelude
-
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 import           Cardano.Api

--- a/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
@@ -8,20 +8,19 @@ module Cardano.Node.Protocol.Alonzo
   , validateGenesis
   ) where
 
-import           Prelude (String)
-import           Cardano.Prelude
-
 import           Cardano.Api
 
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 
-import           Cardano.Node.Types
 import           Cardano.Node.Orphans ()
+import           Cardano.Node.Types
 
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
 
-import           Cardano.Node.Protocol.Shelley (readGenesisAny, GenesisReadError)
+import           Cardano.Node.Protocol.Shelley (GenesisReadError, readGenesisAny)
+
+import           Control.Monad.Except (ExceptT)
 
 --
 -- Alonzo genesis

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -12,10 +12,12 @@ module Cardano.Node.Protocol.Byron
   , readLeaderCredentials
   ) where
 
+import           Cardano.Prelude (ConvertText (..), canonicalDecodePretty)
 
-import           Cardano.Prelude
+import           Control.Monad.Except (throwError)
 import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither, left)
 import qualified Data.ByteString.Lazy as LB
+import           Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 
 import           Cardano.Api.Byron
@@ -42,6 +44,9 @@ import           Cardano.Tracing.OrphanInstances.Shelley ()
 import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.HardFork ()
 import           Cardano.Node.Tracing.Tracers.ChainDB ()
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Text (Text)
 
 
 
@@ -134,7 +139,7 @@ readGenesis (GenesisFile file) mbExpectedGenesisHash ncReqNetworkMagic = do
       $ h
       where
         impossible =
-          panic "fromByronGenesisHash: old and new crypto libs disagree on hash size"
+          error "fromByronGenesisHash: old and new crypto libs disagree on hash size"
 
 
 

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -20,9 +20,11 @@ module Cardano.Node.Protocol.Shelley
   , validateGenesis
   ) where
 
+import           Cardano.Prelude (ConvertText (..))
+import           Control.Exception (IOException)
+import           Control.Monad.Except (ExceptT, MonadError (..))
+
 import qualified Cardano.Api as Api
-import           Cardano.Prelude
-import           Prelude (String, id)
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
@@ -310,7 +312,7 @@ newtype GenesisValidationError = GenesisValidationErrors [Shelley.ValidationErr]
 
 instance Error GenesisValidationError where
   displayError (GenesisValidationErrors vErrs) =
-    T.unpack (unlines (map Shelley.describeValidationErr vErrs))
+    T.unpack (T.unlines (map Shelley.describeValidationErr vErrs))
 
 
 data PraosLeaderCredentialsError =

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -12,10 +12,10 @@ module Cardano.Node.Protocol.Types
   ) where
 
 import qualified Cardano.Api as Api
-import           Cardano.Prelude (Generic, NFData)
-import           Prelude
 
+import           Control.DeepSeq (NFData)
 import           Data.Aeson
+import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 
 import           Cardano.Node.Orphans ()

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -36,12 +36,13 @@ module Cardano.Node.Queries
   , fromSMaybe
   ) where
 
-import           Cardano.Prelude hiding (All, (:.:))
-
+import           Control.Monad.STM (atomically)
+import           Data.ByteString (ByteString)
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import           Data.SOP.Strict
 import qualified Data.UMap as UM
+import           Data.Word (Word64)
 
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron

--- a/cardano-node/src/Cardano/Node/STM.hs
+++ b/cardano-node/src/Cardano/Node/STM.hs
@@ -7,10 +7,6 @@ module Cardano.Node.STM
   , modifyReadTVarIO'
   ) where
 
-import Data.Function
-import Control.Monad
-import System.IO (IO)
-
 import qualified Control.Concurrent.STM as STM
 
 -- | Mutate the contents of a TVar and return the new value of the TVar (non-strict).

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -7,7 +7,7 @@ module Cardano.Node.Tracing.API
   ( initTraceDispatcher
   ) where
 
-import           Cardano.Prelude (first)
+import           Data.Bifunctor (first)
 import           Prelude
 
 import           "contra-tracer" Control.Tracer (traceWith)

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -17,8 +17,11 @@ module Cardano.Node.Tracing.Documentation
   , docTracers
   ) where
 
+import           Control.Exception (SomeException)
 import           Data.Aeson.Types (ToJSON)
+import           Data.Proxy (Proxy (..))
 import qualified Data.Text.IO as T
+import           GHC.Generics (Generic)
 import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import qualified Network.Socket as Socket
 import qualified Options.Applicative as Opt
@@ -26,7 +29,6 @@ import qualified Options.Applicative as Opt
 import           Cardano.Logging
 import           Cardano.Logging.Resources
 import           Cardano.Logging.Resources.Types ()
-import           Cardano.Prelude hiding (trace)
 
 import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
 import           Cardano.Node.Tracing.Formatting ()

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
@@ -16,9 +16,9 @@ module Cardano.Node.Tracing.Era.Byron () where
 import           Cardano.Tracing.OrphanInstances.Byron ()
 
 import           Cardano.Logging
-import           Cardano.Prelude
-import           Data.Aeson (Value (String), (.=))
 
+import           Data.Aeson (Value (String), (.=))
+import           Data.ByteString (ByteString)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
@@ -32,6 +32,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
 import           Ouroboros.Consensus.Util.Condense (condense)
 
+import           Cardano.Api (textShow)
 import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
                    ChainValidationError (..), delegationCertificate)
 import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
@@ -49,22 +50,22 @@ instance LogFormatting ApplyMempoolPayloadErr where
   forMachine _dtal (MempoolTxErr utxoValidationErr) =
     mconcat
       [ "kind" .= String "MempoolTxErr"
-      , "error" .= String (show utxoValidationErr)
+      , "error" .= String (textShow utxoValidationErr)
       ]
   forMachine _dtal (MempoolDlgErr delegScheduleError) =
     mconcat
       [ "kind" .= String "MempoolDlgErr"
-      , "error" .= String (show delegScheduleError)
+      , "error" .= String (textShow delegScheduleError)
       ]
   forMachine _dtal (MempoolUpdateProposalErr iFaceErr) =
     mconcat
       [ "kind" .= String "MempoolUpdateProposalErr"
-      , "error" .= String (show iFaceErr)
+      , "error" .= String (textShow iFaceErr)
       ]
   forMachine _dtal (MempoolUpdateVoteErr iFaceErrr) =
     mconcat
       [ "kind" .= String "MempoolUpdateVoteErr"
-      , "error" .= String (show iFaceErrr)
+      , "error" .= String (textShow iFaceErrr)
       ]
 
 instance LogFormatting ByronLedgerUpdate where

--- a/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
@@ -15,8 +15,6 @@
 module Cardano.Node.Tracing.Era.HardFork ()
   where
 
-import           Cardano.Prelude hiding (All)
-
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 
 import           Data.Aeson

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -19,7 +19,9 @@ import           Data.Aeson (ToJSON (..), Value (..), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.Types as Aeson
+import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Text (Text)
 
 import           Cardano.Api (textShow)
 import qualified Cardano.Api as Api
@@ -28,7 +30,6 @@ import qualified Cardano.Api.Shelley as Api
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Logging
-import           Cardano.Prelude
 import           Cardano.Slotting.Block (BlockNo (..))
 
 import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockNo, blockSlot)
@@ -144,7 +145,6 @@ instance Core.Crypto era => LogFormatting (TPraosCannotForge era) where
       , "expected" .= genDlgVRFHash
       , "actual" .= coreNodeVRFHash
       ]
-
 
 
 instance ( ShelleyBasedEra era
@@ -514,7 +514,7 @@ renderBadInputsUTxOErr txIns
 
 renderValueNotConservedErr :: Show val => val -> val -> Value
 renderValueNotConservedErr consumed produced = String $
-    "This transaction consumed " <> show consumed <> " but produced " <> show produced
+    "This transaction consumed " <> textShow consumed <> " but produced " <> textShow produced
 
 instance Core.Crypto (Ledger.Crypto era) => LogFormatting (ShelleyPpupPredFailure era) where
   forMachine _dtal (NonGenesisUpdatePPUP proposalKeys genesisKeys) =
@@ -524,7 +524,7 @@ instance Core.Crypto (Ledger.Crypto era) => LogFormatting (ShelleyPpupPredFailur
     mconcat [ "kind" .= String "PPUpdateWrongEpoch"
              , "currentEpoch" .= currEpoch
              , "intendedEpoch" .= intendedEpoch
-             , "votingPeriod"  .= String (show votingPeriod)
+             , "votingPeriod"  .= String (textShow votingPeriod)
              ]
   forMachine _dtal (PVCannotFollowPPUP badPv) =
     mconcat [ "kind" .= String "PVCannotFollowPPUP"
@@ -700,7 +700,7 @@ instance ( LogFormatting (PredicateFailure (Core.EraRule "EPOCH" era))
   forMachine dtal (MirFailure f) = forMachine dtal f
   forMachine _dtal (CorruptRewardUpdate update) =
     mconcat [ "kind" .= String "CorruptRewardUpdate"
-             , "update" .= String (show update) ]
+             , "update" .= String (textShow update) ]
 
 
 instance ( LogFormatting (PredicateFailure (Core.EraRule "POOLREAP" era))
@@ -965,7 +965,7 @@ instance ( Ledger.Era era
          , Show (PredicateFailure (Ledger.EraRule "LEDGERS" era))
          ) => LogFormatting (AlonzoBbodyPredFailure era) where
   forMachine _ err = mconcat [ "kind" .= String "AlonzoBbodyPredFail"
-                            , "error" .= String (show err)
+                            , "error" .= String (textShow err)
                             ]
 --------------------------------------------------------------------------------
 -- Babbage related
@@ -1034,7 +1034,7 @@ instance Core.Crypto crypto => LogFormatting (Praos.PraosValidationErr crypto) w
         mconcat [ "kind" .= String "VRFKeyBadProof"
                 , "slotNumberUsedInVrfCalculation" .= slotNo
                 , "nonceUsedInVrfCalculation" .= nonce
-                , "calculatedVrfValue" .= String (show vrfCalculatedVal)
+                , "calculatedVrfValue" .= String (textShow vrfCalculatedVal)
                 ]
       Praos.VRFLeaderValueTooBig leaderValue sigma f->
         mconcat [ "kind" .= String "VRFLeaderValueTooBig"

--- a/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
@@ -7,11 +7,11 @@ module Cardano.Node.Tracing.Formatting
   (
   ) where
 
-import           Cardano.Prelude ()
 import           Data.Aeson (Value (String), toJSON, (.=))
+import           Data.Proxy (Proxy(..))
+import           Data.Void (Void)
 
 import           Cardano.Logging (LogFormatting (..))
-import           Cardano.Prelude hiding (Show, show)
 
 import           Cardano.Node.Tracing.Render (renderHeaderHashForDetails)
 

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -7,6 +7,7 @@ module Cardano.Node.Tracing.Peers
   ) where
 
 import           Cardano.Prelude
+
 import           Data.Aeson (FromJSON, ToJSON)
 
 import           Cardano.Logging
@@ -41,4 +42,4 @@ traceNodePeers
   :: Trace IO NodePeers
   -> [PeerT blk]
   -> IO ()
-traceNodePeers tr ev = traceWith tr $ NodePeers (map ppPeer ev)
+traceNodePeers tr ev = traceWith tr $ NodePeers (fmap ppPeer ev)

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -6,9 +6,9 @@ module Cardano.Node.Tracing.Peers
   , traceNodePeers
   ) where
 
-import           Cardano.Prelude
-
 import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Text (Text)
+import           GHC.Generics (Generic)
 
 import           Cardano.Logging
 

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -24,10 +24,9 @@ module Cardano.Node.Tracing.Render
   , renderWithOrigin
   ) where
 
-import           Cardano.Prelude
-import           Prelude (id)
-
 import qualified Data.ByteString.Base16 as B16
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -19,11 +19,15 @@ module Cardano.Node.Tracing.StateRep
   , traceNodeStateShutdown
   ) where
 
+import           Cardano.Api (textShow)
+
 import           Cardano.Logging
-import           Cardano.Prelude
+
 import           Data.Aeson
+import           Data.Text (Text)
 import           Data.Time.Clock
 import           Data.Time.Clock.POSIX
+import           GHC.Generics (Generic)
 
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 import qualified Ouroboros.Consensus.Block.RealPoint as RP
@@ -244,7 +248,7 @@ traceNodeStateStartup
 traceNodeStateStartup tr ev =
   case ev of
     Startup.StartupSocketConfigError e ->
-      traceWith tr $ NodeStartup $ StartupSocketConfigError (show e)
+      traceWith tr $ NodeStartup $ StartupSocketConfigError (textShow e)
     Startup.StartupDBValidation ->
       traceWith tr $ NodeStartup StartupDBValidation
     Startup.NetworkConfigUpdate ->

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -13,9 +13,9 @@ module Cardano.Node.Tracing.Tracers
   ) where
 
 import           Codec.CBOR.Read (DeserialiseFailure)
+import           Data.Proxy (Proxy (..))
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (trace)
 
 import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -5,11 +5,13 @@ module Cardano.Node.Tracing.Tracers.BlockReplayProgress
    , ReplayBlockStats(..)
   ) where
 
+import           Control.Monad.IO.Class (MonadIO)
 import           Data.Aeson (Value (String), (.=))
 import           Data.Text (pack)
 
+import           Cardano.Api (textShow)
+
 import           Cardano.Logging
-import           Cardano.Prelude
 
 import           Ouroboros.Consensus.Block (realPointSlot)
 import           Ouroboros.Network.Block (pointSlot, unSlotNo)
@@ -37,7 +39,7 @@ instance LogFormatting ReplayBlockStats where
       [ "kind" .= String "ReplayBlockStats"
       , "progress" .= String (pack $ show rpsProgress)
       ]
-  forHuman ReplayBlockStats {..} = "Block replay progress " <> show rpsProgress <> "%"
+  forHuman ReplayBlockStats {..} = "Block replay progress " <> textShow rpsProgress <> "%"
   asMetrics ReplayBlockStats {..} =
      [DoubleM "ChainDB.BlockReplayProgress" rpsProgress]
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -12,19 +12,21 @@ module Cardano.Node.Tracing.Tracers.ChainDB
    ( withAddedToCurrentChainEmptyLimited
    ) where
 
+import           Cardano.Prelude (maximumDef)
+
 import           Data.Aeson (Value (String), toJSON, (.=))
+import           Data.Int (Int64)
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import           Data.Word (Word64)
 import           Numeric (showFFloat)
-import           Prelude (id)
-import           Text.Show
 
 import           Cardano.Logging
 import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.Shelley ()
 import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
-import           Cardano.Prelude hiding (Show, show, trace)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HeaderEnvelopeError (..), HeaderError (..),
@@ -45,7 +47,6 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.Types as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.Enclose
-
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -24,13 +24,14 @@ module Cardano.Node.Tracing.Tracers.Consensus
 import           Control.Monad.Class.MonadTime (Time (..))
 import           Data.Aeson (ToJSON, Value (Number, String), toJSON, (.=))
 import qualified Data.Aeson as Aeson
+import           Data.Foldable (Foldable (..))
+import           Data.Int (Int64)
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as Pq
 import           Data.SOP.Strict
 import qualified Data.Text as Text
 import           Data.Time (DiffTime, NominalDiffTime)
-import           Text.Show
-
+import           Data.Word (Word32, Word64)
 
 import           Cardano.Slotting.Slot (WithOrigin (..))
 
@@ -42,7 +43,6 @@ import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
 import           Cardano.Node.Tracing.Tracers.ConsensusStartupException ()
 import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck
-import           Cardano.Prelude hiding (All, Show, show)
 
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 
@@ -57,7 +57,6 @@ import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
 import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
 import           Ouroboros.Network.TxSubmission.Inbound hiding (txId)
 import           Ouroboros.Network.TxSubmission.Outbound
-
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
@@ -6,13 +6,11 @@ module Cardano.Node.Tracing.Tracers.ConsensusStartupException
   ( ConsensusStartupException (..)
   ) where
 
-import           Cardano.Prelude hiding (Show, show)
-
 import           Data.Aeson (Value (String), (.=))
 import qualified Data.Text as Text
-import           Text.Show
 
 import           Cardano.Logging.Types
+import           Control.Exception (SomeException)
 
 -- | Exceptions logged when the consensus is initialising.
 --

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -10,15 +10,14 @@ module Cardano.Node.Tracing.Tracers.Diffusion
   () where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (Show, show)
 import           Data.Aeson (Value (String), (.=))
 import           Data.Text (pack)
 import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-import           Text.Show
 
 import           Cardano.Node.Configuration.TopologyP2P (UseLedger (..))
 
+import qualified Data.List as List
 import qualified Ouroboros.Network.Diffusion as ND
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.PeerSelection.LedgerPeers (NumberOfPeers (..), PoolStake (..),
@@ -477,7 +476,7 @@ instance LogFormatting TraceLedgerPeers where
     mconcat
       [ "kind" .= String "PickedPeers"
       , "desiredCount" .= n
-      , "count" .= length addrs
+      , "count" .= List.length addrs
       , "addresses" .= show addrs
       ]
   forMachine _dtal (FetchingNewLedgerState cnt) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
@@ -10,9 +10,13 @@ module Cardano.Node.Tracing.Tracers.ForgingThreadStats
   ) where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (All, concat, (:.:))
+
+import           Control.Concurrent (ThreadId, myThreadId)
+import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Aeson (Value (..), (.=))
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
 
 import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck (ForgeTracerType)
 import           Cardano.Slotting.Slot (SlotNo (..))

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
@@ -49,11 +49,11 @@ instance LogFormatting ForgeThreadStats where
     <> " last slot "      <> showT ftsLastSlot
   forMachine _dtal ForgeThreadStats {..} =
     mconcat [ "kind" .= String "ForgeThreadStats"
-             , "nodeCannotForgeNum" .= String (show ftsNodeCannotForgeNum)
-             , "nodeIsLeaderNum"    .= String (show ftsNodeIsLeaderNum)
-             , "blocksForgedNum"    .= String (show ftsBlocksForgedNum)
-             , "slotsMissed"        .= String (show ftsSlotsMissedNum)
-             , "lastSlot"           .= String (show ftsLastSlot)
+             , "nodeCannotForgeNum" .= String (showT ftsNodeCannotForgeNum)
+             , "nodeIsLeaderNum"    .= String (showT ftsNodeIsLeaderNum)
+             , "blocksForgedNum"    .= String (showT ftsBlocksForgedNum)
+             , "slotsMissed"        .= String (showT ftsSlotsMissedNum)
+             , "lastSlot"           .= String (showT ftsLastSlot)
              ]
   asMetrics ForgeThreadStats {..} =
     [ IntM "Forge.NodeCannotForgeNum" (fromIntegral ftsNodeCannotForgeNum)
@@ -91,10 +91,10 @@ instance LogFormatting ForgingStats where
     <> " slots missed "   <> showT fsSlotsMissedNum
   forMachine _dtal ForgingStats {..} =
     mconcat [ "kind" .= String "ForgingStats"
-             , "nodeCannotForgeNum" .= String (show fsNodeCannotForgeNum)
-             , "nodeIsLeaderNum"    .= String (show fsNodeIsLeaderNum)
-             , "blocksForgedNum"    .= String (show fsBlocksForgedNum)
-             , "slotsMissed"        .= String (show fsSlotsMissedNum)
+             , "nodeCannotForgeNum" .= String (showT fsNodeCannotForgeNum)
+             , "nodeIsLeaderNum"    .= String (showT fsNodeIsLeaderNum)
+             , "blocksForgedNum"    .= String (showT fsBlocksForgedNum)
+             , "slotsMissed"        .= String (showT fsSlotsMissedNum)
              ]
   asMetrics ForgingStats {..} =
     [ IntM "Forge.NodeCannotForgeNum" (fromIntegral fsNodeCannotForgeNum)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
@@ -16,13 +16,13 @@ module Cardano.Node.Tracing.Tracers.KESInfo
       traceAsKESInfo
    ) where
 
+import           Control.Monad.IO.Class (MonadIO)
 import           Data.Aeson (ToJSON (..), Value (..), (.=))
+import           Data.Proxy (Proxy)
 import qualified Data.Text as Text
-import           Prelude (show)
 
 import           Cardano.Logging
 import           Cardano.Node.Queries (GetKESInfo (..))
-import           Cardano.Prelude hiding (All, Show, show)
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
 
 import           Ouroboros.Consensus.Block.Forging

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
@@ -15,7 +15,6 @@ import           Cardano.Prelude hiding (Show, show)
 import           Data.Aeson (Value (String), (.=))
 import           Data.Text (pack)
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-import           Text.Show
 
 import           Ouroboros.Consensus.Ledger.Query (Query)
 import           Ouroboros.Network.Driver.Simple (TraceSendRecv (..))
@@ -91,7 +90,7 @@ instance MetaTrace (AnyMessageAndAgency ps) =>
 
   allNamespaces =
     let cn = allNamespaces :: [Namespace (AnyMessageAndAgency ps)]
-    in map (nsPrependInner "Send") cn ++ map (nsPrependInner "Receive") cn
+    in fmap (nsPrependInner "Send") cn ++ fmap (nsPrependInner "Receive") cn
 
 
 -- --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
@@ -11,9 +11,9 @@
 module Cardano.Node.Tracing.Tracers.NodeToClient () where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (Show, show)
 import           Data.Aeson (Value (String), (.=))
-import           Data.Text (pack)
+import           Data.Text (Text, pack)
+
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
 import           Ouroboros.Consensus.Ledger.Query (Query)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -13,11 +13,10 @@ module Cardano.Node.Tracing.Tracers.NodeToNode
    ) where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (Show, show)
 import           Data.Aeson (Value (String), toJSON, (.=))
+import           Data.Proxy (Proxy (..))
 import           Data.Text (pack)
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-import           Text.Show
 
 import           Cardano.Node.Queries (ConvertTxId)
 import           Cardano.Node.Tracing.Render (renderHeaderHash, renderTxIdForDetails)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
@@ -15,7 +15,6 @@ import           Data.Aeson (Value (String), (.=))
 import qualified Data.IP as IP
 import           Data.Text (pack)
 import qualified Network.Socket as Socket
-import           Text.Show
 
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
@@ -89,7 +88,7 @@ instance MetaTrace tr => MetaTrace (WithIPList tr) where
     privacyFor ns (Just (WithIPList _ _ ev)) =
       privacyFor (nsCast ns) (Just ev)
     documentFor ns = documentFor (nsCast ns :: Namespace tr)
-    allNamespaces  = map nsCast
+    allNamespaces  = fmap nsCast
           (allNamespaces :: [Namespace tr])
 
 instance MetaTrace tr => MetaTrace (WithDomainName tr) where
@@ -104,7 +103,7 @@ instance MetaTrace tr => MetaTrace (WithDomainName tr) where
     privacyFor ns (Just (WithDomainName _ ev)) =
       privacyFor (nsCast ns) (Just ev)
     documentFor ns = documentFor (nsCast ns :: Namespace tr)
-    allNamespaces  = map nsCast
+    allNamespaces  = fmap nsCast
           (allNamespaces :: [Namespace tr])
 
 instance MetaTrace (SubscriptionTrace adr) where
@@ -334,7 +333,7 @@ instance MetaTrace tr => MetaTrace (NtN.WithAddr addr tr) where
     privacyFor ns (Just (NtN.WithAddr _ ev)) =
       privacyFor (nsCast ns) (Just ev)
     documentFor ns = documentFor (nsCast ns :: Namespace tr)
-    allNamespaces  = map nsCast
+    allNamespaces  = fmap nsCast
           (allNamespaces :: [Namespace tr])
 
 instance MetaTrace NtN.ErrorPolicyTrace where

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
@@ -10,7 +10,8 @@ module Cardano.Node.Tracing.Tracers.NonP2P
     () where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (Show, show)
+
+import           Control.Exception (Exception (..), SomeException (..))
 import           Data.Aeson (Value (String), (.=))
 import qualified Data.IP as IP
 import           Data.Text (pack)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -12,16 +12,15 @@ module Cardano.Node.Tracing.Tracers.P2P
   () where
 
 import           Cardano.Logging
-import           Cardano.Prelude hiding (group, show)
 import           Data.Aeson (Object, ToJSON, ToJSONKey, Value (..), object, toJSON, toJSONList,
                    (.=))
 import           Data.Aeson.Types (listValue)
-import           Data.List (last)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Text (pack)
 import           Network.Socket (SockAddr (..))
-import           Prelude (show)
 
 import           Cardano.Node.Configuration.TopologyP2P ()
 import           Cardano.Tracing.OrphanInstances.Network ()

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
@@ -4,10 +4,15 @@ module Cardano.Node.Tracing.Tracers.Resources
   ( startResourceTracer
   ) where
 
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async (async)
+import           Control.Monad (forM_)
+import           Control.Monad.Class.MonadAsync (link)
+import           Control.Monad.Cont (forever)
+
 import           "contra-tracer" Control.Tracer
 
 import           Cardano.Logging.Resources
-import           Cardano.Prelude hiding (trace)
 
 startResourceTracer
   :: Tracer IO ResourceStats
@@ -22,5 +27,5 @@ startResourceTracer tr delayMilliseconds = do
       mbrs <- readResourceStats
       forM_ mbrs $ \rs -> traceWith tr rs
       threadDelay (delayMilliseconds * 1000)
-      maybe (pure ()) (traceWith tr) mbrs
+      forM_ mbrs $ \rs -> traceWith tr rs
       threadDelay (delayMilliseconds * 1000)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
@@ -13,9 +13,11 @@ module Cardano.Node.Tracing.Tracers.StartLeadershipCheck
 
 
 import           Cardano.Logging
-import           Cardano.Prelude
 import qualified "trace-dispatcher" Control.Tracer as T
+
+import           Control.Concurrent.STM (atomically)
 import           Data.IORef (readIORef)
+import           Data.Word (Word64)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (BlockNo (..), blockNo, unBlockNo)

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -29,11 +29,13 @@ module Cardano.Node.Types
   , renderVRFPrivateKeyFilePermissionError
   ) where
 
-import           Cardano.Prelude
-import           Prelude (fail)
-
 import           Data.Aeson
+import           Data.ByteString (ByteString)
+import           Data.Monoid (Last)
+import           Data.String (IsString)
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import           Data.Word (Word16, Word8)
 
 import           Cardano.Api
 import qualified Cardano.Chain.Update as Byron

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -22,14 +22,19 @@ module Cardano.Tracing.Config
   , TraceInboundGovernorCounters
   ) where
 
-import           Cardano.Prelude
-import           Prelude (String)
-
+import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import qualified Data.Aeson.Key as Aeson
 import           Data.Aeson.Types
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Monoid (Last (..))
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Generic.Data (gmappend)
+import           GHC.Generics (Generic)
+import           GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+
 
 import           Cardano.BM.Tracing (TracingVerbosity (..))
 import           Cardano.Node.Orphans ()

--- a/cardano-node/src/Cardano/Tracing/Metrics.hs
+++ b/cardano-node/src/Cardano/Tracing/Metrics.hs
@@ -21,10 +21,13 @@ module Cardano.Tracing.Metrics
   , threadStatsProjection
   ) where
 
-import           Cardano.Prelude hiding (All, (:.:))
-
+import           Control.Concurrent (ThreadId, myThreadId)
 import           Control.Concurrent.STM
+import           Control.Monad (join)
+import           Data.Functor (void)
+import           Data.Int (Int64)
 import           Data.IORef (IORef, atomicModifyIORef', newIORef)
+import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -10,9 +10,10 @@
 
 module Cardano.Tracing.OrphanInstances.Byron () where
 
-import           Cardano.Prelude
+import           Cardano.Api (textShow)
 
 import           Data.Aeson (Value (..))
+import           Data.ByteString (ByteString)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
@@ -47,22 +48,22 @@ instance ToObject ApplyMempoolPayloadErr where
   toObject _verb (MempoolTxErr utxoValidationErr) =
     mconcat
       [ "kind" .= String "MempoolTxErr"
-      , "error" .= String (show utxoValidationErr)
+      , "error" .= String (textShow utxoValidationErr)
       ]
   toObject _verb (MempoolDlgErr delegScheduleError) =
     mconcat
       [ "kind" .= String "MempoolDlgErr"
-      , "error" .= String (show delegScheduleError)
+      , "error" .= String (textShow delegScheduleError)
       ]
   toObject _verb (MempoolUpdateProposalErr iFaceErr) =
     mconcat
       [ "kind" .= String "MempoolUpdateProposalErr"
-      , "error" .= String (show iFaceErr)
+      , "error" .= String (textShow iFaceErr)
       ]
   toObject _verb (MempoolUpdateVoteErr iFaceErrr) =
     mconcat
       [ "kind" .= String "MempoolUpdateVoteErr"
-      , "error" .= String (show iFaceErrr)
+      , "error" .= String (textShow iFaceErrr)
       ]
 
 instance ToObject ByronLedgerUpdate where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -40,16 +39,16 @@ module Cardano.Tracing.OrphanInstances.Common
   , mkLOMeta
   ) where
 
-import           Cardano.Prelude
-import           Prelude (fail)
-
 import           Data.Aeson hiding (Value)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Short as SBS
 import           Data.Scientific (coefficient)
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import           Data.Void (Void)
 import           Network.Socket (PortNumber)
+import           Text.Read (readMaybe)
 
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
                    mkLOMeta)
@@ -83,7 +82,7 @@ instance FromJSON TracingVerbosity where
                             <> "Encountered: " <> show invalid
 
 instance FromJSON PortNumber where
-  parseJSON (Number portNum) = case readMaybe . show @Integer @Text $ coefficient portNum of
+  parseJSON (Number portNum) = case readMaybe . show $ coefficient portNum of
     Just port -> pure port
     Nothing -> fail $ show portNum <> " is not a valid port number."
   parseJSON invalid  = fail $ "Parsing of port number failed due to type mismatch. "

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -12,17 +13,19 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans  #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module Cardano.Tracing.OrphanInstances.Consensus () where
 
-import           Cardano.Prelude hiding (show)
-import           Prelude (id, show)
-
+import           Cardano.Prelude (maximumDef)
 import           Data.Aeson (Value (..))
-import           Data.Text (pack)
+import qualified Data.Aeson as Aeson
+import           Data.Data (Proxy (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Text (Text, pack)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import           Data.Word (Word32)
+import           GHC.Generics (Generic)
 import           Numeric (showFFloat)
 
 import           Cardano.Slotting.Slot (fromWithOrigin)
@@ -33,7 +36,8 @@ import           Cardano.Tracing.Render (renderChainHash, renderChunkNo, renderH
                    renderPointForVerbosity, renderRealPoint, renderRealPointAsPhrase,
                    renderTipBlockNo, renderTipHash, renderWithOrigin)
 
-import           Cardano.Node.Tracing.Tracers.ConsensusStartupException (ConsensusStartupException (..))
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+                   (ConsensusStartupException (..))
 
 import           Ouroboros.Consensus.Block (BlockProtocol, BlockSupportsProtocol, CannotForge,
                    ConvertRawHash (..), ForgeStateUpdateError, Header, RealPoint, blockNo,
@@ -79,7 +83,7 @@ import           Ouroboros.Network.Point (withOrigin)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 -- TODO: 'TraceCacheEvent' should be exported by the 'Impl' module
-import qualified Data.Aeson as Aeson
+import           Data.Function (on)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
@@ -17,8 +17,6 @@
 
 module Cardano.Tracing.OrphanInstances.HardFork () where
 
-import           Cardano.Prelude hiding (All)
-
 import           Data.Aeson
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Short as SBS

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -15,17 +15,19 @@
 
 module Cardano.Tracing.OrphanInstances.Network () where
 
-import           Cardano.Prelude hiding (group, show)
-import           Prelude (String, show)
-
+import           Control.Exception (Exception (..), SomeException (..))
 import           Control.Monad.Class.MonadTime (DiffTime, Time (..))
 import           Data.Aeson (Value (..))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (listValue)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Data (Proxy (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Functor.Identity (Identity (..))
 import qualified Data.IP as IP
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import           Data.Text (pack)
+import           Data.Text (Text, pack)
 
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 import           Network.TypedProtocol.Core (PeerHasAgency (..))

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -10,14 +10,17 @@ module Cardano.Tracing.Peer
   , tracePeers
   ) where
 
-import           Cardano.Prelude hiding (atomically)
-import           Prelude (String)
-
 import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
+import           Control.DeepSeq (NFData (..))
 import           Data.Aeson (ToJSON (..), Value (..), toJSON, (.=))
+import           Data.Functor ((<&>))
+import qualified Data.List as List
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import           GHC.Generics (Generic)
 import           NoThunks.Class (AllowThunk (..), NoThunks)
 import           Text.Printf (printf)
 
@@ -128,7 +131,7 @@ instance ToObject [Peer blk] where
   toObject verb xs = mconcat
     [ "kind"  .= String "NodeKernelPeers"
     , "peers" .= toJSON
-      (foldl' (\acc x -> toObject verb x : acc) [] xs)
+      (List.foldl' (\acc x -> toObject verb x : acc) [] xs)
     ]
 
 instance ToObject (Peer blk) where
@@ -136,7 +139,7 @@ instance ToObject (Peer blk) where
     mconcat [ "peerAddress"   .= String (Text.pack . show . remoteAddress $ cid)
             , "peerStatus"    .= String (Text.pack . ppStatus $ status)
             , "peerSlotNo"    .= String (Text.pack . ppMaxSlotNo . peerFetchMaxSlotNo $ inflight)
-            , "peerReqsInF"   .= String (show . peerFetchReqsInFlight $ inflight)
-            , "peerBlocksInF" .= String (show . Set.size . peerFetchBlocksInFlight $ inflight)
-            , "peerBytesInF"  .= String (show . peerFetchBytesInFlight $ inflight)
+            , "peerReqsInF"   .= String (Text.pack . show . peerFetchReqsInFlight $ inflight)
+            , "peerBlocksInF" .= String (Text.pack . show . Set.size . peerFetchBlocksInFlight $ inflight)
+            , "peerBytesInF"  .= String (Text.pack . show . peerFetchBytesInFlight $ inflight)
             ]

--- a/cardano-node/src/Cardano/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Tracing/Render.hs
@@ -22,10 +22,9 @@ module Cardano.Tracing.Render
   , renderWithOrigin
   ) where
 
-import           Cardano.Prelude
-import           Prelude (id)
-
 import qualified Data.ByteString.Base16 as B16
+import           Data.Proxy (Proxy(..))
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -27,18 +27,24 @@ module Cardano.Tracing.Tracers
   , traceCounter
   ) where
 
-import           Cardano.Prelude hiding (show)
-import           Prelude (String, show)
-
 import           GHC.Clock (getMonotonicTimeNSec)
 
 import           Codec.CBOR.Read (DeserialiseFailure)
+import           Control.Concurrent (MVar, modifyMVar_)
+import           Control.Concurrent.STM (STM, atomically)
+import           Control.Monad (forM_, when)
 import           Data.Aeson (ToJSON (..), Value (..))
+import           Data.Functor ((<&>))
+import           Data.Int (Int64)
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as Pq
 import qualified Data.Map.Strict as Map
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time (NominalDiffTime, UTCTime)
+import           Data.Word (Word64)
+import           GHC.TypeLits (KnownNat, Nat, natVal)
 import qualified System.Metrics.Counter as Counter
 import qualified System.Metrics.Gauge as Gauge
 import qualified System.Metrics.Label as Label

--- a/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
+++ b/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
@@ -11,6 +11,8 @@ module Test.Cardano.Node.FilePermissions
   ( tests
   ) where
 
+import           Control.Monad.Except
+import           Data.Foldable
 import           System.Directory (removeFile)
 
 import           Cardano.Api
@@ -39,6 +41,7 @@ import           System.Posix.Files
 import           System.Posix.IO (closeFd, createFile)
 import           System.Posix.Types (FileMode)
 
+import           Control.Exception (bracket)
 import           Hedgehog (Gen, classify, forAll)
 import qualified Hedgehog.Gen as Gen
 #endif

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -19,25 +19,26 @@ module Test.Cardano.Node.Gen
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as Aeson.KeyMap
-import qualified Data.Vector as Vector
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Vector as Vector
 
-import           Cardano.Prelude
-
-import           Cardano.Node.Configuration.TopologyP2P (NetworkTopology (..), PublicRootPeers (..),
-                   LocalRootPeersGroups (..), LocalRootPeersGroup (..), RootConfig (..),
-                   NodeSetup (..), PeerAdvertise (..), UseLedger (..))
 import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPAddress (..),
-                   NodeHostIPv4Address (..), NodeHostIPv6Address (..),
-                   NodeIPAddress, NodeIPv4Address, NodeIPv6Address)
+                   NodeHostIPv4Address (..), NodeHostIPv6Address (..), NodeIPAddress,
+                   NodeIPv4Address, NodeIPv6Address)
+import           Cardano.Node.Configuration.TopologyP2P (LocalRootPeersGroup (..),
+                   LocalRootPeersGroups (..), NetworkTopology (..), NodeSetup (..),
+                   PeerAdvertise (..), PublicRootPeers (..), RootConfig (..), UseLedger (..))
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (
-                   DomainAccessPoint (..), RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
+                   RelayAccessPoint (..))
 
 
 import qualified Data.IP as IP
 
+import           Cardano.Api (textShow)
+
+import           Data.Word (Word32)
 import           Hedgehog (Gen)
 import           Hedgehog.Corpus (cooking)
 import qualified Hedgehog.Gen as Gen
@@ -60,7 +61,7 @@ genNetworkTopologyEncoding = Aeson.encode <$> genNetworkTopologyValue
 -- | Generate a Aeson.Object which encodes a p2p topology.
 --
 genNetworkTopologyValue :: Gen Aeson.Object
-genNetworkTopologyValue = 
+genNetworkTopologyValue =
     (\a b c -> Aeson.KeyMap.fromList
                  [ ("localRoots", Aeson.Array . Vector.fromList $ a)
                  , ("publicRoots", Aeson.Array . Vector.fromList $ b)
@@ -83,7 +84,7 @@ genNetworkTopologyValue =
 
     genPublicRootsValue :: Gen Aeson.Value
     genPublicRootsValue =
-      (\a b -> Aeson.Object $ Aeson.KeyMap.fromList 
+      (\a b -> Aeson.Object $ Aeson.KeyMap.fromList
                  [ ("accessPoints", Aeson.Array . Vector.fromList $ a)
                  , ("advertise", Aeson.Bool b)
                  ]
@@ -93,7 +94,7 @@ genNetworkTopologyValue =
     genAccessPointValue :: Gen Aeson.Value
     genAccessPointValue =
       (\a -> Aeson.Object $ Aeson.KeyMap.fromList
-                 [ ("address", Aeson.String (show $ naHostAddress a))
+                 [ ("address", Aeson.String (textShow $ naHostAddress a))
                  , ("port", Aeson.Number (fromIntegral $ naPort a))
                  ]
       ) <$> genNodeIPAddress

--- a/cardano-node/test/Test/Cardano/Node/Json.hs
+++ b/cardano-node/test/Test/Cardano/Node/Json.hs
@@ -4,10 +4,10 @@ module Test.Cardano.Node.Json
   ( tests
   ) where
 
-import           Cardano.Prelude
 import           Cardano.Node.Configuration.TopologyP2P (NetworkTopology)
 
 import           Data.Aeson (decode, encode, fromJSON, toJSON)
+import           Data.Maybe (isJust)
 
 import           Hedgehog (Property, discover)
 import qualified Hedgehog

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -5,8 +5,8 @@ module Test.Cardano.Node.POM
   ( tests
   ) where
 
-import           Cardano.Prelude
-
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
 import           Data.Time.Clock (secondsToDiffTime)
 
 import           Cardano.Node.Configuration.POM

--- a/cardano-node/test/cardano-node-test.hs
+++ b/cardano-node/test/cardano-node-test.hs
@@ -4,7 +4,6 @@
 #define UNIX
 #endif
 
-import           Cardano.Prelude
 import           Hedgehog.Main (defaultMain)
 
 #ifdef UNIX

--- a/cardano-submit-api/app/Main.hs
+++ b/cardano-submit-api/app/Main.hs
@@ -1,8 +1,6 @@
 module Main where
 
 import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
-import           Control.Monad ((=<<))
-import           System.IO (IO)
 
 import qualified Options.Applicative as Opt
 

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -19,22 +19,18 @@ extra-source-files:     CHANGELOG.md
 common project-config
   default-language:     Haskell2010
   build-depends:        base >= 4.14 && < 4.17
-  default-extensions:   NoImplicitPrelude
 
   ghc-options:          -Wall
                         -Wcompat
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wno-all-missed-specialisations
-                        -Wno-implicit-prelude
                         -Wno-missing-import-lists
                         -Wno-safe
                         -Wno-unsafe
                         -Wunused-packages
                         -fwarn-incomplete-patterns
                         -fwarn-redundant-constraints
-
-  default-extensions:   NoImplicitPrelude
 
 library
   import:               project-config

--- a/cardano-submit-api/src/Cardano/TxSubmit.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.TxSubmit
@@ -14,13 +13,9 @@ import           Cardano.TxSubmit.Config (GenTxSubmitNodeConfig (..), ToggleLogg
                    TxSubmitNodeConfig, readTxSubmitNodeConfig)
 import           Cardano.TxSubmit.Metrics (registerMetricsServer)
 import           Cardano.TxSubmit.Web (runTxSubmitServer)
-import           Control.Applicative (Applicative (..))
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO (liftIO))
-import           Data.Either (Either (..))
-import           Data.Function (($))
 import           Data.Text (Text)
-import           System.IO (IO)
 
 import qualified Cardano.BM.Setup as Logging
 import qualified Cardano.BM.Trace as Logging

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.TxSubmit.CLI.Parsers
@@ -14,11 +13,7 @@ import           Cardano.Api (AnyConsensusModeParams (..), ConsensusModeParams (
                    EpochSlots (..), NetworkId (..), NetworkMagic (..), SocketPath (..))
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), TxSubmitNodeParams (..))
 import           Cardano.TxSubmit.Rest.Parsers (pWebserverConfig)
-import           Control.Applicative (Alternative (..), Applicative (..), (<**>))
-import           Data.Function ((.))
-import           Data.Functor (Functor (fmap), (<$>))
-import           Data.Int
-import           Data.Semigroup (Semigroup ((<>)))
+import           Control.Applicative (Alternative (..), (<**>))
 import           Data.Word (Word64)
 import           Options.Applicative (Parser, ParserInfo)
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
@@ -6,8 +6,6 @@ module Cardano.TxSubmit.CLI.Types
 
 import           Cardano.Api (AnyConsensusModeParams, NetworkId (..), SocketPath)
 import           Cardano.TxSubmit.Rest.Types (WebserverConfig)
-import           Data.Int
-import           System.IO (FilePath)
 
 -- | The product type of all command line arguments
 data TxSubmitNodeParams = TxSubmitNodeParams

--- a/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -14,20 +13,12 @@ module Cardano.TxSubmit.Config
 
 import           Cardano.Api
 
-import           Control.Applicative (Applicative (pure, (<*>)))
 import           Control.Exception (IOException, catch)
 import           Data.Aeson (FromJSON (..), Object, Value (..), (.:))
 import           Data.Aeson.Types (Parser)
 import           Data.Bool (bool)
 import           Data.ByteString (ByteString)
-import           Data.Either (Either (Left, Right))
-import           Data.Eq (Eq)
-import           Data.Function (($))
-import           Data.Functor (Functor (..), (<$>))
-import           Data.Semigroup (Semigroup ((<>)))
 import           Protolude.Panic (panic)
-import           System.IO (FilePath, IO)
-import           Text.Show (Show)
 
 import qualified Cardano.BM.Configuration as Logging
 import qualified Cardano.BM.Configuration.Model as Logging

--- a/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
@@ -16,7 +16,6 @@ import           Cardano.Api
 import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
 import           Cardano.Chain.UTxO.UTxO (UTxOError (..))
 import           Cardano.Chain.UTxO.Validation (TxValidationError (..), UTxOValidationError (..))
-import           Data.Monoid (Monoid (mconcat), (<>))
 import           Data.Text (Text)
 import           Formatting (build, sformat, stext, (%))
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))

--- a/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.TxSubmit.Metrics
@@ -7,13 +6,8 @@ module Cardano.TxSubmit.Metrics
   , registerMetricsServer
   ) where
 
-import           Control.Applicative (Applicative (pure), (<$>), (<*>))
 import           Control.Concurrent.Async (Async, async)
 import           Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
-import           Data.Function (($), (.))
-import           Data.Int
-import           Data.Monoid (Monoid (mempty))
-import           System.IO (IO)
 import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..), registerGauge,
                    runRegistryT, unRegistryT)
 import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
@@ -7,9 +7,6 @@ module Cardano.TxSubmit.Rest.Parsers
   ) where
 
 import           Cardano.TxSubmit.Rest.Types (WebserverConfig (..))
-import           Control.Applicative (Applicative (pure), (<$>))
-import           Data.Function (($))
-import           Data.Semigroup ((<>))
 import           Data.String (fromString)
 import           Network.Wai.Handler.Warp (HostPreference, Port)
 import           Options.Applicative (Parser, auto, help, long, metavar, option, showDefault,

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
@@ -7,8 +7,6 @@ module Cardano.TxSubmit.Rest.Types
   ) where
 
 import           Data.Function ((&))
-import           Data.Semigroup ((<>))
-import           Text.Show (Show (..))
 
 import qualified Network.Wai.Handler.Warp as Warp
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
@@ -6,15 +6,11 @@ module Cardano.TxSubmit.Rest.Web
 
 import           Cardano.BM.Trace (Trace, logInfo)
 import           Control.Exception (bracket)
-import           Data.Function (($))
-import           Data.Semigroup ((<>))
 import           Data.Streaming.Network (bindPortTCP)
 import           Data.Text (Text)
 import           Network.Socket (close, getSocketName, withSocketsDo)
 import           Network.Wai.Handler.Warp (Settings, getHost, getPort, runSettingsSocket)
 import           Servant (Application)
-import           System.IO (IO)
-import           Text.Show (Show (..))
 
 import qualified Data.Text as T
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
@@ -10,13 +10,9 @@ import           Cardano.BM.Data.Severity (Severity (Debug, Error, Notice, Warni
 import           Cardano.BM.Data.Tracer (HasPrivacyAnnotation, HasSeverityAnnotation (..),
                    HasTextFormatter, ToObject (toObject), Transformable (..), trStructured)
 import           Data.Aeson ((.=))
-import           Data.String (String)
 import           Data.Text (Text)
 import           Ouroboros.Network.NodeToClient (ErrorPolicyTrace (..), WithAddr (..))
-import           System.IO (IO)
-import           Text.Show (Show (..))
 
-import           Data.Monoid (mconcat)
 import qualified Network.Socket as Socket
 
 instance HasPrivacyAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace)

--- a/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
@@ -19,12 +19,6 @@ import           Cardano.Api (AnyCardanoEra, AnyConsensusMode (..), Error (..), 
 import           Cardano.Binary (DecoderError)
 import           Data.Aeson (ToJSON (..), Value (..))
 import           Data.ByteString.Char8 (ByteString)
-import           Data.Either (Either (Right))
-import           Data.Eq (Eq (..))
-import           Data.Function (id, (.))
-import           Data.Functor (Functor (fmap))
-import           Data.Int (Int)
-import           Data.Monoid (Monoid (mconcat), (<>))
 import           Data.Text (Text)
 import           Formatting (build, sformat)
 import           GHC.Generics (Generic)
@@ -33,7 +27,6 @@ import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import           Servant (Accept (..), JSON, MimeRender (..), MimeUnrender (..), PostAccepted,
                    ReqBody, (:>))
 import           Servant.API.Generic (ToServantApi, (:-))
-import           Text.Show (Show (..))
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.List as L

--- a/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-
 module Cardano.TxSubmit.Util
   ( logException
   ) where

--- a/cardano-submit-api/test/test.hs
+++ b/cardano-submit-api/test/test.hs
@@ -1,6 +1,3 @@
-
-import           System.IO (IO)
-
 import qualified System.IO as IO
 
 main :: IO ()

--- a/cardano-testnet/app/cardano-testnet.hs
+++ b/cardano-testnet/app/cardano-testnet.hs
@@ -1,10 +1,7 @@
 module Main where
 
 import           Control.Monad
-import           Data.Function
-import           Data.Semigroup
 import           Options.Applicative
-import           System.IO (IO)
 import           Testnet.Parsers (commands)
 
 main :: IO ()

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -16,7 +16,6 @@ build-type:             Simple
 
 common project-config
   default-language:     Haskell2010
-  default-extensions:   NoImplicitPrelude
   build-depends:        base >= 4.14 && < 4.17
 
   ghc-options:          -Wall

--- a/cardano-testnet/src/Parsers/Byron.hs
+++ b/cardano-testnet/src/Parsers/Byron.hs
@@ -4,16 +4,9 @@ module Parsers.Byron
   , runByronOptions
   ) where
 
-import           Data.Eq
-import           Data.Function
-import           Data.Int
-import           Data.Maybe
-import           Data.Semigroup
 import           Options.Applicative
-import           System.IO (IO)
 import           Testnet.Byron
 import           Testnet.Run (runTestnet)
-import           Text.Show
 
 import qualified Options.Applicative as OA
 

--- a/cardano-testnet/src/Parsers/Version.hs
+++ b/cardano-testnet/src/Parsers/Version.hs
@@ -5,15 +5,10 @@ module Parsers.Version
   ) where
 
 import           Cardano.Git.Rev (gitRev)
-import           Data.Eq
-import           Data.Function
-import           Data.Monoid
 import           Data.Version (showVersion)
 import           Options.Applicative
 import           Paths_cardano_testnet (version)
-import           System.IO (IO)
 import           System.Info (arch, compilerName, compilerVersion, os)
-import           Text.Show
 
 import qualified Data.Text as T
 import qualified System.IO as IO

--- a/cardano-testnet/src/Testnet/Byron.hs
+++ b/cardano-testnet/src/Testnet/Byron.hs
@@ -11,27 +11,16 @@ module Testnet.Byron
   , defaultTestnetOptions
   ) where
 
-import           Control.Monad (Monad(..), forM_, void, (=<<), when)
+import           Control.Monad (forM_, void, when)
 import           Data.Aeson (Value)
-import           Data.Bool (Bool(..))
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Eq (Eq)
-import           Data.Function (($), (.), flip)
-import           Data.Functor (Functor(..), (<&>))
-import           Data.Int (Int)
-import           Data.Maybe (Maybe(Just))
-import           Data.Ord (Ord((<=)))
-import           Data.Semigroup (Semigroup((<>)))
-import           Data.String (String)
-import           GHC.Num (Num((-)))
-import           GHC.Real (fromIntegral)
+import           Data.Functor ((<&>))
 import           Hedgehog.Extras.Stock.Aeson (rewriteObject)
-import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket(..))
+import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           Hedgehog.Extras.Stock.Time (showUTCTimeSeconds)
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 import           System.FilePath.Posix ((</>))
-import           Text.Show (Show(show))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter(..))
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint(..))
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P

--- a/cardano-testnet/src/Testnet/Conf.hs
+++ b/cardano-testnet/src/Testnet/Conf.hs
@@ -8,14 +8,7 @@ module Testnet.Conf
   , mkConf
   ) where
 
-import           Control.Monad
-import           Data.Eq
-import           Data.Function
-import           Data.Int
-import           Data.Maybe
 import           System.FilePath.Posix ((</>))
-import           System.IO (FilePath)
-import           Text.Show
 
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified System.FilePath.Posix as FP

--- a/cardano-testnet/src/Testnet/Parsers.hs
+++ b/cardano-testnet/src/Testnet/Parsers.hs
@@ -2,10 +2,7 @@ module Testnet.Parsers
   ( commands
   ) where
 
-import           Data.Function
-import           Data.Monoid
 import           Options.Applicative
-import           System.IO (IO)
 import           Parsers.Babbage
 import           Parsers.Byron
 import           Parsers.Cardano

--- a/cardano-testnet/src/Testnet/Run.hs
+++ b/cardano-testnet/src/Testnet/Run.hs
@@ -5,13 +5,8 @@ module Testnet.Run
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
-import           Data.Bool
-import           Data.Function
-import           Data.Int
-import           Data.Maybe
 import           System.Console.ANSI (Color (..), ColorIntensity (..), ConsoleLayer (..), SGR (..))
 import           System.FilePath ((</>))
-import           System.IO (IO)
 
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.STM as STM

--- a/cardano-testnet/src/Testnet/Util/Assert.hs
+++ b/cardano-testnet/src/Testnet/Util/Assert.hs
@@ -10,32 +10,23 @@ module Testnet.Util.Assert
   , getRelevantLeaderSlots
   ) where
 
-import           Control.Monad (Monad (..), fail)
+import           Prelude hiding (lines)
+
 import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Reader (ReaderT)
 import           Control.Monad.Trans.Resource (ResourceT)
 import           Data.Aeson (FromJSON (..), Value, (.:))
-import           Data.Bool (Bool (..))
-import           Data.Eq (Eq (..))
-import           Data.Function (($), (.))
-import           Data.Functor ((<$>))
-import           Data.Int (Int)
-import           Data.Maybe (Maybe (..), mapMaybe)
-import           Data.Ord (Ord (..))
-import           Data.Semigroup ((<>))
 import           Data.Text (Text)
 import           Data.Word (Word8)
 import           GHC.Stack (HasCallStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Extras.Internal.Test.Integration (IntegrationState)
-import           System.FilePath (FilePath)
-import           System.IO (IO)
-import           Text.Show (Show (..))
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as L
+import           Data.Maybe (mapMaybe)
 import qualified Data.Maybe as Maybe
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H

--- a/cardano-testnet/src/Testnet/Util/Base.hs
+++ b/cardano-testnet/src/Testnet/Util/Base.hs
@@ -3,9 +3,6 @@ module Testnet.Util.Base
   , isLinux
   ) where
 
-import           Data.Bool (Bool)
-import           Data.Eq (Eq (..))
-import           Data.Function
 import           GHC.Stack (HasCallStack)
 import           System.Info (os)
 


### PR DESCRIPTION
Remove from `NoImplicitPrelude` from `cardano-api` `cardano-submit-api` `cardano-cli` `cardano-testnet` `cardano-node-chairman` `cardano-node` and `cardano-git-rev`.
Remove dependency on `cardano-prelude` wherever possible.

Removed imported of `Cardano.Prelude` where possible (excluding `bench`).  Remaining occurrences are those that are still required:

* `canonicalDecodePretty`
* `canonicalEncodePretty`
* `cborError`
* `ConvertText (..)`
* `FatalError (..)`
* `maximumDef`