### PR TITLE
Modify constructBalancedTx to take LedgerEpochInfo

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -239,6 +239,7 @@ module Cardano.Api (
     totalAndReturnCollateralSupportedInEra,
 
     -- ** Fee calculation
+    LedgerEpochInfo(..),
     transactionFee,
     toLedgerEpochInfo,
     estimateTransactionFee,

--- a/cardano-api/src/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Construction.hs
@@ -44,16 +44,16 @@ constructBalancedTx
   -> Maybe Word       -- ^ Override key witnesses
   -> UTxO era         -- ^ Just the transaction inputs, not the entire 'UTxO'.
   -> ProtocolParameters
-  -> EraHistory CardanoMode
+  -> LedgerEpochInfo
   -> SystemStart
   -> Set PoolId       -- ^ The set of registered stake pools
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
 constructBalancedTx eInMode txbodcontent changeAddr mOverrideWits utxo pparams
-                    eraHistory systemStart stakePools shelleyWitSigningKeys = do
+                    ledgerEpochInfo systemStart stakePools shelleyWitSigningKeys = do
   BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
-         eInMode systemStart eraHistory
+         eInMode systemStart ledgerEpochInfo
          pparams stakePools utxo txbodcontent
          changeAddr mOverrideWits
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -19,6 +19,7 @@ module Cardano.CLI.Shelley.Run.Query
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
   , runQueryCmd
+  , toEpochInfo
   , determineEra
   , mergeDelegsAndRewards
   , percentage

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -428,7 +428,7 @@ runTxBuildCmd
 
                      scriptExecUnitsMap <- firstExceptT ShelleyTxCmdTxExecUnitsErr $ hoistEither
                                              $ evaluateTransactionExecutionUnits
-                                                 eInMode systemStart eraHistory
+                                                 eInMode systemStart (toLedgerEpochInfo eraHistory)
                                                  pparams txEraUtxo balancedTxBody
                      scriptCostOutput <- firstExceptT ShelleyTxCmdPlutusScriptCostErr $ hoistEither
                                            $ renderScriptCosts
@@ -753,7 +753,7 @@ runTxBuild era (AnyConsensusModeParams cModeParams) networkId mScriptValidity
       balancedTxBody@(BalancedTxBody _ _ _ fee) <-
         firstExceptT ShelleyTxCmdBalanceTxBody
           . hoistEither
-          $ makeTransactionBodyAutoBalance eInMode systemStart eraHistory
+          $ makeTransactionBodyAutoBalance eInMode systemStart (toLedgerEpochInfo eraHistory)
                                            pparams stakePools txEraUtxo txBodyContent
                                            cAddr mOverrideWits
 


### PR DESCRIPTION
Modifying `constructBalancedTx` to take `LedgerEpochInfo` instead of `EraHistory mode` makes it significantly easier to use this function with a service such as BlockFrost.  Constructing an `LedgerEpochInfo` value can be done with the helper function [fixedEpochInfo](https://github.com/input-output-hk/cardano-base/blob/631cb6cf1fa01ab346233b610a38b3b4cba6e6ab/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs#L16) which requires the slot length and the epoch length. Both of these values can be retrieved from the ShelleyGenesis whereas constructing an `EraHistory mode` value is difficult without using a local node query (which necessitates running a node locally).