### PR TITLE
Remove usage of nixWrapped.

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -1,19 +1,12 @@
 # Nix dependencies
 
-The nix build use the new flake format to manage dependencies. A flake-compatible nix command is provided from within `nix-shell`. To add flake support to your native nix setup please see https://nixos.wiki/wiki/Flakes.
+The nix build use the new flake format to manage dependencies. To add flake support to your native nix setup please see https://nixos.wiki/wiki/Flakes.
 
 Cardano-node nix build depends primarily on [haskell.nix](https://github.com/input-output-hk/haskell.nix) and secondarily, for some utilities, on [iohk-nix](https://github.com/input-output-hk/iohk-nix/).
 
-Both can be updated from within a cardano-node `nix-shell` with:
+Both can be updated with:
 
 ```
 nix flake lock --update-input haskellNix
 nix flake lock --update-input iohkNix
-```
-
-Or from outside the `nix-shell` with the scripts:
-
-```
-./nix/update-haskellNix.sh
-./nix/update-iohkNix.sh
 ```

--- a/nix/update-haskellNix.sh
+++ b/nix/update-haskellNix.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-cd "$(dirname "$0")/.."
-nix-shell -I nixpkgs=./nix -p nixWrapped \
-  --run "nix flake lock --update-input haskellNix"

--- a/nix/update-iohkNix.sh
+++ b/nix/update-iohkNix.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-cd "$(dirname "$0")/.."
-nix-shell -I nixpkgs=./nix -p nixWrapped \
-  --run "nix flake lock --update-input iohkNix"

--- a/nix/workbench/analyse.nix
+++ b/nix/workbench/analyse.nix
@@ -7,7 +7,7 @@
 pkgs.runCommand "workbench-run-analysis-${profileNix.name}"
   { requiredSystemFeatures = [ "benchmark" ];
     nativeBuildInputs = with pkgs.haskellPackages; with pkgs;
-      [ bash coreutils gnused jq moreutils nixWrapped workbench.workbench ];
+      [ bash coreutils gnused jq moreutils nix workbench.workbench ];
   }
   ''
   echo "analysing run:  ${run}"

--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -84,7 +84,7 @@ in
               gnused
               jq
               moreutils
-              nixWrapped
+              nix
               pstree
               workbench.workbench
               zstd

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -93,7 +93,7 @@ in project.shellFor {
     pkgs.graphviz
     graphmod
     weeder
-    nixWrapped
+    nix
     pkgconfig
     profiteur
     profiterole

--- a/shell.nix
+++ b/shell.nix
@@ -97,7 +97,7 @@ let
     packages = _: [];
 
     nativeBuildInputs = with cardanoNodePackages; [
-      nixWrapped
+      nix
       cardano-cli
       bech32
       cardano-ping


### PR DESCRIPTION
it was introduced for adding flake flags by default and also as a work around for nix flake show/check: https://github.com/NixOS/nix/issues/4265 But the added complexity is not worth it, given it breaks other workflows with nix run (since the wrapper script does not use `exec`).

Also nowadays everyone (should) have flake activated by default in the nix config.