### PR TITLE
workbench:  `make shell-nix` use Nix-built binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ci-targets:  $(CI_TARGETS)
 shell:                                           ## Nix shell, (workbench from /nix/store), vars: PROFILE, CMD, RUN
 	nix-shell -A 'workbench-shell' --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} --argstr backendName ${BACKEND} ${ARGS} ${if ${CMD},--command "${CMD}"} ${if ${RUN},--run "${RUN}"}
 shell-dev shell-prof shell-nix: shell
-shell-nix: ARGS += --arg 'workbenchDevMode' false ## Nix shell, (workbench from Nix store), vars: PROFILE, CMD, RUN
+shell-nix: ARGS += --arg 'useCabalRun' false ## Nix shell, (workbench from Nix store), vars: PROFILE, CMD, RUN
 shell-prof: ARGS += --arg 'profiled' true        ## Nix shell, everything Haskell built profiled
 
 analyse: RUN := wb analyse std ${TAG}


### PR DESCRIPTION
This makes the `shell-nix` Makefile target actually use the Nix derivations for the node and components.