### PR TITLE
workbench:  drop cabalWrapped

### DIFF
--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -15,7 +15,7 @@ let
     ]
   ++ lib.optionals ( useCabalRun)
     (with haskellPackages; [
-      cabalWrapped
+      cabal-install
       ghcid
       haskellBuildUtils
       cabal-plan

--- a/nix/workbench/lib-cabal.sh
+++ b/nix/workbench/lib-cabal.sh
@@ -28,6 +28,7 @@ function workbench-prebuild-executables()
     newline
 
     unset NIX_ENFORCE_PURITY
+    cabal update
     for exe in cardano-node cardano-cli cardano-topology cardano-tracer tx-generator locli
     do echo "workbench:    $(blue prebuilding) $(red $exe)"
        cabal $(test -z "${verbose:-}" && echo '-v0') build ${WB_FLAGS_CABAL} -- exe:$exe 2>&1 >/dev/null || return 1


### PR DESCRIPTION
The end of an era -- the workbench will no longer insist on following the Nix-supplied package DB only -- we're dropping the use of `cabalWrapped`.