### PR TITLE
Detect invalid counter and certificate

### DIFF
--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -56,9 +56,8 @@ import qualified Data.Text as Text
 import           GHC.Records (HasField (..))
 import           Lens.Micro ((^.))
 import           Numeric.Natural
-
-import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.String as PP
+import           Prettyprinter
+import           Prettyprinter.Render.String
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Ledger.BaseTypes as Ledger
@@ -419,10 +418,10 @@ instance Error ScriptExecutionError where
       "The Plutus script evaluation failed: " ++ pp evalErr ++
       "\nScript debugging logs: " <> mconcat (map (\t -> Text.unpack $ t `Text.append` "\n") logs)
     where
-      pp :: PP.Pretty p => p -> String
-      pp = PP.renderString
-         . PP.layoutPretty PP.defaultLayoutOptions
-         . PP.pretty
+      pp :: Pretty p => p -> String
+      pp = renderString
+         . layoutPretty defaultLayoutOptions
+         . pretty
 
   displayError ScriptErrorExecutionUnitsOverflow =
       "The execution units required by this Plutus script overflows a 64bit "

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -142,6 +142,7 @@ library
                       , ouroboros-network-protocols
                       , parsec
                       , prettyprinter
+                      , prettyprinter-ansi-terminal
                       , random
                       , cardano-ledger-shelley ^>= 0.1
                       , set-algebra ^>= 0.1

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -68,6 +68,7 @@ library
                         Cardano.CLI.Byron.UpdateProposal
                         Cardano.CLI.Byron.Vote
 
+                        Cardano.CLI.Pretty
                         Cardano.CLI.IO.Lazy
 
                         Cardano.CLI.Shelley.Commands

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -1,0 +1,44 @@
+module Cardano.CLI.Pretty
+  ( Ann(..),
+    putLn,
+    hPutLn,
+    renderDefault,
+    renderStringDefault,
+  ) where
+
+import           Control.Exception (bracket_)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Data.Eq (Eq)
+import           Data.Function (($), (.))
+import           Data.String (String)
+import           Prelude (IO)
+import           Text.Show (Show)
+
+import qualified Control.Concurrent.QSem as IO
+import qualified Data.Text.Lazy as TextLazy
+import qualified Data.Text.Lazy.IO as LT
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
+import qualified System.IO as IO
+import qualified System.IO.Unsafe as IO
+
+data Ann = Ann deriving (Eq, Show)
+
+sem :: IO.QSem
+sem = IO.unsafePerformIO $ IO.newQSem 1
+{-# NOINLINE sem #-}
+
+consoleBracket :: IO a -> IO a
+consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
+
+putLn :: MonadIO m => PP.Doc Ann -> m ()
+putLn = liftIO . consoleBracket . LT.putStrLn . renderDefault
+
+hPutLn :: MonadIO m => IO.Handle -> PP.Doc Ann -> m ()
+hPutLn h = liftIO . consoleBracket . LT.hPutStr h . renderDefault
+
+renderStringDefault :: PP.Doc ann -> String
+renderStringDefault =  TextLazy.unpack . PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions { PP.layoutPageWidth = PP.Unbounded }
+
+renderDefault :: PP.Doc ann -> TextLazy.Text
+renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions { PP.layoutPageWidth = PP.Unbounded }

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -4,6 +4,15 @@ module Cardano.CLI.Pretty
     hPutLn,
     renderDefault,
     renderStringDefault,
+
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    cyan,
+    white,
   ) where
 
 import           Control.Exception (bracket_)
@@ -39,4 +48,28 @@ renderStringDefault :: PP.Doc PP.AnsiStyle -> String
 renderStringDefault =  TextLazy.unpack . renderDefault
 
 renderDefault :: PP.Doc PP.AnsiStyle -> TextLazy.Text
-renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions-- { PP.layoutPageWidth = PP.Unbounded }
+renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions
+
+black :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+black = PP.annotate (PP.color PP.Black)
+
+red :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+red = PP.annotate (PP.color PP.Red)
+
+green :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+green = PP.annotate (PP.color PP.Green)
+
+yellow :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+yellow = PP.annotate (PP.color PP.Yellow)
+
+blue :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+blue = PP.annotate (PP.color PP.Blue)
+
+magenta :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+magenta = PP.annotate (PP.color PP.Magenta)
+
+cyan :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+cyan = PP.annotate (PP.color PP.Cyan)
+
+white :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
+white = PP.annotate (PP.color PP.White)

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -1,5 +1,5 @@
 module Cardano.CLI.Pretty
-  ( Ann(..),
+  ( Ann,
     putLn,
     hPutLn,
     renderDefault,
@@ -8,21 +8,19 @@ module Cardano.CLI.Pretty
 
 import           Control.Exception (bracket_)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Data.Eq (Eq)
 import           Data.Function (($), (.))
 import           Data.String (String)
 import           Prelude (IO)
-import           Text.Show (Show)
 
 import qualified Control.Concurrent.QSem as IO
 import qualified Data.Text.Lazy as TextLazy
 import qualified Data.Text.Lazy.IO as LT
 import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.Text as PP
+import qualified Prettyprinter.Render.Terminal as PP
 import qualified System.IO as IO
 import qualified System.IO.Unsafe as IO
 
-data Ann = Ann deriving (Eq, Show)
+type Ann = PP.AnsiStyle
 
 sem :: IO.QSem
 sem = IO.unsafePerformIO $ IO.newQSem 1
@@ -31,14 +29,14 @@ sem = IO.unsafePerformIO $ IO.newQSem 1
 consoleBracket :: IO a -> IO a
 consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
 
-putLn :: MonadIO m => PP.Doc Ann -> m ()
+putLn :: MonadIO m => PP.Doc PP.AnsiStyle -> m ()
 putLn = liftIO . consoleBracket . LT.putStrLn . renderDefault
 
-hPutLn :: MonadIO m => IO.Handle -> PP.Doc Ann -> m ()
+hPutLn :: MonadIO m => IO.Handle -> PP.Doc PP.AnsiStyle -> m ()
 hPutLn h = liftIO . consoleBracket . LT.hPutStr h . renderDefault
 
-renderStringDefault :: PP.Doc ann -> String
-renderStringDefault =  TextLazy.unpack . PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions { PP.layoutPageWidth = PP.Unbounded }
+renderStringDefault :: PP.Doc PP.AnsiStyle -> String
+renderStringDefault =  TextLazy.unpack . renderDefault
 
-renderDefault :: PP.Doc ann -> TextLazy.Text
-renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions { PP.layoutPageWidth = PP.Unbounded }
+renderDefault :: PP.Doc PP.AnsiStyle -> TextLazy.Text
+renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions-- { PP.layoutPageWidth = PP.Unbounded }

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -17,19 +17,16 @@ module Cardano.CLI.Pretty
 
 import           Control.Exception (bracket_)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Data.Function (($), (.))
-import           Data.String (String)
-import           Prelude (IO)
+import           Prettyprinter
+import           Prettyprinter.Render.Terminal
 
 import qualified Control.Concurrent.QSem as IO
 import qualified Data.Text.Lazy as TextLazy
-import qualified Data.Text.Lazy.IO as LT
-import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.Terminal as PP
+import qualified Data.Text.Lazy.IO as TextLazy
 import qualified System.IO as IO
 import qualified System.IO.Unsafe as IO
 
-type Ann = PP.AnsiStyle
+type Ann = AnsiStyle
 
 sem :: IO.QSem
 sem = IO.unsafePerformIO $ IO.newQSem 1
@@ -38,38 +35,38 @@ sem = IO.unsafePerformIO $ IO.newQSem 1
 consoleBracket :: IO a -> IO a
 consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
 
-putLn :: MonadIO m => PP.Doc PP.AnsiStyle -> m ()
-putLn = liftIO . consoleBracket . LT.putStrLn . renderDefault
+putLn :: MonadIO m => Doc AnsiStyle -> m ()
+putLn = liftIO . consoleBracket . TextLazy.putStrLn . renderDefault
 
-hPutLn :: MonadIO m => IO.Handle -> PP.Doc PP.AnsiStyle -> m ()
-hPutLn h = liftIO . consoleBracket . LT.hPutStr h . renderDefault
+hPutLn :: MonadIO m => IO.Handle -> Doc AnsiStyle -> m ()
+hPutLn h = liftIO . consoleBracket . TextLazy.hPutStr h . renderDefault
 
-renderStringDefault :: PP.Doc PP.AnsiStyle -> String
+renderStringDefault :: Doc AnsiStyle -> String
 renderStringDefault =  TextLazy.unpack . renderDefault
 
-renderDefault :: PP.Doc PP.AnsiStyle -> TextLazy.Text
-renderDefault =  PP.renderLazy . PP.layoutPretty PP.defaultLayoutOptions
+renderDefault :: Doc AnsiStyle -> TextLazy.Text
+renderDefault =  renderLazy . layoutPretty defaultLayoutOptions
 
-black :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-black = PP.annotate (PP.color PP.Black)
+black :: Doc AnsiStyle -> Doc AnsiStyle
+black = annotate (color Black)
 
-red :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-red = PP.annotate (PP.color PP.Red)
+red :: Doc AnsiStyle -> Doc AnsiStyle
+red = annotate (color Red)
 
-green :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-green = PP.annotate (PP.color PP.Green)
+green :: Doc AnsiStyle -> Doc AnsiStyle
+green = annotate (color Green)
 
-yellow :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-yellow = PP.annotate (PP.color PP.Yellow)
+yellow :: Doc AnsiStyle -> Doc AnsiStyle
+yellow = annotate (color Yellow)
 
-blue :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-blue = PP.annotate (PP.color PP.Blue)
+blue :: Doc AnsiStyle -> Doc AnsiStyle
+blue = annotate (color Blue)
 
-magenta :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-magenta = PP.annotate (PP.color PP.Magenta)
+magenta :: Doc AnsiStyle -> Doc AnsiStyle
+magenta = annotate (color Magenta)
 
-cyan :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-cyan = PP.annotate (PP.color PP.Cyan)
+cyan :: Doc AnsiStyle -> Doc AnsiStyle
+cyan = annotate (color Cyan)
 
-white :: PP.Doc PP.AnsiStyle -> PP.Doc PP.AnsiStyle
-white = PP.annotate (PP.color PP.White)
+white :: Doc AnsiStyle -> Doc AnsiStyle
+white = annotate (color White)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -507,6 +507,7 @@ runQueryKesPeriodInfo (AnyConsensusModeParams cModeParams) network nodeOpCertFil
      -> OpCertNodeAndOnDiskCounterInformation
    opCertNodeAndOnDiskCounters o@(OpCertOnDiskCounter odc) (Just n@(OpCertNodeStateCounter nsc))
      | odc < nsc = OpCertOnDiskCounterBehindNodeState o n
+     | odc > nsc + 1 = OpCertOnDiskCounterTooFarAheadOfNodeState o n
      | otherwise = OpCertOnDiskCounterMoreThanOrEqualToNodeState o n
    opCertNodeAndOnDiskCounters o Nothing = OpCertNoBlocksMintedYet o
 
@@ -529,6 +530,10 @@ runQueryKesPeriodInfo (AnyConsensusModeParams cModeParams) network nodeOpCertFil
      case opCertCounterInfo of
       OpCertOnDiskCounterMoreThanOrEqualToNodeState _ _ ->
         "✓ The operational certificate counter agrees with the node protocol state counter"
+      OpCertOnDiskCounterTooFarAheadOfNodeState onDiskC nodeStateC ->
+        "✗ The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: " <> opCertFile <> "\n" <>
+        "  On disk operational certificate counter: " <> show (unOpCertOnDiskCounter onDiskC) <> "\n" <>
+        "  Protocol state counter: " <> show (unOpCertNodeStateCounter nodeStateC)
       OpCertOnDiskCounterBehindNodeState onDiskC nodeStateC ->
         "✗ The protocol state counter is greater than the counter in the operational certificate at: " <> opCertFile <> "\n" <>
         "  On disk operational certificate counter: " <> show (unOpCertOnDiskCounter onDiskC) <> "\n" <>
@@ -553,6 +558,7 @@ runQueryKesPeriodInfo (AnyConsensusModeParams cModeParams) network nodeOpCertFil
          (onDiskCounter, mNodeCounter) = case oCertCounterInfo of
                                            OpCertOnDiskCounterMoreThanOrEqualToNodeState d n -> (d, Just n)
                                            OpCertOnDiskCounterBehindNodeState d n -> (d, Just n)
+                                           OpCertOnDiskCounterTooFarAheadOfNodeState d n -> (d, Just n)
                                            OpCertNoBlocksMintedYet d -> (d, Nothing)
 
      in O.QueryKesPeriodInfoOutput

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -53,13 +53,13 @@ import           Data.Time.Clock
 import qualified Data.Vector as Vector
 import           Formatting.Buildable (build)
 import           Numeric (showEFloat)
-import qualified Prettyprinter as PP
+import           Prettyprinter
 import qualified System.IO as IO
 import           Text.Printf (printf)
 
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Helpers (HelpersError (..), hushM, pPrintCBOR, renderHelpersError)
-import qualified Cardano.CLI.Pretty as PP
+import           Cardano.CLI.Pretty
 import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Key (VerificationKeyOrHashOrFile,
                    readVerificationKeyOrHashOrFile)
@@ -532,43 +532,43 @@ runQueryKesPeriodInfo (AnyConsensusModeParams cModeParams) network nodeOpCertFil
    renderOpCertNodeAndOnDiskCounterInformation opCertFile opCertCounterInfo =
      case opCertCounterInfo of
       OpCertOnDiskCounterEqualToNodeState _ _ ->
-        PP.renderStringDefault $
-          PP.green "✓" PP.<+> PP.hang 0
-              ( PP.vsep
+        renderStringDefault $
+          green "✓" <+> hang 0
+              ( vsep
                 [ "The operational certificate counter agrees with the node protocol state counter"
                 ]
               )
       OpCertOnDiskCounterAheadOfNodeState _ _ ->
-        PP.renderStringDefault $
-          PP.green "✓" PP.<+> PP.hang 0
-              ( PP.vsep
+        renderStringDefault $
+          green "✓" <+> hang 0
+              ( vsep
                 [ "The operational certificate counter ahead of the node protocol state counter by 1"
                 ]
               )
       OpCertOnDiskCounterTooFarAheadOfNodeState onDiskC nodeStateC ->
-        PP.renderStringDefault $
-          PP.red "✗" PP.<+> PP.hang 0
-            ( PP.vsep
-              [ "The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: " <> PP.pretty opCertFile
-              , "On disk operational certificate counter: " <> PP.pretty (unOpCertOnDiskCounter onDiskC)
-              , "Protocol state counter: " <> PP.pretty (unOpCertNodeStateCounter nodeStateC)
+        renderStringDefault $
+          red "✗" <+> hang 0
+            ( vsep
+              [ "The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: " <> pretty opCertFile
+              , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
+              , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
               ]
             )
       OpCertOnDiskCounterBehindNodeState onDiskC nodeStateC ->
-        PP.renderStringDefault $
-          PP.red "✗" PP.<+> PP.hang 0
-            ( PP.vsep
-              [ "The protocol state counter is greater than the counter in the operational certificate at: " <> PP.pretty opCertFile
-              , "On disk operational certificate counter: " <> PP.pretty (unOpCertOnDiskCounter onDiskC)
-              , "Protocol state counter: " <> PP.pretty (unOpCertNodeStateCounter nodeStateC)
+        renderStringDefault $
+          red "✗" <+> hang 0
+            ( vsep
+              [ "The protocol state counter is greater than the counter in the operational certificate at: " <> pretty opCertFile
+              , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
+              , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
               ]
             )
       OpCertNoBlocksMintedYet (OpCertOnDiskCounter onDiskC) ->
-        PP.renderStringDefault $
-          PP.red "✗" PP.<+> PP.hang 0
-            ( PP.vsep
-              [ "No blocks minted so far with the operational certificate at: " <> PP.pretty opCertFile
-              , "On disk operational certificate counter: " <> PP.pretty onDiskC
+        renderStringDefault $
+          red "✗" <+> hang 0
+            ( vsep
+              [ "No blocks minted so far with the operational certificate at: " <> pretty opCertFile
+              , "On disk operational certificate counter: " <> pretty onDiskC
               ]
             )
 
@@ -635,40 +635,40 @@ runQueryKesPeriodInfo (AnyConsensusModeParams cModeParams) network nodeOpCertFil
 renderOpCertIntervalInformation :: FilePath -> OpCertIntervalInformation -> String
 renderOpCertIntervalInformation opCertFile opCertInfo = case opCertInfo of
   OpCertWithinInterval _start _end _current _stillExp ->
-    PP.renderStringDefault $
-      PP.green "✓" PP.<+> PP.hang 0
-        ( PP.vsep
+    renderStringDefault $
+      green "✓" <+> hang 0
+        ( vsep
           [ "Operational certificate's KES period is within the correct KES period interval"
           ]
         )
   OpCertStartingKesPeriodIsInTheFuture (OpCertStartingKesPeriod start) (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
-    PP.renderStringDefault $
-      PP.red "✗" PP.<+> PP.hang 0
-        ( PP.vsep
-          [ "Node operational certificate at: " <> PP.pretty opCertFile <> " has an incorrectly specified starting KES period. "
-          , "Current KES period: " <> PP.pretty current
-          , "Operational certificate's starting KES period: " <> PP.pretty start
-          , "Operational certificate's expiry KES period: " <> PP.pretty end
+    renderStringDefault $
+      red "✗" <+> hang 0
+        ( vsep
+          [ "Node operational certificate at: " <> pretty opCertFile <> " has an incorrectly specified starting KES period. "
+          , "Current KES period: " <> pretty current
+          , "Operational certificate's starting KES period: " <> pretty start
+          , "Operational certificate's expiry KES period: " <> pretty end
           ]
         )
   OpCertExpired _ (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
-    PP.renderStringDefault $
-      PP.red "✗" PP.<+> PP.hang 0
-        ( PP.vsep
-          [ "Node operational certificate at: " <> PP.pretty opCertFile <> " has expired. "
-          , "Current KES period: " <> PP.pretty current
-          , "Operational certificate's expiry KES period: " <> PP.pretty end
+    renderStringDefault $
+      red "✗" <+> hang 0
+        ( vsep
+          [ "Node operational certificate at: " <> pretty opCertFile <> " has expired. "
+          , "Current KES period: " <> pretty current
+          , "Operational certificate's expiry KES period: " <> pretty end
           ]
         )
 
   OpCertSomeOtherError (OpCertStartingKesPeriod start) (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
-    PP.renderStringDefault $
-      PP.red "✗" PP.<+> PP.hang 0
-        ( PP.vsep
-          [ "An unknown error occurred with operational certificate at: " <> PP.pretty opCertFile
-          , "Current KES period: " <> PP.pretty current
-          , "Operational certificate's starting KES period: " <> PP.pretty start
-          , "Operational certificate's expiry KES period: " <> PP.pretty end
+    renderStringDefault $
+      red "✗" <+> hang 0
+        ( vsep
+          [ "An unknown error occurred with operational certificate at: " <> pretty opCertFile
+          , "Current KES period: " <> pretty current
+          , "Operational certificate's starting KES period: " <> pretty start
+          , "Operational certificate's expiry KES period: " <> pretty end
           ]
         )
 

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -93,22 +93,22 @@ newtype GenesisFile = GenesisFile
 
 data OpCertNodeAndOnDiskCounterInformation
   -- | The on disk operational certificate has a counter
-  -- that is larger than or equal to its corresponding
-  -- counter in the node state. The on disk operational
-  -- certificate therefore has a valid counter.
-  = OpCertOnDiskCounterMoreThanOrEqualToNodeState
+  -- that is equal to its corresponding counter in the
+  -- node state. The on disk operational certificate therefore
+  -- has a valid counter.
+  = OpCertOnDiskCounterEqualToNodeState
+      OpCertOnDiskCounter
+      OpCertNodeStateCounter
+  -- | The on disk operational certificate has a counter
+  -- that is ahead of the counter in the node state by 1.
+  -- The on disk operational certificate is invalid in
+  -- this case.
+  | OpCertOnDiskCounterAheadOfNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
   -- | The on disk operational certificate has a counter
   -- that is less than the counter in the node state. The
   -- on disk operational certificate is invalid in this case.
-  | OpCertOnDiskCounterBehindNodeState
-      OpCertOnDiskCounter
-      OpCertNodeStateCounter
-  -- | The on disk operational certificate has a counter
-  -- that is ahead of the counter in the node state by more
-  -- than 1. The on disk operational certificate is invalid in
-  -- this case.
   | OpCertOnDiskCounterTooFarAheadOfNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
@@ -117,6 +117,13 @@ data OpCertNodeAndOnDiskCounterInformation
   -- stake pool has not minted a block yet. When the stake pool
   -- has minted a block the corresponding operational certificate's
   -- counter will be present in the node state.
+  | OpCertOnDiskCounterBehindNodeState
+      OpCertOnDiskCounter
+      OpCertNodeStateCounter
+  -- | The on disk operational certificate has a counter
+  -- that is ahead of the counter in the node state by more
+  -- than 1. The on disk operational certificate is invalid in
+  -- this case.
   | OpCertNoBlocksMintedYet
       OpCertOnDiskCounter
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -105,6 +105,13 @@ data OpCertNodeAndOnDiskCounterInformation
   | OpCertOnDiskCounterBehindNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
+  -- | The on disk operational certificate has a counter
+  -- that is ahead of the counter in the node state by more
+  -- than 1. The on disk operational certificate is invalid in
+  -- this case.
+  | OpCertOnDiskCounterTooFarAheadOfNodeState
+      OpCertOnDiskCounter
+      OpCertNodeStateCounter
   -- | The corresponding counter for operational certificate
   -- was not found in the node state. This means the relevant
   -- stake pool has not minted a block yet. When the stake pool

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -71,6 +71,7 @@ library
                         Cardano.Node.Handlers.TopLevel
                         Cardano.Node.Orphans
                         Cardano.Node.Parsers
+                        Cardano.Node.Pretty
                         Cardano.Node.Protocol
                         Cardano.Node.Protocol.Alonzo
                         Cardano.Node.Protocol.Byron
@@ -190,6 +191,8 @@ library
                       , ouroboros-network-api
                       , ouroboros-network-framework >= 0.3
                       , ouroboros-network-protocols
+                      , prettyprinter
+                      , prettyprinter-ansi-terminal
                       , psqueues
                       , safe-exceptions
                       , scientific

--- a/cardano-node/src/Cardano/Node/Pretty.hs
+++ b/cardano-node/src/Cardano/Node/Pretty.hs
@@ -1,0 +1,72 @@
+module Cardano.Node.Pretty
+  ( Ann,
+    putLn,
+    hPutLn,
+    renderDefault,
+    renderStringDefault,
+
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    cyan,
+    white,
+  ) where
+
+import           Control.Exception (bracket_)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Prettyprinter
+import           Prettyprinter.Render.Terminal
+
+import qualified Control.Concurrent.QSem as IO
+import qualified Data.Text.Lazy as TextLazy
+import qualified Data.Text.Lazy.IO as TextLazy
+import qualified System.IO as IO
+import qualified System.IO.Unsafe as IO
+
+type Ann = AnsiStyle
+
+sem :: IO.QSem
+sem = IO.unsafePerformIO $ IO.newQSem 1
+{-# NOINLINE sem #-}
+
+consoleBracket :: IO a -> IO a
+consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
+
+putLn :: MonadIO m => Doc AnsiStyle -> m ()
+putLn = liftIO . consoleBracket . TextLazy.putStrLn . renderDefault
+
+hPutLn :: MonadIO m => IO.Handle -> Doc AnsiStyle -> m ()
+hPutLn h = liftIO . consoleBracket . TextLazy.hPutStr h . renderDefault
+
+renderStringDefault :: Doc AnsiStyle -> String
+renderStringDefault =  TextLazy.unpack . renderDefault
+
+renderDefault :: Doc AnsiStyle -> TextLazy.Text
+renderDefault =  renderLazy . layoutPretty defaultLayoutOptions
+
+black :: Doc AnsiStyle -> Doc AnsiStyle
+black = annotate (color Black)
+
+red :: Doc AnsiStyle -> Doc AnsiStyle
+red = annotate (color Red)
+
+green :: Doc AnsiStyle -> Doc AnsiStyle
+green = annotate (color Green)
+
+yellow :: Doc AnsiStyle -> Doc AnsiStyle
+yellow = annotate (color Yellow)
+
+blue :: Doc AnsiStyle -> Doc AnsiStyle
+blue = annotate (color Blue)
+
+magenta :: Doc AnsiStyle -> Doc AnsiStyle
+magenta = annotate (color Magenta)
+
+cyan :: Doc AnsiStyle -> Doc AnsiStyle
+cyan = annotate (color Cyan)
+
+white :: Doc AnsiStyle -> Doc AnsiStyle
+white = annotate (color White)

--- a/cardano-testnet/test/Test/Misc.hs
+++ b/cardano-testnet/test/Test/Misc.hs
@@ -6,7 +6,6 @@ import           Control.Monad.IO.Class
 import           Data.List (isInfixOf)
 import qualified GHC.Stack as GHC
 
-import qualified Cardano.CLI.Pretty as PP
 import           Cardano.CLI.Shelley.Output
 import           Cardano.CLI.Shelley.Run.Query
 import           Cardano.CLI.Types
@@ -23,15 +22,15 @@ prop_op_cert_valid_kes_period opCertFp output =
       info@OpCertStartingKesPeriodIsInTheFuture{} ->
         failMessage GHC.callStack
           $ "Expected OpCertWithinInterval but got: OpCertStartingKesPeriodIsInTheFuture\n"
-          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
+          <> renderOpCertIntervalInformation opCertFp info
       info@OpCertExpired{} ->
         failMessage GHC.callStack
           $ "Expected OpCertWithinInterval but got: OpCertExpired\n"
-          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
+          <> renderOpCertIntervalInformation opCertFp info
       info@OpCertSomeOtherError{} ->
         failMessage GHC.callStack
           $ "Expected OpCertWithinInterval but got: OpCertSomeOtherError\n"
-          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
+          <> renderOpCertIntervalInformation opCertFp info
 
 
 -- | This property parses the node's logs for the output "TraceForgedBlock" to confirm that

--- a/cardano-testnet/test/Test/Misc.hs
+++ b/cardano-testnet/test/Test/Misc.hs
@@ -6,6 +6,7 @@ import           Control.Monad.IO.Class
 import           Data.List (isInfixOf)
 import qualified GHC.Stack as GHC
 
+import qualified Cardano.CLI.Pretty as PP
 import           Cardano.CLI.Shelley.Output
 import           Cardano.CLI.Shelley.Run.Query
 import           Cardano.CLI.Types
@@ -21,16 +22,16 @@ prop_op_cert_valid_kes_period opCertFp output =
       OpCertWithinInterval{} -> success
       info@OpCertStartingKesPeriodIsInTheFuture{} ->
         failMessage GHC.callStack
-          $ "Expected OpCertWithinInterval but got: OpCertStartingKesPeriodIsInTheFuture " <> "\n"
-          <> renderOpCertIntervalInformation opCertFp info
+          $ "Expected OpCertWithinInterval but got: OpCertStartingKesPeriodIsInTheFuture\n"
+          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
       info@OpCertExpired{} ->
         failMessage GHC.callStack
-          $ "Expected OpCertWithinInterval but got: OpCertExpired " <> "\n"
-          <> renderOpCertIntervalInformation opCertFp info
+          $ "Expected OpCertWithinInterval but got: OpCertExpired\n"
+          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
       info@OpCertSomeOtherError{} ->
         failMessage GHC.callStack
-          $ "Expected OpCertWithinInterval but got: OpCertSomeOtherError " <> "\n"
-          <> renderOpCertIntervalInformation opCertFp info
+          $ "Expected OpCertWithinInterval but got: OpCertSomeOtherError\n"
+          <> PP.renderStringDefault (renderOpCertIntervalInformation opCertFp info)
 
 
 -- | This property parses the node's logs for the output "TraceForgedBlock" to confirm that


### PR DESCRIPTION
Reports an warning if on-disk certificate counter is `2` or more than the node state certificate counter:

```bash
$ LC_ALL=en_US.iso88591 CARDANO_NODE_SOCKET_PATH=example/node-spo1/node.sock cardano-cli query kes-period-info --testnet-magic 42 --op-cert-file example/node-spo1/opcert.cert
✓ Operational certificate's KES period is within the correct KES period interval
✗ The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: example/node-spo1/opcert.cert
  On disk operational certificate counter: 4
  Protocol state counter: 2
{
    "qKesCurrentKesPeriod": 0,
    "qKesEndKesInterval": 60,
    "qKesKesKeyExpiry": null,
    "qKesMaxKESEvolutions": 60,
    "qKesNodeStateOperationalCertificateNumber": 2,
    "qKesOnDiskOperationalCertificateNumber": 4,
    "qKesRemainingSlotsInKesPeriod": 7672192,
    "qKesSlotsPerKesPeriod": 129600,
    "qKesStartKesInterval": 0
}
```

The PR also adds colour to the output:

![Screenshot 2023-02-13 at 2 53 59 pm](https://user-images.githubusercontent.com/63014/218366686-646ea316-0d40-41dc-90fe-3858fbe0df62.png)

Resolves https://github.com/input-output-hk/cardano-node/issues/4114