### PR TITLE
Reduce number of calls to toLedgerPParams

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -31,6 +31,11 @@
 
 - **Breaking change** Change return type of `queryNodeLocalState` to new `AcquiringFailure` type.
 
+- **Breaking change** - For performance reasons, `evaluateTransactionFee` to take a
+  `Ledger.PParams (ShelleyLedgerEra era)` argument instead of `ProtocolParameters`
+  New type `BundledProtocolParameters` and new functions `bundleProtocolParams` and `unbundleProtocolParams`.
+  ([PR4903](https://github.com/input-output-hk/cardano-node/pull/4903))
+
 ### Bugs
 
 - Allow reading text envelopes from pipes ([PR 4384](https://github.com/input-output-hk/cardano-node/pull/4384))

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -685,6 +685,11 @@ module Cardano.Api (
 
     NetworkMagic(..),
 
+    -- * Protocol parameters
+    BundledProtocolParameters(..),
+    bundleProtocolParams,
+    unbundleProtocolParams,
+
     -- ** Conversions
     toLedgerPParams,
     fromLedgerPParams,

--- a/cardano-api/src/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Construction.hs
@@ -24,8 +24,6 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Fees
-import           Cardano.Api.IPC
-import           Cardano.Api.Modes
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
 import           Cardano.Api.Tx
@@ -38,8 +36,7 @@ import           Cardano.Api.Utils
 -- for constructBalancedTx.
 constructBalancedTx
   :: IsShelleyBasedEra era
-  => EraInMode era CardanoMode
-  -> TxBodyContent BuildTx era
+  => TxBodyContent BuildTx era
   -> AddressInEra era -- ^ Change address
   -> Maybe Word       -- ^ Override key witnesses
   -> UTxO era         -- ^ Just the transaction inputs, not the entire 'UTxO'.
@@ -49,11 +46,11 @@ constructBalancedTx
   -> Set PoolId       -- ^ The set of registered stake pools
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
-constructBalancedTx eInMode txbodcontent changeAddr mOverrideWits utxo pparams
+constructBalancedTx txbodcontent changeAddr mOverrideWits utxo pparams
                     ledgerEpochInfo systemStart stakePools shelleyWitSigningKeys = do
   BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
-         eInMode systemStart ledgerEpochInfo
+         systemStart ledgerEpochInfo
          pparams stakePools utxo txbodcontent
          changeAddr mOverrideWits
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -375,6 +375,7 @@ nodeToClientVersionToInt = \case
   NodeToClientV_12 -> 12
   NodeToClientV_13 -> 13
   NodeToClientV_14 -> 14
+  NodeToClientV_15 -> 15
 
 nodeToNodeVersionToInt :: NodeToNodeVersion -> Int
 nodeToNodeVersionToInt = \case
@@ -382,6 +383,7 @@ nodeToNodeVersionToInt = \case
   NodeToNodeV_8 -> 8
   NodeToNodeV_9 -> 9
   NodeToNodeV_10 -> 10
+  NodeToNodeV_11 -> 11
 
 -- | Pretty print 'StartupInfoTrace'
 --

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Tracing.Startup where
 
-import           Prelude
 import           Data.Text (Text)
+import           Prelude
 
 import           Cardano.Logging (LogFormatting (..))
 import           Cardano.Node.Startup
@@ -15,14 +15,12 @@ import           Cardano.Node.Tracing.Compat
 import           Cardano.Node.Tracing.Tracers.Startup
 import           Cardano.Tracing.OrphanInstances.Network ()
 
-import           Cardano.BM.Tracing (HasPrivacyAnnotation (..),
-                   HasSeverityAnnotation (..), Severity (..), ToObject (..),
-                   Transformable (..))
-import           Cardano.BM.Data.Tracer (HasTextFormatter (..),
-                   trStructuredText)
+import           Cardano.BM.Data.Tracer (HasTextFormatter (..), trStructuredText)
+import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
+                   Severity (..), ToObject (..), Transformable (..))
 
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                   (BlockNodeToClientVersion, BlockNodeToNodeVersion)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToClientVersion,
+                   BlockNodeToNodeVersion)
 
 
 instance HasSeverityAnnotation (StartupTrace blk) where
@@ -43,10 +41,7 @@ instance ( Show (BlockNodeToNodeVersion blk)
       => Transformable Text IO (StartupTrace blk) where
   trTransformer = trStructuredText
 
-instance ( Show (BlockNodeToNodeVersion blk)
-         , Show (BlockNodeToClientVersion blk)
-         )
-        => HasTextFormatter (StartupTrace blk) where
+instance HasTextFormatter (StartupTrace blk) where
   formatText a _ = ppStartupInfoTrace a
 
 instance ( Show (BlockNodeToNodeVersion blk)


### PR DESCRIPTION
We call `toLedgerPParams` multiple times with the same arguments.  This function is expensive.

The PR calls `toLedgerPParams` once then re-uses the result.  It is necessary to introduce new functions and change the signature of existing functions to do this.

Resolves https://github.com/input-output-hk/cardano-node/issues/4622