### PR TITLE
Fix qKesKesKeyExpiry to not always be null

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -27,6 +27,8 @@
 
 - Query protocol parameters from the node in the `transaction build` command ([PR 4431](https://github.com/input-output-hk/cardano-node/pull/4431))
 
+- Fix `qKesKesKeyExpiry` in `kes-period-info` ([PR 4909](https://github.com/input-output-hk/cardano-node/pull/4909))
+
 ## 1.35.3 -- August 2022
 
 - Update build and build-raw commands to accept simple reference minting scripts (#4087)


### PR DESCRIPTION
Note that `qKesKesKeyExpiry` is only an estimate that is usually correct, but it could be wrong due to a hard fork that changes KES parameters.

The fix involves uses an unsafe query interpreter that ignores forecasting horizon.  Therefore a new `Unsafe` `newtype` has been introduced to clearly show all the code that uses the unsafe query interpreter so that it doesn't accidentally get used where it shouldn't.

Resolves https://github.com/input-output-hk/cardano-node/issues/4396