### PR TITLE
Add slotsInEpoch and slotsToEpochEnd to query tip command

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -12,6 +12,8 @@
 
 - Allow assembling transactions with no witnesses ([PR 4408](https://github.com/input-output-hk/cardano-node/pull/4408))
 
+- Add `slotInEpoch` and `slotsToEpochEnd` to output of `query tip` command ([PR 4912](https://github.com/input-output-hk/cardano-node/pull/4912))
+
 ### Bugs
 
 - Allow reading signing keys from a pipe ([PR 4342](https://github.com/input-output-hk/cardano-node/pull/4342))

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -150,6 +150,8 @@ data QueryTipLocalStateOutput = QueryTipLocalStateOutput
   { localStateChainTip :: ChainTip
   , mEra :: Maybe AnyCardanoEra
   , mEpoch :: Maybe EpochNo
+  , mSlotInEpoch :: Maybe Word64
+  , mSlotsToEpochEnd :: Maybe Word64
   , mSyncProgress :: Maybe Text
   } deriving Show
 
@@ -169,6 +171,8 @@ instance ToJSON QueryTipLocalStateOutput where
       object $
         ( ("era" ..=? mEra a)
         . ("epoch" ..=? mEpoch a)
+        . ("slotInEpoch" ..=? mSlotInEpoch a)
+        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
         . ("syncProgress" ..=? mSyncProgress a)
         ) []
     ChainTip slotNo blockHeader blockNo ->
@@ -178,6 +182,8 @@ instance ToJSON QueryTipLocalStateOutput where
         . ("block" ..= blockNo)
         . ("era" ..=? mEra a)
         . ("epoch" ..=? mEpoch a)
+        . ("slotInEpoch" ..=? mSlotInEpoch a)
+        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
         . ("syncProgress" ..=? mSyncProgress a)
         ) []
   toEncoding a = case localStateChainTip a of
@@ -185,6 +191,8 @@ instance ToJSON QueryTipLocalStateOutput where
       pairs $ mconcat $
         ( ("era" ..=? mEra a)
         . ("epoch" ..=? mEpoch a)
+        . ("slotInEpoch" ..=? mSlotInEpoch a)
+        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
         . ("syncProgress" ..=? mSyncProgress a)
         ) []
     ChainTip slotNo blockHeader blockNo ->
@@ -194,6 +202,8 @@ instance ToJSON QueryTipLocalStateOutput where
         . ("block" ..= blockNo)
         . ("era" ..=? mEra a)
         . ("epoch" ..=? mEpoch a)
+        . ("slotInEpoch" ..=? mSlotInEpoch a)
+        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
         . ("syncProgress" ..=? mSyncProgress a)
         ) []
 
@@ -206,18 +216,24 @@ instance FromJSON QueryTipLocalStateOutput where
     mSlot <- o .:? "slot"
     mHash <- o .:? "hash"
     mBlock <- o .:? "block"
+    mSlotInEpoch' <- o .:? "slotInEpoch"
+    mSlotsToEpochEnd' <- o .:? "slotsToEpochEnd"
     case (mSlot, mHash, mBlock) of
       (Nothing, Nothing, Nothing) ->
         pure $ QueryTipLocalStateOutput
                  ChainTipAtGenesis
                  mEra'
                  mEpoch'
+                 mSlotInEpoch'
+                 mSlotsToEpochEnd'
                  mSyncProgress'
       (Just slot, Just hash, Just block) ->
         pure $ QueryTipLocalStateOutput
                  (ChainTip slot hash block)
                  mEra'
                  mEpoch'
+                 mSlotInEpoch'
+                 mSlotsToEpochEnd'
                  mSyncProgress'
       (_,_,_) ->
         fail $ mconcat

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -340,9 +340,11 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
               , O.mEra = Nothing
               , O.mEpoch = Nothing
               , O.mSyncProgress = Nothing
+              , O.mSlotInEpoch = Nothing
+              , O.mSlotsToEpochEnd = Nothing
               }
 
-          Right (epochNo, _, _) -> do
+          Right (epochNo, SlotsInEpoch slotsInEpoch, SlotsToEpochEnd slotsToEpochEnd) -> do
             syncProgressResult <- runExceptT $ do
               systemStart <- fmap getSystemStart (O.mSystemStart localState) & hoistMaybe ShelleyQueryCmdSystemStartUnavailable
               nowSeconds <- toRelativeTime (SystemStart systemStart) <$> liftIO getCurrentTime
@@ -359,6 +361,8 @@ runQueryTip (AnyConsensusModeParams cModeParams) network mOutFile = do
               { O.localStateChainTip = chainTip
               , O.mEra = Just (O.era localState)
               , O.mEpoch = Just epochNo
+              , O.mSlotInEpoch = Just slotsInEpoch
+              , O.mSlotsToEpochEnd = Just slotsToEpochEnd
               , O.mSyncProgress = mSyncProgress
               }
 


### PR DESCRIPTION
Example output:

```
CARDANO_NODE_SOCKET_PATH=example/node-pool1/node.sock cardano-cli query tip --testnet-magic 42
{
    "block": 768,
    "epoch": 33,
    "era": "Alonzo",
    "hash": "4ca7fd3a9827e74f98e779a8ae333dc6fa3b69832cb11fdbab7af215eb68b1ee",
    "slot": 16814,
    "slotsInEpoch": 314,
    "slotsToEpochEnd": 186,
    "syncProgress": "100.00"
}
```

Resolves https://github.com/input-output-hk/cardano-node/issues/3878
