### PR TITLE
Check CLI argument bounds

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -751,6 +751,9 @@ module Cardano.Api (
     txInsExistInUTxO,
     notScriptLockedTxIns,
     textShow,
+
+    -- ** CLI option parsing
+    bounded,
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -664,12 +664,11 @@ pNetworkId =
 
 pTestnetMagic :: Parser NetworkMagic
 pTestnetMagic =
-  NetworkMagic <$>
-    Opt.option Opt.auto
-      (  Opt.long "testnet-magic"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "Specify a testnet magic id."
-      )
+  fmap NetworkMagic $ Opt.option (bounded "TESTNET_MAGIC") $ mconcat
+    [ Opt.long "testnet-magic"
+    , Opt.metavar "NATURAL"
+    , Opt.help "Specify a testnet magic id."
+    ]
 
 parseNewSigningKeyFile :: String -> Parser NewSigningKeyFile
 parseNewSigningKeyFile opt =

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Helpers
   ( HelpersError(..)
@@ -19,12 +20,22 @@ import           Cardano.Prelude (ConvertText (..))
 import           Codec.CBOR.Pretty (prettyHexEnc)
 import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Term (decodeTerm, encodeTerm)
+import           Control.Exception (Exception (..), IOException)
+import           Control.Monad (unless, when)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LB
+import           Data.Functor (void)
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import qualified System.Console.ANSI as ANSI
 import           System.Console.ANSI
+import qualified System.Directory as IO
 import qualified System.IO as IO
 
 import           Cardano.Binary (Decoder, fromCBOR)
@@ -33,17 +44,6 @@ import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
 import           Cardano.CLI.Types
-
-import           Control.Exception (Exception (..), IOException)
-import           Control.Monad (unless, when)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.ByteString (ByteString)
-import           Data.Functor (void)
-import           Data.Text (Text)
-import qualified Data.Text.IO as Text
-import qualified System.Directory as IO
 
 data HelpersError
   = CBORPrettyPrintError !DeserialiseFailure

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1730,31 +1730,28 @@ pSigningKeyFile fdir =
 
 pKesPeriod :: Parser KESPeriod
 pKesPeriod =
-  KESPeriod <$>
-    Opt.option Opt.auto
-      (  Opt.long "kes-period"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "The start of the KES key validity period."
-      )
+  fmap KESPeriod $ Opt.option (bounded "KES_PERIOD") $ mconcat
+    [ Opt.long "kes-period"
+    , Opt.metavar "NATURAL"
+    , Opt.help "The start of the KES key validity period."
+    ]
 
 pEpochNo :: Parser EpochNo
 pEpochNo =
-  EpochNo <$>
-    Opt.option Opt.auto
-      (  Opt.long "epoch"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "The epoch number."
-      )
+  fmap EpochNo $ Opt.option (bounded "EPOCH") $ mconcat
+    [ Opt.long "epoch"
+    , Opt.metavar "NATURAL"
+    , Opt.help "The epoch number."
+    ]
 
 
 pEpochNoUpdateProp :: Parser EpochNo
 pEpochNoUpdateProp =
-  EpochNo <$>
-    Opt.option Opt.auto
-      (  Opt.long "epoch"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "The epoch number in which the update proposal is valid."
-      )
+  fmap EpochNo $ Opt.option (bounded "EPOCH") $ mconcat
+    [ Opt.long "epoch"
+    , Opt.metavar "EPOCH"
+    , Opt.help "The epoch number in which the update proposal is valid."
+    ]
 
 pGenesisFile :: String -> Parser GenesisFile
 pGenesisFile desc =
@@ -2054,12 +2051,11 @@ pNetworkId =
 
 pTestnetMagic :: Parser NetworkMagic
 pTestnetMagic =
-  NetworkMagic <$>
-    Opt.option Opt.auto
-      (  Opt.long "testnet-magic"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "Specify a testnet magic id."
-      )
+  fmap NetworkMagic $ Opt.option (bounded "TESTNET_MAGIC") $ mconcat
+    [ Opt.long "testnet-magic"
+    , Opt.metavar "TESTNET_MAGIC"
+    , Opt.help "Specify a testnet magic id."
+    ]
 
 pTxSubmitFile :: Parser FilePath
 pTxSubmitFile =
@@ -2367,12 +2363,12 @@ pPolicyId =
 
 pInvalidBefore :: Parser SlotNo
 pInvalidBefore = fmap SlotNo $ asum
-  [ Opt.option Opt.auto $ mconcat
+  [ Opt.option (bounded "SLOT") $ mconcat
     [ Opt.long "invalid-before"
     , Opt.metavar "SLOT"
     , Opt.help "Time that transaction is valid from (in slots)."
     ]
-  , Opt.option Opt.auto $ mconcat
+  , Opt.option (bounded "SLOT") $ mconcat
     [ Opt.long "lower-bound"
     , Opt.metavar "SLOT"
     , Opt.help $ mconcat
@@ -2386,12 +2382,12 @@ pInvalidBefore = fmap SlotNo $ asum
 pInvalidHereafter :: Parser SlotNo
 pInvalidHereafter =
   fmap SlotNo $ asum
-  [ Opt.option Opt.auto $ mconcat
+  [ Opt.option (bounded "SLOT") $ mconcat
     [ Opt.long "invalid-hereafter"
     , Opt.metavar "SLOT"
     , Opt.help "Time that transaction is valid until (in slots)."
     ]
-  , Opt.option Opt.auto $ mconcat
+  , Opt.option (bounded "SLOT") $ mconcat
     [ Opt.long "upper-bound"
     , Opt.metavar "SLOT"
     , Opt.help $ mconcat
@@ -2400,7 +2396,7 @@ pInvalidHereafter =
       ]
     , Opt.internal
     ]
-  , Opt.option Opt.auto $ mconcat
+  , Opt.option (bounded "SLOT") $ mconcat
     [ Opt.long "ttl"
     , Opt.metavar "SLOT"
     , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
@@ -3051,12 +3047,11 @@ pPoolDeposit =
 
 pEpochBoundRetirement :: Parser EpochNo
 pEpochBoundRetirement =
-    EpochNo <$>
-    Opt.option Opt.auto
-      (  Opt.long "pool-retirement-epoch-boundary"
-      <> Opt.metavar "INT"
-      <> Opt.help "Epoch bound on pool retirement."
-      )
+  fmap EpochNo $ Opt.option (bounded "EPOCH_BOUNDARY") $ mconcat
+    [ Opt.long "pool-retirement-epoch-boundary"
+    , Opt.metavar "EPOCH_BOUNDARY"
+    , Opt.help "Epoch bound on pool retirement."
+    ]
 
 pNumberOfPools :: Parser Natural
 pNumberOfPools =
@@ -3248,14 +3243,13 @@ defaultByronEpochSlots = 21600
 
 pEpochSlots :: Parser EpochSlots
 pEpochSlots =
-  EpochSlots <$>
-    Opt.option Opt.auto
-      (  Opt.long "epoch-slots"
-      <> Opt.metavar "NATURAL"
-      <> Opt.help "The number of slots per epoch for the Byron era."
-      <> Opt.value defaultByronEpochSlots -- Default to the mainnet value.
-      <> Opt.showDefault
-      )
+  fmap EpochSlots $ Opt.option (bounded "SLOTS") $ mconcat
+    [ Opt.long "epoch-slots"
+    , Opt.metavar "SLOTS"
+    , Opt.help "The number of slots per epoch for the Byron era."
+    , Opt.value defaultByronEpochSlots -- Default to the mainnet value.
+    , Opt.showDefault
+    ]
 
 pProtocolVersion :: Parser (Natural, Natural)
 pProtocolVersion =

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -10,9 +10,11 @@ module Cardano.TxSubmit.CLI.Parsers
   ) where
 
 import           Cardano.Api (AnyConsensusModeParams (..), ConsensusModeParams (..),
-                   EpochSlots (..), NetworkId (..), NetworkMagic (..), SocketPath (..))
+                   EpochSlots (..), NetworkId (..), NetworkMagic (..), SocketPath (..), bounded)
+
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), TxSubmitNodeParams (..))
 import           Cardano.TxSubmit.Rest.Parsers (pWebserverConfig)
+
 import           Control.Applicative (Alternative (..), (<**>))
 import           Data.Word (Word64)
 import           Options.Applicative (Parser, ParserInfo)
@@ -56,11 +58,12 @@ pNetworkId = pMainnet <|> fmap Testnet pTestnetMagic
       )
 
     pTestnetMagic :: Parser NetworkMagic
-    pTestnetMagic = NetworkMagic <$> Opt.option Opt.auto
-      (   Opt.long "testnet-magic"
-      <>  Opt.metavar "NATURAL"
-      <>  Opt.help "Specify a testnet magic id."
-      )
+    pTestnetMagic =
+      fmap NetworkMagic $ Opt.option (bounded "TESTNET_MAGIC") $ mconcat
+        [ Opt.long "testnet-magic"
+        , Opt.metavar "TESTNET_MAGIC"
+        , Opt.help "Specify a testnet magic id."
+        ]
 
 
 -- TODO: This was ripped from `cardano-cli` because, unfortunately, it's not


### PR DESCRIPTION
The bounds of many CLI arguments are now checked.

```
$ cardano-cli transaction build \
  --alonzo-era \
  --testnet-magic 42 \
  --change-address 'addr_test1vztpl4gth92fpxh3zth7w6v7mm7wewt89edae2hq3rptu5qa7ahzt' \
  --tx-in 'dee44d80c8b9da8cf20d1fae78a79a03b70b8abf76bfda88fe3651efcb0ab0cd#0' \
  --tx-out 'addr_test1vztpl4gth92fpxh3zth7w6v7mm7wewt89edae2hq3rptu5qa7ahzt+1000000' \
  --out-file tx.body --invalid-before -1

option --invalid-before: SLOT must not be less than 0
...
```

Resolves https://github.com/input-output-hk/cardano-node/issues/4863