### PR TITLE
hydra: only build pr jobset to avoid duplicates builds

### DIFF
--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -48,11 +48,11 @@ rec {
 
         command.text = config.preset.github.status.lib.reportBulk {
           bulk.text = ''
-            nix eval .#outputs.hydraJobs --apply __attrNames --json |
+            nix eval .#legacyPackages --apply __attrNames --json |
             nix-systems -i |
             jq 'with_entries(select(.value))' # filter out systems that we cannot build for
           '';
-          each.text = ''nix build -L .#hydraJobs."$1".${jobsAttrs}'';
+          each.text = ''nix build -L .#legacyPackages."$1".hydraJobs.${jobsAttrs}'';
           skippedDescription = lib.escapeShellArg "No nix builder available for this system";
         };
 


### PR DESCRIPTION
 of dockerImages, etc.

currently hydra build both `hydraJobs.required` and `hydraJobs.pr.required` which is unnecessary and slowdown ci. 