### PR TITLE
Only build for Mac and Windows on ghc-9.2.5

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.5"]
+        ghc: ["9.2.5"]
         cabal: ["3.8.1.0"]
         os: [macos-latest, windows-latest]
 


### PR DESCRIPTION
This is to reduce the amount of time spent on MacOS and Windows CI.  MacOS CI in particular has a lot of contention.