### PR TITLE
Create and merge_group triggers in Github Actions

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -2,7 +2,7 @@ name: Check cabal files
 
 on:
   push:
-  create:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -2,6 +2,7 @@ name: Check git dependencies
 
 on:
   push:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -2,6 +2,7 @@ name: Check HLint
 
 on:
   push:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -2,6 +2,7 @@ name: Check mainnet configuration
 
 on:
   push:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -2,6 +2,7 @@ name: Check nix configuration
 
 on:
   push:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -2,7 +2,7 @@ name: Haskell Linux CI
 
 on:
   push:
-  create:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,7 +2,7 @@ name: Haskell Windows & Mac CI
 
 on:
   push:
-  create:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -1,6 +1,8 @@
 name: Check Markdown links
 
-on: push
+on:
+  push:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -2,7 +2,7 @@ name: Check Stylish Haskell
 
 on:
   push:
-  create:
+  merge_group:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:


### PR DESCRIPTION
This will cause merge groups to trigger Github Actions workflows.  See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions