### PR TITLE
Add event.type to concurrency group

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -6,7 +6,7 @@ on:
 
 # Limit concurrent runs of this workflow within a single PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -169,7 +169,7 @@ test-suite test-locli
   build-depends:        cardano-prelude
                       , containers
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , locli
                       , text
 

--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,10 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
-index-state: 2023-01-20T05:50:56Z
+index-state: 2023-03-05T20:17:11Z
 
 index-state:
-  , hackage.haskell.org 2023-01-20T05:50:56Z
+  , hackage.haskell.org 2023-03-05T20:17:11Z
   , cardano-haskell-packages 2022-12-14T00:40:15Z
 
 packages:
@@ -171,7 +171,6 @@ allow-newer:
   , tree-diff:hashable
   , Unique:hashable
   , ouroboros-network:hashable
-  , hedgehog-extras:base
   , libsystemd-journal:base
   -- This is required for 9.2.
   , katip:Win32
@@ -179,13 +178,6 @@ allow-newer:
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-
--- And has the adjustments for the ledger refactor
-source-repository-package
-   type: git
-   location: https://github.com/input-output-hk/hedgehog-extras
-   tag: 9ea1845ca2036e7a1ae9fcebe393526540c5c233
-   --sha256: 1436dwmz9v6ky9kzgnr4flzlzjxwh2zjkds9fnayc1ddang6wwb6
 
 -- And has the adjustments for the ledger refactor
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,10 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
-index-state: 2023-03-05T20:17:11Z
+index-state: 2023-03-06T05:24:58Z
 
 index-state:
-  , hackage.haskell.org 2023-03-05T20:17:11Z
+  , hackage.haskell.org 2023-03-06T05:24:58Z
   , cardano-haskell-packages 2022-12-14T00:40:15Z
 
 packages:

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -221,7 +221,7 @@ test-suite cardano-api-test
                       , cardano-slotting ^>= 0.1
                       , containers
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , mtl
                       , ouroboros-consensus
                       , ouroboros-consensus-shelley

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -186,7 +186,7 @@ test-suite cardano-cli-test
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , parsec
                       , text
                       , time
@@ -233,7 +233,7 @@ test-suite cardano-cli-golden
                       , exceptions
                       , filepath
                       , hedgehog ^>= 1.2
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , text
                       , time
                       , transformers

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -69,7 +69,7 @@ test-suite chairman-tests
                       , directory
                       , filepath
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , network
                       , process
                       , random

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -20,7 +20,7 @@ import qualified Cardano.Testnet as H
 {- HLINT ignore "Redundant flip" -}
 
 hprop_chairman :: H.Property
-hprop_chairman = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
+hprop_chairman = H.integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -11,6 +11,7 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
+import qualified Testnet.Util.Base as H
 
 import qualified Cardano.Testnet as H
 
@@ -19,7 +20,7 @@ import qualified Cardano.Testnet as H
 {- HLINT ignore "Redundant flip" -}
 
 hprop_chairman :: H.Property
-hprop_chairman = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
+hprop_chairman = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing

--- a/cardano-node-chairman/testnet/Testnet/Run.hs
+++ b/cardano-node-chairman/testnet/Testnet/Run.hs
@@ -24,7 +24,7 @@ import qualified Test.Base as H
 import qualified Testnet.Conf as H
 
 testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
+testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "testnet-chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic

--- a/cardano-node-chairman/testnet/Testnet/Run.hs
+++ b/cardano-node-chairman/testnet/Testnet/Run.hs
@@ -24,7 +24,7 @@ import qualified Test.Base as H
 import qualified Testnet.Conf as H
 
 testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty maybeTestnetMagic tn = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
+testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -45,7 +45,7 @@ library
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , optparse-applicative-fork
                       , ouroboros-network
                       , process
@@ -130,7 +130,7 @@ test-suite cardano-testnet-tests
                       , directory
                       , filepath
                       , hedgehog
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.4
                       , process
                       , tasty
                       , text

--- a/cardano-testnet/src/Testnet/Run.hs
+++ b/cardano-testnet/src/Testnet/Run.hs
@@ -21,7 +21,7 @@ import qualified Testnet.Conf as H
 import qualified Testnet.Util.Base as H
 
 testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty maybeTestnetMagic tn = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
+testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic

--- a/cardano-testnet/src/Testnet/Run.hs
+++ b/cardano-testnet/src/Testnet/Run.hs
@@ -21,7 +21,7 @@ import qualified Testnet.Conf as H
 import qualified Testnet.Util.Base as H
 
 testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
+testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "testnet" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -440,7 +440,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
     }
 
 hprop_testnet :: H.Property
-hprop_testnet = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
+hprop_testnet = H.integrationRetryWorkspace 2 "shelley-testnet" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -440,7 +440,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
     }
 
 hprop_testnet :: H.Property
-hprop_testnet = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
+hprop_testnet = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing

--- a/cardano-testnet/src/Testnet/Util/Base.hs
+++ b/cardano-testnet/src/Testnet/Util/Base.hs
@@ -1,5 +1,6 @@
 module Testnet.Util.Base
   ( integration
+  , integrationRetryWorkspace
   , isLinux
   ) where
 
@@ -12,6 +13,10 @@ import qualified Hedgehog.Extras.Test.Base as H
 
 integration :: HasCallStack => H.Integration () -> H.Property
 integration = H.withTests 1 . H.propertyOnce
+
+integrationRetryWorkspace :: Int -> FilePath -> (FilePath -> H.Integration ()) -> H.Property
+integrationRetryWorkspace n workspaceName f = integration $ H.retry n $ \i ->
+  H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
 
 isLinux :: Bool
 isLinux = os == "linux"

--- a/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -52,7 +52,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = integration . H.runFinallies . H.workspace "alonzo" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -52,7 +52,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo-leadership-schedule" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -45,7 +45,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-schedule" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -37,6 +37,7 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Info as SYS
+import qualified Testnet.Util.Base as H
 
 import           Cardano.Testnet
 import           Testnet.Util.Assert
@@ -44,7 +45,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = integration . H.runFinallies . H.workspace "alonzo" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -45,7 +45,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_stakeSnapshot :: Property
-hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
+hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -40,11 +40,12 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
+import qualified Testnet.Util.Base as H
 import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_stakeSnapshot :: Property
-hprop_stakeSnapshot = integration . H.runFinallies . H.workspace "alonzo" $ \tempAbsBasePath' -> do
+hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "alonzo" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
@@ -41,7 +41,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_kes_period_info :: Property
-hprop_kes_period_info = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
+hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.evalIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate

--- a/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/Test/Cli/KesPeriodInfo.hs
@@ -33,6 +33,7 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified System.Directory as IO
 import qualified System.Info as SYS
+import qualified Testnet.Util.Base as H
 
 import           Cardano.Testnet
 import           Test.Misc
@@ -40,7 +41,7 @@ import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
 hprop_kes_period_info :: Property
-hprop_kes_period_info = integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+hprop_kes_period_info = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.evalIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -20,7 +20,7 @@ import qualified Hedgehog.Extras.Test.Base as H
 
 import qualified Cardano.Api as C
 import           Cardano.Testnet as TN
-import qualified Testnet.Util.Base as U
+import qualified Testnet.Util.Base as H
 import           Testnet.Util.Runtime
 
 
@@ -34,7 +34,7 @@ instance Show FoldBlocksException where
 -- events and block, and on reception writes this to the `lock` `MVar`
 -- that main thread blocks on.
 prop_foldBlocks :: H.Property
-prop_foldBlocks = U.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+prop_foldBlocks = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
 
   -- Start testnet
   base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -34,7 +34,7 @@ instance Show FoldBlocksException where
 -- events and block, and on reception writes this to the `lock` `MVar`
 -- that main thread blocks on.
 prop_foldBlocks :: H.Property
-prop_foldBlocks = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
+prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath' -> do
 
   -- Start testnet
   base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase

--- a/cardano-testnet/test/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/Test/Node/Shutdown.hs
@@ -8,12 +8,12 @@ module Test.Node.Shutdown
   ( hprop_shutdown
   ) where
 
-import           Prelude
 import           Control.Monad
 import           Data.Functor ((<&>))
 import qualified Data.List as L
 import           Data.Maybe
 import           Hedgehog (Property, (===))
+import           Prelude
 import           System.FilePath ((</>))
 
 import qualified Hedgehog as H
@@ -27,6 +27,7 @@ import qualified System.Directory as IO
 import qualified System.Exit as IO
 import qualified System.IO as IO
 import qualified System.Process as IO
+import qualified Testnet.Util.Base as H
 
 import           Cardano.Testnet
 import           Testnet.Util.Process (procNode)
@@ -34,7 +35,7 @@ import           Testnet.Util.Process (procNode)
 {- HLINT ignore "Redundant <&>" -}
 
 hprop_shutdown :: Property
-hprop_shutdown = integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+hprop_shutdown = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   Conf { tempBaseAbsPath, tempAbsPath, logDir, socketDir } <- H.noteShowM $

--- a/cardano-testnet/test/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/Test/Node/Shutdown.hs
@@ -35,7 +35,7 @@ import           Testnet.Util.Process (procNode)
 {- HLINT ignore "Redundant <&>" -}
 
 hprop_shutdown :: Property
-hprop_shutdown = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
+hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   Conf { tempBaseAbsPath, tempAbsPath, logDir, socketDir } <- H.noteShowM $

--- a/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
@@ -22,12 +22,13 @@ import           Hedgehog (Property, assert, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
+import qualified Testnet.Util.Base as H
 
 import           Cardano.Testnet
 import           Testnet.Util.Runtime (TestnetRuntime (..))
 
 hprop_shutdownOnSlotSynced :: Property
-hprop_shutdownOnSlotSynced = integration . H.runFinallies . H.workspace "chairman" $ \tempAbsBasePath' -> do
+hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
   -- Start a local test net
   baseDir <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configTemplate <- H.noteShow $ baseDir </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
@@ -28,7 +28,7 @@ import           Cardano.Testnet
 import           Testnet.Util.Runtime (TestnetRuntime (..))
 
 hprop_shutdownOnSlotSynced :: Property
-hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsBasePath' -> do
+hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "shutdown-on-slot-synced" $ \tempAbsBasePath' -> do
   -- Start a local test net
   baseDir <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configTemplate <- H.noteShow $ baseDir </> "configuration/defaults/byron-mainnet/configuration.yaml"

--- a/doc/getting-started/launching-a-testnet.md
+++ b/doc/getting-started/launching-a-testnet.md
@@ -45,7 +45,7 @@ $ cabal run cardano-testnet shelley
 ...
        ┏━━ testnet/Testnet/Run.hs ━━━
     25 ┃ testnetProperty :: (H.Conf -> H.Integration ()) -> H.Property
-    26 ┃ testnetProperty tn = H.integration . H.runFinallies . H.workspace "chairman" $ \tempAbsPath' -> do
+    26 ┃ testnetProperty tn = H.integrationRetryWorkspace 2 "chairman" $ \tempAbsPath' -> do
        ┃ │ Workspace: /private/var/folders/zh/ln41q4zs52x2fd61rxccmq640000gn/T/chairman/test-acaaa345c8802769
     27 ┃   conf@H.Conf {..} <- H.mkConf tempAbsPath' 42
     28 ┃

--- a/flake.lock
+++ b/flake.lock
@@ -1033,11 +1033,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1677976124,
-        "narHash": "sha256-tkvipSaI9asnkgrMT0xQfArOQBIR0T4N1B6dBPKy/OM=",
+        "lastModified": 1678148876,
+        "narHash": "sha256-zsNwGpH1E+Km92ScOOL7mDC1a+6Yia9tFqtxX/VjGec=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7a4c7ed70e382aaa8fd65cc2af57bdf920320ddc",
+        "rev": "2515e96b2e742bd96f0f825b52f42583cce2e4bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is necessary because our workflows can be triggered by more than one event type: `push` and `merge_group`.

When a PR is queued to early after a push, the `merge_group` job would cancel the `push` job or vice-versa causing unnecessary build failures.