### PR TITLE
Update getting started to include MacOS

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -38,7 +38,7 @@ sudo yum install git gcc gcc-c++ tmux gmp-devel make tar xz wget zlib-devel libt
 sudo install systemd-devel ncurses-devel ncurses-compat-libs which jq openssl-devel lmdb-devel -y
 ```
 
-For Debian/Ubuntu, use the following instead:
+For Debian/Ubuntu:
 
 ```bash
 sudo apt-get update -y
@@ -47,7 +47,26 @@ sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev l
 
 Optional dependencies that may be required: llvm libnuma-dev
 
-If you are using a different flavor of Linux, you will need to use the correct package manager for your platform instead of `yum` or `apt-get`, and the names of the packages you need to install might differ.  On MacOSX, use the Homebrew (`brew`) installer.
+If you are using a different flavor of Linux, you will need to use the correct package manager for your platform instead of `yum` or `apt-get`, and the names of the packages you need to install might differ. 
+
+For MacOS:
+
+You'll need the following packages and tools on your MacOS system:
+
+* [Xcode](https://developer.apple.com/xcode) - The Apple Development IDE and SDK/Tools
+* [Xcode Command Line Tools](https://developer.apple.com/xcode/features/), you can install it by typing `xcode-select --install` in the terminal.
+* [Homebrew](https://brew.sh) - The Missing Package Manager for MacOS (or Linux)
+
+Then using homebrew install the following:
+
+```bash
+brew install jq libtool autoconf automake pkg-config openssl
+```
+#### You will need to install llvm in case you are using M1
+
+```
+brew install llvm@13
+```
 
 #### Installing the Haskell environment
 

--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -220,6 +220,37 @@ We explicitly use the GHC version that we installed earlier.  This avoids defaul
 echo "with-compiler: ghc-8.10.7" >> cabal.project.local
 ```
 
+You will need to run following commands on M1, those commands will set some cabal related options before building
+```bash
+echo "package trace-dispatcher" >> cabal.project.local
+echo "  ghc-options: -Wwarn" >> cabal.project.local
+echo "" >> cabal.project.local
+
+echo "package HsOpenSSL" >> cabal.project.local
+echo "  flags: -homebrew-openssl" >> cabal.project.local
+echo "" >> cabal.project.local
+```
+
+More recent versions of MacOS seems to install openssl in a different location than expected by default. If you have installed openssl via homebrew and encounter the following build error:
+
+```bash
+Failed to build HsOpenSSL-0.11.7.2. The failure occurred during the configure
+step.
+[1 of 1] Compiling Main (...)
+Linking .../dist-newstyle/tmp/src-75805/HsOpenSSL-0.11.7.2/dist/setup/setup ...
+Configuring HsOpenSSL-0.11.7.2...
+setup: Can’t find OpenSSL library
+```
+
+You'll most likely need to add relevant symlinks as follows:
+```
+sudo mkdir -p /usr/local/opt/openssl
+sudo ln -s /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl/lib
+sudo ln -s /opt/homebrew/opt/openssl@3/include /usr/local/opt/openssl/include
+```
+
+This is a wart of the `HsOpenSSL` library wrapper, and using classic methods such as setting `LDFLAGS` & `CPPFLAGS`, or using `--extra-include-dirs` and `--extra-lib-dirs` won't work properly.
+
 #### Building and installing the node
 
 Build the node and CLI with `cabal`:


### PR DESCRIPTION
Adding more information in the "getting started" documentation to reflect what is present on https://developers.cardano.org/docs/get-started/installing-cardano-node/#macos