### PR TITLE
Backward compatibility for Prometheus metrics names

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -606,7 +606,7 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
             , " of blocks that could be created over the span of the last @k@ blocks."
             ]
           )
-        , ( "ChainDB.Slots"
+        , ( "ChainDB.SlotNum"
           , "Number of slots in this chain fragment."
           )
         , ( "ChainDB.Blocks"
@@ -629,7 +629,7 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
             , " of blocks that could be created over the span of the last @k@ blocks."
             ]
           )
-        , ( "ChainDB.Slots"
+        , ( "ChainDB.SlotNum"
           , "Number of slots in this chain fragment."
           )
         , ( "ChainDB.Blocks"

--- a/cardano-tracer/bench/cardano-tracer-bench.hs
+++ b/cardano-tracer/bench/cardano-tracer-bench.hs
@@ -119,6 +119,7 @@ main = do
     , logging        = NE.fromList [LoggingParams root FileMode format]
     , rotation       = Nothing
     , verbosity      = Nothing
+    , metricsComp    = Nothing
     }
 
   generate num = replicate num . mkTraceObject <$> getCurrentTime

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -24,7 +24,9 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.List.Extra (notNull)
 import           Data.Maybe (catMaybes)
+import           Data.Map.Strict (Map)
 import           Data.Word (Word16, Word32, Word64)
+import           Data.Text (Text)
 import           Data.Yaml (decodeFileEither)
 import           GHC.Generics (Generic)
 import           System.Exit (die)
@@ -91,6 +93,7 @@ data TracerConfig = TracerConfig
   , logging        :: !(NonEmpty LoggingParams)     -- ^ Logging parameters.
   , rotation       :: !(Maybe RotationParams)       -- ^ Rotation parameters.
   , verbosity      :: !(Maybe Verbosity)            -- ^ Verbosity of the tracer itself.
+  , metricsComp    :: !(Maybe (Map Text Text))      -- ^ Metrics compability map from metrics name to metrics name
   } deriving (Eq, Generic, FromJSON, ToJSON, Show)
 
 -- | Read the tracer's configuration file.

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -93,7 +93,7 @@ data TracerConfig = TracerConfig
   , logging        :: !(NonEmpty LoggingParams)     -- ^ Logging parameters.
   , rotation       :: !(Maybe RotationParams)       -- ^ Rotation parameters.
   , verbosity      :: !(Maybe Verbosity)            -- ^ Verbosity of the tracer itself.
-  , metricsComp    :: !(Maybe (Map Text Text))      -- ^ Metrics compability map from metrics name to metrics name
+  , metricsComp    :: !(Maybe (Map Text Text))      -- ^ Metrics compatibility map from metrics name to metrics name
   } deriving (Eq, Generic, FromJSON, ToJSON, Show)
 
 -- | Read the tracer's configuration file.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
@@ -126,7 +126,7 @@ getMetricsFromNode tracerEnv nodeId acceptedMetrics =
  where
   getListOfMetrics :: Sample -> MetricsList
   getListOfMetrics =
-      metricsCompability
+      metricsCompatibility
       . filter (not . T.null . fst)
       . map metricsWeNeed
       . HM.toList
@@ -149,8 +149,8 @@ getMetricsFromNode tracerEnv nodeId acceptedMetrics =
     . T.replace "-" "_"
     . T.replace "." "_"
 
-  metricsCompability :: MetricsList -> MetricsList
-  metricsCompability metricsList =
+  metricsCompatibility :: MetricsList -> MetricsList
+  metricsCompatibility metricsList =
       case metricsComp (teConfig tracerEnv) of
         Nothing -> metricsList
         Just mmap -> foldl  (\ accu p'@(mn,mv) -> case M.lookup mn mmap of

--- a/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
@@ -90,6 +90,7 @@ launchAcceptorsSimple mode localSock dpName = do
     , logging        = NE.fromList [LoggingParams "/tmp/demo-acceptor" FileMode ForHuman]
     , rotation       = Nothing
     , verbosity      = Just Minimum
+    , metricsComp    = Nothing
     }
 
 -- | To be able to ask any 'DataPoint' by the name without knowing the actual type,

--- a/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
@@ -90,4 +90,5 @@ propDataPoint ts@TestSetup{..} rootDir localSock = do
     , logging        = NE.fromList [LoggingParams rootDir FileMode ForHuman]
     , rotation       = Nothing
     , verbosity      = Just Minimum
+    , metricsComp    = Nothing
     }

--- a/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
@@ -80,6 +80,7 @@ propLogs ts@TestSetup{..} format rootDir localSock = do
                          , rpKeepFilesNum  = 10
                          }
     , verbosity      = Just Minimum
+    , metricsComp    = Nothing
     }
 
 propMultiInit :: TestSetup Identity -> LogFormat -> FilePath -> FilePath -> FilePath -> IO Property
@@ -107,6 +108,7 @@ propMultiInit ts@TestSetup{..} format rootDir localSock1 localSock2 = do
     , logging        = NE.fromList [LoggingParams root FileMode format]
     , rotation       = Nothing
     , verbosity      = Just Minimum
+    , metricsComp    = Nothing
     }
 
 propMultiResp :: TestSetup Identity -> LogFormat -> FilePath -> FilePath -> IO Property
@@ -134,6 +136,7 @@ propMultiResp ts@TestSetup{..} format rootDir localSock = do
     , logging        = NE.fromList [LoggingParams root FileMode format]
     , rotation       = Nothing
     , verbosity      = Just Minimum
+    , metricsComp    = Nothing
     }
 
 checkMultiResults :: FilePath -> IO Property

--- a/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
@@ -98,4 +98,5 @@ mkConfig TestSetup{..} rootDir p = TracerConfig
   , logging        = NE.fromList [LoggingParams rootDir FileMode ForMachine]
   , rotation       = Nothing
   , verbosity      = Just Minimum
+  , metricsComp    = Nothing
   }

--- a/nix/nixos/cardano-tracer-service.nix
+++ b/nix/nixos/cardano-tracer-service.nix
@@ -41,6 +41,11 @@ let serviceConfigToJSON =
           epHost    = "127.0.0.1";
           epPort    = 3200; ## supervisord.portShiftPrometheus
         } // (cfg.prometheus or {});
+        ## TODO YUP: replace with real mappings
+        metricsComp = {
+            "Mempool.TxsInMempool" = "Mempool.TxsInMempool.Mapped";
+            "ChainDB.SlotNum" = "ChainDB.SlotNum.Mapped";
+        };
       };
 in pkgs.commonLib.defServiceModule
   (lib: with lib;

--- a/nix/nixos/cardano-tracer-service.nix
+++ b/nix/nixos/cardano-tracer-service.nix
@@ -41,11 +41,14 @@ let serviceConfigToJSON =
           epHost    = "127.0.0.1";
           epPort    = 3200; ## supervisord.portShiftPrometheus
         } // (cfg.prometheus or {});
-        ## TODO YUP: replace with real mappings
-        metricsComp = {
-            "Mempool.TxsInMempool" = "Mempool.TxsInMempool.Mapped";
-            "ChainDB.SlotNum" = "ChainDB.SlotNum.Mapped";
-        };
+        # Just an example for metrics compatibility mapping.
+        # An entry means the first entry has the second entry as alias.
+        # The Metrics is then avalable, both with the original and the mapped name.
+        # Only one mapping per message is supported.
+        # metricsComp = {
+        #     "Mempool.TxsInMempool" = "Mempool.TxsInMempool.Mapped";
+        #     "ChainDB.SlotNum" = "ChainDB.SlotNum.Mapped";
+        # };
       };
 in pkgs.commonLib.defServiceModule
   (lib: with lib;


### PR DESCRIPTION
With configuration entries
metricsComp = {
            "a" = "b";
            ...
        };
metrics with name a as well appear with name b in Prometheus. The names in the configuration has to be specified as in the original message, and not as in the Prometheus export (Where e.g. a '.' becomes an '_'). 