### PR TITLE
Fix merge group cancelling issue

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -4,9 +4,18 @@ on:
   push:
   merge_group:
 
-# Limit concurrent runs of this workflow within a single PR
+# When pushing branches (and/or updating PRs), we do want to cancel previous
+# build runs. We assume they are stale now; and do not want to spend CI time and
+# resources on continuing to continue those runs. This is what the concurrency.group
+# value lets us express. When using merge queues, we now have to consider
+# - runs triggers by commits per pull-request
+#   we want to cancel any previous run. So they should all get the same group (per PR)
+# - runs refs/heads/gh-readonly-queue/<target branch name> (they should all get their
+#   unique git ref, we don't want to cancel any of the ones in the queue)
+# - if it's neither, we fall back to the run_id (this is a unique number for each
+#   workflow run; it does not change if you "rerun" a job)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.type }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.type }}-${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.ref || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When more than one PR gets added the the merge queue, the earlier ones might cancel due to our concurrency policy.  This is to prevent that.

See https://github.com/orgs/community/discussions/46757?sort=top#discussioncomment-4980818