### PR TITLE
Replace ReaderT with StateT in LocalStateQueryExpr

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -139,7 +139,6 @@ library
                       , iproute
                       , memory
                       , microlens
-                      , mtl
                       , network
                       , nothunks
                       , optparse-applicative-fork

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -715,9 +715,13 @@ module Cardano.Api (
 
     -- ** Monadic queries
     LocalStateQueryExpr,
+    LocalStateQueryFailure,
     executeLocalStateQueryExpr,
     queryExpr,
+    queryExprE,
     determineEraExpr,
+    determineEraInMode,
+    determineShelleyBasedEra,
 
     chainPointToSlotNo,
     chainPointToHeaderHash,

--- a/cardano-api/src/Cardano/Api/Environment.hs
+++ b/cardano-api/src/Cardano/Api/Environment.hs
@@ -13,19 +13,17 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           System.Environment (lookupEnv)
 
-import           Cardano.Api.Utils (textShow)
-
 newtype SocketPath
   = SocketPath { unSocketPath :: FilePath }
   deriving (FromJSON, Show, Eq, Ord)
 
-newtype EnvSocketError = CliEnvVarLookup Text deriving Show
+newtype EnvSocketError = CliEnvVarDoesNotExist Text deriving Show
 
 renderEnvSocketError :: EnvSocketError -> Text
 renderEnvSocketError err =
   case err of
-    CliEnvVarLookup txt ->
-      "Error while looking up environment variable: CARDANO_NODE_SOCKET_PATH " <> " Error: " <> textShow txt
+    CliEnvVarDoesNotExist txt ->
+      "Tried looking up environment variable: " <> txt <> " does not exist"
 
 -- | Read the node socket path from the environment.
 -- Fails if the environment variable is not set.
@@ -36,7 +34,7 @@ readEnvSocketPath = do
       Just sPath ->
         return . Right $ SocketPath sPath
       Nothing ->
-        return . Left $ CliEnvVarLookup (Text.pack envName)
+        return . Left $ CliEnvVarDoesNotExist (Text.pack envName)
   where
     envName :: String
     envName = "CARDANO_NODE_SOCKET_PATH"

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -1,31 +1,39 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.Api.IPC.Monad
   ( LocalStateQueryExpr
+  , LocalStateQueryFailure
+  , determineEraExpr
+  , determineEraInMode
+  , determineShelleyBasedEra
   , executeLocalStateQueryExpr
   , queryExpr
-  , determineEraExpr
+  , queryExprE
   ) where
 
 import           Control.Concurrent.STM
+import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.Reader
 import           Control.Monad.Trans.Cont
-import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
-import           Data.Bifunctor (first)
+import           Control.Monad.Trans.State.Strict
+import qualified Data.Text as Text
 
 import           Cardano.Ledger.Shelley.Scripts ()
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import qualified Ouroboros.Network.Mux as Mux
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Net.Query
 
 import           Cardano.Api.Block
 import           Cardano.Api.Eras
+import           Cardano.Api.Error
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Version
 import           Cardano.Api.Modes
+import           Cardano.Api.Utils
 
 
 {- HLINT ignore "Use const" -}
@@ -43,31 +51,68 @@ import           Cardano.Api.Modes
 -- In order to make pipelining still possible we can explore the use of Selective Functors
 -- which would allow us to straddle both worlds.
 newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
-  { runLocalStateQueryExpr :: ReaderT NodeToClientVersion (ContT (Net.Query.ClientStAcquired block point query m r) m) a
-  } deriving (Functor, Applicative, Monad, MonadReader NodeToClientVersion, MonadIO)
+  { runLocalStateQueryExpr :: StateT QueryState (ContT (Net.Query.ClientStAcquired block point query m r) m) a
+  } deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
+
+-- | 'QueryState' tracks the following:
+--   - If a query has resulted in an 'EraMismatch'
+--   - The node to client version of the node
+--   - the node to client versions of both the node and the query in question
+-- When constructing a 'LocalStateQueryExpr' we can now query the 'State'
+-- before we populate the TMVar with the query result. This helps make the 'LocalStateQueryExpr'
+-- monad be more composable as all the errors can now be handled in one place, 'setupLocalStateQueryExpr'.
+
+data QueryState
+  = NodeVersion NodeToClientVersion
+  | NodeAndQueryVersions
+      NodeToClientVersion -- ^ Node version
+      NodeToClientVersion -- ^ Query version
+  | QSMismatch EraMismatch
+  deriving Show
+
 
 -- | Execute a local state query expression.
 executeLocalStateQueryExpr
   :: LocalNodeConnectInfo mode
   -> Maybe ChainPoint
   -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
-  -> IO (Either AcquiringFailure a)
+  -> IO (Either LocalStateQueryFailure a)
 executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
   let waitResult = readTMVar tmvResultLocalState
 
-  connectToLocalNodeWithVersion
-    connectInfo
-    (\ntcVersion ->
-      LocalNodeClientProtocols
-      { localChainSyncClient    = NoLocalChainSyncClient
-      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint tmvResultLocalState ntcVersion f
-      , localTxSubmissionClient = Nothing
-      , localTxMonitoringClient = Nothing
-      }
-    )
+  r <- try $ connectToLocalNodeWithVersion
+         connectInfo
+         (\nodeVer ->
+           LocalNodeClientProtocols
+           { localChainSyncClient    = NoLocalChainSyncClient
+           , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint tmvResultLocalState nodeVer f
+           , localTxSubmissionClient = Nothing
+           , localTxMonitoringClient = Nothing
+           }
+         )
+  case r of
+    Left ex -> return . Left $ LocalStateQueryMuxError ex
+    Right () -> atomically waitResult
 
-  first toAcquiringFailure <$> atomically waitResult
+data LocalStateQueryFailure
+  = LocalStateQueryAcqFail !AcquiringFailure
+  | LocalStateQueryNtcErrror !UnsupportedNtcVersionError
+  | LocalStateQueryMismatch !EraMismatch
+  | LocalStateQueryMuxError !Mux.MuxError -- The MuxError is an exception that we catch
+  deriving Show
+
+instance Error LocalStateQueryFailure where
+  displayError (LocalStateQueryAcqFail acqFail) = show acqFail
+  displayError (LocalStateQueryNtcErrror (UnsupportedNtcVersionError queryVersion ntcVersion)) =
+    "Unsupported feature for the node-to-client protocol version.\n" <>
+    "This query requires at least " <> show queryVersion <> " but the node negotiated " <> show ntcVersion <> ".\n" <>
+    "Later node qState support later protocol qState (but development protocol qState are not enabled in the node by default)."
+  displayError (LocalStateQueryMismatch eraMismatch) =
+    "A query from a certain era was applied to a ledger from a different era: " <> show eraMismatch
+  displayError (LocalStateQueryMuxError (Mux.MuxError Mux.MuxBearerClosed _e)) =
+    "Connection closed unexpectedly. Check that you specified the correct mode."
+  displayError (LocalStateQueryMuxError muxError) = show muxError
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
 setupLocalStateQueryExpr ::
@@ -76,48 +121,148 @@ setupLocalStateQueryExpr ::
      -- Protocols must wait until 'waitDone' returns because premature exit will
      -- cause other incomplete protocols to abort which may lead to deadlock.
   -> Maybe ChainPoint
-  -> TMVar (Either Net.Query.AcquireFailure a)
+  -> TMVar (Either LocalStateQueryFailure a)
   -> NodeToClientVersion
   -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
   -> Net.Query.LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) IO ()
-setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
+setupLocalStateQueryExpr waitDone mPointVar' resultVar' nodeVer qInMode = do
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring
-    { Net.Query.recvMsgAcquired = runContT (runReaderT (runLocalStateQueryExpr f) ntcVersion) $ \result -> do
-        atomically $ putTMVar resultVar' (Right result)
-        void $ atomically waitDone -- Wait for all protocols to complete before exiting.
-        pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
+    { Net.Query.recvMsgAcquired = do
+      let s = execStateT (runLocalStateQueryExpr qInMode) (NodeVersion nodeVer)
+      runContT s $ \case
+          QSMismatch mismatch -> do
+            atomically $ putTMVar resultVar' $ Left (LocalStateQueryMismatch mismatch)
+            pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
 
+          NodeAndQueryVersions nodeVer' qVer -> do
+            -- Perform version check here
+            if nodeVer >= qVer
+            then runContT (runStateT (runLocalStateQueryExpr qInMode) (NodeAndQueryVersions nodeVer' qVer))
+                   $ \(result, _) -> do
+                      atomically $ putTMVar resultVar' (Right result)
+                      void $ atomically waitDone -- Wait for all protocols to complete before exiting.
+                      pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
+            else do
+              atomically $ putTMVar resultVar' $ Left (LocalStateQueryNtcErrror $ UnsupportedNtcVersionError nodeVer' qVer)
+              pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
+
+          NodeVersion _ -> error "setupLocalStateQueryExpr: NodeVersion only should not be possible"
     , Net.Query.recvMsgFailure = \failure -> do
-        atomically $ putTMVar resultVar' (Left failure)
+        atomically $ putTMVar resultVar' (Left . LocalStateQueryAcqFail $ toAcquiringFailure failure)
         void $ atomically waitDone -- Wait for all protocols to complete before exiting.
         pure $ Net.Query.SendMsgDone ()
     }
 
--- | Get the node server's Node-to-Client version.
-getNtcVersion :: LocalStateQueryExpr block point (QueryInMode mode) r IO NodeToClientVersion
-getNtcVersion = LocalStateQueryExpr ask
+getQueryState :: LocalStateQueryExpr block point (QueryInMode mode) r IO QueryState
+getQueryState = LocalStateQueryExpr get
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: QueryInMode mode a -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError a)
+queryExpr :: QueryInMode mode a -> LocalStateQueryExpr block point (QueryInMode mode) r IO a
 queryExpr q = do
-  let minNtcVersion = nodeToClientVersionOf q
-  ntcVersion <- getNtcVersion
-  if ntcVersion >= minNtcVersion
-    then
-      fmap Right . LocalStateQueryExpr . ReaderT $ \_ -> ContT $ \f -> pure $
-        Net.Query.SendMsgQuery q $
-          Net.Query.ClientStQuerying
-          { Net.Query.recvMsgResult = f
-          }
-    else pure (Left (UnsupportedNtcVersionError minNtcVersion ntcVersion))
+  let queryVersion = nodeToClientVersionOf q
+  currentVersions <- getQueryState
+  case currentVersions of
+    NodeVersion v ->
+      let qState = NodeAndQueryVersions v queryVersion
+      in LocalStateQueryExpr $ do
+           put qState
+           StateT $ \_ ->
+              ContT $ \f ->
+                let t = flip $ curry f
+                in do pure $ Net.Query.SendMsgQuery q
+                           $ Net.Query.ClientStQuerying
+                               { Net.Query.recvMsgResult = t qState }
+
+    QSMismatch{} ->
+      error $ "queryExpr: QSMismatch Shouldn't be possible as we handle this state in setupLocalStateQueryExpr " <>
+              "and we close the connection."
+
+    NodeAndQueryVersions consensusV _previousQueryVersion ->
+      let qState = NodeAndQueryVersions consensusV queryVersion
+      in LocalStateQueryExpr $ do
+           put qState
+           StateT $ \_ ->
+              ContT $ \f ->
+                let t = flip $ curry f
+                in do pure $ Net.Query.SendMsgQuery q
+                           $ Net.Query.ClientStQuerying
+                               { Net.Query.recvMsgResult = t qState }
+
+-- | Handles queries that return `Either EraMismatch a`
+queryExprE :: QueryInMode mode (Either EraMismatch a) -> LocalStateQueryExpr block point (QueryInMode mode) r IO a
+queryExprE q = do
+  let queryVersion = nodeToClientVersionOf q
+  currentVersions <- getQueryState
+  case currentVersions of
+    NodeVersion v -> do
+      let qState = NodeAndQueryVersions v queryVersion
+      r <- LocalStateQueryExpr $ do
+             put qState
+             StateT $ \_ ->
+               ContT $ \f ->
+                 let t = flip $ curry f
+                 in do pure $ Net.Query.SendMsgQuery q
+                              $ Net.Query.ClientStQuerying
+                                  { Net.Query.recvMsgResult = t qState }
+      case r of
+        Left err ->
+          LocalStateQueryExpr $ do
+            put $ QSMismatch err
+            StateT $ \_ -> error $ "queryExprE: This should not get called as the era " <>
+                                   "mismatch is handled in setupLocalStateQueryExpr before " <>
+                                   "the continuation is run."
+
+        Right res -> return res
+    NodeAndQueryVersions consensusVersion _previousQueryVersion -> do
+      let qState = NodeAndQueryVersions consensusVersion queryVersion
+      r <- LocalStateQueryExpr $ do
+             put qState
+             StateT $ \_ ->
+               ContT $ \f ->
+                 let t = flip $ curry f
+                 in do pure $ Net.Query.SendMsgQuery q
+                              $ Net.Query.ClientStQuerying
+                                  { Net.Query.recvMsgResult = t qState }
+      case r of
+        Left err ->
+          LocalStateQueryExpr $ do
+            put $ QSMismatch err
+            StateT $ \_ -> error $ "queryExprE: This should not get called as the era " <>
+                                   "mismatch is handled in setupLocalStateQueryExpr before " <>
+                                   "the continuation is run."
+
+        Right res -> return res
+    QSMismatch{} ->
+      error $ "queryExpr: QSMismatch Shouldn't be possible as we handle this state in setupLocalStateQueryExpr " <>
+              "and we close the connection."
 
 -- | A monad expression that determines what era the node is in.
-determineEraExpr ::
-     ConsensusModeParams mode
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
-determineEraExpr cModeParams = runExceptT $
+determineEraExpr
+  :: ConsensusModeParams mode
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO AnyCardanoEra
+determineEraExpr cModeParams =
   case consensusModeOnly cModeParams of
-    ByronMode -> return $ AnyCardanoEra ByronEra
+    ByronMode   -> return $ AnyCardanoEra ByronEra
     ShelleyMode -> return $ AnyCardanoEra ShelleyEra
-    CardanoMode -> ExceptT $ queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
+    CardanoMode -> queryExpr (QueryCurrentEra CardanoModeIsMultiEra)
+
+determineEraInMode
+  :: CardanoEra era
+  -> ConsensusModeParams mode
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (EraInMode era mode)
+determineEraInMode era cModeParams = do
+  case toEraInMode era $ consensusModeOnly cModeParams of
+    Nothing ->
+      fail $ "determineEraInMode: " <> Text.unpack (renderEra $ anyCardanoEra era) <>
+             " is not supported in " <> show (consensusModeOnly cModeParams)
+    Just eInMode -> return eInMode
+
+determineShelleyBasedEra
+  :: CardanoEra era
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (ShelleyBasedEra era)
+determineShelleyBasedEra era =
+  case cardanoEraStyle era of
+    LegacyByronEra -> fail "determineShelleyBasedEra: The current era is Byron"
+    ShelleyBasedEra sbe -> return sbe
+

--- a/cardano-api/src/Cardano/Api/IPC/Version.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Version.hs
@@ -30,5 +30,7 @@ class NodeToClientVersionOf a where
 
 type MinNodeToClientVersion = NodeToClientVersion
 
-data UnsupportedNtcVersionError = UnsupportedNtcVersionError !MinNodeToClientVersion !NodeToClientVersion
+data UnsupportedNtcVersionError = UnsupportedNtcVersionError
+                                    !MinNodeToClientVersion -- ^ Query version
+                                    !NodeToClientVersion    -- ^ Node version
   deriving (Eq, Show)

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -717,8 +717,7 @@ consensusQueryInEraInMode erainmode =
 fromConsensusQueryResult :: forall mode block result result'. ConsensusBlockForMode mode ~ block
                          => QueryInMode mode result
                          -> Consensus.Query block result'
-                         -> result'
-                         -> result
+                         -> (result' -> result)
 fromConsensusQueryResult (QueryEraHistory CardanoModeIsMultiEra) q' r' =
     case q' of
       Consensus.BlockQuery (Consensus.QueryHardFork Consensus.GetInterpreter)

--- a/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
@@ -49,7 +49,7 @@ data TxSubmitWebApiError
   | TxSubmitBadTx !Text
   | TxSubmitFail TxCmdError
 
-newtype EnvSocketError = CliEnvVarLookup Text deriving (Eq, Show)
+newtype EnvSocketError = CliEnvVarDoesNotExist Text deriving (Eq, Show)
 
 data TxCmdError
   = TxCmdSocketEnvError EnvSocketError

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -101,7 +101,7 @@ txSubmitApp trace metrics connectInfo networkId socketPath =
 -- Fails if the environment variable is not set.
 readEnvSocketPath :: ExceptT EnvSocketError IO SocketPath
 readEnvSocketPath =
-    maybe (left $ CliEnvVarLookup (T.pack envName)) (pure . SocketPath)
+    maybe (left $ CliEnvVarDoesNotExist (T.pack envName)) (pure . SocketPath)
       =<< liftIO (lookupEnv envName)
   where
     envName :: String


### PR DESCRIPTION
 Update `LocalStateQueryExpr` to use `StateT` instead of `ReaderT` in order to improve composability of the monadic queries
