### PR TITLE
Fix flake setup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,6 +37,9 @@ packages:
     trace-resources
     trace-forward
 
+extra-packages:
+  ouroboros-consensus-cardano-tools
+
 package cardano-api
   ghc-options: -Werror
 

--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,6 @@
           inherit (ouroboros-consensus-cardano-tools.components.exes) db-analyser db-synthesizer;
           inherit (bech32.components.exes) bech32;
         } // lib.optionalAttrs hostPlatform.isUnix {
-          inherit (network-mux.components.exes) cardano-ping;
           inherit plutus-example;
         });
 

--- a/nix/workbench/backend/nixops/cluster.nix
+++ b/nix/workbench/backend/nixops/cluster.nix
@@ -88,7 +88,6 @@ in {
 
   environment.systemPackages = with pkgs;
     [ cardano-cli
-      cardano-ping
     ];
 }
 // listToAttrs (concatLists [

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -96,7 +96,6 @@ in project.shellFor {
 
   # These programs will be available inside the nix-shell.
   nativeBuildInputs = with pkgs; with haskellPackages; with cardanoNodePackages; [
-    cardano-ping
     db-analyser
     pkgs.graphviz
     graphmod

--- a/shell.nix
+++ b/shell.nix
@@ -99,7 +99,6 @@ let
       nix
       cardano-cli
       bech32
-      cardano-ping
       cardano-node
       cardano-topology
       cardano-tracer


### PR DESCRIPTION
* Remove cardano-ping from flake.nix since it does not exists anymore in network-mux. It is now part of cardano-cli (`cardano-cli ping`).
* Re-add ouroboros-consensus-cardano-tools to the project to provide db-analyser db-synthesizer, which are part of the flake.
