### PR TITLE
New --stake-address option

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -51,8 +51,8 @@ import           Cardano.Api.Shelley
 
 import           Data.Text (Text)
 
-import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeVerifier, VerificationKeyOrFile,
-                   VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
+import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeAddressSource, StakeVerifier,
+                   VerificationKeyOrFile, VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
@@ -112,13 +112,20 @@ renderAddressCmd cmd =
 data StakeAddressCmd
   = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe OutputFile)
-  | StakeAddressBuild StakeVerifier NetworkId (Maybe OutputFile)
-  | StakeRegistrationCert StakeVerifier OutputFile
+  | StakeAddressBuild
+      StakeAddressSource
+      NetworkId
+      (Maybe OutputFile)
+  | StakeRegistrationCert
+      StakeAddressSource
+      OutputFile
   | StakeCredentialDelegationCert
-      StakeVerifier
+      StakeAddressSource
       (VerificationKeyOrHashOrFile StakePoolKey)
       OutputFile
-  | StakeCredentialDeRegistrationCert StakeVerifier OutputFile
+  | StakeCredentialDeRegistrationCert
+      StakeAddressSource
+      OutputFile
   deriving Show
 
 renderStakeAddressCmd :: StakeAddressCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -21,6 +21,7 @@ module Cardano.CLI.Shelley.Key
 
   , PaymentVerifier(..)
   , StakeVerifier(..)
+  , StakeAddressSource(..)
 
   , generateKeyPair
   ) where
@@ -104,6 +105,11 @@ data StakeVerifier
   | StakeVerifierScriptFile ScriptFile
   | StakeVerifierAddress StakeAddress
   deriving (Eq, Show)
+
+data StakeAddressSource
+  = StakeAddressSourceOfStakeVerifier StakeVerifier
+  | StakeAddressSourceOfStakeKeyHash (Hash StakeKey)
+  deriving Show
 
 -- | Either an unvalidated text representation of a verification key or a path
 -- to a verification key file.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -419,10 +419,10 @@ pStakeAddressSource =
 
 pStakeKeyHash :: Parser (Hash StakeKey)
 pStakeKeyHash =
-  Opt.option (eitherReader (deserialiseFromRawBytesBase16 . BSC.pack)) $ mconcat
+  Opt.option readStakeKeyHash $ mconcat
     [ Opt.long "stake-address"
     , Opt.metavar "HASH"
-    , Opt.help "Stake address key (Bech32 or hex-encoded)."
+    , Opt.help "Stake address key (hex-encoded)."
     ]
 
 pKeyCmd :: Parser KeyCmd
@@ -3349,6 +3349,16 @@ readVerificationKey asType =
     deserialiseFromBech32OrHex str =
       first (Text.unpack . renderInputDecodeError) $
         deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
+
+-- | Read a Bech32 or hex-encoded stake key.
+readStakeKeyHash :: Opt.ReadM (Hash StakeKey)
+readStakeKeyHash = Opt.eitherReader deserialiseFromHex
+  where
+    deserialiseFromHex :: String -> Either String (Hash StakeKey)
+    deserialiseFromHex =
+      first (\e -> "Invalid stake key hash: " ++ displayError e)
+        . deserialiseFromRawBytesHex (AsHash AsStakeKey)
+        . BSC.pack
 
 readOutputFormat :: Opt.ReadM OutputFormat
 readOutputFormat = do


### PR DESCRIPTION
Resolves https://github.com/input-output-hk/cardano-node/issues/2723

```
$ cardano-cli stake-address registration-certificate
Usage: cardano-cli stake-address registration-certificate
            ( --stake-verification-key STRING
            | --stake-verification-key-file FILE
            | --stake-script-file FILE
            | --stake-address HASH
            )
            --out-file FILE

  Create a stake address registration certificate

Available options:
  --stake-verification-key STRING
                           Stake verification key (Bech32 or hex-encoded).
  --stake-verification-key-file FILE
                           Filepath of the staking verification key.
  --stake-script-file FILE Filepath of the staking script.
  --stake-address HASH     Stake address key (Bech32 or hex-encoded).
  --out-file FILE          The output file.
  -h,--help                Show this help text
```

```
$ cardano-cli stake-address deregistration-certificate
Usage: cardano-cli stake-address deregistration-certificate
            ( --stake-verification-key STRING
            | --stake-verification-key-file FILE
            | --stake-script-file FILE
            | --stake-address HASH
            )
            --out-file FILE

  Create a stake address deregistration certificate

Available options:
  --stake-verification-key STRING
                           Stake verification key (Bech32 or hex-encoded).
  --stake-verification-key-file FILE
                           Filepath of the staking verification key.
  --stake-script-file FILE Filepath of the staking script.
  --stake-address HASH     Stake address key (Bech32 or hex-encoded).
  --out-file FILE          The output file.
  -h,--help                Show this help text
```

```
$ cardano-cli stake-address delegation-certificate
Usage: cardano-cli stake-address delegation-certificate
            ( --stake-verification-key STRING
            | --stake-verification-key-file FILE
            | --stake-script-file FILE
            | --stake-address HASH
            )
            ( --stake-pool-verification-key STRING
            | --cold-verification-key-file FILE
            | --stake-pool-id STAKE_POOL_ID
            )
            --out-file FILE

  Create a stake address delegation certificate

Available options:
  --stake-verification-key STRING
                           Stake verification key (Bech32 or hex-encoded).
  --stake-verification-key-file FILE
                           Filepath of the staking verification key.
  --stake-script-file FILE Filepath of the staking script.
  --stake-address HASH     Stake address key (Bech32 or hex-encoded).
  --stake-pool-verification-key STRING
                           Stake pool verification key (Bech32 or hex-encoded).
  --cold-verification-key-file FILE
                           Filepath of the stake pool verification key.
  --stake-pool-id STAKE_POOL_ID
                           Stake pool ID/verification key hash (either
                           Bech32-encoded or hex-encoded). Zero or more
                           occurences of this option is allowed.
  --out-file FILE          The output file.
  -h,--help                Show this help text
```
