### PR TITLE
Script to generate merge summary

### DIFF
--- a/scripts/gen-merge-summary.sh
+++ b/scripts/gen-merge-summary.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+since="$1"
+until="$(date -d "$since +7 days" +%Y-%m-%d)"
+
+echo "# Merge summary for $since to $until"
+
+git log --merges --since $since --until $until --format=fuller \
+  | jc --git-log -p \
+  | jq -r '
+      .[]
+      | select(.author != "iohk-bors[bot]")
+      | (.subject = (.message | split("\n"))[0])
+      | (.body =  (.message | split("\n") | del(.[0]) | del(.[0]) | join("\n")))
+      | select(.subject | startswith("Merge pull request #"))
+      | (.subject |= sub("^.*#"; ""))
+      | ("- [" + (.body | gsub("\n.*"; "")) + "](https://github.com/input-output-hk/cardano-node/pull/" + .subject + ") (" + .author + ")")
+    '


### PR DESCRIPTION
A merge summary is useful for quickly query for data to add to https://github.com/input-output-hk/cardano-updates

```
$ gen-merge-summary.sh [SINCE] [UNTIL]
Generate a merge summary between the SINCE and UNTIL date

Examples:
  gen-merge-summary.sh 2023-01-01 2023-01-08
  gen-merge-summary.sh 2023-01-01 '2023-01-01 +7 days'
```

Example output:

```bash
$ ./scripts/gen-merge-summary.sh 2023-02-07 2023-02-14
- [workbench:  drop cabalWrapped](https://github.com/input-output-hk/cardano-node/pull/4873 from input-output-hk/wb-drop-cabalWrapped) (Kosyrev Serge)
- [workbench:  `make shell-nix` use Nix-built binaries](https://github.com/input-output-hk/cardano-node/pull/4872 from input-output-hk/wb-shell-nix) (Kosyrev Serge)
- [Revert #4855](https://github.com/input-output-hk/cardano-node/pull/4870 from input-output-hk/jordan/remove-4855) (Jordan Millar)
- [Remove cardano-cli's dependency on cardano-node](https://github.com/input-output-hk/cardano-node/pull/4855 from input-output-hk/jordan/remove-cli-node-dependency) (Jordan Millar)
```
