### PR TITLE
New mkExecConfig function

### DIFF
--- a/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -19,7 +19,6 @@ import qualified Data.Aeson.Types as J
 import           Data.List ((\\))
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
-import           Data.Monoid (Last (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Text (Text)
@@ -29,16 +28,15 @@ import           GHC.Stack (callStack)
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import           Prelude
 import qualified System.Directory as IO
-import           System.Environment (getEnvironment)
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
+import qualified Testnet.Util.Process as H
 
 import           Cardano.Api (AlonzoEra, SerialiseAddress (serialiseAddress), UTxO (UTxO))
 import qualified Cardano.Api as Api
@@ -73,17 +71,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo-leadership-schedu
 
   poolNode1 <- H.headM poolNodes
 
-  env <- H.evalIO getEnvironment
-
-  execConfig <- H.noteShow H.ExecConfig
-    { H.execConfigEnv = Last $ Just $
-      [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName $ head $ bftSprockets tr)
-      ]
-      -- The environment must be passed onto child process on Windows in order to
-      -- successfully start that process.
-      <> env
-    , H.execConfigCwd = Last $ Just tempBaseAbsPath
-    }
+  execConfig <- H.headM (bftSprockets tr) >>= H.mkExecConfig tempBaseAbsPath
 
   -- First we note all the relevant files
   H.note_ base

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -19,12 +19,10 @@ module Test.Cli.Babbage.LeadershipSchedule
 import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
 import           Control.Monad (void)
 import           Data.List ((\\))
-import           Data.Monoid (Last (..))
 import           Data.Text (Text)
 import           GHC.Stack (callStack)
 import           Hedgehog (Property, (===))
 import           Prelude
-import           System.Environment (getEnvironment)
 import           System.FilePath ((</>))
 
 import qualified Data.Aeson as J
@@ -32,7 +30,6 @@ import qualified Data.Aeson.Types as J
 import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
@@ -42,6 +39,7 @@ import qualified Testnet.Util.Base as H
 
 import           Cardano.Testnet
 import           Testnet.Util.Assert
+import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
@@ -69,19 +67,9 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
 
   poolNode1 <- H.headM poolNodes
 
-  env <- H.evalIO getEnvironment
-
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
 
-  execConfig <- H.noteShow H.ExecConfig
-    { H.execConfigEnv = Last $ Just $
-      [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName poolSprocket1)
-      ]
-      -- The environment must be passed onto child process on Windows in order to
-      -- successfully start that process.
-      <> env
-    , H.execConfigCwd = Last $ Just tempBaseAbsPath
-    }
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
 
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
 


### PR DESCRIPTION
This makes it easier to construct an `ExecConfig` which is required to pass in `CARDANO_NODE_SOCKET_PATH` variable to invocations of `cardano-cli` in tests.