### PR TITLE
In merge summary construct correct pr link

### DIFF
--- a/scripts/gen-merge-summary.sh
+++ b/scripts/gen-merge-summary.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
-since="$1"
-until="$(date -d "$since +7 days" +%Y-%m-%d)"
+if [ $# -eq 0 ]; then
+    >&2 echo "gen-merge-summary.sh [SINCE] [UNTIL]"
+    >&2 echo "Generate a merge summary between the SINCE and UNTIL date"
+    >&2 echo ""
+    >&2 echo "Examples:"
+    >&2 echo "  gen-merge-summary.sh 2023-01-01 2023-01-08"
+    >&2 echo "  gen-merge-summary.sh 2023-01-01 '2023-01-01 +7 days'"
+    exit 1
+fi
+
+since="$(date -d "$1" +%Y-%m-%d)"
+until="$(date -d "$2" +%Y-%m-%d)"
 
 echo "# Merge summary for $since to $until"
 
@@ -13,6 +23,6 @@ git log --merges --since $since --until $until --format=fuller \
       | (.subject = (.message | split("\n"))[0])
       | (.body =  (.message | split("\n") | del(.[0]) | del(.[0]) | join("\n")))
       | select(.subject | startswith("Merge pull request #"))
-      | (.subject |= sub("^.*#"; ""))
+      | (.subject |= sub("^.*#(?<a>[0-9]+) .*$"; .a))
       | ("- [" + (.body | gsub("\n.*"; "")) + "](https://github.com/input-output-hk/cardano-node/pull/" + .subject + ") (" + .author + ")")
     '


### PR DESCRIPTION
```
$ gen-merge-summary.sh [SINCE] [UNTIL]
Generate a merge summary between the SINCE and UNTIL date

Examples:
  gen-merge-summary.sh 2023-01-01 2023-01-08
  gen-merge-summary.sh 2023-01-01 '2023-01-01 +7 days'
```

Example output:

```bash
./scripts/gen-merge-summary.sh 2023-02-07 2023-02-14
# Merge summary for 2023-02-07 to 2023-02-14
- [workbench:  drop cabalWrapped](https://github.com/input-output-hk/cardano-node/pull/4873) (Kosyrev Serge)
- [workbench:  `make shell-nix` use Nix-built binaries](https://github.com/input-output-hk/cardano-node/pull/4872) (Kosyrev Serge)
- [Revert #4855](https://github.com/input-output-hk/cardano-node/pull/4870) (Jordan Millar)
- [Remove cardano-cli's dependency on cardano-node](https://github.com/input-output-hk/cardano-node/pull/4855) (Jordan Millar)
```
