### PR TITLE
Refactor `data Conf` with `TempAbsolutePath`

### DIFF
--- a/cardano-node-chairman/testnet/Testnet/Run.hs
+++ b/cardano-node-chairman/testnet/Testnet/Run.hs
@@ -27,7 +27,7 @@ testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
 testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "testnet-chairman" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf <- H.mkConf (Just $ H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic
+  conf <- H.mkConf Nothing tempAbsPath' maybeTestnetMagic
 
   -- Fork a thread to keep alive indefinitely any resources allocated by testnet.
   void . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -153,6 +153,7 @@ test-suite cardano-testnet-golden
   build-tool-depends:   cardano-node:cardano-node
                       , cardano-cli:cardano-cli
                       , cardano-submit-api:cardano-submit-api
+                      , cardano-testnet:cardano-testnet
 
 test-suite cardano-testnet-test
   import:               project-config
@@ -197,3 +198,4 @@ test-suite cardano-testnet-test
   build-tool-depends:   cardano-node:cardano-node
                       , cardano-cli:cardano-cli
                       , cardano-submit-api:cardano-submit-api
+                      , cardano-testnet:cardano-testnet

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -76,6 +76,7 @@ library
                         Testnet.Babbage
                         Testnet.Byron
                         Testnet.Commands.Genesis
+                        Testnet.Conf
                         Testnet.Options
                         Testnet.Topology 
                         Testnet.Utils
@@ -95,7 +96,6 @@ library
                         Parsers.Version
                         Testnet
                         Testnet.Cardano
-                        Testnet.Conf
                         Testnet.Commands.Governance
                         Testnet.Run
                         Testnet.Shelley

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -20,8 +20,12 @@ module Cardano.Testnet (
   -- * Configuration
   Conf(..),
   ProjectBase(..),
+  TmpAbsolutePath(..),
   YamlFilePath(..),
   mkConf,
+  makeLogDir,
+  makeSocketDir,
+  makeTmpBaseAbsPath,
 
   -- * Processes
   procChairman,

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Testnet.Cardano
@@ -49,7 +48,6 @@ import qualified Cardano.Node.Configuration.TopologyP2P as P2P
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Aeson as J
 import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
-import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Stock.OS as OS
 import qualified Hedgehog.Extras.Stock.String as S
@@ -66,8 +64,7 @@ import           Testnet.Options hiding (defaultTestnetOptions)
 import qualified Testnet.Util.Assert as H
 import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process (execCli_)
-import           Testnet.Util.Runtime as TR (NodeLoggingFormat (..), PaymentKeyPair (..),
-                   PoolNode (PoolNode), PoolNodeKeys (..), TestnetRuntime (..), startNode)
+import           Testnet.Util.Runtime as TR
 import           Testnet.Utils
 
 {- HLINT ignore "Redundant flip" -}
@@ -181,11 +178,12 @@ mkTopologyConfig numNodes allPorts port True = J.encode topologyP2P
         (P2P.UseLedger DontUseLedger)
 
 cardanoTestnet :: CardanoTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
-cardanoTestnet testnetOptions H.Conf {..} = do
+cardanoTestnet testnetOptions H.Conf {H.tempAbsPath, H.testnetMagic} = do
   void $ H.note OS.os
   currentTime <- H.noteShowIO DTC.getCurrentTime
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
   startTime <- H.noteShow $ DTC.addUTCTime startTimeOffsetSeconds currentTime
-  configurationFile <- H.noteShow $ tempAbsPath </> "configuration.yaml"
+  configurationFile <- H.noteShow $ tempAbsPath' </> "configuration.yaml"
   let numBftNodes = cardanoNumBftNodes $ cardanoNodes testnetOptions
       bftNodesN = [1 .. numBftNodes]
       poolNodesN = [1 .. cardanoNumPoolNodes $ cardanoNodes testnetOptions]
@@ -202,24 +200,24 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   nodeToPort <- H.noteShow (M.fromList (L.zip allNodeNames allPorts))
 
   let securityParam = 10
-
+  let logDir = TR.makeLogDir $ TR.TmpAbsolutePath tempAbsPath'
   H.createDirectoryIfMissing_ logDir
 
   forM_ allNodeNames $ \node -> do
-    H.createDirectoryIfMissing_ $ tempAbsPath </> node
-    H.createDirectoryIfMissing_ $ tempAbsPath </> node </> "byron"
-    H.createDirectoryIfMissing_ $ tempAbsPath </> node </> "shelley"
+    H.createDirectoryIfMissing_ $ tempAbsPath' </> node
+    H.createDirectoryIfMissing_ $ tempAbsPath' </> node </> "byron"
+    H.createDirectoryIfMissing_ $ tempAbsPath' </> node </> "shelley"
 
   -- Make topology files
   forM_ allNodeNames $ \node -> do
     let port = fromJust $ M.lookup node nodeToPort
-    H.lbsWriteFile (tempAbsPath </> node </> "topology.json") $
+    H.lbsWriteFile (tempAbsPath' </> node </> "topology.json") $
       mkTopologyConfig (numBftNodes + cardanoNumPoolNodes (cardanoNodes testnetOptions))
                        allPorts port (cardanoEnableP2P testnetOptions)
 
-    H.writeFile (tempAbsPath </> node </> "port") (show port)
+    H.writeFile (tempAbsPath' </> node </> "port") (show port)
 
-  H.lbsWriteFile (tempAbsPath </> "byron.genesis.spec.json")
+  H.lbsWriteFile (tempAbsPath' </> "byron.genesis.spec.json")
     . J.encode $ defaultByronProtocolParamsJsonValue
 
   -- stuff
@@ -236,51 +234,51 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     , "--delegate-share", "1"
     , "--avvm-entry-count", "0"
     , "--avvm-entry-balance", "0"
-    , "--protocol-parameters-file", tempAbsPath </> "byron.genesis.spec.json"
-    , "--genesis-output-dir", tempAbsPath </> "byron"
+    , "--protocol-parameters-file", tempAbsPath' </> "byron.genesis.spec.json"
+    , "--genesis-output-dir", tempAbsPath' </> "byron"
     ]
 
   H.renameFile
-    (tempAbsPath </> "byron.genesis.spec.json")
-    (tempAbsPath </> "byron/genesis.spec.json")
+    (tempAbsPath' </> "byron.genesis.spec.json")
+    (tempAbsPath' </> "byron/genesis.spec.json")
 
   -- Symlink the BFT operator keys from the genesis delegates, for uniformity
   forM_ bftNodesN $ \n -> do
-    H.createFileLink (tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key") (tempAbsPath </> "node-bft" <> show @Int n </> "byron/delegate.key")
-    H.createFileLink (tempAbsPath </> "byron/delegation-cert.00" <> show @Int (n - 1) <> ".json") (tempAbsPath </> "node-bft" <> show @Int n </> "byron/delegate.cert")
+    H.createFileLink (tempAbsPath' </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key") (tempAbsPath' </> "node-bft" <> show @Int n </> "byron/delegate.key")
+    H.createFileLink (tempAbsPath' </> "byron/delegation-cert.00" <> show @Int (n - 1) <> ".json") (tempAbsPath' </> "node-bft" <> show @Int n </> "byron/delegate.cert")
 
   -- Create keys and addresses to withdraw the initial UTxO into
   forM_ bftNodesN $ \n -> do
     execCli_
       [ "keygen"
-      , "--secret", tempAbsPath </> "byron/payment-keys.00" <> show @Int (n - 1) <> ".key"
+      , "--secret", tempAbsPath' </> "byron/payment-keys.00" <> show @Int (n - 1) <> ".key"
       ]
 
     H.execCli
       [ "signing-key-address"
       , "--testnet-magic", show @Int testnetMagic
-      , "--secret", tempAbsPath </> "byron/payment-keys.00" <> show @Int (n - 1) <> ".key"
-      ] >>= H.writeFile (tempAbsPath </> "byron/address-00" <> show @Int (n - 1))
+      , "--secret", tempAbsPath' </> "byron/payment-keys.00" <> show @Int (n - 1) <> ".key"
+      ] >>= H.writeFile (tempAbsPath' </> "byron/address-00" <> show @Int (n - 1))
 
     -- Write Genesis addresses to files
     H.execCli
       [ "signing-key-address"
       , "--testnet-magic", show @Int testnetMagic
-      , "--secret", tempAbsPath </> "byron/genesis-keys.00" <> show @Int (n - 1) <> ".key"
-      ] >>= H.writeFile (tempAbsPath </> "byron/genesis-address-00" <> show @Int (n - 1))
+      , "--secret", tempAbsPath' </> "byron/genesis-keys.00" <> show @Int (n - 1) <> ".key"
+      ] >>= H.writeFile (tempAbsPath' </> "byron/genesis-address-00" <> show @Int (n - 1))
 
   do
-    richAddrFrom <- S.firstLine <$> H.readFile (tempAbsPath </> "byron/genesis-address-000")
-    txAddr <- S.firstLine <$> H.readFile (tempAbsPath </> "byron/address-000")
+    richAddrFrom <- S.firstLine <$> H.readFile (tempAbsPath' </> "byron/genesis-address-000")
+    txAddr <- S.firstLine <$> H.readFile (tempAbsPath' </> "byron/address-000")
 
     -- Create Byron address that moves funds out of the genesis UTxO into a regular
     -- address.
     execCli_
       [ "issue-genesis-utxo-expenditure"
-      , "--genesis-json", tempAbsPath </> "byron/genesis.json"
+      , "--genesis-json", tempAbsPath' </> "byron/genesis.json"
       , "--testnet-magic", show @Int testnetMagic
-      , "--tx", tempAbsPath </> "tx0.tx"
-      , "--wallet-key", tempAbsPath </> "byron/delegate-keys.000.key"
+      , "--tx", tempAbsPath' </> "tx0.tx"
+      , "--wallet-key", tempAbsPath' </> "byron/delegate-keys.000.key"
       , "--rich-addr-from", richAddrFrom
       , "--txout", show @(String, Word64) (txAddr, fundsPerByronAddress)
       ]
@@ -288,42 +286,42 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   -- Update Proposal and votes
   createByronUpdateProposal
     testnetMagic
-    (tempAbsPath </> "byron/delegate-keys.000.key")
-    (tempAbsPath </> "update-proposal")
+    (tempAbsPath' </> "byron/delegate-keys.000.key")
+    (tempAbsPath' </> "update-proposal")
     1
 
   forM_ bftNodesN $ \n -> do
     createByronUpdateProposalVote
       testnetMagic
-      (tempAbsPath </> "update-proposal")
-      (tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
-      (tempAbsPath </> "update-vote.00" <> show @Int (n - 1))
+      (tempAbsPath' </> "update-proposal")
+      (tempAbsPath' </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
+      (tempAbsPath' </> "update-vote.00" <> show @Int (n - 1))
 
   createByronUpdateProposal
     testnetMagic
-    (tempAbsPath </> "byron/delegate-keys.000.key")
-    (tempAbsPath </> "update-proposal-1")
+    (tempAbsPath' </> "byron/delegate-keys.000.key")
+    (tempAbsPath' </> "update-proposal-1")
     2
 
   forM_ bftNodesN $ \n ->
     createByronUpdateProposalVote
       testnetMagic
-      (tempAbsPath </> "update-proposal-1")
-      (tempAbsPath </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
-      (tempAbsPath </> "update-vote-1.00" <> show @Int (n - 1))
+      (tempAbsPath' </> "update-proposal-1")
+      (tempAbsPath' </> "byron/delegate-keys.00" <> show @Int (n - 1) <> ".key")
+      (tempAbsPath' </> "update-vote-1.00" <> show @Int (n - 1))
 
   -- Generated genesis keys and genesis files
-  H.noteEachM_ . H.listDirectory $ tempAbsPath </> "byron"
+  H.noteEachM_ . H.listDirectory $ tempAbsPath' </> "byron"
 
   -- Set up our template
-  shelleyDir <- H.createDirectoryIfMissing $ tempAbsPath </> "shelley"
+  shelleyDir <- H.createDirectoryIfMissing $ tempAbsPath' </> "shelley"
 
-  alonzoSpecFile <- H.noteTempFile tempAbsPath "shelley/genesis.alonzo.spec.json"
+  alonzoSpecFile <- H.noteTempFile tempAbsPath' "shelley/genesis.alonzo.spec.json"
   gen <- H.evalEither $ first displayError defaultAlonzoGenesis
   H.evalIO $ LBS.writeFile alonzoSpecFile $ J.encode gen
 
 
-  conwaySpecFile <- H.noteTempFile tempAbsPath "shelley/genesis.conway.spec.json"
+  conwaySpecFile <- H.noteTempFile tempAbsPath' "shelley/genesis.conway.spec.json"
   H.evalIO $ LBS.writeFile conwaySpecFile $ J.encode defaultConwayGenesis
 
   execCli_
@@ -338,7 +336,7 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   -- We're going to use really quick epochs (300 seconds), by using short slots 0.2s
   -- and K=10, but we'll keep long KES periods so we don't have to bother
   -- cycling KES keys
-  H.rewriteJsonFile (tempAbsPath </> "shelley/genesis.spec.json") . J.rewriteObject
+  H.rewriteJsonFile (tempAbsPath' </> "shelley/genesis.spec.json") . J.rewriteObject
     $ HM.insert "activeSlotsCoeff" (J.toJSON @Double (cardanoActiveSlotsCoeff testnetOptions))
     . HM.insert "securityParam" (J.toJSON @Int 10)
     . HM.insert "epochLength" (J.toJSON @Int (cardanoEpochLength testnetOptions))
@@ -362,9 +360,9 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     ]
 
   -- Generated genesis keys and genesis files
-  H.noteEachM_ . H.listDirectory $ tempAbsPath </> "shelley"
+  H.noteEachM_ . H.listDirectory $ tempAbsPath' </> "shelley"
 
-  H.rewriteJsonFile (tempAbsPath </> "shelley/genesis.json") . J.rewriteObject
+  H.rewriteJsonFile (tempAbsPath' </> "shelley/genesis.json") . J.rewriteObject
     $ flip HM.adjust "protocolParams"
       ( J.rewriteObject
         ( flip HM.adjust "protocolVersion"
@@ -375,12 +373,12 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     . HM.insert "updateQuorum" (J.toJSON @Int 2)
 
   -- Generated shelley/genesis.json
-  H.cat $ tempAbsPath </> "shelley/genesis.json"
+  H.cat $ tempAbsPath' </> "shelley/genesis.json"
 
   -- Generated alonzo/genesis.json
   --TODO: rationalise the naming convention on these genesis json files.
-  H.cat $ tempAbsPath </> "shelley/genesis.alonzo.json"
-  H.cat $ tempAbsPath </> "shelley/genesis.conway.json"
+  H.cat $ tempAbsPath' </> "shelley/genesis.alonzo.json"
+  H.cat $ tempAbsPath' </> "shelley/genesis.conway.json"
 
   -- Make the pool operator cold keys
   -- This was done already for the BFT nodes as part of the genesis creation
@@ -390,17 +388,17 @@ cardanoTestnet testnetOptions H.Conf {..} = do
 
     execCli_
       [ "node", "key-gen"
-      , "--cold-verification-key-file", tempAbsPath </> node </> "shelley/operator.vkey"
-      , "--cold-signing-key-file", tempAbsPath </> node </> "shelley/operator.skey"
-      , "--operational-certificate-issue-counter-file", tempAbsPath </> node </> "shelley/operator.counter"
+      , "--cold-verification-key-file", tempAbsPath' </> node </> "shelley/operator.vkey"
+      , "--cold-signing-key-file", tempAbsPath' </> node </> "shelley/operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath' </> node </> "shelley/operator.counter"
       ]
 
-    poolNodeKeysColdVkey <- H.note $ tempAbsPath </> "node-pool" <> show i <> "/shelley/operator.vkey"
-    poolNodeKeysColdSkey <- H.note $ tempAbsPath </> "node-pool" <> show i <> "/shelley/operator.skey"
-    poolNodeKeysVrfVkey <- H.note $ tempAbsPath </> node </> "shelley/vrf.vkey"
-    poolNodeKeysVrfSkey <- H.note $ tempAbsPath </> node </> "shelley/vrf.skey"
-    poolNodeKeysStakingVkey <- H.note $ tempAbsPath </> node </> "shelley/staking.vkey"
-    poolNodeKeysStakingSkey <- H.note $ tempAbsPath </> node </> "shelley/staking.skey"
+    poolNodeKeysColdVkey <- H.note $ tempAbsPath' </> "node-pool" <> show i <> "/shelley/operator.vkey"
+    poolNodeKeysColdSkey <- H.note $ tempAbsPath' </> "node-pool" <> show i <> "/shelley/operator.skey"
+    poolNodeKeysVrfVkey <- H.note $ tempAbsPath' </> node </> "shelley/vrf.vkey"
+    poolNodeKeysVrfSkey <- H.note $ tempAbsPath' </> node </> "shelley/vrf.skey"
+    poolNodeKeysStakingVkey <- H.note $ tempAbsPath' </> node </> "shelley/staking.vkey"
+    poolNodeKeysStakingSkey <- H.note $ tempAbsPath' </> node </> "shelley/staking.skey"
 
     execCli_
       [ "node", "key-gen-VRF"
@@ -419,31 +417,31 @@ cardanoTestnet testnetOptions H.Conf {..} = do
 
   -- Symlink the BFT operator keys from the genesis delegates, for uniformity
   forM_ bftNodesN $ \n -> do
-    H.createFileLink (tempAbsPath </> "shelley/delegate-keys/delegate" <> show @Int n <> ".skey") (tempAbsPath </> "node-bft" <> show @Int n </> "shelley/operator.skey")
-    H.createFileLink (tempAbsPath </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vkey") (tempAbsPath </> "node-bft" <> show @Int n </> "shelley/operator.vkey")
-    H.createFileLink (tempAbsPath </> "shelley/delegate-keys/delegate" <> show @Int n <> ".counter") (tempAbsPath </> "node-bft" <> show @Int n </> "shelley/operator.counter")
-    H.createFileLink (tempAbsPath </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vrf.vkey") (tempAbsPath </> "node-bft" <> show @Int n </> "shelley/vrf.vkey")
-    H.createFileLink (tempAbsPath </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vrf.skey") (tempAbsPath </> "node-bft" <> show @Int n </> "shelley/vrf.skey")
+    H.createFileLink (tempAbsPath' </> "shelley/delegate-keys/delegate" <> show @Int n <> ".skey") (tempAbsPath' </> "node-bft" <> show @Int n </> "shelley/operator.skey")
+    H.createFileLink (tempAbsPath' </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vkey") (tempAbsPath' </> "node-bft" <> show @Int n </> "shelley/operator.vkey")
+    H.createFileLink (tempAbsPath' </> "shelley/delegate-keys/delegate" <> show @Int n <> ".counter") (tempAbsPath' </> "node-bft" <> show @Int n </> "shelley/operator.counter")
+    H.createFileLink (tempAbsPath' </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vrf.vkey") (tempAbsPath' </> "node-bft" <> show @Int n </> "shelley/vrf.vkey")
+    H.createFileLink (tempAbsPath' </> "shelley/delegate-keys/delegate" <> show @Int n <> ".vrf.skey") (tempAbsPath' </> "node-bft" <> show @Int n </> "shelley/vrf.skey")
 
   -- Make hot keys and for all nodes
   forM_ allNodeNames $ \node -> do
     execCli_
       [ "node", "key-gen-KES"
-      , "--verification-key-file", tempAbsPath </> node </> "shelley/kes.vkey"
-      , "--signing-key-file",      tempAbsPath </> node </> "shelley/kes.skey"
+      , "--verification-key-file", tempAbsPath' </> node </> "shelley/kes.vkey"
+      , "--signing-key-file",      tempAbsPath' </> node </> "shelley/kes.skey"
       ]
 
     execCli_
       [ "node", "issue-op-cert"
       , "--kes-period", "0"
-      , "--kes-verification-key-file", tempAbsPath </> node </> "shelley/kes.vkey"
-      , "--cold-signing-key-file", tempAbsPath </> node </> "shelley/operator.skey"
-      , "--operational-certificate-issue-counter-file", tempAbsPath </> node </> "shelley/operator.counter"
-      , "--out-file", tempAbsPath </> node </> "shelley/node.cert"
+      , "--kes-verification-key-file", tempAbsPath' </> node </> "shelley/kes.vkey"
+      , "--cold-signing-key-file", tempAbsPath' </> node </> "shelley/operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath' </> node </> "shelley/operator.counter"
+      , "--out-file", tempAbsPath' </> node </> "shelley/node.cert"
       ]
 
   -- Generated node operator keys (cold, hot) and operational certs
-  forM_ allNodeNames $ \node -> H.noteEachM_ . H.listDirectory $ tempAbsPath </> node </> "byron"
+  forM_ allNodeNames $ \node -> H.noteEachM_ . H.listDirectory $ tempAbsPath' </> node </> "byron"
 
   -- Make some payment and stake addresses
   -- user1..n:       will own all the funds in the system, we'll set this up from
@@ -455,11 +453,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
       addrs = userAddrs <> poolAddrs
 
 
-  H.createDirectoryIfMissing_ $ tempAbsPath </> "addresses"
+  H.createDirectoryIfMissing_ $ tempAbsPath' </> "addresses"
 
   wallets <- forM addrs $ \addr -> do
-    let paymentSKey = tempAbsPath </> "addresses/" <> addr <> ".skey"
-    let paymentVKey = tempAbsPath </> "addresses/" <> addr <> ".vkey"
+    let paymentSKey = tempAbsPath' </> "addresses/" <> addr <> ".skey"
+    let paymentVKey = tempAbsPath' </> "addresses/" <> addr <> ".vkey"
 
     -- Payment address keys
     execCli_
@@ -470,50 +468,50 @@ cardanoTestnet testnetOptions H.Conf {..} = do
 
     execCli_
       [ "address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "shelley/utxo-keys/utxo2.vkey"
-      , "--signing-key-file", tempAbsPath </> "shelley/utxo-keys/utxo2.skey"
+      , "--verification-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo2.vkey"
+      , "--signing-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo2.skey"
       ]
 
     execCli_
       [ "stake-address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--signing-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.skey"
+      , "--verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
+      , "--signing-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.skey"
       ]
 
     execCli_
       [ "stake-address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "shelley/utxo-keys/utxo-stake.vkey"
-      , "--signing-key-file", tempAbsPath </> "shelley/utxo-keys/utxo-stake.skey"
+      , "--verification-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo-stake.vkey"
+      , "--signing-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo-stake.skey"
       ]
 
     execCli_
       [ "stake-address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "shelley/utxo-keys/utxo2-stake.vkey"
-      , "--signing-key-file", tempAbsPath </> "shelley/utxo-keys/utxo2-stake.skey"
+      , "--verification-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo2-stake.vkey"
+      , "--signing-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo2-stake.skey"
       ]
 
     -- Payment addresses
     execCli_
       [ "address", "build"
-      , "--payment-verification-key-file", tempAbsPath </> "addresses/" <> addr <> ".vkey"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
+      , "--payment-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> ".vkey"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
       , "--testnet-magic", show @Int testnetMagic
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> ".addr"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> ".addr"
       ]
 
     -- Stake addresses
     execCli_
       [ "stake-address", "build"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
       , "--testnet-magic", show @Int testnetMagic
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> "-stake.addr"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.addr"
       ]
 
     -- Stake addresses registration certs
     execCli_
       [ "stake-address", "registration-certificate"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> "-stake.reg.cert"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.reg.cert"
       ]
 
     pure $ PaymentKeyPair
@@ -526,17 +524,17 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     -- Stake address delegation certs
     execCli_
       [ "stake-address", "delegation-certificate"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/user" <> show @Int n <> "-stake.vkey"
-      , "--cold-verification-key-file", tempAbsPath </> "node-pool" <> show @Int n </> "shelley/operator.vkey"
-      , "--out-file", tempAbsPath </> "addresses/user" <> show @Int n <> "-stake.deleg.cert"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/user" <> show @Int n <> "-stake.vkey"
+      , "--cold-verification-key-file", tempAbsPath' </> "node-pool" <> show @Int n </> "shelley/operator.vkey"
+      , "--out-file", tempAbsPath' </> "addresses/user" <> show @Int n <> "-stake.deleg.cert"
       ]
 
-    H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> show @Int n <> "-stake.vkey") (tempAbsPath </> "node-pool" <> show @Int n </> "owner.vkey")
-    H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> show @Int n <> "-stake.skey") (tempAbsPath </> "node-pool" <> show @Int n </> "owner.skey")
+    H.createFileLink (tempAbsPath' </> "addresses/pool-owner" <> show @Int n <> "-stake.vkey") (tempAbsPath' </> "node-pool" <> show @Int n </> "owner.vkey")
+    H.createFileLink (tempAbsPath' </> "addresses/pool-owner" <> show @Int n <> "-stake.skey") (tempAbsPath' </> "node-pool" <> show @Int n </> "owner.skey")
 
   -- Generated payment address keys, stake address keys,
   -- stake address registration certs, and stake address delegation certs
-  H.noteEachM_ . H.listDirectory $ tempAbsPath </> "addresses"
+  H.noteEachM_ . H.listDirectory $ tempAbsPath' </> "addresses"
 
   -- Next is to make the stake pool registration cert
   forM_ poolNodeNames $ \node -> do
@@ -544,15 +542,15 @@ cardanoTestnet testnetOptions H.Conf {..} = do
       [ "stake-pool", "registration-certificate"
       , "--testnet-magic", show @Int testnetMagic
       , "--pool-pledge", "0", "--pool-cost", "0", "--pool-margin", "0"
-      , "--cold-verification-key-file", tempAbsPath </> node </> "shelley/operator.vkey"
-      , "--vrf-verification-key-file", tempAbsPath </> node </> "shelley/vrf.vkey"
-      , "--reward-account-verification-key-file", tempAbsPath </> node </> "owner.vkey"
-      , "--pool-owner-stake-verification-key-file", tempAbsPath </> node </> "owner.vkey"
-      , "--out-file", tempAbsPath </> node </> "registration.cert"
+      , "--cold-verification-key-file", tempAbsPath' </> node </> "shelley/operator.vkey"
+      , "--vrf-verification-key-file", tempAbsPath' </> node </> "shelley/vrf.vkey"
+      , "--reward-account-verification-key-file", tempAbsPath' </> node </> "owner.vkey"
+      , "--pool-owner-stake-verification-key-file", tempAbsPath' </> node </> "owner.vkey"
+      , "--out-file", tempAbsPath' </> node </> "registration.cert"
       ]
 
   -- Generated stake pool registration certs
-  forM_ poolNodeNames $ \node -> H.assertIO . IO.doesFileExist $ tempAbsPath </> node </> "registration.cert"
+  forM_ poolNodeNames $ \node -> H.assertIO . IO.doesFileExist $ tempAbsPath' </> node </> "registration.cert"
 
   -- Now we'll construct one whopper of a transaction that does everything
   -- just to show off that we can, and to make the script shorter
@@ -564,11 +562,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
     --  2. register the stake pool 1
     --  3. register the user1 stake address
     --  4. delegate from the user1 stake address to the stake pool
-    txIn <- H.noteShow . S.strip =<< createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath </> "shelley/utxo-keys/utxo1.vkey")
+    txIn <- H.noteShow . S.strip =<< createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath' </> "shelley/utxo-keys/utxo1.vkey")
 
     H.note_ txIn
 
-    user1Addr <- H.readFile $ tempAbsPath </> "addresses/user1.addr"
+    user1Addr <- H.readFile $ tempAbsPath' </> "addresses/user1.addr"
 
     execCli_
       [ "transaction", "build-raw"
@@ -576,11 +574,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
       , "--fee", "0"
       , "--tx-in", txIn
       , "--tx-out",  user1Addr <> "+" <> show @Int maxShelleySupply
-      , "--certificate-file", tempAbsPath </> "addresses/pool-owner1-stake.reg.cert"
-      , "--certificate-file", tempAbsPath </> "node-pool1/registration.cert"
-      , "--certificate-file", tempAbsPath </> "addresses/user1-stake.reg.cert"
-      , "--certificate-file", tempAbsPath </> "addresses/user1-stake.deleg.cert"
-      , "--out-file", tempAbsPath </> "tx1.txbody"
+      , "--certificate-file", tempAbsPath' </> "addresses/pool-owner1-stake.reg.cert"
+      , "--certificate-file", tempAbsPath' </> "node-pool1/registration.cert"
+      , "--certificate-file", tempAbsPath' </> "addresses/user1-stake.reg.cert"
+      , "--certificate-file", tempAbsPath' </> "addresses/user1-stake.deleg.cert"
+      , "--out-file", tempAbsPath' </> "tx1.txbody"
       ]
   -- TODO: this will become the transaction to register the pool, etc.
   -- We'll need to pick the tx-in from the actual UTxO since it contains the txid,
@@ -624,26 +622,26 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   -- 3. the pool1 operator key, due to the pool registration cert
   execCli_
     [ "transaction", "sign"
-    , "--signing-key-file", tempAbsPath </> "shelley/utxo-keys/utxo1.skey"
-    , "--signing-key-file", tempAbsPath </> "addresses/user1-stake.skey"
-    , "--signing-key-file", tempAbsPath </> "node-pool1/owner.skey"
-    , "--signing-key-file", tempAbsPath </> "node-pool1/shelley/operator.skey"
+    , "--signing-key-file", tempAbsPath' </> "shelley/utxo-keys/utxo1.skey"
+    , "--signing-key-file", tempAbsPath' </> "addresses/user1-stake.skey"
+    , "--signing-key-file", tempAbsPath' </> "node-pool1/owner.skey"
+    , "--signing-key-file", tempAbsPath' </> "node-pool1/shelley/operator.skey"
     , "--testnet-magic", show @Int testnetMagic
-    , "--tx-body-file", tempAbsPath </> "tx1.txbody"
-    , "--out-file", tempAbsPath </> "tx1.tx"
+    , "--tx-body-file", tempAbsPath' </> "tx1.txbody"
+    , "--out-file", tempAbsPath' </> "tx1.tx"
     ]
 
   -- Generated a signed 'do it all' transaction:
-  H.assertIO . IO.doesFileExist $ tempAbsPath </> "tx1.tx"
+  H.assertIO . IO.doesFileExist $ tempAbsPath' </> "tx1.tx"
 
   -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
   -- TODO: These genesis filepaths should not be hardcoded. Using the cli as a library
   -- rather as an executable will allow us to get the genesis files paths in a more
   -- direct fashion.
-  byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron/genesis.json"
-  shelleyGenesisHash <- getShelleyGenesisHash (tempAbsPath </> "shelley/genesis.json") "ShelleyGenesisHash"
-  alonzoGenesisHash <- getShelleyGenesisHash (tempAbsPath </> "shelley/genesis.alonzo.json") "AlonzoGenesisHash"
-  conwayGenesisHash <- getShelleyGenesisHash (tempAbsPath </> "shelley/genesis.conway.json") "ConwayGenesisHash"
+  byronGenesisHash <- getByronGenesisHash $ tempAbsPath' </> "byron/genesis.json"
+  shelleyGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.json") "ShelleyGenesisHash"
+  alonzoGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.alonzo.json") "AlonzoGenesisHash"
+  conwayGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.conway.json") "ConwayGenesisHash"
 
   -- TODO: We default to defaultYamlHardforkViaConfig however to enable forking to the appropriate era, we need
   -- to be able to create the appropriate default config value, based on the era.
@@ -657,36 +655,36 @@ cardanoTestnet testnetOptions H.Conf {..} = do
                                            , conwayGenesisHash
                                            , defaultYamlHardforkViaConfig $ cardanoEra testnetOptions]
 
-  H.evalIO $ LBS.writeFile (tempAbsPath </> "configuration.yaml") finalYamlConfig
+  H.evalIO $ LBS.writeFile (tempAbsPath' </> "configuration.yaml") finalYamlConfig
 
   --------------------------------
   -- Launch cluster of three nodes
 
   let bftNodeNameAndOpts = L.zip bftNodeNames (cardanoBftNodes $ cardanoNodes testnetOptions)
   bftNodes <- forM bftNodeNameAndOpts $ \(node, nodeOpts) -> do
-    startNode tempBaseAbsPath tempAbsPath logDir socketDir node
+    startNode (TmpAbsolutePath tempAbsPath') node
       ([ "run"
-        , "--config",  tempAbsPath </> "configuration.yaml"
-        , "--topology",  tempAbsPath </> node </> "topology.json"
-        , "--database-path", tempAbsPath </> node </> "db"
-        , "--shelley-kes-key", tempAbsPath </> node </> "shelley/kes.skey"
-        , "--shelley-vrf-key", tempAbsPath </> node </> "shelley/vrf.skey"
-        , "--shelley-operational-certificate", tempAbsPath </> node </> "shelley/node.cert"
-        , "--delegation-certificate",  tempAbsPath </> node </> "byron/delegate.cert"
-        , "--signing-key", tempAbsPath </> node </> "byron/delegate.key"
+        , "--config",  tempAbsPath' </> "configuration.yaml"
+        , "--topology",  tempAbsPath' </> node </> "topology.json"
+        , "--database-path", tempAbsPath' </> node </> "db"
+        , "--shelley-kes-key", tempAbsPath' </> node </> "shelley/kes.skey"
+        , "--shelley-vrf-key", tempAbsPath' </> node </> "shelley/vrf.skey"
+        , "--shelley-operational-certificate", tempAbsPath' </> node </> "shelley/node.cert"
+        , "--delegation-certificate",  tempAbsPath' </> node </> "byron/delegate.cert"
+        , "--signing-key", tempAbsPath' </> node </> "byron/delegate.key"
         ] <> extraBftNodeCliArgs nodeOpts)
 
   H.threadDelay 100000
 
   poolNodes <- forM (L.zip poolNodeNames poolKeys) $ \(node, key) -> do
-    runtime <- startNode tempBaseAbsPath tempAbsPath logDir socketDir node
+    runtime <- startNode (TmpAbsolutePath tempAbsPath') node
         [ "run"
-        , "--config", tempAbsPath </> "configuration.yaml"
-        , "--topology", tempAbsPath </> node </> "topology.json"
-        , "--database-path", tempAbsPath </> node </> "db"
-        , "--shelley-kes-key", tempAbsPath </> node </> "shelley/kes.skey"
-        , "--shelley-vrf-key", tempAbsPath </> node </> "shelley/vrf.skey"
-        , "--shelley-operational-certificate", tempAbsPath </> node </> "shelley/node.cert"
+        , "--config", tempAbsPath' </> "configuration.yaml"
+        , "--topology", tempAbsPath' </> node </> "topology.json"
+        , "--database-path", tempAbsPath' </> node </> "db"
+        , "--shelley-kes-key", tempAbsPath' </> node </> "shelley/kes.skey"
+        , "--shelley-vrf-key", tempAbsPath' </> node </> "shelley/vrf.skey"
+        , "--shelley-operational-certificate", tempAbsPath' </> node </> "shelley/node.cert"
         , "--host-addr", ifaceAddress
         ]
     return $ PoolNode runtime key
@@ -695,7 +693,7 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   deadline <- H.noteShow $ DTC.addUTCTime 90 now
 
   forM_ allNodeNames $ \node -> do
-    sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
+    sprocket <- H.noteShow $ TR.makeSprocket (TR.TmpAbsolutePath tempAbsPath') node
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
     H.byDeadlineM 10 deadline "Failed to connect to node socket" $ H.assertM $ H.doesSprocketExist sprocket
 
@@ -707,7 +705,7 @@ cardanoTestnet testnetOptions H.Conf {..} = do
 
   return TestnetRuntime
     { configurationFile
-    , shelleyGenesisFile = tempAbsPath </> "shelley/genesis.json"
+    , shelleyGenesisFile = tempAbsPath' </> "shelley/genesis.json"
     , testnetMagic
     , bftNodes
     , poolNodes

--- a/cardano-testnet/src/Testnet/Conf.hs
+++ b/cardano-testnet/src/Testnet/Conf.hs
@@ -7,11 +7,9 @@ module Testnet.Conf
   , mkConf
   ) where
 
-import           System.FilePath ((</>))
+import           Testnet.Util.Runtime
 
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified System.FilePath.Posix as FP
 import qualified System.Random as IO
 
 newtype ProjectBase = ProjectBase
@@ -23,11 +21,7 @@ newtype YamlFilePath = YamlFilePath
   } deriving (Eq, Show)
 
 data Conf = Conf
-  { tempAbsPath :: FilePath
-  , tempRelPath :: FilePath
-  , tempBaseAbsPath :: FilePath
-  , logDir :: FilePath
-  , socketDir :: FilePath
+  { tempAbsPath :: TmpAbsolutePath
   , configurationTemplate :: Maybe FilePath
   , testnetMagic :: Int
   } deriving (Eq, Show)
@@ -35,18 +29,12 @@ data Conf = Conf
 mkConf :: Maybe YamlFilePath -> FilePath -> Maybe Int -> H.Integration Conf
 mkConf mConfigTemplate tempAbsPath' maybeMagic = do
   testnetMagic' <- H.noteShowIO $ maybe (IO.randomRIO (1000, 2000)) return maybeMagic
-  tempBaseAbsPath' <- H.noteShow $ FP.takeDirectory tempAbsPath'
-  tempRelPath' <- H.noteShow $ FP.makeRelative tempBaseAbsPath' tempAbsPath'
-  socketDir' <- H.createSubdirectoryIfMissing tempBaseAbsPath' $ tempRelPath' </> "socket"
-  logDir' <- H.createDirectoryIfMissing $ tempAbsPath' </> "logs"
   let configTemplate = unYamlFilePath <$> mConfigTemplate
 
   return $ Conf
-    { tempAbsPath = tempAbsPath'
-    , tempRelPath = tempRelPath'
-    , tempBaseAbsPath = tempBaseAbsPath'
-    , logDir = logDir'
-    , socketDir = socketDir'
+    { tempAbsPath = TmpAbsolutePath tempAbsPath'
     , configurationTemplate = configTemplate
     , testnetMagic = testnetMagic'
     }
+
+

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Testnet.Shelley
@@ -28,7 +27,6 @@ import           Data.String
 import           Data.Time.Clock (UTCTime)
 import           Data.Word
 import           Hedgehog.Extras.Stock.Aeson (rewriteObject)
-import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 import           System.FilePath.Posix ((</>))
@@ -152,9 +150,9 @@ mkTopologyConfig numPraosNodes allPorts port True = J.encode topologyP2P
         (P2P.UseLedger DontUseLedger)
 
 shelleyTestnet :: ShelleyTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
-shelleyTestnet testnetOptions H.Conf {..} = do
+shelleyTestnet testnetOptions H.Conf {H.tempAbsPath, H.testnetMagic} = do
   void $ H.note OS.os
-
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
   let praosNodesN = show @Int <$> [1 .. shelleyNumPraosNodes testnetOptions]
   let praosNodes = ("node-praos" <>) <$> praosNodesN
   let poolNodesN = show @Int <$> [1 .. shelleyNumPoolNodes testnetOptions]
@@ -172,19 +170,19 @@ shelleyTestnet testnetOptions H.Conf {..} = do
   let poolAddrs = ("pool-owner" <>) <$> poolNodesN
   let addrs = userAddrs <> poolAddrs
 
-  alonzoSpecFile <- H.noteTempFile tempAbsPath "genesis.alonzo.spec.json"
+  alonzoSpecFile <- H.noteTempFile tempAbsPath' "genesis.alonzo.spec.json"
   gen <- H.evalEither $ first displayError defaultAlonzoGenesis
   H.evalIO $ LBS.writeFile alonzoSpecFile $ J.encode gen
 
 
-  conwaySpecFile <- H.noteTempFile tempAbsPath "genesis.conway.spec.json"
+  conwaySpecFile <- H.noteTempFile tempAbsPath' "genesis.conway.spec.json"
   H.evalIO $ LBS.writeFile conwaySpecFile $ J.encode defaultConwayGenesis
 
   -- Set up our template
   execCli_
     [ "genesis", "create"
     , "--testnet-magic", show @Int testnetMagic
-    , "--genesis-dir", tempAbsPath
+    , "--genesis-dir", tempAbsPath'
     , "--start-time", DTC.formatIso8601 startTime
     ]
 
@@ -193,79 +191,79 @@ shelleyTestnet testnetOptions H.Conf {..} = do
   -- We're going to use really quick epochs (300 seconds), by using short slots 0.2s
   -- and K=10, but we'll keep long KES periods so we don't have to bother
   -- cycling KES keys
-  H.rewriteJsonFile (tempAbsPath </> "genesis.spec.json") (rewriteGenesisSpec testnetOptions startTime)
-  H.rewriteJsonFile (tempAbsPath </> "genesis.json"     ) (rewriteGenesisSpec testnetOptions startTime)
+  H.rewriteJsonFile (tempAbsPath' </> "genesis.spec.json") (rewriteGenesisSpec testnetOptions startTime)
+  H.rewriteJsonFile (tempAbsPath' </> "genesis.json"     ) (rewriteGenesisSpec testnetOptions startTime)
 
-  H.assertIsJsonFile $ tempAbsPath </> "genesis.spec.json"
+  H.assertIsJsonFile $ tempAbsPath' </> "genesis.spec.json"
 
   -- Now generate for real
   execCli_
     [ "genesis", "create"
     , "--testnet-magic", show @Int testnetMagic
-    , "--genesis-dir", tempAbsPath
+    , "--genesis-dir", tempAbsPath'
     , "--gen-genesis-keys", show numPraosNodes
     , "--gen-utxo-keys", show @Int (shelleyNumPoolNodes testnetOptions)
     , "--start-time", DTC.formatIso8601 startTime
     ]
 
-  forM_ allNodes $ \p -> H.createDirectoryIfMissing_ $ tempAbsPath </> p
+  forM_ allNodes $ \p -> H.createDirectoryIfMissing_ $ tempAbsPath' </> p
 
   -- Make the pool operator cold keys
   -- This was done already for the BFT nodes as part of the genesis creation
   forM_ poolNodes $ \n -> do
     execCli_
       [ "node", "key-gen"
-      , "--cold-verification-key-file", tempAbsPath </> n </> "operator.vkey"
-      , "--cold-signing-key-file", tempAbsPath </> n </> "operator.skey"
-      , "--operational-certificate-issue-counter-file", tempAbsPath </> n </> "operator.counter"
+      , "--cold-verification-key-file", tempAbsPath' </> n </> "operator.vkey"
+      , "--cold-signing-key-file", tempAbsPath' </> n </> "operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath' </> n </> "operator.counter"
       ]
 
-    cliNodeKeyGenVrf tempAbsPath $ KeyNames (n </> "vrf.vkey") (n </> "vrf.skey")
+    cliNodeKeyGenVrf tempAbsPath' $ KeyNames (n </> "vrf.vkey") (n </> "vrf.skey")
   -- Symlink the BFT operator keys from the genesis delegates, for uniformity
   forM_ praosNodesN $ \n -> do
-    H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".skey") (tempAbsPath </> "node-praos" <> n </> "operator.skey")
-    H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".vkey") (tempAbsPath </> "node-praos" <> n </> "operator.vkey")
-    H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".counter") (tempAbsPath </> "node-praos" <> n </> "operator.counter")
-    H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".vrf.vkey") (tempAbsPath </> "node-praos" <> n </> "vrf.vkey")
-    H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".vrf.skey") (tempAbsPath </> "node-praos" <> n </> "vrf.skey")
+    H.createFileLink (tempAbsPath' </> "delegate-keys/delegate" <> n <> ".skey") (tempAbsPath' </> "node-praos" <> n </> "operator.skey")
+    H.createFileLink (tempAbsPath' </> "delegate-keys/delegate" <> n <> ".vkey") (tempAbsPath' </> "node-praos" <> n </> "operator.vkey")
+    H.createFileLink (tempAbsPath' </> "delegate-keys/delegate" <> n <> ".counter") (tempAbsPath' </> "node-praos" <> n </> "operator.counter")
+    H.createFileLink (tempAbsPath' </> "delegate-keys/delegate" <> n <> ".vrf.vkey") (tempAbsPath' </> "node-praos" <> n </> "vrf.vkey")
+    H.createFileLink (tempAbsPath' </> "delegate-keys/delegate" <> n <> ".vrf.skey") (tempAbsPath' </> "node-praos" <> n </> "vrf.skey")
 
   --  Make hot keys and for all nodes
   forM_ allNodes $ \node -> do
-    _keys <- cliNodeKeyGenKes tempAbsPath $ KeyNames (node </> "key.vkey") (node </> "key.skey")
+    _keys <- cliNodeKeyGenKes tempAbsPath' $ KeyNames (node </> "key.vkey") (node </> "key.skey")
 
     execCli_
       [ "node", "issue-op-cert"
       , "--kes-period", "0"
-      , "--kes-verification-key-file", tempAbsPath </> node </> "kes.vkey"
-      , "--cold-signing-key-file", tempAbsPath </> node </> "operator.skey"
-      , "--operational-certificate-issue-counter-file", tempAbsPath </> node </> "operator.counter"
-      , "--out-file", tempAbsPath </> node </> "node.cert"
+      , "--kes-verification-key-file", tempAbsPath' </> node </> "kes.vkey"
+      , "--cold-signing-key-file", tempAbsPath' </> node </> "operator.skey"
+      , "--operational-certificate-issue-counter-file", tempAbsPath' </> node </> "operator.counter"
+      , "--out-file", tempAbsPath' </> node </> "node.cert"
       ]
 
   -- Make topology files
   forM_ allNodes $ \node -> do
     let port = fromJust $ M.lookup node nodeToPort
-    H.lbsWriteFile (tempAbsPath </> node </> "topology.json") $
+    H.lbsWriteFile (tempAbsPath' </> node </> "topology.json") $
       mkTopologyConfig numPraosNodes allPorts port (shelleyEnableP2P testnetOptions)
 
-    H.writeFile (tempAbsPath </> node </> "port") (show port)
+    H.writeFile (tempAbsPath' </> node </> "port") (show port)
 
   -- Generated node operator keys (cold, hot) and operational certs
-  forM_ allNodes $ \n -> H.noteShowM_ . H.listDirectory $ tempAbsPath </> n
+  forM_ allNodes $ \n -> H.noteShowM_ . H.listDirectory $ tempAbsPath' </> n
 
   -- Make some payment and stake addresses
   -- user1..n:       will own all the funds in the system, we'll set this up from
   --                 initial utxo the
   -- pool-owner1..n: will be the owner of the pools and we'll use their reward
   --                 account for pool rewards
-  H.createDirectoryIfMissing_ $ tempAbsPath </> "addresses"
+  H.createDirectoryIfMissing_ $ tempAbsPath' </> "addresses"
 
   forM_ addrs $ \addr -> do
     -- Payment address keys
-    _address <- cliAddressKeyGen tempAbsPath $ KeyNames ("addresses" </> addr <> ".vkey") ("addresses" </> addr <> ".skey")
+    _address <- cliAddressKeyGen tempAbsPath' $ KeyNames ("addresses" </> addr <> ".vkey") ("addresses" </> addr <> ".skey")
 
     -- Stake address keys
-    _stakeAddress <- cliStakeAddressKeyGen tempAbsPath
+    _stakeAddress <- cliStakeAddressKeyGen tempAbsPath'
       $ KeyNames
           ("addresses" </> addr <> "-stake.vkey")
           ("addresses" </> addr <> "-stake.skey")
@@ -273,42 +271,42 @@ shelleyTestnet testnetOptions H.Conf {..} = do
     -- Payment addresses
     execCli_
       [ "address", "build"
-      , "--payment-verification-key-file", tempAbsPath </> "addresses/" <> addr <> ".vkey"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
+      , "--payment-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> ".vkey"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
       , "--testnet-magic", show @Int testnetMagic
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> ".addr"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> ".addr"
       ]
 
     -- Stake addresses
     execCli_
       [ "stake-address", "build"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
       , "--testnet-magic", show @Int testnetMagic
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> "-stake.addr"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.addr"
       ]
 
     -- Stake addresses registration certs
     execCli_
       [ "stake-address", "registration-certificate"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--out-file", tempAbsPath </> "addresses/" <> addr <> "-stake.reg.cert"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.vkey"
+      , "--out-file", tempAbsPath' </> "addresses/" <> addr <> "-stake.reg.cert"
       ]
 
   forM_ userPoolN $ \n -> do
     -- Stake address delegation certs
     execCli_
       [ "stake-address", "delegation-certificate"
-      , "--stake-verification-key-file", tempAbsPath </> "addresses/user" <> n <> "-stake.vkey"
-      , "--cold-verification-key-file", tempAbsPath </> "node-pool" <> n </> "operator.vkey"
-      , "--out-file", tempAbsPath </> "addresses/user" <> n <> "-stake.deleg.cert"
+      , "--stake-verification-key-file", tempAbsPath' </> "addresses/user" <> n <> "-stake.vkey"
+      , "--cold-verification-key-file", tempAbsPath' </> "node-pool" <> n </> "operator.vkey"
+      , "--out-file", tempAbsPath' </> "addresses/user" <> n <> "-stake.deleg.cert"
       ]
 
-    H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> n <> "-stake.vkey") (tempAbsPath </> "node-pool" <> n </> "owner.vkey")
-    H.createFileLink (tempAbsPath </> "addresses/pool-owner" <> n <> "-stake.skey") (tempAbsPath </> "node-pool" <> n </> "owner.skey")
+    H.createFileLink (tempAbsPath' </> "addresses/pool-owner" <> n <> "-stake.vkey") (tempAbsPath' </> "node-pool" <> n </> "owner.vkey")
+    H.createFileLink (tempAbsPath' </> "addresses/pool-owner" <> n <> "-stake.skey") (tempAbsPath' </> "node-pool" <> n </> "owner.skey")
 
   -- Generated payment address keys, stake address keys,
   -- stake address registration certs, and stake address delegation certs
-  H.noteShowM_ . H.listDirectory $ tempAbsPath </> "addresses"
+  H.noteShowM_ . H.listDirectory $ tempAbsPath' </> "addresses"
 
   -- Next is to make the stake pool registration cert
   forM_ poolNodes $ \node -> do
@@ -318,15 +316,15 @@ shelleyTestnet testnetOptions H.Conf {..} = do
       , "--pool-pledge", "0"
       , "--pool-cost", "0"
       , "--pool-margin", "0"
-      , "--cold-verification-key-file", tempAbsPath </> node </> "operator.vkey"
-      , "--vrf-verification-key-file", tempAbsPath </> node </> "vrf.vkey"
-      , "--reward-account-verification-key-file", tempAbsPath </> node </> "owner.vkey"
-      , "--pool-owner-stake-verification-key-file", tempAbsPath </> node </> "owner.vkey"
-      , "--out-file", tempAbsPath </> node </> "registration.cert"
+      , "--cold-verification-key-file", tempAbsPath' </> node </> "operator.vkey"
+      , "--vrf-verification-key-file", tempAbsPath' </> node </> "vrf.vkey"
+      , "--reward-account-verification-key-file", tempAbsPath' </> node </> "owner.vkey"
+      , "--pool-owner-stake-verification-key-file", tempAbsPath' </> node </> "owner.vkey"
+      , "--out-file", tempAbsPath' </> node </> "registration.cert"
       ]
 
   -- Generated stake pool registration certs:
-  forM_ poolNodes $ \node -> H.assertIO . IO.doesFileExist $ tempAbsPath </> node </> "registration.cert"
+  forM_ poolNodes $ \node -> H.assertIO . IO.doesFileExist $ tempAbsPath' </> node </> "registration.cert"
 
   -- Now we'll construct one whopper of a transaction that does everything
   -- just to show off that we can, and to make the script shorter
@@ -339,10 +337,10 @@ shelleyTestnet testnetOptions H.Conf {..} = do
     --  3. register the usern stake address
     --  4. delegate from the usern stake address to the stake pool
     genesisTxinResult
-      <- H.noteShowM $ S.strip <$> createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath </> "utxo-keys/utxo" <> n <> ".vkey")
+      <- H.noteShowM $ S.strip <$> createShelleyGenesisInitialTxIn testnetMagic (tempAbsPath' </> "utxo-keys/utxo" <> n <> ".vkey")
 
 
-    userNAddr <- H.readFile $ tempAbsPath </> "addresses/user" <> n <> ".addr"
+    userNAddr <- H.readFile $ tempAbsPath' </> "addresses/user" <> n <> ".addr"
 
     execCli_
       [ "transaction", "build-raw"
@@ -350,11 +348,11 @@ shelleyTestnet testnetOptions H.Conf {..} = do
       , "--fee", "0"
       , "--tx-in", genesisTxinResult
       , "--tx-out", userNAddr <> "+" <> show @Word64 (shelleyMaxLovelaceSupply testnetOptions)
-      , "--certificate-file", tempAbsPath </> "addresses/pool-owner" <> n <> "-stake.reg.cert"
-      , "--certificate-file", tempAbsPath </> "node-pool" <> n <> "/registration.cert"
-      , "--certificate-file", tempAbsPath </> "addresses/user" <> n <> "-stake.reg.cert"
-      , "--certificate-file", tempAbsPath </> "addresses/user" <> n <> "-stake.deleg.cert"
-      , "--out-file", tempAbsPath </> "tx" <> n <> ".txbody"
+      , "--certificate-file", tempAbsPath' </> "addresses/pool-owner" <> n <> "-stake.reg.cert"
+      , "--certificate-file", tempAbsPath' </> "node-pool" <> n <> "/registration.cert"
+      , "--certificate-file", tempAbsPath' </> "addresses/user" <> n <> "-stake.reg.cert"
+      , "--certificate-file", tempAbsPath' </> "addresses/user" <> n <> "-stake.deleg.cert"
+      , "--out-file", tempAbsPath' </> "tx" <> n <> ".txbody"
       ]
 
     -- So we'll need to sign this with a bunch of keys:
@@ -365,43 +363,42 @@ shelleyTestnet testnetOptions H.Conf {..} = do
 
     execCli_
       [ "transaction", "sign"
-      , "--signing-key-file", tempAbsPath </> "utxo-keys/utxo" <> n <> ".skey"
-      , "--signing-key-file", tempAbsPath </> "addresses/user" <> n <> "-stake.skey"
-      , "--signing-key-file", tempAbsPath </> "node-pool" <> n <> "/owner.skey"
-      , "--signing-key-file", tempAbsPath </> "node-pool" <> n <> "/operator.skey"
+      , "--signing-key-file", tempAbsPath' </> "utxo-keys/utxo" <> n <> ".skey"
+      , "--signing-key-file", tempAbsPath' </> "addresses/user" <> n <> "-stake.skey"
+      , "--signing-key-file", tempAbsPath' </> "node-pool" <> n <> "/owner.skey"
+      , "--signing-key-file", tempAbsPath' </> "node-pool" <> n <> "/operator.skey"
       , "--testnet-magic", show @Int testnetMagic
-      , "--tx-body-file", tempAbsPath </> "tx" <> n <> ".txbody"
-      , "--out-file", tempAbsPath </> "tx" <> n <> ".tx"
+      , "--tx-body-file", tempAbsPath' </> "tx" <> n <> ".txbody"
+      , "--out-file", tempAbsPath' </> "tx" <> n <> ".tx"
       ]
 
     -- Generated a signed 'do it all' transaction:
-    H.assertIO . IO.doesFileExist $ tempAbsPath </> "tx" <> n <> ".tx"
+    H.assertIO . IO.doesFileExist $ tempAbsPath' </> "tx" <> n <> ".tx"
 
   --------------------------------
   -- Launch cluster of three nodes
-  H.evalIO $ LBS.writeFile (tempAbsPath </> "configuration.yaml") $ J.encode defaultShelleyOnlyYamlConfig
-
+  H.evalIO $ LBS.writeFile (tempAbsPath' </> "configuration.yaml") $ J.encode defaultShelleyOnlyYamlConfig
 
   allNodeRuntimes <- forM allNodes
-     $ \node -> startNode tempBaseAbsPath tempAbsPath logDir socketDir node
+     $ \node -> startNode (TmpAbsolutePath tempAbsPath') node
         [ "run"
-        , "--config", tempAbsPath </> "configuration.yaml"
-        , "--topology", tempAbsPath </> node </> "topology.json"
-        , "--database-path", tempAbsPath </> node </> "db"
-        , "--shelley-kes-key", tempAbsPath </> node </> "kes.skey"
-        , "--shelley-vrf-key", tempAbsPath </> node </> "vrf.skey"
-        , "--shelley-operational-certificate" , tempAbsPath </> node </> "node.cert"
+        , "--config", tempAbsPath' </> "configuration.yaml"
+        , "--topology", tempAbsPath' </> node </> "topology.json"
+        , "--database-path", tempAbsPath' </> node </> "db"
+        , "--shelley-kes-key", tempAbsPath' </> node </> "kes.skey"
+        , "--shelley-vrf-key", tempAbsPath' </> node </> "vrf.skey"
+        , "--shelley-operational-certificate" , tempAbsPath' </> node </> "node.cert"
         , "--host-addr", ifaceAddress
         ]
-
   now <- H.noteShowIO DTC.getCurrentTime
   deadline <- H.noteShow $ DTC.addUTCTime 90 now
 
   forM_ allNodes $ \node -> do
-    sprocket <- H.noteShow $ Sprocket tempBaseAbsPath (socketDir </> node)
+    sprocket <- H.noteShow $ makeSprocket (TmpAbsolutePath tempAbsPath') node
     _spocketSystemNameFile <- H.noteShow $ IO.sprocketSystemName sprocket
     H.byDeadlineM 10 deadline "Failed to connect to node socket" $ H.assertM $ H.doesSprocketExist sprocket
 
+  let logDir = makeLogDir (TmpAbsolutePath tempAbsPath')
   forM_ allNodes $ \node -> do
     nodeStdoutFile <- H.noteTempFile logDir $ node <> ".stdout.log"
     H.assertByDeadlineIOCustom "stdout does not contain \"until genesis start time\"" deadline $ IO.fileContains "until genesis start time at" nodeStdoutFile
@@ -411,7 +408,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
 
   return TestnetRuntime
     { configurationFile = alonzoSpecFile
-    , shelleyGenesisFile = tempAbsPath </> "genesis/shelley/genesis.json"
+    , shelleyGenesisFile = tempAbsPath' </> "genesis/shelley/genesis.json"
     , testnetMagic
     , poolNodes = [ ]
     , wallets = [ ]

--- a/cardano-testnet/test/cardano-testnet-test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -44,12 +44,12 @@ import           Testnet.Util.Runtime
 hprop_leadershipSchedule :: Property
 hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-schedule" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
-    mkConf Nothing tempAbsBasePath' Nothing
-
-  work <- H.createDirectoryIfMissing $ tempAbsPath </> "work"
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf Nothing tempAbsBasePath' Nothing
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
   let
+    tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
     testnetOptions = BabbageOnlyTestnetOptions $ babbageDefaultTestnetOptions
       { babbageNodeLoggingFormat = NodeLoggingFormatAsJson
       }
@@ -93,7 +93,7 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   let poolVrfSkey = poolNodeKeysVrfSkey $ poolKeys poolNode1
 
   id do
-    scheduleFile <- H.noteTempFile tempAbsPath "schedule.log"
+    scheduleFile <- H.noteTempFile tempAbsPath' "schedule.log"
 
     leadershipScheduleDeadline <- H.noteShowM $ DTC.addUTCTime 180 <$> H.noteShowIO DTC.getCurrentTime
 
@@ -141,7 +141,7 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
     H.assert $ L.null (expectedLeadershipSlotNumbers \\ leaderSlots)
 
   id do
-    scheduleFile <- H.noteTempFile tempAbsPath "schedule.log"
+    scheduleFile <- H.noteTempFile tempAbsPath' "schedule.log"
 
     leadershipScheduleDeadline <- H.noteShowM $ DTC.addUTCTime 180 <$> H.noteShowIO DTC.getCurrentTime
 

--- a/cardano-testnet/test/cardano-testnet-test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -43,12 +43,12 @@ import           Testnet.Util.Runtime
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
-    mkConf Nothing tempAbsBasePath' Nothing
-
-  work <- H.createDirectoryIfMissing $ tempAbsPath </> "work"
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf Nothing tempAbsBasePath' Nothing
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
   let
+    tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
     testnetOptions = BabbageOnlyTestnetOptions $ babbageDefaultTestnetOptions
       { babbageNodeLoggingFormat = NodeLoggingFormatAsJson
       }

--- a/cardano-testnet/test/cardano-testnet-test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Test/FoldBlocks.hs
@@ -39,7 +39,8 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
   -- Start testnet
   conf <- HE.noteShowM $ TN.mkConf Nothing (tempAbsBasePath' <> "/") Nothing
 
-  let options = CardanoOnlyTestnetOptions $ cardanoDefaultTestnetOptions
+  let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
+      options = CardanoOnlyTestnetOptions $ cardanoDefaultTestnetOptions
         -- NB! The `activeSlotsCoeff` value is very important for
         -- chain extension for the two-node/one-pool testnet that
         -- `defaultTestnetOptions` define. The default 0.2 often fails
@@ -51,9 +52,9 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
   -- Get socketPath
   socketPathAbs <- do
     socketPath' <- HE.sprocketArgumentName <$> HE.headM (nodeSprocket <$> bftNodes runtime)
-    H.noteIO (IO.canonicalizePath $ tempAbsPath conf </> socketPath')
+    H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
 
-  configFile <- H.noteShow $ tempAbsPath conf </> "configuration.yaml"
+  configFile <- H.noteShow $ tempAbsPath' </> "configuration.yaml"
 
   -- Start foldBlocks in a separate thread
   lock <- H.evalIO IO.newEmptyMVar


### PR DESCRIPTION
- The following fields of `Conf`: `tempRelPath`, `tempBaseAbsPath`, `logDir` aand`socketDir` are all derived from the temporary absolute path. We can simplify `Conf` if we provide helper functions that derive the above paths.
- Taken from #4845 
- Resolves: #5293
