### PR TITLE
Concurrency for build job

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -25,8 +25,29 @@ jobs:
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
     
+    concurrency:
+      group: >
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
 
     steps:
+    - name: Concurrency group
+      run: >
+        echo
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
+
     - name: Workaround runner image issue
       # https://github.com/actions/runner-images/issues/7061
       run: sudo chown -R $USER /usr/local/.ghcup

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,7 +25,29 @@ jobs:
       # current ref from: 27.02.2022
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
+    concurrency:
+      group: >
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+
     steps:
+    - name: Concurrency group
+      run: >
+        echo
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
+
     - name: Install Haskell
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell


### PR DESCRIPTION
Concurrency will cancel jobs that are obsolete because they have been superseded by a new job, for example if a new commit was pushed to a branch that has a pull request.

In order for this to work properly, the "concurrency group" needs to be defined correctly for the job.

This PR defines the "concurrency group" thus:

```
a+${{ github.event_name }}
b+${{ github.workflow_ref }}
c+${{ github.job }}
d+${{ matrix.ghc }}
e+${{ matrix.cabal }}
f+${{ matrix.os }}
g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
```

The `<letter>+` prefix makes it easy to line up with debugging in the build output.

An example concurrency group looks like this:

```
a+push
b+input-output-hk/cardano-node/.github/workflows/haskell-linux.yml@refs/heads/newhoggy/concurrency-for-build-job
c+linux_ci
d+8.10.7
e+3.8.1.0
f+ubuntu-latest
g+refs/heads/newhoggy/concurrency-for-build-job
```

These were carefully chosen so that within the same PR request, old jobs are cancelled, but when jobs are created in the job queue, those jobs never get cancelled, because they always get a unique concurrency group.