### PR TITLE
Use Haskell variables for passing values.

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -67,6 +67,7 @@ library
                         Testnet.Byron
                         Testnet.Util.Assert
                         Testnet.Util.Base
+                        Testnet.Util.Cli
                         Testnet.Util.Ignore
                         Testnet.Util.Process
                         Testnet.Util.Runtime

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -57,6 +57,7 @@ import qualified System.Info as OS
 import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
 import qualified Testnet.Util.Base as H
+import           Testnet.Util.Cli
 import qualified Testnet.Util.Process as H
 import           Testnet.Util.Process (execCli_)
 import           Testnet.Util.Runtime hiding (allNodes)
@@ -227,11 +228,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
       , "--operational-certificate-issue-counter-file", tempAbsPath </> n </> "operator.counter"
       ]
 
-    execCli_
-      [ "node", "key-gen-VRF"
-      , "--verification-key-file", tempAbsPath </> n </> "vrf.vkey"
-      , "--signing-key-file", tempAbsPath </> n </> "vrf.skey"
-      ]
+    cliNodeKeyGenVrf tempAbsPath $ KeyNames (n </> "vrf.vkey") (n </> "vrf.skey")
   -- Symlink the BFT operator keys from the genesis delegates, for uniformity
   forM_ praosNodesN $ \n -> do
     H.createFileLink (tempAbsPath </> "delegate-keys/delegate" <> n <> ".skey") (tempAbsPath </> "node-praos" <> n </> "operator.skey")
@@ -242,11 +239,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
 
   --  Make hot keys and for all nodes
   forM_ allNodes $ \node -> do
-    execCli_
-      [ "node", "key-gen-KES"
-      , "--verification-key-file", tempAbsPath </> node </> "kes.vkey"
-      , "--signing-key-file", tempAbsPath </> node </> "kes.skey"
-      ]
+    _keys <- cliNodeKeyGenKes tempAbsPath $ KeyNames (node </> "key.vkey") (node </> "key.skey")
 
     execCli_
       [ "node", "issue-op-cert"
@@ -277,18 +270,13 @@ shelleyTestnet testnetOptions H.Conf {..} = do
 
   forM_ addrs $ \addr -> do
     -- Payment address keys
-    execCli_
-      [ "address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "addresses/" <> addr <> ".vkey"
-      , "--signing-key-file", tempAbsPath </> "addresses/" <> addr <> ".skey"
-      ]
+    _address <- cliAddressKeyGen tempAbsPath $ KeyNames ("addresses" </> addr <> ".vkey") ("addresses" </> addr <> ".skey")
 
     -- Stake address keys
-    execCli_
-      [ "stake-address", "key-gen"
-      , "--verification-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.vkey"
-      , "--signing-key-file", tempAbsPath </> "addresses/" <> addr <> "-stake.skey"
-      ]
+    _stakeAddress <- cliStakeAddressKeyGen tempAbsPath
+      $ KeyNames
+          ("addresses" </> addr <> "-stake.vkey")
+          ("addresses" </> addr <> "-stake.skey")
 
     -- Payment addresses
     execCli_

--- a/cardano-testnet/src/Testnet/Util/Cli.hs
+++ b/cardano-testnet/src/Testnet/Util/Cli.hs
@@ -1,0 +1,138 @@
+module Testnet.Util.Cli
+  ( cliAddressKeyGen
+  , cliNodeKeyGen
+  , cliNodeKeyGenVrf
+  , cliNodeKeyGenKes
+  , cliStakeAddressKeyGen
+  , KeyGen
+  , KeyNames (..)
+
+  , File (..)
+
+  , VKey
+  , SKey
+
+  , OperatorCounter
+
+  , ByronDelegationKey
+  , ByronDelegationCert
+
+  , getVKeyPath
+  , getSKeyPath
+
+  , cliKeyGen
+
+  , cliByronSigningKeyAddress
+  ) where
+
+import           System.FilePath.Posix
+
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H (writeFile)
+
+import           Cardano.Api (ByronAddr, ByronKeyLegacy, PaymentKey, StakeKey)
+import           Cardano.Api.Shelley (KesKey, StakePoolKey, VrfKey)
+
+import           Testnet.Util.Process
+
+data KeyNames = KeyNames
+  { verificationKeyFile :: FilePath
+  , signingKeyFile :: FilePath
+  }
+
+type KeyGen a = (File (VKey a), File (SKey a))
+
+cliAddressKeyGen :: TmpDir -> KeyNames -> H.Integration (KeyGen PaymentKey)
+cliAddressKeyGen = shelleyKeyGen "address" "key-gen"
+
+cliStakeAddressKeyGen :: TmpDir -> KeyNames -> H.Integration (KeyGen StakeKey)
+cliStakeAddressKeyGen = shelleyKeyGen "stake-address" "key-gen"
+
+cliNodeKeyGenVrf :: TmpDir -> KeyNames -> H.Integration (KeyGen VrfKey)
+cliNodeKeyGenVrf = shelleyKeyGen "node" "key-gen-VRF"
+
+cliNodeKeyGenKes :: TmpDir -> KeyNames -> H.Integration (KeyGen KesKey)
+cliNodeKeyGenKes = shelleyKeyGen "node" "key-gen-KES"
+
+shelleyKeyGen :: String -> String -> TmpDir -> KeyNames -> H.Integration (KeyGen x)
+shelleyKeyGen command subCommand tmpDir keyNames = do
+  let
+    vKeyPath = tmpDir </> verificationKeyFile keyNames
+    sKeyPath = tmpDir </> signingKeyFile keyNames
+  execCli_
+      [ command, subCommand
+      , "--verification-key-file", vKeyPath
+      , "--signing-key-file", sKeyPath
+      ]
+  return (File vKeyPath, File sKeyPath)
+
+cliNodeKeyGen
+  :: TmpDir
+  -> FilePath
+  -> FilePath
+  -> FilePath
+  -> H.Integration (File (VKey StakePoolKey), File (SKey StakePoolKey), File OperatorCounter)
+cliNodeKeyGen tmpDir vkey skey counter = do
+  let
+    vkPath = tmpDir </> vkey
+    skPath = tmpDir </> skey
+    counterPath = tmpDir </> counter
+  execCli_
+    [ "node", "key-gen"
+    , "--cold-verification-key-file", vkPath
+    , "--cold-signing-key-file", skPath
+    , "--operational-certificate-issue-counter-file", counterPath
+    ]
+  return (File vkPath, File skPath, File counterPath)
+
+-- | Verification keys
+data VKey a
+
+-- | Signing keys
+data SKey a
+
+-- | The 'OperatorCounter'
+data OperatorCounter
+
+-- | Tag a 'File' that holds a 'ByronDelegationKey'.
+data ByronDelegationKey
+
+-- | Tag a 'File' that holds a 'ByronDelegationKey'.
+data ByronDelegationCert
+
+type TmpDir = FilePath
+
+newtype File a = File {unFile :: FilePath}
+  deriving (Show, Eq)
+
+getVKeyPath ::  (File (VKey a), File (SKey a)) -> FilePath
+getVKeyPath = unFile . fst
+
+getSKeyPath ::  (File (VKey a), File (SKey a)) -> FilePath
+getSKeyPath = unFile . snd
+
+-- Byron
+cliKeyGen :: TmpDir -> FilePath -> H.Integration (File ByronKeyLegacy)
+cliKeyGen tmp key = do
+  let keyPath = tmp </> key
+  execCli_
+      [ "keygen"
+      , "--secret", keyPath
+      ]
+  return $ File keyPath
+
+cliByronSigningKeyAddress
+  :: TmpDir
+  -> Int
+  -> File ByronKeyLegacy
+  -> FilePath
+  -> H.Integration (File ByronAddr)
+cliByronSigningKeyAddress tmp testnetMagic (File key) destPath = do
+  let addrPath = tmp </> destPath
+  addr <- execCli
+      [ "signing-key-address"
+      , "--testnet-magic", show testnetMagic
+      , "--secret", tmp </> key
+      ]
+  H.writeFile addrPath addr
+  return $ File addrPath


### PR DESCRIPTION
Currently the `cardano-testnet` uses filenames (Strings) to reference objects like keys, certs etc.
Two locations in the code refer to the same object by using the same filename.
This means that the data flow is implicit and hard to follow.
Old scheme:
```
do
cli_call_1 "filenameX" "filenameY"
cli_call_2 "filenameX" "filenameZ"
cli_call_3 "filenameA" "filenameB"
```
This PR changes the design as follows:
* File names are stored in an opaque `File` datatype (which wraps the file path).
* A wrapper is used for CLI calls. When a CLI call creates a file, the wrapper returns the corresponding `File` resource.
* While CLI calls have type `IO ()` the wrapper has type `IO (File,..,File).
* CLI calls don't construct Filenames (i.e. as magic constants) , but instead use the `File` resource that was created earlier.

The new scheme is
```
do
(file1, file2) <- cli_call1 arg1 arg2     -- cli_call1 creates file resources file1 and file2
(fileX, fileY) <- cli_call2 file1 file2    -- cli_call2 uses file resourcs file1 and file2
```
Full transformation to the new scheme for filenames is still WIP.
