### PR TITLE
New File type that tracks whether the file is an input or output file or both

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -41,6 +41,7 @@ import           Cardano.Api (BlockType (..), ConsensusModeParams (..), EpochSlo
                    LocalNodeConnectInfo (..), NetworkId (..), PaymentKey, SigningKey, TxInMode,
                    TxValidationErrorInMode, protocolInfo, submitTxToNodeLocal)
 import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesis)
+import           Cardano.Node.Types (File (..))
 
 type CardanoBlock = Consensus.CardanoBlock StandardCrypto
 
@@ -65,6 +66,6 @@ makeLocalConnectInfo networkId sock
   = LocalNodeConnectInfo
       (CardanoModeParams (EpochSlots 21600))
       networkId
-      sock
+      (File sock)
 
 type LocalSubmitTx = (TxInMode CardanoMode -> IO (SubmitResult (TxValidationErrorInMode CardanoMode)))

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -1,5 +1,4 @@
-{- HLINT ignore "Reduce duplication" -}
-{- HLINT ignore "Use uncurry" -}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -12,6 +11,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use uncurry" -}
 
 module Cardano.Benchmarking.Script.Core
 where
@@ -88,7 +90,7 @@ setProtocolParameters s = case s of
     protocolParameters <- liftIO $ readProtocolParametersFile file
     setProtoParamMode $ ProtocolParameterLocal protocolParameters
 
-readSigningKey :: String -> SigningKeyFile -> ActionM ()
+readSigningKey :: String -> SigningKeyFile 'In -> ActionM ()
 readSigningKey name filePath =
   liftIO (readSigningKeyFile filePath) >>= \case
     Left err -> liftTxGenError err

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -50,7 +51,7 @@ data Action where
   InitWallet         :: !String -> Action
   StartProtocol      :: !FilePath -> !(Maybe FilePath) -> Action
   Delay              :: !Double -> Action
-  ReadSigningKey     :: !String -> !SigningKeyFile -> Action
+  ReadSigningKey     :: !String -> !(SigningKeyFile 'In) -> Action
   DefineSigningKey   :: !String -> !(SigningKey PaymentKey) -> Action
   AddFund            :: !AnyCardanoEra -> !String -> !TxIn -> !Lovelace -> !String -> Action
   WaitBenchmark      :: !String -> Action

--- a/bench/tx-generator/src/Cardano/TxGenerator/Internal/Orphans.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Internal/Orphans.hs
@@ -9,15 +9,15 @@ import           Data.Aeson
 
 import qualified Ouroboros.Network.Magic as Ouroboros (NetworkMagic (..))
 
-import           Cardano.Api (NetworkId (..))
+import           Cardano.Api (File (..), NetworkId (..))
 import           Cardano.CLI.Types (SigningKeyFile (..))
 
 
-instance ToJSON SigningKeyFile where
- toJSON (SigningKeyFile a) = toJSON a
+instance ToJSON (SigningKeyFile direction) where
+ toJSON (SigningKeyFile (File a)) = toJSON a
 
-instance FromJSON SigningKeyFile where
-  parseJSON a = SigningKeyFile <$> parseJSON a
+instance FromJSON (SigningKeyFile direction) where
+  parseJSON a = SigningKeyFile . File <$> parseJSON a
 
 
 instance ToJSON NetworkId where

--- a/bench/tx-generator/src/Cardano/TxGenerator/Internal/Orphans.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Internal/Orphans.hs
@@ -9,15 +9,7 @@ import           Data.Aeson
 
 import qualified Ouroboros.Network.Magic as Ouroboros (NetworkMagic (..))
 
-import           Cardano.Api (File (..), NetworkId (..))
-import           Cardano.CLI.Types (SigningKeyFile (..))
-
-
-instance ToJSON (SigningKeyFile direction) where
- toJSON (SigningKeyFile (File a)) = toJSON a
-
-instance FromJSON (SigningKeyFile direction) where
-  parseJSON a = SigningKeyFile . File <$> parseJSON a
+import           Cardano.Api (NetworkId (..))
 
 
 instance ToJSON NetworkId where

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -23,7 +24,7 @@ import           Cardano.CLI.Types (SigningKeyFile (..))
 import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
 import           Cardano.Node.Types (AdjustFilePaths (..))
 
-import           Cardano.Api (AnyCardanoEra, Lovelace)
+import           Cardano.Api (AnyCardanoEra, FileDirection (..), Lovelace, MapFile (..))
 import           Cardano.TxGenerator.Internal.Orphans ()
 import           Cardano.TxGenerator.Types
 
@@ -42,7 +43,7 @@ data NixServiceOptions = NixServiceOptions {
   , _nix_plutus           :: Maybe TxGenPlutusParams
   , _nix_nodeConfigFile       :: Maybe FilePath
   , _nix_cardanoTracerSocket  :: Maybe FilePath
-  , _nix_sigKey               :: SigningKeyFile
+  , _nix_sigKey               :: SigningKeyFile 'In
   , _nix_localNodeSocketPath  :: String
   , _nix_targetNodes          :: NonEmpty NodeIPv4Address
   } deriving (Show, Eq)
@@ -70,7 +71,7 @@ instance AdjustFilePaths NixServiceOptions where
   adjustFilePaths f opts
     = opts {
       _nix_nodeConfigFile = f <$> _nix_nodeConfigFile opts
-    , _nix_sigKey = SigningKeyFile . f . unSigningKeyFile $ _nix_sigKey opts
+    , _nix_sigKey = mapFile f $ _nix_sigKey opts
     }
 
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
@@ -19,7 +19,7 @@ import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Handlers.Shutdown (ShutdownConfig (..))
 import           Cardano.Node.Protocol.Cardano
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
-import           Cardano.Node.Types (ConfigYamlFilePath (..), GenesisFile,
+import           Cardano.Node.Types (ConfigYamlFilePath (..), File (..), GenesisFile,
                    NodeProtocolConfiguration (..), NodeShelleyProtocolConfiguration (..),
                    ProtocolFilepaths (..))
 import           Cardano.TxGenerator.Types
@@ -63,7 +63,7 @@ mkNodeConfig configFp_
         $ first (TxGenError . ("mkNodeConfig: " ++))
         $! makeNodeConfiguration (configYamlPc <> filesPc)
   where
-    configFp = ConfigYamlFilePath configFp_
+    configFp = ConfigYamlFilePath $ File configFp_
 
     filesPc :: PartialNodeConfiguration
     filesPc = defaultPartialNodeConfiguration

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/SigningKey.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/SigningKey.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This module provides convenience functions when dealing with signing keys.
@@ -37,7 +38,7 @@ parseSigningKeyBase16 k
         , teRawCBOR = addr
         }
 
-readSigningKeyFile :: SigningKeyFile -> IO (Either TxGenError (SigningKey PaymentKey))
+readSigningKeyFile :: SigningKeyFile 'In -> IO (Either TxGenError (SigningKey PaymentKey))
 readSigningKeyFile (SigningKeyFile f)
   = first ApiError <$> readFileTextEnvelopeAnyOf acceptedTypes f
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library
                         Cardano.Api.Error
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
+                        Cardano.Api.IO
                         Cardano.Api.GenesisParameters
                         Cardano.Api.Hash
                         Cardano.Api.HasTypeProxy

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -84,6 +84,7 @@ library
                         Cardano.Api.LedgerState
                         Cardano.Api.Modes
                         Cardano.Api.NetworkId
+                        Cardano.Api.Options
                         Cardano.Api.OperationalCertificate
                         Cardano.Api.Protocol
                         Cardano.Api.ProtocolParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -771,7 +771,6 @@ module Cardano.Api (
     chainPointToSlotNo,
     chainPointToHeaderHash,
     makeChainTip,
-    parseFilePath,
     writeSecrets,
 
     -- ** Cast functions
@@ -803,6 +802,14 @@ module Cardano.Api (
 
     -- ** CLI option parsing
     bounded,
+    fileOption,
+    inFileOption,
+    outFileOption,
+    parseFile,
+    parseFileIn,
+    parseFilePath,
+    parseFileOut,
+    parseDirectory,
   ) where
 
 import           Cardano.Api.Address
@@ -833,6 +840,7 @@ import           Cardano.Api.LedgerState
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
+import           Cardano.Api.Options
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query hiding (LedgerState (..))
@@ -851,3 +859,4 @@ import           Cardano.Api.TxMetadata
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
 import           Cardano.Api.ValueParser
+

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -41,8 +41,6 @@ module Cardano.Api (
     Directory(..),
     FileDirection(..),
 
-    OutputFile(..),
-
     writeByteStringFileWithOwnerPermissions,
     writeByteStringFile,
     writeByteStringOutput,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -35,6 +35,12 @@ module Cardano.Api (
     shelleyBasedToCardanoEra,
 
     -- ** IO
+    File(..),
+    MapFile(..),
+    HasFileMode(..),
+    Directory(..),
+    FileDirection(..),
+
     OutputFile(..),
 
     writeByteStringFileWithOwnerPermissions,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -37,9 +37,11 @@ module Cardano.Api (
     -- ** IO
     File(..),
     MapFile(..),
-    HasFileMode(..),
     Directory(..),
     FileDirection(..),
+
+    toFileIn,
+    toFileOut,
 
     writeByteStringFileWithOwnerPermissions,
     writeByteStringFile,
@@ -808,6 +810,13 @@ module Cardano.Api (
     parseFilePath,
     parseFileOut,
     parseDirectory,
+
+    toGenesisFileIn,
+    toGenesisFileOut,
+    toNetworkConfigFileIn,
+    toNetworkConfigFileOut,
+    toNodeConfigIn,
+    toNodeConfigOut,
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -22,9 +22,11 @@ module Cardano.Api.IO
 
   , File(..)
   , MapFile(..)
-  , HasFileMode(..)
   , Directory(..)
   , FileDirection(..)
+
+  , toFileIn
+  , toFileOut
   ) where
 
 #if !defined(mingw32_HOST_OS)
@@ -52,7 +54,6 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy as LBSC
-import           Data.Kind (Type)
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
@@ -60,6 +61,7 @@ import qualified System.IO as IO
 import           System.IO (Handle)
 
 import           Cardano.Api.Error (FileError (..))
+import           Data.Coerce (coerce)
 
 data FileDirection
   = In
@@ -184,13 +186,8 @@ class MapFile a where
 instance MapFile (File direction) where
   mapFile f = File . f . unFile
 
-class HasFileMode (f :: FileDirection -> Type) where
-  usingIn :: f 'InOut -> f 'In
-  usingOut :: f 'InOut -> f 'Out
+toFileIn :: File 'InOut -> File 'In
+toFileIn = coerce
 
-instance HasFileMode File where
-  usingIn :: File 'InOut -> File 'In
-  usingIn = File . unFile
-
-  usingOut :: File 'InOut -> File 'Out
-  usingOut = File . unFile
+toFileOut :: File 'InOut -> File 'Out
+toFileOut = coerce

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -8,9 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Api.IO
-  ( OutputFile(..)
-
-  , writeByteStringFileWithOwnerPermissions
+  ( writeByteStringFileWithOwnerPermissions
   , writeByteStringFile
   , writeByteStringOutput
 
@@ -58,7 +56,6 @@ import           Data.Kind (Type)
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
-import           GHC.Generics (Generic)
 import qualified System.IO as IO
 import           System.IO (Handle)
 
@@ -82,12 +79,6 @@ newtype File (direction :: FileDirection) = File
 newtype Directory = Directory
   { unDirectory :: FilePath
   } deriving newtype (Eq, Ord, Show, IsString, FromJSON, ToJSON)
-
-newtype OutputFile = OutputFile
-  { unOutputFile :: FilePath
-  }
-  deriving Generic
-  deriving newtype (Eq, Ord, Show, IsString, ToJSON, FromJSON)
 
 handleFileForWritingWithOwnerPermission
   :: File 'Out

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -129,6 +129,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 import           Cardano.Api.Block
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.InMode
+import           Cardano.Api.IO (File (..), FileDirection (..))
 import           Cardano.Api.IPC.Version
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
@@ -185,7 +186,7 @@ data LocalNodeConnectInfo mode =
      LocalNodeConnectInfo {
        localConsensusModeParams :: ConsensusModeParams mode,
        localNodeNetworkId       :: NetworkId,
-       localNodeSocketPath      :: FilePath
+       localNodeSocketPath      :: File 'InOut
      }
 
 localConsensusMode :: LocalNodeConnectInfo mode -> ConsensusMode mode
@@ -232,7 +233,7 @@ connectToLocalNodeWithVersion LocalNodeConnectInfo {
           Net.nctHandshakeTracer = nullTracer
         }
         versionedProtocls
-        localNodeSocketPath
+        (unFile localNodeSocketPath)
   where
     versionedProtocls =
       -- First convert from the mode-parametrised view of things to the

--- a/cardano-api/src/Cardano/Api/Keys/Read.hs
+++ b/cardano-api/src/Cardano/Api/Keys/Read.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
@@ -17,6 +18,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.IO (File (..), FileDirection (..))
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.Utils
@@ -28,17 +30,17 @@ import           Cardano.Api.Utils
 readKeyFile
   :: AsType a
   -> NonEmpty (InputFormat a)
-  -> FilePath
+  -> File 'In
   -> IO (Either (FileError InputDecodeError) a)
 readKeyFile asType acceptedFormats path = do
   eContent <- fmap Right (readFileBlocking path) `catches` [Handler handler]
   case eContent of
     Left e -> return $ Left e
     Right content ->
-      return . first (FileError path) $ deserialiseInput asType acceptedFormats content
+      return . first (FileError (unFile path)) $ deserialiseInput asType acceptedFormats content
  where
   handler :: IOException -> IO (Either (FileError InputDecodeError) BS.ByteString)
-  handler e = return . Left $ FileIOError path e
+  handler e = return . Left $ FileIOError (unFile path) e
 
 -- | Read a cryptographic key from a file.
 --
@@ -46,7 +48,7 @@ readKeyFile asType acceptedFormats path = do
 readKeyFileTextEnvelope
   :: HasTextEnvelope a
   => AsType a
-  -> FilePath
+  -> File 'In
   -> IO (Either (FileError InputDecodeError) a)
 readKeyFileTextEnvelope asType fp =
     first (fmap InputTextEnvelopeError) <$> readFileTextEnvelope asType fp
@@ -60,15 +62,15 @@ readKeyFileAnyOf
   :: forall b.
      [FromSomeType SerialiseAsBech32 b]
   -> [FromSomeType HasTextEnvelope b]
-  -> FilePath
+  -> File 'In
   -> IO (Either (FileError InputDecodeError) b)
 readKeyFileAnyOf bech32Types textEnvTypes path = do
   eContent <- fmap Right (readFileBlocking path) `catches` [Handler handler]
   case eContent of
     Left e -> return $ Left e
     Right content ->
-      return . first (FileError path) $ deserialiseInputAnyOf bech32Types textEnvTypes content
+      return . first (FileError (unFile path)) $ deserialiseInputAnyOf bech32Types textEnvTypes content
  where
   handler :: IOException -> IO (Either (FileError InputDecodeError) BS.ByteString)
-  handler e = return . Left $ FileIOError path e
+  handler e = return . Left $ FileIOError (unFile path) e
 

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -968,7 +968,7 @@ data ShelleyConfig = ShelleyConfig
 
 newtype GenesisFile (direction :: FileDirection) = GenesisFile
   { unGenesisFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype GenesisHashByron = GenesisHashByron
   { unGenesisHashByron :: Text
@@ -996,7 +996,7 @@ newtype NetworkName = NetworkName
 
 newtype NetworkConfigFile (direction :: FileDirection) = NetworkConfigFile
   { _unNetworkConfigFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype SocketPath = SocketPath
   { unSocketPath :: FilePath

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -54,6 +54,13 @@ module Cardano.Api.LedgerState
   , constructGlobals
   , currentEpochEligibleLeadershipSlots
   , nextEpochEligibleLeadershipSlots
+
+  , toGenesisFileIn
+  , toGenesisFileOut
+  , toNetworkConfigFileIn
+  , toNetworkConfigFileOut
+  , toNodeConfigIn
+  , toNodeConfigOut
   )
   where
 
@@ -73,7 +80,9 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LB
 import           Data.ByteString.Short as BSS
+import           Data.Coerce (coerce)
 import           Data.Foldable
+import           Data.Function ((&))
 import           Data.IORef
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -84,6 +93,7 @@ import qualified Data.Sequence as Seq
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.SOP.Strict (K (..), NP (..), fn, (:.:) (Comp))
+import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -100,7 +110,7 @@ import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
-import           Cardano.Api.IO (File (..), FileDirection (..), HasFileMode, MapFile (..))
+import           Cardano.Api.IO (File (..), FileDirection (..), MapFile (..))
 import           Cardano.Api.IPC (ConsensusModeParams (..),
                    LocalChainSyncClient (LocalChainSyncClientPipelined),
                    LocalNodeClientProtocols (..), LocalNodeClientProtocolsInMode,
@@ -145,8 +155,6 @@ import           Cardano.Slotting.EpochInfo (EpochInfo)
 import qualified Cardano.Slotting.EpochInfo.API as Slot
 import           Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import qualified Cardano.Slotting.Slot as Slot
-import           Data.Function ((&))
-import           Data.String (IsString)
 import qualified Ouroboros.Consensus.Block.Abstract as Consensus
 import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
 import qualified Ouroboros.Consensus.Byron.Ledger.Ledger as Byron
@@ -788,6 +796,12 @@ data NodeConfig (direction :: FileDirection) = NodeConfig
   , ncBabbageToConway  :: !Consensus.TriggerHardFork
   }
 
+toNodeConfigIn :: NodeConfig 'InOut -> NodeConfig 'In
+toNodeConfigIn = coerce
+
+toNodeConfigOut :: NodeConfig 'InOut -> NodeConfig 'Out
+toNodeConfigOut = coerce
+
 instance FromJSON (NodeConfig direction) where
   parseJSON =
       Aeson.withObject "NodeConfig" parse
@@ -968,7 +982,13 @@ data ShelleyConfig = ShelleyConfig
 
 newtype GenesisFile (direction :: FileDirection) = GenesisFile
   { unGenesisFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toGenesisFileIn :: GenesisFile 'InOut -> GenesisFile 'In
+toGenesisFileIn = coerce
+
+toGenesisFileOut :: GenesisFile 'InOut -> GenesisFile 'Out
+toGenesisFileOut = coerce
 
 newtype GenesisHashByron = GenesisHashByron
   { unGenesisHashByron :: Text
@@ -996,7 +1016,13 @@ newtype NetworkName = NetworkName
 
 newtype NetworkConfigFile (direction :: FileDirection) = NetworkConfigFile
   { _unNetworkConfigFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toNetworkConfigFileIn :: NetworkConfigFile 'InOut -> NetworkConfigFile 'In
+toNetworkConfigFileIn = coerce
+
+toNetworkConfigFileOut :: NetworkConfigFile 'InOut -> NetworkConfigFile 'Out
+toNetworkConfigFileOut = coerce
 
 newtype SocketPath = SocketPath
   { unSocketPath :: FilePath

--- a/cardano-api/src/Cardano/Api/Options.hs
+++ b/cardano-api/src/Cardano/Api/Options.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Options
+  ( fileOption
+  , inFileOption
+  , outFileOption
+  , parseFilePath
+  , parseFile
+  , parseFileIn
+  , parseFileOut
+  , parseDirectory
+  ) where
+
+import           Cardano.Api.IO (Directory, File (..), FileDirection (..))
+
+import           Options.Applicative (OptionFields)
+import qualified Options.Applicative as Opt
+import           Options.Applicative.Builder (Mod)
+import           Options.Applicative.Types (Parser)
+
+fileOption :: forall direction. Mod OptionFields FilePath -> Parser (File direction)
+fileOption = fmap File . Opt.strOption
+
+inFileOption :: forall. Mod OptionFields FilePath -> Parser (File 'In)
+inFileOption = fileOption
+
+outFileOption :: forall. Mod OptionFields FilePath -> Parser (File 'Out)
+outFileOption = fileOption
+
+parseDirectory :: String -> String -> Opt.Parser Directory
+parseDirectory optname desc =
+  Opt.strOption $ mconcat
+    [ Opt.long optname
+    , Opt.metavar "DIRECTORY"
+    , Opt.help desc
+    , Opt.completer (Opt.bashCompleter "directory")
+    ]
+
+parseFilePath :: String -> String -> Opt.Parser FilePath
+parseFilePath optname desc =
+  Opt.strOption $ mconcat
+    [ Opt.long optname
+    , Opt.metavar "FILEPATH"
+    , Opt.help desc
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+-- {-# DEPRECATED parseFilePath "Use parseFile instead" #-}
+
+parseFile :: String -> String -> Opt.Parser (File direction)
+parseFile optname desc =
+  Opt.strOption $ mconcat
+    [ Opt.long optname
+    , Opt.metavar "FILEPATH"
+    , Opt.help desc
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+parseFileIn :: String -> String -> Opt.Parser (File 'In)
+parseFileIn = parseFile
+
+parseFileOut :: String -> String -> Opt.Parser (File 'Out)
+parseFileOut = parseFile

--- a/cardano-api/src/Cardano/Api/Utils.hs
+++ b/cardano-api/src/Cardano/Api/Utils.hs
@@ -19,7 +19,6 @@ module Cardano.Api.Utils
   , failEitherWith
   , noInlineMaybeToStrictMaybe
   , note
-  , parseFilePath
   , readFileBlocking
   , renderEra
   , runParsecParser
@@ -40,7 +39,6 @@ import           Data.Maybe.Strict
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           GHC.IO.Handle.FD (openFileBlocking)
-import qualified Options.Applicative as Opt
 import           System.FilePath ((</>))
 import           System.IO (IOMode (ReadMode), hClose)
 import qualified Text.Parsec as Parsec
@@ -93,15 +91,6 @@ note :: MonadFail m => String -> Maybe a -> m a
 note msg = \case
   Nothing -> fail msg
   Just a -> pure a
-
-parseFilePath :: String -> String -> Opt.Parser FilePath
-parseFilePath optname desc =
-  Opt.strOption
-    ( Opt.long optname
-    <> Opt.metavar "FILEPATH"
-    <> Opt.help desc
-    <> Opt.completer (Opt.bashCompleter "file")
-    )
 
 writeSecrets :: FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
 writeSecrets outDir prefix suffix secretOp xs =

--- a/cardano-api/src/Cardano/Api/Utils.hs
+++ b/cardano-api/src/Cardano/Api/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -52,6 +53,7 @@ import           System.Directory (emptyPermissions, readable, setPermissions)
 #endif
 
 import           Cardano.Api.Eras
+import           Cardano.Api.IO (File (..), FileDirection (..))
 import           Options.Applicative (ReadM)
 import           Options.Applicative.Builder (eitherReader)
 import qualified Text.Read as Read
@@ -104,9 +106,9 @@ writeSecrets outDir prefix suffix secretOp xs =
     setPermissions filename (emptyPermissions {readable = True})
 #endif
 
-readFileBlocking :: FilePath -> IO BS.ByteString
+readFileBlocking :: File 'In -> IO BS.ByteString
 readFileBlocking path = bracket
-  (openFileBlocking path ReadMode)
+  (openFileBlocking (unFile path) ReadMode)
   hClose
   (\fp -> do
     -- An arbitrary block size.

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 module Cardano.CLI.Byron.Commands
@@ -35,31 +36,31 @@ data ByronCommand =
         GenesisParameters
 
   | PrintGenesisHash
-        GenesisFile
+        (GenesisFile 'In)
 
   --- Key Related Commands ---
   | Keygen
-        NewSigningKeyFile
+        (NewSigningKeyFile 'Out)
 
   | ToVerification
         ByronKeyFormat
-        SigningKeyFile
-        NewVerificationKeyFile
+        (SigningKeyFile 'In)
+        (NewVerificationKeyFile 'Out)
 
   | PrettySigningKeyPublic
         ByronKeyFormat
-        SigningKeyFile
+        (SigningKeyFile 'In)
 
   | MigrateDelegateKeyFrom
-        SigningKeyFile
+        (SigningKeyFile 'In)
         -- ^ Old key
-        NewSigningKeyFile
+        (NewSigningKeyFile 'Out)
         -- ^ New Key
 
   | PrintSigningKeyAddress
         ByronKeyFormat
         NetworkId
-        SigningKeyFile
+        (SigningKeyFile 'In)
 
   | GetLocalNodeTip
         NetworkId
@@ -68,16 +69,16 @@ data ByronCommand =
 
   | SubmitTx
         NetworkId
-        TxFile
+        (TxFile 'In)
         -- ^ Filepath of transaction to submit.
 
   | SpendGenesisUTxO
-        GenesisFile
+        (GenesisFile 'In)
         NetworkId
         ByronKeyFormat
-        NewTxFile
+        (NewTxFile 'Out)
         -- ^ Filepath of the newly created transaction.
-        SigningKeyFile
+        (SigningKeyFile 'In)
         -- ^ Signing key of genesis UTxO owner.
         (Address ByronAddr)
         -- ^ Genesis UTxO address.
@@ -86,51 +87,51 @@ data ByronCommand =
   | SpendUTxO
         NetworkId
         ByronKeyFormat
-        NewTxFile
+        (NewTxFile 'Out)
         -- ^ Filepath of the newly created transaction.
-        SigningKeyFile
+        (SigningKeyFile 'In)
         -- ^ Signing key of Tx underwriter.
         [TxIn]
         -- ^ Inputs available for spending to the Tx underwriter's key.
         [TxOut CtxTx ByronEra]
         -- ^ Genesis UTxO output Address.
 
-  | GetTxId TxFile
+  | GetTxId (TxFile 'In)
 
     --- Misc Commands ---
 
   | ValidateCBOR
         CBORObject
         -- ^ Type of the CBOR object
-        FilePath
+        (File 'In)
 
   | PrettyPrintCBOR
-        FilePath
+        (File 'In)
   deriving Show
 
 
 data NodeCmd = CreateVote
                NetworkId
-               SigningKeyFile
-               FilePath -- filepath to update proposal
+               (SigningKeyFile 'In)
+               (File 'In) -- filepath to update proposal
                Bool
-               FilePath
+               (File 'Out)
              | UpdateProposal
                NetworkId
-               SigningKeyFile
+               (SigningKeyFile 'In)
                ProtocolVersion
                SoftwareVersion
                SystemTag
                InstallerHash
-               FilePath
+               (File 'Out)
                ByronProtocolParametersUpdate
              | SubmitUpdateProposal
                NetworkId
-               FilePath
+               (File 'In)
                -- ^ Update proposal filepath.
              | SubmitVote
                NetworkId
-               FilePath
+               (File 'In)
                -- ^ Vote filepath.
               deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -68,19 +69,19 @@ issueByronGenesisDelegation magic epoch issuerSK delegateVK =
 --   to a delegate key, for a given protocol magic.
 --   If certificate fails validation, throw an error.
 checkByronGenesisDelegation
-  :: CertificateFile
+  :: CertificateFile 'In
   -> ProtocolMagicId
   -> Crypto.VerificationKey
   -> Crypto.VerificationKey
   -> ExceptT ByronDelegationError IO ()
 checkByronGenesisDelegation (CertificateFile certF) magic issuer delegate = do
-  ecert <- liftIO $ canonicalDecodePretty <$> LB.readFile certF
+  ecert <- liftIO $ canonicalDecodePretty <$> LB.readFile (unFile certF)
   case ecert of
-    Left e -> left $ DlgCertificateDeserialisationFailed certF e
+    Left e -> left $ DlgCertificateDeserialisationFailed (unFile certF) e
     Right (cert :: Dlg.Certificate) -> do
       let issues = checkDlgCert cert magic issuer delegate
       unless (null issues) $
-        left $ CertificateValidationErrors certF issues
+        left $ CertificateValidationErrors (unFile certF) issues
 
 checkDlgCert
   :: Dlg.ACertificate a

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -63,11 +63,11 @@ renderByronKeyFailure err =
 
 newtype NewSigningKeyFile (direction :: FileDirection) = NewSigningKeyFile
   { unNewSigningKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype NewVerificationKeyFile (direction :: FileDirection) = NewVerificationKeyFile
   { unNewVerificationKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 -- | Print some invariant properties of a public key:
 --   its hash and formatted view.

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -14,6 +14,11 @@ module Cardano.CLI.Byron.Key
   , readPaymentVerificationKey
   , renderByronKeyFailure
   , byronWitnessToVerKey
+
+  , toNewVerificationKeyFileIn
+  , toNewVerificationKeyFileOut
+  , toNewSigningKeyFileIn
+  , toNewSigningKeyFileOut
   )
 where
 
@@ -23,6 +28,7 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
                    right)
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.UTF8 as UTF8
+import           Data.Coerce (coerce)
 import           Data.String (IsString, fromString)
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -63,11 +69,23 @@ renderByronKeyFailure err =
 
 newtype NewSigningKeyFile (direction :: FileDirection) = NewSigningKeyFile
   { unNewSigningKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toNewSigningKeyFileIn :: NewSigningKeyFile 'InOut -> NewSigningKeyFile 'In
+toNewSigningKeyFileIn = coerce
+
+toNewSigningKeyFileOut :: NewSigningKeyFile 'InOut -> NewSigningKeyFile 'Out
+toNewSigningKeyFileOut = coerce
 
 newtype NewVerificationKeyFile (direction :: FileDirection) = NewVerificationKeyFile
   { unNewVerificationKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toNewVerificationKeyFileIn :: NewVerificationKeyFile 'InOut -> NewVerificationKeyFile 'In
+toNewVerificationKeyFileIn = coerce
+
+toNewVerificationKeyFileOut :: NewVerificationKeyFile 'InOut -> NewVerificationKeyFile 'Out
+toNewVerificationKeyFileOut = coerce
 
 -- | Print some invariant properties of a public key:
 --   its hash and formatted view.

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -22,6 +22,9 @@ module Cardano.CLI.Byron.Tx
   , toCborTxAux
 
   , ScriptValidity(..)
+
+  , toNewTxFileIn
+  , toNewTxFileOut
   )
 where
 
@@ -32,6 +35,7 @@ import           Data.Bifunctor (Bifunctor (..))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
+import           Data.Coerce (coerce)
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -81,7 +85,13 @@ renderByronTxError err =
 
 newtype NewTxFile (direction :: FileDirection) = NewTxFile
   { unNewTxFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toNewTxFileIn :: NewTxFile 'InOut -> NewTxFile 'In
+toNewTxFileIn = coerce
+
+toNewTxFileOut :: NewTxFile 'InOut -> NewTxFile 'Out
+toNewTxFileOut = coerce
 
 
 -- | Pretty-print an address in its Base58 form, and also

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -81,7 +81,7 @@ renderByronTxError err =
 
 newtype NewTxFile (direction :: FileDirection) = NewTxFile
   { unNewTxFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 
 -- | Pretty-print an address in its Base58 form, and also

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -564,7 +564,7 @@ data CardanoAddressKeyType
 
 newtype OpCertCounterFile (direction :: FileDirection) = OpCertCounterFile
   { unOpCertCounterFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype PrivKeyFile
   = PrivKeyFile FilePath
@@ -572,7 +572,7 @@ newtype PrivKeyFile
 
 newtype WitnessFile (direction :: FileDirection) = WitnessFile
   { unWitnessFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 -- | A raw verification key given in Base64, and decoded into a ByteString.
 newtype VerificationKeyBase64

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -45,12 +45,19 @@ module Cardano.CLI.Shelley.Commands
   , BlockId (..)
   , WitnessSigningData (..)
   , ColdVerificationKeyOrFile (..)
+
+  , toOpCertCounterFileIn
+  , toOpCertCounterFileOut
+  , toWitnessFileIn
+  , toWitnessFileOut
   ) where
 
 import           Prelude
 
 import           Cardano.Api.Shelley
 
+import           Data.Coerce (coerce)
+import           Data.String (IsString)
 import           Data.Text (Text)
 
 import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeIdentifier, StakeVerifier,
@@ -59,7 +66,6 @@ import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
 import           Cardano.Ledger.Shelley.TxBody (MIRPot)
-import           Data.String (IsString)
 
 --
 -- Shelley CLI command data types
@@ -564,7 +570,13 @@ data CardanoAddressKeyType
 
 newtype OpCertCounterFile (direction :: FileDirection) = OpCertCounterFile
   { unOpCertCounterFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toOpCertCounterFileIn :: OpCertCounterFile 'InOut -> OpCertCounterFile 'In
+toOpCertCounterFileIn = coerce
+
+toOpCertCounterFileOut :: OpCertCounterFile 'InOut -> OpCertCounterFile 'Out
+toOpCertCounterFileOut = coerce
 
 newtype PrivKeyFile
   = PrivKeyFile FilePath
@@ -572,7 +584,13 @@ newtype PrivKeyFile
 
 newtype WitnessFile (direction :: FileDirection) = WitnessFile
   { unWitnessFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toWitnessFileIn :: WitnessFile 'InOut -> WitnessFile 'In
+toWitnessFileIn = coerce
+
+toWitnessFileOut :: WitnessFile 'InOut -> WitnessFile 'Out
+toWitnessFileOut = coerce
 
 -- | A raw verification key given in Base64, and decoded into a ByteString.
 newtype VerificationKeyBase64

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -47,7 +48,7 @@ import           Cardano.CLI.Types
 data VerificationKeyOrFile keyrole
   = VerificationKeyValue !(VerificationKey keyrole)
   -- ^ A verification key.
-  | VerificationKeyFilePath !VerificationKeyFile
+  | VerificationKeyFilePath !(VerificationKeyFile 'In)
   -- ^ A path to a verification key file.
   -- Note that this file hasn't been validated at all (whether it exists,
   -- contains a key of the correct type, etc.)
@@ -114,7 +115,7 @@ data StakeIdentifier
 -- to a verification key file.
 data VerificationKeyTextOrFile
   = VktofVerificationKeyText !Text
-  | VktofVerificationKeyFile !VerificationKeyFile
+  | VktofVerificationKeyFile !(VerificationKeyFile 'In)
   deriving (Eq, Show)
 
 -- | An error in deserialising a 'VerificationKeyTextOrFile' to a
@@ -143,7 +144,7 @@ readVerificationKeyTextOrFileAnyOf verKeyTextOrFile =
       pure $ first VerificationKeyTextError $
         deserialiseAnyVerificationKey (Text.encodeUtf8 vkText)
     VktofVerificationKeyFile (VerificationKeyFile fp) -> do
-      vkBs <- liftIO $ BS.readFile fp
+      vkBs <- liftIO $ BS.readFile (unFile fp)
       pure $ first VerificationKeyTextError $
         deserialiseAnyVerificationKey vkBs
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1438,7 +1438,7 @@ pGenesisCmd =
 -- Shelley CLI flag parsers
 --
 
-data FileDirection
+data ParserFileDirection
   = Input
   | Output
   deriving (Eq, Show)
@@ -1724,7 +1724,7 @@ pWitnessSigningData =
         <*>
           optional pByronAddress
 
-pSigningKeyFile :: FileDirection -> Parser SigningKeyFile
+pSigningKeyFile :: ParserFileDirection -> Parser SigningKeyFile
 pSigningKeyFile fdir =
   SigningKeyFile <$>
     Opt.strOption
@@ -1867,7 +1867,7 @@ pVerificationKeyOrFile asType =
   VerificationKeyValue <$> pVerificationKey asType
     <|> VerificationKeyFilePath <$> pVerificationKeyFile Input
 
-pVerificationKeyFile :: FileDirection -> Parser VerificationKeyFile
+pVerificationKeyFile :: ParserFileDirection -> Parser VerificationKeyFile
 pVerificationKeyFile fdir =
   VerificationKeyFile <$>
     Opt.strOption
@@ -1877,7 +1877,7 @@ pVerificationKeyFile fdir =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pExtendedVerificationKeyFile :: FileDirection -> Parser VerificationKeyFile
+pExtendedVerificationKeyFile :: ParserFileDirection -> Parser VerificationKeyFile
 pExtendedVerificationKeyFile fdir =
   VerificationKeyFile <$>
     Opt.strOption
@@ -2410,7 +2410,7 @@ pWitnessFile =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pTxBodyFile :: FileDirection -> Parser TxBodyFile
+pTxBodyFile :: ParserFileDirection -> Parser TxBodyFile
 pTxBodyFile fdir =
     TxBodyFile <$>
       (  Opt.strOption
@@ -2432,7 +2432,7 @@ pTxBodyFile fdir =
         Output -> "out-file"
 
 
-pTxFile :: FileDirection -> Parser TxFile
+pTxFile :: ParserFileDirection -> Parser TxFile
 pTxFile fdir =
     TxFile <$>
       (  Opt.strOption

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -119,19 +120,20 @@ pTextViewCmd =
           )
     ]
 
-pCBORInFile :: Parser FilePath
+pCBORInFile :: Parser (File 'In)
 pCBORInFile =
-  Opt.strOption
-    (  Opt.long "in-file"
-    <> Opt.metavar "FILE"
-    <> Opt.help "CBOR input file."
-    <> Opt.completer (Opt.bashCompleter "file")
-    )
-  <|>
-  Opt.strOption
-    (  Opt.long "file"
-    <> Opt.internal
-    )
+  asum
+  [ inFileOption $ mconcat
+    [ Opt.long "in-file"
+    , Opt.metavar "FILE"
+    , Opt.help "CBOR input file."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+  , inFileOption $ mconcat
+    [ Opt.long "file"
+    , Opt.internal
+    ]
+  ]
 
 pAddressCmd :: Parser AddressCmd
 pAddressCmd =
@@ -200,7 +202,7 @@ pPaymentVerificationKeyText =
       <> Opt.help "Payment verification key (Bech32-encoded)"
       )
 
-pPaymentVerificationKeyFile :: Parser VerificationKeyFile
+pPaymentVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pPaymentVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -513,12 +515,12 @@ pKeyCmd =
             <> Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
             )
 
-    pByronKeyFile :: Parser SomeKeyFile
+    pByronKeyFile :: Parser (SomeKeyFile direction)
     pByronKeyFile =
           (ASigningKeyFile      <$> pByronSigningKeyFile)
       <|> (AVerificationKeyFile <$> pByronVerificationKeyFile)
 
-    pByronSigningKeyFile :: Parser SigningKeyFile
+    pByronSigningKeyFile :: Parser (SigningKeyFile direction)
     pByronSigningKeyFile =
       SigningKeyFile <$>
         Opt.strOption
@@ -528,7 +530,7 @@ pKeyCmd =
           <> Opt.completer (Opt.bashCompleter "file")
           )
 
-    pByronVerificationKeyFile :: Parser VerificationKeyFile
+    pByronVerificationKeyFile :: Parser (VerificationKeyFile direction)
     pByronVerificationKeyFile =
       VerificationKeyFile <$>
         Opt.strOption
@@ -571,11 +573,11 @@ pKeyCmd =
         <$> pITNSigningKeyFile
         <*> pOutputFile
 
-    pITNKeyFIle :: Parser SomeKeyFile
+    pITNKeyFIle :: Parser (SomeKeyFile direction)
     pITNKeyFIle = pITNSigningKeyFile
               <|> pITNVerificationKeyFile
 
-    pITNSigningKeyFile :: Parser SomeKeyFile
+    pITNSigningKeyFile :: Parser (SomeKeyFile direction)
     pITNSigningKeyFile =
       ASigningKeyFile . SigningKeyFile <$>
         Opt.strOption
@@ -585,7 +587,7 @@ pKeyCmd =
           <> Opt.completer (Opt.bashCompleter "file")
           )
 
-    pITNVerificationKeyFile :: Parser SomeKeyFile
+    pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
     pITNVerificationKeyFile =
       AVerificationKeyFile . VerificationKeyFile <$>
         Opt.strOption
@@ -1234,28 +1236,29 @@ pGenesisCmd =
 
     pGenesisCreateCardano :: Parser GenesisCmd
     pGenesisCreateCardano =
-      GenesisCreateCardano <$> pGenesisDir
-                    <*> pGenesisNumGenesisKeys
-                    <*> pGenesisNumUTxOKeys
-                    <*> pMaybeSystemStart
-                    <*> pInitialSupplyNonDelegated
-                    <*> (BlockCount <$> pSecurityParam)
-                    <*> pSlotLength
-                    <*> pSlotCoefficient
-                    <*> pNetworkId
-                    <*> parseFilePath
-                          "byron-template"
-                          "JSON file with genesis defaults for each byron."
-                    <*> parseFilePath
-                          "shelley-template"
-                          "JSON file with genesis defaults for each shelley."
-                    <*> parseFilePath
-                          "alonzo-template"
-                          "JSON file with genesis defaults for alonzo."
-                    <*> parseFilePath
-                          "conway-template"
-                          "JSON file with genesis defaults for conway."
-                    <*> pNodeConfigTemplate
+      GenesisCreateCardano
+        <$> pGenesisDir
+        <*> pGenesisNumGenesisKeys
+        <*> pGenesisNumUTxOKeys
+        <*> pMaybeSystemStart
+        <*> pInitialSupplyNonDelegated
+        <*> fmap BlockCount pSecurityParam
+        <*> pSlotLength
+        <*> pSlotCoefficient
+        <*> pNetworkId
+        <*> parseFile @'In
+              "byron-template"
+              "JSON file with genesis defaults for each byron."
+        <*> parseFile @'In
+              "shelley-template"
+              "JSON file with genesis defaults for each shelley."
+        <*> parseFile @'In
+              "alonzo-template"
+              "JSON file with genesis defaults for alonzo."
+        <*> parseFile @'In
+              "conway-template"
+              "JSON file with genesis defaults for conway."
+        <*> pNodeConfigTemplate
 
     pGenesisCreate :: Parser GenesisCmd
     pGenesisCreate =
@@ -1315,8 +1318,8 @@ pGenesisCmd =
           <> Opt.value 3
           )
 
-    pNodeConfigTemplate :: Parser (Maybe FilePath)
-    pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node config template"
+    pNodeConfigTemplate :: Parser (Maybe (File 'In))
+    pNodeConfigTemplate = optional $ parseFile @'In "node-config-template" "the node config template"
 
     pGenesisNumUTxOKeys :: Parser Word
     pGenesisNumUTxOKeys =
@@ -1354,14 +1357,14 @@ pGenesisCmd =
           <> Opt.value 0
           )
 
-    pRelayJsonFp :: Parser FilePath
+    pRelayJsonFp :: Parser (File 'In)
     pRelayJsonFp =
-      Opt.strOption
-        (  Opt.long "relay-specification-file"
-        <> Opt.metavar "FILE"
-        <> Opt.help "JSON file specified the relays of each stake pool."
-        <> Opt.completer (Opt.bashCompleter "file")
-        )
+      fileOption $ mconcat
+        [ Opt.long "relay-specification-file"
+        , Opt.metavar "FILE"
+        , Opt.help "JSON file specified the relays of each stake pool."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
     convertTime :: String -> UTCTime
     convertTime =
@@ -1483,20 +1486,21 @@ pCalculatePlutusScriptCost =
 
 pCertificateFile
   :: BalanceTxExecUnits
-  -> Parser (CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))
+  -> Parser (CertificateFile 'In, Maybe (ScriptWitnessFiles WitCtxStake))
 pCertificateFile balanceExecUnits =
-  (,) <$> (CertificateFile
-             <$> (  Opt.strOption
-                      (  Opt.long "certificate-file"
-                      <> Opt.metavar "CERTIFICATEFILE"
-                      <> Opt.help helpText
-                      <> Opt.completer (Opt.bashCompleter "file")
-                      )
-                  <|>
-                     Opt.strOption (Opt.long "certificate" <> Opt.internal)
-                  )
-          )
-      <*> optional (pCertifyingScriptOrReferenceScriptWit balanceExecUnits)
+  (,)
+    <$> ( CertificateFile
+            <$> (  fileOption
+                    (  Opt.long "certificate-file"
+                    <> Opt.metavar "CERTIFICATEFILE"
+                    <> Opt.help helpText
+                    <> Opt.completer (Opt.bashCompleter "file")
+                    )
+                <|>
+                    fileOption (Opt.long "certificate" <> Opt.internal)
+                )
+        )
+    <*> optional (pCertifyingScriptOrReferenceScriptWit balanceExecUnits)
  where
   pCertifyingScriptOrReferenceScriptWit
     :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxStake)
@@ -1623,45 +1627,42 @@ pPlutusScriptLanguage prefix =
     <> Opt.help "Specify a plutus script v2 reference script."
     )
 
-pUpdateProposalFile :: Parser UpdateProposalFile
+pUpdateProposalFile :: Parser (UpdateProposalFile 'In)
 pUpdateProposalFile =
-  UpdateProposalFile <$>
-  ( Opt.strOption
-     (  Opt.long "update-proposal-file"
-     <> Opt.metavar "FILE"
-     <> Opt.help "Filepath of the update proposal."
-     <> Opt.completer (Opt.bashCompleter "file")
-     )
-  <|>
-    Opt.strOption
-      (  Opt.long "update-proposal"
-      <> Opt.internal
-      )
-  )
+  fmap UpdateProposalFile $ asum
+    [ fileOption $ mconcat
+      [ Opt.long "update-proposal-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the update proposal."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
+    , fileOption $ mconcat
+      [ Opt.long "update-proposal"
+      , Opt.internal
+      ]
+    ]
 
-
-pColdSigningKeyFile :: Parser SigningKeyFile
+pColdSigningKeyFile :: Parser (SigningKeyFile direction)
 pColdSigningKeyFile =
-  SigningKeyFile <$>
-    ( Opt.strOption
-        (  Opt.long "cold-signing-key-file"
-        <> Opt.metavar "FILE"
-        <> Opt.help "Filepath of the cold signing key."
-        <> Opt.completer (Opt.bashCompleter "file")
-        )
-    <|>
-      Opt.strOption
-      (  Opt.long "signing-key-file"
-      <> Opt.internal
-      )
-    )
+  fmap SigningKeyFile $ asum
+    [ fileOption $ mconcat
+      [ Opt.long "cold-signing-key-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the cold signing key."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
+    , fileOption $ mconcat
+      [ Opt.long "signing-key-file"
+      , Opt.internal
+      ]
+    ]
 
 pRequiredSigner :: Parser RequiredSigner
 pRequiredSigner =
       RequiredSignerSkeyFile <$> sKeyFile
   <|> RequiredSignerHash <$> sPayKeyHash
  where
-  sKeyFile :: Parser SigningKeyFile
+  sKeyFile :: Parser (SigningKeyFile direction)
   sKeyFile = fmap SigningKeyFile $ Opt.strOption $ mconcat
     [ Opt.long "required-signer"
     , Opt.metavar "FILE"
@@ -1682,7 +1683,7 @@ pRequiredSigner =
         ]
       ]
 
-pVrfSigningKeyFile :: Parser SigningKeyFile
+pVrfSigningKeyFile :: Parser (SigningKeyFile direction)
 pVrfSigningKeyFile =
   SigningKeyFile <$>
     Opt.strOption
@@ -1724,15 +1725,14 @@ pWitnessSigningData =
         <*>
           optional pByronAddress
 
-pSigningKeyFile :: ParserFileDirection -> Parser SigningKeyFile
+pSigningKeyFile :: ParserFileDirection -> Parser (SigningKeyFile direction)
 pSigningKeyFile fdir =
-  SigningKeyFile <$>
-    Opt.strOption
-      (  Opt.long "signing-key-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help (show fdir ++ " filepath of the signing key.")
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+  fmap SigningKeyFile $ Opt.strOption $ mconcat
+    [ Opt.long "signing-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help (show fdir ++ " filepath of the signing key.")
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pKesPeriod :: Parser KESPeriod
 pKesPeriod =
@@ -1759,7 +1759,7 @@ pEpochNoUpdateProp =
     , Opt.help "The epoch number in which the update proposal is valid."
     ]
 
-pGenesisFile :: String -> Parser GenesisFile
+pGenesisFile :: String -> Parser (GenesisFile direction)
 pGenesisFile desc =
   GenesisFile <$>
     Opt.strOption
@@ -1769,7 +1769,7 @@ pGenesisFile desc =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pOperatorCertIssueCounterFile :: Parser OpCertCounterFile
+pOperatorCertIssueCounterFile :: Parser (OpCertCounterFile direction)
 pOperatorCertIssueCounterFile =
   OpCertCounterFile <$>
     ( Opt.strOption
@@ -1785,14 +1785,14 @@ pOperatorCertIssueCounterFile =
         )
     )
 
-pOperationalCertificateFile :: Parser FilePath
+pOperationalCertificateFile :: Parser (File direction)
 pOperationalCertificateFile =
-  Opt.strOption
-    (  Opt.long "op-cert-file"
-    <> Opt.metavar "FILE"
-    <> Opt.help "Filepath of the node's operational certificate."
-    <> Opt.completer (Opt.bashCompleter "file")
-    )
+  fileOption $ mconcat
+    [ Opt.long "op-cert-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the node's operational certificate."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pOutputFormat :: Parser OutputFormat
 pOutputFormat =
@@ -1804,26 +1804,23 @@ pOutputFormat =
     <> Opt.value OutputFormatBech32
     )
 
-pMaybeOutputFile :: Parser (Maybe OutputFile)
+pMaybeOutputFile :: Parser (Maybe (File 'Out))
 pMaybeOutputFile =
-  optional $
-    OutputFile <$>
-      Opt.strOption
-        (  Opt.long "out-file"
-        <> Opt.metavar "FILE"
-        <> Opt.help "Optional output file. Default is to write to stdout."
-        <> Opt.completer (Opt.bashCompleter "file")
-        )
+  optional $ outFileOption $ mconcat
+    [ Opt.long "out-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Optional output file. Default is to write to stdout."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
-pOutputFile :: Parser OutputFile
+pOutputFile :: Parser (File 'Out)
 pOutputFile =
-  OutputFile <$>
-    Opt.strOption
-      (  Opt.long "out-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "The output file."
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+  outFileOption $ mconcat
+    [ Opt.long "out-file"
+    , Opt.metavar "FILE"
+    , Opt.help "The output file."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pColdVerificationKeyOrFile :: Parser ColdVerificationKeyOrFile
 pColdVerificationKeyOrFile =
@@ -1831,7 +1828,7 @@ pColdVerificationKeyOrFile =
     <|> ColdGenesisDelegateVerificationKey <$> pGenesisDelegateVerificationKey
     <|> ColdVerificationKeyFile <$> pColdVerificationKeyFile
 
-pColdVerificationKeyFile :: Parser VerificationKeyFile
+pColdVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pColdVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -1867,7 +1864,7 @@ pVerificationKeyOrFile asType =
   VerificationKeyValue <$> pVerificationKey asType
     <|> VerificationKeyFilePath <$> pVerificationKeyFile Input
 
-pVerificationKeyFile :: ParserFileDirection -> Parser VerificationKeyFile
+pVerificationKeyFile :: ParserFileDirection -> Parser (VerificationKeyFile direction)
 pVerificationKeyFile fdir =
   VerificationKeyFile <$>
     Opt.strOption
@@ -1877,7 +1874,7 @@ pVerificationKeyFile fdir =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pExtendedVerificationKeyFile :: ParserFileDirection -> Parser VerificationKeyFile
+pExtendedVerificationKeyFile :: ParserFileDirection -> Parser (VerificationKeyFile direction)
 pExtendedVerificationKeyFile fdir =
   VerificationKeyFile <$>
     Opt.strOption
@@ -1887,7 +1884,7 @@ pExtendedVerificationKeyFile fdir =
       <> Opt.completer (Opt.bashCompleter "file")
       )
 
-pGenesisVerificationKeyFile :: Parser VerificationKeyFile
+pGenesisVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pGenesisVerificationKeyFile =
   VerificationKeyFile <$>
     Opt.strOption
@@ -1937,7 +1934,7 @@ pGenesisVerificationKeyOrHashOrFile =
   VerificationKeyOrFile <$> pGenesisVerificationKeyOrFile
     <|> VerificationKeyHash <$> pGenesisVerificationKeyHash
 
-pGenesisDelegateVerificationKeyFile :: Parser VerificationKeyFile
+pGenesisDelegateVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pGenesisDelegateVerificationKeyFile =
   VerificationKeyFile <$>
     Opt.strOption
@@ -2028,7 +2025,7 @@ pKesVerificationKey =
             (\e -> "Invalid stake pool verification key: " ++ displayError e) $
           deserialiseFromRawBytesHex asType (BSC.pack str)
 
-pKesVerificationKeyFile :: Parser VerificationKeyFile
+pKesVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pKesVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -2044,14 +2041,14 @@ pKesVerificationKeyFile =
         )
     )
 
-pTxSubmitFile :: Parser FilePath
+pTxSubmitFile :: Parser (File direction)
 pTxSubmitFile =
-  Opt.strOption
-    (  Opt.long "tx-file"
-    <> Opt.metavar "FILE"
-    <> Opt.help "Filepath of the transaction you intend to submit."
-    <> Opt.completer (Opt.bashCompleter "file")
-    )
+  fileOption $ mconcat
+    [ Opt.long "tx-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the transaction you intend to submit."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pCardanoEra :: Parser AnyCardanoEra
 pCardanoEra = asum
@@ -2400,31 +2397,29 @@ pTxFee =
       <> Opt.help "The fee amount in Lovelace."
       )
 
-pWitnessFile :: Parser WitnessFile
+pWitnessFile :: Parser (WitnessFile direction)
 pWitnessFile =
-  WitnessFile <$>
-    Opt.strOption
-      (  Opt.long "witness-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the witness"
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+  fmap WitnessFile $ fileOption $ mconcat
+    [ Opt.long "witness-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the witness"
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
-pTxBodyFile :: ParserFileDirection -> Parser TxBodyFile
+pTxBodyFile :: ParserFileDirection -> Parser (TxBodyFile direction)
 pTxBodyFile fdir =
-    TxBodyFile <$>
-      (  Opt.strOption
-           (  Opt.long optName
-           <> Opt.metavar "FILE"
-           <> Opt.help (show fdir ++ " filepath of the JSON TxBody.")
-           <> Opt.completer (Opt.bashCompleter "file")
-           )
-      <|>
-         Opt.strOption
-           (  Opt.long "tx-body-file"
-           <> Opt.internal
-           )
-      )
+  fmap TxBodyFile $ asum
+    [ fileOption $ mconcat
+      [ Opt.long optName
+      , Opt.metavar "FILE"
+      , Opt.help (show fdir ++ " filepath of the JSON TxBody.")
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
+    , fileOption $ mconcat
+      [ Opt.long "tx-body-file"
+      , Opt.internal
+      ]
+    ]
   where
     optName =
       case fdir of
@@ -2432,21 +2427,20 @@ pTxBodyFile fdir =
         Output -> "out-file"
 
 
-pTxFile :: ParserFileDirection -> Parser TxFile
+pTxFile :: ParserFileDirection -> Parser (TxFile direction)
 pTxFile fdir =
-    TxFile <$>
-      (  Opt.strOption
-           (  Opt.long optName
-           <> Opt.metavar "FILE"
-           <> Opt.help (show fdir ++ " filepath of the JSON Tx.")
-           <> Opt.completer (Opt.bashCompleter "file")
-           )
-      <|>
-         Opt.strOption
-           (  Opt.long "tx-file"
-           <> Opt.internal
-           )
-      )
+  fmap TxFile $ asum
+    [ fileOption $ mconcat
+      [ Opt.long optName
+      , Opt.metavar "FILE"
+      , Opt.help (show fdir ++ " filepath of the JSON Tx.")
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
+    , fileOption $ mconcat
+      [ Opt.long "tx-file"
+      , Opt.internal
+      ]
+    ]
   where
     optName =
       case fdir of
@@ -2582,7 +2576,7 @@ pStakeVerificationKey =
       <> Opt.help "Stake verification key (Bech32 or hex-encoded)."
       )
 
-pStakeVerificationKeyFile :: Parser VerificationKeyFile
+pStakeVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pStakeVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -2599,7 +2593,7 @@ pStakeVerificationKeyFile =
     )
 
 
-pStakePoolVerificationKeyFile :: Parser VerificationKeyFile
+pStakePoolVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pStakePoolVerificationKeyFile =
   VerificationKeyFile <$>
     (  Opt.strOption
@@ -2662,7 +2656,7 @@ pStakePoolVerificationKeyOrHashOrFile =
   VerificationKeyOrFile <$> pStakePoolVerificationKeyOrFile
     <|> VerificationKeyHash <$> pStakePoolVerificationKeyHash
 
-pVrfVerificationKeyFile :: Parser VerificationKeyFile
+pVrfVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pVrfVerificationKeyFile =
   VerificationKeyFile <$>
     Opt.strOption
@@ -2706,7 +2700,7 @@ pVrfVerificationKeyOrHashOrFile =
   VerificationKeyOrFile <$> pVrfVerificationKeyOrFile
     <|> VerificationKeyHash <$> pVrfVerificationKeyHash
 
-pRewardAcctVerificationKeyFile :: Parser VerificationKeyFile
+pRewardAcctVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pRewardAcctVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -2736,7 +2730,7 @@ pRewardAcctVerificationKeyOrFile =
   VerificationKeyValue <$> pRewardAcctVerificationKey
     <|> VerificationKeyFilePath <$> pRewardAcctVerificationKeyFile
 
-pPoolOwnerVerificationKeyFile :: Parser VerificationKeyFile
+pPoolOwnerVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pPoolOwnerVerificationKeyFile =
   VerificationKeyFile <$>
     ( Opt.strOption
@@ -2951,14 +2945,14 @@ pProtocolParametersUpdate =
     <*> optional pMaxCollateralInputs
     <*> optional pUTxOCostPerByte
 
-pCostModels :: Parser FilePath
+pCostModels :: Parser (File 'In)
 pCostModels =
-  Opt.strOption
-    (  Opt.long "cost-model-file"
-    <> Opt.metavar "FILE"
-    <> Opt.help "Filepath of the JSON formatted cost model"
-    <> Opt.completer (Opt.bashCompleter "file")
-    )
+  fileOption $ mconcat
+    [ Opt.long "cost-model-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the JSON formatted cost model"
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pMinFeePerByteFactor :: Parser Lovelace
 pMinFeePerByteFactor =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address/Info.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+
 module Cardano.CLI.Shelley.Run.Address.Info
   ( runAddressInfo
   , ShelleyAddressInfoError(..)
@@ -40,7 +42,7 @@ instance ToJSON AddressInfo where
       , "base16" .= aiBase16 addrInfo
       ]
 
-runAddressInfo :: Text -> Maybe OutputFile -> ExceptT ShelleyAddressInfoError IO ()
+runAddressInfo :: Text -> Maybe (File 'Out) -> ExceptT ShelleyAddressInfoError IO ()
 runAddressInfo addrTxt mOutputFp = do
     addrInfo <- case (Left  <$> deserialiseAddress AsAddressAny addrTxt)
                  <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
@@ -76,6 +78,6 @@ runAddressInfo addrTxt mOutputFp = do
           }
 
     case mOutputFp of
-      Just (OutputFile fpath) -> liftIO $ LBS.writeFile fpath $ encodePretty addrInfo
+      Just fpath -> liftIO $ LBS.writeFile (unFile fpath) $ encodePretty addrInfo
       Nothing -> liftIO $ LBS.putStrLn $ encodePretty addrInfo
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -825,18 +825,18 @@ createDelegateKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   runGenesisKeyGenDelegate
         (VerificationKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vkey")
-        (usingOut coldSK)
-        (usingOut opCertCtr)
+        (usingOut @SigningKeyFile coldSK)
+        (usingOut @OpCertCounterFile opCertCtr)
   runGenesisKeyGenDelegateVRF
         (VerificationKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vrf.vkey")
         (SigningKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
-        (usingOut kesVK)
+        (usingOut @VerificationKeyFile kesVK)
         (SigningKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
     runNodeIssueOpCert
-        (VerificationKeyFilePath (usingIn kesVK))
-        (usingIn coldSK)
+        (VerificationKeyFilePath (usingIn @VerificationKeyFile kesVK))
+        (usingIn @SigningKeyFile coldSK)
         opCertCtr
         (KESPeriod 0)
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
@@ -868,18 +868,18 @@ createPoolCredentials dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
-        (usingOut kesVK)
+        (usingOut @VerificationKeyFile kesVK)
         (SigningKeyFile $ File $ dir </> "kes" ++ strIndex ++ ".skey")
     runNodeKeyGenVRF
         (VerificationKeyFile $ File $ dir </> "vrf" ++ strIndex ++ ".vkey")
         (SigningKeyFile $ File $ dir </> "vrf" ++ strIndex ++ ".skey")
     runNodeKeyGenCold
         (VerificationKeyFile $ File $ dir </> "cold" ++ strIndex ++ ".vkey")
-        (usingOut coldSK)
-        (usingOut opCertCtr)
+        (usingOut @SigningKeyFile coldSK)
+        (usingOut @OpCertCounterFile opCertCtr)
     runNodeIssueOpCert
-        (VerificationKeyFilePath (usingIn kesVK))
-        (usingIn coldSK)
+        (VerificationKeyFilePath (usingIn @VerificationKeyFile kesVK))
+        (usingIn @SigningKeyFile coldSK)
         opCertCtr
         (KESPeriod 0)
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
@@ -1003,7 +1003,7 @@ readShelleyGenesisWithDefault
   -> (ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto)
   -> ExceptT ShelleyGenesisCmdError IO (ShelleyGenesis StandardCrypto)
 readShelleyGenesisWithDefault fpath adjustDefaults = do
-    newExceptT (readAndDecodeShelleyGenesis (usingIn fpath))
+    newExceptT (readAndDecodeShelleyGenesis (usingIn @File fpath))
       `catchError` \err ->
         case err of
           ShelleyGenesisCmdGenesisFileReadError (FileIOError _ ioe)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -825,18 +825,18 @@ createDelegateKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   runGenesisKeyGenDelegate
         (VerificationKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vkey")
-        (usingOut @SigningKeyFile coldSK)
-        (usingOut @OpCertCounterFile opCertCtr)
+        (toSigningKeyFileOut coldSK)
+        (toOpCertCounterFileOut opCertCtr)
   runGenesisKeyGenDelegateVRF
         (VerificationKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vrf.vkey")
         (SigningKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
-        (usingOut @VerificationKeyFile kesVK)
+        (toVerificationKeyFileOut kesVK)
         (SigningKeyFile $ File $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
     runNodeIssueOpCert
-        (VerificationKeyFilePath (usingIn @VerificationKeyFile kesVK))
-        (usingIn @SigningKeyFile coldSK)
+        (VerificationKeyFilePath (toVerificationKeyFileIn kesVK))
+        (toSigningKeyFileIn coldSK)
         opCertCtr
         (KESPeriod 0)
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
@@ -868,18 +868,18 @@ createPoolCredentials dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
     runNodeKeyGenKES
-        (usingOut @VerificationKeyFile kesVK)
+        (toVerificationKeyFileOut kesVK)
         (SigningKeyFile $ File $ dir </> "kes" ++ strIndex ++ ".skey")
     runNodeKeyGenVRF
         (VerificationKeyFile $ File $ dir </> "vrf" ++ strIndex ++ ".vkey")
         (SigningKeyFile $ File $ dir </> "vrf" ++ strIndex ++ ".skey")
     runNodeKeyGenCold
         (VerificationKeyFile $ File $ dir </> "cold" ++ strIndex ++ ".vkey")
-        (usingOut @SigningKeyFile coldSK)
-        (usingOut @OpCertCounterFile opCertCtr)
+        (toSigningKeyFileOut coldSK)
+        (toOpCertCounterFileOut opCertCtr)
     runNodeIssueOpCert
-        (VerificationKeyFilePath (usingIn @VerificationKeyFile kesVK))
-        (usingIn @SigningKeyFile coldSK)
+        (VerificationKeyFilePath (toVerificationKeyFileIn kesVK))
+        (toSigningKeyFileIn coldSK)
         opCertCtr
         (KESPeriod 0)
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
@@ -1003,7 +1003,7 @@ readShelleyGenesisWithDefault
   -> (ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto)
   -> ExceptT ShelleyGenesisCmdError IO (ShelleyGenesis StandardCrypto)
 readShelleyGenesisWithDefault fpath adjustDefaults = do
-    newExceptT (readAndDecodeShelleyGenesis (usingIn @File fpath))
+    newExceptT (readAndDecodeShelleyGenesis (toFileIn fpath))
       `catchError` \err ->
         case err of
           ShelleyGenesisCmdGenesisFileReadError (FileIOError _ ioe)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Cardano.CLI.Shelley.Run.Governance
   ( ShelleyGovernanceCmdError
   , renderShelleyGovernanceError
@@ -77,13 +79,13 @@ runGovernanceMIRCertificatePayStakeAddrs
   :: Shelley.MIRPot
   -> [StakeAddress] -- ^ Stake addresses
   -> [Lovelace]     -- ^ Corresponding reward amounts (same length)
-  -> OutputFile
+  -> File 'Out
   -> ExceptT ShelleyGovernanceCmdError IO ()
-runGovernanceMIRCertificatePayStakeAddrs mirPot sAddrs rwdAmts (OutputFile oFp) = do
+runGovernanceMIRCertificatePayStakeAddrs mirPot sAddrs rwdAmts oFp = do
 
     unless (length sAddrs == length rwdAmts) $
       left $ ShelleyGovernanceCmdMIRCertificateKeyRewardMistmach
-               oFp (length sAddrs) (length rwdAmts)
+               (unFile oFp) (length sAddrs) (length rwdAmts)
 
     let sCreds  = map stakeAddressCredential sAddrs
         mirCert = makeMIRCertificate mirPot (StakeAddressesMIR $ zip sCreds rwdAmts)
@@ -97,10 +99,10 @@ runGovernanceMIRCertificatePayStakeAddrs mirPot sAddrs rwdAmts (OutputFile oFp) 
 
 runGovernanceMIRCertificateTransfer
   :: Lovelace
-  -> OutputFile
+  -> File 'Out
   -> TransferDirection
   -> ExceptT ShelleyGovernanceCmdError IO ()
-runGovernanceMIRCertificateTransfer ll (OutputFile oFp) direction = do
+runGovernanceMIRCertificateTransfer ll oFp direction = do
   mirCert <- case direction of
                  TransferToReserves ->
                    return . makeMIRCertificate Shelley.TreasuryMIR $ SendToReservesMIR ll
@@ -121,12 +123,12 @@ runGovernanceGenesisKeyDelegationCertificate
   :: VerificationKeyOrHashOrFile GenesisKey
   -> VerificationKeyOrHashOrFile GenesisDelegateKey
   -> VerificationKeyOrHashOrFile VrfKey
-  -> OutputFile
+  -> File 'Out
   -> ExceptT ShelleyGovernanceCmdError IO ()
 runGovernanceGenesisKeyDelegationCertificate genVkOrHashOrFp
                                              genDelVkOrHashOrFp
                                              vrfVkOrHashOrFp
-                                             (OutputFile oFp) = do
+                                             oFp = do
     genesisVkHash <- firstExceptT ShelleyGovernanceCmdKeyReadError
       . newExceptT
       $ readVerificationKeyOrHashOrTextEnvFile AsGenesisKey genVkOrHashOrFp
@@ -146,25 +148,26 @@ runGovernanceGenesisKeyDelegationCertificate genVkOrHashOrFp
     genKeyDelegCertDesc = "Genesis Key Delegation Certificate"
 
 runGovernanceUpdateProposal
-  :: OutputFile
+  :: File 'Out
   -> EpochNo
-  -> [VerificationKeyFile]
+  -> [VerificationKeyFile 'In]
   -- ^ Genesis verification keys
   -> ProtocolParametersUpdate
-  -> Maybe FilePath -- ^ Cost models file path
+  -> Maybe (File 'In) -- ^ Cost models file path
   -> ExceptT ShelleyGovernanceCmdError IO ()
-runGovernanceUpdateProposal (OutputFile upFile) eNo genVerKeyFiles upPprams mCostModelFp = do
+runGovernanceUpdateProposal upFile eNo genVerKeyFiles upPprams mCostModelFp = do
   finalUpPprams <- case mCostModelFp of
     Nothing -> return upPprams
     Just fp -> do
-      costModelsBs <- handleIOExceptT (ShelleyGovernanceCmdCostModelReadError . FileIOError fp) $ LB.readFile fp
+      costModelsBs <- LB.readFile (unFile fp)
+        & handleIOExceptT (ShelleyGovernanceCmdCostModelReadError . FileIOError (unFile fp))
 
       cModels <- pure (eitherDecode costModelsBs)
-        & onLeft (left . ShelleyGovernanceCmdCostModelsJsonDecodeErr fp . Text.pack)
+        & onLeft (left . ShelleyGovernanceCmdCostModelsJsonDecodeErr (unFile fp) . Text.pack)
 
       let costModels = fromAlonzoCostModels cModels
 
-      when (null costModels) $ left (ShelleyGovernanceCmdEmptyCostModel fp)
+      when (null costModels) $ left (ShelleyGovernanceCmdEmptyCostModel (unFile fp))
 
       return $ upPprams {protocolUpdateCostModels = costModels}
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Cardano.CLI.Shelley.Run.Node
   ( ShelleyNodeCmdError(ShelleyNodeCmdReadFileError)
   , renderShelleyNodeCmdError
@@ -71,9 +73,9 @@ runNodeCmd (NodeIssueOpCert vk sk ctr p out) =
 -- Node command implementations
 --
 
-runNodeKeyGenCold :: VerificationKeyFile
-                  -> SigningKeyFile
-                  -> OpCertCounterFile
+runNodeKeyGenCold :: VerificationKeyFile 'Out
+                  -> SigningKeyFile 'Out
+                  -> OpCertCounterFile 'Out
                   -> ExceptT ShelleyNodeCmdError IO ()
 runNodeKeyGenCold (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath)
                   (OpCertCounterFile ocertCtrPath) = do
@@ -103,8 +105,8 @@ runNodeKeyGenCold (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath)
     initialCounter = 0
 
 
-runNodeKeyGenKES :: VerificationKeyFile
-                 -> SigningKeyFile
+runNodeKeyGenKES :: VerificationKeyFile 'Out
+                 -> SigningKeyFile 'Out
                  -> ExceptT ShelleyNodeCmdError IO ()
 runNodeKeyGenKES (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     skey <- liftIO $ generateSigningKey AsKesKey
@@ -122,7 +124,7 @@ runNodeKeyGenKES (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     skeyDesc = "KES Signing Key"
     vkeyDesc = "KES Verification Key"
 
-runNodeKeyGenVRF :: VerificationKeyFile -> SigningKeyFile
+runNodeKeyGenVRF :: VerificationKeyFile 'Out -> SigningKeyFile 'Out
                  -> ExceptT ShelleyNodeCmdError IO ()
 runNodeKeyGenVRF (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     skey <- liftIO $ generateSigningKey AsVrfKey
@@ -141,7 +143,7 @@ runNodeKeyGenVRF (VerificationKeyFile vkeyPath) (SigningKeyFile skeyPath) = do
     vkeyDesc = "VRF Verification Key"
 
 runNodeKeyHashVRF :: VerificationKeyOrFile VrfKey
-                  -> Maybe OutputFile
+                  -> Maybe (File 'Out)
                   -> ExceptT ShelleyNodeCmdError IO ()
 runNodeKeyHashVRF verKeyOrFile mOutputFp = do
   vkey <- firstExceptT ShelleyNodeCmdReadKeyFileError
@@ -151,13 +153,13 @@ runNodeKeyHashVRF verKeyOrFile mOutputFp = do
   let hexKeyHash = serialiseToRawBytesHex (verificationKeyHash vkey)
 
   case mOutputFp of
-    Just (OutputFile fpath) -> liftIO $ BS.writeFile fpath hexKeyHash
+    Just (File fpath) -> liftIO $ BS.writeFile fpath hexKeyHash
     Nothing -> liftIO $ BS.putStrLn hexKeyHash
 
 
 runNodeNewCounter :: ColdVerificationKeyOrFile
                   -> Word
-                  -> OpCertCounterFile
+                  -> OpCertCounterFile 'Out
                   -> ExceptT ShelleyNodeCmdError IO ()
 runNodeNewCounter coldVerKeyOrFile counter
                   (OpCertCounterFile ocertCtrPath) = do
@@ -175,24 +177,24 @@ runNodeNewCounter coldVerKeyOrFile counter
 
 runNodeIssueOpCert :: VerificationKeyOrFile KesKey
                    -- ^ This is the hot KES verification key.
-                   -> SigningKeyFile
+                   -> SigningKeyFile 'In
                    -- ^ This is the cold signing key.
-                   -> OpCertCounterFile
+                   -> OpCertCounterFile 'InOut
                    -- ^ Counter that establishes the precedence
                    -- of the operational certificate.
                    -> KESPeriod
                    -- ^ Start of the validity period for this certificate.
-                   -> OutputFile
+                   -> File 'Out
                    -> ExceptT ShelleyNodeCmdError IO ()
 runNodeIssueOpCert kesVerKeyOrFile
                    (SigningKeyFile stakePoolSKeyFile)
                    (OpCertCounterFile ocertCtrPath)
                    kesPeriod
-                   (OutputFile certFile) = do
+                   certFile = do
 
     ocertIssueCounter <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
-      $ readFileTextEnvelope AsOperationalCertificateIssueCounter ocertCtrPath
+      $ readFileTextEnvelope AsOperationalCertificateIssueCounter (usingIn ocertCtrPath)
 
     verKeyKes <- firstExceptT ShelleyNodeCmdReadKeyFileError
       . newExceptT
@@ -218,7 +220,7 @@ runNodeIssueOpCert kesVerKeyOrFile
     -- a new cert but without updating the counter.
     firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
-      $ writeLazyByteStringFile ocertCtrPath
+      $ writeLazyByteStringFile (usingOut ocertCtrPath)
       $ textEnvelopeToJSON (Just $ ocertCtrDesc $ getCounter nextOcertCtr) nextOcertCtr
 
     firstExceptT ShelleyNodeCmdWriteFileError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.Shelley.Run.Node
   ( ShelleyNodeCmdError(ShelleyNodeCmdReadFileError)
@@ -194,7 +195,7 @@ runNodeIssueOpCert kesVerKeyOrFile
 
     ocertIssueCounter <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
-      $ readFileTextEnvelope AsOperationalCertificateIssueCounter (usingIn ocertCtrPath)
+      $ readFileTextEnvelope AsOperationalCertificateIssueCounter (usingIn @File ocertCtrPath)
 
     verKeyKes <- firstExceptT ShelleyNodeCmdReadKeyFileError
       . newExceptT
@@ -220,7 +221,7 @@ runNodeIssueOpCert kesVerKeyOrFile
     -- a new cert but without updating the counter.
     firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
-      $ writeLazyByteStringFile (usingOut ocertCtrPath)
+      $ writeLazyByteStringFile (usingOut @File ocertCtrPath)
       $ textEnvelopeToJSON (Just $ ocertCtrDesc $ getCounter nextOcertCtr) nextOcertCtr
 
     firstExceptT ShelleyNodeCmdWriteFileError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -195,7 +195,7 @@ runNodeIssueOpCert kesVerKeyOrFile
 
     ocertIssueCounter <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT
-      $ readFileTextEnvelope AsOperationalCertificateIssueCounter (usingIn @File ocertCtrPath)
+      $ readFileTextEnvelope AsOperationalCertificateIssueCounter (toFileIn ocertCtrPath)
 
     verKeyKes <- firstExceptT ShelleyNodeCmdReadKeyFileError
       . newExceptT
@@ -221,7 +221,7 @@ runNodeIssueOpCert kesVerKeyOrFile
     -- a new cert but without updating the counter.
     firstExceptT ShelleyNodeCmdWriteFileError
       . newExceptT
-      $ writeLazyByteStringFile (usingOut @File ocertCtrPath)
+      $ writeLazyByteStringFile (toFileOut ocertCtrPath)
       $ textEnvelopeToJSON (Just $ ocertCtrDesc $ getCounter nextOcertCtr) nextOcertCtr
 
     firstExceptT ShelleyNodeCmdWriteFileError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Cardano.CLI.Shelley.Run.Pool
   ( ShelleyPoolCmdError(ShelleyPoolCmdReadFileError)
   , renderShelleyPoolCmdError
@@ -75,7 +77,7 @@ runStakePoolRegistrationCert
   -> Maybe StakePoolMetadataReference
   -- ^ Stake pool metadata.
   -> NetworkId
-  -> OutputFile
+  -> File 'Out
   -> ExceptT ShelleyPoolCmdError IO ()
 runStakePoolRegistrationCert
   stakePoolVerKeyOrFile
@@ -88,7 +90,7 @@ runStakePoolRegistrationCert
   relays
   mbMetadata
   network
-  (OutputFile outfp) = do
+  outfp = do
     -- Pool verification key
     stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
       . newExceptT
@@ -144,9 +146,9 @@ runStakePoolRegistrationCert
 runStakePoolRetirementCert
   :: VerificationKeyOrFile StakePoolKey
   -> Shelley.EpochNo
-  -> OutputFile
+  -> File 'Out
   -> ExceptT ShelleyPoolCmdError IO ()
-runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch (OutputFile outfp) = do
+runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch outfp = do
     -- Pool verification key
     stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
       . newExceptT
@@ -178,7 +180,7 @@ runPoolId verKeyOrFile outputFormat = do
         OutputFormatBech32 ->
           Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
-runPoolMetadataHash :: PoolMetadataFile -> Maybe OutputFile -> ExceptT ShelleyPoolCmdError IO ()
+runPoolMetadataHash :: PoolMetadataFile -> Maybe (File 'Out) -> ExceptT ShelleyPoolCmdError IO ()
 runPoolMetadataHash (PoolMetadataFile poolMDPath) mOutFile = do
   metadataBytes <- handleIOExceptT (ShelleyPoolCmdReadFileError . FileIOError poolMDPath) $
     BS.readFile poolMDPath
@@ -188,6 +190,6 @@ runPoolMetadataHash (PoolMetadataFile poolMDPath) mOutFile = do
     $ validateAndHashStakePoolMetadata metadataBytes
   case mOutFile of
     Nothing -> liftIO $ BS.putStrLn (serialiseToRawBytesHex metadataHash)
-    Just (OutputFile fpath) ->
+    Just (File fpath) ->
       handleIOExceptT (ShelleyPoolCmdWriteFileError . FileIOError fpath)
         $ BS.writeFile fpath (serialiseToRawBytesHex metadataHash)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Cardano.CLI.Shelley.Run.TextView
   ( ShelleyTextViewFileError(..)
   , renderShelleyTextViewFileError
@@ -35,10 +37,10 @@ runTextViewCmd cmd =
   case cmd of
     TextViewInfo fpath mOutfile -> runTextViewInfo fpath mOutfile
 
-runTextViewInfo :: FilePath -> Maybe OutputFile -> ExceptT ShelleyTextViewFileError IO ()
+runTextViewInfo :: File 'In -> Maybe (File 'Out) -> ExceptT ShelleyTextViewFileError IO ()
 runTextViewInfo fpath mOutFile = do
   tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
   let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
   case mOutFile of
-    Just (OutputFile oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
+    Just oFpath -> liftIO $ LBS.writeFile (unFile oFpath) lbCBOR
     Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -41,10 +41,26 @@ module Cardano.CLI.Types
   , Params (..)
   , RequiredSigner (..)
   , AllOrOnly(..)
+
+  , toCertificateFileIn
+  , toCertificateFileOut
+  , toGenesisFileIn
+  , toGenesisFileOut
+  , toSigningKeyFileIn
+  , toSigningKeyFileOut
+  , toTxBodyFileIn
+  , toTxBodyFileOut
+  , toTxFileIn
+  , toTxFileOut
+  , toUpdateProposalFileIn
+  , toUpdateProposalFileOut
+  , toVerificationKeyFileIn
+  , toVerificationKeyFileOut
   ) where
 
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
+import           Data.Coerce (coerce)
 import           Data.String (IsString)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
@@ -52,9 +68,9 @@ import           Data.Word (Word64)
 import qualified Cardano.Chain.Slotting as Byron
 
 import           Cardano.Api (AddressAny, AnyScriptLanguage, EpochNo, ExecutionUnits, File (..),
-                   FileDirection (..), HasFileMode, Hash, HashableScriptData, MapFile, PaymentKey,
-                   PolicyId, ScriptData, SlotNo (SlotNo), TxId, TxIn, Value, WitCtxMint,
-                   WitCtxStake, WitCtxTxIn)
+                   FileDirection (..), Hash, HashableScriptData, MapFile, PaymentKey, PolicyId,
+                   ScriptData, SlotNo (SlotNo), TxId, TxIn, Value, WitCtxMint, WitCtxStake,
+                   WitCtxTxIn)
 
 import qualified Cardano.Ledger.Crypto as Crypto
 
@@ -80,7 +96,13 @@ data CBORObject = CBORBlockByron Byron.EpochSlots
 -- genesis delegate certificates and MIR certificates.
 newtype CertificateFile (direction :: FileDirection) = CertificateFile
   { unCertificateFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toCertificateFileIn :: CertificateFile 'InOut -> CertificateFile 'In
+toCertificateFileIn = coerce
+
+toCertificateFileOut :: CertificateFile 'InOut -> CertificateFile 'Out
+toCertificateFileOut = coerce
 
 newtype CurrentKesPeriod = CurrentKesPeriod { unCurrentKesPeriod :: Word64 } deriving (Eq, Show)
 
@@ -92,7 +114,13 @@ instance FromJSON CurrentKesPeriod where
 
 newtype GenesisFile (direction :: FileDirection) = GenesisFile
   { unGenesisFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, ToJSON)
+
+toGenesisFileIn :: GenesisFile 'InOut -> GenesisFile 'In
+toGenesisFileIn = coerce
+
+toGenesisFileOut :: GenesisFile 'InOut -> GenesisFile 'Out
+toGenesisFileOut = coerce
 
 data OpCertNodeAndOnDiskCounterInformation
   -- | The on disk operational certificate has a counter
@@ -225,15 +253,33 @@ instance Crypto.Crypto crypto =>  ToJSON (Params crypto) where
 
 newtype SigningKeyFile (direction :: FileDirection) = SigningKeyFile
   { unSigningKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toSigningKeyFileIn :: SigningKeyFile 'InOut -> SigningKeyFile 'In
+toSigningKeyFileIn = coerce
+
+toSigningKeyFileOut :: SigningKeyFile 'InOut -> SigningKeyFile 'Out
+toSigningKeyFileOut = coerce
 
 newtype UpdateProposalFile (direction :: FileDirection) = UpdateProposalFile
   { unUpdateProposalFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toUpdateProposalFileIn :: UpdateProposalFile 'InOut -> UpdateProposalFile 'In
+toUpdateProposalFileIn = coerce
+
+toUpdateProposalFileOut :: UpdateProposalFile 'InOut -> UpdateProposalFile 'Out
+toUpdateProposalFileOut = coerce
 
 newtype VerificationKeyFile (direction :: FileDirection) = VerificationKeyFile
   { unVerificationKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toVerificationKeyFileIn :: VerificationKeyFile 'InOut -> VerificationKeyFile 'In
+toVerificationKeyFileIn = coerce
+
+toVerificationKeyFileOut :: VerificationKeyFile 'InOut -> VerificationKeyFile 'Out
+toVerificationKeyFileOut = coerce
 
 newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
                      deriving (Eq, Show)
@@ -356,11 +402,23 @@ data EpochLeadershipSchedule
 
 newtype TxBodyFile direction = TxBodyFile
   { unTxBodyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toTxBodyFileIn :: TxBodyFile 'InOut -> TxBodyFile 'In
+toTxBodyFileIn = coerce
+
+toTxBodyFileOut :: TxBodyFile 'InOut -> TxBodyFile 'Out
+toTxBodyFileOut = coerce
 
 newtype TxFile direction = TxFile
   { unTxFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toTxFileIn :: TxFile 'InOut -> TxFile 'In
+toTxFileIn = coerce
+
+toTxFileOut :: TxFile 'InOut -> TxFile 'Out
+toTxFileOut = coerce
 
 data TxMempoolQuery =
       TxMempoolQueryTxExists TxId

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -80,7 +80,7 @@ data CBORObject = CBORBlockByron Byron.EpochSlots
 -- genesis delegate certificates and MIR certificates.
 newtype CertificateFile (direction :: FileDirection) = CertificateFile
   { unCertificateFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype CurrentKesPeriod = CurrentKesPeriod { unCurrentKesPeriod :: Word64 } deriving (Eq, Show)
 
@@ -92,7 +92,7 @@ instance FromJSON CurrentKesPeriod where
 
 newtype GenesisFile (direction :: FileDirection) = GenesisFile
   { unGenesisFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, ToJSON)
 
 data OpCertNodeAndOnDiskCounterInformation
   -- | The on disk operational certificate has a counter
@@ -225,15 +225,15 @@ instance Crypto.Crypto crypto =>  ToJSON (Params crypto) where
 
 newtype SigningKeyFile (direction :: FileDirection) = SigningKeyFile
   { unSigningKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype UpdateProposalFile (direction :: FileDirection) = UpdateProposalFile
   { unUpdateProposalFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype VerificationKeyFile (direction :: FileDirection) = VerificationKeyFile
   { unVerificationKeyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
                      deriving (Eq, Show)
@@ -356,11 +356,11 @@ data EpochLeadershipSchedule
 
 newtype TxBodyFile direction = TxBodyFile
   { unTxBodyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype TxFile direction = TxFile
   { unTxFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 data TxMempoolQuery =
       TxMempoolQueryTxExists TxId

--- a/cardano-cli/test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/Test/Cli/FilePermissions.hs
@@ -12,6 +12,7 @@ import qualified Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
 import           Hedgehog.Internal.Property (failWith)
 
+import           Cardano.Api (File (..))
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (runExceptT)
@@ -33,7 +34,7 @@ prop_createVRFSigningKeyFilePermissions =
       , "--signing-key-file", vrfSignKey
       ]
 
-    result <- liftIO . runExceptT $ checkVRFFilePermissions vrfSignKey
+    result <- liftIO . runExceptT $ checkVRFFilePermissions $ File vrfSignKey
     case result of
       Left err ->
         failWith Nothing

--- a/cardano-cli/test/Test/Cli/Pipes.hs
+++ b/cardano-cli/test/Test/Cli/Pipes.hs
@@ -19,6 +19,8 @@ import qualified Data.ByteString.Lazy as LBS
 import           System.IO (hClose, hFlush, hPutStr)
 import           System.Posix.IO (closeFd, createPipe, fdToHandle)
 
+import           Cardano.Api
+
 import           Cardano.CLI.Shelley.Run.Read
 import           Test.OptParse
 
@@ -50,7 +52,7 @@ prop_readFromPipe = H.withTests 10 . H.property . H.moduleWorkspace "tmp" $ \ws 
 
   -- We first test that we can read a filepath
   testFp <- noteInputFile testFile
-  testFileOrPipe <- liftIO $ fileOrPipe testFp
+  testFileOrPipe <- liftIO $ fileOrPipe (File testFp)
   testBs <- liftIO $ readFileOrPipe testFileOrPipe
 
   if LBS.null testBs
@@ -81,7 +83,7 @@ withPipe contents = do
   hPutStr writeHandle contents
   hFlush writeHandle
   hClose writeHandle
-  pipe <- fileOrPipe $ "/dev/fd/" ++ show readEnd
+  pipe <- fileOrPipe $ File $ "/dev/fd/" ++ show readEnd
 
   -- Read contents from pipe
   readContents <- readFileOrPipe pipe

--- a/cardano-cli/test/Test/Config/Mainnet.hs
+++ b/cardano-cli/test/Test/Config/Mainnet.hs
@@ -6,7 +6,7 @@ module Test.Config.Mainnet
   ( tests
   ) where
 
-import           Cardano.Api (initialLedgerState, renderInitialLedgerStateError)
+import           Cardano.Api (File (..), initialLedgerState, renderInitialLedgerStateError)
 import           Control.Monad.Trans.Except
 import           Hedgehog (Property, (===))
 import           System.FilePath ((</>))
@@ -23,7 +23,7 @@ import qualified System.Directory as IO
 hprop_configMainnetHash :: Property
 hprop_configMainnetHash = H.propertyOnce $ do
   base <- H.note =<< H.evalIO . IO.canonicalizePath =<< H.getProjectBase
-  result <- H.evalIO $ runExceptT $ initialLedgerState $ base </> "configuration/cardano/mainnet-config.json"
+  result <- H.evalIO $ runExceptT $ initialLedgerState $ File $ base </> "configuration/cardano/mainnet-config.json"
   case result of
     Right (_, _) -> return ()
     Left e -> H.failWithCustom GHC.callStack Nothing (T.unpack (renderInitialLedgerStateError e))

--- a/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/Test/Golden/Byron/SigningKeys.hs
@@ -90,7 +90,7 @@ prop_migrate_legacy_to_nonlegacy_signingkeys =
      ]
 
     eSignKey <- liftIO . runExceptT . readByronSigningKey NonLegacyByronKeyFormat
-                  $ SigningKeyFile nonLegacyKeyFp
+                  $ SigningKeyFile (File nonLegacyKeyFp)
 
     case eSignKey of
       Left err -> failWith Nothing $ show err

--- a/cardano-cli/test/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Byron/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Golden.Byron.Tx
@@ -7,6 +8,7 @@ module Test.Golden.Byron.Tx
 import           Cardano.Chain.UTxO (ATxAux)
 import           Cardano.CLI.Byron.Tx
 
+import           Cardano.Api (File (..), FileDirection (..))
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Except (runExceptT)
@@ -37,7 +39,7 @@ golden_byronTx_legacy = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--txout", "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
     ]
 
-  compareByronTxs createdTx goldenTx
+  compareByronTxs (File createdTx) (File goldenTx)
 
 golden_byronTx :: Property
 golden_byronTx = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
@@ -54,16 +56,16 @@ golden_byronTx = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--txout", "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
     ]
 
-  compareByronTxs createdTx goldenTx
+  compareByronTxs (File createdTx) (File goldenTx)
 
-getTxByteString :: FilePath -> H.PropertyT IO (ATxAux ByteString)
+getTxByteString :: File 'In -> H.PropertyT IO (ATxAux ByteString)
 getTxByteString txFp = do
   eATxAuxBS <- liftIO . runExceptT $ readByronTx $ TxFile txFp
   case eATxAuxBS of
     Left err -> failWith Nothing . Text.unpack $ renderByronTxError err
     Right aTxAuxBS -> return aTxAuxBS
 
-compareByronTxs :: FilePath -> FilePath -> H.PropertyT IO ()
+compareByronTxs :: File 'In -> File 'In -> H.PropertyT IO ()
 compareByronTxs createdTx goldenTx = do
   createdATxAuxBS <- getTxByteString createdTx
   goldenATxAuxBS <- getTxByteString goldenTx

--- a/cardano-cli/test/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/Test/Golden/Byron/UpdateProposal.hs
@@ -9,6 +9,7 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
 
+import           Cardano.Api (File (..))
 import           Cardano.CLI.Byron.UpdateProposal
 
 import           Hedgehog (Property, (===))
@@ -39,12 +40,12 @@ golden_byron_update_proposal = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir
     , "--filepath", createdUpdateProposal
     ]
 
-  eGolden <- liftIO . runExceptT $ readByronUpdateProposal goldenUpdateProposal
+  eGolden <- liftIO . runExceptT $ readByronUpdateProposal $ File goldenUpdateProposal
   golden <- case eGolden of
               Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
               Right prop -> return prop
 
-  eCreated <- liftIO . runExceptT $ readByronUpdateProposal createdUpdateProposal
+  eCreated <- liftIO . runExceptT $ readByronUpdateProposal $ File createdUpdateProposal
   created <- case eCreated of
                Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
                Right prop -> return prop

--- a/cardano-cli/test/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/Test/Golden/Byron/Vote.hs
@@ -4,6 +4,7 @@ module Test.Golden.Byron.Vote
   ( voteTests
   ) where
 
+import           Cardano.Api (File (..))
 import           Cardano.CLI.Byron.Vote
 
 import           Control.Monad (void)
@@ -34,12 +35,12 @@ golden_byron_yes_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--output-filepath", createdYesVote
     ]
 
-  eGolden <- liftIO . runExceptT $ readByronVote goldenYesVote
+  eGolden <- liftIO . runExceptT $ readByronVote $ File goldenYesVote
   golden <- case eGolden of
               Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
               Right prop -> return prop
 
-  eCreated <- liftIO . runExceptT $ readByronVote createdYesVote
+  eCreated <- liftIO . runExceptT $ readByronVote $ File createdYesVote
   created <- case eCreated of
                Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
                Right prop -> return prop
@@ -61,12 +62,12 @@ golden_byron_no_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     , "--output-filepath", createdNoVote
     ]
 
-  eGolden <- liftIO . runExceptT $ readByronVote goldenNoVote
+  eGolden <- liftIO . runExceptT $ readByronVote $ File goldenNoVote
   golden <- case eGolden of
               Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
               Right prop -> return prop
 
-  eCreated <- liftIO . runExceptT $ readByronVote createdNoVote
+  eCreated <- liftIO . runExceptT $ readByronVote $ File createdNoVote
   created <- case eCreated of
                Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
                Right prop -> return prop

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegationCertificate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertifi
   ( golden_shelleyGenesisKeyDelegationCertificate
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -84,5 +84,5 @@ golden_shelleyGenesisKeyDelegationCertificate =
 
     checkTextEnvelopeFormat
       certificateType
-      referenceCertificateFilePath
-      genesisKeyDelegCertFilePath
+      (File referenceCertificateFilePath)
+      (File genesisKeyDelegCertFilePath)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/MIRCertificate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.MIRCertificate
   ( golden_shelleyMIRCertificate
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -50,4 +50,4 @@ golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
 
   let registrationCertificateType = textEnvelopeType AsCertificate
 
-  checkTextEnvelopeFormat registrationCertificateType referenceMIRCertificate mirCertificate
+  checkTextEnvelopeFormat registrationCertificateType (File referenceMIRCertificate) (File mirCertificate)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/OperationalCertificate.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.OperationalCertificate
   ( golden_shelleyOperationalCertificate
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -64,4 +64,4 @@ golden_shelleyOperationalCertificate = propertyOnce . H.moduleWorkspace "tmp" $ 
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat operationalCertificateType referenceOperationalCertificate operationalCert
+  checkTextEnvelopeFormat operationalCertificateType (File referenceOperationalCertificate) (File operationalCert)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddressCertificates.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddressCertificates
   ( golden_shelleyStakeAddressCertificates
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -49,7 +49,7 @@ golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace "tmp" 
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceRegistrationCertificate registrationCertificate
+  checkTextEnvelopeFormat registrationCertificateType (File referenceRegistrationCertificate) (File registrationCertificate)
 
   -- Create stake address deregistration certificate
   void $ execCardanoCLI
@@ -60,7 +60,7 @@ golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace "tmp" 
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
+  checkTextEnvelopeFormat registrationCertificateType (File referenceDeregistrationCertificate) (File deregistrationCertificate)
 
 -- TODO: After delegation-certificate command is fixed to take a hash instead of a verification key
 {-

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Certificates/StakePoolCertificates.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Certificates.StakePoolCertificates
   ( golden_shelleyStakePoolCertificates
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -86,7 +86,7 @@ golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tmp" $ \
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceRegistrationCertificate registrationCertificate
+  checkTextEnvelopeFormat registrationCertificateType (File referenceRegistrationCertificate) (File registrationCertificate)
 
   -- Create stake pool deregistration certificate
   void $ execCardanoCLI
@@ -100,4 +100,4 @@ golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tmp" $ \
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
+  checkTextEnvelopeFormat registrationCertificateType (File referenceDeregistrationCertificate) (File deregistrationCertificate)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
   ( golden_shelleyExtendedPaymentKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -39,5 +39,5 @@ golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \te
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
   ( golden_shelleyGenesisDelegateKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -42,6 +42,6 @@ golden_shelleyGenesisDelegateKeys = propertyOnce . H.moduleWorkspace "tmp" $ \te
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
-  checkTextEnvelopeFormat operationalCertCounterType referenceOpCertCounter opCertCounter
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)
+  checkTextEnvelopeFormat operationalCertCounterType (File referenceOpCertCounter) (File opCertCounter)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys
   ( golden_shelleyGenesisKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyGenesisKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
   ( golden_shelleyGenesisUTxOKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyGenesisUTxOKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDi
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys
   ( golden_shelleyKESKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys
   ( golden_shelleyPaymentKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys
   ( golden_shelleyStakeKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (..), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> d
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -4,7 +4,7 @@ module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys
   ( golden_shelleyVRFKeys
   ) where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import           Cardano.Api (AsType (..), File (File), HasTextEnvelope (..))
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
@@ -38,5 +38,5 @@ golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
-  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+  checkTextEnvelopeFormat verificationKeyType (File referenceVerKey) (File verKey)
+  checkTextEnvelopeFormat signingKeyType (File referenceSignKey) (File signKey)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -8,6 +8,7 @@ import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import           Cardano.Api (File (..))
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -48,4 +49,4 @@ golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTxCddlFormat referenceTx transactionFile
+  checkTxCddlFormat referenceTx (File transactionFile)

--- a/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -7,6 +7,7 @@ module Test.Golden.Shelley.TextEnvelope.Tx.TxBody
 import           Hedgehog (Property)
 import           Test.OptParse
 
+import           Cardano.Api (File (..))
 import           Control.Monad (void)
 import qualified Hedgehog.Extras.Test.Base as H
 
@@ -36,4 +37,4 @@ golden_shelleyTxBody = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTxCddlFormat referenceTxBody transactionBodyFile
+  checkTxCddlFormat (File referenceTxBody) (File transactionBodyFile)

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Test.OptParse
   ( checkTxCddlFormat
   , checkTextEnvelopeFormat
@@ -41,8 +43,8 @@ execCardanoCLI = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI
 checkTextEnvelopeFormat
   :: (MonadTest m, MonadIO m, HasCallStack)
   => TextEnvelopeType
-  -> FilePath
-  -> FilePath
+  -> File 'In
+  -> File 'In
   -> m ()
 checkTextEnvelopeFormat tve reference created = GHC.withFrozenCallStack $ do
   eRefTextEnvelope <- liftIO $ readTextEnvelopeOfTypeFromFile tve reference
@@ -67,8 +69,8 @@ checkTextEnvelopeFormat tve reference created = GHC.withFrozenCallStack $ do
 
 checkTxCddlFormat
   :: (MonadTest m, MonadIO m, HasCallStack)
-  => FilePath -- ^ Reference/golden file
-  -> FilePath -- ^ Newly created file
+  => File 'In -- ^ Reference/golden file
+  -> File 'In -- ^ Newly created file
   -> m ()
 checkTxCddlFormat referencePath createdPath = do
   reference <- liftIO $ fileOrPipe referencePath

--- a/cardano-client-demo/ChainSyncClientWithLedgerState.hs
+++ b/cardano-client-demo/ChainSyncClientWithLedgerState.hs
@@ -45,7 +45,10 @@ import           System.FilePath ((</>))
 main :: IO ()
 main = do
   -- Get config and socket path from CLI argument.
-  configFilePath : socketPath : xs <- getArgs
+  configFilePath : socketFilePath : xs <- getArgs
+
+  let socketPath = File socketFilePath
+
   byronSlotLength <- case xs of
         byronSlotLengthStr : _ -> return (read byronSlotLengthStr)
         _ -> do
@@ -54,7 +57,7 @@ main = do
           return l
 
   -- Use 'chainSyncClientWithLedgerState' to support ledger state.
-  Right (env, initialLedgerState) <- runExceptT $ initialLedgerState configFilePath
+  Right (env, initialLedgerState) <- runExceptT $ initialLedgerState (File configFilePath)
   let client = chainSyncClientWithLedgerState
         env
         initialLedgerState
@@ -71,12 +74,12 @@ main = do
           }
 
   -- Connect to the node.
-  putStrLn $ "Connecting to socket: " <> socketPath
+  putStrLn $ "Connecting to socket: " <> unFile socketPath
   connectToLocalNode
     (connectInfo socketPath)
     protocols
   where
-  connectInfo :: FilePath -> LocalNodeConnectInfo CardanoMode
+  connectInfo :: File 'InOut -> LocalNodeConnectInfo CardanoMode
   connectInfo socketPath =
       LocalNodeConnectInfo {
         localConsensusModeParams = CardanoModeParams (Byron.EpochSlots 21600),

--- a/cardano-client-demo/LedgerState.hs
+++ b/cardano-client-demo/LedgerState.hs
@@ -32,8 +32,8 @@ main = do
   -- Get socket path from CLI argument.
   configFilePath : socketPath : xs <- getArgs
   blockCount <- fmap (either (error . T.unpack . renderFoldBlocksError) id) $ runExceptT $ foldBlocks
-    configFilePath
-    socketPath
+    (File configFilePath)
+    (File socketPath)
     FullValidation
     (0 :: Int) -- We just use a count of the blocks as the current state
     (\_env

--- a/cardano-client-demo/ScanBlocks.hs
+++ b/cardano-client-demo/ScanBlocks.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 
 import           Cardano.Api
 import           Cardano.Api.ChainSync.Client
@@ -27,15 +28,15 @@ main :: IO ()
 main = do
   -- Get socket path from CLI argument.
   socketDir:_ <- getArgs
-  let socketPath = socketDir </> "node.sock"
+  let socketPath = File $ socketDir </> "node.sock"
 
   -- Connect to the node.
-  putStrLn $ "Connecting to socket: " <> socketPath
+  putStrLn $ "Connecting to socket: " <> unFile socketPath
   connectToLocalNode
     (connectInfo socketPath)
     protocols
   where
-  connectInfo :: FilePath -> LocalNodeConnectInfo CardanoMode
+  connectInfo :: File 'InOut -> LocalNodeConnectInfo CardanoMode
   connectInfo socketPath =
       LocalNodeConnectInfo {
         localConsensusModeParams = CardanoModeParams (EpochSlots 21600),

--- a/cardano-client-demo/ScanBlocksPipelined.hs
+++ b/cardano-client-demo/ScanBlocksPipelined.hs
@@ -36,15 +36,15 @@ main :: IO ()
 main = do
   -- Get cocket path from CLI argument.
   socketDir:_ <- getArgs
-  let socketPath = socketDir </> "node.sock"
+  let socketPath = File $ socketDir </> "node.sock"
 
   -- Connect to the node.
-  putStrLn $ "Connecting to socket: " <> socketPath
+  putStrLn $ "Connecting to socket: " <> unFile socketPath
   connectToLocalNode
     (connectInfo socketPath)
     protocols
   where
-  connectInfo :: FilePath -> LocalNodeConnectInfo CardanoMode
+  connectInfo :: File 'InOut -> LocalNodeConnectInfo CardanoMode
   connectInfo socketPath =
       LocalNodeConnectInfo {
         localConsensusModeParams = CardanoModeParams (Byron.EpochSlots 21600),

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -244,8 +244,8 @@ main = do
       targetCredAsAPI = fromShelleyStakeCredential targetCred
       f = either (error . T.unpack . renderFoldBlocksError) id
   !_ <- fmap f $ runExceptT $ foldBlocks
-         (conf args)
-         (socket args)
+         (File (conf args))
+         (File (socket args))
          QuickValidation
          startingState
          (\_env

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -166,7 +166,7 @@ createLoggingLayer ver nodeConfig' p = do
   logConfig <- loggingCLIConfiguration $
     if ncLoggingSwitch nodeConfig'
     -- Re-interpret node config again, as logging 'Configuration':
-    then Just . unConfigPath $ ncConfigFile nodeConfig'
+    then Just . unFile . unConfigYamlFilePath $ ncConfigFile nodeConfig'
     else Nothing
 
   -- These have to be set before the switchboard is set up.

--- a/cardano-node/src/Cardano/Node/Configuration/Socket.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Socket.hs
@@ -12,6 +12,7 @@ module Cardano.Node.Configuration.Socket
   )
 where
 
+import           Cardano.Api (File (..))
 import           Cardano.Prelude hiding (local)
 import           Prelude (String)
 import qualified Prelude
@@ -197,8 +198,8 @@ gatherConfiguredSockets SocketConfig { ncNodeIPv4Addr,
       (Just _, Just _)      -> throwError ClashingLocalSocketGiven
       (Nothing, Just sock)  -> return . Just $ ActualSocket sock
       (Just (SocketPath path), Nothing)
-                            -> removeStaleLocalSocket path
-                            $> Just (SocketInfo (LocalAddress path))
+                            -> removeStaleLocalSocket (unFile path)
+                            $> Just (SocketInfo (LocalAddress (unFile path)))
 
     return (ipv4', ipv6', local)
 

--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -134,7 +134,7 @@ instance ToJSON NetworkTopology where
 -- other remote peers it will attempt to connect to.
 readTopologyFile :: NodeConfiguration -> IO (Either Text NetworkTopology)
 readTopologyFile nc = do
-  eBs <- Exception.try $ BS.readFile (unTopology $ ncTopologyFile nc)
+  eBs <- Exception.try $ BS.readFile (unFile . unTopologyFile $ ncTopologyFile nc)
 
   case eBs of
     Left e -> return . Left $ handler e

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -235,7 +235,7 @@ instance FromJSON (Legacy NetworkTopology) where
 readTopologyFile :: Tracer IO (StartupTrace blk)
                  -> NodeConfiguration -> IO (Either Text NetworkTopology)
 readTopologyFile tr nc = do
-  eBs <- Exception.try $ BS.readFile (unTopology $ ncTopologyFile nc)
+  eBs <- Exception.try $ BS.readFile (unFile . unTopologyFile $ ncTopologyFile nc)
 
   case eBs of
     Left e -> return . Left $ handler e

--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -31,7 +31,7 @@ import           Control.Exception (try)
 import           Control.Exception.Base (throwIO)
 import           Control.Monad (void, when)
 import           Data.Aeson (FromJSON, ToJSON)
-import           Data.Foldable (asum)
+import           Data.Foldable
 import           Data.Text (Text, pack)
 import           Generic.Data.Orphans ()
 import           GHC.Generics (Generic)

--- a/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -159,12 +159,12 @@ readLeaderCredentials genesisConfig
     (Nothing, Just _) -> left DelegationCertificateFilepathNotSpecified
     (Just delegCertFile, Just signingKeyFile) -> do
 
-         signingKeyFileBytes <- liftIO $ LB.readFile signingKeyFile
-         delegCertFileBytes <- liftIO $ LB.readFile delegCertFile
-         ByronSigningKey signingKey <- firstExceptT (const (SigningKeyDeserialiseFailure signingKeyFile))
+         signingKeyFileBytes <- liftIO $ LB.readFile (unFile signingKeyFile)
+         delegCertFileBytes <- liftIO $ LB.readFile (unFile delegCertFile)
+         ByronSigningKey signingKey <- firstExceptT (const (SigningKeyDeserialiseFailure (unFile signingKeyFile)))
                          . hoistEither
                          $ deserialiseFromRawBytes (AsSigningKey AsByronKey) $ LB.toStrict signingKeyFileBytes
-         delegCert  <- firstExceptT (CanonicalDecodeFailure delegCertFile)
+         delegCert  <- firstExceptT (CanonicalDecodeFailure (unFile delegCertFile))
                          . hoistEither
                          $ canonicalDecodePretty delegCertFileBytes
 

--- a/cardano-node/src/Cardano/Node/Protocol/Conway.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Conway.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -60,7 +60,7 @@ initTraceDispatcher ::
   -> NetworkP2PMode p2p
   -> IO (Tracers RemoteConnectionId LocalConnectionId blk p2p)
 initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
-  trConfig <- readConfigurationWithDefault (unConfigPath $ ncConfigFile nc) defaultCardanoConfig
+  trConfig <- readConfigurationWithDefault (unFile . unConfigYamlFilePath $ ncConfigFile nc) defaultCardanoConfig
   putStrLn $ "New tracer configuration: " <> show trConfig
 
   tracers <- mkTracers trConfig
@@ -95,7 +95,7 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
         then do
           -- TODO: check if this is the correct way to use withIOManager
           (forwardSink, dpStore) <- withIOManager $ \iomgr -> do
-            let tracerSocketMode = Just . first unSocketPath =<< ncTraceForwardSocket nc
+            let tracerSocketMode = Just . first (unFile . unSocketPath) =<< ncTraceForwardSocket nc
             initForwarding iomgr trConfig networkMagic (Just ekgStore) tracerSocketMode
           pure (forwardTracer forwardSink, dataPointTracer dpStore)
         else

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing -Wno-orphans #-}
+{-# LANGUAGE DataKinds #-}
 
 module Cardano.Node.Tracing.Tracers.Startup
 
@@ -13,7 +15,7 @@ module Cardano.Node.Tracing.Tracers.Startup
   , ppStartupInfoTrace
   )  where
 
-import           Cardano.Api (NetworkMagic (..), SlotNo (..))
+import           Cardano.Api (File (..), FileDirection (..), NetworkMagic (..), SlotNo (..))
 import qualified Cardano.Api as Api
 import           Prelude
 
@@ -64,7 +66,7 @@ import           Cardano.Node.Startup
 getStartupInfo
   :: NodeConfiguration
   -> SomeConsensusProtocol
-  -> FilePath
+  -> File 'In
   -> IO [StartupTrace blk]
 getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
   nodeStartTime <- getCurrentTime
@@ -74,7 +76,7 @@ getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
               , biVersion  = pack . showVersion $ version
               , biCommit   = gitRev
               , biNodeStartTime = nodeStartTime
-              , biConfigPath = fp
+              , biConfigPath = unFile fp
               , biNetworkMagic = getNetworkMagic $ Consensus.configBlock cfg
               }
       protocolDependentItems =

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -64,11 +64,11 @@ data ConfigError =
 -- (logging, tracing, protocol, slot length etc)
 newtype ConfigYamlFilePath (direction :: FileDirection) = ConfigYamlFilePath
   { unConfigYamlFilePath :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype DbFile (direction :: FileDirection) = DbFile
   { unDbFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 newtype GenesisFile = GenesisFile
   { unGenesisFile :: FilePath
@@ -289,7 +289,7 @@ data NodeHardForkProtocolConfiguration =
 
 newtype TopologyFile (direction :: FileDirection) = TopologyFile
   { unTopologyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile)
+  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
 
 instance AdjustFilePaths NodeProtocolConfiguration where
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -33,10 +33,18 @@ module Cardano.Node.Types
   , NodeConwayProtocolConfiguration(..)
   , VRFPrivateKeyFilePermissionError(..)
   , renderVRFPrivateKeyFilePermissionError
+
+  , toConfigYamlFilePathIn
+  , toConfigYamlFilePathOut
+  , toDbFileIn
+  , toDbFileOut
+  , toTopologyFileIn
+  , toTopologyFileOut
   ) where
 
 import           Data.Aeson
 import           Data.ByteString (ByteString)
+import           Data.Coerce (coerce)
 import           Data.Monoid (Last)
 import           Data.String (IsString)
 import           Data.Text (Text)
@@ -64,11 +72,23 @@ data ConfigError =
 -- (logging, tracing, protocol, slot length etc)
 newtype ConfigYamlFilePath (direction :: FileDirection) = ConfigYamlFilePath
   { unConfigYamlFilePath :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toConfigYamlFilePathIn :: ConfigYamlFilePath 'InOut -> ConfigYamlFilePath 'In
+toConfigYamlFilePathIn = coerce
+
+toConfigYamlFilePathOut :: ConfigYamlFilePath 'InOut -> ConfigYamlFilePath 'Out
+toConfigYamlFilePathOut = coerce
 
 newtype DbFile (direction :: FileDirection) = DbFile
   { unDbFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toDbFileIn :: DbFile 'InOut -> DbFile 'In
+toDbFileIn = coerce
+
+toDbFileOut :: DbFile 'InOut -> DbFile 'Out
+toDbFileOut = coerce
 
 newtype GenesisFile = GenesisFile
   { unGenesisFile :: FilePath
@@ -289,7 +309,13 @@ data NodeHardForkProtocolConfiguration =
 
 newtype TopologyFile (direction :: FileDirection) = TopologyFile
   { unTopologyFile :: File direction
-  } deriving newtype (Eq, Ord, Show, IsString, HasFileMode, MapFile, FromJSON, ToJSON)
+  } deriving newtype (Eq, Ord, Show, IsString, MapFile, FromJSON, ToJSON)
+
+toTopologyFileIn :: TopologyFile 'InOut -> TopologyFile 'In
+toTopologyFileIn = coerce
+
+toTopologyFileOut :: TopologyFile 'InOut -> TopologyFile 'Out
+toTopologyFileOut = coerce
 
 instance AdjustFilePaths NodeProtocolConfiguration where
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -12,7 +12,7 @@ module Cardano.TxSubmit.Web
 
 import           Cardano.Api (AllegraEra, AnyCardanoEra (AnyCardanoEra),
                    AnyConsensusMode (AnyConsensusMode), AnyConsensusModeParams (..), AsType (..),
-                   CardanoEra (..), Error (..), FromSomeType (..), HasTypeProxy (AsType),
+                   CardanoEra (..), Error (..), File (..), FromSomeType (..), HasTypeProxy (AsType),
                    InAnyCardanoEra (..),
                    LocalNodeConnectInfo (LocalNodeConnectInfo, localConsensusModeParams, localNodeNetworkId, localNodeSocketPath),
                    NetworkId, SerialiseAsCBOR (..), ShelleyEra, SocketPath (..), ToJSON, Tx,
@@ -102,7 +102,7 @@ txSubmitApp trace metrics connectInfo networkId socketPath =
 readEnvSocketPath :: ExceptT EnvSocketError IO SocketPath
 readEnvSocketPath =
     maybe (left $ CliEnvVarLookup (T.pack envName)) (pure . SocketPath)
-      =<< liftIO (lookupEnv envName)
+      =<< liftIO (fmap File <$> lookupEnv envName)
   where
     envName :: String
     envName = "CARDANO_NODE_SOCKET_PATH"

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -70,7 +70,7 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
       -- that case we simply restart `foldBlocks` again.
       forever $ do
         let handler _env _ledgerState _ledgerEvents _blockInCardanoMode _ = IO.putMVar lock ()
-        e <- runExceptT (C.foldBlocks configFile socketPathAbs  C.QuickValidation () handler)
+        e <- runExceptT (C.foldBlocks (C.File configFile) (C.File socketPathAbs) C.QuickValidation () handler)
         either (throw . FoldBlocksException) (\_ -> pure ()) e
     link a -- Throw async thread's exceptions in main thread
 


### PR DESCRIPTION
Introduce a `newtype File direction` to track how files are used to replace use of `FilePath`.

The type `File In` indicates that the file is for reading, `File Out` for writing and `File InOut` for both.

Annotating the type of file paths in this way makes it clear how files are used.  The most notable improvements are found where the `InOut` annotation is used.  In these cases, the file path is used to both open the file for reading and writing and in some cases, the fact that the file is written to is non-obvious.

New functions have been added to parse CLI arguments for files in this new typesafe scheme.

The process of making the code more type-safe around files also helped identify a bug where we used a `file` bash completer for a directory when we should have used `directory`.

This is a large PR and it isn't necessary to merge it all at once.  The PR is mostly to demonstrate that this is possible and the first commit serves as a good first step in this direction.

## Future work
This PR lays the ground work for:

* Expanding the `File` type to support special pseudo-files like `"-"` for `stdin` and `stdout` described in https://github.com/input-output-hk/cardano-node/issues/5016.
* Supporting a second type parameter `content` for describing the contents of the file.  For example CBOR vs JSON.
* Tightening type-safety by providing more typesafe versions of read/write functions and not use the escape hatch `File` and `unFile` that is currently used in the code as often.
* Using the annotations to improve the documentation making it clear which CLI options are inputs and which are outputs.