### PR TITLE
Remove dup of index-state, no longer needed with latest haskell.nix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,6 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
-index-state: 2023-03-18T05:24:58Z
-
 index-state:
   , hackage.haskell.org 2023-03-18T05:24:58Z
   , cardano-haskell-packages 2023-03-22T09:20:07Z
@@ -94,7 +92,7 @@ allow-newer:
   -- ekg does not suport newer snap
   , ekg:snap-server
   , ekg:snap-core
-  -- cardano-node-capi depends on aeson > 2.1, even our patched ekg-json only 
+  -- cardano-node-capi depends on aeson > 2.1, even our patched ekg-json only
   -- supports between 2 and 2.1
   , ekg-json:aeson
   -- These are currently required for 9.2.

--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1679444578,
-        "narHash": "sha256-iAGg8IhYPCaJPCeo3hoacVXIGISCFZm1yTgAAvv5aes=",
+        "lastModified": 1680740551,
+        "narHash": "sha256-qJn3uNjYu8WgCzTZSRfwqmVU1fWGuu3G8TvXX4aRHMk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f3793d3d9fa159d0f3a652fc4a50b65ed0e86c27",
+        "rev": "792b6432150f43a88f3d00d6f1375daebd75ba58",
         "type": "github"
       },
       "original": {
@@ -590,6 +590,7 @@
         "hackage": [
           "hackageNix"
         ],
+        "hls-1.10": "hls-1.10",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -607,16 +608,33 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1679800264,
-        "narHash": "sha256-DNXKCVN2e7S/b253bk02Iukxj4QMr4gMFf3yKpEYR5U=",
+        "lastModified": 1680743200,
+        "narHash": "sha256-ivpJ3fZ1eJs02RCs+SHF8u3catSxyIw6DnelQna9gMc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3c3decc5989603df52655317c9f484cf25300d2f",
+        "rev": "d30e47f9f0e1cb02761c00c9d43b59bff4e95f1a",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -1404,11 +1422,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1679702948,
-        "narHash": "sha256-3v6EVGga1QZ+hVeiomAXhqRhSZqboQRMZ0C7Ypb0U/s=",
+        "lastModified": 1680739732,
+        "narHash": "sha256-lKm2BP2k5VktVyowqzeLqrpxR8NYew6rvZOBNt2wUpc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "6ec27bb501b2885765a6a58843d884e13ac42d69",
+        "rev": "cc83e7c8777ea13b08c723d2b500ae362e1bf3f8",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -79,10 +79,10 @@ in with final;
     index-state = "2023-01-20T05:50:56Z";
   };
 
-  haskell-language-server = haskell-nix.tool compiler-nix-name "haskell-language-server" {
-    # ghcide 1.9.0.0 does not compile on ghc 8.10.7
-    version = {ghc8107 = "1.8.0.0";}.${compiler-nix-name} or "1.9.0.0";
-    index-state = "2023-01-20T05:50:56Z";
+  haskell-language-server = haskell-nix.tool compiler-nix-name "haskell-language-server" rec {
+    src = haskell-nix.sources."hls-1.10";
+    cabalProject = builtins.readFile (src + "/cabal.project");
+    sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 
   haskellBuildUtils = prev.haskellBuildUtils.override {

--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -53,7 +53,7 @@ rec {
             jq -r 'with_entries(select(.value)) | keys | .[]')
           targets=$(for s in $systems; do echo .#legacyPackages."$s".hydraJobs.${jobsAttrs}; done)
           # shellcheck disable=SC2086
-          nix build -L $targets
+          nix build --keep-going $targets || nix build -L $targets
         '';
 
         env.NIX_CONFIG = ''
@@ -70,9 +70,9 @@ rec {
     in
     {
       "ci/pr/required" = mkBulkJobsTask "pr.required";
-      "ci/pr/nonrequired" = mkBulkJobsTask "pr.nonrequired --keep-going";
+      "ci/pr/nonrequired" = mkBulkJobsTask "pr.nonrequired";
       "ci/push/required" = mkBulkJobsTask "required";
-      "ci/push/nonrequired" = mkBulkJobsTask "nonrequired --keep-going";
+      "ci/push/nonrequired" = mkBulkJobsTask "nonrequired";
 
       "ci/cardano-deployment" = { lib, ... } @ args: {
         imports = [ common ];


### PR DESCRIPTION
as of https://github.com/input-output-hk/haskell.nix/pull/1903 haskell.nix (the nix part) does not parse the index-state so the duplication which was done for haskell.nix is no longer needed.

There is also a change to use hls from github (hence with access to the cabal.project) instead of hackage (which was breaking regularly), required due to https://github.com/input-output-hk/haskell.nix/pull/1909