### PR TITLE
Split each test functions into two parts, A and B

### DIFF
--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -305,6 +305,9 @@ babbageTestnet testnetOptions H.Conf {..} = do
   return TestnetRuntime
     { configurationFile
     , shelleyGenesisFile = tempAbsPath </> "genesis/shelley/genesis.json"
+{-
+Testnet.Cardano uses : shelleyGenesisFile = tmpDir </> "shelley/genesis.json"
+-}
     , testnetMagic
     , poolNodes
     , wallets = wallets

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -761,6 +761,9 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   return TestnetRuntime
     { configurationFile
     , shelleyGenesisFile = tempAbsPath </> "shelley/genesis.json"
+{-
+Testnet.Babbage uses : shelleyGenesisFile = tmpDir </> "genesis/shelley/genesis.json"
+-}
     , testnetMagic
     , bftNodes
     , poolNodes

--- a/cardano-testnet/test/Main.hs
+++ b/cardano-testnet/test/Main.hs
@@ -37,7 +37,7 @@ tests = pure $ T.testGroup "test/Spec.hs"
       -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
       -- as a result of the kes-period-info output to stdout.
       -- TODO: Babbage temporarily ignored due to broken protocol-state query
-    , H.disabled "kes-period-info" Test.Cli.KesPeriodInfo.hprop_kes_period_info
+    , H.disabled "kes-period-info" Test.Cli.KesPeriodInfo.hprop_kesPeriodInfo
     ]
   , H.ignoreOnWindows "foldBlocks receives ledger state" Test.FoldBlocks.prop_foldBlocks
   ]

--- a/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -13,6 +13,7 @@
 
 module Test.Cli.Babbage.StakeSnapshot
   ( hprop_stakeSnapshot
+  , testStakeSnapshot
   ) where
 
 import           Prelude
@@ -41,6 +42,7 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified Testnet.Util.Base as H
+import           Testnet.Util.Cli
 import           Testnet.Util.Process
 import           Testnet.Util.Runtime
 
@@ -64,12 +66,16 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
     { testnetMagic
     , poolNodes
     } <- testnet testnetOptions conf
-
   poolNode1 <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+  testStakeSnapshot (TmpPath tempAbsPath) testnetMagic poolSprocket1
+
+testStakeSnapshot :: TmpPath -> TestnetMagic -> IO.Sprocket -> H.Integration ()
+testStakeSnapshot tmpPath testnetMagic poolSprocket1 = do
+  work <- H.note $ getWorkDir tmpPath
+  H.createDirectoryIfMissing work
 
   env <- H.evalIO getEnvironment
-
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
 
   execConfig <- H.noteShow H.ExecConfig
     { H.execConfigEnv = Last $ Just $

--- a/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
+++ b/cardano-testnet/test/Test/ShutdownOnSlotSynced.hs
@@ -4,6 +4,7 @@
 
 module Test.ShutdownOnSlotSynced
   ( hprop_shutdownOnSlotSynced
+  , testShutdownOnSlotSynced
   ) where
 
 import           Prelude
@@ -46,10 +47,13 @@ hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "shutdown-on-slot-syn
           ]
         }
   TestnetRuntime { bftNodes = node:_ } <- testnet fastTestnetOptions conf
+  let timeout = round (40 + (fromIntegral maxSlot * slotLen))
+  testShutdownOnSlotSynced maxSlot timeout node
 
+---Test core with minimal needed arguments
+testShutdownOnSlotSynced :: Integer -> Int -> NodeRuntime -> H.Integration ()
+testShutdownOnSlotSynced maxSlot timeout node = do
   -- Wait for the node to exit
-  let timeout :: Int
-      timeout = round (40 + (fromIntegral maxSlot * slotLen))
   mExitCodeRunning <- H.waitSecondsForProcess timeout (nodeProcessHandle node)
 
   -- Check results


### PR DESCRIPTION
After the split, function A starts the testnet
and then calls function B with a minimal set of arguments. This is a preparation for removing the `TestnetRuntime` data type. The plan is to call function B directly without creating a `TestnetRuntime` value first.