### PR TITLE
Ignore IntelliJ folder and cabal.project.local*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .nix-shell-cabal.project
 /cabal.project.diff
 /cabal.project.freeze
-/cabal.project.local
+/cabal.project.local*
 /cabal.project.old
 configuration/defaults/simpleview/genesis/
 configuration/defaults/liveview/genesis/
@@ -64,3 +64,7 @@ logs
 /testnet
 
 .vscode/
+
+# IntellIJ project folder
+.idea/
+


### PR DESCRIPTION
Cabal has a tendency to create more files appended with `~x` if you run `cabal update`, for example `cabal.project.local~`.

For users who use IntelliJ, `.idea/` is also ignored.

