### PR TITLE
Default Cardano.Testnet to NodeLoggingFormatAsJson

### DIFF
--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -105,7 +105,7 @@ defaultTestnetOptions = CardanoTestnetOptions
   , cardanoActiveSlotsCoeff = 0.2
   , cardanoMaxSupply = 10020000000
   , cardanoEnableP2P = False
-  , cardanoNodeLoggingFormat = NodeLoggingFormatAsText
+  , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
   }
 
 -- | Specify a BFT node (Pre-Babbage era only) or an SPO (Shelley era onwards only)


### PR DESCRIPTION
Change `hprop_shutdownOnSlotSynced`  to parse JSON logs.