### PR TITLE
Update network internals to use oops

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -148,6 +148,7 @@ library
                       , mtl
                       , network
                       , nothunks
+                      , oops ^>= 0.2
                       , optparse-applicative-fork
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5

--- a/cardano-api/src/Cardano/Api/IPC.hs
+++ b/cardano-api/src/Cardano/Api/IPC.hs
@@ -57,6 +57,7 @@ module Cardano.Api.IPC (
     QueryInEra(..),
     QueryInShelleyBasedEra(..),
     queryNodeLocalState,
+    queryNodeLocalState_,
 
     -- *** Local tx monitoring
     LocalTxMonitorClient(..),
@@ -80,18 +81,24 @@ module Cardano.Api.IPC (
     NodeToClientVersion(..),
 
     UnsupportedNtcVersionError(..),
+
+    -- ** Error types
+    AcquireFailure(..),
   ) where
-
-import           Data.Void (Void)
-
-import           Data.Aeson (ToJSON, object, toJSON, (.=))
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map.Strict as Map
 
 import           Control.Concurrent.STM (TMVar, atomically, newEmptyTMVarIO, putTMVar, takeTMVar,
                    tryPutTMVar)
 import           Control.Monad (void)
+import           Control.Monad.IO.Class
+import           Control.Monad.Oops (CouldBe, Variant, runOopsInEither)
+import qualified Control.Monad.Oops as OO
+import           Control.Monad.Trans.Except
 import           Control.Tracer (nullTracer)
+import           Data.Aeson (ToJSON, object, toJSON, (.=))
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Function ((&))
+import qualified Data.Map.Strict as Map
+import           Data.Void (Void)
 
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import qualified Ouroboros.Network.Block as Net
@@ -586,17 +593,26 @@ queryNodeLocalState :: forall mode result.
                     -> Maybe ChainPoint
                     -> QueryInMode mode result
                     -> IO (Either AcquiringFailure result)
-queryNodeLocalState connctInfo mpoint query = do
-    resultVar <- newEmptyTMVarIO
-    connectToLocalNode
-      connctInfo
+queryNodeLocalState connctInfo mpoint query =
+  runOopsInEither $ queryNodeLocalState_ connctInfo mpoint query
+
+queryNodeLocalState_ :: forall e mode result. ()
+  => e `CouldBe` AcquiringFailure
+  => LocalNodeConnectInfo mode
+  -> Maybe ChainPoint
+  -> QueryInMode mode result
+  -> ExceptT (Variant e) IO result
+queryNodeLocalState_ connectInfo mpoint query = do
+    resultVar <- liftIO newEmptyTMVarIO
+    liftIO $ connectToLocalNode
+      connectInfo
       LocalNodeClientProtocols {
         localChainSyncClient    = NoLocalChainSyncClient,
         localStateQueryClient   = Just (singleQuery mpoint resultVar),
         localTxSubmissionClient = Nothing,
         localTxMonitoringClient = Nothing
       }
-    atomically (takeTMVar resultVar)
+    liftIO (atomically (takeTMVar resultVar)) & OO.onLeft OO.throw
   where
     singleQuery
       :: Maybe ChainPoint

--- a/cardano-api/src/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/src/Cardano/Api/IPC/Monad.hs
@@ -1,20 +1,29 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Api.IPC.Monad
   ( LocalStateQueryExpr
   , executeLocalStateQueryExpr
+  , executeLocalStateQueryExpr_
   , queryExpr
   , determineEraExpr
+
+  , NodeToClientVersionOf (..)
   ) where
 
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           Control.Monad.Oops (CouldBe, Variant, runOopsInEither)
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Cont
 import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
+import qualified Data.Variant as DV
 
 import           Cardano.Ledger.Shelley.Scripts ()
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
@@ -50,44 +59,56 @@ executeLocalStateQueryExpr
   -> Maybe ChainPoint
   -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
   -> IO (Either AcquiringFailure a)
-executeLocalStateQueryExpr connectInfo mpoint f = do
-  tmvResultLocalState <- newEmptyTMVarIO
+executeLocalStateQueryExpr connectInfo mpoint f =
+  runOopsInEither $ executeLocalStateQueryExpr_ connectInfo mpoint (lift f)
+
+-- | Execute a local state query expression.
+executeLocalStateQueryExpr_
+  :: forall e mode a . ()
+  => e `CouldBe` AcquiringFailure
+  => LocalNodeConnectInfo mode
+  -> Maybe ChainPoint
+  -> ExceptT (Variant e) (LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO) a
+  -> ExceptT (Variant e) IO a
+executeLocalStateQueryExpr_ connectInfo mpoint f = do
+  tmvResultLocalState <- liftIO (newEmptyTMVarIO @(Either (Variant e) a))
   let waitResult = readTMVar tmvResultLocalState
 
-  connectToLocalNodeWithVersion
+  liftIO $ connectToLocalNodeWithVersion
     connectInfo
     (\ntcVersion ->
       LocalNodeClientProtocols
       { localChainSyncClient    = NoLocalChainSyncClient
-      , localStateQueryClient   = Just $ setupLocalStateQueryExpr waitResult mpoint tmvResultLocalState ntcVersion f
+      , localStateQueryClient   = Just $ setupLocalStateQueryExpr_ waitResult mpoint tmvResultLocalState ntcVersion f
       , localTxSubmissionClient = Nothing
       , localTxMonitoringClient = Nothing
       }
     )
 
-  atomically waitResult
+  ExceptT . return =<< liftIO (atomically waitResult)
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-setupLocalStateQueryExpr ::
-     STM x
+setupLocalStateQueryExpr_ :: ()
+  => e `CouldBe` AcquiringFailure
+  => STM x
      -- ^ An STM expression that only returns when all protocols are complete.
      -- Protocols must wait until 'waitDone' returns because premature exit will
      -- cause other incomplete protocols to abort which may lead to deadlock.
   -> Maybe ChainPoint
-  -> TMVar (Either AcquiringFailure a)
+  -> TMVar (Either (Variant e) a)
   -> NodeToClientVersion
-  -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
+  -> ExceptT (Variant e) (LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO) a
   -> Net.Query.LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) IO ()
-setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
+setupLocalStateQueryExpr_ waitDone mPointVar' resultVar' ntcVersion f =
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring
-    { Net.Query.recvMsgAcquired = runContT (runReaderT (runLocalStateQueryExpr f) ntcVersion) $ \result -> do
-        atomically $ putTMVar resultVar' (Right result)
+    { Net.Query.recvMsgAcquired = runContT (runReaderT (runLocalStateQueryExpr (runExceptT f)) ntcVersion) $ \result -> do
+        atomically $ putTMVar resultVar' result
         void $ atomically waitDone -- Wait for all protocols to complete before exiting.
         pure $ Net.Query.SendMsgRelease $ pure $ Net.Query.SendMsgDone ()
 
     , Net.Query.recvMsgFailure = \failure -> do
-        atomically $ putTMVar resultVar' (Left (toAcquiringFailure failure))
+        atomically $ putTMVar resultVar' (Left (DV.throw (toAcquiringFailure failure)))
         void $ atomically waitDone -- Wait for all protocols to complete before exiting.
         pure $ Net.Query.SendMsgDone ()
     }


### PR DESCRIPTION
This PR is intentionally a minimal change with the intention of showing how `oops` is used without impacting the rest of the code base.

There is no breaking change as far as API exports is concerned.

In this PR, instead of implementing the networking code directly in `queryNodeLocalState` where it previously was, the networking code is implemented in `queryNodeLocalState_`.  The `queryNodeLocalState_` function uses `oops` style exception handling.  The `queryNodeLocalState` preserves its original type signature and merely delegates to `queryNodeLocalState_`.

The code is written this way to show an important point about `oops`.  The `oops` library is **un-opinionated**.  Unlike many effect systems and some other error handling libraries, `oops` was intentionally designed to interoperate with code that does not use `oops`.  The way it does this is to provide the combinators (in this case `runOopsInEither`) to wrap an `oops` enabled function into a function has has no `oops` influence in its type-signature.

This means that it is possible to write our internals in `oops` and have a public interface that has no `oops` exports whatsoever if that is what we want to do.  By choosing `oops` we are not committed to requiring or recommending our users use `oops`.

Whether or not we do that remains our decision to do now, later or never.

The PR also demonstrates another point, which is that adopting `oops` does not require us to significantly restructure our code and if we wanted to restructure our code because `oops` offers a better way to do it, then it can be done at our own discretion and on our own schedule.

I have worked with libraries before where this was not the case and it was a bad experience because small refactoring in one part of the code triggers a domino of refactoring until nearly all of the code-base use that library.  Some effect libraries 
have that bad quality.  `oops` is intentionally designed to not be like that.

This commit is PR is intentionally small do demonstrate this point.

This PR is the first commit of [a larger PR](https://github.com/input-output-hk/cardano-node/pull/4777) that rewrites much more of the code to use `oops`.  That PR is also broken into lots of commits, every one of which is a small change and compiles - again underscoring that introducing a small amount of `oops` does only just that and does not precipitate much more.

The reason I wanted to stress these important points is because I wanted to show that we can experimentally introduce `oops` into our codebase with minimal risk.  If at any point we find that `oops` is not as good as good an experience as we like, we can pause, think about why it is and fix or back out problematic changes.

It may be the case that `oops` represents to us an unfamiliar way to do error handling.  The hope is that _the only_ barrier to its adoption is a temporary non-familiarity that would go away with knowledge sharing and practise and that the flexibility and usability it affords us would sell itself as we use it.