### PR TITLE
Remove last remaining allow-newers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-03-18T05:24:58Z
-  , cardano-haskell-packages 2023-03-22T09:20:07Z
+  , hackage.haskell.org 2023-03-30T00:00:00Z
+  , cardano-haskell-packages 2023-04-01T00:00:00Z
 
 packages:
     cardano-api
@@ -82,26 +82,6 @@ test-show-details: direct
 
 package snap-server
   flags: +openssl
-
-package comonad
-  flags: -test-doctests
-
-allow-newer:
-  -- ekg does not suport aeson 2: https://github.com/tibbe/ekg/issues/90
-    ekg:aeson
-  -- ekg does not suport newer snap
-  , ekg:snap-server
-  , ekg:snap-core
-  -- cardano-node-capi depends on aeson > 2.1, even our patched ekg-json only
-  -- supports between 2 and 2.1
-  , ekg-json:aeson
-  -- These are currently required for 9.2.
-  , enumerator:base
-  , MonadCatchIO-transformers:base
-  , katip:Win32
-  , ekg:base
-  , ekg:time
-  , libsystemd-journal:base
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1679650731,
-        "narHash": "sha256-KpH4VFrHHRWAG3ZAuSck62GN3ffoP7fbQ7R3AZ3L/hU=",
+        "lastModified": 1681252172,
+        "narHash": "sha256-W0YOpCxZhch3qG4LdTNNsdvsfInJPLKSJT5EtepWJdY=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "c9755b5bb60318fc914139118ed6386d81555755",
+        "rev": "4d701061078101ae0ac45693ac8cdbf384441ced",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1680740551,
-        "narHash": "sha256-qJn3uNjYu8WgCzTZSRfwqmVU1fWGuu3G8TvXX4aRHMk=",
+        "lastModified": 1681259105,
+        "narHash": "sha256-dxyauxwCwA8ZNyRSRx2J9X44hPNXy9Rf0Nogqtohkag=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "792b6432150f43a88f3d00d6f1375daebd75ba58",
+        "rev": "c23bc9ea5ec54b17357671bef540b45cea978cdb",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -119,10 +119,6 @@ let
               ];
             in
             {
-              # Packages we wish to ignore version bounds of.
-              # This is similar to jailbreakCabal, however it
-              # does not require any messing with cabal files.
-              packages.katip.doExactConfig = true;
               # split data output for ekg to reduce closure size
               packages.ekg.components.library.enableSeparateDataOutput = true;
               # cardano-cli tests depend on cardano-cli and some config files:


### PR DESCRIPTION
- I made an upstream PR for the `katip` issue, which got merged and
  released.
- `ekg`, `ekg-json`, and `libsystemd-journal` are unmaintained, so I revised them in
  CHaP.
