### PR TITLE
#5052 Remove reading protocol parameters from Shelley genesis file

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Remove cardano-cli address build-script ([PR 4700](https://github.com/input-output-hk/cardano-node/pull/4700))
+- Remove support for reading protocol parameters from Shelley genesis file ([PR 5053](https://github.com/input-output-hk/cardano-node/pull/5053))
 
 ### Features
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -257,17 +257,10 @@ data InputTxBodyOrTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
   deriving Show
 
 data ProtocolParamsSourceSpec
-  = ParamsFromGenesis !GenesisFile
-    -- ^ We allow an appropriately forewarned user to obtain protocol params
-    --   directly from the genesis file, which allows them to avoid running
-    --   the node in case they would like to estimate the fee using the
-    --   blockchain's initial protocol parameters.
-  | ParamsFromFile !ProtocolParamsFile
+  = ParamsFromFile !ProtocolParamsFile
     -- ^ Obtain protocol parameters from a file structured by the
     --   'cardano-api' 'ProtocolParameters' data type.
   deriving Show
-
-{-# DEPRECATED ParamsFromFile "Protocol params file is deprecated" #-}
 
 renderTransactionCmd :: TransactionCmd -> Text
 renderTransactionCmd cmd =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -267,6 +267,8 @@ data ProtocolParamsSourceSpec
     --   'cardano-api' 'ProtocolParameters' data type.
   deriving Show
 
+{-# DEPRECATED ParamsFromFile "Protocol params file is deprecated" #-}
+
 renderTransactionCmd :: TransactionCmd -> Text
 renderTransactionCmd cmd =
   case cmd of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -31,7 +31,6 @@ module Cardano.CLI.Shelley.Commands
   , OpCertCounterFile (..)
   , OutputFile (..)
   , ProtocolParamsFile (..)
-  , ProtocolParamsSourceSpec (..)
   , WitnessFile (..)
   , TxFile (..)
   , InputTxBodyOrTxFile (..)
@@ -186,7 +185,7 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe ProtocolParamsSourceSpec)
+      (Maybe ProtocolParamsFile)
       (Maybe UpdateProposalFile)
       TxBodyFile
 
@@ -228,7 +227,7 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe ProtocolParamsSourceSpec)
+      (Maybe ProtocolParamsFile)
       (Maybe UpdateProposalFile)
       TxBuildOutputOptions
   | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
@@ -239,14 +238,14 @@ data TransactionCmd
   | TxCalculateMinFee
       TxBodyFile
       (Maybe NetworkId)
-      ProtocolParamsSourceSpec
+      ProtocolParamsFile
       TxInCount
       TxOutCount
       TxShelleyWitnessCount
       TxByronWitnessCount
   | TxCalculateMinRequiredUTxO
       AnyCardanoEra
-      ProtocolParamsSourceSpec
+      ProtocolParamsFile
       TxOutAnyEra
   | TxHashScriptData
       ScriptDataOrFile
@@ -254,12 +253,6 @@ data TransactionCmd
   | TxView InputTxBodyOrTxFile
 
 data InputTxBodyOrTxFile = InputTxBodyFile TxBodyFile | InputTxFile TxFile
-  deriving Show
-
-data ProtocolParamsSourceSpec
-  = ParamsFromFile !ProtocolParamsFile
-    -- ^ Obtain protocol parameters from a file structured by the
-    --   'cardano-api' 'ProtocolParameters' data type.
   deriving Show
 
 renderTransactionCmd :: TransactionCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -814,10 +814,6 @@ pTransaction =
 
   pProtocolParamsSourceSpec :: Parser ProtocolParamsSourceSpec
   pProtocolParamsSourceSpec =
-    ParamsFromGenesis <$>
-      pGenesisFile
-        "[TESTING] The genesis file to take initial protocol parameters from.  For test clusters only, since the parameters are going to be obsolete for production clusters."
-    <|>
     ParamsFromFile <$> pProtocolParamsFile
 
   pTxHashScriptData :: Parser TransactionCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -728,7 +728,7 @@ pTransaction =
                         Nothing
                         "Filepath of auxiliary script(s)")
             <*> many pMetadataFile
-            <*> optional pProtocolParamsSourceSpec
+            <*> optional pProtocolParamsFile
             <*> optional pUpdateProposalFile
             <*> (OutputTxBodyOnly <$> pTxBodyFile Output <|> pCalculatePlutusScriptCost)
 
@@ -764,7 +764,7 @@ pTransaction =
                            Nothing
                            "Filepath of auxiliary script(s)")
                <*> many pMetadataFile
-               <*> optional pProtocolParamsSourceSpec
+               <*> optional pProtocolParamsFile
                <*> optional pUpdateProposalFile
                <*> pTxBodyFile Output
 
@@ -800,7 +800,7 @@ pTransaction =
     TxCalculateMinFee
       <$> pTxBodyFile Input
       <*> optional pNetworkId
-      <*> pProtocolParamsSourceSpec
+      <*> pProtocolParamsFile
       <*> pTxInCount
       <*> pTxOutCount
       <*> pTxShelleyWitnessCount
@@ -809,12 +809,8 @@ pTransaction =
   pTransactionCalculateMinReqUTxO :: Parser TransactionCmd
   pTransactionCalculateMinReqUTxO = TxCalculateMinRequiredUTxO
     <$> pCardanoEra
-    <*> pProtocolParamsSourceSpec
+    <*> pProtocolParamsFile
     <*> pTxOut
-
-  pProtocolParamsSourceSpec :: Parser ProtocolParamsSourceSpec
-  pProtocolParamsSourceSpec =
-    ParamsFromFile <$> pProtocolParamsFile
 
   pTxHashScriptData :: Parser TransactionCmd
   pTxHashScriptData = TxHashScriptData <$>
@@ -1454,7 +1450,6 @@ pAddressKeyType =
       )
   <|>
     pure AddressKeyShelley
-
 
 pProtocolParamsFile :: Parser ProtocolParamsFile
 pProtocolParamsFile =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -1368,14 +1368,10 @@ renderProtocolParamsError (ProtocolParamsErrorGenesis err) =
 
 readProtocolParametersSourceSpec :: ProtocolParamsSourceSpec
                                  -> ExceptT ProtocolParamsError IO ProtocolParameters
-readProtocolParametersSourceSpec (ParamsFromGenesis (GenesisFile f)) =
-  fromShelleyPParams . sgProtocolParams
-    <$> firstExceptT ProtocolParamsErrorGenesis (readShelleyGenesisWithDefault f id)
 readProtocolParametersSourceSpec (ParamsFromFile f) = readProtocolParameters f
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.
-{-# DEPRECATED readProtocolParameters "Query the node instead of using a parameters file" #-}
 readProtocolParameters :: ProtocolParamsFile
                        -> ExceptT ProtocolParamsError IO ProtocolParameters
 readProtocolParameters (ProtocolParamsFile fpath) = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -26,7 +26,7 @@ module Cardano.CLI.Shelley.Run.Genesis
   -- * Protocol Parameters
   , ProtocolParamsError(..)
   , renderProtocolParamsError
-  , readProtocolParametersSourceSpec
+  , readProtocolParameters
   ) where
 
 import           Control.DeepSeq (NFData, force)
@@ -1356,19 +1356,12 @@ readConwayGenesis fpath = do
 data ProtocolParamsError
   = ProtocolParamsErrorFile (FileError ())
   | ProtocolParamsErrorJSON !FilePath !Text
-  | ProtocolParamsErrorGenesis !ShelleyGenesisCmdError
 
 renderProtocolParamsError :: ProtocolParamsError -> Text
 renderProtocolParamsError (ProtocolParamsErrorFile fileErr) =
   Text.pack $ displayError fileErr
 renderProtocolParamsError (ProtocolParamsErrorJSON fp jsonErr) =
   "Error while decoding the protocol parameters at: " <> Text.pack fp <> " Error: " <> jsonErr
-renderProtocolParamsError (ProtocolParamsErrorGenesis err) =
-  Text.pack $ displayError  err
-
-readProtocolParametersSourceSpec :: ProtocolParamsSourceSpec
-                                 -> ExceptT ProtocolParamsError IO ProtocolParameters
-readProtocolParametersSourceSpec (ParamsFromFile f) = readProtocolParameters f
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -26,7 +26,6 @@ module Cardano.CLI.Shelley.Run.Genesis
   -- * Protocol Parameters
   , ProtocolParamsError(..)
   , renderProtocolParamsError
-  , readProtocolParameters
   , readProtocolParametersSourceSpec
   ) where
 
@@ -1376,6 +1375,7 @@ readProtocolParametersSourceSpec (ParamsFromFile f) = readProtocolParameters f
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.
+{-# DEPRECATED readProtocolParameters "Query the node instead of using a parameters file" #-}
 readProtocolParameters :: ProtocolParamsFile
                        -> ExceptT ProtocolParamsError IO ProtocolParameters
 readProtocolParameters (ProtocolParamsFile fpath) = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -14,7 +14,6 @@ module Cardano.CLI.Shelley.Run.Transaction
   , renderShelleyTxCmdError
   , runTransactionCmd
   , readFileTx
-  , readProtocolParametersSourceSpec
   , toTxOutInAnyEra
   ) where
 
@@ -271,27 +270,24 @@ runTransactionCmd cmd =
   case cmd of
     TxBuild era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mPparams
+            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mProtocolParamsFile
             mUpProp outputOptions -> do
       runTxBuildCmd era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mPparams
-            mUpProp outputOptions
+            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp outputOptions
     TxBuildRaw era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-               metadataSchema scriptFiles metadataFiles mpparams mUpProp out -> do
+               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
       runTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-               metadataSchema scriptFiles metadataFiles mpparams mUpProp out
+               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
     TxSign txinfile skfiles network txoutfile ->
       runTxSign txinfile skfiles network txoutfile
     TxSubmit anyConsensusModeParams network txFp ->
       runTxSubmit anyConsensusModeParams network txFp
-    TxCalculateMinFee txbody mnw pGenesisOrParamsFile nInputs nOutputs
-                      nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runTxCalculateMinFee txbody mnw pGenesisOrParamsFile nInputs nOutputs
-                           nShelleyKeyWitnesses nByronKeyWitnesses
-    TxCalculateMinRequiredUTxO era pParamSpec txOuts -> runTxCalculateMinRequiredUTxO era pParamSpec txOuts
+    TxCalculateMinFee txbody mnw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
+      runTxCalculateMinFee txbody mnw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+    TxCalculateMinRequiredUTxO era pParamsFile txOuts -> runTxCalculateMinRequiredUTxO era pParamsFile txOuts
     TxHashScriptData scriptDataOrFile -> runTxHashScriptData scriptDataOrFile
     TxGetTxId txinfile -> runTxGetTxId txinfile
     TxView txinfile -> runTxView txinfile
@@ -327,14 +323,14 @@ runTxBuildCmd
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]
-  -> Maybe ProtocolParamsSourceSpec
+  -> Maybe ProtocolParamsFile
   -> Maybe UpdateProposalFile
   -> TxBuildOutputOptions
   -> ExceptT ShelleyTxCmdError IO ()
 runTxBuildCmd
   (AnyCardanoEra cEra) consensusModeParams@(AnyConsensusModeParams cModeParams) nid mScriptValidity mOverrideWits txins readOnlyRefIns
   reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-  mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mPparams mUpProp outputOptions = do
+  mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp outputOptions = do
   -- The user can specify an era prior to the era that the node is currently in.
   -- We cannot use the user specified era to construct a query against a node because it may differ
   -- from the node's era and this will result in the 'QueryEraMismatch' failure.
@@ -365,8 +361,8 @@ runTxBuildCmd
   scripts <- firstExceptT ShelleyTxCmdScriptFileError $
                      mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
   txAuxScripts <- hoistEither $ first ShelleyTxCmdAuxScriptsValidationError $ validateTxAuxScripts cEra scripts
-  mpparams <- forM mPparams $ \ppFp ->
-    firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParametersSourceSpec ppFp)
+  mpparams <- forM mProtocolParamsFile $ \ppf ->
+    firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParameters ppf)
 
   mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
     firstExceptT ShelleyTxCmdReadTextViewFileError (newExceptT $ readFileTextEnvelope AsUpdateProposal upFp)
@@ -462,14 +458,14 @@ runTxBuildRawCmd
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]
-  -> Maybe ProtocolParamsSourceSpec
+  -> Maybe ProtocolParamsFile
   -> Maybe UpdateProposalFile
   -> TxBodyFile
   -> ExceptT ShelleyTxCmdError IO ()
 runTxBuildRawCmd
   (AnyCardanoEra cEra) mScriptValidity txins readOnlyRefIns txinsc mReturnColl
   mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-  metadataSchema scriptFiles metadataFiles mpparams mUpProp (TxBodyFile out) = do
+  metadataSchema scriptFiles metadataFiles mpParamsFile mUpProp (TxBodyFile out) = do
   inputsAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError
                                 $ readScriptWitnessFiles cEra txins
   certFilesAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError
@@ -488,8 +484,8 @@ runTxBuildRawCmd
                      mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
   txAuxScripts <- hoistEither $ first ShelleyTxCmdAuxScriptsValidationError $ validateTxAuxScripts cEra scripts
 
-  pparams <- forM mpparams $ \ppFp ->
-    firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParametersSourceSpec ppFp)
+  pparams <- forM mpParamsFile $ \ppf ->
+    firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParameters ppf)
 
   mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
     firstExceptT ShelleyTxCmdReadTextViewFileError (newExceptT $ readFileTextEnvelope AsUpdateProposal upFp)
@@ -1146,13 +1142,13 @@ runTxSubmit (AnyConsensusModeParams cModeParams) network txFilePath = do
 runTxCalculateMinFee
   :: TxBodyFile
   -> Maybe NetworkId
-  -> ProtocolParamsSourceSpec
+  -> ProtocolParamsFile
   -> TxInCount
   -> TxOutCount
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT ShelleyTxCmdError IO ()
-runTxCalculateMinFee (TxBodyFile txbodyFilePath) nw protocolParamsSourceSpec
+runTxCalculateMinFee (TxBodyFile txbodyFilePath) nw pParamsFile
                      (TxInCount nInputs) (TxOutCount nOutputs)
                      (TxShelleyWitnessCount nShelleyKeyWitnesses)
                      (TxByronWitnessCount nByronKeyWitnesses) = do
@@ -1160,8 +1156,7 @@ runTxCalculateMinFee (TxBodyFile txbodyFilePath) nw protocolParamsSourceSpec
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
     unwitnessed <- firstExceptT ShelleyTxCmdCddlError . newExceptT
                      $ readFileTxBody txbodyFile
-    pparams <- firstExceptT ShelleyTxCmdProtocolParamsError
-                 $ readProtocolParametersSourceSpec protocolParamsSourceSpec
+    pparams <- firstExceptT ShelleyTxCmdProtocolParamsError $ readProtocolParameters pParamsFile
     case unwitnessed of
       IncompleteCddlFormattedTx anyTx -> do
         InAnyShelleyBasedEra _era unwitTx <-
@@ -1200,12 +1195,11 @@ runTxCalculateMinFee (TxBodyFile txbodyFilePath) nw protocolParamsSourceSpec
 
 runTxCalculateMinRequiredUTxO
   :: AnyCardanoEra
-  -> ProtocolParamsSourceSpec
+  -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT ShelleyTxCmdError IO ()
-runTxCalculateMinRequiredUTxO (AnyCardanoEra era) protocolParamsSourceSpec txOut = do
-  pp <- firstExceptT ShelleyTxCmdProtocolParamsError
-          $ readProtocolParametersSourceSpec protocolParamsSourceSpec
+runTxCalculateMinRequiredUTxO (AnyCardanoEra era) pParamsFile txOut = do
+  pp <- firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParameters pParamsFile)
   out <- toTxOutInAnyEra era txOut
   case cardanoEraStyle era of
     LegacyByronEra -> error "runTxCalculateMinRequiredUTxO: Byron era not implemented yet"


### PR DESCRIPTION
As a goal of https://github.com/input-output-hk/cardano-node/issues/5052 we should transition to reading protocol parameters by querying a node instead of using a Shelley genesis file.

This PR removes CLI option to read parameters from Shelley genesis file.

Command line arguments diff for example for `cardano-cli transaction build`:
```
--- before.out  2023-04-13 12:51:08.911896348 +0200
+++ after.out   2023-04-13 12:54:23.558643977 +0200
@@ -96,21 +96,21 @@
               | --withdrawal-tx-in-reference TX-IN
                 --withdrawal-plutus-script-v2
                 ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
                 | --withdrawal-reference-tx-in-redeemer-file JSON FILE
                 | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
                 )
               ]]
             [--json-metadata-no-schema | --json-metadata-detailed-schema]
             [--auxiliary-script-file FILE]
             [--metadata-json-file FILE | --metadata-cbor-file FILE]
-            [--genesis FILE | --protocol-params-file FILE]
+            [--protocol-params-file FILE]
             [--update-proposal-file FILE]
             (--out-file FILE | --calculate-plutus-script-cost FILE)
 
   Build a balanced transaction (automatically calculates fees)
 
   Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.
 
 Available options:
   --byron-era              Specify the Byron era
   --shelley-era            Specify the Shelley era
@@ -365,22 +365,18 @@
                            metadata.
   --json-metadata-detailed-schema
                            Use the "detailed schema" conversion from JSON to tx
                            metadata.
   --auxiliary-script-file FILE
                            Filepath of auxiliary script(s)
   --metadata-json-file FILE
                            Filepath of the metadata file, in JSON format.
   --metadata-cbor-file FILE
                            Filepath of the metadata, in raw CBOR format.
-  --genesis FILE           [TESTING] The genesis file to take initial protocol
-                           parameters from. For test clusters only, since the
-                           parameters are going to be obsolete for production
-                           clusters.
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --update-proposal-file FILE
                            Filepath of the update proposal.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            Output filepath of the script cost information.
   -h,--help                Show this help text
```
