### PR TITLE
Option to write keys in bech32

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -56,6 +56,18 @@
   ([PR5119](https://github.com/input-output-hk/cardano-node/pull/5119))
   ([PR5119](https://github.com/input-output-hk/cardano-node/pull/5119))
 
+- Add `--out-file` argument to the shelley stake-pool id command.
+  Add `--key-format-output` argument to the following commands:
+  - `address key-gen`
+  - `stake-address key-gen`
+  - `node key-gen`
+  - `node key-gen-KES`
+  - `node key-gen-VRF`
+  - `genesis create-staked`
+  - `genesis create`
+  [PR5058](https://github.com/input-output-hk/cardano-node/pull/5058)
+
+
 ### Features
 
 - The `--socket-path` option is now a required CLI argument for relevant commands if `CARDANO_NODE_SOCKET_PATH` is not supplied.

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -252,6 +252,7 @@ test-suite cardano-cli-golden
                       , hedgehog ^>= 1.2
                       , hedgehog-extras ^>= 0.4.5.1
                       , regex-compat
+                      , regex-tdfa
                       , text
                       , time
                       , transformers

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -277,9 +277,9 @@ renderTransactionCmd cmd =
     TxView {} -> "transaction view"
 
 data NodeCmd
-  = NodeKeyGenCold (VerificationKeyFile Out) (SigningKeyFile Out) (OpCertCounterFile Out)
-  | NodeKeyGenKES  (VerificationKeyFile Out) (SigningKeyFile Out)
-  | NodeKeyGenVRF  (VerificationKeyFile Out) (SigningKeyFile Out)
+  = NodeKeyGenCold KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out) (OpCertCounterFile Out)
+  | NodeKeyGenKES  KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
+  | NodeKeyGenVRF  KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
   | NodeKeyHashVRF  (VerificationKeyOrFile VrfKey) (Maybe (File () Out))
   | NodeNewCounter ColdVerificationKeyOrFile Word (OpCertCounterFile InOut)
   | NodeIssueOpCert (VerificationKeyOrFile KesKey) (SigningKeyFile In) (OpCertCounterFile InOut)
@@ -450,9 +450,17 @@ renderTextViewCmd :: TextViewCmd -> Text
 renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"
 
 data GenesisCmd
-  = GenesisCreate GenesisDir Word Word (Maybe SystemStart) (Maybe Lovelace) NetworkId
+  = GenesisCreate
+      KeyOutputFormat
+      GenesisDir
+      Word
+      Word
+      (Maybe SystemStart)
+      (Maybe Lovelace)
+      NetworkId
   | GenesisCreateCardano GenesisDir Word Word (Maybe SystemStart) (Maybe Lovelace) BlockCount Word Rational NetworkId FilePath FilePath FilePath FilePath (Maybe FilePath)
   | GenesisCreateStaked
+      KeyOutputFormat
       GenesisDir
       Word
       Word

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -323,7 +323,7 @@ data PoolCmd
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
       (File Certificate Out)
-  | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
+  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat
   | PoolMetadataHash (File StakePoolMetadata In) (Maybe (File () Out))
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -324,8 +325,8 @@ data PoolCmd
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
       (File Certificate Out)
-  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat
-  | PoolMetadataHash (File StakePoolMetadata In) (Maybe (File () Out))
+  | PoolGetId (VerificationKeyOrFile StakePoolKey) PoolIdOutputFormat (Maybe (File () Out))
+  | PoolMetadataHash (StakePoolMetadataFile In) (Maybe (File () Out))
   deriving Show
 
 renderPoolCmd :: PoolCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -38,6 +38,7 @@ module Cardano.CLI.Shelley.Commands
   , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
   , MetadataFile (..)
+  , StakePoolMetadataFile
   , PrivKeyFile (..)
   , BlockId (..)
   , WitnessSigningData (..)
@@ -525,6 +526,8 @@ data MetadataFile = MetadataFileJSON (File () In)
                   | MetadataFileCBOR (File () In)
 
   deriving Show
+
+type StakePoolMetadataFile = File StakePoolMetadata
 
 newtype GenesisDir
   = GenesisDir FilePath

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -113,7 +113,7 @@ renderAddressCmd cmd =
     AddressInfo {} -> "address info"
 
 data StakeAddressCmd
-  = StakeAddressKeyGen (VerificationKeyFile Out) (SigningKeyFile Out)
+  = StakeAddressKeyGen KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe (File () Out))
   | StakeAddressBuild StakeVerifier NetworkId (Maybe (File () Out))
   | StakeRegistrationCert StakeIdentifier (File () Out)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -93,7 +93,7 @@ renderShelleyCommand sc =
     TextViewCmd cmd -> renderTextViewCmd cmd
 
 data AddressCmd
-  = AddressKeyGen AddressKeyType (VerificationKeyFile Out) (SigningKeyFile Out)
+  = AddressKeyGen KeyOutputFormat AddressKeyType (VerificationKeyFile Out) (SigningKeyFile Out)
   | AddressKeyHash VerificationKeyTextOrFile (Maybe (File () Out))
   | AddressBuild
       PaymentVerifier

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -916,7 +916,7 @@ pPoolCmd  envCli =
     ]
   where
     pId :: Parser PoolCmd
-    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pOutputFormat
+    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat
 
     pPoolMetadataHashSubCmd :: Parser PoolCmd
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
@@ -1923,15 +1923,17 @@ pOperationalCertificateFile =
     <> Opt.completer (Opt.bashCompleter "file")
     )
 
-pOutputFormat :: Parser OutputFormat
-pOutputFormat =
-  Opt.option readOutputFormat
-    (  Opt.long "output-format"
-    <> Opt.metavar "STRING"
-    <> Opt.help "Optional output format. Accepted output formats are \"hex\" \
-                \and \"bech32\" (default is \"bech32\")."
-    <> Opt.value OutputFormatBech32
-    )
+pPoolIdOutputFormat :: Parser PoolIdOutputFormat
+pPoolIdOutputFormat =
+  Opt.option readPoolIdOutputFormat $ mconcat
+    [ Opt.long "output-format"
+    , Opt.metavar "STRING"
+    , Opt.help $ mconcat
+      [ "Optional pool id output format. Accepted output formats are \"hex\" "
+      , "and \"bech32\" (default is \"bech32\")."
+      ]
+    , Opt.value PoolIdOutputFormatBech32
+    ]
 
 pMaybeOutputFile :: Parser (Maybe (File content Out))
 pMaybeOutputFile =
@@ -3380,12 +3382,12 @@ readVerificationKey asType =
       first (Text.unpack . renderInputDecodeError) $
         deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str)
 
-readOutputFormat :: Opt.ReadM OutputFormat
-readOutputFormat = do
+readPoolIdOutputFormat :: Opt.ReadM PoolIdOutputFormat
+readPoolIdOutputFormat = do
   s <- Opt.str
   case s of
-    "hex" -> pure OutputFormatHex
-    "bech32" -> pure OutputFormatBech32
+    "hex" -> pure PoolIdOutputFormatHex
+    "bech32" -> pure PoolIdOutputFormatBech32
     _ ->
       fail $ "Invalid output format: \""
         <> s

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -863,17 +863,24 @@ pNodeCmd =
     pKeyGenOperator :: Parser NodeCmd
     pKeyGenOperator =
       NodeKeyGenCold
-        <$> pColdVerificationKeyFile
+        <$> pKeyOutputFormat
+        <*> pColdVerificationKeyFile
         <*> pColdSigningKeyFile
         <*> pOperatorCertIssueCounterFile
 
     pKeyGenKES :: Parser NodeCmd
     pKeyGenKES =
-      NodeKeyGenKES <$> pVerificationKeyFileOut <*> pSigningKeyFileOut
+      NodeKeyGenKES
+        <$> pKeyOutputFormat
+        <*> pVerificationKeyFileOut
+        <*> pSigningKeyFileOut
 
     pKeyGenVRF :: Parser NodeCmd
     pKeyGenVRF =
-      NodeKeyGenVRF <$> pVerificationKeyFileOut <*> pSigningKeyFileOut
+      NodeKeyGenVRF
+        <$> pKeyOutputFormat
+        <*> pVerificationKeyFileOut
+        <*> pSigningKeyFileOut
 
     pKeyHashVRF :: Parser NodeCmd
     pKeyHashVRF =
@@ -1387,7 +1394,8 @@ pGenesisCmd envCli =
     pGenesisCreate :: Parser GenesisCmd
     pGenesisCreate =
       GenesisCreate
-        <$> pGenesisDir
+        <$> pKeyOutputFormat
+        <*> pGenesisDir
         <*> pGenesisNumGenesisKeys
         <*> pGenesisNumUTxOKeys
         <*> pMaybeSystemStart
@@ -1397,7 +1405,8 @@ pGenesisCmd envCli =
     pGenesisCreateStaked :: Parser GenesisCmd
     pGenesisCreateStaked =
       GenesisCreateStaked
-        <$> pGenesisDir
+        <$> pKeyOutputFormat
+        <*> pGenesisDir
         <*> pGenesisNumGenesisKeys
         <*> pGenesisNumUTxOKeys
         <*> pGenesisNumPools
@@ -1922,6 +1931,18 @@ pOperationalCertificateFile =
     <> Opt.help "Filepath of the node's operational certificate."
     <> Opt.completer (Opt.bashCompleter "file")
     )
+
+pKeyOutputFormat :: Parser KeyOutputFormat
+pKeyOutputFormat =
+  Opt.option readKeyOutputFormat $ mconcat
+    [ Opt.long "key-output-format"
+    , Opt.metavar "STRING"
+    , Opt.help $ mconcat
+      [ "Optional key output format. Accepted output formats are \"text-envelope\" "
+      , "and \"bech32\" (default is \"bech32\")."
+      ]
+    , Opt.value KeyOutputFormatTextEnvelope
+    ]
 
 pPoolIdOutputFormat :: Parser PoolIdOutputFormat
 pPoolIdOutputFormat =
@@ -3392,6 +3413,18 @@ readPoolIdOutputFormat = do
       fail $ mconcat
         [ "Invalid output format: " <> show s
         , ". Accepted output formats are \"hex\" and \"bech32\"."
+        ]
+
+readKeyOutputFormat :: Opt.ReadM KeyOutputFormat
+readKeyOutputFormat = do
+  s <- Opt.str @String
+  case s of
+    "text-envelope" -> pure KeyOutputFormatTextEnvelope
+    "bech32" -> pure KeyOutputFormatBech32
+    _ ->
+      fail $ mconcat
+        [ "Invalid key output format: " <> show s
+        , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
         ]
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1638,7 +1638,7 @@ pCertificateFile balanceExecUnits =
     , "stake key certificates etc). Optionally specify a script witness."
     ]
 
-pPoolMetadataFile :: Parser (File StakePoolMetadata In)
+pPoolMetadataFile :: Parser (StakePoolMetadataFile In)
 pPoolMetadataFile =
   fmap File $ Opt.strOption $ mconcat
     [ Opt.long "pool-metadata-file"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -144,10 +144,12 @@ pAddressCmd envCli =
      ]
   where
     pAddressKeyGen :: Parser AddressCmd
-    pAddressKeyGen = AddressKeyGen
-      <$> pAddressKeyType
-      <*> pVerificationKeyFileOut
-      <*> pSigningKeyFileOut
+    pAddressKeyGen =
+      AddressKeyGen
+        <$> pKeyOutputFormat
+        <*> pAddressKeyType
+        <*> pVerificationKeyFileOut
+        <*> pSigningKeyFileOut
 
     pAddressKeyHash :: Parser AddressCmd
     pAddressKeyHash =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -916,7 +916,7 @@ pPoolCmd  envCli =
     ]
   where
     pId :: Parser PoolCmd
-    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat
+    pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat <*> pMaybeOutputFile
 
     pPoolMetadataHashSubCmd :: Parser PoolCmd
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
@@ -3384,14 +3384,15 @@ readVerificationKey asType =
 
 readPoolIdOutputFormat :: Opt.ReadM PoolIdOutputFormat
 readPoolIdOutputFormat = do
-  s <- Opt.str
+  s <- Opt.str @String
   case s of
     "hex" -> pure PoolIdOutputFormatHex
     "bech32" -> pure PoolIdOutputFormatBech32
     _ ->
-      fail $ "Invalid output format: \""
-        <> s
-        <> "\". Accepted output formats are \"hex\" and \"bech32\"."
+      fail $ mconcat
+        [ "Invalid output format: " <> show s
+        , ". Accepted output formats are \"hex\" and \"bech32\"."
+        ]
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -382,7 +382,8 @@ pStakeAddressCmd envCli =
     pStakeAddressKeyGen :: Parser StakeAddressCmd
     pStakeAddressKeyGen =
       StakeAddressKeyGen
-        <$> pVerificationKeyFileOut
+        <$> pKeyOutputFormat
+        <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
     pStakeAddressKeyHash :: Parser StakeAddressCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -909,6 +909,7 @@ createPoolCredentials fmt dir index = do
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
   firstExceptT ShelleyGenesisCmdStakeAddressCmdError $
     runStakeAddressKeyGenToFile
+        fmt
         (File @(VerificationKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".vkey")
         (File @(SigningKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".skey")
  where

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -15,7 +15,6 @@ import qualified Data.ByteString.Char8 as BS
 import           Data.Function ((&))
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
@@ -48,7 +47,7 @@ runPoolCmd (PoolRegistrationCert sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerV
   runStakePoolRegistrationCert sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
 runPoolCmd (PoolRetirementCert sPvkeyFp retireEpoch outfp) =
   runStakePoolRetirementCert sPvkeyFp retireEpoch outfp
-runPoolCmd (PoolGetId sPvkey outputFormat) = runPoolId sPvkey outputFormat
+runPoolCmd (PoolGetId sPvkey outputFormat mOutFile) = runPoolId sPvkey outputFormat mOutFile
 runPoolCmd (PoolMetadataHash poolMdFile mOutFile) = runPoolMetadataHash poolMdFile mOutFile
 
 
@@ -170,17 +169,24 @@ runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch outfp = do
 runPoolId
   :: VerificationKeyOrFile StakePoolKey
   -> PoolIdOutputFormat
+  -> Maybe (File () Out)
   -> ExceptT ShelleyPoolCmdError IO ()
-runPoolId verKeyOrFile outputFormat = do
-    stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
-      . newExceptT
-      $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
-    liftIO $
-      case outputFormat of
-        PoolIdOutputFormatHex ->
-          BS.putStrLn $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
-        PoolIdOutputFormatBech32 ->
-          Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
+runPoolId verKeyOrFile outputFormat mOutFile = do
+  stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
+    . newExceptT
+    $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
+
+  case outputFormat of
+    PoolIdOutputFormatHex ->
+      firstExceptT ShelleyPoolCmdWriteFileError
+        . newExceptT
+        $ writeByteStringOutput mOutFile
+        $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
+    PoolIdOutputFormatBech32 ->
+      firstExceptT ShelleyPoolCmdWriteFileError
+        . newExceptT
+        $ writeTextOutput mOutFile
+        $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
 runPoolMetadataHash :: StakePoolMetadataFile In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()
 runPoolMetadataHash poolMDPath mOutFile = do

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -21,7 +21,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
-import           Cardano.CLI.Types (OutputFormat (..))
+import           Cardano.CLI.Types (PoolIdOutputFormat (..))
 
 import qualified Cardano.Ledger.Slot as Shelley
 
@@ -169,7 +169,7 @@ runStakePoolRetirementCert stakePoolVerKeyOrFile retireEpoch outfp = do
 
 runPoolId
   :: VerificationKeyOrFile StakePoolKey
-  -> OutputFormat
+  -> PoolIdOutputFormat
   -> ExceptT ShelleyPoolCmdError IO ()
 runPoolId verKeyOrFile outputFormat = do
     stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
@@ -177,9 +177,9 @@ runPoolId verKeyOrFile outputFormat = do
       $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
     liftIO $
       case outputFormat of
-        OutputFormatHex ->
+        PoolIdOutputFormatHex ->
           BS.putStrLn $ serialiseToRawBytesHex (verificationKeyHash stakePoolVerKey)
-        OutputFormatBech32 ->
+        PoolIdOutputFormatBech32 ->
           Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
 runPoolMetadataHash :: File StakePoolMetadata In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs
@@ -182,7 +182,7 @@ runPoolId verKeyOrFile outputFormat = do
         PoolIdOutputFormatBech32 ->
           Text.putStrLn $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
-runPoolMetadataHash :: File StakePoolMetadata In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()
+runPoolMetadataHash :: StakePoolMetadataFile In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()
 runPoolMetadataHash poolMDPath mOutFile = do
   metadataBytes <- lift (readByteStringFile poolMDPath)
     & onLeft (left . ShelleyPoolCmdReadFileError)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Types
   , CurrentKesPeriod (..)
   , EpochLeadershipSchedule (..)
   , GenesisFile (..)
+  , KeyOutputFormat(..)
   , OpCertEndingKesPeriod (..)
   , OpCertIntervalInformation (..)
   , OpCertOnDiskCounter (..)
@@ -197,6 +198,11 @@ instance FromJSON GenesisFile where
 data PoolIdOutputFormat
   = PoolIdOutputFormatHex
   | PoolIdOutputFormatBech32
+  deriving (Eq, Show)
+
+data KeyOutputFormat
+  = KeyOutputFormatTextEnvelope
+  | KeyOutputFormatBech32
   deriving (Eq, Show)
 
 data AllOrOnly a = All | Only a deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/Types.hs
@@ -18,7 +18,7 @@ module Cardano.CLI.Types
   , OpCertNodeAndOnDiskCounterInformation (..)
   , OpCertNodeStateCounter (..)
   , OpCertStartingKesPeriod (..)
-  , OutputFormat (..)
+  , PoolIdOutputFormat (..)
   , TxBuildOutputOptions(..)
   , ReferenceScriptAnyEra (..)
   , SigningKeyFile
@@ -194,9 +194,9 @@ instance FromJSON GenesisFile where
                            <> "Encountered: " <> show invalid
 
 -- | The desired output format.
-data OutputFormat
-  = OutputFormatHex
-  | OutputFormatBech32
+data PoolIdOutputFormat
+  = PoolIdOutputFormatHex
+  | PoolIdOutputFormatBech32
   deriving (Eq, Show)
 
 data AllOrOnly a = All | Only a deriving (Eq, Show)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
@@ -76,7 +76,8 @@ import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
                    (golden_shelleyGenesisUTxOKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys,
+                   golden_shelleyStakeKeys_bech32, golden_shelleyStakeKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
                    golden_shelleyVRFKeys_bech32, golden_shelleyVRFKeys_te)
 import           Test.Golden.Shelley.TextView.DecodeCbor (golden_shelleyTextViewDecodeCbor)
@@ -135,6 +136,8 @@ keyTests =
         , ("golden_shelleyStakeAddressKeyGen", golden_shelleyStakeAddressKeyGen)
         , ("golden_shelleyStakeAddressRegistrationCertificate", golden_shelleyStakeAddressRegistrationCertificate)
         , ("golden_shelleyStakeKeys", golden_shelleyStakeKeys)
+        , ("golden_shelleyStakeKeys_bech32", golden_shelleyStakeKeys_bech32)
+        , ("golden_shelleyStakeKeys_te", golden_shelleyStakeKeys_te)
         , ("golden_shelleyStakePoolRegistrationCertificate", golden_shelleyStakePoolRegistrationCertificate)
         , ("golden_shelleyTextViewDecodeCbor", golden_shelleyTextViewDecodeCbor)
         , ("golden_shelleyTransactionBuild", golden_shelleyTransactionBuild)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
@@ -12,7 +12,8 @@ module Test.Golden.Shelley
 
 import           Test.Golden.Shelley.Address.Build (golden_shelleyAddressBuild)
 import           Test.Golden.Shelley.Address.Info (golden_shelleyAddressInfo)
-import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressKeyGen)
+import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressExtendedKeyGen,
+                   golden_shelleyAddressKeyGen)
 import           Test.Golden.Shelley.Genesis.Create (golden_shelleyGenesisCreate)
 import           Test.Golden.Shelley.Genesis.InitialTxIn (golden_shelleyGenesisInitialTxIn)
 import           Test.Golden.Shelley.Genesis.KeyGenDelegate (golden_shelleyGenesisKeyGenDelegate)
@@ -38,9 +39,12 @@ import           Test.Golden.Shelley.Key.ConvertCardanoAddressKey
                    golden_convertCardanoAddressShelleyPaymentSigningKey,
                    golden_convertCardanoAddressShelleyStakeSigningKey)
 import           Test.Golden.Shelley.Node.IssueOpCert (golden_shelleyNodeIssueOpCert)
-import           Test.Golden.Shelley.Node.KeyGen (golden_shelleyNodeKeyGen)
-import           Test.Golden.Shelley.Node.KeyGenKes (golden_shelleyNodeKeyGenKes)
-import           Test.Golden.Shelley.Node.KeyGenVrf (golden_shelleyNodeKeyGenVrf)
+import           Test.Golden.Shelley.Node.KeyGen (golden_shelleyNodeKeyGen,
+                   golden_shelleyNodeKeyGen_bech32, golden_shelleyNodeKeyGen_te)
+import           Test.Golden.Shelley.Node.KeyGenKes (golden_shelleyNodeKeyGenKes,
+                   golden_shelleyNodeKeyGenKes_bech32, golden_shelleyNodeKeyGenKes_te)
+import           Test.Golden.Shelley.Node.KeyGenVrf (golden_shelleyNodeKeyGenVrf,
+                   golden_shelleyNodeKeyGenVrf_bech32, golden_shelleyNodeKeyGenVrf_te)
 import           Test.Golden.Shelley.StakeAddress.Build (golden_shelleyStakeAddressBuild)
 import           Test.Golden.Shelley.StakeAddress.DeregistrationCertificate
                    (golden_shelleyStakeAddressDeregistrationCertificate)
@@ -73,7 +77,8 @@ import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
+                   golden_shelleyVRFKeys_bech32, golden_shelleyVRFKeys_te)
 import           Test.Golden.Shelley.TextView.DecodeCbor (golden_shelleyTextViewDecodeCbor)
 import           Test.Golden.Shelley.Transaction.Assemble
                    (golden_shelleyTransactionAssembleWitness_SigningKey)
@@ -101,6 +106,7 @@ keyTests =
     $ H.Group "TextEnvelope Key Goldens"
         [ ("golden_shelleyAddressInfo", golden_shelleyAddressInfo)
         , ("golden_shelleyAddressKeyGen", golden_shelleyAddressKeyGen)
+        , ("golden_shelleyAddressExtendedKeyGen", golden_shelleyAddressExtendedKeyGen)
         , ("golden_shelleyAddressBuild", golden_shelleyAddressBuild)
         , ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
         , ("golden_shelleyGenesisCreate", golden_shelleyGenesisCreate)
@@ -115,8 +121,14 @@ keyTests =
         , ("golden_shelleyKESKeys", golden_shelleyKESKeys)
         , ("golden_shelleyNodeIssueOpCert", golden_shelleyNodeIssueOpCert)
         , ("golden_shelleyNodeKeyGen", golden_shelleyNodeKeyGen)
+        , ("golden_shelleyNodeKeyGen_bech32", golden_shelleyNodeKeyGen_bech32)
+        , ("golden_shelleyNodeKeyGen_te", golden_shelleyNodeKeyGen_te)
         , ("golden_shelleyNodeKeyGenKes", golden_shelleyNodeKeyGenKes)
+        , ("golden_shelleyNodeKeyGenKes_bech32", golden_shelleyNodeKeyGenKes_bech32)
+        , ("golden_shelleyNodeKeyGenKes_te", golden_shelleyNodeKeyGenKes_te)
         , ("golden_shelleyNodeKeyGenVrf", golden_shelleyNodeKeyGenVrf)
+        , ("golden_shelleyNodeKeyGenVrf_bech32", golden_shelleyNodeKeyGenVrf_bech32)
+        , ("golden_shelleyNodeKeyGenVrf_te", golden_shelleyNodeKeyGenVrf_te)
         , ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
         , ("golden_shelleyStakeAddressBuild", golden_shelleyStakeAddressBuild)
         , ("golden_shelleyStakeAddressDeregistrationCertificate", golden_shelleyStakeAddressDeregistrationCertificate)
@@ -133,6 +145,8 @@ keyTests =
         , ("golden_shelleyTransactionCalculateMinFee", golden_shelleyTransactionCalculateMinFee)
         , ("golden_shelleyTransactionSign", golden_shelleyTransactionSign)
         , ("golden_shelleyVRFKeys", golden_shelleyVRFKeys)
+        , ("golden_shelleyVRFKeys_bech32", golden_shelleyVRFKeys_bech32)
+        , ("golden_shelleyVRFKeys_te", golden_shelleyVRFKeys_te)
         , ("golden_version", golden_version)
         ]
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
@@ -68,14 +68,16 @@ import           Test.Golden.Shelley.Metadata.StakePoolMetadata (golden_stakePoo
 import           Test.Golden.Shelley.MultiSig.Address (golden_shelleyAllMultiSigAddressBuild,
                    golden_shelleyAnyMultiSigAddressBuild, golden_shelleyAtLeastMultiSigAddressBuild)
 import           Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
-                   (golden_shelleyExtendedPaymentKeys)
+                   (golden_shelleyExtendedPaymentKeys, golden_shelleyExtendedPaymentKeys_bech32,
+                   golden_shelleyExtendedPaymentKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
                    (golden_shelleyGenesisDelegateKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys (golden_shelleyGenesisKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
                    (golden_shelleyGenesisUTxOKeys)
 import           Test.Golden.Shelley.TextEnvelope.Keys.KESKeys (golden_shelleyKESKeys)
-import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys)
+import           Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys (golden_shelleyPaymentKeys,
+                   golden_shelleyPaymentKeys_bech32, golden_shelleyPaymentKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelleyStakeKeys,
                    golden_shelleyStakeKeys_bech32, golden_shelleyStakeKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
@@ -110,6 +112,8 @@ keyTests =
         , ("golden_shelleyAddressExtendedKeyGen", golden_shelleyAddressExtendedKeyGen)
         , ("golden_shelleyAddressBuild", golden_shelleyAddressBuild)
         , ("golden_shelleyExtendedPaymentKeys", golden_shelleyExtendedPaymentKeys)
+        , ("golden_shelleyExtendedPaymentKeys_bech32", golden_shelleyExtendedPaymentKeys_bech32)
+        , ("golden_shelleyExtendedPaymentKeys_te", golden_shelleyExtendedPaymentKeys_te)
         , ("golden_shelleyGenesisCreate", golden_shelleyGenesisCreate)
         , ("golden_shelleyGenesisDelegateKeys", golden_shelleyGenesisDelegateKeys)
         , ("golden_shelleyGenesisInitialTxIn", golden_shelleyGenesisInitialTxIn)
@@ -131,6 +135,8 @@ keyTests =
         , ("golden_shelleyNodeKeyGenVrf_bech32", golden_shelleyNodeKeyGenVrf_bech32)
         , ("golden_shelleyNodeKeyGenVrf_te", golden_shelleyNodeKeyGenVrf_te)
         , ("golden_shelleyPaymentKeys", golden_shelleyPaymentKeys)
+        , ("golden_shelleyPaymentKeys_bech32", golden_shelleyPaymentKeys_bech32)
+        , ("golden_shelleyPaymentKeys_te", golden_shelleyPaymentKeys_te)
         , ("golden_shelleyStakeAddressBuild", golden_shelleyStakeAddressBuild)
         , ("golden_shelleyStakeAddressDeregistrationCertificate", golden_shelleyStakeAddressDeregistrationCertificate)
         , ("golden_shelleyStakeAddressKeyGen", golden_shelleyStakeAddressKeyGen)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -2,6 +2,7 @@
 
 module Test.Golden.Shelley.Address.KeyGen
   ( golden_shelleyAddressKeyGen
+  , golden_shelleyAddressExtendedKeyGen
   ) where
 
 import           Control.Monad (void)
@@ -27,8 +28,23 @@ golden_shelleyAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
   void $ H.readFile addressVKeyFile
   void $ H.readFile addressSKeyFile
 
-  H.assertFileOccurences 1 "PaymentVerificationKeyShelley" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentVerificationKeyShelley_ed25519" addressVKeyFile
   H.assertFileOccurences 1 "PaymentSigningKeyShelley_ed25519" addressSKeyFile
 
-  H.assertEndsWithSingleNewline addressVKeyFile
-  H.assertEndsWithSingleNewline addressSKeyFile
+golden_shelleyAddressExtendedKeyGen :: Property
+golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  addressVKeyFile <- noteTempFile tempDir "address.vkey"
+  addressSKeyFile <- noteTempFile tempDir "address.skey"
+
+  void $ execCardanoCLI
+    [ "shelley","address","key-gen"
+    , "--extended-key"
+    , "--verification-key-file", addressVKeyFile
+    , "--signing-key-file", addressSKeyFile
+    ]
+
+  void $ H.readFile addressVKeyFile
+  void $ H.readFile addressSKeyFile
+
+  H.assertFileOccurences 1 "PaymentExtendedVerificationKeyShelley_ed25519_bip32" addressVKeyFile
+  H.assertFileOccurences 1 "PaymentExtendedSigningKeyShelley_ed25519_bip32" addressSKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGen
   ( golden_shelleyNodeKeyGen
+  , golden_shelleyNodeKeyGen_bech32
+  , golden_shelleyNodeKeyGen_te
   ) where
 
 import           Control.Monad (void)
@@ -32,4 +34,45 @@ golden_shelleyNodeKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> 
 
   H.assertEndsWithSingleNewline verificationKeyFile
   H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline opCertCounterFile
+
+golden_shelleyNodeKeyGen_te :: Property
+golden_shelleyNodeKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- noteTempFile tempDir "key-gen.skey"
+  opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
+
+  void $ execCardanoCLI
+    [ "node","key-gen"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    , "--operational-certificate-issue-counter", opCertCounterFile
+    ]
+
+  H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
+  H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+
+  H.assertEndsWithSingleNewline verificationKeyFile
+  H.assertEndsWithSingleNewline signingKeyFile
+  H.assertEndsWithSingleNewline opCertCounterFile
+
+golden_shelleyNodeKeyGen_bech32 :: Property
+golden_shelleyNodeKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
+  signingKeyFile <- noteTempFile tempDir "key-gen.skey"
+  opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
+
+  void $ execCardanoCLI
+    [ "node","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKeyFile
+    , "--signing-key-file", signingKeyFile
+    , "--operational-certificate-issue-counter", opCertCounterFile
+    ]
+
+  H.assertFileOccurences 1 "pool_vk" verificationKeyFile
+  H.assertFileOccurences 1 "pool_sk" signingKeyFile
+  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+
   H.assertEndsWithSingleNewline opCertCounterFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGenKes
   ( golden_shelleyNodeKeyGenKes
+  , golden_shelleyNodeKeyGenKes_bech32
+  , golden_shelleyNodeKeyGenKes_te
   ) where
 
 import           Control.Monad (void)
@@ -29,3 +31,36 @@ golden_shelleyNodeKeyGenKes = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenKes_te :: Property
+golden_shelleyNodeKeyGenKes_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
+  H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenKes_bech32 :: Property
+golden_shelleyNodeKeyGenKes_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "kes_vk" verificationKey
+  H.assertFileOccurences 1 "kes_sk" signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -2,6 +2,8 @@
 
 module Test.Golden.Shelley.Node.KeyGenVrf
   ( golden_shelleyNodeKeyGenVrf
+  , golden_shelleyNodeKeyGenVrf_bech32
+  , golden_shelleyNodeKeyGenVrf_te
   ) where
 
 import           Control.Monad (void)
@@ -29,3 +31,36 @@ golden_shelleyNodeKeyGenVrf = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenVrf_te :: Property
+golden_shelleyNodeKeyGenVrf_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "VRF Verification Key" verificationKey
+  H.assertFileOccurences 1 "VRF Signing Key" signingKey
+
+  H.assertEndsWithSingleNewline verificationKey
+  H.assertEndsWithSingleNewline signingKey
+
+golden_shelleyNodeKeyGenVrf_bech32 :: Property
+golden_shelleyNodeKeyGenVrf_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  verificationKey <- noteTempFile tempDir "kes.vkey"
+  signingKey <- noteTempFile tempDir "kes.skey"
+
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verificationKey
+    , "--signing-key-file", signingKey
+    ]
+
+  H.assertFileOccurences 1 "vrf_vk" verificationKey
+  H.assertFileOccurences 1 "vrf_sk" signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -26,6 +26,3 @@ golden_shelleyStakeAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tem
 
   H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile
-
-  H.assertEndsWithSingleNewline verificationKeyFile
-  H.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
   ( golden_shelleyExtendedPaymentKeys
+  , golden_shelleyExtendedPaymentKeys_bech32
+  , golden_shelleyExtendedPaymentKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
+import           Text.Regex.TDFA ((=~))
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -41,3 +48,59 @@ golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \te
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyExtendedPaymentKeys_te :: Property
+golden_shelleyExtendedPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "extended-payment-verification-key-file"
+  signKey <- noteTempFile tempDir "extended-payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--extended-key"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyExtendedPaymentKeys_bech32 :: Property
+golden_shelleyExtendedPaymentKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "payment-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--extended-key"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "^addr_xvk[a-z0-9]{110}$"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "^addr_xsk[a-z0-9]{212}$"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys
   ( golden_shelleyKESKeys
+  , golden_shelleyKESKeys_bech32
+  , golden_shelleyKESKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +47,57 @@ golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyKESKeys_te :: Property
+golden_shelleyKESKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "kes-verification-key-file"
+  signKey <- noteTempFile tempDir "kes-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyKESKeys_bech32 :: Property
+golden_shelleyKESKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "kes-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "kes-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-KES"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "kes_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "kes_sk[a-z0-9]{980}"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys
   ( golden_shelleyPaymentKeys
+  , golden_shelleyPaymentKeys_te
+  , golden_shelleyPaymentKeys_bech32
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
@@ -9,7 +12,10 @@ import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +46,57 @@ golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyPaymentKeys_te :: Property
+golden_shelleyPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "payment-verification-key-file"
+  signKey <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyPaymentKeys_bech32 :: Property
+golden_shelleyPaymentKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "payment-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
+
+  -- Generate payment verification key
+  void $ execCardanoCLI
+    [ "address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "^addr_vk[a-z0-9]{59}$"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "^addr_sk[a-z0-9]{59}$"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys
   ( golden_shelleyStakeKeys
+  , golden_shelleyStakeKeys_bech32
+  , golden_shelleyStakeKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
@@ -9,7 +12,10 @@ import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -40,3 +46,57 @@ golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> d
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyStakeKeys_te :: Property
+golden_shelleyStakeKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "stake-verification-key-file"
+  signKey <- noteTempFile tempDir "stake-signing-key-file"
+
+  -- Generate stake key pair
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyStakeKeys_bech32 :: Property
+golden_shelleyStakeKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "stake-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "stake-signing-key-file"
+
+  -- Generate stake key pair
+  void $ execCardanoCLI
+    [ "stake-address","key-gen"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "stake_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "stake_sk[a-z0-9]{59}"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -1,15 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys
   ( golden_shelleyVRFKeys
+  , golden_shelleyVRFKeys_bech32
+  , golden_shelleyVRFKeys_te
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
 import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -18,6 +25,8 @@ import qualified Hedgehog.Extras.Test.Base as H
 --   3. Check the TextEnvelope serialization format has not changed.
 golden_shelleyVRFKeys :: Property
 golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
   -- Reference keys
   referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
   referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
@@ -40,3 +49,59 @@ golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- golden files
   checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
   checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the TextEnvelope serialization format has not changed.
+golden_shelleyVRFKeys_te :: Property
+golden_shelleyVRFKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Reference keys
+  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"
+
+  -- Key filepaths
+  verKey <- noteTempFile tempDir "vrf-verification-key-file"
+  signKey <- noteTempFile tempDir "vrf-signing-key-file"
+
+  -- Generate vrf verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "text-envelope"
+    , "--verification-key-file", verKey
+    , "--signing-key-file", signKey
+    ]
+
+  let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
+      verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
+
+  -- Check the newly created files have not deviated from the
+  -- golden files
+  checkTextEnvelopeFormat verificationKeyType referenceVerKey verKey
+  checkTextEnvelopeFormat signingKeyType referenceSignKey signKey
+
+-- | 1. Generate a key pair
+--   2. Check for the existence of the key pair
+--   3. Check the bech32 serialization format has not changed.
+golden_shelleyVRFKeys_bech32 :: Property
+golden_shelleyVRFKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  H.note_ tempDir
+
+  -- Key filepaths
+  verKeyFile <- noteTempFile tempDir "vrf-verification-key-file"
+  signKeyFile <- noteTempFile tempDir "vrf-signing-key-file"
+
+  -- Generate vrf verification key
+  void $ execCardanoCLI
+    [ "node","key-gen-VRF"
+    , "--key-output-format", "bech32"
+    , "--verification-key-file", verKeyFile
+    , "--signing-key-file", signKeyFile
+    ]
+
+  verKey <- H.readFile verKeyFile
+  H.assert $ verKey =~ id @String "vrf_vk[a-z0-9]{59}"
+
+  signKey <- H.readFile signKeyFile
+  H.assert $ signKey =~ id @String "vrf_sk[a-z0-9]{110}"


### PR DESCRIPTION
Add the ability to output keys in `bech32` format.

The functionality was extracted from https://github.com/input-output-hk/cardano-node/pull/1979 and refactored to make https://github.com/input-output-hk/cardano-node/issues/5016 easier to implement.

The functionality was extracted because there was concern about backwards compatibility in that PR.  This PR implements the change in a backwards compatible way by introducing a new optional flag.

This PR is limited to the writing of bech32.  The reading of bech32 is to be implemented separately to avoid making this PR to large.

Changes:

* Add `--out-file` argument to the `shelley stake-pool id` command.
* Add `--key-format-output` argument to the following commands:
  * `address key-gen`
  * `stake-address key-gen`
  * `node key-gen`
  * `node key-gen-KES`
  * `node key-gen-VRF`
  * `genesis create-staked`
  * `genesis create`

Depends on https://github.com/input-output-hk/cardano-node/pull/5049, https://github.com/input-output-hk/cardano-node/pull/5057 and https://github.com/input-output-hk/cardano-node/pull/5059.  Please review those first.

Before those are merged, it is recommended to review this PR commit-by-commit starting from the commit with the message "Rename OutputFormat to PoolIdOutputFormat for clarity"