### PR TITLE
Remove --stake-address option from stake-address build

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -51,8 +51,8 @@ import           Cardano.Api.Shelley
 
 import           Data.Text (Text)
 
-import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeVerifier, VerificationKeyOrFile,
-                   VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
+import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeIdentifier, StakeVerifier,
+                   VerificationKeyOrFile, VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
@@ -94,7 +94,7 @@ data AddressCmd
   | AddressKeyHash VerificationKeyTextOrFile (Maybe OutputFile)
   | AddressBuild
       PaymentVerifier
-      (Maybe StakeVerifier)
+      (Maybe StakeIdentifier)
       NetworkId
       (Maybe OutputFile)
   | AddressInfo Text (Maybe OutputFile)
@@ -113,12 +113,12 @@ data StakeAddressCmd
   = StakeAddressKeyGen VerificationKeyFile SigningKeyFile
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe OutputFile)
   | StakeAddressBuild StakeVerifier NetworkId (Maybe OutputFile)
-  | StakeRegistrationCert StakeVerifier OutputFile
+  | StakeRegistrationCert StakeIdentifier OutputFile
   | StakeCredentialDelegationCert
-      StakeVerifier
+      StakeIdentifier
       (VerificationKeyOrHashOrFile StakePoolKey)
       OutputFile
-  | StakeCredentialDeRegistrationCert StakeVerifier OutputFile
+  | StakeCredentialDeRegistrationCert StakeIdentifier OutputFile
   deriving Show
 
 renderStakeAddressCmd :: StakeAddressCmd -> Text

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -20,6 +20,7 @@ module Cardano.CLI.Shelley.Key
   , readVerificationKeyOrHashOrTextEnvFile
 
   , PaymentVerifier(..)
+  , StakeIdentifier(..)
   , StakeVerifier(..)
 
   , generateKeyPair
@@ -102,7 +103,11 @@ data PaymentVerifier
 data StakeVerifier
   = StakeVerifierKey (VerificationKeyOrFile StakeKey)
   | StakeVerifierScriptFile ScriptFile
-  | StakeVerifierAddress StakeAddress
+  deriving (Eq, Show)
+
+data StakeIdentifier
+  = StakeIdentifierVerifier StakeVerifier
+  | StakeIdentifierAddress StakeAddress
   deriving (Eq, Show)
 
 -- | Either an unvalidated text representation of a verification key or a path


### PR DESCRIPTION
The option `--stake-address` does not make sense for `stake-address build` command.