### PR TITLE
Improve roundtrip functions to report annotations on callsite

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -203,6 +203,7 @@ library gen
                       , cardano-ledger-shelley ^>= 0.1
                       , containers
                       , hedgehog
+                      , hedgehog-extras
                       , text
 
 test-suite cardano-api-test

--- a/cardano-api/src/Cardano/Api/Address.hs
+++ b/cardano-api/src/Cardano/Api/Address.hs
@@ -87,7 +87,6 @@ import           Data.Either.Combinators (rightToMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import           Data.Typeable (Typeable)
 import qualified Text.Parsec as Parsec
 import qualified Text.Parsec.String as Parsec
 
@@ -445,7 +444,7 @@ instance HasTypeProxy era => HasTypeProxy (AddressInEra era) where
     data AsType (AddressInEra era) = AsAddressInEra (AsType era)
     proxyToAsType _ = AsAddressInEra (proxyToAsType (Proxy :: Proxy era))
 
-instance (IsCardanoEra era, Typeable era) => SerialiseAsRawBytes (AddressInEra era) where
+instance IsCardanoEra era => SerialiseAsRawBytes (AddressInEra era) where
 
     serialiseToRawBytes (AddressInEra ByronAddressInAnyEra addr) =
       serialiseToRawBytes addr

--- a/cardano-api/src/Cardano/Api/HasTypeProxy.hs
+++ b/cardano-api/src/Cardano/Api/HasTypeProxy.hs
@@ -8,11 +8,12 @@ module Cardano.Api.HasTypeProxy
   , FromSomeType(..)
   ) where
 
+import           Data.Kind (Constraint, Type)
 import           Data.Proxy (Proxy (..))
-import           Data.Kind (Type, Constraint)
+import           Data.Typeable (Typeable)
 
 
-class HasTypeProxy t where
+class Typeable t => HasTypeProxy t where
   -- | A family of singleton types used in this API to indicate which type to
   -- use where it would otherwise be ambiguous or merely unclear.
   --

--- a/cardano-api/src/Cardano/Api/Script.hs
+++ b/cardano-api/src/Cardano/Api/Script.hs
@@ -967,15 +967,14 @@ instance HasTypeProxy lang => HasTypeProxy (PlutusScript lang) where
     data AsType (PlutusScript lang) = AsPlutusScript (AsType lang)
     proxyToAsType _ = AsPlutusScript (proxyToAsType (Proxy :: Proxy lang))
 
-instance (HasTypeProxy lang, Typeable lang) => SerialiseAsRawBytes (PlutusScript lang) where
+instance HasTypeProxy lang => SerialiseAsRawBytes (PlutusScript lang) where
     serialiseToRawBytes (PlutusScriptSerialised sbs) = SBS.fromShort sbs
 
     deserialiseFromRawBytes (AsPlutusScript _) bs =
       -- TODO alonzo: validate the script syntax and fail decoding if invalid
       Right (PlutusScriptSerialised (SBS.toShort bs))
 
-instance (IsPlutusScriptLanguage lang, Typeable lang) =>
-         HasTextEnvelope (PlutusScript lang) where
+instance IsPlutusScriptLanguage lang => HasTextEnvelope (PlutusScript lang) where
     textEnvelopeType _ =
       case plutusScriptVersion :: PlutusScriptVersion lang of
         PlutusScriptV1 -> "PlutusScriptV1"


### PR DESCRIPTION
Before this fix, hedgehog reports look like this:

```
    roundtrip tx CBOR
      BabbageEra: FAIL (9.47s)
          ✗ BabbageEra failed at gen/Test/Hedgehog/Roundtrip/CBOR.hs:21:5
            after 36 tests and 388 shrinks.
            shrink path: 36:a2B3aB5cm34EX32aCL36ew32A6cCL49cmCL185

               ┏━━ gen/Test/Hedgehog/Roundtrip/CBOR.hs ━━━
            15 ┃ roundtrip_CBOR
            16 ┃   :: (SerialiseAsCBOR a, Eq a, Show a)
            17 ┃   => AsType a -> Gen a -> Property
            18 ┃ roundtrip_CBOR typeProxy gen =
            19 ┃   H.property $ do
            20 ┃     val <- H.forAll gen
               ┃     │ ShelleyTx
               ┃     │   ShelleyBasedEraBabbage
               ┃     │   AlonzoTx
               ┃     │     { body =
...
               ┃     │           , _txscripts = fromList []
               ┃     │           , _txdats = TxDatsRaw (fromList [])
               ┃     │           , _txrdmrs = RedeemersRaw (fromList [])
               ┃     │           }
               ┃     │     , isValid = IsValid False
               ┃     │     , auxiliaryData = SNothing
               ┃     │     }
            21 ┃     H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
               ┃     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               ┃     │ ━━━ Intermediate ━━━
...
               ┃     │ ━━━ - Original) (+ Roundtrip ━━━
               ┃     │ - Right
               ┃     │ -   (ShelleyTx
               ┃     │ -      ShelleyBasedEraBabbage
               ┃     │ -      AlonzoTx
               ┃     │ -        { body =
...
               ┃     │ -        })
               ┃     │ + Left
               ┃     │ +   (DecoderErrorDeserialiseFailure
               ┃     │ +      "Shelley Tx"
               ┃     │ +      (DeserialiseFailure
               ┃     │ +         439
               ┃     │ +         "Expected array with 166 entries, but encoded array has 175 entries."))

            This failure can be reproduced by running:
            > recheckAt (Seed 12871014892817788416 11819258044470470495) "36:a2B3aB5cm34EX32aCL36ew32A6cCL49cmCL185" BabbageEra

        Use "--pattern '$NF ~ /BabbageEra/' --hedgehog-replay '36:a2B3aB5cm34EX32aCL36ew32A6cCL49cmCL185 Seed 12871014892817788416 11819258044470470495'" to reproduce from the command-line.

        Use -p '/BabbageEra/&&$0=="Cardano.Api.Test.Cardano.Api.Typed.CBOR.roundtrip tx CBOR.BabbageEra"' to rerun this test only.
```

There is not information to allow jumping directly the the failing test.

After the change the report additionally includes this:

```
               ┏━━ test/Test/Cardano/Api/Typed/CBOR.hs ━━━
            32 ┃ test_roundtrip_tx_CBOR :: [TestTree]
            33 ┃ test_roundtrip_tx_CBOR =
            34 ┃   [ testPropertyNamed (show era) (fromString (show era)) $ roundtrip_CBOR (proxyToAsType Proxy) (genTx era)
               ┃   │ Tx BabbageEra
            35 ┃   | AnyCardanoEra era <- [minBound..(AnyCardanoEra BabbageEra)]
            36 ┃   ]
```

The additional information locates the failing test down to the line number where the failure happened.