### PR TITLE
Remove non-round-trippable value TxInsReferenceNone for babbage onwards in generator

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -641,15 +641,12 @@ genTxInsCollateral era =
                           [ pure TxInsCollateralNone
                           , TxInsCollateral supported <$> Gen.list (Range.linear 0 10) genTxIn
                           ]
+
 genTxInsReference :: CardanoEra era -> Gen (TxInsReference BuildTx era)
 genTxInsReference era =
     case refInsScriptsAndInlineDatsSupportedInEra era of
       Nothing        -> pure TxInsReferenceNone
-      Just supported -> Gen.choice
-                          [ pure TxInsReferenceNone
-                          , TxInsReference supported <$> Gen.list (Range.linear 0 10) genTxIn
-                          ]
-
+      Just supported -> TxInsReference supported <$> Gen.list (Range.linear 0 10) genTxIn
 
 genTxReturnCollateral :: CardanoEra era -> Gen (TxReturnCollateral CtxTx era)
 genTxReturnCollateral era =


### PR DESCRIPTION
In eras where `TxInsReference` is supported it is mandatory in the ledger.

We can't have both `Just []` and `None` represent the same ledger value or round tripping can't work.

We will choose `Just []` as the to represent the ledger's empty list value for this field.