### PR TITLE
Replace roundtripCBOR with trippingCbor

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -305,7 +305,7 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       let
         fundSource = walletSource wallet 1
         inToOut = Utils.includeChange fee coins
-        txGenerator = genTx protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
+        txGenerator = genTx (cardanoEra @era) protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
         sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut $ mangleWithChange toUTxOChange toUTxO
       return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
@@ -316,7 +316,7 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       let
         fundSource = walletSource wallet 1
         inToOut = Utils.inputsToOutputsWithFee fee count
-        txGenerator = genTx protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
+        txGenerator = genTx (cardanoEra @era) protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
         sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut (mangle $ repeat toUTxO)
       return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
@@ -328,7 +328,7 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       let
         fundSource = walletSource wallet inputs
         inToOut = Utils.inputsToOutputsWithFee fee outputs
-        txGenerator = genTx protocolParameters collaterals feeInEra (toMetadata metadataSize)
+        txGenerator = genTx (cardanoEra @era) protocolParameters collaterals feeInEra (toMetadata metadataSize)
         sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut (mangle $ repeat toUTxO)
 
       fundPreview <- liftIO $ walletPreview wallet inputs

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -22,8 +22,8 @@ import           Cardano.TxGenerator.FundQueue
 import           Cardano.TxGenerator.Setup.SigningKey
 import           Cardano.TxGenerator.Tx (genTx, sourceToStoreTransaction)
 import           Cardano.TxGenerator.Types (TxEnvironment (..), TxGenError (..), TxGenerator)
-import           Cardano.TxGenerator.UTxO (makeToUTxOList, mkUTxOVariant)
 import           Cardano.TxGenerator.Utils (inputsToOutputsWithFee)
+import           Cardano.TxGenerator.UTxO (makeToUTxOList, mkUTxOVariant)
 
 import           Paths_tx_generator
 
@@ -103,7 +103,7 @@ generateTx TxEnvironment{..}
     TxFeeExplicit _ fee = txEnvFee
 
     generator :: TxGenerator BabbageEra
-    generator = genTx txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
+    generator = genTx BabbageEra txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
       where
         -- collateralFunds are needed for Plutus transactions
         collateralFunds :: (TxInsCollateral BabbageEra, [Fund])
@@ -150,7 +150,7 @@ generateTxPure TxEnvironment{..} inQueue
     TxFeeExplicit _ fee = txEnvFee
 
     generator :: TxGenerator BabbageEra
-    generator = genTx txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
+    generator = genTx BabbageEra txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
       where
         -- collateralFunds are needed for Plutus transactions
         collateralFunds :: (TxInsCollateral BabbageEra, [Fund])

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -81,13 +81,15 @@ sourceTransactionPreview txGenerator inputFunds valueSplitter toStore =
   split         = valueSplitter $ map getFundLovelace inputFunds
   (outputs, _)  = toStore split
 
-genTx :: forall era. IsShelleyBasedEra era =>
-     ProtocolParameters
+genTx :: forall era. ()
+  => IsShelleyBasedEra era
+  => CardanoEra era
+  -> ProtocolParameters
   -> (TxInsCollateral era, [Fund])
   -> TxFee era
   -> TxMetadataInEra era
   -> TxGenerator era
-genTx protocolParameters (collateral, collFunds) fee metadata inFunds outputs
+genTx _era protocolParameters (collateral, collFunds) fee metadata inFunds outputs
   = bimap
       ApiError
       (\b -> (signShelleyTransaction b $ map WitnessPaymentKey allKeys, getTxId b))

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -204,7 +204,6 @@ library gen
                       , cardano-ledger-shelley >= 1.1
                       , containers
                       , hedgehog
-                      , hedgehog-extras
                       , text
 
 test-suite cardano-api-test

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -602,7 +602,7 @@ genTxUpdateProposal era =
     Just supported ->
       Gen.choice
         [ pure TxUpdateProposalNone
-        , TxUpdateProposal supported <$> genUpdateProposal
+        , TxUpdateProposal supported <$> genUpdateProposal era
         ]
 
 genTxMintValue :: CardanoEra era -> Gen (TxMintValue BuildTx era)
@@ -890,8 +890,8 @@ genProtocolParametersUpdate = do
   pure ProtocolParametersUpdate{..}
 
 
-genUpdateProposal :: Gen UpdateProposal
-genUpdateProposal =
+genUpdateProposal :: CardanoEra era -> Gen UpdateProposal
+genUpdateProposal _era = -- TODO Make era specific
   UpdateProposal
     <$> Gen.map (Range.constant 1 3)
                 ((,) <$> genVerificationKeyHash AsGenesisKey

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -5,6 +5,7 @@
 
 module Test.Hedgehog.Roundtrip.CBOR
   ( roundtrip_CBOR
+  , trippingCbor
   ) where
 
 import           Cardano.Api
@@ -20,7 +21,11 @@ import qualified Hedgehog.Extras.Test.Base as H
 {- HLINT ignore "Use camelCase" -}
 
 roundtrip_CBOR
-  :: forall a. (SerialiseAsCBOR a, Eq a, Show a, HasCallStack)
+  :: forall a. ()
+  => SerialiseAsCBOR a
+  => Eq a
+  => Show a
+  => HasCallStack
   => AsType a
   -> Gen a
   -> Property
@@ -29,3 +34,16 @@ roundtrip_CBOR typeProxy gen =
     GHC.withFrozenCallStack $ H.noteShow_ $ typeRep $ Proxy @a
     val <- H.forAll gen
     H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
+
+-- | Assert that CBOR serialisation and deserialisation roundtrips.
+trippingCbor :: ()
+  => HasCallStack
+  => H.MonadTest m
+  => Show a
+  => Eq a
+  => SerialiseAsCBOR a
+  => AsType a
+  -> a
+  -> m ()
+trippingCbor typeProxy v = GHC.withFrozenCallStack $
+  H.tripping v serialiseToCBOR (deserialiseFromCBOR typeProxy)

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -1,39 +1,18 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Hedgehog.Roundtrip.CBOR
-  ( roundtrip_CBOR
-  , trippingCbor
+  ( trippingCbor
   ) where
 
 import           Cardano.Api
 
-import           Data.Proxy (Proxy (..))
-import           Data.Typeable (typeRep)
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
-import           Hedgehog (Gen, Property)
 import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
-
-roundtrip_CBOR
-  :: forall a. ()
-  => SerialiseAsCBOR a
-  => Eq a
-  => Show a
-  => HasCallStack
-  => AsType a
-  -> Gen a
-  -> Property
-roundtrip_CBOR typeProxy gen =
-  H.property $ do
-    GHC.withFrozenCallStack $ H.noteShow_ $ typeRep $ Proxy @a
-    val <- H.forAll gen
-    H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
 
 -- | Assert that CBOR serialisation and deserialisation roundtrips.
 trippingCbor :: ()

--- a/cardano-api/test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/Test/Cardano/Api/KeysByron.hs
@@ -8,17 +8,19 @@ import           Cardano.Api (AsType (AsByronKey, AsSigningKey), Key (determinis
 
 import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
-import           Test.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR)
+import           Test.Hedgehog.Roundtrip.CBOR (trippingCbor)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 
+import qualified Hedgehog as H
 import qualified Test.Gen.Cardano.Crypto.Seed as Gen
 
 {- HLINT ignore "Use camelCase" -}
 
 prop_roundtrip_byron_key_CBOR :: Property
-prop_roundtrip_byron_key_CBOR =
-  roundtrip_CBOR (AsSigningKey AsByronKey) (deterministicSigningKey AsByronKey <$> Gen.genSeedForKey AsByronKey)
+prop_roundtrip_byron_key_CBOR = H.property $ do
+  seed <- H.forAll $ deterministicSigningKey AsByronKey <$> Gen.genSeedForKey AsByronKey
+  trippingCbor (AsSigningKey AsByronKey) seed
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.KeysByron"

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -177,8 +177,9 @@ prop_roundtrip_ScriptData_CBOR = H.property $ do
 
 prop_roundtrip_UpdateProposal_CBOR :: Property
 prop_roundtrip_UpdateProposal_CBOR = H.property $ do
-  x <- H.forAll genUpdateProposal
-  H.trippingCbor AsUpdateProposal x
+  AnyCardanoEra era <- H.forAll $ Gen.element [minBound .. maxBound]
+  proposal <- H.forAll $ genUpdateProposal era
+  H.trippingCbor AsUpdateProposal proposal
 
 prop_roundtrip_Tx_Cddl :: Property
 prop_roundtrip_Tx_Cddl = H.property $ do

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -9,13 +9,12 @@ module Test.Cardano.Api.Typed.CBOR
 import           Cardano.Api
 
 import           Data.Proxy (Proxy (..))
-import           Data.String (IsString (..))
 import           Hedgehog (Property, forAll, tripping)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Gen.Cardano.Api.Typed
-import           Test.Hedgehog.Roundtrip.CBOR (roundtrip_CBOR)
+import qualified Test.Hedgehog.Roundtrip.CBOR as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 
@@ -30,131 +29,156 @@ prop_roundtrip_txbody_CBOR = H.property $ do
   x <- H.forAll $ makeSignedTransaction [] <$> genTxBody era
   H.tripping x serialiseTxLedgerCddl (deserialiseTxLedgerCddl era)
 
-test_roundtrip_tx_CBOR :: [TestTree]
-test_roundtrip_tx_CBOR =
-  [ testPropertyNamed (show era) (fromString (show era)) $ roundtrip_CBOR (proxyToAsType Proxy) (genTx era)
-  | AnyCardanoEra era <- [minBound..(AnyCardanoEra BabbageEra)]
-  ]
+prop_roundtrip_tx_CBOR :: Property
+prop_roundtrip_tx_CBOR = H.property $ do
+  AnyCardanoEra era <- H.forAll $ Gen.element [minBound..AnyCardanoEra BabbageEra]
+  x <- H.forAll $ genTx era
+  H.trippingCbor (proxyToAsType Proxy) x
 
 prop_roundtrip_witness_byron_CBOR :: Property
-prop_roundtrip_witness_byron_CBOR =
-  roundtrip_CBOR (AsKeyWitness AsByronEra) genByronKeyWitness
+prop_roundtrip_witness_byron_CBOR = H.property $ do
+  x <- H.forAll genByronKeyWitness
+  H.trippingCbor (AsKeyWitness AsByronEra) x
 
 prop_roundtrip_witness_shelley_CBOR :: Property
-prop_roundtrip_witness_shelley_CBOR =
-  roundtrip_CBOR (AsKeyWitness AsShelleyEra) (genShelleyWitness ShelleyEra)
+prop_roundtrip_witness_shelley_CBOR = H.property $ do
+  x <- H.forAll $ genShelleyWitness ShelleyEra
+  H.trippingCbor (AsKeyWitness AsShelleyEra) x
 
 prop_roundtrip_witness_allegra_CBOR :: Property
-prop_roundtrip_witness_allegra_CBOR =
-  roundtrip_CBOR (AsKeyWitness AsAllegraEra) (genShelleyWitness AllegraEra)
+prop_roundtrip_witness_allegra_CBOR = H.property $ do
+  x <- H.forAll $ genShelleyWitness AllegraEra
+  H.trippingCbor (AsKeyWitness AsAllegraEra) x
 
 prop_roundtrip_witness_mary_CBOR :: Property
-prop_roundtrip_witness_mary_CBOR =
-  roundtrip_CBOR (AsKeyWitness AsMaryEra) (genShelleyWitness MaryEra)
+prop_roundtrip_witness_mary_CBOR = H.property $ do
+  x <- H.forAll $ genShelleyWitness MaryEra
+  H.trippingCbor (AsKeyWitness AsMaryEra) x
 
 prop_roundtrip_witness_alonzo_CBOR :: Property
-prop_roundtrip_witness_alonzo_CBOR =
-  roundtrip_CBOR (AsKeyWitness AsAlonzoEra) (genShelleyWitness AlonzoEra)
+prop_roundtrip_witness_alonzo_CBOR = H.property $ do
+  x <- H.forAll $ genShelleyWitness AlonzoEra
+  H.trippingCbor (AsKeyWitness AsAlonzoEra) x
 
 prop_roundtrip_operational_certificate_CBOR :: Property
-prop_roundtrip_operational_certificate_CBOR =
-  roundtrip_CBOR AsOperationalCertificate genOperationalCertificate
+prop_roundtrip_operational_certificate_CBOR = H.property $ do
+  x <- H.forAll genOperationalCertificate
+  H.trippingCbor AsOperationalCertificate x
 
 prop_roundtrip_operational_certificate_issue_counter_CBOR :: Property
-prop_roundtrip_operational_certificate_issue_counter_CBOR =
-  roundtrip_CBOR AsOperationalCertificateIssueCounter genOperationalCertificateIssueCounter
+prop_roundtrip_operational_certificate_issue_counter_CBOR = H.property $ do
+  x <- H.forAll genOperationalCertificateIssueCounter
+  H.trippingCbor AsOperationalCertificateIssueCounter x
 
 prop_roundtrip_verification_key_byron_CBOR :: Property
-prop_roundtrip_verification_key_byron_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsByronKey) (genVerificationKey AsByronKey)
+prop_roundtrip_verification_key_byron_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsByronKey
+  H.trippingCbor (AsVerificationKey AsByronKey) x
 
 prop_roundtrip_signing_key_byron_CBOR :: Property
-prop_roundtrip_signing_key_byron_CBOR =
-  roundtrip_CBOR (AsSigningKey AsByronKey) (genSigningKey AsByronKey)
+prop_roundtrip_signing_key_byron_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsByronKey
+  H.trippingCbor (AsSigningKey AsByronKey) x
 
 prop_roundtrip_verification_key_payment_CBOR :: Property
-prop_roundtrip_verification_key_payment_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsPaymentKey) (genVerificationKey AsPaymentKey)
+prop_roundtrip_verification_key_payment_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsPaymentKey
+  H.trippingCbor (AsVerificationKey AsPaymentKey) x
 
 prop_roundtrip_signing_key_payment_CBOR :: Property
-prop_roundtrip_signing_key_payment_CBOR =
-  roundtrip_CBOR (AsSigningKey AsPaymentKey) (genSigningKey AsPaymentKey)
+prop_roundtrip_signing_key_payment_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsPaymentKey
+  H.trippingCbor (AsSigningKey AsPaymentKey) x
 
 prop_roundtrip_verification_key_stake_CBOR :: Property
-prop_roundtrip_verification_key_stake_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsStakeKey) (genVerificationKey AsStakeKey)
+prop_roundtrip_verification_key_stake_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsStakeKey
+  H.trippingCbor (AsVerificationKey AsStakeKey) x
 
 prop_roundtrip_signing_key_stake_CBOR :: Property
-prop_roundtrip_signing_key_stake_CBOR =
-  roundtrip_CBOR (AsSigningKey AsStakeKey) (genSigningKey AsStakeKey)
+prop_roundtrip_signing_key_stake_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsStakeKey
+  H.trippingCbor (AsSigningKey AsStakeKey) x
 
 prop_roundtrip_verification_key_genesis_CBOR :: Property
-prop_roundtrip_verification_key_genesis_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsGenesisKey) (genVerificationKey AsGenesisKey)
+prop_roundtrip_verification_key_genesis_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsGenesisKey
+  H.trippingCbor (AsVerificationKey AsGenesisKey) x
 
 prop_roundtrip_signing_key_genesis_CBOR :: Property
-prop_roundtrip_signing_key_genesis_CBOR =
-  roundtrip_CBOR (AsSigningKey AsGenesisKey) (genSigningKey AsGenesisKey)
+prop_roundtrip_signing_key_genesis_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsGenesisKey
+  H.trippingCbor (AsSigningKey AsGenesisKey) x
 
 prop_roundtrip_verification_key_genesis_delegate_CBOR :: Property
-prop_roundtrip_verification_key_genesis_delegate_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsGenesisDelegateKey) (genVerificationKey AsGenesisDelegateKey)
+prop_roundtrip_verification_key_genesis_delegate_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsGenesisDelegateKey
+  H.trippingCbor (AsVerificationKey AsGenesisDelegateKey) x
 
 prop_roundtrip_signing_key_genesis_delegate_CBOR :: Property
-prop_roundtrip_signing_key_genesis_delegate_CBOR =
-  roundtrip_CBOR (AsSigningKey AsGenesisDelegateKey) (genSigningKey AsGenesisDelegateKey)
+prop_roundtrip_signing_key_genesis_delegate_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsGenesisDelegateKey
+  H.trippingCbor (AsSigningKey AsGenesisDelegateKey) x
 
 prop_roundtrip_verification_key_stake_pool_CBOR :: Property
-prop_roundtrip_verification_key_stake_pool_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsStakePoolKey) (genVerificationKey AsStakePoolKey)
+prop_roundtrip_verification_key_stake_pool_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsStakePoolKey
+  H.trippingCbor (AsVerificationKey AsStakePoolKey) x
 
 prop_roundtrip_signing_key_stake_pool_CBOR :: Property
-prop_roundtrip_signing_key_stake_pool_CBOR =
-  roundtrip_CBOR (AsSigningKey AsStakePoolKey) (genSigningKey AsStakePoolKey)
+prop_roundtrip_signing_key_stake_pool_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsStakePoolKey
+  H.trippingCbor (AsSigningKey AsStakePoolKey) x
 
 prop_roundtrip_verification_key_vrf_CBOR :: Property
-prop_roundtrip_verification_key_vrf_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsVrfKey) (genVerificationKey AsVrfKey)
+prop_roundtrip_verification_key_vrf_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsVrfKey
+  H.trippingCbor (AsVerificationKey AsVrfKey) x
 
 prop_roundtrip_signing_key_vrf_CBOR :: Property
-prop_roundtrip_signing_key_vrf_CBOR =
-  roundtrip_CBOR (AsSigningKey AsVrfKey) (genSigningKey AsVrfKey)
+prop_roundtrip_signing_key_vrf_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsVrfKey
+  H.trippingCbor (AsSigningKey AsVrfKey) x
 
 prop_roundtrip_verification_key_kes_CBOR :: Property
-prop_roundtrip_verification_key_kes_CBOR =
-  roundtrip_CBOR (AsVerificationKey AsKesKey) (genVerificationKey AsKesKey)
+prop_roundtrip_verification_key_kes_CBOR = H.property $ do
+  x <- H.forAll $ genVerificationKey AsKesKey
+  H.trippingCbor (AsVerificationKey AsKesKey) x
 
 prop_roundtrip_signing_key_kes_CBOR :: Property
-prop_roundtrip_signing_key_kes_CBOR =
-  roundtrip_CBOR (AsSigningKey AsKesKey) (genSigningKey AsKesKey)
+prop_roundtrip_signing_key_kes_CBOR = H.property $ do
+  x <- H.forAll $ genSigningKey AsKesKey
+  H.trippingCbor (AsSigningKey AsKesKey) x
 
 prop_roundtrip_script_SimpleScriptV1_CBOR :: Property
-prop_roundtrip_script_SimpleScriptV1_CBOR =
-  roundtrip_CBOR (AsScript AsSimpleScript)
-                 (genScript SimpleScriptLanguage)
+prop_roundtrip_script_SimpleScriptV1_CBOR = H.property $ do
+  x <- H.forAll $ genScript SimpleScriptLanguage
+  H.trippingCbor (AsScript AsSimpleScript) x
 
 prop_roundtrip_script_SimpleScriptV2_CBOR :: Property
-prop_roundtrip_script_SimpleScriptV2_CBOR =
-  roundtrip_CBOR (AsScript AsSimpleScript)
-                 (genScript SimpleScriptLanguage)
+prop_roundtrip_script_SimpleScriptV2_CBOR = H.property $ do
+  x <- H.forAll $ genScript SimpleScriptLanguage
+  H.trippingCbor (AsScript AsSimpleScript) x
 
 prop_roundtrip_script_PlutusScriptV1_CBOR :: Property
-prop_roundtrip_script_PlutusScriptV1_CBOR =
-  roundtrip_CBOR (AsScript AsPlutusScriptV1)
-                 (genScript (PlutusScriptLanguage PlutusScriptV1))
+prop_roundtrip_script_PlutusScriptV1_CBOR = H.property $ do
+  x <- H.forAll $ genScript (PlutusScriptLanguage PlutusScriptV1)
+  H.trippingCbor (AsScript AsPlutusScriptV1) x
 
 prop_roundtrip_script_PlutusScriptV2_CBOR :: Property
-prop_roundtrip_script_PlutusScriptV2_CBOR =
-  roundtrip_CBOR (AsScript AsPlutusScriptV2)
-                 (genScript (PlutusScriptLanguage PlutusScriptV2))
+prop_roundtrip_script_PlutusScriptV2_CBOR = H.property $ do
+  x <- H.forAll $ genScript (PlutusScriptLanguage PlutusScriptV2)
+  H.trippingCbor (AsScript AsPlutusScriptV2) x
 
 prop_roundtrip_ScriptData_CBOR :: Property
-prop_roundtrip_ScriptData_CBOR =
-  roundtrip_CBOR AsHashableScriptData genHashableScriptData
+prop_roundtrip_ScriptData_CBOR = H.property $ do
+  x <- H.forAll genHashableScriptData
+  H.trippingCbor AsHashableScriptData x
 
 prop_roundtrip_UpdateProposal_CBOR :: Property
-prop_roundtrip_UpdateProposal_CBOR =
-  roundtrip_CBOR AsUpdateProposal genUpdateProposal
+prop_roundtrip_UpdateProposal_CBOR = H.property $ do
+  x <- H.forAll genUpdateProposal
+  H.trippingCbor AsUpdateProposal x
 
 prop_roundtrip_Tx_Cddl :: Property
 prop_roundtrip_Tx_Cddl = H.property $ do
@@ -205,5 +229,5 @@ tests = testGroup "Test.Cardano.Api.Typed.CBOR"
   , testPropertyNamed "roundtrip txbody CBOR"                                "roundtrip txbody CBOR"                                prop_roundtrip_txbody_CBOR
   , testPropertyNamed "roundtrip Tx Cddl"                                    "roundtrip Tx Cddl"                                    prop_roundtrip_Tx_Cddl
   , testPropertyNamed "roundtrip TxWitness Cddl"                             "roundtrip TxWitness Cddl"                             prop_roundtrip_TxWitness_Cddl
-  , testGroup "roundtrip tx CBOR"         test_roundtrip_tx_CBOR
+  , testPropertyNamed "roundtrip tx CBOR"                                    "roundtrip tx CBOR"                                    prop_roundtrip_tx_CBOR
   ]

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -35,30 +35,11 @@ prop_roundtrip_tx_CBOR = H.property $ do
   x <- H.forAll $ genTx era
   H.trippingCbor (proxyToAsType Proxy) x
 
-prop_roundtrip_witness_byron_CBOR :: Property
-prop_roundtrip_witness_byron_CBOR = H.property $ do
-  x <- H.forAll genByronKeyWitness
-  H.trippingCbor (AsKeyWitness AsByronEra) x
-
-prop_roundtrip_witness_shelley_CBOR :: Property
-prop_roundtrip_witness_shelley_CBOR = H.property $ do
-  x <- H.forAll $ genShelleyWitness ShelleyEra
-  H.trippingCbor (AsKeyWitness AsShelleyEra) x
-
-prop_roundtrip_witness_allegra_CBOR :: Property
-prop_roundtrip_witness_allegra_CBOR = H.property $ do
-  x <- H.forAll $ genShelleyWitness AllegraEra
-  H.trippingCbor (AsKeyWitness AsAllegraEra) x
-
-prop_roundtrip_witness_mary_CBOR :: Property
-prop_roundtrip_witness_mary_CBOR = H.property $ do
-  x <- H.forAll $ genShelleyWitness MaryEra
-  H.trippingCbor (AsKeyWitness AsMaryEra) x
-
-prop_roundtrip_witness_alonzo_CBOR :: Property
-prop_roundtrip_witness_alonzo_CBOR = H.property $ do
-  x <- H.forAll $ genShelleyWitness AlonzoEra
-  H.trippingCbor (AsKeyWitness AsAlonzoEra) x
+prop_roundtrip_witness_CBOR :: Property
+prop_roundtrip_witness_CBOR = H.property $ do
+  AnyCardanoEra era <- H.forAll $ Gen.element [minBound..maxBound]
+  x <- H.forAll $ genCardanoKeyWitness era
+  H.trippingCbor (AsKeyWitness (proxyToAsType Proxy)) x
 
 prop_roundtrip_operational_certificate_CBOR :: Property
 prop_roundtrip_operational_certificate_CBOR = H.property $ do
@@ -198,11 +179,7 @@ prop_roundtrip_TxWitness_Cddl = H.property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.CBOR"
-  [ testPropertyNamed "roundtrip witness byron CBOR"                         "roundtrip witness byron CBOR"                         prop_roundtrip_witness_byron_CBOR
-  , testPropertyNamed "roundtrip witness shelley CBOR"                       "roundtrip witness shelley CBOR"                       prop_roundtrip_witness_shelley_CBOR
-  , testPropertyNamed "roundtrip witness allegra CBOR"                       "roundtrip witness allegra CBOR"                       prop_roundtrip_witness_allegra_CBOR
-  , testPropertyNamed "roundtrip witness mary CBOR"                          "roundtrip witness mary CBOR"                          prop_roundtrip_witness_mary_CBOR
-  , testPropertyNamed "roundtrip witness alonzo CBOR"                        "roundtrip witness alonzo CBOR"                        prop_roundtrip_witness_alonzo_CBOR
+  [ testPropertyNamed "roundtrip witness CBOR"                               "roundtrip witness CBOR"                               prop_roundtrip_witness_CBOR
   , testPropertyNamed "roundtrip operational certificate CBOR"               "roundtrip operational certificate CBOR"               prop_roundtrip_operational_certificate_CBOR
   , testPropertyNamed "roundtrip operational certificate issue counter CBOR" "roundtrip operational certificate issue counter CBOR" prop_roundtrip_operational_certificate_issue_counter_CBOR
   , testPropertyNamed "roundtrip verification key byron CBOR"                "roundtrip verification key byron CBOR"                prop_roundtrip_verification_key_byron_CBOR


### PR DESCRIPTION
`roundtripCBOR` was used to reduce the amount of code for round trip tests, but it does not work well with GADTs.

We expect to use GADTs more in these tests in order to make them era independent.

Work-arounds for `roundtripCBOR` have been used to make it possible to encode tests for multiple eras.  These include:

* Writing an property test per era
* Generating a property test per era with a test function that returns a `[TestTree]` instead of a `Property`

This PR introduces `trippingCbor` which captures the tripping part of the property test.

It turns out that writing out the property test directly rather than generating the property gives us the flexibility to use GADTs and thus be able to encode era independent property tests, which allows us to eliminate per era duplication and avoid generating test groups.

