### PR TITLE
Simplify cddl tests

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -240,6 +240,7 @@ test-suite cardano-api-test
                       , time
 
   other-modules:        Test.Cardano.Api.Crypto
+                        Test.Cardano.Api.Eras
                         Test.Cardano.Api.Genesis
                         Test.Cardano.Api.Json
                         Test.Cardano.Api.KeysByron

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -5,7 +5,7 @@
 
 module Test.Hedgehog.Roundtrip.CBOR
   ( roundtrip_CBOR
-  , roundtrip_CDDL_Tx
+  -- , roundtrip_CDDL_Tx
   ) where
 
 import           Cardano.Api
@@ -30,15 +30,3 @@ roundtrip_CBOR typeProxy gen =
     GHC.withFrozenCallStack $ H.noteShow_ $ typeRep $ Proxy @a
     val <- H.forAll gen
     H.tripping val serialiseToCBOR (deserialiseFromCBOR typeProxy)
-
-
-roundtrip_CDDL_Tx
-  :: (IsCardanoEra era, HasCallStack)
-  => CardanoEra era
-  -> Gen (Tx era)
-  -> Property
-roundtrip_CDDL_Tx era gen =
-  H.property $ do
-    GHC.withFrozenCallStack $ H.noteShow_ era
-    val <- H.forAll gen
-    H.tripping val serialiseTxLedgerCddl (deserialiseTxLedgerCddl era)

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -5,7 +5,6 @@
 
 module Test.Hedgehog.Roundtrip.CBOR
   ( roundtrip_CBOR
-  -- , roundtrip_CDDL_Tx
   ) where
 
 import           Cardano.Api

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -28,6 +28,7 @@ module Cardano.Api (
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
+    AnyShelleyBasedEra(..),
     InAnyShelleyBasedEra(..),
     CardanoEraStyle(..),
     cardanoEraStyle,

--- a/cardano-api/src/Cardano/Api/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Eras.hs
@@ -342,12 +342,7 @@ deriving instance Ord  (ShelleyBasedEra era)
 deriving instance Show (ShelleyBasedEra era)
 
 instance ToJSON (ShelleyBasedEra era) where
-   toJSON ShelleyBasedEraShelley = "Shelley"
-   toJSON ShelleyBasedEraAllegra = "Allegra"
-   toJSON ShelleyBasedEraMary    = "Mary"
-   toJSON ShelleyBasedEraAlonzo  = "Alonzo"
-   toJSON ShelleyBasedEraBabbage = "Babbage"
-   toJSON ShelleyBasedEraConway  = "Conway"
+   toJSON = toJSON . shelleyBasedToCardanoEra
 
 instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraShelley ShelleyBasedEraShelley = Just Refl
@@ -436,7 +431,7 @@ instance FromJSON AnyShelleyBasedEra where
         "Alonzo" -> pure $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
         "Babbage" -> pure $ AnyShelleyBasedEra ShelleyBasedEraBabbage
         "Conway" -> pure $ AnyShelleyBasedEra ShelleyBasedEraConway
-        wrong -> fail $ "Failed to parse unknown era: " <> Text.unpack wrong
+        wrong -> fail $ "Failed to parse unknown shelley-based era: " <> Text.unpack wrong
 
 
 -- | This pairs up some era-dependent type with a 'ShelleyBasedEra' value that

--- a/cardano-api/test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/Test/Cardano/Api/Eras.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Api.Eras
+  ( tests
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Orphans ()
+import           Data.Aeson (ToJSON (..), decode, encode)
+import           Hedgehog (Property, forAll, property, (===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testPropertyNamed)
+
+--------------------------------------------------------------------------------
+-- Bounded instances
+
+prop_maxBound_CardanoMatchesShelley :: Property
+prop_maxBound_CardanoMatchesShelley = property $ do
+  AnyCardanoEra era <- forAll $ Gen.element [maxBound]
+  AnyShelleyBasedEra sbe <- forAll $ Gen.element [maxBound]
+
+  fromEnum (AnyCardanoEra era) === fromEnum (AnyCardanoEra (shelleyBasedToCardanoEra sbe))
+
+--------------------------------------------------------------------------------
+-- Aeson instances
+
+prop_roundtrip_JSON_Shelley :: Property
+prop_roundtrip_JSON_Shelley = property $ do
+  anySbe <- forAll $ Gen.element @_ @AnyShelleyBasedEra [minBound..maxBound]
+
+  H.tripping anySbe encode decode
+
+prop_roundtrip_JSON_Cardano :: Property
+prop_roundtrip_JSON_Cardano = property $ do
+  anyEra <- forAll $ Gen.element @_ @AnyCardanoEra [minBound..maxBound]
+
+  H.tripping anyEra encode decode
+
+prop_toJSON_CardanoMatchesShelley :: Property
+prop_toJSON_CardanoMatchesShelley = property $ do
+  AnyShelleyBasedEra sbe <- forAll $ Gen.element [minBound..maxBound]
+
+  toJSON (AnyShelleyBasedEra sbe) === toJSON (AnyCardanoEra (shelleyBasedToCardanoEra sbe))
+
+tests :: TestTree
+tests = testGroup "Test.Cardano.Api.Json"
+  [ testPropertyNamed "maxBound cardano matches shelley"           "maxBound cardano matches shelley"           prop_maxBound_CardanoMatchesShelley
+  , testPropertyNamed "roundtrip JSON shelley"                     "roundtrip JSON shelley"                     prop_roundtrip_JSON_Shelley
+  , testPropertyNamed "roundtrip JSON cardano"                     "roundtrip JSON cardano"                     prop_roundtrip_JSON_Cardano
+  , testPropertyNamed "toJSON cardano matches shelley"             "toJSON cardano matches shelley"             prop_toJSON_CardanoMatchesShelley
+  ]

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -4,6 +4,7 @@ import           Cardano.Crypto.Libsodium (sodiumInit)
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Test.Cardano.Api.Crypto
+import qualified Test.Cardano.Api.Eras
 import qualified Test.Cardano.Api.Json
 import qualified Test.Cardano.Api.KeysByron
 import qualified Test.Cardano.Api.Ledger
@@ -29,6 +30,7 @@ tests :: TestTree
 tests =
   testGroup "Cardano.Api"
     [ Test.Cardano.Api.Crypto.tests
+    , Test.Cardano.Api.Eras.tests
     , Test.Cardano.Api.Json.tests
     , Test.Cardano.Api.KeysByron.tests
     , Test.Cardano.Api.Ledger.tests


### PR DESCRIPTION
Introduce new `AnyShelleyBasedEra` type and simplify CDDL types.

We inline roundtrip functions that are rarely used and convert test groups to property tests for consistency.