### PR TITLE
Expose SerialiseAsRawBytesError in Cardano.Api

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -518,6 +518,7 @@ module Cardano.Api (
     SerialiseAsRawBytes,
     serialiseToRawBytes,
     deserialiseFromRawBytes,
+    SerialiseAsRawBytesError(..),
     eitherDeserialiseFromRawBytes,
     serialiseToRawBytesHex,
     deserialiseFromRawBytesHex,


### PR DESCRIPTION
The function `deserialiseFromRawBytes` was changed from `Maybe` to `Either SerialiseAsRawBytesError`, but the error type was not exposed in the `Cardano.API`.