### PR TITLE
Expose UsingRawBytes et al types

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -506,6 +506,7 @@ module Cardano.Api (
     deserialiseFromBech32,
     deserialiseAnyOfFromBech32,
     Bech32DecodeError(..),
+    UsingBech32(..),
 
     -- ** Addresses
     -- | Address serialisation is (sadly) special
@@ -523,6 +524,8 @@ module Cardano.Api (
     deserialiseFromRawBytesHex,
     serialiseToRawBytesHexText,
     RawBytesHexError(..),
+    UsingRawBytes(..),
+    UsingRawBytesHex(..),
 
     -- ** Text envelope
     -- | Support for a envelope file format with text headers and a hex-encoded
@@ -837,6 +840,7 @@ import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseLedgerCddl
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody


### PR DESCRIPTION
This makes it simple to re-use de/serialisation for new types with DerivingVia. It is extensively used inside cardano-api and hence provides a clear value to users of the SDK as well.