### PR TITLE
Workflow dispatch to take inputs

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -1,9 +1,22 @@
 name: Haskell Linux CI
 
 on:
-  workflow_dispatch: # This is required for nightly builds
   push:
   merge_group:
+
+  # DO NOT DELETE.
+  # This is required for nightly builds and is invoked by nightly-trigger.yml
+  # on a schedule trigger.
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason'
+        required: false
+        default: manual
+      tests:
+        description: 'Tests'
+        required: false
+        default: some
 
 jobs:
   linux_ci:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,9 +1,22 @@
 name: Haskell Windows & Mac CI
 
 on:
-  workflow_dispatch: # This is required for nightly builds
   push:
   merge_group:
+
+  # DO NOT DELETE.
+  # This is required for nightly builds and is invoked by nightly-trigger.yml
+  # on a schedule trigger.
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason'
+        required: false
+        default: manual
+      tests:
+        description: 'Tests'
+        required: false
+        default: some
 
 jobs:
   build:


### PR DESCRIPTION
Workflow dispatch needs to take inputs because the nightly trigger provides them.