### PR TITLE
Add two digesting datapoints.

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -241,6 +241,13 @@ instance MetaTrace (TraceChainSyncClientEvent blk) where
     , Namespace [] ["Termination"]
     ]
 
+instance (LogFormatting (TraceChainSyncClientEvent blk))
+         => ToJSON (TraceChainSyncClientEvent blk)
+  where
+  toJSON = Aeson.Object . forMachine DMaximum
+  -- this needed to put TraceChainSyncCLientEvent into a Datapoint.           
+
+
 --------------------------------------------------------------------------------
 -- ChainSyncServer Tracer
 --------------------------------------------------------------------------------
@@ -613,6 +620,12 @@ instance MetaTrace (BlockFetch.TraceFetchClientState header) where
        , Namespace [] ["RejectedFetchBatch"]
        , Namespace [] ["ClientTerminating"]
       ]
+
+instance (LogFormatting (BlockFetch.TraceFetchClientState h))
+         => ToJSON (BlockFetch.TraceFetchClientState h)
+  where
+  toJSON = Aeson.Object . forMachine DMaximum
+  -- this needed to put TraceFetchClientState into a Datapoint.
 
 --------------------------------------------------------------------------------
 -- BlockFetchServerEvent

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -234,6 +234,9 @@ instance (BlockSupportsProtocol blk, Show peer, Show (Header blk))
     => HasTextFormatter (TraceLabelPeer peer (TraceChainSyncClientEvent blk)) where
   formatText a _ = pack $ show a
 
+deriving instance Generic (TraceLabelPeer p b)
+instance (ToJSON p, ToJSON b) => ToJSON (TraceLabelPeer p b)
+
 instance HasPrivacyAnnotation (TraceChainSyncClientEvent blk)
 instance HasSeverityAnnotation (TraceChainSyncClientEvent blk) where
   getSeverityAnnotation (TraceDownloadedHeader _) = Info


### PR DESCRIPTION
We add a concept of a "digesting" datapoint: its purpose is to transform a sequence of events (such as we get with "logging tracers") into a datapoint (with its stateless protocol) from which one can reconstruct the sequence of events on the datapoint client side.

Two new "digesting" datapoints are added to the tracing system.
  - ChainSync.Client  
  - BlockFetch.Client These datapoints turn the logging tracers of the same name into "digesting datapoints".

Issues:
- See PR #5104 for the implementation of a client for these digesting datapoints.  Due to the stateless nature of the datapoint mini-protocol, the client (/server) must receive (/send) a higher than needed number of packets in order to be able to not lose events. One possible extension to datapoints could alleviate this
  - The ability to configure the initialization of datapoints.  E.g.,
    ```
     off | on: Parameters -- I.e., Maybe DatapointParameter   
    ```