### PR TITLE
CIP-1694 make space for DRep certificates

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -360,7 +360,7 @@ module Cardano.Api (
     -- choice for a stake address.
     makeStakeAddressRegistrationCertificate,
     makeStakeAddressDeregistrationCertificate,
-    makeStakeAddressDelegationCertificate,
+    makeStakeAddressPoolDelegationCertificate,
 
     -- ** Registering stake pools
     -- | Certificates that are embedded in transactions for registering and

--- a/cardano-api/src/Cardano/Api/Certificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate.hs
@@ -12,7 +12,7 @@ module Cardano.Api.Certificate (
     -- * Registering stake address and delegating
     makeStakeAddressRegistrationCertificate,
     makeStakeAddressDeregistrationCertificate,
-    makeStakeAddressDelegationCertificate,
+    makeStakeAddressPoolDelegationCertificate,
     PoolId,
 
     -- * Registering stake pools
@@ -83,7 +83,7 @@ data Certificate =
      -- Stake address certificates
      StakeAddressRegistrationCertificate   StakeCredential
    | StakeAddressDeregistrationCertificate StakeCredential
-   | StakeAddressDelegationCertificate     StakeCredential PoolId
+   | StakeAddressPoolDelegationCertificate StakeCredential PoolId
 
      -- Stake pool certificates
    | StakePoolRegistrationCertificate StakePoolParameters
@@ -113,7 +113,7 @@ instance HasTextEnvelope Certificate where
     textEnvelopeDefaultDescr cert = case cert of
       StakeAddressRegistrationCertificate{}   -> "Stake address registration"
       StakeAddressDeregistrationCertificate{} -> "Stake address de-registration"
-      StakeAddressDelegationCertificate{}     -> "Stake address delegation"
+      StakeAddressPoolDelegationCertificate{} -> "Stake address stake pool delegation"
       StakePoolRegistrationCertificate{}      -> "Pool registration"
       StakePoolRetirementCertificate{}        -> "Pool retirement"
       GenesisKeyDelegationCertificate{}       -> "Genesis key delegation"
@@ -191,8 +191,8 @@ makeStakeAddressRegistrationCertificate = StakeAddressRegistrationCertificate
 makeStakeAddressDeregistrationCertificate :: StakeCredential -> Certificate
 makeStakeAddressDeregistrationCertificate = StakeAddressDeregistrationCertificate
 
-makeStakeAddressDelegationCertificate :: StakeCredential -> PoolId -> Certificate
-makeStakeAddressDelegationCertificate = StakeAddressDelegationCertificate
+makeStakeAddressPoolDelegationCertificate :: StakeCredential -> PoolId -> Certificate
+makeStakeAddressPoolDelegationCertificate = StakeAddressPoolDelegationCertificate
 
 makeStakePoolRegistrationCertificate :: StakePoolParameters -> Certificate
 makeStakePoolRegistrationCertificate = StakePoolRegistrationCertificate
@@ -225,7 +225,7 @@ toShelleyCertificate (StakeAddressDeregistrationCertificate stakecred) =
       Shelley.DeRegKey
         (toShelleyStakeCredential stakecred)
 
-toShelleyCertificate (StakeAddressDelegationCertificate
+toShelleyCertificate (StakeAddressPoolDelegationCertificate
                         stakecred (StakePoolKeyHash poolid)) =
     Shelley.DCertDeleg $
     Shelley.Delegate $
@@ -295,7 +295,7 @@ fromShelleyCertificate (Shelley.DCertDeleg (Shelley.DeRegKey stakecred)) =
 
 fromShelleyCertificate (Shelley.DCertDeleg
                          (Shelley.Delegate (Shelley.Delegation stakecred poolid))) =
-    StakeAddressDelegationCertificate
+    StakeAddressPoolDelegationCertificate
       (fromShelleyStakeCredential stakecred)
       (StakePoolKeyHash poolid)
 

--- a/cardano-api/src/Cardano/Api/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Fees.hs
@@ -1293,7 +1293,7 @@ mapTxScriptWitnesses f txbodycontent@TxBodyContent {
     selectStakeCredential cert =
       case cert of
         StakeAddressDeregistrationCertificate stakecred   -> Just stakecred
-        StakeAddressDelegationCertificate     stakecred _ -> Just stakecred
+        StakeAddressPoolDelegationCertificate stakecred _ -> Just stakecred
         _                                                 -> Nothing
 
     mapScriptWitnessesMinting

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -4208,7 +4208,7 @@ collectTxBodyScriptWitnesses TxBodyContent {
     selectStakeCredential cert =
       case cert of
         StakeAddressDeregistrationCertificate stakecred   -> Just stakecred
-        StakeAddressDelegationCertificate     stakecred _ -> Just stakecred
+        StakeAddressPoolDelegationCertificate stakecred _ -> Just stakecred
         _                                                 -> Nothing
 
     scriptWitnessesMinting

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -315,7 +315,7 @@ friendlyCertificate =
       StakeAddressDeregistrationCertificate credential ->
         "stake address deregistration"
           .= object [friendlyStakeCredential credential]
-      StakeAddressDelegationCertificate credential poolId ->
+      StakeAddressPoolDelegationCertificate credential poolId ->
         "stake address delegation"
           .= object [friendlyStakeCredential credential, "pool" .= poolId]
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -50,8 +50,9 @@ import           Cardano.Api.Shelley
 
 import           Data.Text (Text)
 
-import           Cardano.CLI.Shelley.Key (PaymentVerifier, StakeIdentifier, StakeVerifier,
-                   VerificationKeyOrFile, VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
+import           Cardano.CLI.Shelley.Key (DelegationTarget, PaymentVerifier, StakeIdentifier,
+                   StakeVerifier, VerificationKeyOrFile, VerificationKeyOrHashOrFile,
+                   VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
@@ -115,7 +116,7 @@ data StakeAddressCmd
   | StakeRegistrationCert StakeIdentifier OutputFile
   | StakeCredentialDelegationCert
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      DelegationTarget
       OutputFile
   | StakeCredentialDeRegistrationCert StakeIdentifier OutputFile
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -24,6 +24,8 @@ module Cardano.CLI.Shelley.Key
   , StakeVerifier(..)
 
   , generateKeyPair
+
+  , DelegationTarget(..)
   ) where
 
 import           Cardano.Api
@@ -36,6 +38,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
+import           Cardano.Api.Shelley (StakePoolKey)
 import           Cardano.CLI.Types
 
 
@@ -109,6 +112,12 @@ data StakeIdentifier
   = StakeIdentifierVerifier StakeVerifier
   | StakeIdentifierAddress StakeAddress
   deriving (Eq, Show)
+
+-- | A resource that identifies the delegation target.  At the moment a delegation
+-- target can only be a stake pool.
+newtype DelegationTarget
+  = StakePoolDelegationTarget (VerificationKeyOrHashOrFile StakePoolKey)
+  deriving Show
 
 -- | Either an unvalidated text representation of a verification key or a path
 -- to a verification key file.

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -60,9 +60,9 @@ import           Cardano.Chain.Common (BlockCount (BlockCount))
 
 import           Cardano.CLI.Common.Parsers (pConsensusModeParams, pNetworkId)
 import           Cardano.CLI.Shelley.Commands
-import           Cardano.CLI.Shelley.Key (PaymentVerifier (..), StakeIdentifier (..),
-                   StakeVerifier (..), VerificationKeyOrFile (..), VerificationKeyOrHashOrFile (..),
-                   VerificationKeyTextOrFile (..))
+import           Cardano.CLI.Shelley.Key (DelegationTarget (..), PaymentVerifier (..),
+                   StakeIdentifier (..), StakeVerifier (..), VerificationKeyOrFile (..),
+                   VerificationKeyOrHashOrFile (..), VerificationKeyTextOrFile (..))
 import           Cardano.CLI.Types
 
 {- HLINT ignore "Use <$>" -}
@@ -413,7 +413,7 @@ pStakeAddressCmd =
     pStakeAddressDelegationCert =
       StakeCredentialDelegationCert
         <$> pStakeIdentifier
-        <*> pStakePoolVerificationKeyOrHashOrFile
+        <*> pDelegationTarget
         <*> pOutputFile
 
 pKeyCmd :: Parser KeyCmd
@@ -2655,6 +2655,10 @@ pStakePoolVerificationKeyOrFile
 pStakePoolVerificationKeyOrFile =
   VerificationKeyValue <$> pStakePoolVerificationKey
     <|> VerificationKeyFilePath <$> pStakePoolVerificationKeyFile
+
+pDelegationTarget
+  :: Parser DelegationTarget
+pDelegationTarget = StakePoolDelegationTarget <$> pStakePoolVerificationKeyOrHashOrFile
 
 pStakePoolVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile StakePoolKey)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -379,7 +379,7 @@ pStakeAddressCmd =
       , subParser "deregistration-certificate"
           (Opt.info pStakeAddressDeregistrationCert $ Opt.progDesc "Create a stake address deregistration certificate")
       , subParser "delegation-certificate"
-          (Opt.info pStakeAddressDelegationCert $ Opt.progDesc "Create a stake address delegation certificate")
+          (Opt.info pStakeAddressPoolDelegationCert $ Opt.progDesc "Create a stake address pool delegation certificate")
       ]
   where
     pStakeAddressKeyGen :: Parser StakeAddressCmd
@@ -409,8 +409,8 @@ pStakeAddressCmd =
         <$> pStakeIdentifier
         <*> pOutputFile
 
-    pStakeAddressDelegationCert :: Parser StakeAddressCmd
-    pStakeAddressDelegationCert =
+    pStakeAddressPoolDelegationCert :: Parser StakeAddressCmd
+    pStakeAddressPoolDelegationCert =
       StakeCredentialDelegationCert
         <$> pStakeIdentifier
         <*> pDelegationTarget

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -147,7 +147,7 @@ runStakeCredentialDelegationCert stakeVerifier delegationTarget (OutputFile outF
       -> Hash StakePoolKey
       -> ExceptT ShelleyStakeAddressCmdError IO ()
     writeDelegationCert sCred poolStakeVKeyHash = do
-      let delegCert = makeStakeAddressDelegationCertificate sCred poolStakeVKeyHash
+      let delegCert = makeStakeAddressPoolDelegationCertificate sCred poolStakeVKeyHash
       firstExceptT ShelleyStakeAddressCmdWriteFileError
         . newExceptT
         $ writeLazyByteStringFile outFp

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -18,8 +18,8 @@ import qualified Data.Text.IO as Text
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Shelley.Key (StakeIdentifier (..), StakeVerifier (..),
-                   VerificationKeyOrFile, VerificationKeyOrHashOrFile, readVerificationKeyOrFile,
+import           Cardano.CLI.Shelley.Key (DelegationTarget (..), StakeIdentifier (..),
+                   StakeVerifier (..), VerificationKeyOrFile, readVerificationKeyOrFile,
                    readVerificationKeyOrHashOrFile)
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Shelley.Run.Read
@@ -126,18 +126,20 @@ runStakeCredentialRegistrationCert stakeIdentifier (OutputFile oFp) = do
 runStakeCredentialDelegationCert
   :: StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
-  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> DelegationTarget
   -- ^ Delegatee stake pool verification key or verification key file or
   -- verification key hash.
   -> OutputFile
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runStakeCredentialDelegationCert stakeVerifier poolVKeyOrHashOrFile (OutputFile outFp) = do
-  poolStakeVKeyHash <-
-    firstExceptT
-      ShelleyStakeAddressCmdReadKeyFileError
-      (newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile)
-  stakeCred <- getStakeCredentialFromIdentifier stakeVerifier
-  writeDelegationCert stakeCred poolStakeVKeyHash
+runStakeCredentialDelegationCert stakeVerifier delegationTarget (OutputFile outFp) =
+  case delegationTarget of
+    StakePoolDelegationTarget poolVKeyOrHashOrFile -> do
+      poolStakeVKeyHash <-
+        firstExceptT
+          ShelleyStakeAddressCmdReadKeyFileError
+          (newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile)
+      stakeCred <- getStakeCredentialFromIdentifier stakeVerifier
+      writeDelegationCert stakeCred poolStakeVKeyHash
 
   where
     writeDelegationCert

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Validate.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Validate.hs
@@ -283,7 +283,7 @@ validateTxCertificates era certsAndScriptWitnesses =
    deriveStakeCredentialWitness cert = do
      case cert of
        StakeAddressDeregistrationCertificate sCred -> Just sCred
-       StakeAddressDelegationCertificate sCred _ -> Just sCred
+       StakeAddressPoolDelegationCertificate sCred _ -> Just sCred
        _ -> Nothing
 
    convert

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -346,7 +346,7 @@ main = do
       if t == cred then Just (StakeRegistrationEvent epochNo slotNo) else Nothing
     targetedCert t epochNo slotNo (StakeAddressDeregistrationCertificate cred) =
       if t == cred then Just (StakeDeRegistrationEvent epochNo slotNo) else Nothing
-    targetedCert t _epochNo slotNo (StakeAddressDelegationCertificate cred pool) =
+    targetedCert t _epochNo slotNo (StakeAddressPoolDelegationCertificate cred pool) =
       if t == cred then Just (DelegationEvent slotNo pool) else Nothing
     targetedCert t _epochNo slotNo (StakePoolRegistrationCertificate pool)      =
       inPoolCert t slotNo pool


### PR DESCRIPTION
[CIP-1694](https://github.com/JaredCorduan/CIPs/blob/voltaire-v1/CIP-1694/README.md) introduces the idea of also delegating DReps in addition to stake pools.

The code currently use names that assume we can only delegate to stake pools from a stake-address.

This PR renames them to specifically refer to stake pools so that it is easier to add support for DReps later.