### PR TITLE
New environment variable CARDANO_NODE_NETWORK_ID

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -22,6 +22,11 @@
 
   See [CIP proposal](https://github.com/cardano-foundation/CIPs/pull/496) for details.
 
+- Any command that takes a `--mainnet` flag or a `--testnet-magic` flag can have that setting
+  supplied with the `CARDANO_NODE_NETWORK_ID=mainnet` or `CARDANO_NODE_NETWORK_ID=<number>`
+  instead where `<number>` is the network id.
+  [PR5119](https://github.com/input-output-hk/cardano-node/pull/5119)
+
 ### Features
 
 - Default to the ledger's CDDL format for transaction body creation by removing flags `--cddl-format` and `--cli-format` from `build` and `build-raw` ([PR 4303](https://github.com/input-output-hk/cardano-node/pull/4303))

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -8,7 +8,7 @@
 import           Control.Monad.Trans.Except.Exit (orDie)
 import qualified Options.Applicative as Opt
 
-import           Cardano.CLI.Environment (getEnvNetworkId)
+import           Cardano.CLI.Environment (getEnvCli)
 import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
@@ -21,7 +21,7 @@ import qualified GHC.IO.Encoding as GHC
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
-  mNetworkId <- getEnvNetworkId
+  envCli <- getEnvCli
 
   -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
   Crypto.sodiumInit
@@ -29,6 +29,6 @@ main = toplevelExceptionHandler $ do
 #ifdef UNIX
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
 #endif
-  co <- Opt.customExecParser pref (opts mNetworkId)
+  co <- Opt.customExecParser pref (opts envCli)
 
   orDie renderClientCommandError $ runClientCommand co

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -8,6 +8,7 @@
 import           Control.Monad.Trans.Except.Exit (orDie)
 import qualified Options.Applicative as Opt
 
+import           Cardano.CLI.Environment (getEnvNetworkId)
 import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
@@ -20,12 +21,14 @@ import qualified GHC.IO.Encoding as GHC
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
+  mNetworkId <- getEnvNetworkId
+
   -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
   Crypto.sodiumInit
   GHC.mkTextEncoding "UTF-8" >>= GHC.setLocaleEncoding
 #ifdef UNIX
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
 #endif
-  co <- Opt.customExecParser pref opts
+  co <- Opt.customExecParser pref (opts mNetworkId)
 
   orDie renderClientCommandError $ runClientCommand co

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -50,7 +50,8 @@ library
 
   hs-source-dirs:       src
 
-  exposed-modules:      Cardano.CLI.Helpers
+  exposed-modules:      Cardano.CLI.Environment
+                        Cardano.CLI.Helpers
                         Cardano.CLI.Parsers
                         Cardano.CLI.Render
                         Cardano.CLI.Run

--- a/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
@@ -5,6 +5,7 @@ module Cardano.CLI.Common.Parsers
 
 import           Cardano.Api (AnyConsensusModeParams (..), ConsensusModeParams (..),
                    EpochSlots (..), NetworkId (..), NetworkMagic (..), bounded)
+import           Cardano.CLI.Environment (EnvCli (envCliNetworkId))
 
 import           Data.Foldable
 import           Data.Maybe (maybeToList)
@@ -12,8 +13,8 @@ import           Data.Word (Word64)
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
-pNetworkId :: Maybe NetworkId -> Parser NetworkId
-pNetworkId mNetworkId = asum $ mconcat
+pNetworkId :: EnvCli -> Parser NetworkId
+pNetworkId envCli = asum $ mconcat
   [ [ Opt.flag' Mainnet $ mconcat
       [ Opt.long "mainnet"
       , Opt.help $ mconcat
@@ -31,7 +32,7 @@ pNetworkId mNetworkId = asum $ mconcat
       ]
     ]
   , -- Default to the network id specified by the environment variable if it is available.
-    pure <$> maybeToList mNetworkId
+    pure <$> maybeToList (envCliNetworkId envCli)
   ]
 
 pConsensusModeParams :: Parser AnyConsensusModeParams

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module defines constants derived from the environment.
+module Cardano.CLI.Environment
+  ( getEnvNetworkId
+  ) where
+
+import           Cardano.Api (NetworkId (..), NetworkMagic (..))
+
+import           Data.Word (Word32)
+import qualified System.Environment as IO
+import qualified System.IO as IO
+import           Text.Read (readMaybe)
+
+-- | If the environment variable @CARDANO_NODE_NETWORK_ID@ is set, then return the network id therein.
+-- Otherwise, return 'Nothing'.
+getEnvNetworkId :: IO (Maybe NetworkId)
+getEnvNetworkId = do
+  mNetworkIdString <- IO.lookupEnv "CARDANO_NODE_NETWORK_ID"
+
+  case mNetworkIdString of
+    Nothing -> pure Nothing
+    Just networkIdString -> do
+      case networkIdString of
+        "mainnet" -> pure $ Just Mainnet
+        _ ->
+          case readMaybe @Word32 networkIdString of
+            Just networkId -> pure $ Just $ Testnet $ NetworkMagic networkId
+            Nothing -> do
+              IO.hPutStrLn IO.stderr $ mconcat
+                [ "The network id specified in CARDANO_NODE_NETWORK_ID invalid: " <> networkIdString
+                , " It should be either 'mainnet' or a number."
+                ]
+              pure Nothing

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -15,7 +15,7 @@ import qualified System.IO as IO
 import           Text.Read (readMaybe)
 
 newtype EnvCli = EnvCli
-  { cliEnvNetworkId :: Maybe NetworkId
+  { envCliNetworkId :: Maybe NetworkId
   }
 
 getEnvCli :: IO EnvCli

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -2,7 +2,9 @@
 
 -- | This module defines constants derived from the environment.
 module Cardano.CLI.Environment
-  ( getEnvNetworkId
+  ( EnvCli(..)
+  , getEnvCli
+  , getEnvNetworkId
   ) where
 
 import           Cardano.Api (NetworkId (..), NetworkMagic (..))
@@ -11,6 +13,13 @@ import           Data.Word (Word32)
 import qualified System.Environment as IO
 import qualified System.IO as IO
 import           Text.Read (readMaybe)
+
+newtype EnvCli = EnvCli
+  { cliEnvNetworkId :: Maybe NetworkId
+  }
+
+getEnvCli :: IO EnvCli
+getEnvCli = EnvCli <$> getEnvNetworkId
 
 -- | If the environment variable @CARDANO_NODE_NETWORK_ID@ is set, then return the network id therein.
 -- Otherwise, return 'Nothing'.

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Parsers
 
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
 import           Cardano.CLI.Common.Parsers (pConsensusModeParams, pNetworkId)
+import           Cardano.CLI.Environment (EnvCli)
 import           Cardano.CLI.Ping (parsePingCmd)
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run (ClientCommand (..))
@@ -20,7 +21,6 @@ import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
 import           Data.Foldable
 import           Options.Applicative
 
-import           Cardano.Api (NetworkId)
 import qualified Options.Applicative as Opt
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
@@ -28,9 +28,9 @@ command' c descr p =
     command c $ info (p <**> helper)
               $ mconcat [ progDesc descr ]
 
-opts :: Maybe NetworkId -> ParserInfo ClientCommand
-opts mNetworkId =
-  Opt.info (parseClientCommand mNetworkId <**> Opt.helper) $ mconcat
+opts :: EnvCli -> ParserInfo ClientCommand
+opts envCli =
+  Opt.info (parseClientCommand envCli <**> Opt.helper) $ mconcat
     [ Opt.fullDesc
     , Opt.header $ mconcat
       [ "cardano-cli - General purpose command-line utility to interact with cardano-node."
@@ -45,21 +45,21 @@ pref = Opt.prefs $ mempty
   <> helpHangUsageOverflow 10
   <> helpRenderHelp customRenderHelp
 
-parseClientCommand :: Maybe NetworkId -> Parser ClientCommand
-parseClientCommand mNetworkId =
+parseClientCommand :: EnvCli -> Parser ClientCommand
+parseClientCommand envCli =
   asum
     -- There are name clashes between Shelley commands and the Byron backwards
     -- compat commands (e.g. "genesis"), and we need to prefer the Shelley ones
     -- so we list it first.
-    [ parseShelley mNetworkId
-    , parseByron mNetworkId
+    [ parseShelley envCli
+    , parseByron envCli
     , parsePing
-    , parseDeprecatedShelleySubcommand mNetworkId
-    , backwardsCompatibilityCommands mNetworkId
-    , parseDisplayVersion (opts mNetworkId)
+    , parseDeprecatedShelleySubcommand envCli
+    , backwardsCompatibilityCommands envCli
+    , parseDisplayVersion (opts envCli)
     ]
 
-parseByron :: Maybe NetworkId -> Parser ClientCommand
+parseByron :: EnvCli -> Parser ClientCommand
 parseByron mNetworkId =
   fmap ByronCommand $
   subparser $ mconcat
@@ -72,15 +72,15 @@ parsePing :: Parser ClientCommand
 parsePing = CliPingCommand <$> parsePingCmd
 
 -- | Parse Shelley-related commands at the top level of the CLI.
-parseShelley :: Maybe NetworkId -> Parser ClientCommand
-parseShelley mNetworkId = ShelleyCommand <$> parseShelleyCommands mNetworkId
+parseShelley :: EnvCli -> Parser ClientCommand
+parseShelley envCli = ShelleyCommand <$> parseShelleyCommands envCli
 
 -- | Parse Shelley-related commands under the now-deprecated \"shelley\"
 -- subcommand.
 --
 -- Note that this subcommand is 'internal' and is therefore hidden from the
 -- help text.
-parseDeprecatedShelleySubcommand :: Maybe NetworkId -> Parser ClientCommand
+parseDeprecatedShelleySubcommand :: EnvCli -> Parser ClientCommand
 parseDeprecatedShelleySubcommand mNetworkId =
   subparser $ mconcat
     [ commandGroup "Shelley specific commands (deprecated)"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -240,7 +240,7 @@ data TransactionCmd
   | TxMintedPolicyId ScriptFile
   | TxCalculateMinFee
       (TxBodyFile In)
-      (Maybe NetworkId)
+      NetworkId
       ProtocolParamsFile
       TxInCount
       TxOutCount

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -810,7 +810,7 @@ pTransaction envCli =
   pTransactionCalculateMinFee =
     TxCalculateMinFee
       <$> pTxBodyFileIn
-      <*> optional (pNetworkId envCli)
+      <*> pNetworkId envCli
       <*> pProtocolParamsFile
       <*> pTxInCount
       <*> pTxOutCount

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -283,8 +283,8 @@ runTransactionCmd cmd =
       runTxSign txinfile skfiles network txoutfile
     TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
       runTxSubmit mNodeSocketPath anyConsensusModeParams network txFp
-    TxCalculateMinFee txbody mnw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runTxCalculateMinFee txbody mnw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+    TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
+      runTxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
     TxCalculateMinRequiredUTxO era pParamsFile txOuts -> runTxCalculateMinRequiredUTxO era pParamsFile txOuts
     TxHashScriptData scriptDataOrFile -> runTxHashScriptData scriptDataOrFile
     TxGetTxId txinfile -> runTxGetTxId txinfile
@@ -1146,7 +1146,7 @@ runTxSubmit mNodeSocketPath (AnyConsensusModeParams cModeParams) network txFileP
 
 runTxCalculateMinFee
   :: TxBodyFile In
-  -> Maybe NetworkId
+  -> NetworkId
   -> ProtocolParamsFile
   -> TxInCount
   -> TxOutCount
@@ -1169,7 +1169,7 @@ runTxCalculateMinFee (File txbodyFilePath) nw pParamsFile
         let txbody =  getTxBody unwitTx
         let tx = makeSignedTransaction [] txbody
             Lovelace fee = estimateTransactionFee
-                             (fromMaybe Mainnet nw)
+                             nw
                              (protocolParamTxFeeFixed pparams)
                              (protocolParamTxFeePerByte pparams)
                              tx
@@ -1185,7 +1185,7 @@ runTxCalculateMinFee (File txbodyFilePath) nw pParamsFile
 
         let tx = makeSignedTransaction [] txbody
             Lovelace fee = estimateTransactionFee
-                             (fromMaybe Mainnet nw)
+                             nw
                              (protocolParamTxFeeFixed pparams)
                              (protocolParamTxFeePerByte pparams)
                              tx

--- a/cardano-submit-api/app/Main.hs
+++ b/cardano-submit-api/app/Main.hs
@@ -1,11 +1,11 @@
 module Main where
 
-import           Cardano.CLI.Environment (getEnvNetworkId)
+import           Cardano.CLI.Environment (getEnvCli)
 import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
 
 import qualified Options.Applicative as Opt
 
 main :: IO ()
 main = do
-  mNetworkId <- getEnvNetworkId
-  runTxSubmitWebapi =<< Opt.execParser (opts mNetworkId)
+  envCli <- getEnvCli
+  runTxSubmitWebapi =<< Opt.execParser (opts envCli)

--- a/cardano-submit-api/app/Main.hs
+++ b/cardano-submit-api/app/Main.hs
@@ -1,8 +1,11 @@
 module Main where
 
+import           Cardano.CLI.Environment (getEnvNetworkId)
 import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
 
 import qualified Options.Applicative as Opt
 
 main :: IO ()
-main = runTxSubmitWebapi =<< Opt.execParser opts
+main = do
+  mNetworkId <- getEnvNetworkId
+  runTxSubmitWebapi =<< Opt.execParser (opts mNetworkId)

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -85,6 +85,7 @@ executable cardano-submit-api
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T -I0"
   build-depends:        base >= 4.14 && < 4.17
                       , optparse-applicative-fork >= 0.16.1.0
+                      , cardano-cli
                       , cardano-submit-api
 
 test-suite unit

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -7,7 +7,7 @@ module Cardano.TxSubmit.CLI.Parsers
   , pSocketPath
   ) where
 
-import           Cardano.Api (SocketPath (..))
+import           Cardano.Api (NetworkId, SocketPath (..))
 
 import           Cardano.CLI.Parsers (pConsensusModeParams, pNetworkId)
 
@@ -19,17 +19,18 @@ import           Options.Applicative (Parser, ParserInfo)
 
 import qualified Options.Applicative as Opt
 
-opts :: ParserInfo TxSubmitNodeParams
-opts = Opt.info (pTxSubmitNodeParams <**> Opt.helper)
-  (   Opt.fullDesc
-  <>  Opt.progDesc "Cardano transaction submission web API."
-  )
+opts :: Maybe NetworkId -> ParserInfo TxSubmitNodeParams
+opts mNetworkId =
+  Opt.info (pTxSubmitNodeParams mNetworkId <**> Opt.helper) $ mconcat
+    [ Opt.fullDesc
+    , Opt.progDesc "Cardano transaction submission web API."
+    ]
 
-pTxSubmitNodeParams :: Parser TxSubmitNodeParams
-pTxSubmitNodeParams = TxSubmitNodeParams
+pTxSubmitNodeParams :: Maybe NetworkId -> Parser TxSubmitNodeParams
+pTxSubmitNodeParams mNetworkId = TxSubmitNodeParams
   <$> pConfigFile
   <*> pConsensusModeParams
-  <*> pNetworkId
+  <*> pNetworkId mNetworkId
   <*> pSocketPath
   <*> pWebserverConfig 8090
   <*> pMetricsPort 8081

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -7,8 +7,9 @@ module Cardano.TxSubmit.CLI.Parsers
   , pSocketPath
   ) where
 
-import           Cardano.Api (NetworkId, SocketPath (..))
+import           Cardano.Api (SocketPath (..))
 
+import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.Parsers (pConsensusModeParams, pNetworkId)
 
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), TxSubmitNodeParams (..))
@@ -19,18 +20,18 @@ import           Options.Applicative (Parser, ParserInfo)
 
 import qualified Options.Applicative as Opt
 
-opts :: Maybe NetworkId -> ParserInfo TxSubmitNodeParams
-opts mNetworkId =
-  Opt.info (pTxSubmitNodeParams mNetworkId <**> Opt.helper) $ mconcat
+opts :: EnvCli -> ParserInfo TxSubmitNodeParams
+opts envCli =
+  Opt.info (pTxSubmitNodeParams envCli <**> Opt.helper) $ mconcat
     [ Opt.fullDesc
     , Opt.progDesc "Cardano transaction submission web API."
     ]
 
-pTxSubmitNodeParams :: Maybe NetworkId -> Parser TxSubmitNodeParams
-pTxSubmitNodeParams mNetworkId = TxSubmitNodeParams
+pTxSubmitNodeParams :: EnvCli -> Parser TxSubmitNodeParams
+pTxSubmitNodeParams envCli = TxSubmitNodeParams
   <$> pConfigFile
   <*> pConsensusModeParams
-  <*> pNetworkId mNetworkId
+  <*> pNetworkId envCli
   <*> pSocketPath
   <*> pWebserverConfig 8090
   <*> pMetricsPort 8081


### PR DESCRIPTION
`CARDANO_NODE_SOCKET_PATH` environment variable is now recognised by every command that took a `--testnet-magic` CLI argument.

```
CARDANO_NODE_SOCKET_PATH=... cardano-cli query tip --testnet-magic 1706
```

Can now be written as:

```
CARDANO_NODE_NETWORK_ID=1706 CARDANO_NODE_SOCKET_PATH=... cardano-cli query tip
```
