### PR TITLE
UTC Time to slots conversion function

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog for cardano-api
 
 ## vNext
+- Add `getSlotForRelativeTime` function [PR5130](https://github.com/input-output-hk/cardano-node/pull/5130)
 
 ### Features
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -695,6 +695,7 @@ module Cardano.Api (
 
     EraHistory(..),
     getProgress,
+    getSlotForRelativeTime,
 
     -- *** Common queries
     determineEra,

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -71,6 +71,7 @@ module Cardano.Api.Query (
     LedgerState(..),
 
     getProgress,
+    getSlotForRelativeTime,
 
     -- * Internal conversion functions
     toLedgerUTxO,
@@ -81,6 +82,7 @@ import           Control.Monad (forM)
 import           Control.Monad.Trans.Except
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Aeson.Types (Parser)
 import           Data.Bifunctor (bimap, first)
 import qualified Data.ByteString.Lazy as LBS
@@ -95,6 +97,7 @@ import           Data.SOP.Strict (SListI)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable
+import           Data.Word (Word64)
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
 
@@ -142,9 +145,7 @@ import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.TxBody
 import           Cardano.Api.Value
-import           Data.Word (Word64)
 
-import qualified Data.Aeson.KeyMap as KeyMap
 
 -- ----------------------------------------------------------------------------
 -- Queries
@@ -192,6 +193,11 @@ data EraHistory mode where
 getProgress :: SlotNo -> EraHistory mode -> Either Qry.PastHorizonException (RelativeTime, SlotLength)
 getProgress slotNo (EraHistory _ interpreter) = Qry.interpretQuery interpreter (Qry.slotToWallclock slotNo)
 
+-- | Returns the slot number for provided relative time from 'SystemStart'
+getSlotForRelativeTime :: RelativeTime -> EraHistory mode -> Either Qry.PastHorizonException SlotNo
+getSlotForRelativeTime relTime (EraHistory _ interpreter) = do
+  (slotNo, _, _) <- Qry.interpretQuery interpreter $ Qry.wallclockToSlot relTime
+  pure slotNo
 
 newtype LedgerEpochInfo = LedgerEpochInfo { unLedgerEpochInfo :: Consensus.EpochInfo (Either Text) }
 

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -48,6 +48,8 @@
 
 - Add `--socket-path` CLI option for CLI commands that use `CARDANO_NODE_SOCKET_PATH` ([PR 4910](https://github.com/input-output-hk/cardano-node/pull/4910))
 
+- Add `utcTimeToSlotNo` function to support UTC -> slot number conversion ([PR 5130](https://github.com/input-output-hk/cardano-node/pull/5130))
+
 ### Bugs
 
 - Allow reading signing keys from a pipe ([PR 4342](https://github.com/input-output-hk/cardano-node/pull/4342))


### PR DESCRIPTION
# Description

This is a part of https://github.com/input-output-hk/cardano-node/issues/4928 . This changeset introduces a conversion function: UTC time -> slot number.

The function was tested in https://github.com/input-output-hk/cardano-node/pull/5142

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` for to get the `hlint` version
- [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` for to get the `stylish-haskell` version
- [x] Self-reviewed the diff
