### PR TITLE
Modify golden test functions to automatically create parent directories

### DIFF
--- a/cardano-cli/test/Test/Utilities.hs
+++ b/cardano-cli/test/Test/Utilities.hs
@@ -16,6 +16,7 @@ import           Hedgehog.Extras.Test.Base (failMessage)
 import qualified Hedgehog.Internal.Property as H
 import qualified System.Directory as IO
 import qualified System.Environment as IO
+import           System.FilePath (takeDirectory)
 import qualified System.IO.Unsafe as IO
 
 -- | Whether the test should create the golden files if the file does ont exist.
@@ -57,6 +58,7 @@ diffVsGoldenFile actualContent referenceFile = GHC.withFrozenCallStack $ do
         -- CREATE_GOLDEN_FILES is set, so we create any golden files that don't
         -- already exist.
         H.note_ $ "Creating golden file " <> referenceFile
+        H.createDirectoryIfMissing_ (takeDirectory referenceFile)
         H.writeFile referenceFile actualContent
       else do
         H.note_ $ mconcat


### PR DESCRIPTION
# Description
This is useful for when writing new golden tests.  Generating golden files from tests is easier if the directories are automatically created for you.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` for to get the `hlint` version
- [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` for to get the `stylish-haskell` version
- [x] Self-reviewed the diff
