### PR TITLE
Scripts for summarising merged PRs between two dates

### DIFF
--- a/scripts/distribute-merged-prs
+++ b/scripts/distribute-merged-prs
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+(yq --version | grep https://github.com/mikefarah/yq/ > /dev/null) || {
+  echo "Please install yq from https://github.com/mikefarah/yq/" > /dev/stderr
+  exit 1
+}
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 repository sub_dir start_date end_date" >&2
+  echo "Example: $0 input-output-hk/cardano-node v8.0.0 2023-02-22 '2023-02-22 +14 days'" >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  date_cmd=gdate
+else
+  date_cmd=date
+fi
+
+repository="$1"
+subdir="$2"
+start_date="$("$date_cmd" -u -d "$3" +"%Y-%m-%dT%H:%M:%SZ")"
+end_date="$("$date_cmd" -u -d "$4" +"%Y-%m-%dT%H:%M:%SZ")"
+
+work_dir="gen/$repository"
+work_subdir="$work_dir/$subdir"
+download_file="$work_dir/download.yaml"
+filtered_file="$work_subdir/filtered.yaml"
+
+mkdir -p "$work_dir"
+mkdir -p "$work_subdir"
+mkdir -p "$work_subdir/detail"
+
+cat "$download_file" | yq -o json | jq -r "$(
+cat <<EOF
+  map
+  ( select
+    ( true
+      and (.baseRefName = "master")
+      and (.mergedAt >= "$start_date")
+      and (.mergedAt < "$end_date")
+    )
+  | { "title": .title
+    , "author": .author.name
+    , "url": .url
+    , "number": .number
+    , "mergedAt": .mergedAt
+    , "files": .files | map(.path)
+    , "include": "undecided"
+    }
+  )
+EOF
+  )" \
+  | yq -P > "$filtered_file"
+
+for dir in $(
+    cat "$filtered_file" \
+      | yq -o json \
+      | jq -r '
+            map (.files[])
+          | flatten
+          | sort
+          | unique
+          | map
+            ( split("/")
+            | select(length > 1)
+            | .[0]
+            )
+          | sort
+          | unique
+          | .[]'); do
+  cat "$filtered_file" | yq -o json | jq '
+    map
+    ( select
+      ( .files
+      | map
+        ( split("/")
+        | .[0]
+        )
+      | sort
+      | unique
+      | map(select(. == "'$dir'"))
+      | (length > 0)
+      )
+    )' | yq -P > "$work_subdir/detail/$dir.yaml"
+done
+
+cat "$filtered_file" | yq -o json | jq '
+    map
+    ( select
+      ( .files
+      | map
+        ( split("/")
+        | select
+          ( length == 1
+          )
+        | .[0]
+        )
+      | (length > 0)
+      )
+    )
+    ' | yq -P > "$work_subdir/detail/top.yaml"
+
+echo "Output generated in $work_subdir/detail"

--- a/scripts/download-prs
+++ b/scripts/download-prs
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+(yq --version | grep https://github.com/mikefarah/yq/ > /dev/null) || {
+  echo "Please install yq from https://github.com/mikefarah/yq/" > /dev/stderr
+  exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 repository" >&2
+  echo "Example: $0 input-output-hk/cardano-node" >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  date_cmd=gdate
+else
+  date_cmd=date
+fi
+
+repository="$1"
+
+out_dir="gen/$repository"
+
+mkdir -p "$out_dir"
+
+temp_json_file="$(mktemp).json"
+
+gh pr list --repo "$repository" \
+  -L 1000 \
+  --state all \
+  --json number,title,author,createdAt,closedAt,files,mergedAt,baseRefName,url \
+  > "$temp_json_file"
+
+cat "$temp_json_file" | yq -P > "$out_dir/download.yaml"

--- a/scripts/summarise-merged-prs
+++ b/scripts/summarise-merged-prs
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+(yq --version | grep https://github.com/mikefarah/yq/ > /dev/null) || {
+  echo "Please install yq from https://github.com/mikefarah/yq/" > /dev/stderr
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 repository output_subdir" >&2
+  echo "Example: $0 input-output-hk/cardano-node v8.0.0" >&2
+  exit 1
+fi
+
+repository="$1"
+subdir="$2"
+
+work_dir="gen/$repository"
+work_subdir="$work_dir/$subdir"
+detail_dir="$work_subdir/detail"
+summary_dir="$work_subdir/summary"
+
+mkdir -p "$work_dir"
+mkdir -p "$work_subdir"
+mkdir -p "$detail_dir"
+mkdir -p "$summary_dir"
+
+(yq --version | grep https://github.com/mikefarah/yq/ > /dev/null) || {
+  echo "Please install yq from https://github.com/mikefarah/yq/" > /dev/stderr
+  exit 1
+}
+
+for path in "$detail_dir"/*.yaml; do
+  echo "$path"
+  file="$(basename $path)"
+  target="$summary_dir/${file%.yaml}.md"
+  rm -f "$target"
+
+  for pr in $(
+      cat "$detail_dir/$file" \
+        | yq -o json \
+        | jq '
+              .[]
+            | select(.include or .include == "undecided")
+            | .number
+          '); do
+    tmp_file="$(mktemp).json"
+    cat "$detail_dir/$file" | yq -o json | jq '.[] | select(.number == '$pr')' > "$tmp_file"
+    cat "$tmp_file" | jq -r '"- [\(.title)](\(.url)) by \(.author)"' >> "$target"
+  done
+done


### PR DESCRIPTION
NOTE: I'm think that this PR belongs in `cardano-update` because it's not specific to `cardano-node` and with a bit of work it could be made to work on a variety of project structures.

Therefore I can recreated the PR there: https://github.com/input-output-hk/cardano-node/pull/5138

# Description

This PR adds three scripts to produce a merged PR summary that can be used to build change logs for releases:

* `scripts/download-prs`
* `scripts/distribute-merged-prs`
* `scripts/summarise-merged-prs`

The scripts are meant to be run in order like this:

```bash
./scripts/merged-prs/download-prs input-output-hk/cardano-node
./scripts/distribute-merged-prs input-output-hk/cardano-node v8.0.0 2022-06-25 2023-04-18
./scripts/summarise-merged-prs input-output-hk/cardano-node v8.0.0
```

The above:

* Downloads the PRs that were merged between the two dates _exclusive of the latter date_. ie the example includes the day `2023-04-17` but not `2023-04-18`.
* Distributes the PRs according to what files the PRs touched.
* Creates a summaries that can be pasted into change logs.

For an example of what each script produces, see https://github.com/input-output-hk/cardano-node/pull/5137/commits

This is split into three scripts for two reasons:

* The download is slow, so it is useful to script the download from the other scripts.
* Manual intervention is required between the distribute and summarise stages.  This is where the detail can be hand edited (for example irrelevant PRs deleted) from the detail.  The detail contains a file list to make it easy to judge whether the PR is actually relevant to the component.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` for to get the `hlint` version
- [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` for to get the `stylish-haskell` version
- [ ] Self-reviewed the diff
