### PR TITLE
Spending from a simple script with new method

### DIFF
--- a/doc/reference/simple-scripts.md
+++ b/doc/reference/simple-scripts.md
@@ -472,6 +472,7 @@ will be "guarded" by the script.
 cardano-cli transaction build-raw \
     --invalid-hereafter 1000 \
     --fee 0 \
+    --tx-in-script-file allMultiSigScript \
     --tx-in (txin of script address)
     --tx-out yourspecifiedtxout \
     --out-file spendScriptTxBody
@@ -483,12 +484,6 @@ To construct the script witness and three key witnesses required by the example
 `all` script, run the following commands:
 
 ```bash
-cardano-cli transaction witness \
-  --tx-body-file spendScriptTxBody \
-  --script-file allMultiSigScript \
-  --testnet-magic 42 \
-  --out-file scriptWitness
-
 cardano-cli transaction witness \
   --tx-body-file spendScriptTxBody \
   --signing-key-file paySignKey1 \
@@ -516,7 +511,6 @@ witness and all the other required key witnesses.
 ```bash
 cardano-cli transaction assemble \
   --tx-body-file spendScriptTxBody \
-  --witness-file scriptWitness \
   --witness-file key1witness \
   --witness-file key2witness \
   --witness-file key3witness \
@@ -601,6 +595,7 @@ above this means >= 1000.
 cardano-cli transaction build-raw \
     --invalid-before 1000 \
     --fee 0 \
+    --tx-in-script-file allMultiSigScript \
     --tx-in (txin of script address)
     --tx-out yourspecifiedtxout \
     --out-file spendScriptTxBody
@@ -635,6 +630,7 @@ above this means <= 3000:
 cardano-cli transaction build-raw \
     --invalid-hereafter 3000\
     --fee 0 \
+    --tx-in-script-file allMultiSigScript \
     --tx-in (txin of script address)
     --tx-out yourspecifiedtxout \
     --out-file spendScriptTxBody


### PR DESCRIPTION
The old described way of creating witnesses for a simple script file doesn't seem to work anymore. Now you have to specify the script file while creating the tx instead of creating a witness.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
