### PR TITLE
Workbench: make shell pure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ workbench-internals-walkthrough:
 ## Base targets:
 ##
 shell:                                           ## Nix shell, (workbench from /nix/store), vars: PROFILE, CMD, RUN
-	nix-shell -A 'workbench-shell' --max-jobs 8 --cores 0 --show-trace --argstr profileName ${PROFILE} --argstr backendName ${BACKEND} ${ARGS} ${if ${CMD},--command "${CMD}"} ${if ${RUN},--run "${RUN}"}
+	nix-shell -A 'workbench-shell' --max-jobs 8 --cores 0 --show-trace --pure --argstr profileName ${PROFILE} --argstr backendName ${BACKEND} ${ARGS} ${if ${CMD},--command "${CMD}"} ${if ${RUN},--run "${RUN}"}
 shell-dev shell-prof shell-nix: shell
 shell-nix: ARGS += --arg 'useCabalRun' false ## Nix shell, (workbench from Nix store), vars: PROFILE, CMD, RUN
 shell-prof: ARGS += --arg 'profiling' '"space"'  ## Nix shell, everything Haskell built profiled

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -116,6 +116,8 @@ in project.shellFor {
     ghc-prof-flamegraph
     sqlite-interactive
     tmux
+    pkgs.cacert
+    pkgs.curl
     pkgs.git
     pkgs.hlint
     pkgs.moreutils


### PR DESCRIPTION
# Description

This change makes the workbench shell `pure`. Nix will do its best to strip off the current environment and will give the user a pristine shell, where the only environment variables are set by nix. This prevents unintentional mingling of system- and nix-provided libraries.

Tested with:

- make shell
- start-cluster
- wb a
- wb a std 2023-04-26-08-40-28344-default-bage-sup
- wb a compare 2023-04-26-08-40-28344-default-bage-sup 2023-04-26-08-40-28344-default-bage-sup
