### PR TITLE
Generate Plutus bytecode as backup.

### DIFF
--- a/bench/plutus-scripts-bench/app/gen-plutus.hs
+++ b/bench/plutus-scripts-bench/app/gen-plutus.hs
@@ -1,10 +1,37 @@
+{-# LANGUAGE RecordWildCards #-}
+
 import Cardano.Benchmarking.PlutusScripts (findPlutusScript, encodePlutusScript)
-import qualified Data.ByteString.Lazy as LBS (putStr)
-import System.Environment (getArgs)
+import qualified Data.ByteString.Lazy as LBS (hPut)
+import Options.Applicative
+import System.IO (IOMode(..), openFile, stdout)
+
+data Options = Options
+   { optOut :: Maybe FilePath
+   , optMod :: String
+   } deriving (Eq, Read, Show)
+
+opts :: Parser Options
+opts = Options
+       <$>
+        optional (strOption
+                   (  long "output"
+                   <> short 'o'
+                   <> metavar "FILE"
+                   <> help "Write output to FILE"
+                   )
+                 )
+       <*>
+        strArgument
+        (  metavar "SCRIPT"
+        <> help "Write SCRIPT to output"
+        )
 
 main :: IO ()
 main =
   do
-    a:_ <- getArgs
-    let Just s = findPlutusScript a
-    LBS.putStr $ encodePlutusScript s
+    Options {..} <- execParser (info opts fullDesc)
+    let Just s = findPlutusScript optMod
+    h <- case optOut of
+           Just file -> openFile file WriteMode
+           Nothing   -> pure stdout
+    LBS.hPut h $ encodePlutusScript s

--- a/bench/plutus-scripts-bench/app/gen-plutus.hs
+++ b/bench/plutus-scripts-bench/app/gen-plutus.hs
@@ -1,0 +1,10 @@
+import Cardano.Benchmarking.PlutusScripts (findPlutusScript, encodePlutusScript)
+import qualified Data.ByteString.Lazy as LBS (putStr)
+import System.Environment (getArgs)
+
+main :: IO ()
+main =
+  do
+    a:_ <- getArgs
+    let Just s = findPlutusScript a
+    LBS.putStr $ encodePlutusScript s

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -95,4 +95,6 @@ executable gen-plutus
 
   build-depends:        base >=4.12 && <5
                       , bytestring
+                      , filepath
+                      , optparse-applicative
                       , plutus-scripts-bench

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -82,3 +82,17 @@ library
     , serialise
     , template-haskell
     , text
+
+executable gen-plutus
+  import:               project-config
+  hs-source-dirs:       app
+  main-is:              gen-plutus.hs
+  default-language:     Haskell2010
+  ghc-options:          -threaded
+                        -Wall
+                        -rtsopts
+                        "-with-rtsopts=-T"
+
+  build-depends:        base >=4.12 && <5
+                      , bytestring
+                      , plutus-scripts-bench


### PR DESCRIPTION
This creates some executables to serve as backups in case the next version bump has tension between ghc versions & the Plutus libs.