### PR TITLE
Use -Werror for all sub-projects

### DIFF
--- a/bench/plutus-scripts-bench/app/gen-plutus.hs
+++ b/bench/plutus-scripts-bench/app/gen-plutus.hs
@@ -3,6 +3,7 @@
 import Cardano.Benchmarking.PlutusScripts (findPlutusScript, encodePlutusScript)
 import qualified Data.ByteString.Lazy as LBS (hPut)
 import Options.Applicative
+import System.Exit (die)
 import System.IO (IOMode(..), openFile, stdout)
 
 data Options = Options
@@ -30,8 +31,10 @@ main :: IO ()
 main =
   do
     Options {..} <- execParser (info opts fullDesc)
-    let Just s = findPlutusScript optMod
+    s <- case findPlutusScript optMod of
+          Just s  -> pure s
+          Nothing -> die $ "unable to find plutus script for `" ++ optMod ++ "'"
     h <- case optOut of
-           Just file -> openFile file WriteMode
-           Nothing   -> pure stdout
+          Just file -> openFile file WriteMode
+          Nothing   -> pure stdout
     LBS.hPut h $ encodePlutusScript s

--- a/cabal.project
+++ b/cabal.project
@@ -44,31 +44,52 @@ package cardano-api
 package cardano-cli
   ghc-options: -Werror
 
+package cardano-client-demo
+  ghc-options: -Werror
+
 package cardano-git-rev
   ghc-options: -Werror
 
-package cardano-node
+package cardano-node-capi
   ghc-options: -Werror
 
 package cardano-node-chairman
   ghc-options: -Werror
 
+package cardano-node
+  ghc-options: -Werror
+
+package cardano-submit-api
+  ghc-options: -Werror
+
 package cardano-testnet
   ghc-options: -Werror
 
-package tx-generator
-  ghc-options: -Werror
-
-package trace-dispatcher
-  ghc-options: -Werror
-
-package trace-resources
+package cardano-topology
   ghc-options: -Werror
 
 package cardano-tracer
   ghc-options: -Werror
 
-package submit-api
+package locli
+  ghc-options: -Werror
+
+package plutus-scripts-bench
+  ghc-options: -Werror
+
+package trace-analyzer
+  ghc-options: -Werror
+
+package trace-dispatcher
+  ghc-options: -Werror
+
+package trace-forward
+  ghc-options: -Werror
+
+package trace-resources
+  ghc-options: -Werror
+
+package tx-generator
   ghc-options: -Werror
 
 package cryptonite

--- a/flake.nix
+++ b/flake.nix
@@ -268,7 +268,14 @@
                     inherit pkgs;
                     inherit (exes.cardano-node.identifier) version;
                     platform = "linux";
-                    exes = lib.collect lib.isDerivation projectExes;
+                    exes = lib.collect lib.isDerivation (
+                      # FIXME: restore tx-generator and gen-plutus once
+                      #        plutus-scripts-bench is fixed for musl
+                      #
+                      # It stands to question though, whether or not we want those to be
+                      # in the cardano-node-linux as executables anyway?
+                      removeAttrs projectExes [ "tx-generator" "gen-plutus" ]
+                    );
                   };
                   internal.roots.project = muslProject.roots;
                   variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
@@ -318,6 +325,9 @@
               "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
               #FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
               "windows\\.(.*\\.)?tx-generator.*"
+              #FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
+              "musl\\.(.*\\.)?tx-generator.*"
+              "musl\\.(.*\\.)?gen-plutus.*"
               # hlint required status is controled via the github action:
               "native\\.(.*\\.)?checks/hlint"
               #system-tests are build and run separately:


### PR DESCRIPTION
# Description

`nix` based builds enforce `Werror` so GHA builds should do the same.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
