### PR TITLE
Give errmsg in lieu of irrefutable match

### DIFF
--- a/bench/plutus-scripts-bench/app/gen-plutus.hs
+++ b/bench/plutus-scripts-bench/app/gen-plutus.hs
@@ -3,6 +3,7 @@
 import Cardano.Benchmarking.PlutusScripts (findPlutusScript, encodePlutusScript)
 import qualified Data.ByteString.Lazy as LBS (hPut)
 import Options.Applicative
+import System.Exit (die)
 import System.IO (IOMode(..), openFile, stdout)
 
 data Options = Options
@@ -30,7 +31,9 @@ main :: IO ()
 main =
   do
     Options {..} <- execParser (info opts fullDesc)
-    let Just s = findPlutusScript optMod
+    s <- case findPlutusScript optMod of
+           Just s' -> pure s'
+           Nothing -> die $ "module " ++ optMod ++ " not found"
     h <- case optOut of
            Just file -> openFile file WriteMode
            Nothing   -> pure stdout


### PR DESCRIPTION
Serge noted it would be better practice to handle the match failure & give an explicit errmsg.

This should be minor.