### PR TITLE
Freeze callstack in integration and integrationRetryWorkspace functions

### DIFF
--- a/cardano-testnet/src/Testnet/Util/Base.hs
+++ b/cardano-testnet/src/Testnet/Util/Base.hs
@@ -7,16 +7,18 @@ module Testnet.Util.Base
 import           GHC.Stack (HasCallStack)
 import           System.Info (os)
 
+import qualified GHC.Stack as GHC
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 
 
 integration :: HasCallStack => H.Integration () -> H.Property
-integration = H.withTests 1 . H.propertyOnce
+integration f = GHC.withFrozenCallStack $ H.withTests 1 $ H.propertyOnce f
 
-integrationRetryWorkspace :: Int -> FilePath -> (FilePath -> H.Integration ()) -> H.Property
-integrationRetryWorkspace n workspaceName f = integration $ H.retry n $ \i ->
-  H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
+integrationRetryWorkspace :: HasCallStack => Int -> FilePath -> (FilePath -> H.Integration ()) -> H.Property
+integrationRetryWorkspace n workspaceName f = GHC.withFrozenCallStack $
+  integration $ H.retry n $ \i ->
+    H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
 
 isLinux :: Bool
 isLinux = os == "linux"


### PR DESCRIPTION
# Description

This is needed so that the generated `module` file contains the correct module name.

Before:
```
$ cabal test cardano-testnet --enable-tests --test-options '-p query-slot-number'
$ cat /private/tmp/nix-shell.wBf3gI/query-slot-number-0-test-744fa3ec7ae64cea/module
Testnet.Util.Base
```

After:
```
$ cabal test cardano-testnet --enable-tests --test-options '-p query-slot-number'
$ cat /private/tmp/nix-shell.wBf3gI/query-slot-number-0-test-744fa3ec7ae64cea/module
Test.Cli.QuerySlotNumber
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
