### PR TITLE
Add git hook for code style and linting

### DIFF
--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -1,0 +1,19 @@
+#!/bin/sh
+# This script validates the staged changes in Haskell files using stylish-haskell and hlint and returns non-zero
+# code when there are linting or style issues.
+#
+# To set this script as your pre-commit hook, use the following command:
+#
+# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git-root)/.git/hooks/pre-commit
+#
+
+for x in $(git diff --staged --name-only --diff-filter=ACM | tr '\n' ' '); do
+  if [ "${x##*.}" = "hs" ]; then
+    stylish-haskell -i "$x"
+    # fail on linting issues
+    hlint "$x"
+  fi
+done
+
+# fail if there are style issues
+git --no-pager diff --exit-code


### PR DESCRIPTION
# Description

Git hook for styling and linking. Everyone interested in needs to enable it yourself. See the comment in the hook script.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
