### PR TITLE
Upload failed tests workspaces to artifacts in GitHub CI

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -158,6 +158,22 @@ jobs:
         KEEP_WORKSPACE: 1
       run: cabal test cardano-testnet cardano-api cardano-node cardano-node-chairman cardano-cli cardano-submit-api
 
+    - name: Tar failed tests workspaces
+      if: ${{ failure() }}
+      env:
+        TMP: ${{ runner.temp }}
+      shell: bash
+      run: |
+        cd $TMP
+        find . -name 'module' -type f -printf '%h\n' | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
+
+    - name: Upload workspaces on tests failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: failed-test-workspaces-${{ matrix.os }}-ghc${{ matrix.ghc }}-cabal${{ matrix.cabal }}.tgz
+        path: ${{ runner.temp }}/workspaces.tgz
+
     - name: "Tar artifacts"
       shell: bash
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -187,6 +187,22 @@ jobs:
         ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
         cabal test cardano-testnet cardano-api cardano-node cardano-node-chairman cardano-cli cardano-submit-api
 
+    - name: Tar failed tests workspaces
+      if: ${{ failure() }}
+      env:
+        TMP: ${{ runner.temp }}
+      shell: bash
+      run: |
+        cd $TMP
+        find . -name 'module' -type f -printf '%h\n' | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
+
+    - name: Upload workspaces on tests failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: failed-test-workspaces-${{ matrix.os }}-ghc${{ matrix.ghc }}-cabal${{ matrix.cabal }}.tgz
+        path: ${{ runner.temp }}/workspaces.tgz
+
     - name: "Tar artifacts"
       shell: bash
       run: |


### PR DESCRIPTION
# Description

This PR modifies CI pipeline to add test workspaces on failure to artifacts. See an example artifact here: https://github.com/input-output-hk/cardano-node/actions/runs/4828693143#artifacts

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
