### PR TITLE
Use machine readable output for ToJSON ScriptWitnessIndex

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -3,6 +3,10 @@
 ## vNext
 - Add `getSlotForRelativeTime` function ([PR 5130](https://github.com/input-output-hk/cardano-node/pull/5130))
 
+- New `ToJSON ScriptWitnessIndex` instance that produces machine readable output.
+  Any `JSON` output uses this instance.
+  [PR 5168](https://github.com/input-output-hk/cardano-node/pull/5168)
+
 ### Features
 
 - Expose node config reading functionality: `NodeConfig`, `NodeConfigFile` and `readNodeConfig`

--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
@@ -4128,6 +4129,29 @@ data ScriptWitnessIndex =
      -- | The n'th withdrawal, in the order of the 'StakeAddress's.
    | ScriptWitnessIndexWithdrawal !Word
   deriving (Eq, Ord, Show)
+
+instance ToJSON ScriptWitnessIndex where
+  toJSON = \case
+    ScriptWitnessIndexTxIn n ->
+      object
+      [ "kind" .= Aeson.String "ScriptWitnessIndexTxIn"
+      , "value" .= n
+      ]
+    ScriptWitnessIndexMint n ->
+      object
+      [ "kind" .= Aeson.String "ScriptWitnessIndexMint"
+      , "value" .= n
+      ]
+    ScriptWitnessIndexCertificate n ->
+      object
+      [ "kind" .= Aeson.String "ScriptWitnessIndexCertificate"
+      , "value" .= n
+      ]
+    ScriptWitnessIndexWithdrawal n ->
+      object
+      [ "kind" .= Aeson.String "ScriptWitnessIndexWithdrawal"
+      , "value" .= n
+      ]
 
 renderScriptWitnessIndex :: ScriptWitnessIndex -> String
 renderScriptWitnessIndex (ScriptWitnessIndexTxIn index) =

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- In JSON logging, `"ExtraRedeemers"` object contents are machine readable rather than
+  difficult-to-parse user-friendly-string.
+  [PR 5168](https://github.com/input-output-hk/cardano-node/pull/5168)
+
 ### node changes
 
 - So far the `AcceptedConnectionLimit`s from the configuration file where

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -69,12 +69,12 @@ import           Cardano.Ledger.Shelley.Rules
 
 import           Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
-import           Cardano.Ledger.Conway.Governance (govActionIdToText)
 import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure, AlonzoUtxoPredFailure,
                    AlonzoUtxosPredFailure, AlonzoUtxowPredFailure (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import           Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
+import           Cardano.Ledger.Conway.Governance (govActionIdToText)
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
@@ -295,7 +295,7 @@ instance ( ShelleyBasedEra era
              ]
   forMachine _ (ExtraRedeemers rdmrs) =
     mconcat [ "kind" .= String "ExtraRedeemers"
-             , "rdmrs" .= map (Api.renderScriptWitnessIndex . Api.fromAlonzoRdmrPtr) rdmrs
+             , "rdmrs" .= map Api.fromAlonzoRdmrPtr rdmrs
              ]
 
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -303,9 +303,10 @@ instance ( ShelleyBasedEra era
              , "acceptable" .= Set.toList acceptable
              ]
   toObject _ (ExtraRedeemers rdmrs) =
-    mconcat [ "kind" .= String "ExtraRedeemers"
-             , "rdmrs" .= map (Api.renderScriptWitnessIndex . Api.fromAlonzoRdmrPtr) rdmrs
-             ]
+    mconcat
+      [ "kind" .= String "ExtraRedeemers"
+      , "rdmrs" .= map Api.fromAlonzoRdmrPtr rdmrs
+      ]
 
 renderScriptIntegrityHash :: Maybe (Alonzo.ScriptIntegrityHash StandardCrypto) -> Aeson.Value
 renderScriptIntegrityHash (Just witPPDataHash) =
@@ -1039,7 +1040,7 @@ instance ToJSON (Alonzo.CollectError StandardCrypto) where
               Alonzo.RdmrPtrPointsToNothing ptr ->
                 object
                   [ "kind" .= String "RedeemerPointerPointsToNothing"
-                  , "ptr" .= (Api.renderScriptWitnessIndex . Api.fromAlonzoRdmrPtr) ptr
+                  , "ptr" .= Api.fromAlonzoRdmrPtr ptr
                   ]
               Alonzo.LanguageNotSupported lang ->
                 String $ "Language not supported: " <> textShow lang


### PR DESCRIPTION
# Description

* New `ToJSON ScriptWitnessIndex` instance
* Any `JSON` output uses this instance.
* In JSON logging, `"ExtraRedeemers"` object contents are machine readable rather than difficult-to-parse user-friendly-string.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
