### PR TITLE
Fix `toEraInMode` for conway

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -2,9 +2,12 @@
 
 ## 8.1.0
 
--
+### Bugfix
 
-## 8.0.0 - May 2023
+- Fix `toEraInMode` for Conway
+  ([PR 5175](https://github.com/input-output-hk/cardano-node/pull/5175))
+
+## 8.0.0 -- May 2023
 
 - Add `getSlotForRelativeTime` function ([PR 5130](https://github.com/input-output-hk/cardano-node/pull/5130))
 

--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -132,14 +132,16 @@ deriving instance Show (ConsensusModeIsMultiEra mode)
 
 toEraInMode :: CardanoEra era -> ConsensusMode mode -> Maybe (EraInMode era mode)
 toEraInMode ByronEra   ByronMode   = Just ByronEraInByronMode
+toEraInMode _          ByronMode   = Nothing
 toEraInMode ShelleyEra ShelleyMode = Just ShelleyEraInShelleyMode
+toEraInMode _          ShelleyMode = Nothing
 toEraInMode ByronEra   CardanoMode = Just ByronEraInCardanoMode
 toEraInMode ShelleyEra CardanoMode = Just ShelleyEraInCardanoMode
 toEraInMode AllegraEra CardanoMode = Just AllegraEraInCardanoMode
 toEraInMode MaryEra    CardanoMode = Just MaryEraInCardanoMode
 toEraInMode AlonzoEra  CardanoMode = Just AlonzoEraInCardanoMode
 toEraInMode BabbageEra CardanoMode = Just BabbageEraInCardanoMode
-toEraInMode _ _                    = Nothing
+toEraInMode ConwayEra  CardanoMode = Just ConwayEraInCardanoMode
 
 -- | A representation of which 'CardanoEra's are included in each
 -- 'ConsensusMode'.

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -4,7 +4,7 @@
 
 -
 
-## 8.0.0 - May 2023
+## 8.0.0 -- May 2023
 
 - Remove cardano-cli address build-script ([PR 4700](https://github.com/input-output-hk/cardano-node/pull/4700))
 - Remove support for reading protocol parameters from Shelley genesis file ([PR 5053](https://github.com/input-output-hk/cardano-node/pull/5053))

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -4,7 +4,7 @@
 
 -
 
-## 8.0.0 - May 2023
+## 8.0.0 -- May 2023
 
 - In JSON logging, `"ExtraRedeemers"` object contents are machine readable rather than
   difficult-to-parse user-friendly-string.

--- a/cardano-submit-api/CHANGELOG.md
+++ b/cardano-submit-api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-## 8.0.0 - May 2023
+## 8.0.0 -- May 2023
 
 - [Add tx_submit_fail_count metric](https://github.com/input-output-hk/cardano-node/pull/4566)
 - [Configurable metrics port in submit-api](https://github.com/input-output-hk/cardano-node/pull/4281)


### PR DESCRIPTION
# Description

The pattern match for `ConwayEra` era was missing and is added.

Also restructure the pattern match so this doesn't happen again for future eras.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
