### PR TITLE
Remove use of `pushd`/`popd`

### DIFF
--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -108,7 +108,7 @@ $SED -i "${ROOT}/configuration.yaml" \
   echo "TestConwayHardForkAtEpoch: 0" >> "${ROOT}/configuration.yaml"
   echo "ExperimentalProtocolsEnabled: True" >> "${ROOT}/configuration.yaml"
 
-# Copy the cost mode
+# Copy the cost model
 
 
 $CARDANO_CLI genesis create-staked --genesis-dir "${ROOT}" \

--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -79,11 +79,6 @@ $CARDANO_CLI byron genesis genesis \
   --protocol-parameters-file "${ROOT}/byron.genesis.spec.json" \
   --genesis-output-dir "${ROOT}/byron-gen-command"
 
-# Because in Babbage the overlay schedule and decentralization parameter
-# are deprecated, we must use the "create-staked" cli command to create
-# SPOs in the ShelleyGenesis
-
-
 cp scripts/babbage/alonzo-babbage-test-genesis.json "${ROOT}/genesis.alonzo.spec.json"
 cp scripts/babbage/conway-babbage-test-genesis.json "${ROOT}/genesis.conway.spec.json"
 
@@ -108,9 +103,9 @@ $SED -i "${ROOT}/configuration.yaml" \
   echo "TestConwayHardForkAtEpoch: 0" >> "${ROOT}/configuration.yaml"
   echo "ExperimentalProtocolsEnabled: True" >> "${ROOT}/configuration.yaml"
 
-# Copy the cost model
-
-
+# Because in Babbage the overlay schedule and decentralization parameter
+# are deprecated, we must use the "create-staked" cli command to create
+# SPOs in the ShelleyGenesis
 $CARDANO_CLI genesis create-staked --genesis-dir "${ROOT}" \
   --testnet-magic "${NETWORK_MAGIC}" \
   --gen-pools 3 \


### PR DESCRIPTION
# Description

This moves the style of `scripts/byron-to-alonzo/mkfiles.hs` to be closer to `scripts/babbage/mkfiles.hs` which is newer.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
