### PR TITLE
Update libsodium installation instructions

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -98,15 +98,7 @@ and it should return a path of this shape: `/home/<user>/.ghcup/bin/cabal`.
 Cardano uses a custom fork of `libsodium` which exposes some internal functions
 and adds some other new functions. This fork lives in
 [https://github.com/input-output-hk/libsodium](https://github.com/input-output-hk/libsodium).
-Users can choose to either install that custom version of `libsodium` or
-otherwise tell `cabal` to use a ported version included in Cardano crypto
-libraries.
-
-The C code is merely a port of the bits missing in a normal `libsodium`
-installation, so it should be as performant as installing the custom `libsodium`
-fork.
-
-##### Installing the custom libsodium
+Users need to install that custom version of `libsodium` with the following steps.
 
 Create a working directory for your builds:
 
@@ -140,25 +132,6 @@ the executable is linked with the right `libsodium.so` file (which you can
 check by running `ldd`), the running binary might still use the wrong library.
 You can check this by running `pldd`. If the `pldd` shows that the running executable
 is using the wrong library, run `ldconfig`.
-
-##### Using the ported `c` code
-
-In order to avoid having to install the custom version, `cardano-crypto-praos`
-defines a `cabal` flag that makes use of C code located
-[here](https://github.com/input-output-hk/cardano-base/tree/master/cardano-crypto-praos/cbits).
-To enable this code, one has to add the following code in the
-`cabal.project.local` file:
-
-```bash
-package cardano-crypto-praos
-  flags: -external-libsodium-vrf
-```
-
-For this to work, `libsodium` has to be in the system. For Ubuntu, this is achieved by:
-
-```bash
-sudo apt install libsodium-dev
-```
 
 #### Installing Secp256k1
 

--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -112,7 +112,7 @@ Download and install libsodium:
 ```bash
 git clone https://github.com/input-output-hk/libsodium
 cd libsodium
-git checkout 66f017f1
+git checkout dbb48cc
 ./autogen.sh
 ./configure
 make

--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -140,7 +140,9 @@ used for development purposes.
 In order to avoid having to install the custom version of libsodium for development
 purposes, `cardano-crypto-praos` defines a `cabal` flag that makes use of C code located
 [here](https://github.com/input-output-hk/cardano-base/tree/master/cardano-crypto-praos/cbits).
-To enable this code, one has to add the following code in the
+
+The C code is merely a port of the bits missing in a normal `libsodium`
+installation. To enable this code, one has to add the following code in the
 `cabal.project.local` file:
 
 ```bash

--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -133,6 +133,27 @@ check by running `ldd`), the running binary might still use the wrong library.
 You can check this by running `pldd`. If the `pldd` shows that the running executable
 is using the wrong library, run `ldconfig`.
 
+##### Using the ported `c` code for development
+**Note:** the ported `c` code should not be used to run the node, and should only be
+used for development purposes. 
+
+In order to avoid having to install the custom version of libsodium for development
+purposes, `cardano-crypto-praos` defines a `cabal` flag that makes use of C code located
+[here](https://github.com/input-output-hk/cardano-base/tree/master/cardano-crypto-praos/cbits).
+To enable this code, one has to add the following code in the
+`cabal.project.local` file:
+
+```bash
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf
+```
+
+For this to work, `libsodium` has to be in the system. For Ubuntu, this is achieved by:
+
+```bash
+sudo apt install libsodium-dev
+```
+
 #### Installing Secp256k1
 
 Create a working directory for your builds:


### PR DESCRIPTION
The libsodium library has certain supported and documented ways to build and use the library. In particular it involves building the whole library using libsodium's own build system. Turning on the external-libsodium-vrf flag (and thus using the bundled C code instead) does neither of these things: it only builds little bits of libsodium and does not use the libsodium build system. So from the perspective of the libsodium developers it is not a supported configuration. For that reason it's not something we can currently recommend to use in production.

In summary, it's not known to be wrong, rather it's not known to be ok, and since this is critical to security, as a cautionary measure we don't recommend its usage in production. We will look more carefully into the security implications for using this flag, but in the meantime we do not advise its usage. 