### PR TITLE
Rename --signed-tx-file argument to --tx-file argument in verify-poll command

### DIFF
--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -25,6 +25,7 @@
   - ([PR 5132](https://github.com/input-output-hk/cardano-node/pull/5132))
   - ([PR 5112](https://github.com/input-output-hk/cardano-node/pull/5112))
   - ([PR 5172](https://github.com/input-output-hk/cardano-node/pull/5172))
+  - ([PR 5184](https://github.com/input-output-hk/cardano-node/pull/5184))
 
 - Any command that takes a `--mainnet` flag or a `--testnet-magic` flag can have that setting
   supplied with the `CARDANO_NODE_NETWORK_ID=mainnet` or `CARDANO_NODE_NETWORK_ID=<number>`

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1232,9 +1232,9 @@ pPollFile =
 pPollTxFile :: Parser (TxFile In)
 pPollTxFile =
   fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "signed-tx-file"
+    [ Opt.long "tx-file"
     , Opt.metavar "FILE"
-    , Opt.help "Filepath to a signed transaction carrying a valid poll answer."
+    , Opt.help "Filepath to the JSON TxBody or JSON Tx carrying a valid poll answer."
     , Opt.completer (Opt.bashCompleter "file")
     ]
 

--- a/cardano-cli/test/Test/Golden/Shelley/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Governance/VerifyPoll.hs
@@ -14,13 +14,12 @@ import           Hedgehog (Property)
 import           Test.OptParse
 
 import           Cardano.Api
-import           Cardano.CLI.Shelley.Key
-                   (VerificationKeyOrFile (..),
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile (..),
                    readVerificationKeyOrTextEnvFile)
 
+import qualified Data.ByteString.Char8 as BSC
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
-import qualified Data.ByteString.Char8 as BSC
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -34,7 +33,7 @@ golden_shelleyGovernanceVerifyPoll = propertyOnce $ do
   stdout <- BSC.pack <$> execCardanoCLI
     [ "governance", "verify-poll"
     , "--poll-file", pollFile
-    , "--signed-tx-file", txFile
+    , "--tx-file", txFile
     ]
 
   liftIO (readVerificationKeyOrTextEnvFile AsStakePoolKey vkFile) >>= \case
@@ -52,7 +51,7 @@ golden_shelleyGovernanceVerifyPollMismatch = propertyOnce $ do
   result <- tryExecCardanoCLI
     [ "governance", "verify-poll"
     , "--poll-file", pollFile
-    , "--signed-tx-file", txFile
+    , "--tx-file", txFile
     ]
 
   either (const H.success) (H.failWith Nothing) result
@@ -65,7 +64,7 @@ golden_shelleyGovernanceVerifyPollNoAnswer = propertyOnce $ do
   result <- tryExecCardanoCLI
     [ "governance", "verify-poll"
     , "--poll-file", pollFile
-    , "--signed-tx-file", txFile
+    , "--tx-file", txFile
     ]
 
   either (const H.success) (H.failWith Nothing) result
@@ -78,7 +77,7 @@ golden_shelleyGovernanceVerifyPollMalformedAnswer = propertyOnce $ do
   result <- tryExecCardanoCLI
     [ "governance", "verify-poll"
     , "--poll-file", pollFile
-    , "--signed-tx-file", txFile
+    , "--tx-file", txFile
     ]
 
   either (const H.success) (H.failWith Nothing) result
@@ -91,7 +90,7 @@ golden_shelleyGovernanceVerifyPollInvalidAnswer = propertyOnce $ do
   result <- tryExecCardanoCLI
     [ "governance", "verify-poll"
     , "--poll-file", pollFile
-    , "--signed-tx-file", txFile
+    , "--tx-file", txFile
     ]
 
   either (const H.success) (H.failWith Nothing) result


### PR DESCRIPTION
# Description

Renamed `--signed-tx-file` argument to `--tx-file` argument because it turns out this also accepted an unsigned txbody.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
