### PR TITLE
Expose config reader

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -5,6 +5,17 @@
 
 ### Features
 
+- Expose node config reading functionality: `NodeConfig`, `NodeConfigFile` and `readNodeConfig`
+
+- Expose genesis file reading functionality:
+  - All eras: `GenesisConfig` and `readCardanoGenesisConfig`
+  - Byron: `readByronGenesisConfig`
+  - Shelley: `ShelleyConfig`, `GenesisHashShelley`, `readShelleyGenesisConfig` and `shelleyPraosNonce`
+  - Alonzo: `GenesisHashAlonzo` and `readAlonzoGenesisConfig`
+  - Conway: `GenesisHashConway` and `readConwayGenesisConfig`
+
+- Expose envirnment construction functionality: `mkProtocolInfoCardano` and `genesisConfigToEnv`
+
 - Rename `TestEnableDevelopmentHardForkEras` to `ExperimentalHardForksEnabled` and
   `TestEnableDevelopmentNetworkProtocols` to `ExperimentalProtocolsEnabled`
   ([PR 4341](https://github.com/input-output-hk/cardano-node/pull/4341))

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -591,12 +591,35 @@ module Cardano.Api (
     -- * Node interaction
     -- | Operations that involve talking to a local Cardano node.
 
+    -- ** Node Config
+    -- *** Network Config
+    NetworkConfigFile (..),
+    readNetworkConfig,
+    -- *** Genesis Config
+    GenesisConfig (..),
+    readCardanoGenesisConfig,
+    -- **** Byron Genesis Config
+    readByronGenesisConfig,
+    -- **** Shelley Genesis Config
+    ShelleyConfig (..),
+    GenesisHashShelley (..),
+    readShelleyGenesisConfig,
+    shelleyPraosNonce,
+    -- **** Alonzo Genesis Config
+    GenesisHashAlonzo (..),
+    readAlonzoGenesisConfig,
+    -- **** Conway Genesis Config
+    GenesisHashConway (..),
+    readConwayGenesisConfig,
+    -- *** Environment
+    Env(..),
+    genesisConfigToEnv,
+
     -- ** Queries
     -- ** Submitting transactions
 
     -- ** High level protocol interaction with a Cardano node
     -- *** Initialization / Accumulation
-    Env(..),
     envSecurityParam,
     LedgerState(..),
     initialLedgerState,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -592,12 +592,13 @@ module Cardano.Api (
     -- | Operations that involve talking to a local Cardano node.
 
     -- ** Node Config
-    -- *** Network Config
-    NetworkConfigFile (..),
-    readNetworkConfig,
+    NodeConfig (..),
+    NodeConfigFile (..),
+    readNodeConfig,
     -- *** Genesis Config
     GenesisConfig (..),
     readCardanoGenesisConfig,
+    mkProtocolInfoCardano,
     -- **** Byron Genesis Config
     readByronGenesisConfig,
     -- **** Shelley Genesis Config

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -55,11 +55,12 @@ module Cardano.Api.LedgerState
   -- * Node Config
   , NodeConfig(..)
   -- ** Network Config
-  , NetworkConfigFile (..)
-  , readNetworkConfig
+  , NodeConfigFile (..)
+  , readNodeConfig
   -- ** Genesis Config
   , GenesisConfig (..)
   , readCardanoGenesisConfig
+  , mkProtocolInfoCardano
   -- *** Byron Genesis Config
   , readByronGenesisConfig
   -- *** Shelley Genesis Config
@@ -254,7 +255,7 @@ initialLedgerState networkConfigFile = do
   -- can remove the networkConfigFile argument and much of the code in this
   -- module.
   config <- withExceptT ILSEConfigFile
-                  (readNetworkConfig (NetworkConfigFile networkConfigFile))
+                  (readNodeConfig (NodeConfigFile networkConfigFile))
   genesisConfig <- withExceptT ILSEGenesisFile (readCardanoGenesisConfig config)
   env <- withExceptT ILSELedgerConsensusConfig (except (genesisConfigToEnv genesisConfig))
   let ledgerState = initLedgerStateVar genesisConfig
@@ -773,8 +774,8 @@ genesisConfigToEnv
                   , envProtocolConfig = Consensus.topLevelConfigProtocol topLevelConfig
                   }
 
-readNetworkConfig :: NetworkConfigFile -> ExceptT Text IO NodeConfig
-readNetworkConfig (NetworkConfigFile ncf) = do
+readNodeConfig :: NodeConfigFile -> ExceptT Text IO NodeConfig
+readNodeConfig (NodeConfigFile ncf) = do
     ncfg <- (except . parseNodeConfig) =<< readByteString ncf "node"
     return ncfg
       { ncByronGenesisFile = adjustGenesisFilePath (mkAdjustPath ncf) (ncByronGenesisFile ncfg)
@@ -1015,8 +1016,8 @@ newtype NetworkName = NetworkName
   { unNetworkName :: Text
   } deriving Show
 
-newtype NetworkConfigFile = NetworkConfigFile
-  { unNetworkConfigFile :: FilePath
+newtype NodeConfigFile = NodeConfigFile
+  { unNodeConfigFile :: FilePath
   } deriving Show
 
 newtype SocketPath = SocketPath

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -147,7 +147,7 @@ import qualified Cardano.Crypto.ProtocolMagic
 import qualified Cardano.Crypto.VRF as Crypto
 import qualified Cardano.Crypto.VRF.Class as VRF
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
-import           Cardano.Ledger.BaseTypes (Globals (..), Nonce, (⭒))
+import           Cardano.Ledger.BaseTypes (Globals (..), Nonce, ProtVer (..), natVersion, (⭒))
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.BHeaderView as Ledger
 import           Cardano.Ledger.Binary (DecoderError, FromCBOR)
@@ -1050,27 +1050,27 @@ mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis alonzoGene
             , Consensus.shelleyBasedLeaderCredentials = []
             }
           Consensus.ProtocolParamsShelley
-            { Consensus.shelleyProtVer = shelleyProtVer dnc
+            { Consensus.shelleyProtVer = ProtVer (natVersion @3) 0
             , Consensus.shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           Consensus.ProtocolParamsAllegra
-            { Consensus.allegraProtVer = shelleyProtVer dnc
+            { Consensus.allegraProtVer = ProtVer (natVersion @4) 0
             , Consensus.allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           Consensus.ProtocolParamsMary
-            { Consensus.maryProtVer = shelleyProtVer dnc
+            { Consensus.maryProtVer = ProtVer (natVersion @5) 0
             , Consensus.maryMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           Consensus.ProtocolParamsAlonzo
-            { Consensus.alonzoProtVer = shelleyProtVer dnc
+            { Consensus.alonzoProtVer = ProtVer (natVersion @7) 0
             , Consensus.alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           Consensus.ProtocolParamsBabbage
-            { Consensus.babbageProtVer = shelleyProtVer dnc
+            { Consensus.babbageProtVer = ProtVer (natVersion @9) 0
             , Consensus.babbageMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           Consensus.ProtocolParamsConway
-            { Consensus.conwayProtVer = shelleyProtVer dnc
+            { Consensus.conwayProtVer = ProtVer (natVersion @10) 0
             , Consensus.conwayMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
           (ncByronToShelley dnc)
@@ -1084,14 +1084,6 @@ mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis alonzoGene
 shelleyPraosNonce :: ShelleyConfig -> Ledger.Nonce
 shelleyPraosNonce sCfg =
   Ledger.Nonce (Cardano.Crypto.Hash.Class.castHash . unGenesisHashShelley $ scGenesisHash sCfg)
-
-shelleyProtVer :: NodeConfig -> Ledger.ProtVer
-shelleyProtVer dnc =
-  let bver = ncByronProtocolVersion dnc
-      majVer = Cardano.Chain.Update.pvMajor bver
-  in Ledger.ProtVer
-       (fromMaybe (error $ "Invalid major version: " ++ show majVer) $ mkVersion majVer)
-       (fromIntegral $ Cardano.Chain.Update.pvMinor bver)
 
 readCardanoGenesisConfig
         :: NodeConfig

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -207,6 +207,9 @@ data InitialLedgerStateError
   -- ^ Failed to read or parse a genesis file linked from the network config file.
   | ILSELedgerConsensusConfig GenesisConfigError
   -- ^ Failed to derive the Ledger or Consensus config.
+  deriving Show
+
+instance Exception InitialLedgerStateError
 
 renderInitialLedgerStateError :: InitialLedgerStateError -> Text
 renderInitialLedgerStateError ilse = case ilse of
@@ -232,6 +235,7 @@ data LedgerStateError
       ChainPoint -- ^ Rollback was attempted to this point.
   deriving (Show)
 
+instance Exception LedgerStateError
 
 
 renderLedgerStateError :: LedgerStateError -> Text
@@ -1106,6 +1110,9 @@ data GenesisConfigError
   | NEAlonzoConfig !FilePath !Text
   | NEConwayConfig !FilePath !Text
   | NECardanoConfig !Text
+  deriving Show
+
+instance Exception GenesisConfigError
 
 renderGenesisConfigError :: GenesisConfigError -> Text
 renderGenesisConfigError ne =
@@ -1203,6 +1210,8 @@ data ShelleyGenesisError
      | ShelleyGenesisDecodeError !FilePath !Text
      deriving Show
 
+instance Exception ShelleyGenesisError
+
 renderShelleyGenesisError :: ShelleyGenesisError -> Text
 renderShelleyGenesisError sge =
     case sge of
@@ -1247,6 +1256,8 @@ data AlonzoGenesisError
      | AlonzoGenesisDecodeError !FilePath !Text
      deriving Show
 
+instance Exception AlonzoGenesisError
+
 renderAlonzoGenesisError :: AlonzoGenesisError -> Text
 renderAlonzoGenesisError sge =
     case sge of
@@ -1290,6 +1301,8 @@ data ConwayGenesisError
      | ConwayGenesisHashMismatch !GenesisHashConway !GenesisHashConway -- actual, expected
      | ConwayGenesisDecodeError !FilePath !Text
      deriving Show
+
+instance Exception ConwayGenesisError
 
 renderConwayGenesisError :: ConwayGenesisError -> Text
 renderConwayGenesisError sge =

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -1140,18 +1140,6 @@ renderGenesisConfigError ne =
         , "   ", err
         ]
 
-data LookupFail
-  = DbLookupBlockHash !ByteString
-  | DbLookupBlockId !Word64
-  | DbLookupMessage !Text
-  | DbLookupTxHash !ByteString
-  | DbLookupTxOutPair !ByteString !Word16
-  | DbLookupEpochNo !Word64
-  | DbLookupSlotNo !Word64
-  | DbMetaEmpty
-  | DbMetaMultipleRows
-  deriving (Eq, Show)
-
 readByronGenesisConfig
         :: NodeConfig
         -> ExceptT GenesisConfigError IO Cardano.Chain.Genesis.Config


### PR DESCRIPTION
# Description

There is quite useful functionality for reading the config file that is currently hidden in `Cardano.Api.LedgerState`. There is a similar implementation in `db-analyser`, `db-sync` likely has one like that (since comment literally says stolen from db-sync) and cardano-node has a form of this functionality. Anyone else writing a tool that would like to deal with consensus directly would have to rewrite it from scratch as well.

So, I think it makes sense to expose it and later trying to reuse it wherever possible.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
