### PR TITLE
IO functions for reading. Remove PoolMetadataFile type

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -2,12 +2,18 @@
 
 ## 8.1.0
 
-### Bugfix
+### Features
+
+- New functions: `intoFile`, `readByteStringFile`, `readLazyByteStringFile`, `readTextFile`.
+  Modify functions in `Cardano.Api.IO` to use unspecified content type rather than `()`.
+  ([PR 5194](https://github.com/input-output-hk/cardano-node/pull/5194))
+
+### Bugs
 
 - Fix `toEraInMode` for Conway
   ([PR 5175](https://github.com/input-output-hk/cardano-node/pull/5175))
 
-## 8.0.0 -- May 2023
+### 8.0.0 -- May 2023
 
 - Add `getSlotForRelativeTime` function ([PR 5130](https://github.com/input-output-hk/cardano-node/pull/5130))
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -43,6 +43,10 @@ module Cardano.Api (
     onlyOut,
     intoFile,
 
+    readByteStringFile,
+    readLazyByteStringFile,
+    readTextFile,
+
     writeByteStringFileWithOwnerPermissions,
     writeByteStringFile,
     writeByteStringOutput,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -37,9 +37,11 @@ module Cardano.Api (
     -- ** IO
     File(..),
     FileDirection(..),
+
     mapFile,
     onlyIn,
     onlyOut,
+    intoFile,
 
     writeByteStringFileWithOwnerPermissions,
     writeByteStringFile,

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -6,7 +6,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Api.IO
-  ( writeByteStringFileWithOwnerPermissions
+  ( readByteStringFile
+  , readLazyByteStringFile
+  , readTextFile
+
+  , writeByteStringFileWithOwnerPermissions
   , writeByteStringFile
   , writeByteStringOutput
 
@@ -118,6 +122,27 @@ handleFileForWritingWithOwnerPermission path f = do
   where
     (targetDir, targetFile) = splitFileName path
 #endif
+
+readByteStringFile :: ()
+  => MonadIO m
+  => File content In
+  -> m (Either (FileError e) ByteString)
+readByteStringFile fp = runExceptT $
+  handleIOExceptT (FileIOError (unFile fp)) $ BS.readFile (unFile fp)
+
+readLazyByteStringFile :: ()
+  => MonadIO m
+  => File content In
+  -> m (Either (FileError e) LBS.ByteString)
+readLazyByteStringFile fp = runExceptT $
+  handleIOExceptT (FileIOError (unFile fp)) $ LBS.readFile (unFile fp)
+
+readTextFile :: ()
+  => MonadIO m
+  => File content In
+  -> m (Either (FileError e) Text)
+readTextFile fp = runExceptT $
+  handleIOExceptT (FileIOError (unFile fp)) $ Text.readFile (unFile fp)
 
 writeByteStringFile :: ()
   => MonadIO m

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -78,7 +78,7 @@ newtype File content (direction :: FileDirection) = File
 handleFileForWritingWithOwnerPermission
   :: FilePath
   -> (Handle -> IO ())
-  -> IO (Either (FileError ()) ())
+  -> IO (Either (FileError e) ())
 handleFileForWritingWithOwnerPermission path f = do
 #ifdef UNIX
   -- On a unix based system, we grab a file descriptor and set ourselves as owner.
@@ -123,14 +123,14 @@ writeByteStringFile :: ()
   => MonadIO m
   => File content Out
   -> ByteString
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeByteStringFile fp bs = runExceptT $
   handleIOExceptT (FileIOError (unFile fp)) $ BS.writeFile (unFile fp) bs
 
 writeByteStringFileWithOwnerPermissions
   :: FilePath
   -> BS.ByteString
-  -> IO (Either (FileError ()) ())
+  -> IO (Either (FileError e) ())
 writeByteStringFileWithOwnerPermissions fp bs =
   handleFileForWritingWithOwnerPermission fp $ \h ->
     BS.hPut h bs
@@ -139,7 +139,7 @@ writeByteStringOutput :: ()
   => MonadIO m
   => Maybe (File content Out)
   -> ByteString
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeByteStringOutput mOutput bs = runExceptT $
   case mOutput of
     Just fp -> handleIOExceptT (FileIOError (unFile fp)) $ BS.writeFile (unFile fp) bs
@@ -149,14 +149,14 @@ writeLazyByteStringFile :: ()
   => MonadIO m
   => File content Out
   -> LBS.ByteString
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeLazyByteStringFile fp bs = runExceptT $
   handleIOExceptT (FileIOError (unFile fp)) $ LBS.writeFile (unFile fp) bs
 
 writeLazyByteStringFileWithOwnerPermissions
   :: File content Out
   -> LBS.ByteString
-  -> IO (Either (FileError ()) ())
+  -> IO (Either (FileError e) ())
 writeLazyByteStringFileWithOwnerPermissions fp lbs =
   handleFileForWritingWithOwnerPermission (unFile fp) $ \h ->
     LBS.hPut h lbs
@@ -165,7 +165,7 @@ writeLazyByteStringOutput :: ()
   => MonadIO m
   => Maybe (File content Out)
   -> LBS.ByteString
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeLazyByteStringOutput mOutput bs = runExceptT $
   case mOutput of
     Just fp -> handleIOExceptT (FileIOError (unFile fp)) $ LBS.writeFile (unFile fp) bs
@@ -175,14 +175,14 @@ writeTextFile :: ()
   => MonadIO m
   => File content Out
   -> Text
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeTextFile fp t = runExceptT $
   handleIOExceptT (FileIOError (unFile fp)) $ Text.writeFile (unFile fp) t
 
 writeTextFileWithOwnerPermissions
   :: File content Out
   -> Text
-  -> IO (Either (FileError ()) ())
+  -> IO (Either (FileError e) ())
 writeTextFileWithOwnerPermissions fp t =
   handleFileForWritingWithOwnerPermission (unFile fp) $ \h ->
     Text.hPutStr h t
@@ -191,7 +191,7 @@ writeTextOutput :: ()
   => MonadIO m
   => Maybe (File content Out)
   -> Text
-  -> m (Either (FileError ()) ())
+  -> m (Either (FileError e) ())
 writeTextOutput mOutput t = runExceptT $
   case mOutput of
     Just fp -> handleIOExceptT (FileIOError (unFile fp)) $ Text.writeFile (unFile fp) t

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -24,6 +24,8 @@ module Cardano.Api.IO
   , mapFile
   , onlyIn
   , onlyOut
+
+  , intoFile
   ) where
 
 #if !defined(mingw32_HOST_OS)
@@ -203,3 +205,20 @@ onlyIn = File . unFile
 
 onlyOut :: File content InOut -> File content Out
 onlyOut = File . unFile
+
+-- | Given a way to serialise a value and a way to write the stream to a file, serialise
+-- a value into a stream, and write it to a file.
+--
+-- Whilst it is possible to call the serialisation and writing functions separately,
+-- doing so means the compiler is unable to match the content type of the file with
+-- the type of the content being serialised.
+--
+-- Using this function ensures that the content type of the file always matches with the
+-- content value and prevents any type mismatches.
+intoFile :: ()
+  => File content 'Out
+  -> content
+  -> (File content 'Out -> stream -> result)
+  -> (content -> stream)
+  -> result
+intoFile fp content write serialise = write fp (serialise content)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -38,7 +38,6 @@ module Cardano.CLI.Shelley.Commands
   , VerificationKeyBase64 (..)
   , GenesisKeyFile (..)
   , MetadataFile (..)
-  , PoolMetadataFile (..)
   , PrivKeyFile (..)
   , BlockId (..)
   , WitnessSigningData (..)
@@ -322,9 +321,9 @@ data PoolCmd
       -- ^ Stake pool verification key.
       EpochNo
       -- ^ Epoch in which to retire the stake pool.
-      (File () Out)
+      (File Certificate Out)
   | PoolGetId (VerificationKeyOrFile StakePoolKey) OutputFormat
-  | PoolMetadataHash PoolMetadataFile (Maybe (File () Out))
+  | PoolMetadataHash (File StakePoolMetadata In) (Maybe (File () Out))
   deriving Show
 
 renderPoolCmd :: PoolCmd -> Text
@@ -522,10 +521,6 @@ newtype GenesisKeyFile
 data MetadataFile = MetadataFileJSON (File () In)
                   | MetadataFileCBOR (File () In)
 
-  deriving Show
-
-newtype PoolMetadataFile = PoolMetadataFile
-  { unPoolMetadataFile :: FilePath }
   deriving Show
 
 newtype GenesisDir

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1626,15 +1626,14 @@ pCertificateFile balanceExecUnits =
     , "stake key certificates etc). Optionally specify a script witness."
     ]
 
-pPoolMetadataFile :: Parser PoolMetadataFile
+pPoolMetadataFile :: Parser (File StakePoolMetadata In)
 pPoolMetadataFile =
-  PoolMetadataFile <$>
-    Opt.strOption
-      (  Opt.long "pool-metadata-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the pool metadata."
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "pool-metadata-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the pool metadata."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pTxMetadataJsonSchema :: Parser TxMetadataJsonSchema
 pTxMetadataJsonSchema =

--- a/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
+++ b/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE TypeApplications #-}
 
 #if !defined(mingw32_HOST_OS)
 #define UNIX
@@ -66,7 +67,7 @@ createFileWithOwnerPermissions :: HasTextEnvelope a => File () Out -> a -> Prope
 createFileWithOwnerPermissions targetfp value = do
   result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions targetfp $ textEnvelopeToJSON Nothing value
   case result of
-    Left err -> failWith Nothing $ displayError err
+    Left err -> failWith Nothing $ displayError @(FileError ()) err
     Right () -> return ()
 
 #ifdef UNIX


### PR DESCRIPTION
# Description

Add IO functions for reading files.
Remove `PoolMetadataFile` type and use `File` type instead.
Work around some type-inference issues that shouldn't exist.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
