### PR TITLE
Make UTCTime test generator ignore leap seconds

### DIFF
--- a/cardano-cli/test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/Test/Cli/JSON.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -10,7 +11,7 @@ import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAdd
 import           Data.Aeson
 import qualified Data.Map.Strict as Map
 import           Data.Time
-import           Data.Time.Clock.System
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Data.Word (Word64)
 
 import           Cardano.CLI.Shelley.Output (QueryKesPeriodInfoOutput (..),
@@ -54,10 +55,9 @@ genWord64 :: Gen Word64
 genWord64 = Gen.word64 Range.constantBounded
 
 genUTCTime :: Gen UTCTime
-genUTCTime =
- systemToUTCTime <$>
-   (MkSystemTime <$> Gen.int64 Range.constantBounded
-                 <*> Gen.word32 Range.constantBounded)
+genUTCTime = do
+  t <- Gen.int64 Range.constantBounded
+  pure . posixSecondsToUTCTime $ fromIntegral t / 1_000_000
 
 genKesPeriodInfoOutput :: Gen QueryKesPeriodInfoOutput
 genKesPeriodInfoOutput =


### PR DESCRIPTION
# Description

Previous `UTCTime` generator was using `SystemTime` which was breaking on leap seconds for very large values and was producing invalid timestamps. Observed failure: https://ci.zw3rk.com/build/2171231/nixlog/2
See also: https://github.com/haskell/time/issues/242 
This one does not use `SystemTime`, and ignores leap seconds which should be fine for the test purposes. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
<!--
# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
-->