### PR TITLE
Avoid bare IO in tests

### DIFF
--- a/cardano-cli/test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/Test/Cli/ITN.hs
@@ -8,7 +8,6 @@ import           Cardano.CLI.Shelley.Run.Key (decodeBech32)
 
 import qualified Codec.Binary.Bech32 as Bech32
 import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
 import           Data.Text (Text)
@@ -42,8 +41,8 @@ prop_convertITNKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   outputHaskellSignKeyFp <- noteTempFile tempDir "haskell-signing-key.key"
 
   -- Write ITN keys to disk
-  liftIO $ Text.writeFile itnVerKeyFp itnVerKey
-  liftIO $ Text.writeFile itnSignKeyFp itnSignKey
+  H.evalIO $ Text.writeFile itnVerKeyFp itnVerKey
+  H.evalIO $ Text.writeFile itnSignKeyFp itnSignKey
   H.assertFilesExist [itnVerKeyFp, itnSignKeyFp]
 
   -- Generate haskell stake verification key
@@ -77,7 +76,7 @@ prop_convertITNExtendedSigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \te
   outputHaskellSignKeyFp <- noteTempFile tempDir "stake-signing.key"
 
   -- Write ITN keys to disk
-  liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
+  H.evalIO $ writeFile itnSignKeyFp itnExtendedSignKey
   H.assertFilesExist [itnSignKeyFp]
 
   -- Generate haskell signing key
@@ -106,7 +105,7 @@ prop_convertITNBIP32SigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \tempD
   outputHaskellSignKeyFp <- noteTempFile tempDir "stake-signing.key"
 
   -- Write ITN keys to disk
-  liftIO $ writeFile itnSignKeyFp itnExtendedSignKey
+  H.evalIO $ writeFile itnSignKeyFp itnExtendedSignKey
 
   H.assertFilesExist [itnSignKeyFp]
 

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -78,9 +78,9 @@ golden_shelleyGenesisCreate = propertyOnce $ do
     alonzoSpecFile <- noteTempFile tempDir "genesis.alonzo.spec.json"
     conwaySpecFile <- noteTempFile tempDir "genesis.conway.spec.json"
 
-    liftIO $ IO.copyFile sourceGenesisSpecFile genesisSpecFile
-    liftIO $ IO.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
-    liftIO $ IO.copyFile sourceConwayGenesisSpecFile conwaySpecFile
+    H.copyFile sourceGenesisSpecFile genesisSpecFile
+    H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
+    H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
 
     let genesisFile = tempDir <> "/genesis.json"
 
@@ -164,11 +164,11 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     sourceAlonzoGenesisSpecFile <- noteInputFile "test/data/golden/alonzo/genesis.alonzo.spec.json"
     alonzoSpecFile <- noteTempFile tempDir "genesis.alonzo.spec.json"
-    liftIO $ IO.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
+    H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
 
     sourceConwayGenesisSpecFile <- noteInputFile "test/data/golden/conway/genesis.conway.spec.json"
     conwaySpecFile <- noteTempFile tempDir "genesis.conway.spec.json"
-    liftIO $ IO.copyFile sourceConwayGenesisSpecFile conwaySpecFile
+    H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
 
     -- Create the genesis json file and required keys
     void $ execCardanoCLI

--- a/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Genesis/Create.hs
@@ -6,7 +6,6 @@ module Test.Golden.Shelley.Genesis.Create
   ) where
 
 import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Foldable (for_)
 
@@ -27,7 +26,6 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Gen as G
 import qualified Hedgehog.Range as R
-import qualified System.Directory as IO
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}
@@ -84,7 +82,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap H.formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
 
     (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
@@ -103,7 +101,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     H.assertFilesExist [genesisFile]
 
-    genesisContents <- liftIO $ LBS.readFile genesisFile
+    genesisContents <- H.evalIO $ LBS.readFile genesisFile
 
     actualJson <- H.evalEither $ J.eitherDecode genesisContents
     actualSupply <- H.evalEither $ J.parseEither parseMaxLovelaceSupply actualJson
@@ -156,7 +154,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
   H.moduleWorkspace "tmp" $ \tempDir -> do
     let genesisFile = tempDir <> "/genesis.json"
 
-    fmtStartTime <- fmap H.formatIso8601 $ liftIO DT.getCurrentTime
+    fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
 
     (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
@@ -183,7 +181,7 @@ golden_shelleyGenesisCreate = propertyOnce $ do
 
     H.assertFilesExist [genesisFile]
 
-    genesisContents <- liftIO $ LBS.readFile genesisFile
+    genesisContents <- H.evalIO $ LBS.readFile genesisFile
 
     actualJson <- H.evalEither $ J.eitherDecode genesisContents
     actualSupply <- H.evalEither $ J.parseEither parseMaxLovelaceSupply actualJson

--- a/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -5,12 +5,12 @@ module Test.Golden.Shelley.Metadata.StakePoolMetadata
   ) where
 
 import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
 import           Hedgehog (Property)
 import           Test.OptParse as OP
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -24,7 +24,7 @@ golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
   outputStakePoolMetadataHashFp <- noteTempFile tempDir "stake-pool-metadata-hash.txt"
 
   -- Write the example stake pool metadata to disk
-  liftIO $ Text.writeFile stakePoolMetadataFile exampleStakePoolMetadata
+  H.evalIO $ Text.writeFile stakePoolMetadataFile exampleStakePoolMetadata
 
   -- Hash the stake pool metadata
   void $ execCardanoCLI

--- a/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -5,13 +5,11 @@ module Test.Golden.Shelley.Node.IssueOpCert
   ) where
 
 import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Hedgehog (Property)
 import           Test.OptParse
 
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import qualified System.Directory as IO
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -23,7 +21,7 @@ golden_shelleyNodeIssueOpCert = propertyOnce . H.moduleWorkspace "tmp" $ \tempDi
   operationalCertificateIssueCounterFile <- noteTempFile tempDir "delegate-op-cert.counter"
   operationalCertFile <- noteTempFile tempDir "operational.cert"
 
-  void . liftIO $ IO.copyFile originalOperationalCertificateIssueCounterFile operationalCertificateIssueCounterFile
+  H.copyFile originalOperationalCertificateIssueCounterFile operationalCertificateIssueCounterFile
 
   -- We could generate the required keys here, but then if the KES generation fails this
   -- test would also fail which is misleading.

--- a/cardano-cli/test/Test/OptParse.hs
+++ b/cardano-cli/test/Test/OptParse.hs
@@ -17,9 +17,9 @@ import           Cardano.Api
 
 import           Cardano.CLI.Shelley.Run.Read
 
+import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except (runExceptT)
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Function ((&))
 import           GHC.Stack (CallStack, HasCallStack)
 import qualified Hedgehog as H
@@ -63,10 +63,10 @@ checkTextEnvelopeFormat
   -> FilePath
   -> m ()
 checkTextEnvelopeFormat tve reference created = GHC.withFrozenCallStack $ do
-  eRefTextEnvelope <- liftIO $ readTextEnvelopeOfTypeFromFile tve reference
+  eRefTextEnvelope <- H.evalIO $ readTextEnvelopeOfTypeFromFile tve reference
   refTextEnvelope <- handleTextEnvelope eRefTextEnvelope
 
-  eCreatedTextEnvelope <- liftIO $ readTextEnvelopeOfTypeFromFile tve created
+  eCreatedTextEnvelope <- H.evalIO $ readTextEnvelopeOfTypeFromFile tve created
   createdTextEnvelope <- handleTextEnvelope eCreatedTextEnvelope
 
   typeTitleEquivalence refTextEnvelope createdTextEnvelope
@@ -89,10 +89,10 @@ checkTxCddlFormat
   -> FilePath -- ^ Newly created file
   -> m ()
 checkTxCddlFormat referencePath createdPath = do
-  reference <- liftIO $ fileOrPipe referencePath
-  created <- liftIO $ fileOrPipe createdPath
-  r <- liftIO $ readCddlTx reference
-  c <- liftIO $ readCddlTx created
+  reference <- H.evalIO $ fileOrPipe referencePath
+  created <- H.evalIO $ fileOrPipe createdPath
+  r <- H.evalIO $ readCddlTx reference
+  c <- H.evalIO $ readCddlTx created
   r H.=== c
 
 

--- a/cardano-cli/test/Test/Utilities.hs
+++ b/cardano-cli/test/Test/Utilities.hs
@@ -5,7 +5,7 @@ module Test.Utilities
 
 import           Cardano.Prelude (ConvertText (..), HasCallStack)
 
-import           Control.Monad.IO.Class (MonadIO (liftIO))
+import           Control.Monad.IO.Class (MonadIO)
 import           Data.Algorithm.Diff (PolyDiff (Both), getGroupedDiff)
 import           Data.Algorithm.DiffOutput (ppDiff)
 import           GHC.Stack (callStack)
@@ -39,12 +39,13 @@ createFiles = IO.unsafePerformIO $ do
 -- each input.
 diffVsGoldenFile
   :: HasCallStack
-  => (MonadIO m, MonadTest m)
+  => MonadTest m
+  => MonadIO m
   => String   -- ^ Actual content
   -> FilePath -- ^ Reference file
   -> m ()
 diffVsGoldenFile actualContent referenceFile = GHC.withFrozenCallStack $ do
-  fileExists <- liftIO $ IO.doesFileExist referenceFile
+  fileExists <- H.evalIO $ IO.doesFileExist referenceFile
 
   if fileExists
     then do
@@ -80,7 +81,8 @@ diffVsGoldenFile actualContent referenceFile = GHC.withFrozenCallStack $ do
 -- files are never overwritten.
 diffFileVsGoldenFile
   :: HasCallStack
-  => (MonadIO m, MonadTest m)
+  => MonadIO m
+  => MonadTest m
   => FilePath -- ^ Actual file
   -> FilePath -- ^ Reference file
   -> m ()

--- a/cardano-node-chairman/test/Spec/Network.hs
+++ b/cardano-node-chairman/test/Spec/Network.hs
@@ -12,7 +12,6 @@ module Spec.Network
 
 import           Control.Exception (IOException)
 import           Control.Monad
-import           Control.Monad.IO.Class (liftIO)
 import           Data.Bool
 import           Data.Either
 import           Data.Function
@@ -47,7 +46,7 @@ hprop_isPortOpen_True = H.propertyOnce . H.workspace "temp-network" $ \_ -> do
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program
   ports <- H.evalIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
-  (socket, port) <- liftIO $ openOnePortFrom ports
+  (socket, port) <- H.evalIO $ openOnePortFrom ports
   void $ IO.register $ IO.close socket
   result <- H.isPortOpen port
   result === True
@@ -55,7 +54,7 @@ hprop_isPortOpen_True = H.propertyOnce . H.workspace "temp-network" $ \_ -> do
         openOnePortFrom ports = case ports of
           [] -> error "Could not open any ports"
           (n:ns) -> do
-            socketResult <- IO.try . liftIO $ IO.listenOn n
+            socketResult <- IO.try $ IO.listenOn n
             case socketResult of
               Right socket -> return (socket, n)
               Left (_ :: IOException) -> openOnePortFrom ns

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -24,7 +24,7 @@ module Testnet.Cardano
 import           Prelude
 
 import           Control.Monad
-import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Except
 import qualified Data.Aeson as J
 import qualified Data.ByteString as BS
@@ -777,6 +777,6 @@ getByronGenesisHash path = do
 
 getShelleyGenesisHash :: (H.MonadTest m, MonadIO m) => FilePath -> m J.Value
 getShelleyGenesisHash path = do
-  content <- liftIO $ BS.readFile path
+  content <- H.evalIO $ BS.readFile path
   let genesisHash = Cardano.Crypto.Hash.Class.hashWith id content :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 BS.ByteString
   pure $ J.toJSON genesisHash

--- a/cardano-testnet/src/Testnet/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Cardano.hs
@@ -383,11 +383,11 @@ cardanoTestnet testnetOptions H.Conf {..} = do
   -- configuration files.
   let sourceAlonzoGenesisSpecFile = base </> "cardano-cli/test/data/golden/alonzo/genesis.alonzo.spec.json"
   alonzoSpecFile <- H.noteTempFile tempAbsPath "shelley/genesis.alonzo.spec.json"
-  liftIO $ IO.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
+  H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
 
   let sourceConwayGenesisSpecFile = base </> "cardano-cli/test/data/golden/conway/genesis.conway.spec.json"
   conwaySpecFile <- H.noteTempFile tempAbsPath "shelley/genesis.conway.spec.json"
-  liftIO $ IO.copyFile sourceConwayGenesisSpecFile conwaySpecFile
+  H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
 
   execCli_
     [ "genesis", "create"

--- a/cardano-testnet/src/Testnet/Run.hs
+++ b/cardano-testnet/src/Testnet/Run.hs
@@ -27,7 +27,7 @@ testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "testnet" $
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic
 
   -- Fork a thread to keep alive indefinitely any resources allocated by testnet.
-  void . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000
+  void . H.evalM . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000
 
   void $ tn conf
 

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -435,7 +435,7 @@ hprop_testnet = H.integrationRetryWorkspace 2 "shelley-testnet" $ \tempAbsPath' 
   configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- H.mkConf (H.ProjectBase base) (H.YamlFilePath configurationTemplate) tempAbsPath' Nothing
 
-  void . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000
+  void . H.evalM . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000
 
   void $ shelleyTestnet defaultTestnetOptions conf
 
@@ -443,4 +443,4 @@ hprop_testnet = H.integrationRetryWorkspace 2 "shelley-testnet" $ \tempAbsPath' 
 
 hprop_testnet_pause :: H.Property
 hprop_testnet_pause = H.integration $ do
-  void . forever . liftIO $ IO.threadDelay 10000000
+  void . forever . H.evalIO $ IO.threadDelay 10000000

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -182,11 +182,11 @@ shelleyTestnet testnetOptions H.Conf {..} = do
   -- configuration files.
   let sourceAlonzoGenesisSpecFile = base </> "cardano-cli/test/data/golden/alonzo/genesis.alonzo.spec.json"
   alonzoSpecFile <- H.noteTempFile tempAbsPath "genesis.alonzo.spec.json"
-  liftIO $ IO.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
+  H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
 
   let sourceConwayGenesisSpecFile = base </> "cardano-cli/test/data/golden/conway/genesis.conway.spec.json"
   conwaySpecFile <- H.noteTempFile tempAbsPath "genesis.conway.spec.json"
-  liftIO $ IO.copyFile sourceConwayGenesisSpecFile conwaySpecFile
+  H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
 
   -- Set up our template
   execCli_

--- a/cardano-testnet/src/Testnet/Util/Process.hs
+++ b/cardano-testnet/src/Testnet/Util/Process.hs
@@ -131,12 +131,12 @@ assertByDeadlineIOCustom
   :: (MonadTest m, MonadIO m, HasCallStack)
   => String -> UTCTime -> IO Bool -> m ()
 assertByDeadlineIOCustom str deadline f = GHC.withFrozenCallStack $ do
-  success <- liftIO f
+  success <- H.evalIO f
   unless success $ do
-    currentTime <- liftIO DTC.getCurrentTime
+    currentTime <- H.evalIO DTC.getCurrentTime
     if currentTime < deadline
       then do
-        liftIO $ IO.threadDelay 1000000
+        H.evalIO $ IO.threadDelay 1000000
         assertByDeadlineIOCustom str deadline f
       else do
         H.annotateShow currentTime

--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -14,7 +14,6 @@ import           Cardano.Api
 import           Prelude
 
 import           Cardano.CLI.Shelley.Output
-import           Control.Concurrent (threadDelay)
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad
 import           Control.Monad.IO.Class
@@ -24,11 +23,13 @@ import           GHC.Stack
 import           Options.Applicative
 import           System.Directory (doesFileExist, removeFile)
 
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import           Hedgehog.Extras.Test.Process (ExecConfig)
 import           Hedgehog.Internal.Property (MonadTest)
 
+import qualified Hedgehog.Extras.Test.Concurrent as H
 import           Testnet.Cardano (CardanoTestnetOptions (..), defaultTestnetOptions)
 import qualified Testnet.Util.Process as H
 
@@ -44,8 +45,8 @@ waitUntilEpoch
   -- ^ Desired epoch
   -> m EpochNo
 waitUntilEpoch fp testnetMagic execConfig desiredEpoch = do
-  exists <- liftIO $ doesFileExist fp
-  when exists $ liftIO $ removeFile fp
+  exists <- H.evalIO $ doesFileExist fp
+  when exists $ H.evalIO $ removeFile fp
 
   void $ H.execCli' execConfig
     [ "query",  "tip"
@@ -62,7 +63,7 @@ waitUntilEpoch fp testnetMagic execConfig desiredEpoch = do
     Just currEpoch ->
       if currEpoch >= desiredEpoch
       then return currEpoch
-      else do liftIO $ threadDelay 10_000_000
+      else do H.threadDelay 10_000_000
               waitUntilEpoch fp testnetMagic execConfig desiredEpoch
 
 queryTip
@@ -74,8 +75,8 @@ queryTip
   -> ExecConfig
   -> m QueryTipLocalStateOutput
 queryTip (QueryTipOutput fp) testnetMag execConfig = do
-  exists <- liftIO $ doesFileExist fp
-  when exists $ liftIO $ removeFile fp
+  exists <- H.evalIO $ doesFileExist fp
+  when exists $ H.evalIO $ removeFile fp
 
   void $ H.execCli' execConfig
     [ "query",  "tip"

--- a/cardano-testnet/test/Test/Misc.hs
+++ b/cardano-testnet/test/Test/Misc.hs
@@ -2,7 +2,6 @@ module Test.Misc where
 
 import           Prelude
 
-import           Control.Monad.IO.Class
 import           Data.List (isInfixOf)
 import qualified GHC.Stack as GHC
 
@@ -11,6 +10,7 @@ import           Cardano.CLI.Shelley.Run.Query
 import           Cardano.CLI.Types
 
 import           Hedgehog (success)
+import qualified Hedgehog as H
 import           Hedgehog.Extras.Test.Base (Integration, failMessage, note_)
 
 -- | This property checks that a given operational certificate has a valid specified KES starting period.
@@ -37,7 +37,7 @@ prop_op_cert_valid_kes_period opCertFp output =
 -- the node has minted blocks at any time in the past.
 prop_node_minted_block :: GHC.HasCallStack => FilePath -> Integration ()
 prop_node_minted_block nodeLogFp  = do
-  logs <- liftIO $ readFile nodeLogFp
+  logs <- H.evalIO $ readFile nodeLogFp
   -- TODO: Ideally we would parse the node's json logging file via the FromJSON LogObject
   -- instance. This will require all properties that depend on parsing the node's logs to
   -- only parse the JSON logs and not the plain text logs.


### PR DESCRIPTION
# Description

Avoid use of `liftIO` and use `evalIO` and `hedgehog-extras` versions of functions instead.

Using `liftIO` in `hedgehog` tests means that exceptions that are thrown are not ascribed to the correct file and line number in failure reports.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
