### PR TITLE
Delete `readEnvSocketPath` function

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -5,6 +5,9 @@
 
 ### Features
 
+- Delete `readEnvSocketPath` function.
+  ([PR 5207](https://github.com/input-output-hk/cardano-node/pull/5207))
+
 - Expose node config reading functionality: `NodeConfig`, `NodeConfigFile` and `readNodeConfig`
 
 - Expose genesis file reading functionality:
@@ -21,8 +24,8 @@
   ([PR 4341](https://github.com/input-output-hk/cardano-node/pull/4341))
 
 - Changed type of `protocolParamTxFeeFixed`, `protocolParamTxFeePerByte` from `Natural` to
-  `Lovelace` and `protocolUpdateTxFeeFixed` and `protocolUpdateTxFeePerByte` from `Maybe
-  Natural` to `Maybe Lovelace` ([PR 5013](https://github.com/input-output-hk/cardano-node/pull/5013))
+  `Lovelace` and `protocolUpdateTxFeeFixed` and `protocolUpdateTxFeePerByte` from `Maybe Natural`
+  to `Maybe Lovelace` ([PR 5013](https://github.com/input-output-hk/cardano-node/pull/5013))
 
 - Append, not prepend change output when balancing a transaction ([PR 4343](https://github.com/input-output-hk/cardano-node/pull/4343))
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -787,7 +787,6 @@ module Cardano.Api (
     -- * Node socket related
     EnvSocketError(..),
     SocketPath(..),
-    readEnvSocketPath,
     renderEnvSocketError,
 
     NodeToClientVersion(..),

--- a/cardano-api/src/Cardano/Api/Environment.hs
+++ b/cardano-api/src/Cardano/Api/Environment.hs
@@ -4,14 +4,11 @@
 module Cardano.Api.Environment
   ( EnvSocketError(..)
   , SocketPath(..)
-  , readEnvSocketPath
   , renderEnvSocketError
   ) where
 
 import           Data.Aeson
 import           Data.Text (Text)
-import qualified Data.Text as Text
-import           System.Environment (lookupEnv)
 
 import           Cardano.Api.Utils (textShow)
 
@@ -26,17 +23,3 @@ renderEnvSocketError err =
   case err of
     CliEnvVarLookup txt ->
       "Error while looking up environment variable: CARDANO_NODE_SOCKET_PATH " <> " Error: " <> textShow txt
-
--- | Read the node socket path from the environment.
--- Fails if the environment variable is not set.
-readEnvSocketPath :: IO (Either EnvSocketError SocketPath)
-readEnvSocketPath = do
-    mEnvName <- lookupEnv envName
-    case mEnvName of
-      Just sPath ->
-        return . Right $ SocketPath sPath
-      Nothing ->
-        return . Left $ CliEnvVarLookup (Text.pack envName)
-  where
-    envName :: String
-    envName = "CARDANO_NODE_SOCKET_PATH"

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -97,16 +97,6 @@ txSubmitApp trace metrics connectInfo networkId socketPath =
       { _txSubmitPost = txSubmitPost trace metrics connectInfo networkId socketPath
       }
 
--- | Read the node socket path from the environment.
--- Fails if the environment variable is not set.
-readEnvSocketPath :: ExceptT EnvSocketError IO SocketPath
-readEnvSocketPath =
-    maybe (left $ CliEnvVarLookup (T.pack envName)) (pure . SocketPath)
-      =<< liftIO (lookupEnv envName)
-  where
-    envName :: String
-    envName = "CARDANO_NODE_SOCKET_PATH"
-
 deserialiseOne :: forall b. ()
   => FromSomeType SerialiseAsCBOR b
   -> ByteString


### PR DESCRIPTION
# Description

Delete `readEnvSocketPath` function pass in the `SocketPath` as argument explicitly instead.

This remnant code was causing `CARDANO_NODE_SOCKET_PATH` to be mandatory for a small number of commands.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
