### PR TITLE
CIP-1694 CLI commands

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -106,3 +106,11 @@ package snap-server
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+    type: git
+    location: git@github.com:input-output-hk/cardano-api.git
+    tag: 9b7c5f730a050c8c75c1f35752f287e07412abd7
+    subdir:
+      cardano-api
+      cardano-api-gen

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -82,6 +82,7 @@ library
                         Cardano.CLI.Shelley.Run
                         Cardano.CLI.Shelley.Run.Address
                         Cardano.CLI.Shelley.Run.Address.Info
+                        Cardano.CLI.Shelley.Run.DRep
                         Cardano.CLI.Shelley.Run.Genesis
                         Cardano.CLI.Shelley.Run.Governance
                         Cardano.CLI.Shelley.Run.Key

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -114,7 +114,7 @@ data StakeAddressCmd
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe (File () Out))
   | StakeAddressBuild StakeVerifier NetworkId (Maybe (File () Out))
   | StakeRegistrationCert StakeIdentifier (File () Out)
-  | StakeCredentialDelegationCert
+  | StakeCredentialPoolDelegationCert
       StakeIdentifier
       PoolDelegationTarget
       (File () Out)
@@ -128,7 +128,7 @@ renderStakeAddressCmd cmd =
     StakeAddressKeyHash {} -> "stake-address key-hash"
     StakeAddressBuild {} -> "stake-address build"
     StakeRegistrationCert {} -> "stake-address registration-certificate"
-    StakeCredentialDelegationCert {} -> "stake-address delegation-certificate"
+    StakeCredentialPoolDelegationCert {} -> "stake-address pool-delegation-certificate"
     StakeCredentialDeRegistrationCert {} -> "stake-address deregistration-certificate"
 
 data KeyCmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -117,7 +117,7 @@ data StakeAddressCmd
   | StakeCredentialPoolDelegationCert
       StakeIdentifier
       PoolDelegationTarget
-      (File () Out)
+      (File Certificate Out)
   | StakeCredentialDeRegistrationCert StakeIdentifier (File () Out)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Shelley.Commands
   ( -- * CLI command types
     ShelleyCommand (..)
   , AddressCmd (..)
+  , DRepCmd (..)
   , StakeAddressCmd (..)
   , KeyCmd (..)
   , TransactionCmd (..)
@@ -46,7 +47,7 @@ module Cardano.CLI.Shelley.Commands
 
 import           Prelude
 
-import           Cardano.Api.Shelley
+import           Cardano.Api.Shelley hiding (DRepMetadataHash)
 
 import           Data.Text (Text)
 
@@ -65,6 +66,7 @@ import           Cardano.Ledger.Shelley.TxBody (MIRPot)
 --
 data ShelleyCommand
   = AddressCmd      AddressCmd
+  | DRepCmd         DRepCmd
   | StakeAddressCmd StakeAddressCmd
   | KeyCmd          KeyCmd
   | TransactionCmd  TransactionCmd
@@ -79,6 +81,7 @@ renderShelleyCommand :: ShelleyCommand -> Text
 renderShelleyCommand sc =
   case sc of
     AddressCmd cmd -> renderAddressCmd cmd
+    DRepCmd cmd -> renderDRepCmd cmd
     StakeAddressCmd cmd -> renderStakeAddressCmd cmd
     KeyCmd cmd -> renderKeyCmd cmd
     TransactionCmd cmd -> renderTransactionCmd cmd
@@ -326,6 +329,28 @@ data PoolCmd
   | PoolMetadataHash (File StakePoolMetadata In) (Maybe (File () Out))
   deriving Show
 
+data DRepCmd
+  = DRepRegistrationCert
+      NetworkId
+      -- ^ Network ID.
+      (VerificationKeyOrFile DRepKey)
+      -- ^ DRep verification key.
+      (VerificationKeyOrFile VrfKey)
+      -- ^ VRF Verification key.
+      (Maybe DRepMetadataReference)
+      -- ^  DRep metadata.
+      (File () Out)
+      -- ^ File path to where the certificate will be written.
+  | DRepRetirementCert
+      (VerificationKeyOrFile DRepKey)
+      -- ^ DRep verification key.
+      EpochNo
+      -- ^ Epoch in which to retire the  DRep.
+      (File Certificate Out)
+  | DRepGetId (VerificationKeyOrFile DRepKey) OutputFormat
+  | DRepMetadataHash (File DRepMetadata In) (Maybe (File () Out))
+  deriving Show
+
 renderPoolCmd :: PoolCmd -> Text
 renderPoolCmd cmd =
   case cmd of
@@ -333,6 +358,14 @@ renderPoolCmd cmd =
     PoolRetirementCert {} -> "stake-pool deregistration-certificate"
     PoolGetId {} -> "stake-pool id"
     PoolMetadataHash {} -> "stake-pool metadata-hash"
+
+renderDRepCmd :: DRepCmd -> Text
+renderDRepCmd cmd =
+  case cmd of
+    DRepRegistrationCert {} -> "drep registration-certificate"
+    DRepRetirementCert {} -> "drep deregistration-certificate"
+    DRepGetId {} -> "drep id"
+    DRepMetadataHash {} -> "drep metadata-hash"
 
 data QueryCmd =
     QueryLeadershipSchedule

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -14,7 +14,15 @@ module Cardano.CLI.Shelley.Commands
   , NodeCmd (..)
   , PoolCmd (..)
   , QueryCmd (..)
+  , Vote (..)
+  , GovernanceAction (..)
+  , GovernanceVote (..)
   , GovernanceCmd (..)
+  , GovernanceActionCmd (..)
+  , GovernanceVoteCmd (..)
+  , GovernanceActionId (..)
+  , GovernanceActionReceipt (..)
+  , GovernanceActionQueryResult (..)
   , GenesisCmd (..)
   , TextViewCmd (..)
   , renderShelleyCommand
@@ -43,6 +51,7 @@ module Cardano.CLI.Shelley.Commands
   , BlockId (..)
   , WitnessSigningData (..)
   , ColdVerificationKeyOrFile (..)
+  , GovernanceActionInfoResource(..)
   ) where
 
 import           Prelude
@@ -51,9 +60,9 @@ import           Cardano.Api.Shelley hiding (DRepMetadataHash)
 
 import           Data.Text (Text)
 
-import           Cardano.CLI.Shelley.Key (PaymentVerifier, PoolDelegationTarget, StakeIdentifier,
-                   StakeVerifier, VerificationKeyOrFile, VerificationKeyOrHashOrFile,
-                   VerificationKeyTextOrFile)
+import           Cardano.CLI.Shelley.Key (DRepDelegationTarget, PaymentVerifier,
+                   PoolDelegationTarget, StakeIdentifier, StakeVerifier, VerificationKeyOrFile,
+                   VerificationKeyOrHashOrFile, VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
 
 import           Cardano.Chain.Common (BlockCount)
@@ -121,6 +130,10 @@ data StakeAddressCmd
       StakeIdentifier
       PoolDelegationTarget
       (File Certificate Out)
+  | StakeCredentialDRepDelegationCert
+      StakeIdentifier
+      DRepDelegationTarget
+      (File Certificate Out)
   | StakeCredentialDeRegistrationCert StakeIdentifier (File () Out)
   deriving Show
 
@@ -132,6 +145,7 @@ renderStakeAddressCmd cmd =
     StakeAddressBuild {} -> "stake-address build"
     StakeRegistrationCert {} -> "stake-address registration-certificate"
     StakeCredentialPoolDelegationCert {} -> "stake-address pool-delegation-certificate"
+    StakeCredentialDRepDelegationCert {} -> "stake-address drep-delegation-certificate"
     StakeCredentialDeRegistrationCert {} -> "stake-address deregistration-certificate"
 
 data KeyCmd
@@ -335,8 +349,6 @@ data DRepCmd
       -- ^ Network ID.
       (VerificationKeyOrFile DRepKey)
       -- ^ DRep verification key.
-      (VerificationKeyOrFile VrfKey)
-      -- ^ VRF Verification key.
       (Maybe DRepMetadataReference)
       -- ^  DRep metadata.
       (File () Out)
@@ -425,6 +437,69 @@ renderQueryCmd cmd =
         TxMempoolQueryNextTx -> "next-tx"
         TxMempoolQueryInfo -> "info"
 
+data GovernanceAction =
+    GovernanceActionOfNoConfidenceMotion
+  | GovernanceActionOfNewCommittee
+  | GovernanceActionOfConstitutionUpdate
+  | GovernanceActionOfHardForkInitiation
+  | GovernanceActionOfProtocolParameterUpdate
+      ProtocolParametersUpdate
+  | GovernanceActionOfTreasuryWithdrawal
+  | GovernanceActionOfInfo
+      GovernanceActionInfoResource
+  deriving Show
+
+data GovernanceActionInfoResource
+  = GovernanceActionInfoResourceOfFile (File () In)
+  | GovernanceActionInfoResourceOfUrl (File () In)
+  deriving Show
+
+data Vote = VoteYes | VoteNo | VoteAbstain deriving Show
+
+data GovernanceVote = GovernanceVote deriving Show
+
+data GovernanceActionId = GovernanceActionId deriving Show
+
+newtype GovernanceActionReceipt = GovernanceActionReceipt
+  { governanceActionSubmissionActionId :: GovernanceActionId
+  } deriving Show
+
+newtype GovernanceActionQueryResult = GovernanceActionQueryResult
+  { governanceActionQueryResultActionId :: GovernanceActionId
+  } deriving Show
+
+data GovernanceActionCmd
+  = GovernanceActionCreate
+      [StakeVerifier] -- ^ Signing keys for any ADA holder XXXXX
+      GovernanceAction
+      (File GovernanceAction Out) -- ^ Filepath to write the governance action
+  | GovernanceActionView
+      (File GovernanceAction In) -- ^ Filepath to write the governance action
+  | GovernanceActionQuery
+      SocketPath
+      NetworkId
+      GovernanceActionId -- ^ The ID of the governance action
+      (Maybe (File GovernanceActionQueryResult Out))
+  | GovernanceActionSubmit
+      SocketPath
+      NetworkId
+      (File GovernanceAction In) -- ^ Filepath to write the governance action
+      (Maybe (File GovernanceActionReceipt Out)) -- ^ Receipt of the submission of the action
+  deriving Show
+
+data GovernanceVoteCmd
+  = GovernanceVoteCreate
+      (SigningKeyFile In)
+      (File GovernanceAction In) -- ^ Filepath to governance action
+      Vote -- ^ Vote in favour?
+      (File GovernanceVote Out) -- ^ Filepath to write the governance vote
+  | GovernanceVoteView
+      (File GovernanceVote In) -- ^ Filepath to write the governance vote
+  | GovernanceVoteSubmit
+      SocketPath
+      NetworkId
+      (File GovernanceVote In) -- ^ Filepath to write the governance vote
+  deriving Show
 
 data GovernanceCmd
   = GovernanceMIRPayStakeAddressesCertificate
@@ -442,6 +517,8 @@ data GovernanceCmd
                              [VerificationKeyFile In]
                              ProtocolParametersUpdate
                              (Maybe FilePath)
+  | GovernanceActionCmd GovernanceActionCmd
+  | GovernanceVoteCmd GovernanceVoteCmd
   | GovernanceCreatePoll
       Text -- Prompt
       [Text] -- Choices
@@ -464,6 +541,8 @@ renderGovernanceCmd cmd =
     GovernanceMIRPayStakeAddressesCertificate {} -> "governance create-mir-certificate stake-addresses"
     GovernanceMIRTransfer _ _ TransferToTreasury -> "governance create-mir-certificate transfer-to-treasury"
     GovernanceMIRTransfer _ _ TransferToReserves -> "governance create-mir-certificate transfer-to-reserves"
+    GovernanceActionCmd {} -> "governance action"
+    GovernanceVoteCmd {} -> "governance vote"
     GovernanceUpdateProposal {} -> "governance create-update-proposal"
     GovernanceCreatePoll{} -> "governance create-poll"
     GovernanceAnswerPoll{} -> "governance answer-poll"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -50,7 +50,7 @@ import           Cardano.Api.Shelley
 
 import           Data.Text (Text)
 
-import           Cardano.CLI.Shelley.Key (DelegationTarget, PaymentVerifier, StakeIdentifier,
+import           Cardano.CLI.Shelley.Key (PaymentVerifier, PoolDelegationTarget, StakeIdentifier,
                    StakeVerifier, VerificationKeyOrFile, VerificationKeyOrHashOrFile,
                    VerificationKeyTextOrFile)
 import           Cardano.CLI.Types
@@ -116,7 +116,7 @@ data StakeAddressCmd
   | StakeRegistrationCert StakeIdentifier (File () Out)
   | StakeCredentialDelegationCert
       StakeIdentifier
-      DelegationTarget
+      PoolDelegationTarget
       (File () Out)
   | StakeCredentialDeRegistrationCert StakeIdentifier (File () Out)
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -26,7 +26,7 @@ module Cardano.CLI.Shelley.Key
 
   , generateKeyPair
 
-  , DelegationTarget(..)
+  , PoolDelegationTarget(..)
   ) where
 
 import           Cardano.Api
@@ -115,7 +115,7 @@ data StakeIdentifier
 
 -- | A resource that identifies the delegation target.  At the moment a delegation
 -- target can only be a stake pool.
-newtype DelegationTarget
+newtype PoolDelegationTarget
   = StakePoolDelegationTarget (VerificationKeyOrHashOrFile StakePoolKey)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -27,6 +27,7 @@ module Cardano.CLI.Shelley.Key
   , generateKeyPair
 
   , PoolDelegationTarget(..)
+  , DRepDelegationTarget(..)
   ) where
 
 import           Cardano.Api
@@ -113,10 +114,15 @@ data StakeIdentifier
   | StakeIdentifierAddress StakeAddress
   deriving (Eq, Show)
 
--- | A resource that identifies the delegation target.  At the moment a delegation
+-- | A resource that identifies the pool delegation target.  At the moment a delegation
 -- target can only be a stake pool.
 newtype PoolDelegationTarget
   = StakePoolDelegationTarget (VerificationKeyOrHashOrFile StakePoolKey)
+  deriving Show
+
+-- | A resource that identifies the drep delegation target.
+newtype DRepDelegationTarget
+  = DRepDelegationTarget (VerificationKeyOrHashOrFile DRepKey)
   deriving Show
 
 -- | Either an unvalidated text representation of a verification key or a path

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -409,7 +409,7 @@ pStakeAddressCmd envCli =
 
     pStakeAddressPoolDelegationCert :: Parser StakeAddressCmd
     pStakeAddressPoolDelegationCert =
-      StakeCredentialDelegationCert
+      StakeCredentialPoolDelegationCert
         <$> pStakeIdentifier
         <*> pPoolDelegationTarget
         <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -62,7 +62,7 @@ import           Cardano.Chain.Common (BlockCount (BlockCount))
 import           Cardano.CLI.Common.Parsers
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.Shelley.Commands
-import           Cardano.CLI.Shelley.Key (DelegationTarget (..), PaymentVerifier (..),
+import           Cardano.CLI.Shelley.Key (PaymentVerifier (..), PoolDelegationTarget (..),
                    StakeIdentifier (..), StakeVerifier (..), VerificationKeyOrFile (..),
                    VerificationKeyOrHashOrFile (..), VerificationKeyTextOrFile (..))
 import           Cardano.CLI.Types
@@ -411,7 +411,7 @@ pStakeAddressCmd envCli =
     pStakeAddressPoolDelegationCert =
       StakeCredentialDelegationCert
         <$> pStakeIdentifier
-        <*> pDelegationTarget
+        <*> pPoolDelegationTarget
         <*> pOutputFile
 
 pKeyCmd :: Parser KeyCmd
@@ -2744,9 +2744,9 @@ pStakePoolVerificationKeyOrFile =
   VerificationKeyValue <$> pStakePoolVerificationKey
     <|> VerificationKeyFilePath <$> pStakePoolVerificationKeyFile
 
-pDelegationTarget
-  :: Parser DelegationTarget
-pDelegationTarget = StakePoolDelegationTarget <$> pStakePoolVerificationKeyOrHashOrFile
+pPoolDelegationTarget
+  :: Parser PoolDelegationTarget
+pPoolDelegationTarget = StakePoolDelegationTarget <$> pStakePoolVerificationKeyOrHashOrFile
 
 pStakePoolVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile StakePoolKey)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run.hs
@@ -23,11 +23,13 @@ import           Cardano.CLI.Shelley.Run.Query
 import           Cardano.CLI.Shelley.Run.StakeAddress
 import           Cardano.CLI.Shelley.Run.Transaction
                                          -- Block, System, DevOps
+import           Cardano.CLI.Shelley.Run.DRep
 import           Cardano.CLI.Shelley.Run.Genesis
 import           Cardano.CLI.Shelley.Run.TextView
 
 data ShelleyClientCmdError
   = ShelleyCmdAddressError !ShelleyAddressCmdError
+  | ShelleyCmdDRepError !ShelleyDRepCmdError
   | ShelleyCmdGenesisError !ShelleyGenesisCmdError
   | ShelleyCmdGovernanceError !ShelleyGovernanceCmdError
   | ShelleyCmdNodeError !ShelleyNodeCmdError
@@ -43,6 +45,8 @@ renderShelleyClientCmdError cmd err =
   case err of
     ShelleyCmdAddressError addrCmdErr ->
        renderError cmd renderShelleyAddressCmdError addrCmdErr
+    ShelleyCmdDRepError addrCmdErr ->
+       renderError cmd renderShelleyDRepCmdError addrCmdErr
     ShelleyCmdGenesisError genesisCmdErr ->
        renderError cmd (Text.pack . displayError) genesisCmdErr
     ShelleyCmdGovernanceError govCmdErr ->
@@ -77,6 +81,7 @@ renderShelleyClientCmdError cmd err =
 
 runShelleyClientCommand :: ShelleyCommand -> ExceptT ShelleyClientCmdError IO ()
 runShelleyClientCommand (AddressCmd      cmd) = firstExceptT ShelleyCmdAddressError $ runAddressCmd cmd
+runShelleyClientCommand (DRepCmd         cmd) = firstExceptT ShelleyCmdDRepError $ runDRepCmd cmd
 runShelleyClientCommand (StakeAddressCmd cmd) = firstExceptT ShelleyCmdStakeAddressError $ runStakeAddressCmd cmd
 runShelleyClientCommand (KeyCmd          cmd) = firstExceptT ShelleyCmdKeyError $ runKeyCmd cmd
 runShelleyClientCommand (TransactionCmd  cmd) = firstExceptT ShelleyCmdTransactionError $ runTransactionCmd  cmd

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/DRep.hs
@@ -18,7 +18,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 
 import           Cardano.Api
-import           Cardano.Api.Shelley hiding (DRepMetadataHash)
 import           Cardano.CLI.Shelley.Commands
 import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
 import           Cardano.CLI.Types (OutputFormat (..))
@@ -44,8 +43,8 @@ renderShelleyDRepCmdError err =
 
 
 runDRepCmd :: DRepCmd -> ExceptT ShelleyDRepCmdError IO ()
-runDRepCmd (DRepRegistrationCert network sPvkey vrfVkey mbMetadata outfp) =
-  runDRepRegistrationCert network sPvkey vrfVkey mbMetadata outfp
+runDRepCmd (DRepRegistrationCert network sPvkey mbMetadata outfp) =
+  runDRepRegistrationCert network sPvkey mbMetadata outfp
 runDRepCmd (DRepRetirementCert sPvkeyFp retireEpoch outfp) =
   runDRepRetirementCert sPvkeyFp retireEpoch outfp
 runDRepCmd (DRepGetId sPvkey outputFormat) = runDRepId sPvkey outputFormat
@@ -63,15 +62,12 @@ runDRepRegistrationCert
   -- ^ Network ID.
   -> VerificationKeyOrFile DRepKey
   -- ^ DRep verification key.
-  -> VerificationKeyOrFile VrfKey
-  -- ^ VRF Verification key.
   -> Maybe DRepMetadataReference
   -- ^ DRep metadata.
   -> File () Out
   -> ExceptT ShelleyDRepCmdError IO ()
 runDRepRegistrationCert
   _drepVerKeyOrFile
-  _vrfVerKeyOrFile
   _mbMetadata
   _network
   _outfp = error "Not implemented"

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/DRep.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.CLI.Shelley.Run.DRep
+  ( ShelleyDRepCmdError(ShelleyDRepCmdReadFileError)
+  , renderShelleyDRepCmdError
+  , runDRepCmd
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans (lift)
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
+                   newExceptT, onLeft)
+import qualified Data.ByteString.Char8 as BS
+import           Data.Function ((&))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+
+import           Cardano.Api
+import           Cardano.Api.Shelley hiding (DRepMetadataHash)
+import           Cardano.CLI.Shelley.Commands
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
+import           Cardano.CLI.Types (OutputFormat (..))
+
+import qualified Cardano.Ledger.Slot as Shelley
+
+data ShelleyDRepCmdError
+  = ShelleyDRepCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyDRepCmdReadKeyFileError !(FileError InputDecodeError)
+  | ShelleyDRepCmdWriteFileError !(FileError ())
+  | ShelleyDRepCmdMetadataValidationError !DRepMetadataValidationError
+  deriving Show
+
+renderShelleyDRepCmdError :: ShelleyDRepCmdError -> Text
+renderShelleyDRepCmdError err =
+  case err of
+    ShelleyDRepCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyDRepCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyDRepCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyDRepCmdMetadataValidationError validationErr ->
+      "Error validating drep metadata: " <> Text.pack (displayError validationErr)
+
+
+
+runDRepCmd :: DRepCmd -> ExceptT ShelleyDRepCmdError IO ()
+runDRepCmd (DRepRegistrationCert network sPvkey vrfVkey mbMetadata outfp) =
+  runDRepRegistrationCert network sPvkey vrfVkey mbMetadata outfp
+runDRepCmd (DRepRetirementCert sPvkeyFp retireEpoch outfp) =
+  runDRepRetirementCert sPvkeyFp retireEpoch outfp
+runDRepCmd (DRepGetId sPvkey outputFormat) = runDRepId sPvkey outputFormat
+runDRepCmd (DRepMetadataHash drepMetadataFile mOutFile) = runDRepMetadataHash drepMetadataFile mOutFile
+
+--
+-- DRep command implementations
+--
+
+-- | Create a drep registration cert.
+-- TODO: Metadata and more drep relay support to be
+-- added in the future.
+runDRepRegistrationCert
+  :: NetworkId
+  -- ^ Network ID.
+  -> VerificationKeyOrFile DRepKey
+  -- ^ DRep verification key.
+  -> VerificationKeyOrFile VrfKey
+  -- ^ VRF Verification key.
+  -> Maybe DRepMetadataReference
+  -- ^ DRep metadata.
+  -> File () Out
+  -> ExceptT ShelleyDRepCmdError IO ()
+runDRepRegistrationCert
+  _drepVerKeyOrFile
+  _vrfVerKeyOrFile
+  _mbMetadata
+  _network
+  _outfp = error "Not implemented"
+
+runDRepRetirementCert
+  :: VerificationKeyOrFile DRepKey
+  -> Shelley.EpochNo
+  -> File Certificate Out
+  -> ExceptT ShelleyDRepCmdError IO ()
+runDRepRetirementCert _drepVerKeyOrFile _retireEpoch _outfp = error "Not implemented"
+
+runDRepId
+  :: VerificationKeyOrFile DRepKey
+  -> OutputFormat
+  -> ExceptT ShelleyDRepCmdError IO ()
+runDRepId verKeyOrFile outputFormat = do
+    drepVerKey <- firstExceptT ShelleyDRepCmdReadKeyFileError
+      . newExceptT
+      $ readVerificationKeyOrFile AsDRepKey verKeyOrFile
+    liftIO $
+      case outputFormat of
+        OutputFormatHex ->
+          BS.putStrLn $ serialiseToRawBytesHex (verificationKeyHash drepVerKey)
+        OutputFormatBech32 ->
+          Text.putStrLn $ serialiseToBech32 (verificationKeyHash drepVerKey)
+
+runDRepMetadataHash :: File DRepMetadata In -> Maybe (File () Out) -> ExceptT ShelleyDRepCmdError IO ()
+runDRepMetadataHash drepMDPath mOutFile = do
+  metadataBytes <- lift (readByteStringFile drepMDPath)
+    & onLeft (left . ShelleyDRepCmdReadFileError)
+
+  (_metadata, metadataHash) <-
+      firstExceptT ShelleyDRepCmdMetadataValidationError
+    . hoistEither
+    $ validateAndHashDRepMetadata metadataBytes
+  case mOutFile of
+    Nothing -> liftIO $ BS.putStrLn (serialiseToRawBytesHex metadataHash)
+    Just (File fpath) ->
+      handleIOExceptT (ShelleyDRepCmdWriteFileError . FileIOError fpath)
+        $ BS.writeFile fpath (serialiseToRawBytesHex metadataHash)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -31,7 +32,7 @@ import           System.IO (stderr, stdin, stdout)
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Shelley.Key (VerificationKeyOrHashOrFile,
+import           Cardano.CLI.Shelley.Key (StakeVerifier, VerificationKeyOrHashOrFile,
                    readVerificationKeyOrHashOrFile, readVerificationKeyOrHashOrTextEnvFile)
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Shelley.Run.Read (CddlError, fileOrPipe, readFileTx)
@@ -101,21 +102,44 @@ renderShelleyGovernanceError err =
       renderGovernancePollError pollError
     ShelleyGovernanceCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
 
+runGovernanceActionCmd :: GovernanceActionCmd -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceActionCmd = \case
+  GovernanceActionCreate genVKeys action out ->
+    runGovernanceActionCreate genVKeys action out
+  GovernanceActionView actionFile ->
+    runGovernanceActionView actionFile
+  GovernanceActionQuery socketPath nw actionId mResultFile ->
+    runGovernanceActionQuery socketPath nw actionId mResultFile
+  GovernanceActionSubmit socketPath nw actionFile receiptFile ->
+    runGovernanceActionSubmit socketPath nw actionFile receiptFile
+
+runGovernanceVoteCmd :: GovernanceVoteCmd -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceVoteCmd = \case
+  GovernanceVoteCreate signinKeyFile action vote out ->
+    runGovernanceVoteCreate signinKeyFile action vote out
+  GovernanceVoteView voteFile ->
+    runGovernanceVoteView voteFile
+  GovernanceVoteSubmit socketPath nw voteFile ->
+    runGovernanceVoteSubmit socketPath nw voteFile
+
 runGovernanceCmd :: GovernanceCmd -> ExceptT ShelleyGovernanceCmdError IO ()
-runGovernanceCmd (GovernanceMIRPayStakeAddressesCertificate mirpot vKeys rewards out) =
-  runGovernanceMIRCertificatePayStakeAddrs mirpot vKeys rewards out
-runGovernanceCmd (GovernanceMIRTransfer amt out direction) =
-  runGovernanceMIRCertificateTransfer amt out direction
-runGovernanceCmd (GovernanceGenesisKeyDelegationCertificate genVk genDelegVk vrfVk out) =
-  runGovernanceGenesisKeyDelegationCertificate genVk genDelegVk vrfVk out
-runGovernanceCmd (GovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp) =
-  runGovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp
-runGovernanceCmd (GovernanceCreatePoll prompt choices nonce out) =
-  runGovernanceCreatePoll prompt choices nonce out
-runGovernanceCmd (GovernanceAnswerPoll poll ix mOutFile) =
-  runGovernanceAnswerPoll poll ix mOutFile
-runGovernanceCmd (GovernanceVerifyPoll poll metadata mOutFile) =
-  runGovernanceVerifyPoll poll metadata mOutFile
+runGovernanceCmd = \case
+  GovernanceMIRPayStakeAddressesCertificate mirpot vKeys rewards out ->
+    runGovernanceMIRCertificatePayStakeAddrs mirpot vKeys rewards out
+  GovernanceMIRTransfer amt out direction ->
+    runGovernanceMIRCertificateTransfer amt out direction
+  GovernanceGenesisKeyDelegationCertificate genVk genDelegVk vrfVk out ->
+    runGovernanceGenesisKeyDelegationCertificate genVk genDelegVk vrfVk out
+  GovernanceActionCmd cmd -> runGovernanceActionCmd cmd
+  GovernanceVoteCmd cmd -> runGovernanceVoteCmd cmd
+  GovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp ->
+    runGovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp
+  GovernanceCreatePoll prompt choices nonce out ->
+    runGovernanceCreatePoll prompt choices nonce out
+  GovernanceAnswerPoll poll ix mOutFile ->
+    runGovernanceAnswerPoll poll ix mOutFile
+  GovernanceVerifyPoll poll metadata mOutFile ->
+    runGovernanceVerifyPoll poll metadata mOutFile
 
 runGovernanceMIRCertificatePayStakeAddrs
   :: Shelley.MIRPot
@@ -188,6 +212,69 @@ runGovernanceGenesisKeyDelegationCertificate genVkOrHashOrFp
   where
     genKeyDelegCertDesc :: TextEnvelopeDescr
     genKeyDelegCertDesc = "Genesis Key Delegation Certificate"
+
+runGovernanceActionCreate
+  :: [StakeVerifier]
+  -- ^ Genesis verification keys
+  -> GovernanceAction
+  -> File GovernanceAction Out
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceActionCreate _genVerKeyFiles _action _outFile =
+  error "TODO CIP-1694 Not implemented"
+
+runGovernanceActionView
+  :: File GovernanceAction In
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceActionView _actionFile =
+  error "TODO CIP-1694 Not implemented"
+
+runGovernanceActionQuery
+  :: SocketPath
+  -> NetworkId
+  -> GovernanceActionId
+  -> Maybe (File GovernanceActionQueryResult Out)
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceActionQuery _socketPath _nw _actionId _outFile =
+  error "TODO CIP-1694 Not implemented"
+
+runGovernanceActionSubmit
+  :: SocketPath
+  -> NetworkId
+  -> File GovernanceAction In
+  -> Maybe (File GovernanceActionReceipt Out)
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceActionSubmit _socketPath _nw _actionFile _outFile =
+  error "TODO CIP-1694 Not implemented"
+
+runGovernanceVoteCreate
+  :: SigningKeyFile In
+  -> File GovernanceAction In -- ^ Filepath to governance action
+  -> Vote -- ^ Vote in favour?
+  -> File GovernanceVote Out -- ^ Filepath to write the governance vote
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceVoteCreate _signinKeyFile _action _vote _out =
+  error "TODO CIP-1694 Not implemented"
+
+  -- TODO potentially things to store in the governance action transaction:
+  --
+  --   the governance action ID
+  --   the epoch that the action expires
+  --   the deposit amount
+  --   the rewards address that will receive the deposit when it is returned
+
+runGovernanceVoteView
+  :: File GovernanceVote In -- ^ Filepath to governance vote
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceVoteView _voteFile =
+  error "TODO CIP-1694 Not implemented"
+
+runGovernanceVoteSubmit
+  :: SocketPath
+  -> NetworkId
+  -> File GovernanceVote In -- ^ Filepath to governance vote
+  -> ExceptT ShelleyGovernanceCmdError IO ()
+runGovernanceVoteSubmit _socketPath _nw _voteFile =
+  error "TODO CIP-1694 Not implemented"
 
 runGovernanceUpdateProposal
   :: File () Out

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -49,8 +49,8 @@ runStakeAddressCmd (StakeAddressBuild stakeVerifier nw mOutputFp) =
   runStakeAddressBuild stakeVerifier nw mOutputFp
 runStakeAddressCmd (StakeRegistrationCert stakeIdentifier outputFp) =
   runStakeCredentialRegistrationCert stakeIdentifier outputFp
-runStakeAddressCmd (StakeCredentialDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
-  runStakeCredentialDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp
+runStakeAddressCmd (StakeCredentialPoolDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
+  runStakeCredentialPoolDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp
 runStakeAddressCmd (StakeCredentialDeRegistrationCert stakeIdentifier outputFp) =
   runStakeCredentialDeRegistrationCert stakeIdentifier outputFp
 
@@ -127,7 +127,7 @@ runStakeCredentialRegistrationCert stakeIdentifier oFp = do
   regCertDesc = "Stake Address Registration Certificate"
 
 
-runStakeCredentialDelegationCert
+runStakeCredentialPoolDelegationCert
   :: StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
   -> PoolDelegationTarget
@@ -135,7 +135,7 @@ runStakeCredentialDelegationCert
   -- verification key hash.
   -> File () Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runStakeCredentialDelegationCert stakeVerifier delegationTarget outFp =
+runStakeCredentialPoolDelegationCert stakeVerifier delegationTarget outFp =
   case delegationTarget of
     StakePoolDelegationTarget poolVKeyOrHashOrFile -> do
       poolStakeVKeyHash <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -20,7 +20,7 @@ import qualified Data.Text.IO as Text
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Shelley.Key (DelegationTarget (..), StakeIdentifier (..),
+import           Cardano.CLI.Shelley.Key (PoolDelegationTarget (..), StakeIdentifier (..),
                    StakeVerifier (..), VerificationKeyOrFile, readVerificationKeyOrFile,
                    readVerificationKeyOrHashOrFile)
 import           Cardano.CLI.Shelley.Parsers
@@ -130,7 +130,7 @@ runStakeCredentialRegistrationCert stakeIdentifier oFp = do
 runStakeCredentialDelegationCert
   :: StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
-  -> DelegationTarget
+  -> PoolDelegationTarget
   -- ^ Delegatee stake pool verification key or verification key file or
   -- verification key hash.
   -> File () Out

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -133,7 +133,7 @@ runStakeCredentialPoolDelegationCert
   -> PoolDelegationTarget
   -- ^ Delegatee stake pool verification key or verification key file or
   -- verification key hash.
-  -> File () Out
+  -> File Certificate Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
 runStakeCredentialPoolDelegationCert stakeVerifier delegationTarget outFp =
   case delegationTarget of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/StakeAddress.hs
@@ -20,9 +20,9 @@ import qualified Data.Text.IO as Text
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Shelley.Key (PoolDelegationTarget (..), StakeIdentifier (..),
-                   StakeVerifier (..), VerificationKeyOrFile, readVerificationKeyOrFile,
-                   readVerificationKeyOrHashOrFile)
+import           Cardano.CLI.Shelley.Key (DRepDelegationTarget (..), PoolDelegationTarget (..),
+                   StakeIdentifier (..), StakeVerifier (..), VerificationKeyOrFile,
+                   readVerificationKeyOrFile, readVerificationKeyOrHashOrFile)
 import           Cardano.CLI.Shelley.Parsers
 import           Cardano.CLI.Shelley.Run.Read
 import           Cardano.CLI.Types
@@ -51,6 +51,8 @@ runStakeAddressCmd (StakeRegistrationCert stakeIdentifier outputFp) =
   runStakeCredentialRegistrationCert stakeIdentifier outputFp
 runStakeAddressCmd (StakeCredentialPoolDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
   runStakeCredentialPoolDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp
+runStakeAddressCmd (StakeCredentialDRepDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
+  runStakeCredentialDRepDelegationCert stakeIdentifier stkPoolVerKeyHashOrFp outputFp
 runStakeAddressCmd (StakeCredentialDeRegistrationCert stakeIdentifier outputFp) =
   runStakeCredentialDeRegistrationCert stakeIdentifier outputFp
 
@@ -146,6 +148,17 @@ runStakeCredentialPoolDelegationCert stakeVerifier delegationTarget outFp =
         . newExceptT
         $ writeLazyByteStringFile outFp
         $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Address Delegation Certificate") delegCert
+
+runStakeCredentialDRepDelegationCert
+  :: StakeIdentifier
+  -- ^ Delegator stake verification key, verification key file or script file.
+  -> DRepDelegationTarget
+  -- ^ Delegatee drep verification key or verification key file or
+  -- verification key hash.
+  -> File Certificate Out
+  -> ExceptT ShelleyStakeAddressCmdError IO ()
+runStakeCredentialDRepDelegationCert _stakeVerifier _delegationTarget _outFp =
+  error "TODO CIP-1694 Not implemented"
 
 runStakeCredentialDeRegistrationCert
   :: StakeIdentifier

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -12,6 +12,8 @@ Usage: cardano-cli text-view decode-cbor --in-file FILE [--out-file FILE]
 Usage: cardano-cli governance 
             ( create-mir-certificate
             | create-genesis-key-delegation-certificate
+            | action
+            | vote
             | create-update-proposal
             | create-poll
             | answer-poll
@@ -68,6 +70,149 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
             --out-file FILE
 
   Create a genesis key delegation certificate
+
+Usage: cardano-cli governance action 
+            ( create-no-confidence-motion
+            | create-new-committee
+            | create-constitution-update
+            | create-hard-fork-initiation
+            | create-protocol-parameter-update
+            | create-treasury-withdrawal
+            | create-info
+            | view
+            | query
+            | submit
+            )
+
+  Commands related to governance actions
+
+Usage: cardano-cli governance action create-no-confidence-motion 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a no-confidence motion action
+
+Usage: cardano-cli governance action create-new-committee 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a new-committee action
+
+Usage: cardano-cli governance action create-constitution-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a constitution-update action
+
+Usage: cardano-cli governance action create-hard-fork-initiation 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a hard-fork-initiation action
+
+Usage: cardano-cli governance action create-protocol-parameter-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
+            [--decentralization-parameter RATIONAL]
+            [--extra-entropy HEX | --reset-extra-entropy]
+            [--max-block-header-size NATURAL]
+            [--max-block-body-size NATURAL]
+            [--max-tx-size NATURAL]
+            [--min-fee-constant LOVELACE]
+            [--min-fee-linear LOVELACE]
+            [--min-utxo-value NATURAL]
+            [--key-reg-deposit-amt NATURAL]
+            [--pool-reg-deposit NATURAL]
+            [--min-pool-cost NATURAL]
+            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+            [--number-of-pools NATURAL]
+            [--pool-influence RATIONAL]
+            [--monetary-expansion RATIONAL]
+            [--treasury-expansion RATIONAL]
+            [--utxo-cost-per-word LOVELACE]
+            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
+            [--max-tx-execution-units (INT, INT)]
+            [--max-block-execution-units (INT, INT)]
+            [--max-value-size INT]
+            [--collateral-percent INT]
+            [--max-collateral-inputs INT]
+            [--utxo-cost-per-byte LOVELACE]
+            --out-file FILE
+
+  Create an protocol-parameter-update action
+
+Usage: cardano-cli governance action create-treasury-withdrawal 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create an treasury-withdrawal action
+
+Usage: cardano-cli governance action create-info 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            (--metadata-url URL | --metadata-file FILE)
+            --out-file FILE
+
+  Create an info action
+
+Usage: cardano-cli governance action view --action-file FILE
+
+  View an action
+
+Usage: cardano-cli governance action query --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-id STRING
+            [--out-file FILE]
+
+  Query an on-chain action
+
+Usage: cardano-cli governance action submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-file FILE
+            [--out-file FILE]
+
+  Submit an action
+
+Usage: cardano-cli governance vote (create | view | submit)
+
+  Commands related to governance votes
+
+Usage: cardano-cli governance vote create --signing-key-file FILE
+            --action-file FILE
+            (--vote-yes | --vote-no | --vote-abstain)
+            --out-file FILE
+
+  Create a vote
+
+Usage: cardano-cli governance vote view --vote-file FILE
+
+  View a vote
+
+Usage: cardano-cli governance vote submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --vote-file FILE
+
+  Submit a vote
 
 Usage: cardano-cli governance create-update-proposal --out-file FILE
             --epoch EPOCH
@@ -410,6 +555,47 @@ Usage: cardano-cli query tx-mempool next-tx
 Usage: cardano-cli query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli drep 
+            ( registration-certificate
+            | deregistration-certificate
+            | id
+            | metadata-hash
+            )
+
+  DRep commands
+
+Usage: cardano-cli drep registration-certificate 
+            (--mainnet | --testnet-magic NATURAL)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--metadata-url URL --metadata-hash HASH]
+            --out-file FILE
+
+  Create a DRep registration certificate
+
+Usage: cardano-cli drep deregistration-certificate 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            --epoch NATURAL
+            --out-file FILE
+
+  Create a DRep deregistration certificate
+
+Usage: cardano-cli drep id 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--output-format STRING]
+
+  Build DRep id from the offline key
+
+Usage: cardano-cli drep metadata-hash --drep-metadata-file FILE
+            [--out-file FILE]
+
+  Print the hash of DRep metadata.
 
 Usage: cardano-cli stake-pool 
             ( registration-certificate
@@ -968,7 +1154,8 @@ Usage: cardano-cli stake-address
             | key-hash
             | registration-certificate
             | deregistration-certificate
-            | delegation-certificate
+            | pool-delegation-certificate
+            | drep-delegation-certificate
             )
 
   Stake address commands
@@ -1016,7 +1203,7 @@ Usage: cardano-cli stake-address deregistration-certificate
 
   Create a stake address deregistration certificate
 
-Usage: cardano-cli stake-address delegation-certificate 
+Usage: cardano-cli stake-address pool-delegation-certificate 
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
             | --stake-script-file FILE
@@ -1029,6 +1216,20 @@ Usage: cardano-cli stake-address delegation-certificate
             --out-file FILE
 
   Create a stake address pool delegation certificate
+
+Usage: cardano-cli stake-address drep-delegation-certificate 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            | --stake-address ADDRESS
+            )
+            [ --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            | --drep-id DREP_ID
+            ]
+            --out-file FILE
+
+  Create a stake address drep delegation certificate
 
 Usage: cardano-cli address (key-gen | key-hash | build | info)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/drep.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/drep.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli drep 
+            ( registration-certificate
+            | deregistration-certificate
+            | id
+            | metadata-hash
+            )
+
+  DRep commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a DRep registration certificate
+  deregistration-certificate
+                           Create a DRep deregistration certificate
+  id                       Build DRep id from the offline key
+  metadata-hash            Print the hash of DRep metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli drep deregistration-certificate 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            --epoch NATURAL
+            --out-file FILE
+
+  Create a DRep deregistration certificate
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_id.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli drep id 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--output-format STRING]
+
+  Build DRep id from the offline key
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --output-format STRING   Optional output format. Accepted output formats are
+                           "hex" and "bech32" (default is "bech32").
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli drep metadata-hash --drep-metadata-file FILE
+            [--out-file FILE]
+
+  Print the hash of DRep metadata.
+
+Available options:
+  --drep-metadata-file FILE
+                           Filepath of the drep metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/drep_registration-certificate.cli
@@ -1,0 +1,23 @@
+Usage: cardano-cli drep registration-certificate 
+            (--mainnet | --testnet-magic NATURAL)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--metadata-url URL --metadata-hash HASH]
+            --out-file FILE
+
+  Create a DRep registration certificate
+
+Available options:
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli governance 
             ( create-mir-certificate
             | create-genesis-key-delegation-certificate
+            | action
+            | vote
             | create-update-proposal
             | create-poll
             | answer-poll
@@ -17,6 +19,8 @@ Available commands:
                            certificate
   create-genesis-key-delegation-certificate
                            Create a genesis key delegation certificate
+  action                   Commands related to governance actions
+  vote                     Commands related to governance votes
   create-update-proposal   Create an update proposal
   create-poll              Create an SPO poll
   answer-poll              Answer an SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli governance action 
+            ( create-no-confidence-motion
+            | create-new-committee
+            | create-constitution-update
+            | create-hard-fork-initiation
+            | create-protocol-parameter-update
+            | create-treasury-withdrawal
+            | create-info
+            | view
+            | query
+            | submit
+            )
+
+  Commands related to governance actions
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-no-confidence-motion
+                           Create a no-confidence motion action
+  create-new-committee     Create a new-committee action
+  create-constitution-update
+                           Create a constitution-update action
+  create-hard-fork-initiation
+                           Create a hard-fork-initiation action
+  create-protocol-parameter-update
+                           Create an protocol-parameter-update action
+  create-treasury-withdrawal
+                           Create an treasury-withdrawal action
+  create-info              Create an info action
+  view                     View an action
+  query                    Query an on-chain action
+  submit                   Submit an action

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-constitution-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-constitution-update.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-constitution-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a constitution-update action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-hard-fork-initiation.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-hard-fork-initiation.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-hard-fork-initiation 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a hard-fork-initiation action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-info.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action create-info 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            (--metadata-url URL | --metadata-file FILE)
+            --out-file FILE
+
+  Create an info action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --metadata-url URL       The metadata url.
+  --metadata-file FILE     The metadata file.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-new-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-new-committee.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-new-committee 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a new-committee action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-no-confidence-motion.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-no-confidence-motion.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-no-confidence-motion 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a no-confidence motion action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-protocol-parameter-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-protocol-parameter-update.cli
@@ -1,0 +1,110 @@
+Usage: cardano-cli governance action create-protocol-parameter-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
+            [--decentralization-parameter RATIONAL]
+            [--extra-entropy HEX | --reset-extra-entropy]
+            [--max-block-header-size NATURAL]
+            [--max-block-body-size NATURAL]
+            [--max-tx-size NATURAL]
+            [--min-fee-constant LOVELACE]
+            [--min-fee-linear LOVELACE]
+            [--min-utxo-value NATURAL]
+            [--key-reg-deposit-amt NATURAL]
+            [--pool-reg-deposit NATURAL]
+            [--min-pool-cost NATURAL]
+            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+            [--number-of-pools NATURAL]
+            [--pool-influence RATIONAL]
+            [--monetary-expansion RATIONAL]
+            [--treasury-expansion RATIONAL]
+            [--utxo-cost-per-word LOVELACE]
+            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
+            [--max-tx-execution-units (INT, INT)]
+            [--max-block-execution-units (INT, INT)]
+            [--max-value-size INT]
+            [--collateral-percent INT]
+            [--max-collateral-inputs INT]
+            [--utxo-cost-per-byte LOVELACE]
+            --out-file FILE
+
+  Create an protocol-parameter-update action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --max-block-header-size NATURAL
+                           Maximum block header size.
+  --max-block-body-size NATURAL
+                           Maximal block body size.
+  --max-tx-size NATURAL    Maximum transaction size.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --pool-retirement-epoch-boundary EPOCH_BOUNDARY
+                           Epoch bound on pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --utxo-cost-per-word LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Alonzo era).
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --utxo-cost-per-byte LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Babbage era).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-treasury-withdrawal.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-treasury-withdrawal 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create an treasury-withdrawal action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_query.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action query --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-id STRING
+            [--out-file FILE]
+
+  Query an on-chain action
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --action-id STRING       The governance action id.
+  --out-file FILE          Output filepath of the governance action receipt.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_submit.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-file FILE
+            [--out-file FILE]
+
+  Submit an action
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --action-file FILE       Input filepath of the governance action.
+  --out-file FILE          Output filepath of the governance action receipt.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_view.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli governance action view --action-file FILE
+
+  View an action
+
+Available options:
+  --action-file FILE       Input filepath of the governance action.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli governance vote (create | view | submit)
+
+  Commands related to governance votes
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create                   Create a vote
+  view                     View a vote
+  submit                   Submit a vote

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli governance vote create --signing-key-file FILE
+            --action-file FILE
+            (--vote-yes | --vote-no | --vote-abstain)
+            --out-file FILE
+
+  Create a vote
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --action-file FILE       Input filepath of the governance action.
+  --vote-yes               Specify the Byron era
+  --vote-no                Specify the Byron era
+  --vote-abstain           Specify the Byron era
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_submit.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli governance vote submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --vote-file FILE
+
+  Submit a vote
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --vote-file FILE         Input filepath of the governance vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_view.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli governance vote view --vote-file FILE
+
+  View a vote
+
+Available options:
+  --vote-file FILE         Input filepath of the governance vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address.cli
@@ -4,7 +4,8 @@ Usage: cardano-cli stake-address
             | key-hash
             | registration-certificate
             | deregistration-certificate
-            | delegation-certificate
+            | pool-delegation-certificate
+            | drep-delegation-certificate
             )
 
   Stake address commands
@@ -19,4 +20,7 @@ Available commands:
   registration-certificate Create a stake address registration certificate
   deregistration-certificate
                            Create a stake address deregistration certificate
-  delegation-certificate   Create a stake address pool delegation certificate
+  pool-delegation-certificate
+                           Create a stake address pool delegation certificate
+  drep-delegation-certificate
+                           Create a stake address drep delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_drep-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_drep-delegation-certificate.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli stake-address drep-delegation-certificate 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            | --stake-address ADDRESS
+            )
+            [ --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            | --drep-id DREP_ID
+            ]
+            --out-file FILE
+
+  Create a stake address drep delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --drep-id DREP_ID        DRep ID/verification key hash (either Bech32-encoded
+                           or hex-encoded). Zero or more occurences of this
+                           option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_pool-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_pool-delegation-certificate.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli stake-address delegation-certificate 
+Usage: cardano-cli stake-address pool-delegation-certificate 
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
             | --stake-script-file FILE

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -411,6 +411,42 @@ Usage: cardano-cli query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
+Usage: cardano-cli drep 
+            ( registration-certificate
+            | deregistration-certificate
+            | id
+            | metadata-hash
+            )
+
+  DRep commands
+
+Usage: cardano-cli drep registration-certificate 
+            (--mainnet | --testnet-magic NATURAL)
+            (--drep-verification-key STRING | --cold-verification-key-file FILE)
+            (--vrf-verification-key STRING | --vrf-verification-key-file FILE)
+            [--metadata-url URL --metadata-hash HASH]
+            --out-file FILE
+
+  Create a DRep registration certificate
+
+Usage: cardano-cli drep deregistration-certificate 
+            (--drep-verification-key STRING | --cold-verification-key-file FILE)
+            --epoch NATURAL
+            --out-file FILE
+
+  Create a DRep deregistration certificate
+
+Usage: cardano-cli drep id 
+            (--drep-verification-key STRING | --cold-verification-key-file FILE)
+            [--output-format STRING]
+
+  Build DRep id from the offline key
+
+Usage: cardano-cli drep metadata-hash --drep-metadata-file FILE
+            [--out-file FILE]
+
+  Print the hash of DRep metadata.
+
 Usage: cardano-cli stake-pool 
             ( registration-certificate
             | deregistration-certificate

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -12,6 +12,8 @@ Usage: cardano-cli text-view decode-cbor --in-file FILE [--out-file FILE]
 Usage: cardano-cli governance 
             ( create-mir-certificate
             | create-genesis-key-delegation-certificate
+            | action
+            | vote
             | create-update-proposal
             | create-poll
             | answer-poll
@@ -68,6 +70,149 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
             --out-file FILE
 
   Create a genesis key delegation certificate
+
+Usage: cardano-cli governance action 
+            ( create-no-confidence-motion
+            | create-new-committee
+            | create-constitution-update
+            | create-hard-fork-initiation
+            | create-protocol-parameter-update
+            | create-treasury-withdrawal
+            | create-info
+            | view
+            | query
+            | submit
+            )
+
+  Commands related to governance actions
+
+Usage: cardano-cli governance action create-no-confidence-motion 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a no-confidence motion action
+
+Usage: cardano-cli governance action create-new-committee 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a new-committee action
+
+Usage: cardano-cli governance action create-constitution-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a constitution-update action
+
+Usage: cardano-cli governance action create-hard-fork-initiation 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a hard-fork-initiation action
+
+Usage: cardano-cli governance action create-protocol-parameter-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
+            [--decentralization-parameter RATIONAL]
+            [--extra-entropy HEX | --reset-extra-entropy]
+            [--max-block-header-size NATURAL]
+            [--max-block-body-size NATURAL]
+            [--max-tx-size NATURAL]
+            [--min-fee-constant LOVELACE]
+            [--min-fee-linear LOVELACE]
+            [--min-utxo-value NATURAL]
+            [--key-reg-deposit-amt NATURAL]
+            [--pool-reg-deposit NATURAL]
+            [--min-pool-cost NATURAL]
+            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+            [--number-of-pools NATURAL]
+            [--pool-influence RATIONAL]
+            [--monetary-expansion RATIONAL]
+            [--treasury-expansion RATIONAL]
+            [--utxo-cost-per-word LOVELACE]
+            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
+            [--max-tx-execution-units (INT, INT)]
+            [--max-block-execution-units (INT, INT)]
+            [--max-value-size INT]
+            [--collateral-percent INT]
+            [--max-collateral-inputs INT]
+            [--utxo-cost-per-byte LOVELACE]
+            --out-file FILE
+
+  Create an protocol-parameter-update action
+
+Usage: cardano-cli governance action create-treasury-withdrawal 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create an treasury-withdrawal action
+
+Usage: cardano-cli governance action create-info 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            (--metadata-url URL | --metadata-file FILE)
+            --out-file FILE
+
+  Create an info action
+
+Usage: cardano-cli governance action view --action-file FILE
+
+  View an action
+
+Usage: cardano-cli governance action query --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-id STRING
+            [--out-file FILE]
+
+  Query an on-chain action
+
+Usage: cardano-cli governance action submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-file FILE
+            [--out-file FILE]
+
+  Submit an action
+
+Usage: cardano-cli governance vote (create | view | submit)
+
+  Commands related to governance votes
+
+Usage: cardano-cli governance vote create --signing-key-file FILE
+            --action-file FILE
+            (--vote-yes | --vote-no | --vote-abstain)
+            --out-file FILE
+
+  Create a vote
+
+Usage: cardano-cli governance vote view --vote-file FILE
+
+  View a vote
+
+Usage: cardano-cli governance vote submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --vote-file FILE
+
+  Submit a vote
 
 Usage: cardano-cli governance create-update-proposal --out-file FILE
             --epoch EPOCH
@@ -422,22 +567,27 @@ Usage: cardano-cli drep
 
 Usage: cardano-cli drep registration-certificate 
             (--mainnet | --testnet-magic NATURAL)
-            (--drep-verification-key STRING | --cold-verification-key-file FILE)
-            (--vrf-verification-key STRING | --vrf-verification-key-file FILE)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
             [--metadata-url URL --metadata-hash HASH]
             --out-file FILE
 
   Create a DRep registration certificate
 
 Usage: cardano-cli drep deregistration-certificate 
-            (--drep-verification-key STRING | --cold-verification-key-file FILE)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
             --epoch NATURAL
             --out-file FILE
 
   Create a DRep deregistration certificate
 
 Usage: cardano-cli drep id 
-            (--drep-verification-key STRING | --cold-verification-key-file FILE)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
             [--output-format STRING]
 
   Build DRep id from the offline key
@@ -1004,7 +1154,8 @@ Usage: cardano-cli stake-address
             | key-hash
             | registration-certificate
             | deregistration-certificate
-            | delegation-certificate
+            | pool-delegation-certificate
+            | drep-delegation-certificate
             )
 
   Stake address commands
@@ -1052,7 +1203,7 @@ Usage: cardano-cli stake-address deregistration-certificate
 
   Create a stake address deregistration certificate
 
-Usage: cardano-cli stake-address delegation-certificate 
+Usage: cardano-cli stake-address pool-delegation-certificate 
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
             | --stake-script-file FILE
@@ -1065,6 +1216,20 @@ Usage: cardano-cli stake-address delegation-certificate
             --out-file FILE
 
   Create a stake address pool delegation certificate
+
+Usage: cardano-cli stake-address drep-delegation-certificate 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            | --stake-address ADDRESS
+            )
+            [ --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            | --drep-id DREP_ID
+            ]
+            --out-file FILE
+
+  Create a stake address drep delegation certificate
 
 Usage: cardano-cli address (key-gen | key-hash | build | info)
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli drep 
+            ( registration-certificate
+            | deregistration-certificate
+            | id
+            | metadata-hash
+            )
+
+  DRep commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a DRep registration certificate
+  deregistration-certificate
+                           Create a DRep deregistration certificate
+  id                       Build DRep id from the offline key
+  metadata-hash            Print the hash of DRep metadata.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_deregistration-certificate.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli drep deregistration-certificate 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            --epoch NATURAL
+            --out-file FILE
+
+  Create a DRep deregistration certificate
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_id.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_id.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli drep id 
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--output-format STRING]
+
+  Build DRep id from the offline key
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --output-format STRING   Optional output format. Accepted output formats are
+                           "hex" and "bech32" (default is "bech32").
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_metadata-hash.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli drep metadata-hash --drep-metadata-file FILE
+            [--out-file FILE]
+
+  Print the hash of DRep metadata.
+
+Available options:
+  --drep-metadata-file FILE
+                           Filepath of the drep metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_registration-certificate.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/drep_registration-certificate.cli
@@ -1,0 +1,23 @@
+Usage: cardano-cli drep registration-certificate 
+            (--mainnet | --testnet-magic NATURAL)
+            ( --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            )
+            [--metadata-url URL --metadata-hash HASH]
+            --out-file FILE
+
+  Create a DRep registration certificate
+
+Available options:
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli governance 
             ( create-mir-certificate
             | create-genesis-key-delegation-certificate
+            | action
+            | vote
             | create-update-proposal
             | create-poll
             | answer-poll
@@ -17,6 +19,8 @@ Available commands:
                            certificate
   create-genesis-key-delegation-certificate
                            Create a genesis key delegation certificate
+  action                   Commands related to governance actions
+  vote                     Commands related to governance votes
   create-update-proposal   Create an update proposal
   create-poll              Create an SPO poll
   answer-poll              Answer an SPO poll

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli governance action 
+            ( create-no-confidence-motion
+            | create-new-committee
+            | create-constitution-update
+            | create-hard-fork-initiation
+            | create-protocol-parameter-update
+            | create-treasury-withdrawal
+            | create-info
+            | view
+            | query
+            | submit
+            )
+
+  Commands related to governance actions
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-no-confidence-motion
+                           Create a no-confidence motion action
+  create-new-committee     Create a new-committee action
+  create-constitution-update
+                           Create a constitution-update action
+  create-hard-fork-initiation
+                           Create a hard-fork-initiation action
+  create-protocol-parameter-update
+                           Create an protocol-parameter-update action
+  create-treasury-withdrawal
+                           Create an treasury-withdrawal action
+  create-info              Create an info action
+  view                     View an action
+  query                    Query an on-chain action
+  submit                   Submit an action

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-constitution-update.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-constitution-update.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-constitution-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a constitution-update action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-hard-fork-initiation.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-hard-fork-initiation.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-hard-fork-initiation 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a hard-fork-initiation action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-info.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-info.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action create-info 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            (--metadata-url URL | --metadata-file FILE)
+            --out-file FILE
+
+  Create an info action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --metadata-url URL       The metadata url.
+  --metadata-file FILE     The metadata file.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-new-committee.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-new-committee.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-new-committee 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a new-committee action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-no-confidence-motion.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-no-confidence-motion.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-no-confidence-motion 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create a no-confidence motion action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-protocol-parameter-update.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-protocol-parameter-update.cli
@@ -1,0 +1,110 @@
+Usage: cardano-cli governance action create-protocol-parameter-update 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
+            [--decentralization-parameter RATIONAL]
+            [--extra-entropy HEX | --reset-extra-entropy]
+            [--max-block-header-size NATURAL]
+            [--max-block-body-size NATURAL]
+            [--max-tx-size NATURAL]
+            [--min-fee-constant LOVELACE]
+            [--min-fee-linear LOVELACE]
+            [--min-utxo-value NATURAL]
+            [--key-reg-deposit-amt NATURAL]
+            [--pool-reg-deposit NATURAL]
+            [--min-pool-cost NATURAL]
+            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+            [--number-of-pools NATURAL]
+            [--pool-influence RATIONAL]
+            [--monetary-expansion RATIONAL]
+            [--treasury-expansion RATIONAL]
+            [--utxo-cost-per-word LOVELACE]
+            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
+            [--max-tx-execution-units (INT, INT)]
+            [--max-block-execution-units (INT, INT)]
+            [--max-value-size INT]
+            [--collateral-percent INT]
+            [--max-collateral-inputs INT]
+            [--utxo-cost-per-byte LOVELACE]
+            --out-file FILE
+
+  Create an protocol-parameter-update action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --max-block-header-size NATURAL
+                           Maximum block header size.
+  --max-block-body-size NATURAL
+                           Maximal block body size.
+  --max-tx-size NATURAL    Maximum transaction size.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --pool-retirement-epoch-boundary EPOCH_BOUNDARY
+                           Epoch bound on pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --utxo-cost-per-word LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Alonzo era).
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --utxo-cost-per-byte LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Babbage era).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-treasury-withdrawal.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_create-treasury-withdrawal.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli governance action create-treasury-withdrawal 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            )
+            --out-file FILE
+
+  Create an treasury-withdrawal action
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_query.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_query.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action query --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-id STRING
+            [--out-file FILE]
+
+  Query an on-chain action
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --action-id STRING       The governance action id.
+  --out-file FILE          Output filepath of the governance action receipt.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_submit.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_submit.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli governance action submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --action-file FILE
+            [--out-file FILE]
+
+  Submit an action
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --action-file FILE       Input filepath of the governance action.
+  --out-file FILE          Output filepath of the governance action receipt.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_view.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_action_view.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli governance action view --action-file FILE
+
+  View an action
+
+Available options:
+  --action-file FILE       Input filepath of the governance action.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli governance vote (create | view | submit)
+
+  Commands related to governance votes
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create                   Create a vote
+  view                     View a vote
+  submit                   Submit a vote

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_create.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_create.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli governance vote create --signing-key-file FILE
+            --action-file FILE
+            (--vote-yes | --vote-no | --vote-abstain)
+            --out-file FILE
+
+  Create a vote
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --action-file FILE       Input filepath of the governance action.
+  --vote-yes               Specify the Byron era
+  --vote-no                Specify the Byron era
+  --vote-abstain           Specify the Byron era
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_submit.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_submit.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli governance vote submit --socket-path SOCKET_PATH
+            (--mainnet | --testnet-magic NATURAL)
+            --vote-file FILE
+
+  Submit a vote
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --vote-file FILE         Input filepath of the governance vote.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_view.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/governance_vote_view.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli governance vote view --vote-file FILE
+
+  View a vote
+
+Available options:
+  --vote-file FILE         Input filepath of the governance vote.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address.cli
@@ -4,7 +4,8 @@ Usage: cardano-cli stake-address
             | key-hash
             | registration-certificate
             | deregistration-certificate
-            | delegation-certificate
+            | pool-delegation-certificate
+            | drep-delegation-certificate
             )
 
   Stake address commands
@@ -19,4 +20,7 @@ Available commands:
   registration-certificate Create a stake address registration certificate
   deregistration-certificate
                            Create a stake address deregistration certificate
-  delegation-certificate   Create a stake address pool delegation certificate
+  pool-delegation-certificate
+                           Create a stake address pool delegation certificate
+  drep-delegation-certificate
+                           Create a stake address drep delegation certificate

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_drep-delegation-certificate.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_drep-delegation-certificate.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli stake-address drep-delegation-certificate 
+            ( --stake-verification-key STRING
+            | --stake-verification-key-file FILE
+            | --stake-script-file FILE
+            | --stake-address ADDRESS
+            )
+            [ --drep-verification-key STRING
+            | --drep-cold-verification-key-file FILE
+            | --drep-id DREP_ID
+            ]
+            --out-file FILE
+
+  Create a stake address drep delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-cold-verification-key-file FILE
+                           Filepath of the drep verification key.
+  --drep-id DREP_ID        DRep ID/verification key hash (either Bech32-encoded
+                           or hex-encoded). Zero or more occurences of this
+                           option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_pool-delegation-certificate.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_pool-delegation-certificate.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli stake-address delegation-certificate 
+Usage: cardano-cli stake-address pool-delegation-certificate 
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
             | --stake-script-file FILE


### PR DESCRIPTION
# Description

This PR documents the new CLI commands for [CIP-1694](https://github.com/JaredCorduan/CIPs/blob/voltaire-v1/CIP-1694/README.md)

This PR is for comment only and is not meant to be merged.  The design is presented as a diff from usage text from before the CIP-1694 commands were added to after they have been added.

The usage text was generated by golden tests in PR https://github.com/input-output-hk/cardano-node/pull/5196

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
