### PR TITLE
Bump up versions and fix changelogs

### DIFF
--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-topology
-version:                8.0.0
+version:                8.1.0
 synopsis:               A cardano topology generator
 description:            A cardano topology generator.
 category:               Cardano,

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,7 +1,8 @@
 # Changelog for cardano-api
 
-## vNext
+## 8.1.0
 
+-
 
 ## 8.0.0 - May 2023
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api
-version:                8.0.0
+version:                8.1.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,

--- a/cardano-cli/ChangeLog.md
+++ b/cardano-cli/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for cardano-cli
 
-## vNext
+## 8.1.0
+
+-
 
 ## 8.0.0 - May 2023
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-cli
-version:                8.0.0
+version:                8.1.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).

--- a/cardano-git-rev/cardano-git-rev.cabal
+++ b/cardano-git-rev/cardano-git-rev.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-git-rev
-version:                0.1.0.0
+version:                0.1.1.0
 synopsis:               Git revisioning
 description:            Embeds git revision into Haskell packages.
 category:               Cardano,

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-chairman
-version:                8.0.0
+version:                8.1.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for cardano-node
 
-## vNext
+## 8.1.0
+
+-
 
 ## 8.0.0 - May 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.0.0
+version:                8.1.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -192,9 +192,9 @@ library
                       , strict-stm
                       , text
                       , time
-                      , trace-dispatcher
-                      , trace-forward
-                      , trace-resources
+                      , trace-dispatcher ^>= 2.0
+                      , trace-forward ^>= 2.0
+                      , trace-resources ^>= 0.2
                       , tracer-transformers
                       , transformers
                       , transformers-except

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-testnet
-version:                8.0.0
+version:                8.1.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 copyright:              2021-2023 Input Output Global Inc (IOG).

--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Revision history for trace-dispatcher
 
+## 2.0.0 -- May 2023
+
+* First version that diverges from caradno-node versioning scheme
+
+* GHC-9.2 support
+
+* Many undocumented changes
+
+## 1.35.4 -- November 2022
+
+* Undocumented changes
+
 ## 1.29.0 -- September 2021
 
 * Initial version.

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                1.29.0
+version:                2.0.0
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package

--- a/trace-forward/CHANGELOG.md
+++ b/trace-forward/CHANGELOG.md
@@ -1,3 +1,13 @@
 # ChangeLog
 
-# 0.1.0
+## 2.0.0 - May 2023
+
+* Undocumented changes
+
+## 1.34.5 - November 2022
+
+* No changes
+
+## 0.1.0 - October 2022
+
+* Initial Release

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-forward
-version:                0.1.0
+version:                2.0.0
 synopsis:               The forwarding protocols library for cardano node.
 description:            The library providing typed protocols for forwarding different
                         information from the cardano node to an external application.

--- a/trace-resources/CHANGELOG.md
+++ b/trace-resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for trace-dispatcher
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.2.0.0 -- May 2023
+
+* Undocumented changes
+
+## 0.1.0.0 -- October 2022
 
 * First version. Released on an unsuspecting world.

--- a/trace-resources/trace-resources.cabal
+++ b/trace-resources/trace-resources.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-resources
-version:                0.1.0.0
+version:                0.2.0.0
 synopsis:               Package for tracing resources for linux, mac and windows
 description:            Package for tracing resources for linux, mac and windows.
 category:               Cardano,


### PR DESCRIPTION
# Description

A few packages needs releasing in order for carano-node-8.0.0 et al. to land in CHaPs:

* `trace-forward-2.0.0`
* `trace-dispatcher-2.0.0`
* `trace-resources-0.2.0`
* `cardano-git-rev-0.1.1.0`

Note that the first two get the top most version bump, because they have been released with a wrong version `1.34.5` in the past. To battle this mistake we had to go straight to `2.0`

Per @disassembler request, this PR also bumps up all relevant packages to `8.1.0`, since that is the version for the next expected release. Reflected both in cabal and changelogs files.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
