### PR TITLE
Replace remaining `FilePath` use in `cardano-api`

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -20,9 +20,15 @@
   ([PR 5194](https://github.com/input-output-hk/cardano-node/pull/5194))
 
 - **Breaking change**
-  Delete `Cardano.Api.Environment` module.  Merge two `SocketPath` type definitions to the one defined in `Cardano.Api.IO`
+
+- Delete `Cardano.Api.Environment` module.  Merge two `SocketPath` type definitions to the one defined in `Cardano.Api.IO`
   Delete `EnvSocketError` and associated functions and types.
   ([PR 5215](https://github.com/input-output-hk/cardano-node/pull/5215))
+
+- `NodeConfigFile` newtype replaced with `NodeConfigFile` type alias.
+  `GenesisConfigFile` newtype replaced with `ByronGenesisFile`, `ShelleyGenesisFile`, `AlonzoGenesisFile`, `ConwayGenesisFile` type aliases.
+  New `ByronGenesisConfig`, `ShelleyGenesisConfig`, `AlonzoGenesisConfig`, `ConwayGenesisConfig` type aliases.
+  ([PR 5217](https://github.com/input-output-hk/cardano-node/pull/5217))
 
 ### Bugs
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -602,7 +602,7 @@ module Cardano.Api (
 
     -- ** Node Config
     NodeConfig (..),
-    NodeConfigFile (..),
+    NodeConfigFile,
     readNodeConfig,
     -- *** Genesis Config
     GenesisConfig (..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -604,6 +604,11 @@ module Cardano.Api (
     NodeConfig (..),
     NodeConfigFile,
     readNodeConfig,
+    -- ** Genesis Files
+    ByronGenesisFile,
+    ShelleyGenesisFile,
+    AlonzoGenesisFile,
+    ConwayGenesisFile,
     -- *** Genesis Config
     GenesisConfig (..),
     readCardanoGenesisConfig,
@@ -852,6 +857,7 @@ import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Fees
+import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/Genesis.hs
+++ b/cardano-api/src/Cardano/Api/Genesis.hs
@@ -1,25 +1,88 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Api.Genesis
   ( ShelleyGenesis(..)
   , shelleyGenesisDefaults
+
+  -- ** Configuration
+  , ByronGenesisConfig
+  , ShelleyGenesisConfig
+  , AlonzoGenesisConfig
+  , ConwayGenesisConfig
+
+  , ShelleyConfig(..)
+  , GenesisHashByron(..)
+  , GenesisHashShelley(..)
+  , GenesisHashAlonzo(..)
+  , GenesisHashConway(..)
+
+  -- ** Files
+  , ByronGenesisFile
+  , ShelleyGenesisFile
+  , AlonzoGenesisFile
+  , ConwayGenesisFile
   ) where
 
+import           Data.ByteString (ByteString)
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
 import qualified Data.Time as Time
 import           Lens.Micro
 
+import qualified Cardano.Crypto.Hash.Blake2b
+import qualified Cardano.Crypto.Hash.Class
+
+import           Cardano.Api.IO
+
+import qualified Cardano.Chain.Genesis
+
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import           Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Coin (Coin (..))
+import           Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Shelley.Core
 import           Cardano.Ledger.Shelley.Genesis (NominalDiffTimeMicro, ShelleyGenesis (..),
                    emptyGenesisStaking)
 
+import qualified Cardano.Ledger.Shelley.Genesis as Ledger
 
+import qualified Ouroboros.Consensus.Shelley.Eras as Shelley
+
+data ShelleyConfig = ShelleyConfig
+  { scConfig :: !(Ledger.ShelleyGenesis Shelley.StandardCrypto)
+  , scGenesisHash :: !GenesisHashShelley
+  }
+
+newtype GenesisHashByron = GenesisHashByron
+  { unGenesisHashByron :: Text
+  } deriving newtype (Eq, Show)
+
+newtype GenesisHashShelley = GenesisHashShelley
+  { unGenesisHashShelley :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
+  } deriving newtype (Eq, Show)
+
+newtype GenesisHashAlonzo = GenesisHashAlonzo
+  { unGenesisHashAlonzo :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
+  } deriving newtype (Eq, Show)
+
+newtype GenesisHashConway = GenesisHashConway
+  { unGenesisHashConway :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
+  } deriving newtype (Eq, Show)
+
+type ByronGenesisConfig = Cardano.Chain.Genesis.Config
+type ShelleyGenesisConfig = ShelleyConfig
+type AlonzoGenesisConfig = AlonzoGenesis
+type ConwayGenesisConfig = ConwayGenesis Shelley.StandardCrypto
+
+type ByronGenesisFile = File ByronGenesisConfig
+type ShelleyGenesisFile = File ShelleyGenesisConfig
+type AlonzoGenesisFile = File AlonzoGenesisConfig
+type ConwayGenesisFile = File ConwayGenesisConfig
 
 -- | Some reasonable starting defaults for constructing a 'ShelleyGenesis'.
 --

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -78,14 +77,6 @@ module Cardano.Api.LedgerState
   , Env(..)
   , genesisConfigToEnv
 
-  , ByronGenesisConfig
-  , ShelleyGenesisConfig
-  , AlonzoGenesisConfig
-  , ConwayGenesisConfig
-  , ByronGenesisFile
-  , ShelleyGenesisFile
-  , AlonzoGenesisFile
-  , ConwayGenesisFile
   )
   where
 
@@ -132,6 +123,7 @@ import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Genesis
 import           Cardano.Api.IO
 import           Cardano.Api.IPC (ConsensusModeParams (..),
                    LocalChainSyncClient (LocalChainSyncClientPipelined),
@@ -202,7 +194,6 @@ import qualified Ouroboros.Consensus.Protocol.TPraos as TPraos
 import qualified Ouroboros.Consensus.Shelley.Eras as Shelley
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import qualified Ouroboros.Consensus.Shelley.Ledger.Ledger as Shelley
-import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..))
 import qualified Ouroboros.Consensus.Shelley.Node.Praos as Consensus
 import           Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerEvent (WrapLedgerEvent))
 import qualified Ouroboros.Network.Block
@@ -796,16 +787,6 @@ readNodeConfig (File ncf) = do
       , ncConwayGenesisFile = mapFile (mkAdjustPath ncf) (ncConwayGenesisFile ncfg)
       }
 
-type ByronGenesisConfig = Cardano.Chain.Genesis.Config
-type ShelleyGenesisConfig = ShelleyConfig
-type AlonzoGenesisConfig = AlonzoGenesis
-type ConwayGenesisConfig = ConwayGenesis Shelley.StandardCrypto
-
-type ByronGenesisFile = File ByronGenesisConfig
-type ShelleyGenesisFile = File ShelleyGenesisConfig
-type AlonzoGenesisFile = File AlonzoGenesisConfig
-type ConwayGenesisFile = File ConwayGenesisConfig
-
 data NodeConfig = NodeConfig
   { ncPBftSignatureThreshold :: !(Maybe Double)
   , ncByronGenesisFile :: !(File ByronGenesisConfig 'In)
@@ -1001,27 +982,6 @@ data GenesisConfig
       !ShelleyConfig
       !AlonzoGenesis
       !(ConwayGenesis Shelley.StandardCrypto)
-
-data ShelleyConfig = ShelleyConfig
-  { scConfig :: !(Ledger.ShelleyGenesis Shelley.StandardCrypto)
-  , scGenesisHash :: !GenesisHashShelley
-  }
-
-newtype GenesisHashByron = GenesisHashByron
-  { unGenesisHashByron :: Text
-  } deriving newtype (Eq, Show)
-
-newtype GenesisHashShelley = GenesisHashShelley
-  { unGenesisHashShelley :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
-  } deriving newtype (Eq, Show)
-
-newtype GenesisHashAlonzo = GenesisHashAlonzo
-  { unGenesisHashAlonzo :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
-  } deriving newtype (Eq, Show)
-
-newtype GenesisHashConway = GenesisHashConway
-  { unGenesisHashConway :: Cardano.Crypto.Hash.Class.Hash Cardano.Crypto.Hash.Blake2b.Blake2b_256 ByteString
-  } deriving newtype (Eq, Show)
 
 newtype LedgerStateDir = LedgerStateDir
   {  unLedgerStateDir :: FilePath

--- a/cardano-cli/test/Test/Config/Mainnet.hs
+++ b/cardano-cli/test/Test/Config/Mainnet.hs
@@ -6,7 +6,7 @@ module Test.Config.Mainnet
   ( tests
   ) where
 
-import           Cardano.Api (initialLedgerState, renderInitialLedgerStateError)
+import           Cardano.Api (File (..), initialLedgerState, renderInitialLedgerStateError)
 import           Control.Monad.Trans.Except
 import           Hedgehog (Property, (===))
 import           System.FilePath ((</>))
@@ -23,7 +23,7 @@ import qualified System.Directory as IO
 hprop_configMainnetHash :: Property
 hprop_configMainnetHash = H.propertyOnce $ do
   base <- H.note =<< H.evalIO . IO.canonicalizePath =<< H.getProjectBase
-  result <- H.evalIO $ runExceptT $ initialLedgerState $ base </> "configuration/cardano/mainnet-config.json"
+  result <- H.evalIO $ runExceptT $ initialLedgerState $ File $ base </> "configuration/cardano/mainnet-config.json"
   case result of
     Right (_, _) -> return ()
     Left e -> H.failWithCustom GHC.callStack Nothing (T.unpack (renderInitialLedgerStateError e))

--- a/cardano-client-demo/ChainSyncClientWithLedgerState.hs
+++ b/cardano-client-demo/ChainSyncClientWithLedgerState.hs
@@ -54,7 +54,7 @@ main = do
           return l
 
   -- Use 'chainSyncClientWithLedgerState' to support ledger state.
-  Right (env, initialLedgerState) <- runExceptT $ initialLedgerState configFilePath
+  Right (env, initialLedgerState) <- runExceptT $ initialLedgerState (File configFilePath)
   let client = chainSyncClientWithLedgerState
         env
         initialLedgerState

--- a/cardano-client-demo/LedgerState.hs
+++ b/cardano-client-demo/LedgerState.hs
@@ -33,7 +33,7 @@ main = do
   -- Get socket path from CLI argument.
   configFilePath : socketPath : xs <- getArgs
   blockCount <- fmap (either (error . T.unpack . renderFoldBlocksError) id) $ runExceptT $ foldBlocks
-    configFilePath
+    (File configFilePath)
     (File socketPath)
     FullValidation
     (0 :: Int) -- We just use a count of the blocks as the current state

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -244,7 +244,7 @@ main = do
       targetCredAsAPI = fromShelleyStakeCredential targetCred
       f = either (error . T.unpack . renderFoldBlocksError) id
   !_ <- fmap f $ runExceptT $ foldBlocks
-         (conf args)
+         (File (conf args))
          (File (socket args))
          QuickValidation
          startingState

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -51,7 +51,7 @@ import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
-import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
 data NetworkP2PMode = EnabledP2PMode | DisabledP2PMode
   deriving (Eq, Show, Generic)

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -13,7 +13,7 @@ module Cardano.Node.Parsers
 
 import           Cardano.Prelude (ConvertText (..))
 
-import           Data.Foldable (asum)
+import           Data.Foldable
 import           Data.Maybe (fromMaybe)
 import           Data.Monoid (Last (..))
 import           Data.Text (Text)

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -17,11 +17,12 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as HE
 import qualified Hedgehog.Extras.Test as HE
 import qualified Hedgehog.Extras.Test.Base as H
 
+import           Cardano.Api (File (..))
 import qualified Cardano.Api as C
 import           Cardano.Testnet as TN
+
 import qualified Testnet.Util.Base as H
 import           Testnet.Util.Runtime
-
 
 newtype FoldBlocksException = FoldBlocksException C.FoldBlocksError
 instance Exception FoldBlocksException
@@ -69,7 +70,7 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
       -- that case we simply restart `foldBlocks` again.
       forever $ do
         let handler _env _ledgerState _ledgerEvents _blockInCardanoMode _ = IO.putMVar lock ()
-        e <- runExceptT (C.foldBlocks configFile (C.File socketPathAbs) C.QuickValidation () handler)
+        e <- runExceptT (C.foldBlocks (File configFile) (C.File socketPathAbs) C.QuickValidation () handler)
         either (throw . FoldBlocksException) (\_ -> pure ()) e
     link a -- Throw async thread's exceptions in main thread
 


### PR DESCRIPTION
# Description

After this change, `cardano-api` is using `File` types exclusively.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
