### PR TITLE
Implement deposit handling when balancing transactions

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -2,6 +2,17 @@
 
 ## 8.1.0
 
+- Addition of `QueryStakeDelegDeposits` ledger state query.
+
+- **Breaking change** - `evaluateTransactionBalance`, `makeTransactionBodyAutoBalance` and
+  `constructBalancedTx` requires a mapping from `StakeCredential` to a deposit for every
+  unregistration certificate present in the transaction
+
+- **Breaking change** - `queryStateForBalancedTx` now requires a list of certificates and
+  produces a Map with `StakeCredential` to a deposit for every deregistration certificate
+  in the supplied list
+
+
 ### Features
 
 - New functions: `intoFile`, `readByteStringFile`, `readLazyByteStringFile`, `readTextFile`.

--- a/cardano-api/golden/files/errors/ScriptExecutionError/ScriptErrorNotPlutusWitnessedTxIn.txt
+++ b/cardano-api/golden/files/errors/ScriptExecutionError/ScriptErrorNotPlutusWitnessedTxIn.txt
@@ -1,1 +1,1 @@
-transaction input 0 (in the order of the TxIds) is not a Plutus script witnessed tx input and cannot be spent using a Plutus script witness.The script hash is "a0d442ce189bc932515c85be74ac939df19ea8450c03030234790921".
+transaction input 0 (in ascending order of the TxIds) is not a Plutus script witnessed tx input and cannot be spent using a Plutus script witness.The script hash is "a0d442ce189bc932515c85be74ac939df19ea8450c03030234790921".

--- a/cardano-api/golden/files/errors/ScriptExecutionError/ScriptErrorRedeemerPointsToUnknownScriptHash.txt
+++ b/cardano-api/golden/files/errors/ScriptExecutionError/ScriptErrorRedeemerPointsToUnknownScriptHash.txt
@@ -1,1 +1,1 @@
-transaction input 0 (in the order of the TxIds) points to a script hash that is not known.
+transaction input 0 (in ascending order of the TxIds) points to a script hash that is not known.

--- a/cardano-api/golden/files/errors/TxBodyErrorAutoBalance/TxBodyScriptExecutionError.txt
+++ b/cardano-api/golden/files/errors/TxBodyErrorAutoBalance/TxBodyScriptExecutionError.txt
@@ -1,3 +1,3 @@
 The following scripts have execution failures:
-the script for transaction input 1 (in the order of the TxIds) failed with: 
+the script for transaction input 1 (in ascending order of the TxIds) failed with: 
 The execution units required by this Plutus script overflows a 64bit word. In a properly configured chain this should be practically impossible. So this probably indicates a chain configuration problem, perhaps with the values in the cost model.

--- a/cardano-api/src/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/src/Cardano/Api/Convenience/Construction.hs
@@ -29,6 +29,7 @@ import           Cardano.Api.Query
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
+import           Cardano.Api.Value
 
 -- | Construct a balanced transaction.
 -- See Cardano.Api.Convenience.Query.queryStateForBalancedTx for a
@@ -44,14 +45,16 @@ constructBalancedTx
   -> LedgerEpochInfo
   -> SystemStart
   -> Set PoolId       -- ^ The set of registered stake pools
+  -> Map.Map StakeCredential Lovelace
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
 constructBalancedTx txbodcontent changeAddr mOverrideWits utxo pparams
-                    ledgerEpochInfo systemStart stakePools shelleyWitSigningKeys = do
+                    ledgerEpochInfo systemStart stakePools
+                    stakeDelegDeposits shelleyWitSigningKeys = do
   BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
          systemStart ledgerEpochInfo
-         pparams stakePools utxo txbodcontent
+         pparams stakePools stakeDelegDeposits utxo txbodcontent
          changeAddr mOverrideWits
 
   let keyWits = map (makeShelleyKeyWitness txbody) shelleyWitSigningKeys

--- a/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
@@ -6,9 +6,8 @@ module Cardano.CLI.Common.Parsers
 
 import           Cardano.Api (AnyConsensusModeParams (..), ConsensusModeParams (..),
                    EpochSlots (..), NetworkId (..), NetworkMagic (..), SocketPath (..), bounded)
-import           Cardano.CLI.Environment (EnvCli (envCliNetworkId))
+import           Cardano.CLI.Environment (EnvCli (envCliNetworkId, envCliSocketPath))
 
-import           Cardano.CLI.Environment (EnvCli (envCliSocketPath))
 import           Data.Foldable
 import           Data.Maybe (maybeToList)
 import           Data.Word (Word64)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -40,10 +40,10 @@ import qualified Ouroboros.Network.Block as Net
 import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
 import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
                    PeerFetchStatus (..), readFetchClientState)
+import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import           Cardano.Logging hiding (traceWith)
 import           Cardano.Node.Queries
-import Ouroboros.Network.NodeToNode (RemoteAddress)
 
 {- HLINT ignore "Use =<<" -}
 {- HLINT ignore "Use <=<" -}

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -17,10 +17,10 @@ module Cardano.Tracing.OrphanInstances.Network () where
 
 import           Control.Exception (Exception (..), SomeException (..))
 import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (..))
-import           Data.Aeson (Value (..), FromJSON (..))
+import           Data.Aeson (FromJSON (..), Value (..))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (listValue)
-import           Data.Bifunctor (Bifunctor (..))
+import           Data.Bifunctor (Bifunctor (first))
 import           Data.Data (Proxy (..))
 import           Data.Foldable (Foldable (..))
 import           Data.Functor.Identity (Identity (..))
@@ -67,7 +67,8 @@ import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
 import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
 import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..), NodeToClientVersionData (..))
+import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..),
+                   NodeToClientVersionData (..))
 import qualified Ouroboros.Network.NodeToClient as NtC
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), NodeToNodeVersion (..),
                    NodeToNodeVersionData (..), RemoteAddress, TraceSendRecv (..), WithAddr (..))
@@ -95,12 +96,13 @@ import           Ouroboros.Network.Protocol.LocalTxMonitor.Type (LocalTxMonitor)
 import qualified Ouroboros.Network.Protocol.LocalTxMonitor.Type as LocalTxMonitor
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (LocalTxSubmission)
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Type as LocalTxSub
+import           Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingResult (..))
 import           Ouroboros.Network.Protocol.TxSubmission2.Type as TxSubmission2
 import           Ouroboros.Network.RethrowPolicy (ErrorCommand (..))
 import           Ouroboros.Network.Server2 (ServerTrace (..))
 import qualified Ouroboros.Network.Server2 as Server
-import           Ouroboros.Network.Snocket (LocalAddress (..))
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
+import           Ouroboros.Network.Snocket (LocalAddress (..))
 import           Ouroboros.Network.Subscription (ConnectResult (..), DnsTrace (..),
                    SubscriberError (..), SubscriptionTrace (..), WithDomainName (..),
                    WithIPList (..))
@@ -109,7 +111,6 @@ import           Ouroboros.Network.TxSubmission.Inbound (ProcessedTxCount (..),
 import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound (..))
 
 import qualified Ouroboros.Network.Diffusion as ND
-import Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingResult (..))
 
 {- HLINT ignore "Use record patterns" -}
 

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -40,9 +40,9 @@ import qualified Ouroboros.Network.Block as Net
 import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
 import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
                    PeerFetchStatus (..), readFetchClientState)
+import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import           Cardano.Node.Queries
-import Ouroboros.Network.NodeToNode (RemoteAddress)
 
 {- HLINT ignore "Use =<<" -}
 {- HLINT ignore "Use <=<" -}


### PR DESCRIPTION
# Description

* `evaluateTransactionBalance`, `makeTransactionBodyAutoBalance` and
  `constructBalancedTx` requires a mapping from `StakeCredential` to a deposit for every
  unregistration certificate present in the transaction

* `queryStateForBalancedTx` now requires a list of certificates and
  produces a Map with `StakeCredential` to a deposit for every deregistration certificate
  in the supplied list

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
