### PR TITLE
refactor: make renderScriptWitnessIndex output more explicit

### DIFF
--- a/cardano-api/src/Cardano/Api/TxBody.hs
+++ b/cardano-api/src/Cardano/Api/TxBody.hs
@@ -4155,13 +4155,13 @@ instance ToJSON ScriptWitnessIndex where
 
 renderScriptWitnessIndex :: ScriptWitnessIndex -> String
 renderScriptWitnessIndex (ScriptWitnessIndexTxIn index) =
-  "transaction input " <> show index <> " (in the order of the TxIds)"
+  "transaction input " <> show index <> " (in ascending order of the TxIds)"
 renderScriptWitnessIndex (ScriptWitnessIndexMint index) =
-  "policyId " <> show index <> " (in the order of the PolicyIds)"
+  "policyId " <> show index <> " (in ascending order of the PolicyIds)"
 renderScriptWitnessIndex (ScriptWitnessIndexCertificate index) =
   "certificate " <> show index <> " (in the list order of the certificates)"
 renderScriptWitnessIndex (ScriptWitnessIndexWithdrawal index) =
-  "withdrawal " <> show index <> " (in the order of the StakeAddresses)"
+  "withdrawal " <> show index <> " (in ascending order of the StakeAddresses)"
 
 toAlonzoRdmrPtr :: ScriptWitnessIndex -> Alonzo.RdmrPtr
 toAlonzoRdmrPtr widx =


### PR DESCRIPTION
# Description

Original issue: https://github.com/input-output-hk/cardano-node/pull/3811

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
