### PR TITLE
temporarily increase file-embed hole

### DIFF
--- a/cardano-git-rev/src/Cardano/Git/Rev.hs
+++ b/cardano-git-rev/src/Cardano/Git/Rev.hs
@@ -22,7 +22,7 @@ gitRev | gitRevEmbed /= zeroRev = gitRevEmbed
   -- Data.FileEmbed.injectWith. If nothing has been injected,
   -- this will be filled with 0 characters.
   gitRevEmbed :: Text
-  gitRevEmbed = decodeUtf8 $(dummySpaceWith "gitrev" 40)
+  gitRevEmbed = decodeUtf8 $(dummySpaceWith "gitrev" 45)
 
   -- Git revision found during compilation by running git. If
   -- git could not be run, then this will be empty.


### PR DESCRIPTION
# Description

`dummySpaceWith "gitrev" 40` generates a special hole in the compiled binary, which is made up of 3 parts
1st: `fegitrev` a magic string prepended to the user magic, to make it more unique
2nd: `00000000000000000040`, the length, padded to 20 chars
3rd: `0000000000000000000000000000000000000000` 40 0's

when you later embed a string (such as with set-git-rev), it will search for the magic, then modify the size and string in-place
and at runtime, it will respect that new size

https://github.com/input-output-hk/cardano-ledger/blob/master/eras/byron/ledger/impl/src/Cardano/Chain/Delegation/Certificate.hs#L175
```
-- | A 'Certificate' is valid if the 'Signature' is valid
isValid ::
  Annotated ProtocolMagicId ByteString ->
  ACertificate ByteString ->
  Bool
isValid pm UnsafeACertificate {aEpoch, issuerVK, delegateVK, signature} =
  verifySignatureDecoded
    pm
    SignCertificate
    issuerVK
    ( serialize' byronProtVer
        . mappend ("00" <> CC.unXPub (unVerificationKey delegateVK))
        <$> aEpoch
    )
    signature
```
this chunk of code, just happens to have a "00" in it

~GHC~ the linker decided to save 3 bytes of space, by sharing this "00" (and terminating null), with the 3rd part of the git-rev

and when file-embed modifies the rev to `dd7bc6914a6aa8b0870bbee0d1c24a088048648f`
boom!, `isValid` is now prepending `8f` onto the cert, and all your certs are invalid! https://github.com/input-output-hk/cardano-node/issues/5213

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
