### PR TITLE
Improvements to Babbage cardano-testnet

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -46,6 +46,7 @@ library
                       , filepath
                       , hedgehog
                       , hedgehog-extras ^>= 0.4
+                      , network
                       , optparse-applicative-fork
                       , ouroboros-network
                       , ouroboros-network-api

--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -21,6 +21,20 @@ data BabbageOptions = BabbageOptions
 optsTestnet :: Parser BabbageTestnetOptions
 optsTestnet = BabbageTestnetOptions
   <$> OA.option auto
+      (   OA.long "protocol-version"
+      <>  OA.help "Protocol version"
+      <>  OA.metavar "INT"
+      <>  OA.showDefault
+      <>  OA.value (babbageProtocolVersion defaultTestnetOptions)
+      )
+  <*> OA.option auto
+      (   OA.long "epoch-length"
+      <>  OA.help "Length of epoch in slots"
+      <>  OA.metavar "COUNT"
+      <>  OA.showDefault
+      <>  OA.value (babbageEpochLength defaultTestnetOptions)
+      )
+  <*> OA.option auto
       (   OA.long "num-spo-nodes"
       <>  OA.help "Number of SPO nodes"
       <>  OA.metavar "COUNT"

--- a/cardano-testnet/src/Testnet/Options.hs
+++ b/cardano-testnet/src/Testnet/Options.hs
@@ -15,7 +15,9 @@ import           Testnet.Util.Runtime (NodeLoggingFormat (..))
 {- HLINT ignore "Redundant flip" -}
 
 data BabbageTestnetOptions = BabbageTestnetOptions
-  { babbageNumSpoNodes :: Int
+  { babbageProtocolVersion :: Int
+  , babbageEpochLength :: Int
+  , babbageNumSpoNodes :: Int
   , babbageSlotDuration :: Int
   , babbageSecurityParam :: Int
   , babbageTotalBalance :: Int
@@ -24,7 +26,9 @@ data BabbageTestnetOptions = BabbageTestnetOptions
 
 defaultTestnetOptions :: BabbageTestnetOptions
 defaultTestnetOptions = BabbageTestnetOptions
-  { babbageNumSpoNodes = 3
+  { babbageProtocolVersion = 8
+  , babbageEpochLength = 500
+  , babbageNumSpoNodes = 3
   , babbageSlotDuration = 200
   , babbageSecurityParam = 10
   , babbageTotalBalance = 10020000000


### PR DESCRIPTION
Add to `Testnet.Babbage`:
-  Configurable protocol version, useful for testing node and ledger rules in version 7 or 8.
-  Configurable epoch length, useful for testing scripts that validate slot to time
-  Use random ports to avoid collision in build machine running tests in CI

# Description

It is useful to be able to configure the protocol version and epoch length when testing the node and ledger in Babbage era.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
