### PR TITLE
Improve Babbage testnet

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -46,6 +46,7 @@ library
                       , filepath
                       , hedgehog
                       , hedgehog-extras ^>= 0.4.3
+                      , network
                       , optparse-applicative-fork
                       , ouroboros-network
                       , ouroboros-network-api

--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -21,6 +21,20 @@ data BabbageOptions = BabbageOptions
 optsTestnet :: Parser BabbageTestnetOptions
 optsTestnet = BabbageTestnetOptions
   <$> OA.option auto
+      (   OA.long "protocol-version"
+      <>  OA.help "Protocol version"
+      <>  OA.metavar "INT"
+      <>  OA.showDefault
+      <>  OA.value (babbageProtocolVersion defaultTestnetOptions)
+      )
+  <*> OA.option auto
+      (   OA.long "epoch-length"
+      <>  OA.help "Length of epoch in slots"
+      <>  OA.metavar "COUNT"
+      <>  OA.showDefault
+      <>  OA.value (babbageEpochLength defaultTestnetOptions)
+      )
+  <*> OA.option auto
       (   OA.long "num-spo-nodes"
       <>  OA.help "Number of SPO nodes"
       <>  OA.metavar "COUNT"

--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unused-local-binds -Wno-unused-matches #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Testnet.Babbage
   ( TestnetRuntime (..)
@@ -29,7 +30,14 @@ import qualified Hedgehog.Extras.Test.File as H
 import           System.FilePath.Posix ((</>))
 import qualified System.Info as OS
 
-
+import           Control.Concurrent (threadDelay)
+import qualified Control.Exception as IO
+import           Control.Monad.IO.Class (MonadIO (liftIO))
+import           Data.Functor (($>))
+import           Hedgehog (MonadTest)
+import qualified Hedgehog as H
+import           Hedgehog.Extras.Stock (allocateRandomPorts)
+import qualified Network.Socket as IO
 import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
 import           Testnet.Options
@@ -46,6 +54,37 @@ import           Testnet.Util.Runtime (Delegator (..), NodeLoggingFormat (..), P
 -- MacOS.  We need to allow a lot more time to set up a testnet.
 startTimeOffsetSeconds :: DTC.NominalDiffTime
 startTimeOffsetSeconds = if OS.isWin32 then 90 else 15
+
+
+-- | Check if a TCP port is open
+isPortOpen :: Int -> IO Bool
+isPortOpen port = do
+  socketAddressInfos <- IO.getAddrInfo Nothing (Just "127.0.0.1") (Just (show port))
+  case socketAddressInfos of
+    socketAddressInfo:_ -> canConnect (IO.addrAddress socketAddressInfo) $> True
+    []                  -> return False
+
+-- | Check if it is possible to connect to a socket address
+-- TODO: upstream fix to Hedgehog Extras
+canConnect :: IO.SockAddr -> IO Bool
+canConnect sockAddr = IO.bracket (IO.socket IO.AF_INET IO.Stream 6) IO.close' $ \sock -> do
+  res <- IO.try $ IO.connect sock sockAddr
+  case res of
+    Left (_ :: IO.IOException) -> return False
+    Right _                    -> return True
+
+-- | Get random list of open ports. Timeout after 60seconds if unsuccessful.
+getOpenPorts :: (MonadTest m, MonadIO m) => Int -> Int -> m [Int]
+getOpenPorts n numberOfPorts = do
+  when (n == 0) $ do
+   error "getOpenPorts timeout"
+  ports <- liftIO $ allocateRandomPorts numberOfPorts
+  allOpen <- liftIO $ mapM isPortOpen ports
+  unless (and allOpen) $ do
+    H.annotate "Some ports are not open, trying again..."
+    liftIO $ threadDelay 1_000_000 -- wait 1 sec
+    void $ getOpenPorts (pred n) numberOfPorts
+  pure ports
 
 babbageTestnet :: BabbageTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
 babbageTestnet testnetOptions H.Conf {..} = do
@@ -183,8 +222,8 @@ babbageTestnet testnetOptions H.Conf {..} = do
   H.rewriteJsonFile (genesisShelleyDir </> "genesis.json") $ J.rewriteObject
     ( HM.insert "slotLength"             (toJSON @Double 0.1)
     . HM.insert "activeSlotsCoeff"       (toJSON @Double 0.1)
-    . HM.insert "securityParam"          (toJSON @Int 6)    -- TODO: USE config parameter
-    . HM.insert "epochLength"            (toJSON @Int 600)  -- Should be "10 * k / f" where "k = securityParam, f = activeSlotsCoeff"
+    . HM.insert "securityParam"          (toJSON @Int $ babbageSecurityParam testnetOptions)
+    . HM.insert "epochLength"            (toJSON @Int $ babbageEpochLength testnetOptions) -- Should be "10 * k / f" where "k = securityParam, f = activeSlotsCoeff"
     . HM.insert "maxLovelaceSupply"      (toJSON @Int 1000000000000)
     . HM.insert "minFeeA"                (toJSON @Int 44)
     . HM.insert "minFeeB"                (toJSON @Int 155381)
@@ -193,7 +232,7 @@ babbageTestnet testnetOptions H.Conf {..} = do
     . flip HM.adjust "protocolParams"
       ( J.rewriteObject
         ( flip HM.adjust "protocolVersion"
-          ( J.rewriteObject ( HM.insert "major" (toJSON @Int 8)))
+          ( J.rewriteObject ( HM.insert "major" (toJSON @Int $ babbageProtocolVersion testnetOptions)))
         )
       )
     . HM.insert "rho"                    (toJSON @Double 0.1)
@@ -223,9 +262,11 @@ babbageTestnet testnetOptions H.Conf {..} = do
   H.renameFile (tempAbsPath </> "byron-gen-command/delegation-cert.001.json") (tempAbsPath </> "node-spo2/byron-delegation.cert")
   H.renameFile (tempAbsPath </> "byron-gen-command/delegation-cert.002.json") (tempAbsPath </> "node-spo3/byron-delegation.cert")
 
-  H.writeFile (tempAbsPath </> "node-spo1/port") "3001"
-  H.writeFile (tempAbsPath </> "node-spo2/port") "3002"
-  H.writeFile (tempAbsPath </> "node-spo3/port") "3003"
+  [port1, port2, port3] <- getOpenPorts 60 $ babbageNumSpoNodes testnetOptions
+
+  H.writeFile (tempAbsPath </> "node-spo1/port") (show port1)
+  H.writeFile (tempAbsPath </> "node-spo2/port") (show port2)
+  H.writeFile (tempAbsPath </> "node-spo3/port") (show port3)
 
 
   -- Make topology files
@@ -236,12 +277,12 @@ babbageTestnet testnetOptions H.Conf {..} = do
     [ "Producers" .= toJSON
       [ object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3002
+        , "port"    .= toJSON @Int port2
         , "valency" .= toJSON @Int 1
         ]
       , object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3003
+        , "port"    .= toJSON @Int port3
         , "valency" .= toJSON @Int 1
         ]
       ]
@@ -252,12 +293,12 @@ babbageTestnet testnetOptions H.Conf {..} = do
     [ "Producers" .= toJSON
       [ object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3001
+        , "port"    .= toJSON @Int port1
         , "valency" .= toJSON @Int 1
         ]
       , object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3003
+        , "port"    .= toJSON @Int port3
         , "valency" .= toJSON @Int 1
         ]
       ]
@@ -268,12 +309,12 @@ babbageTestnet testnetOptions H.Conf {..} = do
     [ "Producers" .= toJSON
       [ object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3001
+        , "port"    .= toJSON @Int port1
         , "valency" .= toJSON @Int 1
         ]
       , object
         [ "addr"    .= toJSON @String "127.0.0.1"
-        , "port"    .= toJSON @Int 3002
+        , "port"    .= toJSON @Int port2
         , "valency" .= toJSON @Int 1
         ]
       ]

--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -17,27 +17,25 @@ module Testnet.Babbage
 
 import           Prelude
 
+import           Control.Concurrent (threadDelay)
+import qualified Control.Exception as IO
 import           Control.Monad
+import           Control.Monad.IO.Class (MonadIO (liftIO))
 import           Data.Aeson (encode, object, toJSON, (.=))
+import           Data.Functor (($>))
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock as H
 import qualified Hedgehog.Extras.Stock.Aeson as J
 import qualified Hedgehog.Extras.Stock.OS as OS
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
+import qualified Network.Socket as IO
 import           System.FilePath.Posix ((</>))
 import qualified System.Info as OS
 
-import           Control.Concurrent (threadDelay)
-import qualified Control.Exception as IO
-import           Control.Monad.IO.Class (MonadIO (liftIO))
-import           Data.Functor (($>))
-import           Hedgehog (MonadTest)
-import qualified Hedgehog as H
-import           Hedgehog.Extras.Stock (allocateRandomPorts)
-import qualified Network.Socket as IO
 import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
 import           Testnet.Options
@@ -74,11 +72,11 @@ canConnect sockAddr = IO.bracket (IO.socket IO.AF_INET IO.Stream 6) IO.close' $ 
     Right _                    -> return True
 
 -- | Get random list of open ports. Timeout after 60seconds if unsuccessful.
-getOpenPorts :: (MonadTest m, MonadIO m) => Int -> Int -> m [Int]
+getOpenPorts :: (H.MonadTest m, MonadIO m) => Int -> Int -> m [Int]
 getOpenPorts n numberOfPorts = do
   when (n == 0) $ do
    error "getOpenPorts timeout"
-  ports <- liftIO $ allocateRandomPorts numberOfPorts
+  ports <- liftIO $ H.allocateRandomPorts numberOfPorts
   allOpen <- liftIO $ mapM isPortOpen ports
   unless (and allOpen) $ do
     H.annotate "Some ports are not open, trying again..."

--- a/cardano-testnet/src/Testnet/Options.hs
+++ b/cardano-testnet/src/Testnet/Options.hs
@@ -27,7 +27,9 @@ import           Testnet.Util.Runtime (NodeLoggingFormat (..))
 {- HLINT ignore "Redundant flip" -}
 
 data BabbageTestnetOptions = BabbageTestnetOptions
-  { babbageNumSpoNodes :: Int
+  { babbageProtocolVersion :: Int
+  , babbageEpochLength :: Int
+  , babbageNumSpoNodes :: Int
   , babbageSlotDuration :: Int
   , babbageSecurityParam :: Int
   , babbageTotalBalance :: Int
@@ -36,7 +38,9 @@ data BabbageTestnetOptions = BabbageTestnetOptions
 
 defaultTestnetOptions :: BabbageTestnetOptions
 defaultTestnetOptions = BabbageTestnetOptions
-  { babbageNumSpoNodes = 3
+  { babbageProtocolVersion = 8
+  , babbageEpochLength = 500
+  , babbageNumSpoNodes = 3
   , babbageSlotDuration = 200
   , babbageSecurityParam = 10
   , babbageTotalBalance = 10020000000

--- a/cardano-testnet/src/Testnet/Options.hs
+++ b/cardano-testnet/src/Testnet/Options.hs
@@ -39,10 +39,10 @@ data BabbageTestnetOptions = BabbageTestnetOptions
 defaultTestnetOptions :: BabbageTestnetOptions
 defaultTestnetOptions = BabbageTestnetOptions
   { babbageProtocolVersion = 8
-  , babbageEpochLength = 500
+  , babbageEpochLength = 600 -- Should be "10 * k / f" where "k = securityParam, f = activeSlotsCoeff"
   , babbageNumSpoNodes = 3
   , babbageSlotDuration = 200
-  , babbageSecurityParam = 10
+  , babbageSecurityParam = 6
   , babbageTotalBalance = 10020000000
   , babbageNodeLoggingFormat = NodeLoggingFormatAsJson
   }


### PR DESCRIPTION


# Description

Add to `Testnet.Babbage`:
-  Configurable protocol version, useful for testing node and ledger rules in version 7 or 8.
-  Configurable epoch length, useful for testing scripts that validate slot to time
-  Use random ports to avoid collision in build machine running tests in CI

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
