### PR TITLE
Ensure build complete job fails if build jobs fail

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -19,7 +19,7 @@ on:
         default: some
 
 jobs:
-  linux_ci:
+  build:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -231,14 +231,21 @@ jobs:
     #     limit-access-to-actor: true
 
   build-complete:
-    needs: [linux_ci]
+    needs: [build]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
-    - name: Build complete
-      run: echo 'Build complete'
+    - name: Builds jobs complete
+      run: |
+        if ${{ needs.build.result }}; then
+          echo 'Linux CI job passed'
+        else
+          echo 'Linux CI job failed'
+          exit 1
+        fi
 
   release:
-    needs: [linux_ci]
+    needs: [build]
     if: ${{ startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -262,9 +262,16 @@ jobs:
   build-complete:
     needs: [build]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
-    - name: Build complete
-      run: echo 'Build complete'
+    - name: Builds jobs complete
+      run: |
+        if ${{ needs.linux_ci.result }}; then
+          echo 'Linux CI job passed'
+        else
+          echo 'Linux CI job failed'
+          exit 1
+        fi
 
   release:
     needs: [build]


### PR DESCRIPTION
# Description

`build-complete` is a required check and depends on build jobs.  It should fail rather than be skipped if any of the build jobs fail to avoid the merge queue merging PRs that actually failed one of the build jobs.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
