### PR TITLE
Fix cardano-testnet help

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -68,16 +68,12 @@ import           Cardano.CLI.Byron.Commands
 import           Cardano.CLI.Byron.Genesis
 import           Cardano.CLI.Byron.Key
 import           Cardano.CLI.Byron.Tx
-import           Cardano.CLI.Common.Parsers (pNetworkId, pSocketPath)
+import           Cardano.CLI.Common.Parsers
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.Run (ClientCommand (ByronCommand))
 import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
 import           Cardano.CLI.Types
 
-command' :: String -> String -> Parser a -> Mod CommandFields a
-command' c descr p =
-    command c $ info (p <**> helper)
-              $ mconcat [ progDesc descr ]
 
 backwardsCompatibilityCommands :: EnvCli -> Parser ClientCommand
 backwardsCompatibilityCommands envCli =

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -23,15 +23,16 @@ module Cardano.CLI.Byron.Parsers
   , parseUpdateVoteThd
   ) where
 
+
 import           Cardano.Prelude (ConvertText (..))
 
+import           Control.Applicative
 import           Control.Monad (when)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import           Data.Attoparsec.Combinator ((<?>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
-import           Data.Foldable
 import           Data.Text (Text)
 import           Data.Time (UTCTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
@@ -85,29 +86,29 @@ backwardsCompatibilityCommands envCli =
 
     hiddenCmds :: [Parser ClientCommand]
     hiddenCmds =
-      map convertToByronCommand
-        [ parseGenesisRelatedValues
-        , parseKeyRelatedValues envCli
-        , parseTxRelatedValues envCli
-        , parseLocalNodeQueryValues envCli
-        , parseMiscellaneous
-        ]
+     concatMap (fmap convertToByronCommand)
+          [ parseGenesisRelatedValues
+          , parseKeyRelatedValues envCli
+          , parseTxRelatedValues envCli
+          , return (parseLocalNodeQueryValues envCli)
+          , parseMiscellaneous
+          ]
 
 -- Implemented with asum so all commands don't get hidden when trying to hide
 -- the 'pNodeCmdBackwardCompatible' parser.
 parseByronCommands :: EnvCli -> Parser ByronCommand
 parseByronCommands envCli = asum
-  [ subParser "key" (Opt.info (Opt.subparser (parseKeyRelatedValues envCli))
+  [ subParser "key" (Opt.info (asum $ map Opt.subparser (parseKeyRelatedValues envCli))
       $ Opt.progDesc "Byron key utility commands")
-  , subParser "transaction" (Opt.info (Opt.subparser (parseTxRelatedValues envCli))
+  , subParser "transaction" (Opt.info (asum $ map Opt.subparser (parseTxRelatedValues envCli))
       $ Opt.progDesc "Byron transaction commands")
   , subParser "query" (Opt.info (Opt.subparser (parseLocalNodeQueryValues envCli))
       $ Opt.progDesc "Byron node query commands.")
-  , subParser "genesis" (Opt.info (Opt.subparser parseGenesisRelatedValues)
+  , subParser "genesis" (Opt.info (asum $ map Opt.subparser parseGenesisRelatedValues)
       $ Opt.progDesc "Byron genesis block commands")
   , subParser "governance" (Opt.info (NodeCmd <$> Opt.subparser (pNodeCmd envCli))
       $ Opt.progDesc "Byron governance commands")
-  , subParser "miscellaneous" (Opt.info (Opt.subparser parseMiscellaneous)
+  , subParser "miscellaneous" (Opt.info (asum $ map Opt.subparser parseMiscellaneous)
       $ Opt.progDesc "Byron miscellaneous commands")
   , NodeCmd <$> pNodeCmdBackwardCompatible envCli
   ]
@@ -170,9 +171,8 @@ parseGenesisParameters =
             "Optionally specify the seed of generation."
         )
 
-parseGenesisRelatedValues :: Mod CommandFields ByronCommand
+parseGenesisRelatedValues :: [Mod CommandFields ByronCommand]
 parseGenesisRelatedValues =
-  mconcat
     [ command' "genesis" "Create genesis."
       $ Genesis
           <$> parseNewDirectory
@@ -186,9 +186,8 @@ parseGenesisRelatedValues =
 
 -- | Values required to create keys and perform
 -- transformation on keys.
-parseKeyRelatedValues :: EnvCli -> Mod CommandFields ByronCommand
+parseKeyRelatedValues :: EnvCli -> [Mod CommandFields ByronCommand]
 parseKeyRelatedValues envCli =
-  mconcat
     [ command' "keygen" "Generate a signing key."
         $ Keygen
             <$> parseNewSigningKeyFile "secret"
@@ -228,15 +227,14 @@ parseKeyRelatedValues envCli =
 
 parseLocalNodeQueryValues :: EnvCli -> Mod CommandFields ByronCommand
 parseLocalNodeQueryValues envCli =
-  mconcat
-    [ command' "get-tip" "Get the tip of your local node's blockchain"
-        $ GetLocalNodeTip
-            <$> pSocketPath envCli
-            <*> pNetworkId envCli
-    ]
+  command' "get-tip" "Get the tip of your local node's blockchain"
+    $ GetLocalNodeTip
+        <$> pSocketPath envCli
+        <*> pNetworkId envCli
 
-parseMiscellaneous :: Mod CommandFields ByronCommand
-parseMiscellaneous = mconcat
+
+parseMiscellaneous :: [Mod CommandFields ByronCommand]
+parseMiscellaneous =
   [ command'
       "validate-cbor"
       "Validate a CBOR blockchain object."
@@ -321,9 +319,8 @@ readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
 readerFromAttoParser p =
   Opt.eitherReader (Atto.parseOnly (p <* Atto.endOfInput) . BSC.pack)
 
-parseTxRelatedValues :: EnvCli -> Mod CommandFields ByronCommand
+parseTxRelatedValues :: EnvCli -> [Mod CommandFields ByronCommand]
 parseTxRelatedValues envCli =
-  mconcat
     [ command'
         "submit-tx"
         "Submit a raw, signed transaction, in its on-wire representation."

--- a/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
@@ -1,5 +1,6 @@
 module Cardano.CLI.Common.Parsers
-  ( pCardanoEra
+  ( command'
+  , pCardanoEra
   , pNetworkId
   , pConsensusModeParams
   , pSocketPath
@@ -13,7 +14,7 @@ import           Cardano.CLI.Environment (EnvCli (..))
 import           Data.Foldable
 import           Data.Maybe (maybeToList)
 import           Data.Word (Word64)
-import           Options.Applicative (Parser)
+import           Options.Applicative
 import qualified Options.Applicative as Opt
 
 pCardanoEra :: Parser AnyCardanoEra
@@ -45,6 +46,12 @@ pCardanoEra = asum
     -- Default for now:
   , pure (AnyCardanoEra BabbageEra)
   ]
+command' :: String -> String -> Parser a -> Mod CommandFields a
+command' c descr p =
+  mconcat
+    [ command c (info (p <**> helper) $ mconcat [ progDesc descr ])
+    , metavar c
+    ]
 
 pNetworkId :: EnvCli -> Parser NetworkId
 pNetworkId envCli = asum $ mconcat

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -9,6 +9,7 @@ module Cardano.CLI.Parsers
   ) where
 
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
+import           Cardano.CLI.Common.Parsers
 import           Cardano.CLI.Environment (EnvCli)
 import           Cardano.CLI.Ping (parsePingCmd)
 import           Cardano.CLI.Render (customRenderHelp)
@@ -20,10 +21,6 @@ import           Options.Applicative
 
 import qualified Options.Applicative as Opt
 
-command' :: String -> String -> Parser a -> Mod CommandFields a
-command' c descr p =
-    command c $ info (p <**> helper)
-              $ mconcat [ progDesc descr ]
 
 opts :: EnvCli -> ParserInfo ClientCommand
 opts envCli =
@@ -37,10 +34,11 @@ opts envCli =
     ]
 
 pref :: ParserPrefs
-pref = Opt.prefs $ mempty
-  <> showHelpOnEmpty
-  <> helpHangUsageOverflow 10
-  <> helpRenderHelp customRenderHelp
+pref = Opt.prefs $ mconcat
+         [ showHelpOnEmpty
+         , helpHangUsageOverflow 10
+         , helpRenderHelp customRenderHelp
+         ]
 
 parseClientCommand :: EnvCli -> Parser ClientCommand
 parseClientCommand envCli =

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -94,5 +94,7 @@ runVersionCommand =
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =
-    command c $ info (p <**> helper)
-              $ mconcat [ progDesc descr ]
+  mconcat
+    [ command c (info (p <**> helper) $ mconcat [ progDesc descr ])
+    , metavar c
+    ]

--- a/cardano-testnet/app/cardano-testnet.hs
+++ b/cardano-testnet/app/cardano-testnet.hs
@@ -1,10 +1,11 @@
 module Main where
 
-import           Control.Monad
 import           Options.Applicative
-import           Testnet.Parsers (commands)
+import           Testnet.Parsers
 
 main :: IO ()
-main = join $ customExecParser
-  (prefs $ showHelpOnEmpty <> showHelpOnError)
-  (info (commands <**> helper) idm)
+main = do
+  tNetCmd <- customExecParser
+               (prefs $ showHelpOnEmpty <> showHelpOnError)
+               (info (commands <**> helper) idm)
+  runTestnetCmd tNetCmd

--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -4,9 +4,12 @@ module Parsers.Babbage
   , runBabbageOptions
   ) where
 
+import           Prelude
+
 import           Options.Applicative
 import qualified Options.Applicative as OA
-import           Prelude
+
+import           Cardano.CLI.Common.Parsers
 
 import           Testnet
 import           Testnet.Options
@@ -71,5 +74,5 @@ runBabbageOptions :: BabbageOptions -> IO ()
 runBabbageOptions options = runTestnet (maybeTestnetMagic options) $
   Testnet.testnet (BabbageOnlyTestnetOptions $ testnetOptions options)
 
-cmdBabbage :: Mod CommandFields (IO ())
-cmdBabbage = command "babbage"  $ flip info idm $ runBabbageOptions <$> optsBabbage
+cmdBabbage :: Mod CommandFields BabbageOptions
+cmdBabbage = command' "babbage" "Start a babbage testnet " optsBabbage

--- a/cardano-testnet/src/Parsers/Byron.hs
+++ b/cardano-testnet/src/Parsers/Byron.hs
@@ -5,10 +5,12 @@ module Parsers.Byron
   ) where
 
 import           Options.Applicative
+import qualified Options.Applicative as OA
+
+import           Cardano.CLI.Common.Parsers
+
 import           Testnet.Byron
 import           Testnet.Run (runTestnet)
-
-import qualified Options.Applicative as OA
 
 data ByronOptions = ByronOptions
   { maybeTestnetMagic :: Maybe Int
@@ -74,5 +76,5 @@ optsTestnet = TestnetOptions
 runByronOptions :: ByronOptions -> IO ()
 runByronOptions opts = runTestnet (maybeTestnetMagic opts) (Testnet.Byron.testnet (testnetOptions opts))
 
-cmdByron :: Mod CommandFields (IO ())
-cmdByron = command "byron" $ flip info idm $ runByronOptions <$> optsByron
+cmdByron :: Mod CommandFields ByronOptions
+cmdByron = command' "byron" "Start a Byron testnet" optsByron

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -99,5 +99,5 @@ runCardanoOptions :: CardanoOptions -> IO ()
 runCardanoOptions options = runTestnet (maybeTestnetMagic options) $
   Testnet.testnet (CardanoOnlyTestnetOptions $ testnetOptions options)
 
-cmdCardano :: Mod CommandFields (IO ())
-cmdCardano = command "cardano"  $ flip info idm $ runCardanoOptions <$> optsCardano
+cmdCardano :: Mod CommandFields CardanoOptions
+cmdCardano = command' "cardano" "Start a testnet in any era" optsCardano

--- a/cardano-testnet/src/Parsers/Shelley.hs
+++ b/cardano-testnet/src/Parsers/Shelley.hs
@@ -9,6 +9,8 @@ import           Prelude
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
+import           Cardano.CLI.Common.Parsers
+
 import           Testnet
 import           Testnet.Run (runTestnet)
 import           Testnet.Shelley
@@ -88,5 +90,5 @@ runShelleyOptions :: ShelleyOptions -> IO ()
 runShelleyOptions options = runTestnet (maybeTestnetMagic options) $
   Testnet.testnet (ShelleyOnlyTestnetOptions $ testnetOptions options)
 
-cmdShelley :: Mod CommandFields (IO ())
-cmdShelley = command "shelley"  $ flip info idm $ runShelleyOptions <$> optsShelley
+cmdShelley :: Mod CommandFields ShelleyOptions
+cmdShelley = command' "shelley" "Start a Shelley testnet" optsShelley

--- a/cardano-testnet/src/Parsers/Version.hs
+++ b/cardano-testnet/src/Parsers/Version.hs
@@ -5,15 +5,20 @@ module Parsers.Version
   ) where
 
 import           Cardano.Git.Rev (gitRev)
+import qualified Data.Text as T
 import           Data.Version (showVersion)
 import           Options.Applicative
 import           Paths_cardano_testnet (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
-
-import qualified Data.Text as T
 import qualified System.IO as IO
 
-data VersionOptions = VersionOptions deriving (Eq, Show)
+import           Cardano.CLI.Common.Parsers
+
+
+data VersionOptions = VersionOptions
+  deriving (Eq, Show)
+
+
 
 optsVersion :: Parser VersionOptions
 optsVersion = pure VersionOptions
@@ -27,5 +32,5 @@ runVersionOptions VersionOptions = do
     , "\ngit rev ", T.unpack gitRev
     ]
 
-cmdVersion :: Mod CommandFields (IO ())
-cmdVersion = command "version" $ flip info idm $ runVersionOptions <$> optsVersion
+cmdVersion :: Mod CommandFields VersionOptions
+cmdVersion = command' "version" "Show cardano-testnet version" optsVersion

--- a/cardano-testnet/src/Testnet/Parsers.hs
+++ b/cardano-testnet/src/Testnet/Parsers.hs
@@ -1,5 +1,6 @@
 module Testnet.Parsers
   ( commands
+  , runTestnetCmd
   ) where
 
 import           Options.Applicative
@@ -9,20 +10,28 @@ import           Parsers.Cardano
 import           Parsers.Shelley
 import           Parsers.Version
 
-{- HLINT ignore "Monoid law, left identity" -}
+-- TODO: Remove StartBabbageTestnet and StartShelleyTestnet
+-- by allowing the user to start testnets in any era (excluding Byron)
+-- via StartCardanoTestnet
+data CardanoTestnetCommands
+  = StartBabbageTestnet BabbageOptions
+  | StartByrontestnet ByronOptions -- TODO: Do we care about being able to start a Byron only testnet?
+  | StartCardanoTestnet CardanoOptions
+  | StartShelleyTestnet ShelleyOptions
+  | GetVersion VersionOptions
 
-commands :: Parser (IO ())
-commands = commandsTestnet <|> commandsGeneral
+commands :: Parser CardanoTestnetCommands
+commands =
+  asum [ fmap StartCardanoTestnet (subparser cmdCardano)
+       , fmap StartByrontestnet (subparser cmdByron)
+       , fmap StartShelleyTestnet (subparser cmdShelley)
+       , fmap StartBabbageTestnet (subparser cmdBabbage)
+       , fmap GetVersion (subparser cmdVersion)
+       ]
 
-commandsTestnet :: Parser (IO ())
-commandsTestnet = hsubparser $ mempty
-  <>  commandGroup "Testnets:"
-  <>  cmdBabbage
-  <>  cmdByron
-  <>  cmdCardano
-  <>  cmdShelley
-
-commandsGeneral :: Parser (IO ())
-commandsGeneral = hsubparser $ mempty
-  <>  commandGroup "General:"
-  <>  cmdVersion
+runTestnetCmd :: CardanoTestnetCommands -> IO ()
+runTestnetCmd (StartBabbageTestnet opts) = runBabbageOptions opts
+runTestnetCmd (StartByrontestnet opts) = runByronOptions opts
+runTestnetCmd (StartCardanoTestnet opts) = runCardanoOptions opts
+runTestnetCmd (StartShelleyTestnet opts) = runShelleyOptions opts
+runTestnetCmd (GetVersion opts) = runVersionOptions opts


### PR DESCRIPTION
# Description

Prior to this fix the cardano-testnet help output was as follows:
```
cardano-testnet --help    
Usage: cardano-testnet (COMMAND | COMMAND)

Available options:
  -h,--help                Show this help text

Testnets:
  babbage                  
  byron                    
  cardano                  
  shelley                  

General:
  version          
```
We have improved it to:
```
cardano-testnet --help                                                                                             
Usage: cardano-testnet (cardano | byron | shelley | babbage | version)

Available options:
  -h,--help                Show this help text

Available commands:
  cardano                  Start a testnet in any era
  byron                    Start a Byron testnet
  shelley                  Start a Shelley testnet
  babbage                  Start a babbage testnet
  version                  Show cardano-testnet version
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
