### PR TITLE
#5222 Remove `ApplicationName` and `ApplicationVersion` config parameters

### DIFF
--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -33,21 +33,27 @@ jobs:
     - name: Refresh cardano-node mainnet configuration
       run: |
         nix build --no-update-lock-file .#hydraJobs.cardano-deployment
-        SOURCE=$(pwd)/result
-        TARGET=$(pwd)/configuration/cardano
 
-        copyFile() {
-          echo $1
-          cp ${SOURCE}/$1 ${TARGET}/$1
-        }
-
-        copyFile "mainnet-alonzo-genesis.json"
-        copyFile "mainnet-byron-genesis.json"
-        copyFile "mainnet-conway-genesis.json"
-        copyFile "mainnet-config.json"
-        copyFile "mainnet-shelley-genesis.json"
-        copyFile "mainnet-topology.json"
-
-    - name: Check mainnet for mainnet configuration differences
+    - name: Check if configuration from nix is a superset of in-repo configuration
       run: |
-        git diff --exit-code
+        set -uo pipefail
+
+        test_files=(
+          'mainnet-alonzo-genesis.json'
+          'mainnet-byron-genesis.json'
+          'mainnet-conway-genesis.json'
+          'mainnet-config.json'
+          'mainnet-shelley-genesis.json'
+          'mainnet-topology.json'
+        )
+
+        for f in "${test_files[@]}"; do
+          nix_file="result/$f"
+          repo_file="configuration/cardano/$f"
+          if ! jq -e --argfile nix "$nix_file" --argfile repo "$repo_file" -n '$repo | reduce keys[] as $k (true; . and $repo[$k] == $nix[$k])' &>/dev/null ; then
+            echo "Nix file $nix_file does not have all the same top-level entries as the file from repository $repo_file"
+            diff "$nix_file" "$repo_file"
+            exit 1
+          fi
+        done
+

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -32,7 +32,7 @@ import           Data.Attoparsec.Combinator ((<?>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
-import           Data.Foldable (asum)
+import           Data.Foldable
 import           Data.Text (Text)
 import           Data.Time (UTCTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -32,7 +32,7 @@ import           Data.Attoparsec.Combinator ((<?>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
-import           Data.Foldable
+import           Data.Foldable (asum)
 import           Data.Text (Text)
 import           Data.Time (UTCTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -37,7 +37,7 @@ golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \
   addressSKeyFile <- noteTempFile tempDir "address.skey"
 
   void $ execCardanoCLI
-    [ "shelley","address","key-gen"
+    [ "address","key-gen"
     , "--extended-key"
     , "--verification-key-file", addressVKeyFile
     , "--signing-key-file", addressSKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -55,8 +55,8 @@ golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \te
 golden_shelleyExtendedPaymentKeys_te :: Property
 golden_shelleyExtendedPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/extended_payment_keys/signing_key"
+  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "extended-payment-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -54,8 +54,8 @@ golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 golden_shelleyKESKeys_te :: Property
 golden_shelleyKESKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/kes_keys/signing_key"
+  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "kes-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -53,8 +53,8 @@ golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
 golden_shelleyPaymentKeys_te :: Property
 golden_shelleyPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/payment_keys/signing_key"
+  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "payment-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -53,8 +53,8 @@ golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> d
 golden_shelleyStakeKeys_te :: Property
 golden_shelleyStakeKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/stake_keys/signing_key"
+  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -58,8 +58,8 @@ golden_shelleyVRFKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> 
   H.note_ tempDir
 
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/data/golden/shelley/keys/vrf_keys/signing_key"
+  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "vrf-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -191,7 +191,8 @@ Usage: cardano-cli genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create --genesis-dir DIR
+Usage: cardano-cli genesis create [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--start-time UTC-TIME]
@@ -201,7 +202,8 @@ Usage: cardano-cli genesis create --genesis-dir DIR
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create-staked --genesis-dir DIR
+Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--gen-pools INT]
@@ -471,6 +473,7 @@ Usage: cardano-cli stake-pool id
             | --cold-verification-key-file FILE
             )
             [--output-format STRING]
+            [--out-file FILE]
 
   Build pool id from the offline key
 
@@ -490,19 +493,22 @@ Usage: cardano-cli node
 
   Node operation commands
 
-Usage: cardano-cli node key-gen --cold-verification-key-file FILE
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+            --cold-verification-key-file FILE
             --cold-signing-key-file FILE
             --operational-certificate-issue-counter-file FILE
 
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
-Usage: cardano-cli node key-gen-KES --verification-key-file FILE
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 
-Usage: cardano-cli node key-gen-VRF --verification-key-file FILE
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
@@ -984,7 +990,8 @@ Usage: cardano-cli stake-address
 
   Stake address commands
 
-Usage: cardano-cli stake-address key-gen --verification-key-file FILE
+Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a stake address key pair
@@ -1045,7 +1052,8 @@ Usage: cardano-cli address (key-gen | key-hash | build | info)
 
   Payment address commands
 
-Usage: cardano-cli address key-gen [--normal-key | --extended-key | --byron-key]
+Usage: cardano-cli address key-gen [--key-output-format STRING]
+            [--normal-key | --extended-key | --byron-key]
             --verification-key-file FILE
             --signing-key-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
@@ -1,10 +1,15 @@
-Usage: cardano-cli address key-gen [--normal-key | --extended-key | --byron-key]
+Usage: cardano-cli address key-gen [--key-output-format STRING]
+            [--normal-key | --extended-key | --byron-key]
             --verification-key-file FILE
             --signing-key-file FILE
 
   Create an address key pair.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli genesis create-staked --genesis-dir DIR
+Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--gen-pools INT]
@@ -16,6 +17,10 @@ Usage: cardano-cli genesis create-staked --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli genesis create --genesis-dir DIR
+Usage: cardano-cli genesis create [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--start-time UTC-TIME]
@@ -9,6 +10,10 @@ Usage: cardano-cli genesis create --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli node key-gen-KES --verification-key-file FILE
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli node key-gen-VRF --verification-key-file FILE
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli node key-gen --cold-verification-key-file FILE
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+            --cold-verification-key-file FILE
             --cold-signing-key-file FILE
             --operational-certificate-issue-counter-file FILE
 
@@ -6,6 +7,10 @@ Usage: cardano-cli node key-gen --cold-verification-key-file FILE
   issue counter
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli stake-address key-gen --verification-key-file FILE
+Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a stake address key pair
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_id.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli stake-pool id
             | --cold-verification-key-file FILE
             )
             [--output-format STRING]
+            [--out-file FILE]
 
   Build pool id from the offline key
 
@@ -11,6 +12,7 @@ Available options:
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
-  --output-format STRING   Optional output format. Accepted output formats are
-                           "hex" and "bech32" (default is "bech32").
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -37,7 +37,6 @@ import           GHC.Generics (Generic)
 import           Options.Applicative
 import           System.FilePath (takeDirectory, (</>))
 
-import qualified Cardano.Chain.Update as Byron
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Logging.Types
 import           Cardano.Node.Configuration.NodeAddress (SocketPath)
@@ -351,9 +350,6 @@ instance FromJSON PartialNodeConfiguration where
         npcByronReqNetworkMagic     <- v .:? "RequiresNetworkMagic"
                                          .!= RequiresNoMagic
         npcByronPbftSignatureThresh <- v .:? "PBftSignatureThreshold"
-        npcByronApplicationName     <- v .:? "ApplicationName"
-                                         .!= Byron.ApplicationName "cardano-sl"
-        npcByronApplicationVersion  <- v .:? "ApplicationVersion" .!= 1
         protVerMajor                <- v .: "LastKnownBlockVersion-Major"
         protVerMinor                <- v .: "LastKnownBlockVersion-Minor"
         protVerAlt                  <- v .: "LastKnownBlockVersion-Alt" .!= 0
@@ -363,8 +359,6 @@ instance FromJSON PartialNodeConfiguration where
              , npcByronGenesisFileHash
              , npcByronReqNetworkMagic
              , npcByronPbftSignatureThresh
-             , npcByronApplicationName
-             , npcByronApplicationVersion
              , npcByronSupportedProtocolVersionMajor = protVerMajor
              , npcByronSupportedProtocolVersionMinor = protVerMinor
              , npcByronSupportedProtocolVersionAlt   = protVerAlt

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -20,31 +20,28 @@ import           Prelude
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
-import qualified Cardano.Chain.Update as Byron
-
 import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
+import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
+import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
 import qualified Ouroboros.Consensus.Shelley.Node.Praos as Praos
 
-import           Ouroboros.Consensus.Cardano.Condense ()
-import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
-
 import           Cardano.Api
-import           Cardano.Node.Types
-
-import           Cardano.Tracing.OrphanInstances.Byron ()
-import           Cardano.Tracing.OrphanInstances.Shelley ()
+import           Cardano.Api.Byron as Byron
+import qualified Cardano.Chain.Update as Update
 
 import           Cardano.Ledger.BaseTypes (natVersion)
 import           Cardano.Ledger.Shelley.Translation (emptyFromByronTranslationContext)
-
 import qualified Cardano.Node.Protocol.Alonzo as Alonzo
 import qualified Cardano.Node.Protocol.Byron as Byron
 import qualified Cardano.Node.Protocol.Conway as Conway
 import qualified Cardano.Node.Protocol.Shelley as Shelley
 import           Cardano.Node.Protocol.Types
+import           Cardano.Node.Types
+import           Cardano.Tracing.OrphanInstances.Byron ()
+import           Cardano.Tracing.OrphanInstances.Shelley ()
 
 ------------------------------------------------------------------------------
 -- Real Cardano protocol
@@ -75,8 +72,6 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcByronGenesisFileHash,
                              npcByronReqNetworkMagic,
                              npcByronPbftSignatureThresh,
-                             npcByronApplicationName,
-                             npcByronApplicationVersion,
                              npcByronSupportedProtocolVersionMajor,
                              npcByronSupportedProtocolVersionMinor,
                              npcByronSupportedProtocolVersionAlt
@@ -161,14 +156,11 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- protocol version is 1, this should be 2 to indicate we are ready
           -- to move into the Shelley era.
           byronProtocolVersion =
-            Byron.ProtocolVersion
+            Update.ProtocolVersion
               npcByronSupportedProtocolVersionMajor
               npcByronSupportedProtocolVersionMinor
               npcByronSupportedProtocolVersionAlt,
-          byronSoftwareVersion =
-            Byron.SoftwareVersion
-              npcByronApplicationName
-              npcByronApplicationVersion,
+          byronSoftwareVersion = Byron.softwareVersion,
           byronLeaderCredentials =
             byronLeaderCredentials,
           byronMaxTxCapacityOverrides =

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -39,7 +39,6 @@ import qualified Data.Text as Text
 import           Data.Word (Word16, Word8)
 
 import           Cardano.Api
-import qualified Cardano.Chain.Update as Byron
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
@@ -156,14 +155,6 @@ data NodeByronProtocolConfiguration =
      , npcByronGenesisFileHash               :: !(Maybe GenesisHash)
      , npcByronReqNetworkMagic               :: !RequiresNetworkMagic
      , npcByronPbftSignatureThresh           :: !(Maybe Double)
-
-       --TODO: eliminate these two: it can be hard-coded
-       -- | Update application name.
-     , npcByronApplicationName               :: !Byron.ApplicationName
-
-       -- | Application (ie software) version.
-     , npcByronApplicationVersion            :: !Byron.NumSoftwareVersion
-
        --TODO: eliminate these: it can be done automatically in consensus
        -- | These declare the version of the protocol that the node is prepared
        -- to run. This is usually the version of the protocol in use on the

--- a/cardano-testnet/src/Testnet/Options.hs
+++ b/cardano-testnet/src/Testnet/Options.hs
@@ -50,13 +50,8 @@ defaultYamlHardforkViaConfig :: AnyCardanoEra -> KeyMapAeson.KeyMap Aeson.Value
 defaultYamlHardforkViaConfig era =
   mconcat $ map (uncurry KeyMapAeson.singleton)
     [
-    -- TODO: Remnants from the Byron era that we can actually eliminate
-    -- and hardcode.
-      ("ApplicationName", "cardano-sl")
-    , ("ApplicationVersion", Aeson.Number 1)
-
     -- The consensus protocol to use
-    , ("Protocol", "Cardano")
+      ("Protocol", "Cardano")
 
     -- Socket path of the node
     , ("SocketPath", "db/node.socket")

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -191,7 +191,8 @@ Usage: cardano-cli genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create --genesis-dir DIR
+Usage: cardano-cli genesis create [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--start-time UTC-TIME]
@@ -201,7 +202,8 @@ Usage: cardano-cli genesis create --genesis-dir DIR
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create-staked --genesis-dir DIR
+Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--gen-pools INT]
@@ -471,6 +473,7 @@ Usage: cardano-cli stake-pool id
             | --cold-verification-key-file FILE
             )
             [--output-format STRING]
+            [--out-file FILE]
 
   Build pool id from the offline key
 
@@ -490,19 +493,22 @@ Usage: cardano-cli node
 
   Node operation commands
 
-Usage: cardano-cli node key-gen --cold-verification-key-file FILE
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+            --cold-verification-key-file FILE
             --cold-signing-key-file FILE
             --operational-certificate-issue-counter-file FILE
 
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
-Usage: cardano-cli node key-gen-KES --verification-key-file FILE
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 
-Usage: cardano-cli node key-gen-VRF --verification-key-file FILE
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
@@ -984,7 +990,8 @@ Usage: cardano-cli stake-address
 
   Stake address commands
 
-Usage: cardano-cli stake-address key-gen --verification-key-file FILE
+Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a stake address key pair
@@ -1045,7 +1052,8 @@ Usage: cardano-cli address (key-gen | key-hash | build | info)
 
   Payment address commands
 
-Usage: cardano-cli address key-gen [--normal-key | --extended-key | --byron-key]
+Usage: cardano-cli address key-gen [--key-output-format STRING]
+            [--normal-key | --extended-key | --byron-key]
             --verification-key-file FILE
             --signing-key-file FILE
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/address_key-gen.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/address_key-gen.cli
@@ -1,10 +1,15 @@
-Usage: cardano-cli address key-gen [--normal-key | --extended-key | --byron-key]
+Usage: cardano-cli address key-gen [--key-output-format STRING]
+            [--normal-key | --extended-key | --byron-key]
             --verification-key-file FILE
             --signing-key-file FILE
 
   Create an address key pair.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/genesis_create-staked.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/genesis_create-staked.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli genesis create-staked --genesis-dir DIR
+Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--gen-pools INT]
@@ -16,6 +17,10 @@ Usage: cardano-cli genesis create-staked --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/genesis_create.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/genesis_create.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli genesis create --genesis-dir DIR
+Usage: cardano-cli genesis create [--key-output-format STRING]
+            --genesis-dir DIR
             [--gen-genesis-keys INT]
             [--gen-utxo-keys INT]
             [--start-time UTC-TIME]
@@ -9,6 +10,10 @@ Usage: cardano-cli genesis create --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen-KES.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli node key-gen-KES --verification-key-file FILE
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen-VRF.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli node key-gen-VRF --verification-key-file FILE
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/node_key-gen.cli
@@ -1,4 +1,5 @@
-Usage: cardano-cli node key-gen --cold-verification-key-file FILE
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+            --cold-verification-key-file FILE
             --cold-signing-key-file FILE
             --operational-certificate-issue-counter-file FILE
 
@@ -6,6 +7,10 @@ Usage: cardano-cli node key-gen --cold-verification-key-file FILE
   issue counter
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_key-gen.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-address_key-gen.cli
@@ -1,9 +1,14 @@
-Usage: cardano-cli stake-address key-gen --verification-key-file FILE
+Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
+            --verification-key-file FILE
             --signing-key-file FILE
 
   Create a stake address key pair
 
 Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-pool_id.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/stake-pool_id.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli stake-pool id
             | --cold-verification-key-file FILE
             )
             [--output-format STRING]
+            [--out-file FILE]
 
   Build pool id from the offline key
 
@@ -11,6 +12,7 @@ Available options:
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
-  --output-format STRING   Optional output format. Accepted output formats are
-                           "hex" and "bech32" (default is "bech32").
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/allegra_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/allegra_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/alonzo_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/alonzo_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/babbage_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/babbage_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/byron_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/byron_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/conway_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/conway_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/mary_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/mary_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/shelley_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/shelley_node_default_config.json
@@ -1,7 +1,5 @@
 {
     "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
-    "ApplicationName": "cardano-sl",
-    "ApplicationVersion": 1,
     "ByronGenesisFile": "byron/genesis.json",
     "ConwayGenesisFile": "shelley/genesis.conway.json",
     "EnableLogMetrics": false,

--- a/configuration/cardano/mainnet-config-new-tracing.yaml
+++ b/configuration/cardano/mainnet-config-new-tracing.yaml
@@ -28,11 +28,6 @@ LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 MaxKnownMajorProtocolVersion: 2
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "mainnet-alonzo-genesis.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 1,
   "ByronGenesisFile": "mainnet-byron-genesis.json",
   "ByronGenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",
   "ConwayGenesisFile": "mainnet-conway-genesis.json",

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -30,11 +30,6 @@ LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 MaxKnownMajorProtocolVersion: 2
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/cardano/shelley_qa-config.json
+++ b/configuration/cardano/shelley_qa-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "shelley_qa-alonzo-genesis.json",
   "AlonzoGenesisHash": "fd77bbad445e6c438e2755d5e939a818d5d231316f882c7725988ebfac8442f8",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "shelley_qa-byron-genesis.json",
   "ByronGenesisHash": "9325495d3ac7554d4bfaf2392cc3c74676d5add873d6ef8862d7562e660940bf",
   "LastKnownBlockVersion-Alt": 0,

--- a/configuration/cardano/testnet-config.json
+++ b/configuration/cardano/testnet-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "testnet-alonzo-genesis.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "testnet-byron-genesis.json",
   "ByronGenesisHash": "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471",
   "LastKnownBlockVersion-Alt": 0,

--- a/configuration/chairman/byron-shelley/configuration.yaml
+++ b/configuration/chairman/byron-shelley/configuration.yaml
@@ -45,11 +45,6 @@ LastKnownBlockVersion-Major: 1
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
 ##### Enable P2P Mode #####
 EnableP2P: False
 ExperimentalProtocolsEnabled: True

--- a/configuration/chairman/defaults/simpleview/config-0.yaml
+++ b/configuration/chairman/defaults/simpleview/config-0.yaml
@@ -72,8 +72,6 @@ EnableP2P: False
 
 #####    Update Parameters    #####
 
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/configuration/chairman/defaults/simpleview/config-1.yaml
+++ b/configuration/chairman/defaults/simpleview/config-1.yaml
@@ -71,8 +71,6 @@ EnableP2P: True
 
 #####    Update Parameters    #####
 
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/configuration/chairman/defaults/simpleview/config-2.yaml
+++ b/configuration/chairman/defaults/simpleview/config-2.yaml
@@ -72,8 +72,6 @@ EnableP2P: True
 
 #####    Update Parameters    #####
 
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/configuration/chairman/shelley-only/configuration.yaml
+++ b/configuration/chairman/shelley-only/configuration.yaml
@@ -40,11 +40,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
 ##### Enable P2P Mode #####
 EnableP2P: False
 

--- a/configuration/defaults/byron-mainnet/configuration.yaml
+++ b/configuration/defaults/byron-mainnet/configuration.yaml
@@ -40,12 +40,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/defaults/byron-staging/configuration.yaml
+++ b/configuration/defaults/byron-staging/configuration.yaml
@@ -33,12 +33,6 @@ LastKnownBlockVersion-Major: 1
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/defaults/byron-testnet/configuration.yaml
+++ b/configuration/defaults/byron-testnet/configuration.yaml
@@ -33,12 +33,6 @@ LastKnownBlockVersion-Major: 1
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 0
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/defaults/mainnet-silent/configuration.yaml
+++ b/configuration/defaults/mainnet-silent/configuration.yaml
@@ -5,8 +5,6 @@ RequiresNetworkMagic: RequiresNoMagic
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 
 # Minimal logging
 TurnOnLogging: False

--- a/configuration/defaults/mainnet-via-fetcher/configuration.yaml
+++ b/configuration/defaults/mainnet-via-fetcher/configuration.yaml
@@ -31,12 +31,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/configuration/defaults/simpleview/config-0.yaml
+++ b/configuration/defaults/simpleview/config-0.yaml
@@ -70,8 +70,6 @@ SocketPath:
 
 #####    Update Parameters    #####
 
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/configuration/defaults/simpleview/config-1.yaml
+++ b/configuration/defaults/simpleview/config-1.yaml
@@ -68,9 +68,6 @@ SocketPath:
 
 
 #####    Update Parameters    #####
-
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/configuration/defaults/simpleview/config-2.yaml
+++ b/configuration/defaults/simpleview/config-2.yaml
@@ -69,9 +69,6 @@ SocketPath:
 
 
 #####    Update Parameters    #####
-
-ApplicationName: cardano-sl
-ApplicationVersion: 1
 LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -246,8 +246,6 @@ First section relates the basic node configuration parameters. Make sure you hav
 
 This protocol version number gets used by block producing nodes as part of the system for agreeing on and synchronising protocol updates. You just need to be aware of the latest version supported by the network. You don't need to change anything here.
 
-	  "ApplicationName": "cardano-sl",
-	  "ApplicationVersion": 0,
 	  "LastKnownBlockVersion-Alt": 0,
 	  "LastKnownBlockVersion-Major": 2,
 	  "LastKnownBlockVersion-Minor": 0,

--- a/doc/reference/configuring-a-node-using-yaml.md
+++ b/doc/reference/configuring-a-node-using-yaml.md
@@ -34,8 +34,6 @@ Block-producing nodes use a protocol version number as part of the system for th
 
 The update parameters section might look like this:
 ```
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "LastKnownBlockVersion-Alt": 0,
   "LastKnownBlockVersion-Major": 2,
   "LastKnownBlockVersion-Minor": 0,

--- a/nix/workbench/chaindb.sh
+++ b/nix/workbench/chaindb.sh
@@ -129,10 +129,8 @@ snapshot-at-slot )
              , ShelleyGenesisHash:            "'$shelleyGenesisHash'"
              , RequiresNetworkMagic:          "RequiresNoMagic"
              # , Protocol:                      "Cardano"
-             # , ApplicationVersion:            1
              # , "LastKnownBlockVersion-Major": 3
              ##
-             , ApplicationName:               "cardano-sl"
              }' <<<$geneses > $analyser_config
          local maybe_precedent=$(chaindb_mainnet_ledger_snapshots_before_slot $cachedir $slotno)
          cmd=(db-analyser

--- a/nix/workbench/profile/presets/mainnet/config.json
+++ b/nix/workbench/profile/presets/mainnet/config.json
@@ -1,7 +1,5 @@
 {
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 1,
   "ByronGenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",
   "LastKnownBlockVersion-Major": 3,
   "Protocol": "Cardano",

--- a/scripts/lite/configuration/shelley-1.yaml
+++ b/scripts/lite/configuration/shelley-1.yaml
@@ -38,12 +38,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/scripts/lite/configuration/shelley-2.yaml
+++ b/scripts/lite/configuration/shelley-2.yaml
@@ -38,12 +38,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall

--- a/scripts/lite/configuration/shelley-3.yaml
+++ b/scripts/lite/configuration/shelley-3.yaml
@@ -38,12 +38,6 @@ LastKnownBlockVersion-Major: 0
 LastKnownBlockVersion-Minor: 2
 LastKnownBlockVersion-Alt: 0
 
-# In the Byron era some software versions are also published on the chain.
-# We do this only for Byron compatibility now.
-ApplicationName: cardano-sl
-ApplicationVersion: 1
-
-
 ##### Logging configuration #####
 
 # Enable or disable logging overall


### PR DESCRIPTION
# Description

This PR removes unnecessary configuration parametes from `cardano-node` config.
https://github.com/input-output-hk/cardano-node/issues/5222
Requires https://github.com/input-output-hk/cardano-api/pull/8
see also: https://input-output-rnd.slack.com/archives/CCRB7BU8Y/p1683739407050779


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

<!-- # Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
-->