### PR TITLE
Remove all hardcoded yaml files from cardano-testnet

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -67,6 +67,7 @@ library
   hs-source-dirs:       src
   exposed-modules:      Cardano.Testnet
                         Testnet.Byron
+                        Testnet.Options
                         Testnet.Util.Assert
                         Testnet.Util.Base
                         Testnet.Util.Cli
@@ -86,7 +87,6 @@ library
                         Testnet.Conf
                         Testnet.Commands.Genesis
                         Testnet.Commands.Governance
-                        Testnet.Options
                         Testnet.Run
                         Testnet.Shelley
                         Testnet.Utils
@@ -118,6 +118,7 @@ test-suite cardano-testnet-tests
                         Test.Cli.Babbage.StakeSnapshot
                         Test.Cli.KesPeriodInfo
                         Test.FoldBlocks
+                        Test.Golden.All
                         Test.Misc
                         Test.Node.Shutdown
                         Test.ShutdownOnSlotSynced
@@ -125,6 +126,7 @@ test-suite cardano-testnet-tests
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson
+                      , aeson-pretty
                       , async
                       , bytestring
                       , cardano-api ^>= 8.1.0.1

--- a/cardano-testnet/src/Testnet/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Babbage.hs
@@ -14,7 +14,6 @@ module Testnet.Babbage
   , babbageTestnet
   ) where
 
-import           Cardano.Api
 import           Prelude
 
 import           Control.Monad
@@ -23,14 +22,10 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
 import qualified Data.Time.Clock as DTC
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Stock.Aeson as J
-import qualified Hedgehog.Extras.Stock.OS as OS
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
 import           System.FilePath.Posix ((</>))
 import qualified System.Info as OS
 
+import           Cardano.Api
 
 import           Testnet.Commands.Genesis
 import qualified Testnet.Conf as H
@@ -43,6 +38,11 @@ import           Testnet.Util.Runtime (Delegator (..), PaymentKeyPair (..), Pool
                    PoolNodeKeys (..), StakingKeyPair (..), TestnetRuntime (..), startNode)
 import           Testnet.Utils
 
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.Aeson as J
+import qualified Hedgehog.Extras.Stock.OS as OS
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Redundant flip" -}
 

--- a/cardano-testnet/src/Testnet/Run.hs
+++ b/cardano-testnet/src/Testnet/Run.hs
@@ -6,7 +6,6 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
 import           System.Console.ANSI (Color (..), ColorIntensity (..), ConsoleLayer (..), SGR (..))
-import           System.FilePath ((</>))
 
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.STM as STM
@@ -23,8 +22,7 @@ import qualified Testnet.Util.Base as H
 testnetProperty :: Maybe Int -> (H.Conf -> H.Integration ()) -> H.Property
 testnetProperty maybeTestnetMagic tn = H.integrationRetryWorkspace 2 "testnet" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf <- H.mkConf (H.ProjectBase base) (Just $ H.YamlFilePath configurationTemplate) tempAbsPath' maybeTestnetMagic
+  conf <- H.mkConf (H.ProjectBase base) Nothing tempAbsPath' maybeTestnetMagic
 
   -- Fork a thread to keep alive indefinitely any resources allocated by testnet.
   void . H.evalM . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000

--- a/cardano-testnet/src/Testnet/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Shelley.hs
@@ -432,8 +432,7 @@ shelleyTestnet testnetOptions H.Conf {..} = do
 hprop_testnet :: H.Property
 hprop_testnet = H.integrationRetryWorkspace 2 "shelley-testnet" $ \tempAbsPath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
-  conf <- H.mkConf (H.ProjectBase base) (Just $ H.YamlFilePath configurationTemplate) tempAbsPath' Nothing
+  conf <- H.mkConf (H.ProjectBase base) Nothing tempAbsPath' Nothing
 
   void . H.evalM . liftResourceT . resourceForkIO . forever . liftIO $ IO.threadDelay 10000000
 

--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -35,18 +35,17 @@ import           Options.Applicative
 import           System.Directory (doesFileExist, removeFile)
 
 import           Cardano.Chain.Genesis (GenesisHash (unGenesisHash), readGenesisData)
-
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
 import qualified Cardano.Crypto.Hash.Class as Crypto
 
+import qualified Testnet.Util.Process as H
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import           Hedgehog.Extras.Test.Process (ExecConfig)
 import           Hedgehog.Internal.Property (MonadTest)
-
-import qualified Hedgehog.Extras.Test.Concurrent as H
-import qualified Testnet.Util.Process as H
 
 -- | Submit the desired epoch to wait to.
 waitUntilEpoch

--- a/cardano-testnet/src/Testnet/Utils.hs
+++ b/cardano-testnet/src/Testnet/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Testnet.Utils
@@ -8,6 +9,10 @@ module Testnet.Utils
 
   -- ** Parsers
   , pMaxLovelaceSupply
+
+  -- ** Genesis
+  , getByronGenesisHash
+  , getShelleyGenesisHash
   ) where
 
 import           Cardano.Api
@@ -17,11 +22,22 @@ import           Cardano.CLI.Shelley.Output
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Aeson
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Key
+import           Data.Aeson.KeyMap
+import qualified Data.ByteString as BS
+import           Data.Text (Text)
 import           Data.Word
 import           GHC.Stack
 import           Options.Applicative
 import           System.Directory (doesFileExist, removeFile)
+
+import           Cardano.Chain.Genesis (GenesisHash (unGenesisHash), readGenesisData)
+
+import qualified Cardano.Crypto.Hash.Blake2b as Crypto
+import qualified Cardano.Crypto.Hash.Class as Crypto
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
@@ -30,7 +46,6 @@ import           Hedgehog.Extras.Test.Process (ExecConfig)
 import           Hedgehog.Internal.Property (MonadTest)
 
 import qualified Hedgehog.Extras.Test.Concurrent as H
-import           Testnet.Cardano (CardanoTestnetOptions (..), defaultTestnetOptions)
 import qualified Testnet.Util.Process as H
 
 -- | Submit the desired epoch to wait to.
@@ -99,5 +114,20 @@ pMaxLovelaceSupply =
       <>  help "Max lovelace supply that your testnet starts with."
       <>  metavar "WORD64"
       <>  showDefault
-      <>  value (cardanoMaxSupply defaultTestnetOptions)
+      <>  value 10_020_000_000
       )
+
+-- * Generate hashes for genesis.json files
+
+getByronGenesisHash :: (H.MonadTest m, MonadIO m) => FilePath -> m (KeyMap Aeson.Value)
+getByronGenesisHash path = do
+  e <- runExceptT $ readGenesisData path
+  (_, genesisHash) <- H.leftFail e
+  let genesisHash' = unGenesisHash genesisHash
+  pure . singleton "ByronGenesisHash" $ toJSON genesisHash'
+
+getShelleyGenesisHash :: (H.MonadTest m, MonadIO m) => FilePath -> Text -> m (KeyMap Aeson.Value)
+getShelleyGenesisHash path key = do
+  content <- H.evalIO  $ BS.readFile path
+  let genesisHash = Crypto.hashWith id content :: Crypto.Hash Crypto.Blake2b_256 BS.ByteString
+  pure . singleton (fromText key) $ toJSON genesisHash

--- a/cardano-testnet/test/Main.hs
+++ b/cardano-testnet/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Cli.Babbage.LeadershipSchedule
 import qualified Test.Cli.Babbage.StakeSnapshot
 import qualified Test.Cli.KesPeriodInfo
 import qualified Test.FoldBlocks
+import qualified Test.Golden.All
 import qualified Test.Node.Shutdown
 import qualified Test.ShutdownOnSlotSynced
 
@@ -26,7 +27,9 @@ import           Test.Gen.Cardano.Api.Empty ()
 
 tests :: IO TestTree
 tests = pure $ T.testGroup "test/Spec.hs"
-  [ T.testGroup "Spec"
+  [ T.testGroup "Golden"
+    [ H.ignoreOnWindows "Default JSON node configuration" Test.Golden.All.goldenDefaultConfigYaml ]
+  , T.testGroup "Spec"
     [ H.ignoreOnWindows "Shutdown" Test.Node.Shutdown.hprop_shutdown
     , H.ignoreOnWindows "ShutdownOnSlotSynced" Test.ShutdownOnSlotSynced.hprop_shutdownOnSlotSynced
     -- TODO: This is failing. Disabling until we can figure out why

--- a/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -54,9 +54,8 @@ hprop_leadershipSchedule :: Property
 hprop_leadershipSchedule = integrationRetryWorkspace 2 "alonzo-leadership-schedule" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
-    mkConf (ProjectBase base) (Just $ YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+    mkConf (ProjectBase base) Nothing tempAbsBasePath' Nothing
   let
     fastTestnetOptions = CardanoOnlyTestnetOptions cardanoDefaultTestnetOptions
       { cardanoEpochLength = 500

--- a/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -47,9 +47,8 @@ hprop_leadershipSchedule :: Property
 hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-schedule" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
-    mkConf (ProjectBase base) (Just $ YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+    mkConf (ProjectBase base) Nothing tempAbsBasePath' Nothing
 
   work <- H.createDirectoryIfMissing $ tempAbsPath </> "work"
 

--- a/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/Test/Cli/Babbage/StakeSnapshot.hs
@@ -46,9 +46,8 @@ hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf@Conf { tempBaseAbsPath, tempAbsPath } <- H.noteShowM $
-    mkConf (ProjectBase base) (Just $ YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+    mkConf (ProjectBase base) Nothing tempAbsBasePath' Nothing
 
   work <- H.createDirectoryIfMissing $ tempAbsPath </> "work"
 

--- a/cardano-testnet/test/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/Test/FoldBlocks.hs
@@ -38,9 +38,8 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
 
   -- Start testnet
   base <- HE.noteM $ H.evalIO . IO.canonicalizePath =<< HE.getProjectBase
-  configTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   conf <- HE.noteShowM $
-    TN.mkConf (TN.ProjectBase base) (Just $ TN.YamlFilePath configTemplate)
+    TN.mkConf (TN.ProjectBase base) Nothing
       (tempAbsBasePath' <> "/")
       Nothing
 

--- a/cardano-testnet/test/Test/Golden/All.hs
+++ b/cardano-testnet/test/Test/Golden/All.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTs #-}
+
+module Test.Golden.All where
+
+import           Prelude
+
+import           Data.Aeson
+import           Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+import           Cardano.Api
+
+import           Testnet.Options
+
+import           Hedgehog
+import           Hedgehog.Extras.Test.Base (propertyOnce)
+import           Hedgehog.Extras.Test.Golden (diffVsGoldenFile)
+
+
+goldenDefaultConfigYaml :: Property
+goldenDefaultConfigYaml = propertyOnce $ do
+  let allEras = map createConfigStringAndPath [minBound..maxBound]
+  mapM_ (uncurry diffVsGoldenFile) allEras
+ where
+  createConfigStringAndPath :: AnyCardanoEra -> (String, FilePath)
+  createConfigStringAndPath era =
+    let configStr = createConfigYamlString era
+        configPath = createGoldenFilePath era
+    in (configStr, configPath)
+
+  createGoldenFilePath :: AnyCardanoEra -> FilePath
+  createGoldenFilePath (AnyCardanoEra ByronEra) =
+    "test/Test/Golden/files/byron_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra ShelleyEra) =
+    "test/Test/Golden/files/shelley_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra AllegraEra) =
+    "test/Test/Golden/files/allegra_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra MaryEra) =
+    "test/Test/Golden/files/mary_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra AlonzoEra) =
+    "test/Test/Golden/files/alonzo_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra BabbageEra) =
+    "test/Test/Golden/files/babbage_node_default_config.json"
+  createGoldenFilePath (AnyCardanoEra ConwayEra) =
+    "test/Test/Golden/files/conway_node_default_config.json"
+
+  createConfigYamlString :: AnyCardanoEra -> String
+  createConfigYamlString era =
+    let configBs = LB.toStrict . encodePretty
+                   . Object . defaultYamlHardforkViaConfig $ era
+        configStr = Text.unpack $ Text.decodeUtf8 configBs
+    in configStr

--- a/cardano-testnet/test/Test/Golden/files/allegra_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/allegra_node_default_config.json
@@ -1,0 +1,94 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 3,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestAllegraHardForkAtEpoch": 0,
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/alonzo_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/alonzo_node_default_config.json
@@ -1,0 +1,96 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 5,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestAllegraHardForkAtEpoch": 0,
+    "TestAlonzoHardForkAtEpoch": 0,
+    "TestMaryHardForkAtEpoch": 0,
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/babbage_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/babbage_node_default_config.json
@@ -1,0 +1,97 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 8,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestAllegraHardForkAtEpoch": 0,
+    "TestAlonzoHardForkAtEpoch": 0,
+    "TestBabbageHardForkAtEpoch": 0,
+    "TestMaryHardForkAtEpoch": 0,
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/byron_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/byron_node_default_config.json
@@ -1,0 +1,91 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 1,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/conway_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/conway_node_default_config.json
@@ -1,0 +1,98 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 9,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestAllegraHardForkAtEpoch": 0,
+    "TestAlonzoHardForkAtEpoch": 0,
+    "TestBabbageHardForkAtEpoch": 0,
+    "TestConwayHardForkAtEpoch": 0,
+    "TestMaryHardForkAtEpoch": 0,
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/mary_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/mary_node_default_config.json
@@ -1,0 +1,95 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 4,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestAllegraHardForkAtEpoch": 0,
+    "TestMaryHardForkAtEpoch": 0,
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Golden/files/shelley_node_default_config.json
+++ b/cardano-testnet/test/Test/Golden/files/shelley_node_default_config.json
@@ -1,0 +1,93 @@
+{
+    "AlonzoGenesisFile": "shelley/genesis.alonzo.json",
+    "ApplicationName": "cardano-sl",
+    "ApplicationVersion": 1,
+    "ByronGenesisFile": "byron/genesis.json",
+    "ConwayGenesisFile": "shelley/genesis.conway.json",
+    "EnableLogMetrics": false,
+    "EnableLogging": true,
+    "EnableP2P": false,
+    "ExperimentalHardForksEnabled": true,
+    "LastKnownBlockVersion-Alt": 0,
+    "LastKnownBlockVersion-Major": 2,
+    "LastKnownBlockVersion-Minor": 0,
+    "MaxConcurrencyBulkSync": 1,
+    "MaxConcurrencyDeadline": 2,
+    "PBftSignatureThreshold": 0.6,
+    "Protocol": "Cardano",
+    "RequiresNetworkMagic": "RequiresMagic",
+    "ShelleyGenesisFile": "shelley/genesis.json",
+    "SocketPath": "db/node.socket",
+    "TestShelleyHardForkAtEpoch": 0,
+    "TraceBlockFetchClient": false,
+    "TraceBlockFetchDecisions": false,
+    "TraceBlockFetchProtocol": false,
+    "TraceBlockFetchProtocolSerialised": false,
+    "TraceBlockFetchServer": false,
+    "TraceBlockchainTime": true,
+    "TraceChainDb": true,
+    "TraceChainSyncBlockServer": false,
+    "TraceChainSyncClient": false,
+    "TraceChainSyncHeaderServer": false,
+    "TraceChainSyncProtocol": false,
+    "TraceConnectionManager": true,
+    "TraceDnsResolver": true,
+    "TraceDnsSubscription": true,
+    "TraceErrorPolicy": true,
+    "TraceForge": true,
+    "TraceHandshake": false,
+    "TraceIpSubscription": true,
+    "TraceLocalChainSyncProtocol": false,
+    "TraceLocalConnectionManager": false,
+    "TraceLocalErrorPolicy": true,
+    "TraceLocalHandshake": false,
+    "TraceLocalRootPeers": true,
+    "TraceLocalServer": false,
+    "TraceLocalTxSubmissionProtocol": false,
+    "TraceLocalTxSubmissionServer": false,
+    "TraceMempool": true,
+    "TraceMux": false,
+    "TracePeerSelection": true,
+    "TracePeerSelectionActions": true,
+    "TracePublicRootPeers": true,
+    "TraceServer": true,
+    "TraceTxInbound": false,
+    "TraceTxOutbound": false,
+    "TraceTxSubmissionProtocol": false,
+    "TurnOnLogMetrics": false,
+    "defaultBackends": [
+        "KatipBK"
+    ],
+    "defaultScribes": [
+        [
+            "FileSK",
+            "logs/mainnet.log"
+        ],
+        [
+            "StdoutSK",
+            "stdout"
+        ]
+    ],
+    "minSeverity": "Debug",
+    "options": {},
+    "rotation": {
+        "rpKeepFilesNum": 3,
+        "rpLogLimitBytes": 5000000,
+        "rpMaxAgeHours": 24
+    },
+    "setupBackends": [
+        "KatipBK"
+    ],
+    "setupScribes": [
+        {
+            "scFormat": "ScJson",
+            "scKind": "FileSK",
+            "scName": "logs/node.log"
+        },
+        {
+            "scFormat": "ScJson",
+            "scKind": "StdoutSK",
+            "scName": "stdout"
+        }
+    ]
+}

--- a/cardano-testnet/test/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/Test/Node/Shutdown.hs
@@ -37,9 +37,8 @@ import           Testnet.Util.Process (procNode)
 hprop_shutdown :: Property
 hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> do
   base <- H.note =<< H.noteIO . IO.canonicalizePath =<< H.getProjectBase
-  configurationTemplate <- H.noteShow $ base </> "configuration/defaults/byron-mainnet/configuration.yaml"
   Conf { tempBaseAbsPath, tempAbsPath, logDir, socketDir } <- H.noteShowM $
-    mkConf (ProjectBase base) (Just $ YamlFilePath configurationTemplate) tempAbsBasePath' Nothing
+    mkConf (ProjectBase base) Nothing tempAbsBasePath' Nothing
 
   [port] <- H.noteShowIO $ IO.allocateRandomPorts 1
 


### PR DESCRIPTION
# Description
Hardcoding configuration files makes `cardano-testnet` less portable and also introduces ambiguity into what your node configuration actually is.
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
