### PR TITLE
default.nix: one semicolon too much

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ in
   withHoogle ? defaultCustomConfig.withHoogle
 , profileData ? null
 , profileName ? if profileData != null then profileData.profileName
-                else defaultCustomConfig.localCluster.profileName;
+                else defaultCustomConfig.localCluster.profileName
 , workbenchDevMode ? defaultCustomConfig.localCluster.workbenchDevMode
 , workbenchStartArgs ? defaultCustomConfig.localCluster.workbenchStartArgs
 , customConfig ? {


### PR DESCRIPTION
```
error: syntax error, unexpected ';', expecting '}'

       at cardano-node/default.nix:10:66:

            9| , profileName ? if profileData != null then profileData.profileName
           10|                 else defaultCustomConfig.localCluster.profileName;
             |                                                                  ^
           11| , workbenchDevMode ? defaultCustomConfig.localCluster.workbenchDevMode
```

Possibly a typo in default.nix.