### PR TITLE
Bench nomad healthchecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,28 +90,32 @@ PROFILES_FORGE_STRESS_PRE := forge-stress-pre forge-stress-pre-plutus forge-stre
 PROFILES_CHAINSYNC        := chainsync-early-byron  chainsync-early-byron-notracer  chainsync-early-byron-oldtracing
 PROFILES_CHAINSYNC        += chainsync-early-alonzo chainsync-early-alonzo-notracer chainsync-early-alonzo-oldtracing chainsync-early-alonzo-p2p
 PROFILES_VENDOR           := dish dish-plutus dish-10M dish-10M-plutus
-PROFILES_CARDANO_WORLD_QA := cwqa-default cwqa-ci-test cwqa-ci-bench
-PROFILES_CARDANO_WORLD_QA += cwqa-value
+# "qa" and "perf" namespaces for cardano world (world.dev.cardano.org) Nomad
+# Not all local profiles are compatible (yet) with a cloud run
+# Cloud version of "default", "ci-test" and "ci-bench"
+PROFILES_CW_QA            := cw-qa-default cw-qa-ci-test cw-qa-ci-bench
+# The 52+explorer profile
+PROFILES_CW_PERF          := cw-perf-value
 
-SHELL_PROFILES       += $(PROFILES_BASE)
-SHELL_PROFILES       += $(PROFILES_FAST)
-SHELL_PROFILES       += $(PROFILES_CI_TEST)
-SHELL_PROFILES       += $(PROFILES_CI_BENCH)
-SHELL_PROFILES       += $(PROFILES_TRACE_BENCH)
-SHELL_PROFILES       += $(PROFILES_EPOCHTRANS)
-SHELL_PROFILES       += $(PROFILES_PLUTUSCALL)
-SHELL_PROFILES       += $(PROFILES_MODEL)
-SHELL_PROFILES       += $(PROFILES_10)
-SHELL_PROFILES       += $(PROFILES_FORGE_STRESS)
-SHELL_PROFILES       += $(PROFILES_FORGE_STRESS_PRE)
-SHELL_PROFILES       += $(PROFILES_CHAINSYNC)
-SHELL_PROFILES       += $(PROFILES_VENDOR)
-SHELL_PROFILES_CLOUD += $(PROFILES_CARDANO_WORLD_QA)
+LOCAL_PROFILES += $(PROFILES_BASE)
+LOCAL_PROFILES += $(PROFILES_FAST)
+LOCAL_PROFILES += $(PROFILES_CI_TEST)
+LOCAL_PROFILES += $(PROFILES_CI_BENCH)
+LOCAL_PROFILES += $(PROFILES_TRACE_BENCH)
+LOCAL_PROFILES += $(PROFILES_EPOCHTRANS)
+LOCAL_PROFILES += $(PROFILES_PLUTUSCALL)
+LOCAL_PROFILES += $(PROFILES_MODEL)
+LOCAL_PROFILES += $(PROFILES_10)
+LOCAL_PROFILES += $(PROFILES_FORGE_STRESS)
+LOCAL_PROFILES += $(PROFILES_FORGE_STRESS_PRE)
+LOCAL_PROFILES += $(PROFILES_CHAINSYNC)
+LOCAL_PROFILES += $(PROFILES_VENDOR)
+CLOUD_PROFILES += $(PROFILES_CW_QA) $(PROFILES_CW_PERF)
 
 ## Note:  to enable a shell for a profile, just add its name (one of names from 'make ps') to SHELL_PROFILES
 
-$(eval $(call define_profile_targets,           $(SHELL_PROFILES)))
-$(eval $(call define_profile_targets_nomadcloud,$(SHELL_PROFILES_CLOUD)))
+$(eval $(call define_profile_targets,           $(LOCAL_PROFILES)))
+$(eval $(call define_profile_targets_nomadcloud,$(CLOUD_PROFILES)))
 
 ###
 ### Misc
@@ -128,4 +132,4 @@ full-clean: clean
 cls:
 	echo -en "\ec"
 
-.PHONY: cabal-hashes clean cli cls cluster-profiles help node run-test shell shell-dev stylish-haskell $(SHELL_PROFILES) workbench-ci-test
+.PHONY: cabal-hashes clean cli cls cluster-profiles help node run-test shell shell-dev stylish-haskell $(LOCAL_PROFILES) workbench-ci-test

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -164,6 +164,12 @@ let
     # SRE: Only 3 Nomad datacenters exist actually.
     datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
 
+    # Specifies user-defined constraints on the task. This can be provided
+    # multiple times to define additional constraints.
+    # Cloud runs set the distinct hosts constraint here but local runs can't
+    # because we are only starting one Nomad client.
+    constraint = null;
+
     # The reschedule stanza specifies the group's rescheduling strategy. If
     # specified at the job level, the configuration will apply to all groups
     # within the job. If the reschedule stanza is present on both the job and
@@ -193,11 +199,11 @@ let
       ONE_TRACER_PER_NODE = oneTracerPerNode;
     };
 
-    # A group defines a series of tasks that should be co-located
-    # on the same client (host). All tasks within a group will be
-    # placed on the same host.
+    # A group defines a series of tasks that should be co-located on the same
+    # client (host). All tasks within a group will be placed on the same host.
     # https://developer.hashicorp.com/nomad/docs/job-specification/group
     group = let
+      # For each node-specs.json object
       valueF = (taskName: serviceName: portName: portNum: nodeSpec: (groupDefaults // {
 
         # Specifies the number of instances that should be running under for
@@ -255,8 +261,8 @@ let
         constraint = {
           attribute = "\${node.class}";
           operator = "=";
-          # For testing best to avoid using "infra" node class as HA jobs runs
-          # there, for benchmarking dedicated static machines in the "perf"
+          # For testing we avoid using "infra" node class as HA jobs runs there
+          # For benchmarking dedicated static machines in the "perf"
           # class are used and this value should be updated accordingly.
           value = "qa";
         };
@@ -327,6 +333,8 @@ let
 
           # Sensible defaults to run cloud version of "default", "ci-test" and
           # "ci-bench" in cardano-world qa class Nomad nodes.
+          # For benchmarking dedicated static machines in the "perf" class are
+          # used and this value should be updated accordingly.
           resources = {
             # Task can only ask for 'cpu' or 'cores' resource, not both.
             #cpu = 512;

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -162,19 +162,7 @@ let
     #  A list of datacenters in the region which are eligible for task
     # placement. This must be provided, and does not have a default.
     # SRE: Only 3 Nomad datacenters exist actually.
-    datacenters = [ "eu-central-1" "eu-west-1" "us-east-2" ];
-
-    # This can be provided multiple times to define additional constraints. See
-    # the Nomad constraint reference for more details.
-    # https://developer.hashicorp.com/nomad/docs/job-specification/constraint
-    constraint = {
-      attribute = "\${node.class}";
-      operator = "=";
-      # For testing best to avoid using "infra" node class as HA jobs runs
-      # there, for benchmarking dedicated static machines are need and this
-      # should be updated accordingly.
-      value = "qa";
-    };
+    datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
 
     # The reschedule stanza specifies the group's rescheduling strategy. If
     # specified at the job level, the configuration will apply to all groups
@@ -260,6 +248,18 @@ let
                 value     = region;
               }
         ;
+
+        # This can be provided multiple times to define additional constraints.
+        # See the Nomad constraint reference for more details.
+        # https://developer.hashicorp.com/nomad/docs/job-specification/constraint
+        constraint = {
+          attribute = "\${node.class}";
+          operator = "=";
+          # For testing best to avoid using "infra" node class as HA jobs runs
+          # there, for benchmarking dedicated static machines in the "perf"
+          # class are used and this value should be updated accordingly.
+          value = "qa";
+        };
 
         # The network stanza specifies the networking requirements for the task
         # group, including the network mode and port allocations.

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -3,12 +3,11 @@
 # clusters and SRE infrastructure used for long-running cloud benchmarks. Why?
 # To make it easier to improve and debug the almighty workbench!
 ################################################################################
-{ lib
+{ pkgs
+, lib
 , stateDir
 , profileData
 , containerSpecs
-# Needs unix_http_server.file
-, supervisorConf
 , execTaskDriver
 , oneTracerPerNode ? false
 }:
@@ -58,7 +57,8 @@ let
   # the container I get (from journald):
   # Nov 02 11:44:36 hostname cluster-18f3852f-e067-6394-8159-66a7b8da2ecc[1088457]: Error: Cannot open an HTTP server: socket.error reported -2
   # Nov 02 11:44:36 hostname cluster-18f3852f-e067-6394-8159-66a7b8da2ecc[1088457]: For help, use /nix/store/izqhlj5i1x9ldyn43d02kcy4mafmj3ci-python3.9-supervisor-4.2.4/bin/supervisord -h
-  task_supervisord_url = "unix://${supervisorConf.value.unix_http_server.file}";
+  unixHttpServerPort = "/tmp/supervisor.sock";
+  task_supervisord_url = "unix://${unixHttpServerPort}";
   # Location of the supervisord config file inside the container.
   # This file can be mounted as a volume or created as a template.
   task_supervisord_conf = "${task_statedir}/supervisor/supervisord.conf";
@@ -452,8 +452,21 @@ let
             {
               env = false;
               destination = "${task_supervisord_conf}";
-              data = escapeTemplate (__readFile
-                supervisorConf.INI);
+              data = escapeTemplate (__readFile (
+                let supervisorConf = import ./supervisor-conf.nix
+                  { inherit pkgs lib stateDir;
+                    # Include only this taks' node
+                    nodeSpecs = if taskName == "tracer"
+                      then {}
+                      else {"${nodeSpec.name}"=nodeSpec;}
+                    ;
+                    # Only for the tracer task or also nodes if oneTracerPerNode
+                    withTracer = oneTracerPerNode || taskName == "tracer";
+                    # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
+                    inherit unixHttpServerPort;
+                  };
+                in supervisorConf.INI
+              ));
               change_mode = "noop";
               error_on_missing_key = true;
             }
@@ -521,54 +534,51 @@ let
             }
           ])
           ++
-          # Node(s)
-          (lib.lists.flatten (lib.mapAttrsToList
-            (_: nodeSpec: [
-              ## Node start.sh script.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/start.sh";
-                data = escapeTemplate (
-                  let scriptValue = profileData.node-services."${nodeSpec.name}".startupScript.value;
-                  in if execTaskDriver
-                    then (startScriptToGoTemplate
-                      nodeSpec.name
-                      ("perf-" + nodeSpec.name)
-                      ("node" + (toString nodeSpec.i))
-                      nodeSpec
-                      scriptValue
-                    )
-                    else scriptValue
-                );
-                change_mode = "noop";
-                error_on_missing_key = true;
-                perms = "744"; # Only for every "start.sh" script. Default: "644"
-              }
-              ## Node configuration file.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/config.json";
-                data = escapeTemplate (lib.generators.toJSON {}
-                  profileData.node-services."${nodeSpec.name}".nodeConfig.value);
-                change_mode = "noop";
-                error_on_missing_key = true;
-              }
-              ## Node topology file.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/topology.json";
-                data = escapeTemplate (
-                  let topology = profileData.node-services."${nodeSpec.name}".topology;
-                  in if execTaskDriver
-                    then (topologyToGoTemplate topology.value)
-                    else (__readFile           topology.JSON )
-                );
-                change_mode = "noop";
-                error_on_missing_key = true;
-              }
-            ])
-            profileData.node-specs.value
-          ))
+          # Node
+          (lib.optionals (taskName != "tracer") [
+            ## Node start.sh script.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/start.sh";
+              data = escapeTemplate (
+                let scriptValue = profileData.node-services."${nodeSpec.name}".startupScript.value;
+                in if execTaskDriver
+                  then (startScriptToGoTemplate
+                    taskName                         # taskName
+                    serviceName                      # serviceName
+                    portName                         # portName (can't have "-")
+                    nodeSpec                         # nodeSpec
+                    scriptValue                      # startScript
+                  )
+                  else scriptValue
+              );
+              change_mode = "noop";
+              error_on_missing_key = true;
+              perms = "744"; # Only for every "start.sh" script. Default: "644"
+            }
+            ## Node configuration file.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/config.json";
+              data = escapeTemplate (lib.generators.toJSON {}
+                profileData.node-services."${nodeSpec.name}".nodeConfig.value);
+              change_mode = "noop";
+              error_on_missing_key = true;
+            }
+            ## Node topology file.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/topology.json";
+              data = escapeTemplate (
+                let topology = profileData.node-services."${nodeSpec.name}".topology;
+                in if execTaskDriver
+                  then (topologyToGoTemplate topology.value)
+                  else (__readFile           topology.JSON )
+              );
+              change_mode = "noop";
+              error_on_missing_key = true;
+            }
+          ])
           ;
 
           # Specifies logging configuration for the stdout and stderr of the
@@ -687,7 +697,7 @@ let
               "tracer"                               # portName (can't have "-")
               0                                      # portNum
               # TODO: Which region?
-              {region=null;};                        # node-specs
+              {region=null;};                        # node-spec
           }
         ]
         ++
@@ -706,7 +716,7 @@ let
               ("perf-node-" + (toString nodeSpec.i)) # serviceName
               ("node" + (toString nodeSpec.i))       # portName (can't have "-")
               nodeSpec.port                          # portNum
-              nodeSpec;                              # node-specs
+              nodeSpec;                              # node-spec
           })
           (profileData.node-specs.value)
         )

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -15,13 +15,6 @@ let
   materialise-profile =
     { profileData }:
       let
-        supervisorConf = import ./supervisor-conf.nix
-          { inherit profileData;
-            inherit pkgs lib stateDir;
-            # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
-            unixHttpServerPort = "/tmp/supervisor.sock";
-          }
-        ;
         # Intermediate / workbench-adhoc container specifications
         containerSpecs = rec {
           #
@@ -120,19 +113,17 @@ let
             podman = {
               # TODO: oneTracerPerGroup
               oneTracerPerCluster = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
                   oneTracerPerNode = true;
@@ -141,19 +132,17 @@ let
             exec = {
               # TODO: oneTracerPerGroup
               oneTracerPerCluster = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
                   oneTracerPerNode = true;

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -69,7 +69,22 @@ let
               flake-output = "legacyPackages.x86_64-linux.python3Packages.supervisor";
               installable = "${flake-reference}/${gitrev}#${flake-output}";
             };
-            # TODO: profileData.node-services."node-0".serviceConfig.value.eventlog
+            gnugrep = rec {
+              nix-store-path  = pkgs.gnugrep;
+              flake-reference = "github:input-output-hk/cardano-node";
+              flake-output = "legacyPackages.x86_64-linux.gnugrep";
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            jq = rec {
+              nix-store-path  = pkgs.jq;
+              flake-reference = "github:input-output-hk/cardano-node";
+              flake-output = "legacyPackages.x86_64-linux.jq";
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            # TODO: - cardano-node.passthru.profiled
+            #       - cardano-node.passthru.eventlogged
+            #       - cardano-node.passthru.asserted
+            # profileData.node-services."node-0".serviceConfig.value.eventlog
             # builtins.trace (builtins.attrNames profileData.node-services."node-0".serviceConfig.value.eventlog) XXXX
             cardano-node = rec {
               nix-store-path  = with pkgs;
@@ -83,6 +98,12 @@ let
                   then "cardanoNodePackages.cardano-node.passthru.eventlogged"
                   else "cardanoNodePackages.cardano-node"
               ;
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            cardano-cli = rec {
+              nix-store-path  = pkgs.cardanoNodePackages.cardano-cli;
+              flake-reference = "github:input-output-hk/cardano-cli";
+              flake-output = "cardanoNodePackages.cardano-cli";
               installable = "${flake-reference}/${gitrev}#${flake-output}";
             };
             cardano-tracer = rec {

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -1628,24 +1628,29 @@ backend_nomad() {
               else
                 # The whole cluster is about to finish!
                 touch "${dir}"/generator/quit
+                # Show the warning and continue with the counter
+                echo -ne "\n"
+                msg "$(yellow "WARNING: supervisord program \"generator\" (always inside Nomad Task \"node-0\" quit with an error exit code")"
+                msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
               fi
             else
               touch "${dir}"/generator/quit
               # Show the warning and continue with the counter
-              echo -e "\n"
+              echo -ne "\n"
               msg "$(yellow "WARNING: supervisord program \"generator\" (always inside Nomad Task \"node-0\" quit with a non-error exit code")"
               msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
             fi
-          fi
+          fi # Finish generator checks.
           local elapsed="$(($(date +%s) - start_time))"
           echo -ne "\b\b\b\b\b\b"
           printf "%6d" "${elapsed}"
           sleep 1
-        done   # While
+        done # While
         if ! test -f "${dir}"/flag/cluster-stopping
         then
-            echo -ne "\b\b\b\b\b\b"
-            echo -n "node-${pool_ix} 000000"
+          echo -ne "\n"
+          msg "$(yellow "supervisord program \"node-${pool_ix}\" stopped")"
+          msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
         fi
       done >&2 # For
       echo -ne "\b\b\b\b\b\b"
@@ -1653,10 +1658,12 @@ backend_nomad() {
       local elapsed=$(($(date +%s) - start_time))
       if test -f "${dir}"/flag/cluster-stopping
       then
-        echo " Termination requested -- after $(yellow ${elapsed})s" >&2;
+        echo -ne "\n"
+        msg "Termination requested -- after $(yellow ${elapsed})s"
       else
         touch "${dir}"/flag/cluster-stopping
-        echo " All nodes exited      -- after $(yellow ${elapsed})s" >&2
+        echo -ne "\n"
+        msg "All nodes exited      -- after $(yellow ${elapsed})s"
       fi
     ;;
 

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -824,7 +824,6 @@ backend_nomad() {
       local nomad_task_driver=$(envjqr   'nomad_task_driver')
       local one_tracer_per_node=$(envjqr 'one_tracer_per_node')
 
-      # TODO: Make it in parallel ?
       msg "Fetch logs ..."
 
       # Download healthcheck(s) logs.

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -238,13 +238,13 @@ backend_nomad() {
       done
     ;;
 
-    allocate-run-nomad-job-patch-constraints )
+    allocate-run-nomad-job-patch-group-constraints )
       local usage="USAGE: wb backend $op RUN-DIR CONSTRAINTS-JSON-ARRAY"
       local dir=${1:?$usage}; shift
       local constraints_array=${1:?$usage}; shift
       local nomad_environment=$(envjqr 'nomad_environment')
       local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      jq ".[\"job\"][\"${nomad_job_name}\"][\"constraint\"] = \$constraints_array" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
+      jq ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$constraints_array)" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
     ;;
 
     # Called by the sub-backends, don't use `fatal` and let them do the cleaning

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -238,15 +238,6 @@ backend_nomad() {
       done
     ;;
 
-    allocate-run-nomad-job-patch-group-constraints )
-      local usage="USAGE: wb backend $op RUN-DIR CONSTRAINTS-JSON-ARRAY"
-      local dir=${1:?$usage}; shift
-      local constraints_array=${1:?$usage}; shift
-      local nomad_environment=$(envjqr 'nomad_environment')
-      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      jq ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$constraints_array)" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
-    ;;
-
     # Called by the sub-backends, don't use `fatal` and let them do the cleaning
     deploy-genesis-wget )
       local usage="USAGE: wb backend $op RUN-DIR"

--- a/nix/workbench/backend/nomad/cloud.nix
+++ b/nix/workbench/backend/nomad/cloud.nix
@@ -26,7 +26,7 @@ let
   validateNodeSpecs = { nodeSpecsValue }:
     let
       # SRE is using these 3 Nomad "datacenters" (how they are called in Nomad)
-      datacenters = [ "eu-central-1" "eu-west-1" "us-east-2" ];
+      datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
       regions = lib.attrsets.mapAttrsToList
         (name: value: value.region)
         nodeSpecsValue

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -211,43 +211,147 @@ backend_nomadcloud() {
       # The job file is "slightly" modified (jq) to suit the running environment.
       backend_nomad allocate-run-nomad-job-patch-namespace         "${dir}" "${NOMAD_NAMESPACE}"
       backend_nomad allocate-run-nomad-job-patch-nix               "${dir}"
+
+      # Set the placement info and resources accordingly
+      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
       if test -z "${WB_SHELL_PROFILE}"
       then
         fatal "Envar \"WB_SHELL_PROFILE\" is empty!"
       else
+        # PLacement:
+        ############
+        ## "distinct_hosts": Instructs the scheduler to not co-locate any groups
+        ## on the same machine. When specified as a job constraint, it applies
+        ## to all groups in the job. When specified as a group constraint, the
+        ## effect is constrained to that group. This constraint can not be
+        ## specified at the task level. Note that the attribute parameter should
+        ## be omitted when using this constraint.
+        ## https://developer.hashicorp.com/nomad/docs/job-specification/constraint#distinct_hosts
+        local job_constraints_array
+        job_constraints_array='
+          [
+            {
+              "operator":  "distinct_hosts"
+            , "value":     "true"
+            }
+          ]
+        '
+          jq \
+            --argjson job_constraints_array "${job_constraints_array}" \
+            ".[\"job\"][\"${nomad_job_name}\"].constraint |= \$job_constraints_array" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
+        # Resources:
+        ############
+        local group_constraints_array
+        # "perf" profiles run on the "perf" class
         if test "${WB_SHELL_PROFILE:0:6}" != 'cw-perf'
         then
           # Right now only "live" is using "perf" class distinct nodes!
-          backend_nomad allocate-run-nomad-job-patch-group-constraints "${dir}" \
-            "[                                                \
-                {                                             \
-                  \"operator\":  \"=\"                        \
-                , \"attribute\": \"\${node.class}\"           \
-                , \"value\":     \"perf\"                     \
-                }                                             \
-              , {                                             \
-                  \"operator\":  \"distinct_property\"        \
-                , \"attribute\": \"\${attr.unique.hostname}\" \
-                , \"value\":     1                            \
-                }                                             \
-            ]"
+          group_constraints_array='
+            [
+              {
+                "operator":  "="
+              , "attribute": "${node.class}"
+              , "value":     "perf"
+              }
+            ]
+          '
+          # Set the resources, only for perf!
+          # AWS:
+          ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
+          ## https://aws.amazon.com/ec2/instance-types/c5/
+          # Nomad:
+          ## - cpu.reservablecores  = 8
+          ## - cpu.arch:            = amd64
+          ## - cpu.frequency:       = 3400
+          ## - cpu.modelname:       = Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
+          ## - cpu.numcores:        = 8
+          ## - cpu.reservablecores: = 8
+          ## - cpu.totalcompute:    = 27200
+          ## - memory.totalbytes    = 16300142592
+          ## Pesimistic: 1,798 MiB / 15,545 MiB Total
+          ## Optimistic: 1,396 MiB / 15,545 MiB Total
+          local resources='{
+              "cores":      8
+            , "memory":     12000
+            , "memory_max": 15000
+          }'
+            jq \
+              --argjson resources "${resources}" \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.task |= with_entries( .value.resources = \$resources ) )" \
+              "${dir}"/nomad/nomad-job.json \
+          | \
+            sponge "${dir}"/nomad/nomad-job.json
+        # Non "perf" profiles run on the "qa" class
         else
           # Right now only testing, using "qa" class distinct nodes!
-          backend_nomad allocate-run-nomad-job-patch-group-constraints "${dir}" \
-            "[                                                \
-                {                                             \
-                  \"operator\":  \"=\"                        \
-                , \"attribute\": \"\${node.class}\"           \
-                , \"value\":     \"qa\"                       \
-                }                                             \
-              , {                                             \
-                  \"operator\":  \"distinct_property\"        \
-                , \"attribute\": \"\${attr.unique.hostname}\" \
-                , \"value\":     1                            \
-                }                                             \
-            ]"
+          group_constraints_array='
+            [
+              {
+                "operator":  "="
+              , "attribute": "${node.class}"
+              , "value":     "qa"
+              }
+            ]
+          '
         fi
+          jq \
+            --argjson group_constraints_array "${group_constraints_array}" \
+            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
       fi
+
+      # Fix for region mismatches
+      ###########################
+      # There are USx16 and APx18 and we need USx17 and APx17
+        jq \
+          ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"node-49\"][\"affinity\"][\"value\"] = \"ap-southeast-2\"" \
+          "${dir}"/nomad/nomad-job.json \
+      | \
+        sponge "${dir}"/nomad/nomad-job.json
+      # We use "us-east-2" and they use "us-east-1"
+        jq \
+          ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
+          "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
+        jq \
+          ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
+          "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
+
+      # Store a summary of the job.
+      jq \
+        '{
+            "namespace":   ( .job["workbench-cluster-job"].namespace   )
+          , "datacenters": ( .job["workbench-cluster-job"].datacenters )
+          , "constraint":  ( .job["workbench-cluster-job"].constraint  )
+          , "groups":      (
+                .job["workbench-cluster-job"].group
+              | with_entries(
+                  .value |= {
+                      "constraint": .constraint
+                    , "affinity":   .affinity
+                    , "tasks":      (
+                        .task | with_entries(
+                          .value |= {
+                              "resources":          .resources
+                            , "nix_installables":   .config.nix_installables
+                            , "templates":        ( .template | map(.destination) )
+                          }
+                        )
+                      )
+                  }
+                )
+            )
+        }' \
+        "${dir}"/nomad/nomad-job.json \
+      > "${dir}"/nomad/nomad-job.summary.json
 
       backend_nomad allocate-run "${dir}"
     ;;
@@ -319,7 +423,7 @@ backend_nomadcloud() {
           --region "${s3_region}"                         \
         || true
         # Reminder to remove old files.
-        msg "Still avaiable files at $(yellow "\"s3://${s3_bucket_name}\""):"
+        msg "Still available files at $(yellow "\"s3://${s3_bucket_name}\""):"
         aws s3 ls                   \
           s3://"${s3_bucket_name}"/ \
           --region "${s3_region}"

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -29,12 +29,45 @@ let
   ## Refer to:
   ## - http://supervisord.org/configuration.html
   supervisorConf =
+    ##
+    ## [unix_http_server] Section Settings
+    ##
+    ## Refer to:
+    ## - http://supervisord.org/configuration.html#unix-http-server-section-settings
+    lib.attrsets.optionalAttrs (unixHttpServerPort != null) {
+      unix_http_server = {
+        file = unixHttpServerPort;
+        chmod = "0777";
+      };
+    }
+    ##
+    ## [inet_http_server] Section Settings
+    ##
+    ## Refer to:
+    ## - http://supervisord.org/configuration.html#inet-http-server-section-settings
+    //
+    lib.attrsets.optionalAttrs (inetHttpServerPort != null) {
+      inet_http_server = {
+        port = inetHttpServerPort;
+      };
+    }
+    //
     {
+      ##
+      ## [supervisord] Section Settings
+      ##
+      ## Refer to:
+      ## http://supervisord.org/configuration.html#supervisord-section-settings
       supervisord = {
         logfile = "${stateDir}/supervisor/supervisord.log";
         pidfile = "${stateDir}/supervisor/supervisord.pid";
         strip_ansi = true;
       };
+      ##
+      ## [supervisorctl] Section Settings
+      ##
+      ## Refer to:
+      ## http://supervisord.org/configuration.html#supervisorctl-section-settings
       supervisorctl = {};
       "rpcinterface:supervisor" = {
         "supervisor.rpcinterface_factory" = "supervisor.rpcinterface:make_main_rpcinterface";
@@ -45,24 +78,6 @@ let
     ##
     ## Refer to:
     ## - http://supervisord.org/configuration.html#program-x-section-settings
-    //
-    {
-      "program:generator" = {
-        # "command" below assumes "directory" is set accordingly.
-        directory      = "${stateDir}/generator";
-        command        = "${command}";
-        stdout_logfile = "${stateDir}/generator/stdout";
-        stderr_logfile = "${stateDir}/generator/stderr";
-        stopasgroup    = false;
-        killasgroup    = false;
-        autostart      = false;
-        autorestart    = false;
-        # Don't attempt any restart!
-        startretries   = 0;
-        # Seconds it needs to stay running to consider the start successful
-        startsecs      = 5;
-      };
-    }
     //
     lib.attrsets.optionalAttrs withTracer
     {
@@ -106,23 +121,24 @@ let
     ## Refer to:
     ## - http://supervisord.org/configuration.html#unix-http-server-section-settings
     //
-    lib.attrsets.optionalAttrs (unixHttpServerPort != null) {
-      unix_http_server = {
-        file = unixHttpServerPort;
-        chmod = "0777";
+    {
+      "program:generator" = {
+        # "command" below assumes "directory" is set accordingly.
+        directory      = "${stateDir}/generator";
+        command        = "${command}";
+        stdout_logfile = "${stateDir}/generator/stdout";
+        stderr_logfile = "${stateDir}/generator/stderr";
+        stopasgroup    = false;
+        killasgroup    = false;
+        autostart      = false;
+        autorestart    = false;
+        # Don't attempt any restart!
+        startretries   = 0;
+        # Seconds it needs to stay running to consider the start successful
+        startsecs      = 5;
       };
     }
-    ##
-    ## [inet_http_server] Section Settings
-    ##
-    ## Refer to:
-    ## - http://supervisord.org/configuration.html#inet-http-server-section-settings
-    //
-    lib.attrsets.optionalAttrs (inetHttpServerPort != null) {
-      inet_http_server = {
-        port = inetHttpServerPort;
-      };
-    };
+    ;
 
 in {
   value = supervisorConf;

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -136,6 +136,24 @@ let
         startsecs      = 5;
       };
     }
+    //
+    {
+      "program:healthcheck" = {
+        # "command" below assumes "directory" is set accordingly.
+        directory      = "${stateDir}/healthcheck";
+        command        = "${command}";
+        stdout_logfile = "${stateDir}/healthcheck/stdout";
+        stderr_logfile = "${stateDir}/healthcheck/stderr";
+        stopasgroup    = false;
+        killasgroup    = false;
+        autostart      = false;
+        autorestart    = false;
+        # Don't attempt any restart!
+        startretries   = 0;
+        # Seconds it needs to stay running to consider the start successful
+        startsecs      = 5;
+      };
+    }
     ;
 
 in {

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -14,15 +14,13 @@ let
   # may run in the most unexpected places where we can't asume what is or isn't
   # included in $PATH. Just make sure pkgs.bashInteractive is in the nix store.
   sh = "${pkgs.bashInteractive}/bin/sh";
-  # Same as above for `sh` applies for pkgs.coreutils.
-  touch = "${pkgs.coreutils}/bin/touch";
   # We can't obtain the exit codes using `supervisorctl status`, it returns zero
   # when RUNNING and non-zero for STOPPED, EXITED, FATAL, and UNKNOWN, so as we
   # are not using any "autorestart" like functionality supervisord programs are
   # echoing their exit code after the script to a file named `exit_code` that is
-  # created empty just before starting the script.
+  # created and/or emptied before every script run.
   # Warning: This command assumes the "directory" is set correctly.
-  command = "${sh} -c \"${touch} ./exit_code; ./start.sh; echo \"$?\" > ./exit_code\"";
+  command = "${sh} -c \":> ./exit_code; ./start.sh; echo \"$?\" > ./exit_code\"";
   ##
   ## supervisorConf :: SupervisorConf
   ##

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -38,8 +38,10 @@ let
   materialise-profile =
     { profileData }:
       let supervisorConf = import ./supervisor-conf.nix
-        { inherit profileData;
-          inherit pkgs lib stateDir;
+        { inherit pkgs lib stateDir;
+          # Create a `supervisord.conf`
+          nodeSpecs = profileData.node-specs.value;
+          withTracer = profileData.value.node.tracer;
           inetHttpServerPort = "127.0.0.1:9001";
         };
       in pkgs.runCommand "workbench-backend-output-${profileData.profileName}-supervisor"

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -205,7 +205,11 @@ EOF
              echo "$(white -------------------------------------------------)" >&2
              fatal "could not start $(white supervisord)"
         fi
-        backend_supervisor save-child-pids "$dir";;
+        backend_supervisor save-child-pids "$dir"
+        if ! supervisorctl start healthcheck
+        then
+          msg "$(red "supervisorctl start healthcheck failed")"
+        fi;;
 
     wait-node-stopped )
         local usage="USAGE: wb backend $op RUN-DIR NODE"

--- a/nix/workbench/lib.sh
+++ b/nix/workbench/lib.sh
@@ -247,7 +247,7 @@ git_repo_commit_description() {
 wait_fail_any () {
   local processes=("$@")
   # There are any processes left?
-  if test -n "${processes[*]}"
+  if test -n "${processes[*]:-}"
   then
     local wait_exit_status
     local exited_process
@@ -263,7 +263,7 @@ wait_fail_any () {
       fi
     done
     # Something else to wait for?
-    if test -n "${processes_p[*]}"
+    if test -n "${processes_p[*]:-}"
     then
       # Keep waiting or kill 'em all ?'
       if test "${wait_exit_status}" -eq 0

--- a/nix/workbench/nomad.sh
+++ b/nix/workbench/nomad.sh
@@ -1577,7 +1577,7 @@ EOF
           local eval_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Evaluation \"${eval_id}\"") to be \"complete\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && ( test "${status:-pending}" = "pending" || test "${status:-running}" = "running" )
           do
@@ -1648,7 +1648,7 @@ EOF
           local deploy_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Deployment \"${deploy_id}\"") to be \"successful\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && ! test -f "${job_file}.run/allocations.ok" && ( test "${status:-pending}" = "pending" || test "${status:-running}" = "running" )
           do
@@ -1695,7 +1695,7 @@ EOF
           local alloc_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Allocation \"${alloc_id}\"") to be \"running\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && test "${status:-pending}" = "pending"
           do
@@ -1770,7 +1770,7 @@ EOF
           local task_name=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Task \"${task_name}\"") to be \"running\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && test "${status:-pending}" = "pending"
           do

--- a/nix/workbench/nomad.sh
+++ b/nix/workbench/nomad.sh
@@ -69,7 +69,7 @@ usage_nomad() {
     $(helpcmd job monitor)
     $(helpcmd job monitor-job-evals)
     $(helpcmd job monitor-job-allocs)
-    $(helpcmd job monitor-alloc-tasks)
+    $(helpcmd job monitor-job-alloc-tasks)
     $(helpcmd job check-eval-id-placement-failures)
     $(helpcmd job monitor-eval-id)
     $(helpcmd job monitor-deploy-id)
@@ -78,8 +78,6 @@ usage_nomad() {
     $(helpcmd job task-name-allocation-id)
 EOF
 }
-
-publish_default_op='local'
 
 wb_nomad() {
 
@@ -567,7 +565,7 @@ wb_nomad() {
             fi
           done
           # Remove PID file if process was really killed (or wasn't running)!
-          if test -z $(wb_nomad server pids-array "${name}")
+          if test -z "$(wb_nomad server pids-array "${name}")"
           then
             local pid_file=$(wb_nomad server pid-filepath "${name}")
             if test -f "${pid_file}"
@@ -796,7 +794,6 @@ wb_nomad() {
           # client as eligible
           local i=0 patience=25
           msg "$(blue Waiting) until the Nomad server sees the client (${patience}s) ..."
-          local ans=""
           until nomad node status -filter "\"workbench-nomad-client-${name}\" in Name" -json | jq -r '.[0].Status' | grep --quiet "^ready"
           do printf "%3d" $i; sleep 1
             i=$((i+1))
@@ -891,7 +888,7 @@ wb_nomad() {
             fi
           done
           # Remove PID file if process was really killed (or wasn't running)!
-          if test -z $(wb_nomad client pids-array "${name}")
+          if test -z "$(wb_nomad client pids-array "${name}")"
           then
             # WHY? The client is keeping some directories mounted!
             # Maybe because of the 2 processes it creates (testes running
@@ -1331,29 +1328,50 @@ EOF
           wait_fail_any "${jobs_array[@]}" || touch "${job_file}.run/job.error"
           # Check for every possible error
           local return_code=0
-          # Any failed evaluations?
+          # Any failed evaluation(s)?
           if test -f "${job_file}.run/evaluations.error"
           then
             return_code=1
             msg "$(red "FATAL: One or more Nomad Evaluations failed!")"
             # Due to race conditions the *.error file may not be preset.
-            msg "$(yellow "See logs on: $(ls "${job_file}.run/evaluation.*.error.json" 2>/dev/null || true)")"
+            msg \
+              "$(yellow \
+                "See logs on: $( \
+                    ls "${job_file}.run/evaluation.*.error.json" 2>/dev/null \
+                  || \
+                    echo "${job_file}.run/evaluation.*.error.json" \
+                )"\
+              )"
           fi
-          # Any failed allocations?
+          # Any failed allocation(s)?
           if test -f "${job_file}.run/allocations.error"
           then
             return_code=1
             msg "$(red "FATAL: One or more Nomad Allocations failed!")"
             # Due to race conditions the *.error file may not be preset.
-            msg "$(yellow "See logs on: $(ls "${job_file}.run/allocation.*.error.json" 2>/dev/null || true)")"
+            msg \
+              "$(yellow \
+                "See logs on: $( \
+                    ls "${job_file}.run/allocation.*.error.json" 2>/dev/null \
+                  || \
+                    echo "${job_file}.run/allocation.*.error.json" \
+                )"\
+              )"
           fi
-          # Any allocation's tasks failed?
-          if test -f "${job_file}.run/tasks.*.error"
+          # Any failed allocations' task(s)?
+          if test -f "${job_file}.run/tasks.error"
           then
             return_code=1
-            msg "$(red "FATAL: One or more Nomad Allocation Tasks failed!")"
+            msg "$(red "FATAL: One or more Nomad Allocation's Tasks failed!")"
             # Due to race conditions the *.error file may not be preset.
-            msg "$(yellow "See logs on: $(ls "${job_file}.run/task.*.error.json" 2>/dev/null || true)")"
+            msg \
+              "$(yellow \
+                "See logs on: $( \
+                    ls "${job_file}.run/task.*.error.json" 2>/dev/null \
+                  || \
+                    echo "${job_file}.run/task.*.error.json" \
+                )"\
+              )"
           fi
           # Any other generic error?
           if test -f "${job_file}.run/job.error"
@@ -1368,35 +1386,43 @@ EOF
           local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME MSGOFF"
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};   shift
           # Fetch the evaluations IDs and monitor them.
-          local job_evals_result
-          if ! job_evals_result=$(nomad eval list -json -job "${job_name}")
+          local nomad_command_stdout # Don't masquerade errors behind `local`
+          if ! nomad_command_stdout=$(nomad eval list -json -job "${job_name}")
           then
             "${msgoff}" || msg "$(red "FATAL: Command \"nomad eval list\" failed")"
-            "${msgoff}" || msg "${job_evals_result}"
+            # Error messages surely shown on stderr and this variable is empty
+            if test -n "${nomad_command_stdout}"
+            then
+              "${msgoff}" || msg "${nomad_command_stdout}"
+            fi
             # Send fatal job error signal after printing this error's messages!
             touch "${job_file}.run/job.error"
             return 1
           fi
-          local evals_array=($(echo "${job_evals_result}" | jq "map(.ID)? | join (\" \")" --raw-output))
+          # IDs Bash array with the command result if any (jq query using "?")
+          local ids_array # Don't masquerade errors behind `local`
+          ids_array=($(echo "${nomad_command_stdout}" | jq --raw-output "map(.ID)? | join (\" \")"))
           # If no evaluations start all over again
-          if test -z "${evals_array:-}"
+          if test -z "${ids_array:-}" # If = () "unbound variable" error
           then
             # But stop if any other cluster failure happens
             if test -f "${job_file}.run/job.error"
             then
+              # Monitor was not started, IDs not known, no messages to show
               return 1
             else
               sleep 1
+              # Iterate and exit with the return code of the new call
               wb_nomad job monitor-job-evals            \
                 "${job_file}" "${job_name}" "${msgoff}"
             fi
           else
             # Iterate through evaluations
             local jobs_array=()
-            "${msgoff}" || msg "Entering monitor of Nomad $(yellow "Evaluations: [${evals_array[@]}]")"
-            for eval_id in ${evals_array[*]}
+            "${msgoff}" || msg "Entering monitor of Nomad $(yellow "Evaluation(s) [${ids_array[@]}]")"
+            for eval_id in ${ids_array[*]}
             do
               # Create file "evaluations.error" is any evaluation fails
                   wb_nomad job monitor-eval-id               \
@@ -1410,17 +1436,14 @@ EOF
             # Wait for all processes to finish or kill them if at least one fails!
             if ! wait_fail_any "${jobs_array[@]}" || test -f "${job_file}.run/evaluations.error"
             then
-              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Evaluations [${evals_array[@]}] due to errors")"
+              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Evaluation(s) [${ids_array[@]}] due to errors")"
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
             else
-              # If nobody else failed!
-              if ! test -f "${job_file}.run/job.error"
-              then
-                touch "${job_file}.run/evaluations.ok"
-                "${msgoff}" || msg "Exiting monitor of Nomad Evaluations"
-              fi
+              touch "${job_file}.run/evaluations.ok"
+              "${msgoff}" || msg "Exiting monitor of Nomad Evaluation(s) [${ids_array[@]}]"
+              return 0
             fi
           fi
         ;;
@@ -1429,35 +1452,43 @@ EOF
           local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME MSGOFF"
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};   shift
           # Fetch the allocations IDs and monitor them.
-          local job_allocs_result
-          if ! job_allocs_result=$(nomad job allocs -json "${job_name}")
+          local nomad_command_stdout # Don't masquerade errors behind `local`
+          if ! nomad_command_stdout=$(nomad job allocs -json "${job_name}")
           then
             "${msgoff}" || msg "$(red "FATAL: Command \"nomad job allocs\" failed")"
-            "${msgoff}" || msg "${job_allocs_result}"
+            # Error messages surely shown on stderr and this variable is empty
+            if test -n "${nomad_command_stdout}"
+            then
+              "${msgoff}" || msg "${nomad_command_stdout}"
+            fi
             # Send fatal job error signal after printing this error's messages!
             touch "${job_file}.run/job.error"
             return 1
           fi
-          local allocs_array=($(echo "${job_allocs_result}" | jq "map(.ID)? | join (\" \")" --raw-output))
+          # IDs Bash array with the command result if any (jq query using "?")
+          local ids_array # Don't masquerade errors behind `local`
+          ids_array=($(echo "${nomad_command_stdout}" | jq --raw-output "map(.ID)? | join (\" \")"))
           # If no allocations start all over again
-          if test -z "${allocs_array:-}"
+          if test -z "${ids_array:-}" # If = () "unbound variable" error
           then
             # But stop if any other cluster failure happens
             if test -f "${job_file}.run/job.error"
             then
+              # Monitor was not started, IDs not known, no messages to show
               return 1
             else
               sleep 1
+              # Iterate and exit with the return code of the new call
               wb_nomad job monitor-job-allocs           \
                 "${job_file}" "${job_name}" "${msgoff}"
             fi
           else
             # Iterate through allocations
             local jobs_array=()
-            "${msgoff}" || msg "Entering monitor of Nomad $(yellow "Allocations: [${allocs_array[@]}]")"
-            for alloc_id in ${allocs_array[*]}
+            "${msgoff}" || msg "Entering monitor of Nomad $(yellow "Allocation(s) [${ids_array[@]}]")"
+            for alloc_id in ${ids_array[*]}
             do
               # Create file "allocations.error" is any allocation fails
                   wb_nomad job monitor-alloc-id               \
@@ -1471,79 +1502,81 @@ EOF
             # Wait for all processes to finish or kill them if at least one fails!
             if ! wait_fail_any "${jobs_array[@]}" || test -f "${job_file}.run/allocations.error"
             then
-              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Allocations [${allocs_array[@]}] due to errors")"
+              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Allocation(s) [${ids_array[@]}] due to errors")"
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
             else
-              # If nobody else failed!
-              if ! test -f "${job_file}.run/job.error"
-              then
-                touch "${job_file}.run/allocations.ok"
-                "${msgoff}" || msg "Exiting monitor of Nomad Allocations"
-              fi
+              touch "${job_file}.run/allocations.ok"
+              "${msgoff}" || msg "Exiting monitor of Nomad Allocation(s) [${ids_array[@]}]"
+              return 0
             fi
           fi
         ;;
-####### job -> monitor-alloc-tasks )############################################
-        monitor-alloc-tasks )
-          local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME MSGOFF"
+####### job -> monitor-job-alloc-tasks )########################################
+        monitor-job-alloc-tasks )
+          local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME ALLOC-ID MSGOFF"
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
           local alloc_id=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};   shift
           # Fetch the allocation's status and monitor its Tasks.
-          local alloc_status_result
-          if ! alloc_status_result=$(nomad alloc status -json "${alloc_id}")
+          local nomad_command_stdout # Don't masquerade errors behind `local`
+          if ! nomad_command_stdout=$(nomad alloc status -json "${alloc_id}")
           then
             "${msgoff}" || msg "$(red "FATAL: Command \"nomad alloc status\" failed")"
-            "${msgoff}" || msg "${alloc_status_result}"
+            # Error messages surely shown on stderr and this variable is empty
+            if test -n "${nomad_command_stdout}"
+            then
+              "${msgoff}" || msg "${nomad_command_stdout}"
+            fi
             # Send fatal job error signal after printing this error's messages!
             touch "${job_file}.run/job.error"
             return 1
           fi
+          # IDs Bash array with the command result if any (jq query using "?")
+          local ids_array # Don't masquerade errors behind `local`
+          ids_array=($(echo "${nomad_command_stdout}" | jq --raw-output ".TaskStates? | keys? | join (\" \")"))
           # If no tasks start all over again
-          local tasks_array=($(echo "${alloc_status_result}" | jq ".TaskStates? | keys? | join (\" \")" --raw-output))
-          if test -z "${tasks_array:-}"
+          if test -z "${ids_array:-}" # If = () "unbound variable" error
           then
             # But stop if any other cluster failure happens
             if test -f "${job_file}.run/job.error"
             then
+              # Monitor was not started, IDs not known, no messages to show
               return 1
             else
               sleep 1
-              wb_nomad job monitor-alloc-tasks                        \
+              # Iterate and exit with the return code of the new call
+              wb_nomad job monitor-job-alloc-tasks                    \
                 "${job_file}" "${job_name}" "${alloc_id}" "${msgoff}"
             fi
           else
             # Iterate through allocation's tasks
             local jobs_array=()
-            "${msgoff}" || msg "Entering monitor of Nomad $(yellow "Tasks: [${tasks_array[@]}]")"
-            for task_name in ${tasks_array[*]}
+            "${msgoff}" || msg "Entering monitor of Nomad Allocation \"${alloc_id}\" $(yellow "Task(s) [${ids_array[@]}]")"
+            for task_name in ${ids_array[*]}
             do
-              # Create file "tasks.ALLOC_ID.error" is any task fails
+              # Create file "tasks.error" is any task fails
                   wb_nomad job monitor-alloc-id-task-name                    \
                     "${job_file}" "${job_name}" "${alloc_id}" "${task_name}" \
                     "${msgoff}"                                              \
                 ||                                                           \
-                  touch "${job_file}.run/tasks.${alloc_id}.error"            \
+                  touch "${job_file}.run/tasks.error"                        \
               &
               jobs_array+=("$!")
             done
             # Wait for all processes to finish or kill them if at least one fails!
-            if ! wait_fail_any "${jobs_array[@]}" || test -f "${job_file}.run/tasks.${alloc_id}.error"
+            if ! wait_fail_any "${jobs_array[@]}" || test -f "${job_file}.run/tasks.error"
             then
-              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Tasks [${tasks_array[@]}] due to errors")"
+              "${msgoff}" || msg "$(red "Exiting monitor of Nomad Allocation \"${alloc_id}\" Task(s) [${ids_array[@]}] due to errors")"
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
             else
-              # If nobody else failed!
-              if ! test -f "${job_file}.run/job.error"
-              then
-                touch "${job_file}.run/tasks.${alloc_id}.ok"
-                "${msgoff}" || msg "Exiting monitor of Nomad Tasks"
-              fi
+              touch "${job_file}.run/tasks.${alloc_id}.ok"
+              "${msgoff}" || msg "Exiting monitor of Nomad Allocation \"${alloc_id}\" Task(s) [${ids_array[@]}]"
+              return 0
             fi
           fi
         ;;
@@ -1552,14 +1585,17 @@ EOF
           local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME EVAL-ID MSGOFF"
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
-          local eval_id=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local eval_id=${1:?$usage};  shift
+          local msgoff=${1:?$usage};   shift
           "${msgoff}" || msg "$(blue Checking) for \"Placement Failures\" in Nomad $(blue Evaluation) $(yellow "\"${eval_id}\"") ..."
           local status_response
           if ! status_response=$(nomad eval status "${eval_id}")
           then
             "${msgoff}" || msg "$(red "FATAL: Command \"nomad eval status\" failed")"
-            "${msgoff}" || msg "${status_response}"
+            if test -n "${status_response}"
+            then
+              "${msgoff}" || msg "${status_response}"
+            fi
             # Send fatal job error signal after printing this error's messages!
             touch "${job_file}.run/job.error"
             return 1
@@ -1577,8 +1613,8 @@ EOF
           local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME EVAL-ID MSGOFF"
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
-          local eval_id=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local eval_id=${1:?$usage};  shift
+          local msgoff=${1:?$usage};   shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Evaluation \"${eval_id}\"") to be \"complete\" ..."
           local status=""
           local status_response
@@ -1587,7 +1623,10 @@ EOF
             if ! status_response=$(nomad eval status -json "${eval_id}")
             then
               "${msgoff}" || msg "$(red "FATAL: Command \"nomad eval status\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1607,7 +1646,10 @@ EOF
                 # When done building Tasks run just fine but the deployment
                 # is already considered failed.
                 "${msgoff}" || msg "$(yellow "WARNING: A Nomad Deployment failed while waiting for its Evaluation")"
-                "${msgoff}" || msg "${deploy_output}"
+                if test -n "${deploy_output}"
+                then
+                  "${msgoff}" || msg "${deploy_output}"
+                fi
               fi
             fi
           done
@@ -1621,7 +1663,10 @@ EOF
               echo "${status_response}" > "${job_file}.run/evaluation.${eval_id}.error.json"
               # Show this error messages.
               "${msgoff}" || msg "$(red "FATAL: Nomad Evaluation \"${eval_id}\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1632,9 +1677,12 @@ EOF
             if ! placement_response=$(wb_nomad job check-eval-id-placement-failures "${job_file}" "${job_name}" "${eval_id}" "${msgoff}")
             then
               # Store the error response that ended the loop!
-              echo "${status_response}" > "${job_file}.run/evaluation.${eval_id}.error.json"
+              echo "${placement_response}" > "${job_file}.run/evaluation.${eval_id}.error.json"
               # Show this error messages.
-              "${msgoff}" || msg "${placement_response}"
+              if test -n "${placement_response}"
+              then
+                "${msgoff}" || msg "${placement_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1648,10 +1696,10 @@ EOF
 ####### job -> monitor-deploy-id )##############################################
         monitor-deploy-id )
           local usage="USAGE:wb nomad ${op} ${subop} JOB-FILE JOB-NAME DEPLOY-ID MSGOFF"
-          local job_file=${1:?$usage}; shift
-          local job_name=${1:?$usage}; shift
+          local job_file=${1:?$usage};  shift
+          local job_name=${1:?$usage};  shift
           local deploy_id=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};    shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Deployment \"${deploy_id}\"") to be \"successful\" ..."
           local status=""
           local status_response
@@ -1660,7 +1708,10 @@ EOF
             if ! status_response=$(nomad deployment status -json "${deploy_id}")
             then
               "${msgoff}" || msg "$(red "FATAL: Command \"nomad deployment status\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1678,7 +1729,10 @@ EOF
               # Store the error response that ended the loop!
               echo "${status_response}" > "${job_file}.run/deployment.${deploy_id}.error.json"
               "${msgoff}" || msg "$(yellow "WARNING: Nomad Deployment \"${deploy_id}\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Deployment failures are not considered fatal!
             else
               if test -f "${job_file}.run/allocations.ok"
@@ -1698,7 +1752,7 @@ EOF
           local job_file=${1:?$usage}; shift
           local job_name=${1:?$usage}; shift
           local alloc_id=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};   shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Allocation \"${alloc_id}\"") to be \"running\" ..."
           local status=""
           local status_response
@@ -1707,7 +1761,10 @@ EOF
             if ! status_response=$(nomad alloc status -json "${alloc_id}")
             then
               "${msgoff}" || msg "$(red "FATAL: Command \"nomad alloc status\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1715,13 +1772,16 @@ EOF
             status=$(echo "${status_response}" | jq -r .ClientStatus)
             echo "${status_response}" > "${job_file}.run/allocation.${alloc_id}.$(date +%Y-%m-%d-%H-%M-%S-%N).json"
             # Monitor tasks "concurrently" (no need for sleeps here)!
-            if ! test -f "${job_file}.run/tasks.${alloc_id}.ok" && ! test -f "${job_file}.run/tasks.${alloc_id}.error"
+            if ! test -f "${job_file}.run/tasks.${alloc_id}.ok" && ! test -f "${job_file}.run/tasks.error"
             then
               local tasks_output
-              if ! tasks_output=$(wb_nomad job monitor-alloc-tasks "${job_file}" "${job_name}" "${alloc_id}" "false")
+              if ! tasks_output=$(wb_nomad job monitor-job-alloc-tasks "${job_file}" "${job_name}" "${alloc_id}" "false")
               then
                 "${msgoff}" || msg "$(red "FATAL: A Nomad Task failed while waiting for its Allocation")"
-                "${msgoff}" || msg "${tasks_output}"
+                if test -n "${tasks_output}"
+                then
+                  "${msgoff}" || msg "${tasks_output}"
+                fi
                 msg "$(yellow "INFO: Nomad Allocation \"${alloc_id}\" entrypoint stdout:")"
                 nomad alloc logs -verbose         "${alloc_id}" > "${job_file}.run/allocation.${alloc_id}.stdout"
                 cat "${job_file}.run/allocation.${alloc_id}.stdout"
@@ -1769,11 +1829,11 @@ EOF
 ####### job -> monitor-alloc-id-task-name )#####################################
         monitor-alloc-id-task-name )
           local usage="USAGE: wb nomad ${op} ${subop} JOB-FILE JOB-NAME ALLOC-ID MSGOFF"
-          local job_file=${1:?$usage}; shift
-          local job_name=${1:?$usage}; shift
-          local alloc_id=${1:?$usage}; shift
+          local job_file=${1:?$usage};  shift
+          local job_name=${1:?$usage};  shift
+          local alloc_id=${1:?$usage};  shift
           local task_name=${1:?$usage}; shift
-          local msgoff=${1:?$usage}; shift
+          local msgoff=${1:?$usage};    shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Task \"${task_name}\"") to be \"running\" ..."
           local status=""
           local status_response
@@ -1782,7 +1842,10 @@ EOF
             if ! status_response=$(nomad alloc status -json "${alloc_id}")
             then
               "${msgoff}" || msg "$(red "FATAL: Command \"nomad alloc status\" failed")"
-              "${msgoff}" || msg "${status_response}"
+              if test -n "${status_response}"
+              then
+                "${msgoff}" || msg "${status_response}"
+              fi
               # Send fatal job error signal after printing this error's messages!
               touch "${job_file}.run/job.error"
               return 1
@@ -1822,7 +1885,7 @@ EOF
 ####### job -> task-name-allocation-id )########################################
         task-name-allocation-id )
           local usage="USAGE:wb nomad ${op} ${subop} JOB-FILE TASK-NAME"
-          local job_file=${1:?$usage}; shift
+          local job_file=${1:?$usage};  shift
           local task_name=${1:?$usage}; shift
           jq -r '.ID' "${job_file}.run/task.${task_name}.final.json"
         ;;
@@ -1850,3 +1913,12 @@ EOF
   esac
 
 }
+
+# TODO: `nomad-retry`
+# Example errors:
+# - Error retrieving deployment: Get "https://nomad.world.dev.cardano.org/v1/deployment/f8921691-abad-567c-dd79-f1fa8ae672eb?namespace=perf": net/http: TLS handshake timeout
+# - Error querying allocation: Get "https://nomad.world.dev.cardano.org/v1/allocations?namespace=perf&prefix=3e9f7b8e-56ef-3548-3c5b-c6406424608c": net/http: TLS handshake timeout
+# - Error reading file: Unexpected response code: 404 (task "node-50" not started yet. No logs available)
+# - failed to exec into task: unexpected EOF
+# - failed to exec into task: read tcp 10.0.101.184:58166->3.72.231.105:443: read: connection reset by peer
+# - failed to exec into task: websocket closed before receiving exit code: websocket: close 1000 (normal)

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -173,13 +173,21 @@ def all_profile_variants:
       }
     } as $chainsync_cluster
   |
-    # Uses: ["eu-west-1", "eu-central-1", "us-east-2"]
+    # "qa" class Nomad Nodes in ["eu-central-1", "us-east-2"] datacenters
     { composition:
       { locations:                      ["EU", "US"]
       , topology:                       "torus"
       , with_explorer:                  true
       }
     } as $cardano_world_qa
+  |
+    # "perf" class Nomad Nodes in ["eu-central-1", "us-east-2", "ap-southeast-2"] datacenters
+    { composition:
+      { locations:                      ["EU", "US", "AP"]
+      , topology:                       "torus"
+      , with_explorer:                  true
+      }
+    } as $cardano_world_perf
   |
   ##
   ### Definition vocabulary:  filtering
@@ -262,7 +270,7 @@ def all_profile_variants:
     ) as $current_tps_saturation_value
   | ({}|
      .generator.tps                   = 12
-    ) as $cwqa_tps_saturation_value
+    ) as $cw_perf_tps_saturation_value
   | ({}|
      .generator.tps                   = 9
     ) as $model_tps_saturation_value
@@ -405,9 +413,9 @@ def all_profile_variants:
     { scenario:                        "fixed-loaded"
     }) as $scenario_fixed_loaded
   |
-   ($model_timescale * $cwqa_tps_saturation_value *
+   ($model_timescale * $cw_perf_tps_saturation_value *
     { scenario:                        "fixed-loaded"
-    }) as $scenario_cwqa
+    }) as $scenario_cw_perf
   |
    ($model_timescale * $model_tps_saturation_value *
     { scenario:                        "fixed-loaded"
@@ -452,7 +460,7 @@ def all_profile_variants:
       , desc: "Small dataset, honest 15 epochs duration"
     }) as $plutuscall_base
   |
-   ($scenario_cwqa * $compose_fiftytwo * $dataset_oct2021 * $for_7ep *
+   ($scenario_cw_perf * $compose_fiftytwo * $dataset_oct2021 * $for_7ep *
     { node:
         { shutdown_on_slot_synced:        56000
         }
@@ -467,7 +475,7 @@ def all_profile_variants:
         , max_block_size:                 88000
         }
       , desc: "AWS c5-2xlarge cluster dataset, 7 epochs"
-    }) as $cwqa_base
+    }) as $cw_perf_base
   |
    ($scenario_model * $quadruplet * $dataset_current * $for_7ep *
     { node:
@@ -584,7 +592,7 @@ def all_profile_variants:
     , desc: "Idle scenario:  start only the tracer & detach from tty;  no termination"
     }
   , $cardano_world_qa *
-    { name: "cwqa-default"
+    { name: "cw-qa-default"
     , desc: "Default, but on Cardano World QA"
     }
 
@@ -622,7 +630,8 @@ def all_profile_variants:
     { name: "ci-test-rtview"
     }
   , $citest_base * $cardano_world_qa *
-    { name: "cwqa-ci-test"
+    { name: "cw-qa-ci-test"
+    , desc: "ci-test, but on Cardano World QA"
     }
 
   ## CI variants: bench duration, 15 blocks
@@ -648,7 +657,8 @@ def all_profile_variants:
     { name: "ci-bench-rtview"
     }
   , $cibench_base * $cardano_world_qa *
-    { name: "cwqa-ci-bench"
+    { name: "cw-qa-ci-bench"
+    , desc: "ci-bench but on Cardano World QA"
     }
 
   ## CI variants: test duration, 3 blocks, dense10
@@ -704,9 +714,9 @@ def all_profile_variants:
     { name: "plutuscall-secp-schnorr-double"
     }
 
-## Cardano World QA cluster: 52 nodes, 2 regions, value variant
-  , $cwqa_base * $cardano_world_qa *
-    { name: "cwqa-value"
+## Cardano World QA cluster: 52 nodes, 3 regions, value variant
+  , $cw_perf_base * $cardano_world_perf *
+    { name: "cw-perf-value"
     }
 
 ## Model value variant: 7 epochs (128GB RAM needed; 16GB for testing locally)

--- a/nix/workbench/profile/profile.nix
+++ b/nix/workbench/profile/profile.nix
@@ -51,6 +51,15 @@ rec {
             inherit runJq nodeSpecs;
           })
         tracer-service;
+
+      inherit
+        (pkgs.callPackage
+          ../service/healthcheck.nix
+          {
+            inherit backend profile;
+            inherit runJq nodeSpecs;
+          })
+        healthcheck-service;
     };
 
   ## WARNING:  IFD !!
@@ -96,7 +105,8 @@ rec {
         })
         node-services
         generator-service
-        tracer-service;
+        tracer-service
+        healthcheck-service;
     };
 
   profileData = { profile }:
@@ -136,11 +146,18 @@ rec {
             config               = config.JSON;
             start                = startupScript.JSON;
           };
+        healthcheckService =
+          with profile.healthcheck-service;
+          __toJSON
+          { name                 = "healthcheck";
+            start                = startupScript.JSON;
+          };
         passAsFile =
           [
             "nodeServices"
             "generatorService"
             "tracerService"
+            "healthcheckService"
             "topologyJson"
             "topologyDot"
           ];
@@ -154,6 +171,7 @@ rec {
       cp    $nodeServicesPath             $out/node-services.json
       cp    $generatorServicePath         $out/generator-service.json
       cp    $tracerServicePath            $out/tracer-service.json
+      cp    $healthcheckServicePath       $out/healthcheck-service.json
       ''
   // profile;
 

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -1045,6 +1045,7 @@ run_instantiate_rundir_profile_services() {
     local svcs=$dir/profile/node-services.json
     local gtor=$dir/profile/generator-service.json
     local trac=$dir/profile/tracer-service.json
+    local hche=$dir/profile/healthcheck-service.json
 
     for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
     do local node_dir="$dir"/$node
@@ -1068,4 +1069,8 @@ run_instantiate_rundir_profile_services() {
     cp $(jq '."service-config"'                -r $trac) "$trac_dir"/service-config.json
     cp $(jq '."config"'                        -r $trac) "$trac_dir"/config.json
     cp $(jq '."start"'                         -r $trac) "$trac_dir"/start.sh
+
+    local hche_dir="$dir"/healthcheck
+    mkdir -p                                    "$hche_dir"
+    cp $(jq '."start"'                         -r $hche) "$hche_dir"/start.sh
 }

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -17,23 +17,535 @@ let
       bashInteractive = pkgs.bashInteractive;
       coreutils       = pkgs.coreutils;
       supervisor      = pkgs.supervisor;
+      grep            = pkgs.gnugrep;
+      jq              = pkgs.jq;
+      cardano-cli     = pkgs.cardanoNodePackages.cardano-cli;
     in {
       startupScript = rec {
         JSON = pkgs.writeScript "startup-healthcheck.sh" value;
+        jqFilter = "";
+        # Assumptions:
+        # - Command `date` and node's log use the same timezone!
         value = ''
           #!${bashInteractive}/bin/sh
 
-          # Store the entrypoint env vars for debugging purposes
-          ${coreutils}/bin/env > /local/healthcheck.env
+          NOMAD_DEBUG=1
 
-          # Only needed for "exec" ?
-          if test "''${TASK_DRIVER}" = "exec"
+          # e:        Immediately exit if any command has a non-zero exit status
+          # u:        Reference to non previously defined variables is an error
+          # pipefail: Any failed command in a pipeline is used as return code
+          set -euo pipefail
+
+          echo "$(${coreutils}/bin/date --rfc-3339=seconds): started"
+
+          # Fetch every node name (Including "explorer" nodes)
+          nodes=$(${jq}/bin/jq --raw-output "keys | join (\" \")"      ../node-specs.json)
+          pools=$(${jq}/bin/jq 'map(select(.kind == "pool")) | length' ../node-specs.json)
+          echo "Nodes: [''${nodes}]"
+          echo "Pools: ''${pools}"
+
+          # Set the defaults!
+          now=$(${coreutils}/bin/date +%s)
+          for node in ''${nodes[*]}
+          do
+            # Create a healthcheck directory inside every node directory
+            ${coreutils}/bin/mkdir "../''${node}/healthcheck"
+            # TODO: Store the `+RTS --info`
+            # Save the starting time
+            echo "''${now}" > "../''${node}/healthcheck/start_time"
+          done
+
+          # Fetch profile parameters
+          network_magic=$(${jq}/bin/jq      .genesis.network_magic      ../profile.json)
+          slot_duration=$(${jq}/bin/jq      .genesis.slot_duration      ../profile.json)
+          epoch_length=$(${jq}/bin/jq       .genesis.epoch_length       ../profile.json)
+          active_slots_coeff=$(${jq}/bin/jq .genesis.active_slots_coeff ../profile.json)
+          #active_slots="$((epoch_length * active_slots_coeff))"
+          echo "network_magic:      ''${network_magic}"
+          echo "slot_duration:      ''${slot_duration}"
+          echo "epoch_length:       ''${epoch_length}"
+          echo "active_slots_coeff: ''${active_slots_coeff}"
+          #echo "active_slots:      ''${active_slots}"
+
+          # The main function, called at the end of the file/script.
+          function healthcheck() {
+            # Start the healthcheck infinite loop
+            trap "" PIPE
+            while true
+            do
+              for node in ''${nodes[*]}
+              do
+                node_healthcheck "''${node}"
+              done
+              sleep 5 # Enough?
+            done
+            trap - PIPE
+          }
+
+          function node_healthcheck() {
+            local node=$1
+            local exit_code_path="../''${node}/exit_code"
+            # File exists and is a regular file?
+            if test -f "''${exit_code_path}"
+            then
+              # The node was started!
+              # File exists and has a size greater than zero?
+              if test -s "''${exit_code_path}"
+              then
+                # The node exited!
+                # Node failed with non-zero exit code?
+                if test "''${exit_code}" != "0"
+                then
+                  # The node exited with a non-zero exit code!
+                  exit_healthcheck "Node \"''${node}\" exited with a non-zero exit code!"
+                else
+                  # The node exited with a zero exit code!
+                  echo "Node \"''${node}\" exited with a zero exit code!"
+                fi
+              else
+                # The node is running!
+                if is_node_synced_and_past_slot_zero "''${node}"
+                then
+                  node_healthcheck_block "''${node}"
+                  node_healthcheck_txs   "''${node}"
+                else
+                  local now=$(${coreutils}/bin/date +%s)
+                  local start_time=$(cat "../''${node}/healthcheck/start_time")
+                  if test $((now - start_time)) -ge 300
+                  then
+                    exit_healthcheck "''${node}: More than 5m waiting for slot 0"
+                  fi
+                fi
+              fi
+            fi
+          }
+
+          # {
+          #     "epoch": 0,
+          #     "era": "Babbage",
+          #     "slotInEpoch": 0,
+          #     "slotsToEpochEnd": 600,
+          #     "syncProgress": "100.00"
+          # }
+          # {
+          #     "block": 1,
+          #     "epoch": 0,
+          #     "era": "Babbage",
+          #     "hash": "9777....8833",
+          #     "slot": 22,
+          #     "slotInEpoch": 22,
+          #     "slotsToEpochEnd": 578,
+          #     "syncProgress": "100.00"
+          # }
+          function is_node_synced_and_past_slot_zero() {
+            local node=$1
+            local socket_path="../''${node}/node.socket"
+            local db_path="../''${node}/run/current/''${node}/db-testnet/"
+            # Socket and db folder exist!
+            if ! test -S "''${socket_path}" || ! test -d "''${db_path}"
+            then
+              false
+            else
+              local tip block slot
+              tip=$(${cardano-cli}/bin/cardano-cli query tip \
+                --testnet-magic "''${network_magic}"         \
+                --socket-path "../''${node}/node.socket"
+              )
+              block=$(echo "''${tip}" | ${jq}/bin/jq .block)
+              slot=$(echo  "''${tip}" | ${jq}/bin/jq .slot)
+              # Block greater than or qeual to zero!
+              if test -n "''${block}" && test "''${block}" != "null" && test "''${block}" -ge 0
+              then
+                # Slot greater than zero!
+                if test -n "''${slot}" && test "''${slot}" != "null" && test "''${slot}" -gt 0
+                then
+                  true
+                else
+                  false
+                fi
+              else
+                false
+              fi
+            fi
+          }
+
+          function node_healthcheck_forge() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_forged
+            last_forged=$(last_block_forged "''${node}" 2>&1)
+            if test -z "''${last_forged}"
+            then
+              start_time=$(cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                exit_healthcheck "''${node}: More than 5m with no blocks forged at all"
+              fi
+            else
+              echo "''${last_forged}" > "../''${node}/healthcheck/last_forged"
+              start_time=$(echo "''${last_forged}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 120
+              then
+                exit_healthcheck "''${node}: More than 2m with no newer blocks forged"
+              fi
+            fi
+          }
+
+          function node_healthcheck_block() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_block
+            last_block=$(last_block_transmitted "''${node}" 2>&1)
+            if test -z "''${last_block}"
+            then
+              start_time=$(cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                # Stderr
+                echo "$(${coreutils}/bin/date --rfc-3339=seconds): ''${node}: More than 5m without a first block sent or received" >&2
+                exit 1
+              fi
+            else
+              echo "''${last_block}" > "../''${node}/healthcheck/last_block"
+              start_time=$(echo "''${last_block}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 60
+              then
+                exit_healthcheck "''${node}: More than 60s with no newer blocks sent or received\n''${last_block}"
+              fi
+            fi
+          }
+
+          function node_healthcheck_txs() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_txs
+            last_txs=$(last_block_with_txs "''${node}" 2>&1)
+            if test -z "''${last_txs}"
+            then
+              start_time=$(cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                exit_healthcheck "''${node}: More than 5m without a first block with transactions"
+              fi
+            else
+              echo "''${last_txs}" > "../''${node}/healthcheck/last_txs"
+              start_time=$(echo "''${last_txs}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 60
+              then
+                exit_healthcheck "''${node}: More than 60s with no newer blocks with transactions\n''${last_txs}"
+              fi
+            fi
+          }
+
+          # We have txIds
+          # 20 seconds for new one, 3 minutes for first one!
+          # Also check block number to see if slots are going forward!
+          # A specific number of slot before looking for txIds ?
+
+          # Helper/auxiliary functions!
+          ######################################################################
+
+          # Gets the last "matching" JSON message from a Node's stdout file.
+          #
+          # To do this the stdout file is reversed using `tac`, `jq` is applied
+          # and its answers fetched using `head --lines=1`. To avoid reading the
+          # whole file (and assuming `tac` is efficient) `jq` is called with
+          # `--unbuffered`.
+          #
+          # Note that the log file is composed of one JSON object per line and
+          # we are using `--compact-output` to make sure every output log
+          # message matched by `jq` is contained within a line.
+          #
+          # Also, the stdout of the node starts with some text that echoed by
+          # node's start.sh script that is not valid JSON, so we `grep` for
+          # "{"at": ... }". We still need to check the exit code of these
+          # functions just in case because if it fails a query may have failed
+          # and the healthcheck should fail.
+          #
+          # Finally the "at" time has format "2023-05-16 19:57:19.0231Z" and I
+          # can't parse it using any standard `date` format so I'm stripping the
+          # milliseconds part and converting to Unix time (Integer).
+          #
+          # To avoid "Error: writing output failed: Broken pipe"!" we use
+          # `tail -n +1` between `jq` and `head`, is smart enough to check
+          # standard output and closes the pipe down cleanly.
+          #
+          # $1: node name
+          # $2: jq's query string
+          function jq_node_stdout_last() {
+            local node=$1
+            local select=$2
+            local stdout_path="../''${node}/stdout"
+            if !  ${coreutils}/bin/tac "''${stdout_path}" \
+                | \
+                  ${grep}/bin/grep -E "^{\"at\":.*}$" \
+                | \
+                  ${jq}/bin/jq                             \
+                    --compact-output                       \
+                    --unbuffered                           \
+                    --null-input                           \
+                    "nth(0; inputs | select(''${select}))" \
+                | \
+                  ${jq}/bin/jq \
+                    '
+                        .at
+                      |=
+                        (.[:20] | strptime("%Y-%m-%d %H:%M:%S.") | mktime)
+                    '
+            then
+              exit_22 "stdout error: jq_node_stdout_last: ''${node}"
+            fi
+          }
+
+          # This one exists with "write error: Broken pipe"
+          function jq_node_stdout_last_v0() {
+            local node=$1
+            local select=$2
+            local stdout_path="../''${node}/stdout"
+            if !  ${coreutils}/bin/tac "''${stdout_path}" \
+                | \
+                  ${grep}/bin/grep -E "^{\"at\":.*}$" \
+                | \
+                  ${jq}/bin/jq --compact-output --unbuffered "''$2" \
+                | \
+                  ${coreutils}/bin/head --lines=+1 \
+                | \
+                  ${jq}/bin/jq \
+                    '
+                        .at
+                      |=
+                        (.[:20] | strptime("%Y-%m-%d %H:%M:%S.") | mktime)
+                    '
+            then
+              exit_22 "stdout error: jq_node_stdout_last: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-16 15:02:46.0051Z",
+          #   "ns": "Forge.Loop.AdoptedBlock",
+          #   "data": {
+          #     "blockHash": "26ab7db1ca55e69885665f625262118ef7db99172be6d3591ad2a8e9bfeabffa",
+          #     "blockSize": 864,
+          #     "kind": "TraceAdoptedBlock",
+          #     "slot": 627
+          #   },
+          #   "sev": "Info",
+          #   "thread": "34",
+          #   "host": "ip-10-24-123-88.eu-central-1.compute.internal"
+          # }
+          function last_block_forged() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Forge.Loop.AdoptedBlock")
+                and
+                (.data.blockHash?          != null)
+                and
+                (.data.kind?               == "TraceAdoptedBlock")
+              '
+            then
+              exit_22 "jq error: last_block_forged: ''${node}"
+            fi
+          }
+
+          # Block sent:
+          # {
+          #   "at": "2023-05-17 16:00:57.0222Z",
+          #   "ns": "BlockFetch.Server.SendBlock",
+          #   "data": {
+          #     "block": "dde....414",
+          #     "kind": "BlockFetchServer"
+          #   },
+          #   "sev": "Info",
+          #   "thread": "67",
+          #   "host": "rapide"
+          # }
+          # Block received:
+          # {
+          #   "at": "2023-05-17 16:00:57.0246Z",
+          #   "ns": "BlockFetch.Remote.Receive.Block",
+          #   "data": {
+          #     "kind": "Recv",
+          #     "msg": {
+          #       "agency": "ServerAgency TokStreaming",
+          #       "blockHash": "dde....414",
+          #       "blockSize": 64334,
+          #       "kind": "MsgBlock",
+          #       "txIds": [
+          #         "60e....6ec",
+          #         ...
+          #         "95d....165"
+          #       ]
+          #     },
+          #     "peer": {
+          #       "connectionId": "127.0.0.1:37117 127.0.0.1:30000"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "77",
+          #   "host": "rapide"
+          # }
+
+          function last_block_transmitted() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (
+                  (.ns                     == "BlockFetch.Server.SendBlock")
+                  and
+                  (.data.block?            != null)
+                  and
+                  (.data.kind?             == "BlockFetchServer")
+                ) or (
+                  (.ns                     == "BlockFetch.Remote.Receive.Block")
+                  and
+                  (.data.kind?             == "Recv")
+                  and
+                  (.data.msg?.blockHash    != null)
+                  and
+                  (.data.msg?.kind         == "MsgBlock")
+                )
+              '
+            then
+              exit_22 "jq error: last_block_transmitted: ''${node}"
+            fi
+          }
+
+          function last_block_sent() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Server.SendBlock")
+                and
+                (.data.block?              != null)
+                and
+                (.data.kind?               == "BlockFetchServer")
+              '
+            then
+              exit_22 "jq error: last_block_sent: ''${node}"
+            fi
+          }
+
+          function last_block_received() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Remote.Receive.Block")
+                and
+                (.data.kind?               == "Recv")
+                and
+                (.data.msg?.blockHash      != null)
+                and
+                (.data.msg?.kind           == "MsgBlock")
+              '
+            then
+              exit_22 "jq error: last_block_received: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-17 16:00:57.0246Z",
+          #   "ns": "BlockFetch.Remote.Receive.Block",
+          #   "data": {
+          #     "kind": "Recv",
+          #     "msg": {
+          #       "agency": "ServerAgency TokStreaming",
+          #       "blockHash": "dde....414",
+          #       "blockSize": 64334,
+          #       "kind": "MsgBlock",
+          #       "txIds": [
+          #         "60e....6ec",
+          #         ...
+          #         "95d....165"
+          #       ]
+          #     },
+          #     "peer": {
+          #       "connectionId": "127.0.0.1:37117 127.0.0.1:30000"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "77",
+          #   "host": "rapide"
+          # }
+          function last_block_with_txs() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Remote.Receive.Block")
+                and
+                (.data.kind?               == "Recv")
+                and
+                (.data.msg?.blockHash      != null)
+                and
+                (.data.msg?.kind           == "MsgBlock")
+                and
+                (.data.msg?.txIds          != null)
+                and
+                (.data.msg?.txIds          != [])
+              '
+            then
+              exit_22 "jq error: last_block_with_txs: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-17 16:00:08.3351Z",
+          #   "ns": "Mempool.AddedTx",
+          #   "data": {
+          #     "kind": "TraceMempoolAddedTx",
+          #     "mempoolSize": {
+          #       "bytes": 1328,
+          #       "numTxs": 1
+          #     },
+          #     "tx": {
+          #       "txid": "3d724466"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "66",
+          #   "host": "rapide"
+          # }
+          function last_mempool_txs_added() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Mempool.AddedTx")
+                and
+                (.data.kind?               == "TraceMempoolAddedTx")
+                and
+                (.data.mempoolSize?.numTxs >= 1)
+              '
+            then
+              exit_22 "jq error: last_mempool_txs_added: ''${node}"
+            fi
+          }
+
+          function exit_healthcheck {
+            # Unbuffered stderr, if not the error message may be lost!
+            stdbuf -o0 -e0 echo -e "$(${coreutils}/bin/date --rfc-3339=seconds): $1" >&2
+            exit 1
+          }
+
+          function exit_22 {
+            # Unbuffered stderr, if not the error message may be lost!
+            stdbuf -o0 -e0 echo -e "$(${coreutils}/bin/date --rfc-3339=seconds): $1" >&2
+            exit 22
+          }
+
+          if test -n "''${NOMAD_DEBUG:-}"
           then
-            cd "''${TASK_WORKDIR}"
+            exec 5> "$(dirname "$(readlink -f "$0")")"/start.sh.debug
+            BASH_XTRACEFD="5"
+            PS4='$LINENO: '
+            set -x
           fi
 
-          sleep 100000
-          '';
+          healthcheck $@
+        '';
       };
     })
     nodeSpecs.value;

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -1,0 +1,41 @@
+{ pkgs
+, runJq
+, backend
+, profile
+, nodeSpecs
+}:
+
+with pkgs.lib;
+
+let
+  ##
+  ## generator-service :: (TracerConfig, NixosServiceConfig, Config, StartScript)
+  ##
+  healthcheck-service =
+    (nodeSpecs:
+    let
+      bashInteractive = pkgs.bashInteractive;
+      coreutils       = pkgs.coreutils;
+      supervisor      = pkgs.supervisor;
+    in {
+      startupScript = rec {
+        JSON = pkgs.writeScript "startup-healthcheck.sh" value;
+        value = ''
+          #!${bashInteractive}/bin/sh
+
+          # Store the entrypoint env vars for debugging purposes
+          ${coreutils}/bin/env > /local/healthcheck.env
+
+          # Only needed for "exec" ?
+          if test "''${TASK_DRIVER}" = "exec"
+          then
+            cd "''${TASK_WORKDIR}"
+          fi
+
+          sleep 100000
+          '';
+      };
+    })
+    nodeSpecs.value;
+in
+  { inherit healthcheck-service; }


### PR DESCRIPTION
WIP: Adding a backend agnostic healthcheck service, same code that can be run by either `supervisord` or `nomad` as an extra "program" that can be run inside a workbench cluster and controlled using `supervisorctl` (cluster runs using the workbench use the "supervisord" model)

The initial idea was to use Nomad's builtin `service -> check` functionality but it won't be compatible/interchangeable with local runs using the `supervisord` backend and critical business logic, like when to start it/how to control it, will be delegated to Nomad