### PR TITLE
Add DevX:Core-Tech to CI related items in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,15 +28,15 @@ trace-resources/                                              @deepfire @jutaro 
 Makefile                                                      @deepfire @mgmeier @fmaste
 *.mk                                                          @deepfire @mgmeier @fmaste
 
-nix/                                                          @input-output-hk/devops @deepfire @mgmeier @fmaste
-*.nix                                                         @input-output-hk/devops @deepfire @mgmeier @fmaste
-flake.lock                                                    @input-output-hk/devops @deepfire @mgmeier @fmaste
+nix/                                                          @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
+*.nix                                                         @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
+flake.lock                                                    @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
 
-.buildkite                                                    @Jimbo4350 @newhoggy @input-output-hk/devops
-.github                                                       @Jimbo4350 @newhoggy @input-output-hk/devops
-ci/                                                           @Jimbo4350 @newhoggy @input-output-hk/devops
-configuration/                                                @Jimbo4350 @newhoggy @input-output-hk/devops
-bors.toml                                                     @Jimbo4350 @newhoggy @input-output-hk/devops
-docker-compose.yml                                            @Jimbo4350 @newhoggy @input-output-hk/devops
+.buildkite                                                    @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
+.github                                                       @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
+ci/                                                           @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
+configuration/                                                @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
+bors.toml                                                     @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
+docker-compose.yml                                            @Jimbo4350 @newhoggy @input-output-hk/devx-core-tech @input-output-hk/devops
 cardano-node/src/Cardano/Node/Tracing/                        @Jimbo4350 @newhoggy @deepfire @jutaro @coot
 cardano-node/src/Cardano/Tracing/OrphanInstances/             @Jimbo4350 @newhoggy @input-output-hk/devops @coot


### PR DESCRIPTION
DevX:Core-Tech should be code owners for CI related topics in node as well.