### PR TITLE
workbench: new profile; fix shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ PROFILES_FORGE_STRESS_PRE := forge-stress-pre forge-stress-pre-plutus forge-stre
 PROFILES_CHAINSYNC        := chainsync-early-byron  chainsync-early-byron-notracer  chainsync-early-byron-oldtracing
 PROFILES_CHAINSYNC        += chainsync-early-alonzo chainsync-early-alonzo-notracer chainsync-early-alonzo-oldtracing chainsync-early-alonzo-p2p
 PROFILES_VENDOR           := dish dish-plutus dish-10M dish-10M-plutus
-PROFILES_CARDANO_WORLD_QA := cardano-world-qa cardano-world-qa-test cardano-world-qa-bench
+PROFILES_CARDANO_WORLD_QA := cwqa-default cwqa-ci-test cwqa-ci-bench
+PROFILES_CARDANO_WORLD_QA += cwqa-value
 
 SHELL_PROFILES       += $(PROFILES_BASE)
 SHELL_PROFILES       += $(PROFILES_FAST)

--- a/flake.lock
+++ b/flake.lock
@@ -65,23 +65,6 @@
         "type": "github"
       }
     },
-    "blst": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
-        "owner": "supranational",
-        "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "supranational",
-        "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
-        "type": "github"
-      }
-    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -267,11 +250,11 @@
     "em": {
       "flake": false,
       "locked": {
-        "lastModified": 1681835843,
-        "narHash": "sha256-3DAErIv40Wl/PmzazYl+fMo1lMQH20qZbXJtuBbAv/Q=",
+        "lastModified": 1684271538,
+        "narHash": "sha256-rQN8OKDNrVswL3TAVLt/P2eVrfw6SwgQUzUM3LZozLw=",
         "owner": "deepfire",
         "repo": "em",
-        "rev": "04b3add6fc018beaabade9381af707a0af8e0598",
+        "rev": "7e473e81a304888b41bf6eae6b161f21717598ab",
         "type": "github"
       },
       "original": {
@@ -1095,40 +1078,6 @@
         ],
         "tullia": "tullia",
         "utils": "utils_2"
-      }
-    },
-    "secp256k1": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1683999695,
-        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
-        "owner": "bitcoin-core",
-        "repo": "secp256k1",
-        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bitcoin-core",
-        "ref": "v0.3.2",
-        "repo": "secp256k1",
-        "type": "github"
-      }
-    },
-    "sodium": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1675156279,
-        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
       }
     },
     "secp256k1": {


### PR DESCRIPTION
# Description

* Port 52-node cluster profile from `cardano-ops` to `workbench`
* Fix `workbench` shell entry

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
