### PR TITLE
tx-generator documentation

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE GADTs #-}
+{-|
+Module      : Cardano.Benchmarking.Script.Action
+Description : Convert an 'Action' to a monadic 'ActionM'.
+
+This is just exporting 'action', and 'liftToAction' is tough
+to use because of the risk of circular imports.
+-}
 
 module Cardano.Benchmarking.Script.Action
        ( action
@@ -20,6 +27,14 @@ import           Cardano.TxGenerator.Setup.NodeConfig
 import           Cardano.TxGenerator.Types (TxGenError)
 
 
+-- | 'action' has as its sole callers
+-- 'Cardano.Benchmark.Script.runScript' from "Cardano.Benchmark.Script"
+-- and 'Cardano.Benchmark.Script.Selftest' from
+-- "Cardano.Benchmark.Script.Selftest".
+-- It translates the various cases of the 'Action' to monadic values
+-- which execute the specified actions when evaluated. It passes all
+-- the cases' fields to functions with very similar names to the
+-- constructors.
 action :: Action -> ActionM ()
 action a = case a of
   SetNetworkId val -> setEnvNetworkId val
@@ -38,9 +53,15 @@ action a = case a of
   LogMsg txt -> traceDebug $ Text.unpack txt
   Reserved options -> reserved options
 
+-- | 'liftToAction' first lifts from IO, then converts an 'Either'
+-- to an 'Control.Monad.Trans.Except.ExceptT' and then transforms
+-- the error type to 'Cardano.Benchmarking.Script.Env.Error'.
 liftToAction :: IO (Either TxGenError a) -> ActionM a
 liftToAction = firstExceptT TxGenError . newExceptT . liftIO
 
+-- | 'startProtocol' sets up the protocol for the transaction
+-- generator from the first argument, @configFile@ and optionally
+-- traces to the second, @tracerSocket@.
 startProtocol :: FilePath -> Maybe FilePath -> ActionM ()
 startProtocol configFile tracerSocket = do
   nodeConfig <- liftToAction $ mkNodeConfig configFile

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -298,6 +298,11 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
           return $ Right tx
       return $ Streaming.effect (Streaming.yield <$> gen)
 
+    -- 'Split' combines regular payments and payments for change.
+    -- There are lists of payments buried in the 'PayWithChange'
+    -- type conditionally sent back by 'Utils.includeChange', to
+    -- then be used while partially applied as the @valueSplitter@
+    -- in 'sourceToStoreTransactionNew'.
     Split walletName payMode payModeChange coins -> do
       wallet <- getEnvWallets walletName
       (toUTxO, addressOut) <- interpretPayMode payMode
@@ -311,6 +316,11 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
         sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut $ mangleWithChange toUTxOChange toUTxO
       return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
+    -- The 'SplitN' case's call chain is somewhat elaborate.
+    -- The division is done in 'Utils.inputsToOutputsWithFee' 
+    -- but things are threaded through
+    -- 'Cardano.Benchmarking.Wallet.mangle' and packed into
+    -- the transaction assembled by 'sourceToStoreTransactionNew'.
     SplitN walletName payMode count -> do
       wallet <- getEnvWallets walletName
       (toUTxO, addressOut) <- interpretPayMode payMode

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -124,6 +124,16 @@ runActionM = runActionMEnv emptyEnv
 runActionMEnv :: Env -> ActionM ret -> IOManager -> IO (Either Error ret, Env, ())
 runActionMEnv env action iom = RWS.runRWST (runExceptT action) iom env
 
+-- | 'Error' adds two cases to 'Cardano.TxGenerator.Types.TxGenError' 
+-- which in turn wraps 'Cardano.Api.Error' implicit contexts to a
+-- couple of its constructors. These represent errors that might arise
+-- in the execution of a transaction with some distinctions as to the
+-- layers where the errors could arise. At this highest level, invalid
+-- users and wallets are potentially encountered. Plutus, protocol, API
+-- and some arbitrary errors are potentially encountered at the next
+-- layer. The layers correspond to "Cardano.Benchmarking.Script.Core"
+-- for the outermost and "Cardano.Benchmarking.Set.Plutus" for the
+-- middle, and the innermost to "Cardano.Api.Error".
 data Error where
   TxGenError  :: !TxGenError -> Error
   UserError   :: !String     -> Error

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -10,6 +10,21 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-|
+Module      : Cardano.Benchmarking.Script.Env
+Description : State type for 'ActionM' monad stack and its accessors.
+
+The 'Env' type is the ADT for the state component of the 'ActionM'
+monad stack. Its actual definition isn't exported in part because of a
+transition from an earlier very generic and polymorphic definition.
+In a number of respects, this module covers more of the 'ActionM'
+like 'runActionM' and 'liftTxGenError', but the only significant
+structure is 'Env' for state. The accessors could likely be removed
+in favour of just using the record syntax to trim a few lines of
+code at the cost of exposing the structure's internals. Some of the
+naming related to the fact that "Cardano.Benchmarking.Script.Action"
+ran into circular dependency issues during the above transition.
+ -}
 module Cardano.Benchmarking.Script.Env (
         ActionM
         , Error(..)

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -70,7 +70,13 @@ import           Cardano.TxGenerator.PlutusContext (PlutusBudgetSummary)
 import           Cardano.TxGenerator.Types (TxGenError (..))
 
 
-data Env = Env { protoParams :: Maybe ProtocolParameterMode
+-- | The 'Env' type represents the state maintained while executing
+-- a series of actions. The 'Maybe' types are largely to represent
+-- as-of-yet unset values.
+data Env = Env { -- | 'Cardano.Api.ProtocolParameters' is ultimately
+                 -- wrapped by 'ProtocolParameterMode' which itself is
+                 -- a sort of custom 'Maybe'.
+                 protoParams :: Maybe ProtocolParameterMode
                , benchTracers :: Maybe Tracer.BenchTracers
                , envGenesis :: Maybe (ShelleyGenesis StandardCrypto)
                , envProtocol :: Maybe SomeConsensusProtocol

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
+{-|
+Module      : Cardano.Benchmarking.Script.Selftest
+Description : Run self-tests using statically-defined data.
+
+The statically-defined data is the action list to execute, 'testScript'.
+It actually does use a protocol file taken in from IO.
+-}
 module Cardano.Benchmarking.Script.Selftest
 where
 
@@ -24,6 +31,13 @@ import           Cardano.TxGenerator.Types
 
 import           Paths_tx_generator
 
+-- | 'runSelftest' is the interface to actually run the self-test.
+-- @iom@ is the IO manager from "Ouroboros.Network.IOManager".
+-- @outFile@ is the file to output to;
+-- 'Cardano.Benchmarking.Script.Core.evalGenerator' returns a
+-- transaction 'Streaming.Stream' that
+-- 'Cardano.Benchmarking.Script.Core.submitInEra'
+-- does 'show' and 'writeFile' on.
 runSelftest :: IOManager -> Maybe FilePath -> IO (Either Script.Error ())
 runSelftest iom outFile = do
   protocolFile <-  getDataFileName "data/protocol-parameters.json"
@@ -36,9 +50,14 @@ runSelftest iom outFile = do
     (Right a  , _ ,  ()) -> return $ Right a
     (Left err , _  , ()) -> return $ Left err
 
+-- | 'printJSON' prints out the list of actions using Aeson.
+-- It has no callers within @cardano-node@.
 printJSON :: IO ()
 printJSON = BSL.putStrLn $ prettyPrint $ testScript "/dev/zero" DiscardTX
 
+-- | 'testScript' is a static list of 'Action' parametrised with a
+-- file name and a mode indicating how to submit a transaction in
+-- 'SubmitMode' passed along as a parameter within a 'Submit' action.
 testScript :: FilePath -> SubmitMode -> [Action]
 testScript protocolFile submitMode =
   [ SetProtocolParameters (UseLocalProtocolFile protocolFile)

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -135,11 +135,14 @@ data Generator where
   -- 'Cardano.TxGenerator.Genesis.genesisSecureInitialFundForKey'.
   -- This is where streams of transactions start.
   SecureGenesis :: !String -> !String -> !String -> Generator -- 0 to N
-  -- 'Split' is difficult to interpret as a particular kind of
-  -- transaction, but appears limited to 3 participants.
+  -- | 'Split' makes payments with change depending on the pay mode.
+  -- The splitting is from potentially sending the change to a
+  -- different place.
   Split :: !String -> !PayMode -> !PayMode -> [ Lovelace ] -> Generator
-  -- 'SplitN' seems to infinitely 'repeat' the operation but
-  -- it's less clear where the fee came from or other things.
+  -- | 'SplitN' divides the funds by N and divides them up into that
+  -- many transactions in a finite sequence. The handling starts from
+  -- a case in 'Cardano.Benchmarking.Script.Core.evalGenerator' and
+  -- has some complexity to it.
   SplitN :: !String -> !PayMode -> !Int -> Generator            -- 1 to N
   -- 'NtoM' seems like it should issue a single N-to-M transaction,
   -- but it's difficult to tell what it's doing.

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -39,6 +39,9 @@ inputsToOutputsWithFee fee count inputs = map (quantityToLovelace . Quantity) ou
     (out, rest) = divMod totalAvailable (fromIntegral count)
     outputs = (out + rest) : replicate (count-1) out
 
+-- | 'includeChange' gets use made of it as a value splitter in
+-- 'Cardano.TxGenerator.Tx.sourceToStoreTransactionNew' by
+-- 'Cardano.Benchmarking.Script.Core.evalGenerator'.
 includeChange :: Lovelace -> [Lovelace] -> [Lovelace] -> PayWithChange
 includeChange fee spend have = case compare changeValue 0 of
   GT -> PayWithChange changeValue spend


### PR DESCRIPTION
This documentation meant to cover the important types and API functions and modules of the transaction generator. Some familiarisation with haddock was needed to get started and the Action type was chosen as a starting point on the basis of having had prior experience working with it. Ultimately, this is meant to contribute to an exportable API so other things can generate transaction streams for their own use e.g. analyses involving ledgers, direct examination of or analysis of streams of generated transactions etc. Feedback on the content or style of the documentation can also be taken onboard to revise it.