### PR TITLE
Bench nomad 53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,28 +90,32 @@ PROFILES_FORGE_STRESS_PRE := forge-stress-pre forge-stress-pre-plutus forge-stre
 PROFILES_CHAINSYNC        := chainsync-early-byron  chainsync-early-byron-notracer  chainsync-early-byron-oldtracing
 PROFILES_CHAINSYNC        += chainsync-early-alonzo chainsync-early-alonzo-notracer chainsync-early-alonzo-oldtracing chainsync-early-alonzo-p2p
 PROFILES_VENDOR           := dish dish-plutus dish-10M dish-10M-plutus
-PROFILES_CARDANO_WORLD_QA := cwqa-default cwqa-ci-test cwqa-ci-bench
-PROFILES_CARDANO_WORLD_QA += cwqa-value
+# "qa" and "perf" namespaces for cardano world (world.dev.cardano.org) Nomad
+# Not all local profiles are compatible (yet) with a cloud run
+# Cloud version of "default", "ci-test" and "ci-bench"
+PROFILES_CW_QA            := cw-qa-default cw-qa-ci-test cw-qa-ci-bench
+# The 52+explorer profile
+PROFILES_CW_PERF          := cw-perf-value
 
-SHELL_PROFILES       += $(PROFILES_BASE)
-SHELL_PROFILES       += $(PROFILES_FAST)
-SHELL_PROFILES       += $(PROFILES_CI_TEST)
-SHELL_PROFILES       += $(PROFILES_CI_BENCH)
-SHELL_PROFILES       += $(PROFILES_TRACE_BENCH)
-SHELL_PROFILES       += $(PROFILES_EPOCHTRANS)
-SHELL_PROFILES       += $(PROFILES_PLUTUSCALL)
-SHELL_PROFILES       += $(PROFILES_MODEL)
-SHELL_PROFILES       += $(PROFILES_10)
-SHELL_PROFILES       += $(PROFILES_FORGE_STRESS)
-SHELL_PROFILES       += $(PROFILES_FORGE_STRESS_PRE)
-SHELL_PROFILES       += $(PROFILES_CHAINSYNC)
-SHELL_PROFILES       += $(PROFILES_VENDOR)
-SHELL_PROFILES_CLOUD += $(PROFILES_CARDANO_WORLD_QA)
+LOCAL_PROFILES += $(PROFILES_BASE)
+LOCAL_PROFILES += $(PROFILES_FAST)
+LOCAL_PROFILES += $(PROFILES_CI_TEST)
+LOCAL_PROFILES += $(PROFILES_CI_BENCH)
+LOCAL_PROFILES += $(PROFILES_TRACE_BENCH)
+LOCAL_PROFILES += $(PROFILES_EPOCHTRANS)
+LOCAL_PROFILES += $(PROFILES_PLUTUSCALL)
+LOCAL_PROFILES += $(PROFILES_MODEL)
+LOCAL_PROFILES += $(PROFILES_10)
+LOCAL_PROFILES += $(PROFILES_FORGE_STRESS)
+LOCAL_PROFILES += $(PROFILES_FORGE_STRESS_PRE)
+LOCAL_PROFILES += $(PROFILES_CHAINSYNC)
+LOCAL_PROFILES += $(PROFILES_VENDOR)
+CLOUD_PROFILES += $(PROFILES_CW_QA) $(PROFILES_CW_PERF)
 
 ## Note:  to enable a shell for a profile, just add its name (one of names from 'make ps') to SHELL_PROFILES
 
-$(eval $(call define_profile_targets,           $(SHELL_PROFILES)))
-$(eval $(call define_profile_targets_nomadcloud,$(SHELL_PROFILES_CLOUD)))
+$(eval $(call define_profile_targets,           $(LOCAL_PROFILES)))
+$(eval $(call define_profile_targets_nomadcloud,$(CLOUD_PROFILES)))
 
 ###
 ### Misc
@@ -128,4 +132,4 @@ full-clean: clean
 cls:
 	echo -en "\ec"
 
-.PHONY: cabal-hashes clean cli cls cluster-profiles help node run-test shell shell-dev stylish-haskell $(SHELL_PROFILES) workbench-ci-test
+.PHONY: cabal-hashes clean cli cls cluster-profiles help node run-test shell shell-dev stylish-haskell $(LOCAL_PROFILES) workbench-ci-test

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -164,6 +164,12 @@ let
     # SRE: Only 3 Nomad datacenters exist actually.
     datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
 
+    # Specifies user-defined constraints on the task. This can be provided
+    # multiple times to define additional constraints.
+    # Cloud runs set the distinct hosts constraint here but local runs can't
+    # because we are only starting one Nomad client.
+    constraint = null;
+
     # The reschedule stanza specifies the group's rescheduling strategy. If
     # specified at the job level, the configuration will apply to all groups
     # within the job. If the reschedule stanza is present on both the job and
@@ -193,11 +199,11 @@ let
       ONE_TRACER_PER_NODE = oneTracerPerNode;
     };
 
-    # A group defines a series of tasks that should be co-located
-    # on the same client (host). All tasks within a group will be
-    # placed on the same host.
+    # A group defines a series of tasks that should be co-located on the same
+    # client (host). All tasks within a group will be placed on the same host.
     # https://developer.hashicorp.com/nomad/docs/job-specification/group
     group = let
+      # For each node-specs.json object
       valueF = (taskName: serviceName: portName: portNum: nodeSpec: (groupDefaults // {
 
         # Specifies the number of instances that should be running under for
@@ -255,8 +261,8 @@ let
         constraint = {
           attribute = "\${node.class}";
           operator = "=";
-          # For testing best to avoid using "infra" node class as HA jobs runs
-          # there, for benchmarking dedicated static machines in the "perf"
+          # For testing we avoid using "infra" node class as HA jobs runs there
+          # For benchmarking dedicated static machines in the "perf"
           # class are used and this value should be updated accordingly.
           value = "qa";
         };
@@ -327,6 +333,8 @@ let
 
           # Sensible defaults to run cloud version of "default", "ci-test" and
           # "ci-bench" in cardano-world qa class Nomad nodes.
+          # For benchmarking dedicated static machines in the "perf" class are
+          # used and this value should be updated accordingly.
           resources = {
             # Task can only ask for 'cpu' or 'cores' resource, not both.
             #cpu = 512;

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -162,19 +162,7 @@ let
     #  A list of datacenters in the region which are eligible for task
     # placement. This must be provided, and does not have a default.
     # SRE: Only 3 Nomad datacenters exist actually.
-    datacenters = [ "eu-central-1" "eu-west-1" "us-east-2" ];
-
-    # This can be provided multiple times to define additional constraints. See
-    # the Nomad constraint reference for more details.
-    # https://developer.hashicorp.com/nomad/docs/job-specification/constraint
-    constraint = {
-      attribute = "\${node.class}";
-      operator = "=";
-      # For testing best to avoid using "infra" node class as HA jobs runs
-      # there, for benchmarking dedicated static machines are need and this
-      # should be updated accordingly.
-      value = "qa";
-    };
+    datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
 
     # The reschedule stanza specifies the group's rescheduling strategy. If
     # specified at the job level, the configuration will apply to all groups
@@ -260,6 +248,18 @@ let
                 value     = region;
               }
         ;
+
+        # This can be provided multiple times to define additional constraints.
+        # See the Nomad constraint reference for more details.
+        # https://developer.hashicorp.com/nomad/docs/job-specification/constraint
+        constraint = {
+          attribute = "\${node.class}";
+          operator = "=";
+          # For testing best to avoid using "infra" node class as HA jobs runs
+          # there, for benchmarking dedicated static machines in the "perf"
+          # class are used and this value should be updated accordingly.
+          value = "qa";
+        };
 
         # The network stanza specifies the networking requirements for the task
         # group, including the network mode and port allocations.

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -3,12 +3,11 @@
 # clusters and SRE infrastructure used for long-running cloud benchmarks. Why?
 # To make it easier to improve and debug the almighty workbench!
 ################################################################################
-{ lib
+{ pkgs
+, lib
 , stateDir
 , profileData
 , containerSpecs
-# Needs unix_http_server.file
-, supervisorConf
 , execTaskDriver
 , oneTracerPerNode ? false
 }:
@@ -58,7 +57,8 @@ let
   # the container I get (from journald):
   # Nov 02 11:44:36 hostname cluster-18f3852f-e067-6394-8159-66a7b8da2ecc[1088457]: Error: Cannot open an HTTP server: socket.error reported -2
   # Nov 02 11:44:36 hostname cluster-18f3852f-e067-6394-8159-66a7b8da2ecc[1088457]: For help, use /nix/store/izqhlj5i1x9ldyn43d02kcy4mafmj3ci-python3.9-supervisor-4.2.4/bin/supervisord -h
-  task_supervisord_url = "unix://${supervisorConf.value.unix_http_server.file}";
+  unixHttpServerPort = "/tmp/supervisor.sock";
+  task_supervisord_url = "unix://${unixHttpServerPort}";
   # Location of the supervisord config file inside the container.
   # This file can be mounted as a volume or created as a template.
   task_supervisord_conf = "${task_statedir}/supervisor/supervisord.conf";
@@ -452,8 +452,21 @@ let
             {
               env = false;
               destination = "${task_supervisord_conf}";
-              data = escapeTemplate (__readFile
-                supervisorConf.INI);
+              data = escapeTemplate (__readFile (
+                let supervisorConf = import ./supervisor-conf.nix
+                  { inherit pkgs lib stateDir;
+                    # Include only this taks' node
+                    nodeSpecs = if taskName == "tracer"
+                      then {}
+                      else {"${nodeSpec.name}"=nodeSpec;}
+                    ;
+                    # Only for the tracer task or also nodes if oneTracerPerNode
+                    withTracer = oneTracerPerNode || taskName == "tracer";
+                    # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
+                    inherit unixHttpServerPort;
+                  };
+                in supervisorConf.INI
+              ));
               change_mode = "noop";
               error_on_missing_key = true;
             }
@@ -521,54 +534,51 @@ let
             }
           ])
           ++
-          # Node(s)
-          (lib.lists.flatten (lib.mapAttrsToList
-            (_: nodeSpec: [
-              ## Node start.sh script.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/start.sh";
-                data = escapeTemplate (
-                  let scriptValue = profileData.node-services."${nodeSpec.name}".startupScript.value;
-                  in if execTaskDriver
-                    then (startScriptToGoTemplate
-                      nodeSpec.name
-                      ("perf-" + nodeSpec.name)
-                      ("node" + (toString nodeSpec.i))
-                      nodeSpec
-                      scriptValue
-                    )
-                    else scriptValue
-                );
-                change_mode = "noop";
-                error_on_missing_key = true;
-                perms = "744"; # Only for every "start.sh" script. Default: "644"
-              }
-              ## Node configuration file.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/config.json";
-                data = escapeTemplate (lib.generators.toJSON {}
-                  profileData.node-services."${nodeSpec.name}".nodeConfig.value);
-                change_mode = "noop";
-                error_on_missing_key = true;
-              }
-              ## Node topology file.
-              {
-                env = false;
-                destination = "${task_statedir}/${nodeSpec.name}/topology.json";
-                data = escapeTemplate (
-                  let topology = profileData.node-services."${nodeSpec.name}".topology;
-                  in if execTaskDriver
-                    then (topologyToGoTemplate topology.value)
-                    else (__readFile           topology.JSON )
-                );
-                change_mode = "noop";
-                error_on_missing_key = true;
-              }
-            ])
-            profileData.node-specs.value
-          ))
+          # Node
+          (lib.optionals (taskName != "tracer") [
+            ## Node start.sh script.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/start.sh";
+              data = escapeTemplate (
+                let scriptValue = profileData.node-services."${nodeSpec.name}".startupScript.value;
+                in if execTaskDriver
+                  then (startScriptToGoTemplate
+                    taskName                         # taskName
+                    serviceName                      # serviceName
+                    portName                         # portName (can't have "-")
+                    nodeSpec                         # nodeSpec
+                    scriptValue                      # startScript
+                  )
+                  else scriptValue
+              );
+              change_mode = "noop";
+              error_on_missing_key = true;
+              perms = "744"; # Only for every "start.sh" script. Default: "644"
+            }
+            ## Node configuration file.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/config.json";
+              data = escapeTemplate (lib.generators.toJSON {}
+                profileData.node-services."${nodeSpec.name}".nodeConfig.value);
+              change_mode = "noop";
+              error_on_missing_key = true;
+            }
+            ## Node topology file.
+            {
+              env = false;
+              destination = "${task_statedir}/${nodeSpec.name}/topology.json";
+              data = escapeTemplate (
+                let topology = profileData.node-services."${nodeSpec.name}".topology;
+                in if execTaskDriver
+                  then (topologyToGoTemplate topology.value)
+                  else (__readFile           topology.JSON )
+              );
+              change_mode = "noop";
+              error_on_missing_key = true;
+            }
+          ])
           ;
 
           # Specifies logging configuration for the stdout and stderr of the
@@ -687,7 +697,7 @@ let
               "tracer"                               # portName (can't have "-")
               0                                      # portNum
               # TODO: Which region?
-              {region=null;};                        # node-specs
+              {region=null;};                        # node-spec
           }
         ]
         ++
@@ -706,7 +716,7 @@ let
               ("perf-node-" + (toString nodeSpec.i)) # serviceName
               ("node" + (toString nodeSpec.i))       # portName (can't have "-")
               nodeSpec.port                          # portNum
-              nodeSpec;                              # node-specs
+              nodeSpec;                              # node-spec
           })
           (profileData.node-specs.value)
         )

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -15,13 +15,6 @@ let
   materialise-profile =
     { profileData }:
       let
-        supervisorConf = import ./supervisor-conf.nix
-          { inherit profileData;
-            inherit pkgs lib stateDir;
-            # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
-            unixHttpServerPort = "/tmp/supervisor.sock";
-          }
-        ;
         # Intermediate / workbench-adhoc container specifications
         containerSpecs = rec {
           #
@@ -120,19 +113,17 @@ let
             podman = {
               # TODO: oneTracerPerGroup
               oneTracerPerCluster = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
                   oneTracerPerNode = true;
@@ -141,19 +132,17 @@ let
             exec = {
               # TODO: oneTracerPerGroup
               oneTracerPerCluster = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
-                { inherit lib stateDir;
+                { inherit pkgs lib stateDir;
                   inherit profileData;
                   inherit containerSpecs;
-                  inherit supervisorConf;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
                   oneTracerPerNode = true;

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -1628,24 +1628,29 @@ backend_nomad() {
               else
                 # The whole cluster is about to finish!
                 touch "${dir}"/generator/quit
+                # Show the warning and continue with the counter
+                echo -ne "\n"
+                msg "$(yellow "WARNING: supervisord program \"generator\" (always inside Nomad Task \"node-0\" quit with an error exit code")"
+                msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
               fi
             else
               touch "${dir}"/generator/quit
               # Show the warning and continue with the counter
-              echo -e "\n"
+              echo -ne "\n"
               msg "$(yellow "WARNING: supervisord program \"generator\" (always inside Nomad Task \"node-0\" quit with a non-error exit code")"
               msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
             fi
-          fi
+          fi # Finish generator checks.
           local elapsed="$(($(date +%s) - start_time))"
           echo -ne "\b\b\b\b\b\b"
           printf "%6d" "${elapsed}"
           sleep 1
-        done   # While
+        done # While
         if ! test -f "${dir}"/flag/cluster-stopping
         then
-            echo -ne "\b\b\b\b\b\b"
-            echo -n "node-${pool_ix} 000000"
+          echo -ne "\n"
+          msg "$(yellow "supervisord program \"node-${pool_ix}\" stopped")"
+          msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
         fi
       done >&2 # For
       echo -ne "\b\b\b\b\b\b"
@@ -1653,10 +1658,12 @@ backend_nomad() {
       local elapsed=$(($(date +%s) - start_time))
       if test -f "${dir}"/flag/cluster-stopping
       then
-        echo " Termination requested -- after $(yellow ${elapsed})s" >&2;
+        echo -ne "\n"
+        msg "Termination requested -- after $(yellow ${elapsed})s"
       else
         touch "${dir}"/flag/cluster-stopping
-        echo " All nodes exited      -- after $(yellow ${elapsed})s" >&2
+        echo -ne "\n"
+        msg "All nodes exited      -- after $(yellow ${elapsed})s"
       fi
     ;;
 

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -238,13 +238,13 @@ backend_nomad() {
       done
     ;;
 
-    allocate-run-nomad-job-patch-constraints )
+    allocate-run-nomad-job-patch-group-constraints )
       local usage="USAGE: wb backend $op RUN-DIR CONSTRAINTS-JSON-ARRAY"
       local dir=${1:?$usage}; shift
       local constraints_array=${1:?$usage}; shift
       local nomad_environment=$(envjqr 'nomad_environment')
       local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      jq ".[\"job\"][\"${nomad_job_name}\"][\"constraint\"] = \$constraints_array" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
+      jq ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$constraints_array)" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
     ;;
 
     # Called by the sub-backends, don't use `fatal` and let them do the cleaning

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -238,15 +238,6 @@ backend_nomad() {
       done
     ;;
 
-    allocate-run-nomad-job-patch-group-constraints )
-      local usage="USAGE: wb backend $op RUN-DIR CONSTRAINTS-JSON-ARRAY"
-      local dir=${1:?$usage}; shift
-      local constraints_array=${1:?$usage}; shift
-      local nomad_environment=$(envjqr 'nomad_environment')
-      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      jq ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$constraints_array)" --argjson constraints_array "${constraints_array}" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
-    ;;
-
     # Called by the sub-backends, don't use `fatal` and let them do the cleaning
     deploy-genesis-wget )
       local usage="USAGE: wb backend $op RUN-DIR"

--- a/nix/workbench/backend/nomad/cloud.nix
+++ b/nix/workbench/backend/nomad/cloud.nix
@@ -26,7 +26,7 @@ let
   validateNodeSpecs = { nodeSpecsValue }:
     let
       # SRE is using these 3 Nomad "datacenters" (how they are called in Nomad)
-      datacenters = [ "eu-central-1" "eu-west-1" "us-east-2" ];
+      datacenters = [ "eu-central-1" "us-east-2" "ap-southeast-2" ];
       regions = lib.attrsets.mapAttrsToList
         (name: value: value.region)
         nodeSpecsValue

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -211,43 +211,146 @@ backend_nomadcloud() {
       # The job file is "slightly" modified (jq) to suit the running environment.
       backend_nomad allocate-run-nomad-job-patch-namespace         "${dir}" "${NOMAD_NAMESPACE}"
       backend_nomad allocate-run-nomad-job-patch-nix               "${dir}"
+
+      # Set the placement info and resources accordingly
+      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
       if test -z "${WB_SHELL_PROFILE}"
       then
         fatal "Envar \"WB_SHELL_PROFILE\" is empty!"
       else
-        if test "${WB_SHELL_PROFILE:0:6}" != 'cw-perf'
+        # Placement:
+        ############
+        ## "distinct_hosts": Instructs the scheduler to not co-locate any groups
+        ## on the same machine. When specified as a job constraint, it applies
+        ## to all groups in the job. When specified as a group constraint, the
+        ## effect is constrained to that group. This constraint can not be
+        ## specified at the task level. Note that the attribute parameter should
+        ## be omitted when using this constraint.
+        ## https://developer.hashicorp.com/nomad/docs/job-specification/constraint#distinct_hosts
+        local job_constraints_array
+        job_constraints_array='
+          [
+            {
+              "operator":  "distinct_hosts"
+            , "value":     "true"
+            }
+          ]
+        '
+          jq \
+            --argjson job_constraints_array "${job_constraints_array}" \
+            ".[\"job\"][\"${nomad_job_name}\"].constraint |= \$job_constraints_array" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
+        # Resources:
+        ############
+        local group_constraints_array
+        # "perf" profiles run on the "perf" class
+        if test "${WB_SHELL_PROFILE:0:7}" = 'cw-perf'
         then
           # Right now only "live" is using "perf" class distinct nodes!
-          backend_nomad allocate-run-nomad-job-patch-group-constraints "${dir}" \
-            "[                                                \
-                {                                             \
-                  \"operator\":  \"=\"                        \
-                , \"attribute\": \"\${node.class}\"           \
-                , \"value\":     \"perf\"                     \
-                }                                             \
-              , {                                             \
-                  \"operator\":  \"distinct_property\"        \
-                , \"attribute\": \"\${attr.unique.hostname}\" \
-                , \"value\":     1                            \
-                }                                             \
-            ]"
+          group_constraints_array='
+            [
+              {
+                "operator":  "="
+              , "attribute": "${node.class}"
+              , "value":     "perf"
+              }
+            ]
+          '
+          # Set the resources, only for perf!
+          # AWS:
+          ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
+          ## https://aws.amazon.com/ec2/instance-types/c5/
+          # Nomad:
+          ## - cpu.reservablecores  = 8
+          ## - cpu.arch:            = amd64
+          ## - cpu.frequency:       = 3400
+          ## - cpu.modelname:       = Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
+          ## - cpu.numcores:        = 8
+          ## - cpu.reservablecores: = 8
+          ## - cpu.totalcompute:    = 27200
+          ## - memory.totalbytes    = 16300142592
+          ## Pesimistic: 1,798 MiB / 15,545 MiB Total
+          ## Optimistic: 1,396 MiB / 15,545 MiB Total
+          local resources='{
+              "cores":      8
+            , "memory":     12000
+            , "memory_max": 15000
+          }'
+            jq \
+              --argjson resources "${resources}" \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.task |= with_entries( .value.resources = \$resources ) )" \
+              "${dir}"/nomad/nomad-job.json \
+          | \
+            sponge "${dir}"/nomad/nomad-job.json
+          # Fix for region mismatches
+          ###########################
+          # There are USx16 and APx18 and we need USx17 and APx17
+            jq \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"node-49\"][\"affinity\"][\"value\"] = \"ap-southeast-2\"" \
+              "${dir}"/nomad/nomad-job.json \
+          | \
+            sponge "${dir}"/nomad/nomad-job.json
+          # We use "us-east-2" and they use "us-east-1"
+            jq \
+              ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
+              "${dir}"/nomad/nomad-job.json \
+            | \
+              sponge "${dir}"/nomad/nomad-job.json
+            jq \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
+              "${dir}"/nomad/nomad-job.json \
+            | \
+              sponge "${dir}"/nomad/nomad-job.json
+        # Non "perf" profiles run on the "qa" class
         else
           # Right now only testing, using "qa" class distinct nodes!
-          backend_nomad allocate-run-nomad-job-patch-group-constraints "${dir}" \
-            "[                                                \
-                {                                             \
-                  \"operator\":  \"=\"                        \
-                , \"attribute\": \"\${node.class}\"           \
-                , \"value\":     \"qa\"                       \
-                }                                             \
-              , {                                             \
-                  \"operator\":  \"distinct_property\"        \
-                , \"attribute\": \"\${attr.unique.hostname}\" \
-                , \"value\":     1                            \
-                }                                             \
-            ]"
+          group_constraints_array='
+            [
+              {
+                "operator":  "="
+              , "attribute": "${node.class}"
+              , "value":     "qa"
+              }
+            ]
+          '
         fi
+          jq \
+            --argjson group_constraints_array "${group_constraints_array}" \
+            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
       fi
+
+      # Store a summary of the job.
+      jq \
+        '{
+            "namespace":   ( .job["workbench-cluster-job"].namespace   )
+          , "datacenters": ( .job["workbench-cluster-job"].datacenters )
+          , "constraint":  ( .job["workbench-cluster-job"].constraint  )
+          , "groups":      (
+                .job["workbench-cluster-job"].group
+              | with_entries(
+                  .value |= {
+                      "constraint": .constraint
+                    , "affinity":   .affinity
+                    , "tasks":      (
+                        .task | with_entries(
+                          .value |= {
+                              "resources":          .resources
+                            , "nix_installables":   .config.nix_installables
+                            , "templates":        ( .template | map(.destination) )
+                          }
+                        )
+                      )
+                  }
+                )
+            )
+        }' \
+        "${dir}"/nomad/nomad-job.json \
+      > "${dir}"/nomad/nomad-job.summary.json
 
       backend_nomad allocate-run "${dir}"
     ;;
@@ -319,7 +422,7 @@ backend_nomadcloud() {
           --region "${s3_region}"                         \
         || true
         # Reminder to remove old files.
-        msg "Still avaiable files at $(yellow "\"s3://${s3_bucket_name}\""):"
+        msg "Still available files at $(yellow "\"s3://${s3_bucket_name}\""):"
         aws s3 ls                   \
           s3://"${s3_bucket_name}"/ \
           --region "${s3_region}"

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -38,8 +38,10 @@ let
   materialise-profile =
     { profileData }:
       let supervisorConf = import ./supervisor-conf.nix
-        { inherit profileData;
-          inherit pkgs lib stateDir;
+        { inherit pkgs lib stateDir;
+          # Create a `supervisord.conf`
+          nodeSpecs = profileData.node-specs.value;
+          withTracer = profileData.value.node.tracer;
           inetHttpServerPort = "127.0.0.1:9001";
         };
       in pkgs.runCommand "workbench-backend-output-${profileData.profileName}-supervisor"

--- a/nix/workbench/nomad.sh
+++ b/nix/workbench/nomad.sh
@@ -1577,7 +1577,7 @@ EOF
           local eval_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Evaluation \"${eval_id}\"") to be \"complete\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && ( test "${status:-pending}" = "pending" || test "${status:-running}" = "running" )
           do
@@ -1648,7 +1648,7 @@ EOF
           local deploy_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Deployment \"${deploy_id}\"") to be \"successful\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && ! test -f "${job_file}.run/allocations.ok" && ( test "${status:-pending}" = "pending" || test "${status:-running}" = "running" )
           do
@@ -1695,7 +1695,7 @@ EOF
           local alloc_id=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Allocation \"${alloc_id}\"") to be \"running\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && test "${status:-pending}" = "pending"
           do
@@ -1770,7 +1770,7 @@ EOF
           local task_name=${1:?$usage}; shift
           local msgoff=${1:?$usage}; shift
           "${msgoff}" || msg "$(blue Waiting) for Nomad $(yellow "Task \"${task_name}\"") to be \"running\" ..."
-          local status
+          local status=""
           local status_response
           while ! test -f "${job_file}.run/job.error" && test "${status:-pending}" = "pending"
           do

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -173,13 +173,21 @@ def all_profile_variants:
       }
     } as $chainsync_cluster
   |
-    # Uses: ["eu-west-1", "eu-central-1", "us-east-2"]
+    # "qa" class Nomad Nodes in ["eu-central-1", "us-east-2"] datacenters
     { composition:
       { locations:                      ["EU", "US"]
       , topology:                       "torus"
       , with_explorer:                  true
       }
     } as $cardano_world_qa
+  |
+    # "perf" class Nomad Nodes in ["eu-central-1", "us-east-2", "ap-southeast-2"] datacenters
+    { composition:
+      { locations:                      ["EU", "US", "AP"]
+      , topology:                       "torus"
+      , with_explorer:                  true
+      }
+    } as $cardano_world_perf
   |
   ##
   ### Definition vocabulary:  filtering
@@ -262,7 +270,7 @@ def all_profile_variants:
     ) as $current_tps_saturation_value
   | ({}|
      .generator.tps                   = 12
-    ) as $cwqa_tps_saturation_value
+    ) as $cw_perf_tps_saturation_value
   | ({}|
      .generator.tps                   = 9
     ) as $model_tps_saturation_value
@@ -405,9 +413,9 @@ def all_profile_variants:
     { scenario:                        "fixed-loaded"
     }) as $scenario_fixed_loaded
   |
-   ($model_timescale * $cwqa_tps_saturation_value *
+   ($model_timescale * $cw_perf_tps_saturation_value *
     { scenario:                        "fixed-loaded"
-    }) as $scenario_cwqa
+    }) as $scenario_cw_perf
   |
    ($model_timescale * $model_tps_saturation_value *
     { scenario:                        "fixed-loaded"
@@ -452,7 +460,7 @@ def all_profile_variants:
       , desc: "Small dataset, honest 15 epochs duration"
     }) as $plutuscall_base
   |
-   ($scenario_cwqa * $compose_fiftytwo * $dataset_oct2021 * $for_7ep *
+   ($scenario_cw_perf * $compose_fiftytwo * $dataset_oct2021 * $for_7ep *
     { node:
         { shutdown_on_slot_synced:        56000
         }
@@ -467,7 +475,7 @@ def all_profile_variants:
         , max_block_size:                 88000
         }
       , desc: "AWS c5-2xlarge cluster dataset, 7 epochs"
-    }) as $cwqa_base
+    }) as $cw_perf_base
   |
    ($scenario_model * $quadruplet * $dataset_current * $for_7ep *
     { node:
@@ -584,7 +592,7 @@ def all_profile_variants:
     , desc: "Idle scenario:  start only the tracer & detach from tty;  no termination"
     }
   , $cardano_world_qa *
-    { name: "cwqa-default"
+    { name: "cw-qa-default"
     , desc: "Default, but on Cardano World QA"
     }
 
@@ -622,7 +630,8 @@ def all_profile_variants:
     { name: "ci-test-rtview"
     }
   , $citest_base * $cardano_world_qa *
-    { name: "cwqa-ci-test"
+    { name: "cw-qa-ci-test"
+    , desc: "ci-test, but on Cardano World QA"
     }
 
   ## CI variants: bench duration, 15 blocks
@@ -648,7 +657,8 @@ def all_profile_variants:
     { name: "ci-bench-rtview"
     }
   , $cibench_base * $cardano_world_qa *
-    { name: "cwqa-ci-bench"
+    { name: "cw-qa-ci-bench"
+    , desc: "ci-bench but on Cardano World QA"
     }
 
   ## CI variants: test duration, 3 blocks, dense10
@@ -704,9 +714,9 @@ def all_profile_variants:
     { name: "plutuscall-secp-schnorr-double"
     }
 
-## Cardano World QA cluster: 52 nodes, 2 regions, value variant
-  , $cwqa_base * $cardano_world_qa *
-    { name: "cwqa-value"
+## Cardano World QA cluster: 52 nodes, 3 regions, value variant
+  , $cw_perf_base * $cardano_world_perf *
+    { name: "cw-perf-value"
     }
 
 ## Model value variant: 7 epochs (128GB RAM needed; 16GB for testing locally)


### PR DESCRIPTION
Changes and fixes to make the 52 nodes (+ explorer node) cluster run on "perf" class SRE's Nomad Clients

- Set "resources", "affinity" and "constraints" accordingly
- Download log/run files in parallel
- Automatic retry of downloads when they fail
- Removed downloads of logs that could happen twice
- Changes to supervisord.conf that allowed to trim the Nomad Job JSON file from ~20 mega to ~1 mega
- Renamed workbench shells using Cardano World "qa" and "perf" class Nomad Clients as "cw-qa-*" and "cw-perf-*"
- As they happen, changes for more useful error messages