### PR TITLE
em:  update to fix a load ordering issue for overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,11 +250,11 @@
     "em": {
       "flake": false,
       "locked": {
-        "lastModified": 1684271538,
-        "narHash": "sha256-rQN8OKDNrVswL3TAVLt/P2eVrfw6SwgQUzUM3LZozLw=",
+        "lastModified": 1684791668,
+        "narHash": "sha256-JyPm0RiWCfy/8rs7wd/IRSWIz+bTkD78uxIMnKktU2g=",
         "owner": "deepfire",
         "repo": "em",
-        "rev": "7e473e81a304888b41bf6eae6b161f21717598ab",
+        "rev": "302cdf6d654fb18baff0213bdfa41a653774585a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

1. em:  update to fix a load ordering issue for overrides

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
