### PR TITLE
Fix tar-ing of failed test workspaces on macos in CI

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -165,7 +165,7 @@ jobs:
       shell: bash
       run: |
         cd $TMP
-        find . -name 'module' -type f -printf '%h\n' | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
+        find . -name 'module' -type f -exec dirname {} \; | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
 
     - name: Upload workspaces on tests failure
       if: ${{ failure() }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -194,7 +194,7 @@ jobs:
       shell: bash
       run: |
         cd $TMP
-        find . -name 'module' -type f -printf '%h\n' | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
+        find . -name 'module' -type f -exec dirname {} \; | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
 
     - name: Upload workspaces on tests failure
       if: ${{ failure() }}


### PR DESCRIPTION
# Description

Observed failure: https://github.com/input-output-hk/cardano-node/actions/runs/5048031554/jobs/9055699396#step:18:14

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
