### PR TITLE
Move configuration tests to `cardano-node` tests

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -205,7 +205,6 @@ test-suite cardano-cli-test
                       , cardano-node
                       , cardano-slotting ^>= 0.1
                       , containers
-                      , directory
                       , filepath
                       , hedgehog
                       , hedgehog-extras ^>= 0.4.5.1
@@ -213,10 +212,8 @@ test-suite cardano-cli-test
                       , text
                       , time
                       , transformers
-                      , yaml
 
-  other-modules:        Test.Config.Mainnet
-                        Test.Cli.CliIntermediateFormat
+  other-modules:        Test.Cli.CliIntermediateFormat
                         Test.Cli.FilePermissions
                         Test.Cli.ITN
                         Test.Cli.JSON

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pipes.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pipes.hs
@@ -32,6 +32,7 @@ import           System.FilePath ((</>))
 #else
 
 import           Hedgehog (Property, discover, property, success)
+import           System.FilePath ()
 #endif
 
 import qualified Hedgehog as H

--- a/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
@@ -13,7 +13,6 @@ import qualified Test.Cli.Pioneers.Exercise3
 import qualified Test.Cli.Pioneers.Exercise4
 import qualified Test.Cli.Pipes
 import qualified Test.Cli.Shelley.Run.Query
-import qualified Test.Config.Mainnet
 
 import           Hedgehog.Extras.Stock.OS (isWin32)
 import           Hedgehog.Main (defaultMain)
@@ -36,7 +35,6 @@ main = do
     , Test.Cli.Pioneers.Exercise3.tests
     , Test.Cli.Pioneers.Exercise4.tests
     , Test.Cli.Shelley.Run.Query.tests
-    , Test.Config.Mainnet.tests
     ]
 
 ignoreOnWindows :: IO Bool -> IO Bool

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -237,6 +237,7 @@ test-suite cardano-node-test
                       , cardano-node
                       , cardano-slotting >= 0.1
                       , directory
+                      , filepath
                       , hedgehog
                       , hedgehog-corpus
                       , hedgehog-extras
@@ -249,9 +250,12 @@ test-suite cardano-node-test
                       , ouroboros-network-api
                       , text
                       , time
+                      , transformers
                       , vector
+                      , yaml
 
-  other-modules:        Test.Cardano.Node.FilePermissions
+  other-modules:        Test.Cardano.Config.Mainnet
+                        Test.Cardano.Node.FilePermissions
                         Test.Cardano.Node.Gen
                         Test.Cardano.Node.Json
                         Test.Cardano.Node.POM

--- a/cardano-node/test/Test/Cardano/Config/Mainnet.hs
+++ b/cardano-node/test/Test/Cardano/Config/Mainnet.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Config.Mainnet
+module Test.Cardano.Config.Mainnet
   ( tests
   ) where
 

--- a/cardano-node/test/cardano-node-test.hs
+++ b/cardano-node/test/cardano-node-test.hs
@@ -7,6 +7,7 @@
 import           Hedgehog.Main (defaultMain)
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
+import qualified Test.Cardano.Config.Mainnet
 #ifdef UNIX
 import qualified Test.Cardano.Node.FilePermissions
 #endif
@@ -25,7 +26,8 @@ main = do
       [ Test.Cardano.Node.FilePermissions.tests
       ] <>
 #endif
-      [ Test.Cardano.Node.Json.tests
+      [ Test.Cardano.Config.Mainnet.tests
+      , Test.Cardano.Node.Json.tests
       , Test.Cardano.Node.POM.tests
       , Test.Cardano.Tracing.OrphanInstances.HardFork.tests
       ]


### PR DESCRIPTION
# Description

These tests lived in `cardano-cli`, they do not test `cardano-cli` functionality at all and `cardano-cli` is soon to be moved to its own repository.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
