### PR TITLE
Bench nomad healthchecks

### DIFF
--- a/nix/workbench/backend/backend.sh
+++ b/nix/workbench/backend/backend.sh
@@ -51,6 +51,7 @@ case "${op}" in
     wait-node-stopped )          backend_$WB_BACKEND "$@";;
     get-node-socket-path )       backend_$WB_BACKEND "$@";;
     start-generator )            backend_$WB_BACKEND "$@";;
+    start-healthchecks )         backend_$WB_BACKEND "$@";;
     wait-pools-stopped )         backend_$WB_BACKEND "$@";;
     stop-cluster )               backend_$WB_BACKEND "$@";;
     cleanup-cluster )            backend_$WB_BACKEND "$@";;

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -9,6 +9,7 @@
 , profileData
 , containerSpecs
 , execTaskDriver
+, generatorTaskName
 , oneTracerPerNode ? false
 }:
 
@@ -471,7 +472,7 @@ let
                       else {"${nodeSpec.name}"=nodeSpec;}
                     ;
                     # Only for the node that will run the generator
-                    withGenerator = taskName == "node-0";
+                    withGenerator = taskName == generatorTaskName;
                     # Only for the tracer task or also nodes if oneTracerPerNode
                     withTracer = oneTracerPerNode || taskName == "tracer";
                     # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
@@ -572,8 +573,8 @@ let
             }
           ])
           ++
-          (lib.optionals (taskName == "node-0") [
-            # Generator
+          # Generator
+          (lib.optionals (taskName == generatorTaskName) [
             ## Generator start.sh script.
             {
               env = false;

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -101,7 +101,9 @@ let
       LOGLEVEL="''${SUPERVISORD_LOGLEVEL:-info}"
 
       # Start `supervisord` on the foreground.
-      ${supervisor}/bin/supervisord --nodaemon --configuration "$SUPERVISORD_CONFIG" --loglevel="$LOGLEVEL"
+      # Avoid buffer related problems with stdout and stderr disabling buffering
+      # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
+      PYTHONUNBUFFERED=TRUE ${supervisor}/bin/supervisord --nodaemon --configuration "$SUPERVISORD_CONFIG" --loglevel="$LOGLEVEL"
       ''
   ;
 

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -470,6 +470,8 @@ let
                       then {}
                       else {"${nodeSpec.name}"=nodeSpec;}
                     ;
+                    # Only for the node that will run the generator
+                    withGenerator = taskName == "node-0";
                     # Only for the tracer task or also nodes if oneTracerPerNode
                     withTracer = oneTracerPerNode || taskName == "tracer";
                     # ''{{ env "NOMAD_TASK_DIR" }}/supervisor.sock''
@@ -477,26 +479,6 @@ let
                   };
                 in supervisorConf.INI
               ));
-              change_mode = "noop";
-              error_on_missing_key = true;
-            }
-            # Generator
-            ## Generator start.sh script.
-            {
-              env = false;
-              destination = "${task_statedir}/generator/start.sh";
-              data = escapeTemplate
-                profileData.generator-service.startupScript.value;
-              change_mode = "noop";
-              error_on_missing_key = true;
-              perms = "744"; # Only for every "start.sh" script. Default: "644"
-            }
-            ## Generator configuration file.
-            {
-              env = false;
-              destination = "${task_statedir}/generator/run-script.json";
-              data = escapeTemplate (__readFile
-                profileData.generator-service.runScript.JSON.outPath);
               change_mode = "noop";
               error_on_missing_key = true;
             }
@@ -585,6 +567,29 @@ let
                   then (topologyToGoTemplate topology.value)
                   else (__readFile           topology.JSON )
               );
+              change_mode = "noop";
+              error_on_missing_key = true;
+            }
+          ])
+          ++
+          (lib.optionals (taskName == "node-0") [
+            # Generator
+            ## Generator start.sh script.
+            {
+              env = false;
+              destination = "${task_statedir}/generator/start.sh";
+              data = escapeTemplate
+                profileData.generator-service.startupScript.value;
+              change_mode = "noop";
+              error_on_missing_key = true;
+              perms = "744"; # Only for every "start.sh" script. Default: "644"
+            }
+            ## Generator configuration file.
+            {
+              env = false;
+              destination = "${task_statedir}/generator/run-script.json";
+              data = escapeTemplate (__readFile
+                profileData.generator-service.runScript.JSON.outPath);
               change_mode = "noop";
               error_on_missing_key = true;
             }

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -15,6 +15,11 @@ let
   materialise-profile =
     { profileData }:
       let
+        # TODO: Repeated code, add the generator's node name to profile.json
+        generatorTaskName = if builtins.hasAttr "explorer" profileData.node-specs.value
+          then "explorer"
+          else "node-0"
+        ;
         # Intermediate / workbench-adhoc container specifications
         containerSpecs = rec {
           #
@@ -110,6 +115,7 @@ let
             }
           ;
           nomadJob = {
+            inherit generatorTaskName;
             podman = {
               # TODO: oneTracerPerGroup
               oneTracerPerCluster = import ./nomad-job.nix
@@ -118,6 +124,7 @@ let
                   inherit containerSpecs;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
+                  inherit generatorTaskName;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
@@ -126,6 +133,7 @@ let
                   inherit containerSpecs;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = false;
+                  inherit generatorTaskName;
                   oneTracerPerNode = true;
                 };
             };
@@ -137,6 +145,7 @@ let
                   inherit containerSpecs;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
+                  inherit generatorTaskName;
                   oneTracerPerNode = false;
                 };
               oneTracerPerNode = import ./nomad-job.nix
@@ -145,6 +154,7 @@ let
                   inherit containerSpecs;
                   # May evolve to a "cloud" flag!
                   execTaskDriver = true;
+                  inherit generatorTaskName;
                   oneTracerPerNode = true;
                 };
             };

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -74,7 +74,22 @@ let
               flake-output = "legacyPackages.x86_64-linux.python3Packages.supervisor";
               installable = "${flake-reference}/${gitrev}#${flake-output}";
             };
-            # TODO: profileData.node-services."node-0".serviceConfig.value.eventlog
+            gnugrep = rec {
+              nix-store-path  = pkgs.gnugrep;
+              flake-reference = "github:input-output-hk/cardano-node";
+              flake-output = "legacyPackages.x86_64-linux.gnugrep";
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            jq = rec {
+              nix-store-path  = pkgs.jq;
+              flake-reference = "github:input-output-hk/cardano-node";
+              flake-output = "legacyPackages.x86_64-linux.jq";
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            # TODO: - cardano-node.passthru.profiled
+            #       - cardano-node.passthru.eventlogged
+            #       - cardano-node.passthru.asserted
+            # profileData.node-services."node-0".serviceConfig.value.eventlog
             # builtins.trace (builtins.attrNames profileData.node-services."node-0".serviceConfig.value.eventlog) XXXX
             cardano-node = rec {
               nix-store-path  = with pkgs;
@@ -88,6 +103,12 @@ let
                   then "cardanoNodePackages.cardano-node.passthru.eventlogged"
                   else "cardanoNodePackages.cardano-node"
               ;
+              installable = "${flake-reference}/${gitrev}#${flake-output}";
+            };
+            cardano-cli = rec {
+              nix-store-path  = pkgs.cardanoNodePackages.cardano-cli;
+              flake-reference = "github:input-output-hk/cardano-cli";
+              flake-output = "cardanoNodePackages.cardano-cli";
               installable = "${flake-reference}/${gitrev}#${flake-output}";
             };
             cardano-tracer = rec {

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -878,7 +878,6 @@ backend_nomad() {
       local one_tracer_per_node=$(envjqr 'one_tracer_per_node')
       local generator_task=$(envjqr 'generator_task_name')
 
-      # TODO: Make it in parallel ?
       msg "Fetch logs ..."
 
       # Download healthcheck(s) logs. ##########################################
@@ -1918,6 +1917,9 @@ backend_nomad() {
           msg "$(yellow "supervisord program \"node-${pool_ix}\" stopped")"
           msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
         fi
+        local elapsed="$(($(date +%s) - start_time))"
+        echo -ne "\b\b\b\b\b\b"
+        printf "%6d" "${elapsed}"
       done >&2 # For
       echo -ne "\b\b\b\b\b\b"
 

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -913,6 +913,7 @@ backend_nomad() {
         if test -n "${healthchecks_array:-}"
         then
           msg "Retrying Healthcheck(s) [${healthchecks_array[@]}] logs download"
+          read -p "Hit enter to continue ..."
         fi
       done
       msg "$(green "Finished downloading Healthcheck(s) logs")"
@@ -928,6 +929,7 @@ backend_nomad() {
       while ! backend_nomad download-logs-generator "${dir}" "${generator_task}"
       do
         msg "Retrying \"generator\" logs download"
+        read -p "Hit enter to continue ..."
       done
       msg "$(green "Finished downloading \"generator\" logs")"
       # Download node(s) logs. #################################################
@@ -964,6 +966,7 @@ backend_nomad() {
         if test -n "${nodes_array:-}"
         then
           msg "Retrying node(s) [${nodes_array[@]}] logs download"
+          read -p "Hit enter to continue ..."
         fi
       done
       msg "$(green "Finished downloading node(s) logs")"
@@ -1013,6 +1016,7 @@ backend_nomad() {
             if test -n "${tracers_array:-}"
             then
               msg "Retrying tracer(s) [${tracers_array[@]}] logs download"
+              read -p "Hit enter to continue ..."
             fi
           done
           msg "$(green "Finished downloading tracer(s) logs")"
@@ -1031,6 +1035,7 @@ backend_nomad() {
           while ! backend_nomad download-logs-tracer "${dir}" "tracer"
           do
             msg "Retrying \"tracer\" logs download from \"tracer\""
+            read -p "Hit enter to continue ..."
           done
           msg "$(green "Finished downloading \"tracer\" logs from \"tracer\"")"
           # TODO: These files are needed at all?

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -702,7 +702,7 @@ backend_nomad() {
           fatal "Failed to stop tracer(s)"
         fi
       else
-        backend_nomad stop-cluster-node "${dir}" "tracer"
+        backend_nomad stop-cluster-tracer "${dir}" "tracer"
       fi
 
       # Download logs!
@@ -1675,6 +1675,8 @@ backend_nomad() {
       return 0
     ;;
 
+    # TODO: scenario.sh is not using it, but should call stop-cluster-node
+    # and/or stop-cluster-healthcheck and set the "stopped" flags
     stop-node )
       local usage="USAGE: wb backend $op RUN-DIR NODE-NAME"
       local dir=${1:?$usage};  shift

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -69,11 +69,12 @@ backend_nomad() {
           * ) break;; esac; shift; done
 
       # Create the dispatcher's local directories hierarchy.
-      backend_nomad allocate-run-directory-nomad      "${dir}"
-      backend_nomad allocate-run-directory-supervisor "${dir}"
-      backend_nomad allocate-run-directory-nodes      "${dir}"
-      backend_nomad allocate-run-directory-generator  "${dir}"
-      backend_nomad allocate-run-directory-tracers    "${dir}"
+      backend_nomad allocate-run-directory-nomad       "${dir}"
+      backend_nomad allocate-run-directory-supervisor  "${dir}"
+      backend_nomad allocate-run-directory-nodes       "${dir}"
+      backend_nomad allocate-run-directory-generator   "${dir}"
+      backend_nomad allocate-run-directory-tracers     "${dir}"
+      backend_nomad allocate-run-directory-healthcheck "${dir}"
 
       # These ones are decided at "setenv-defaults" of each sub-backend.
       local nomad_environment=$(envjqr 'nomad_environment')
@@ -189,10 +190,26 @@ backend_nomad() {
           # FIXME: Looks like I'm not using these ones!!!
          #cp $(jq '."tracer-config"'  -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/tracer-config.json
          #cp $(jq '."service-config"' -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/service-config.json
-          cp $(jq '."config"'         -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/config.json
-          cp $(jq '."start"'          -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/start.sh
+          cp $(jq '."config"' -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/config.json
+          cp $(jq '."start"'  -r ${dir}/profile/tracer-service.json) "${dir}"/tracer/start.sh
         fi
       fi
+    ;;
+
+    allocate-run-directory-healthcheck )
+      local usage="USAGE: wb backend $op RUN-DIR"
+      local dir=${1:?$usage}; shift
+      mkdir "${dir}"/healthcheck
+      # For every node ...
+      local nodes=($(jq_tolist keys "${dir}"/node-specs.json))
+      for node in ${nodes[*]}
+      do
+        # Files "start.sh" and "topology.sh" that usually go in here are copied
+        # from the Task/container once it's started because the contents are
+        # created or patched using Nomad's "template" stanza in the job spec
+        # and we want to hold a copy of what was actually run.
+        mkdir "${dir}"/healthcheck/"${node}"
+      done
     ;;
 
     # Change the Nomad job name to the current run tag. This allows to run
@@ -449,7 +466,14 @@ backend_nomad() {
         backend_nomad download-config-tracer   "${dir}" "tracer" &
         jobs_array+=("$!")
       fi
-
+      # For every node ...
+      local nodes=($(jq_tolist keys "$dir"/node-specs.json))
+      for node in ${nodes[*]}
+      do
+        # Only used for debugging!
+        backend_nomad download-config-healthcheck "${dir}" "${node}" &
+        jobs_array+=("$!")
+      done
       # Wait and check!
       if test -n "${jobs_array}"
       then
@@ -634,6 +658,18 @@ backend_nomad() {
         touch "${dir}"/stopping
       fi
 
+      # Stop healthcheck(s).
+      #####################
+      local jobs_healthchecks_array=()
+      for node in $(jq_tolist 'keys' "${dir}"/node-specs.json)
+      do
+        backend_nomad stop-cluster-healthcheck "${dir}" "${node}" &
+        jobs_healthchecks_array+=("$!")
+      done
+      if ! wait_fail_any "${jobs_healthchecks_array[@]}"
+      then
+        fatal "Failed to stop healthcheck(s)"
+      fi
       # Stop generator.
       #################
       backend_nomad stop-cluster-generator "${dir}" "${generator_task}"
@@ -693,6 +729,44 @@ backend_nomad() {
       #TODO: Remove it?
 
       rm "${dir}"/stopping; touch "${dir}"/stopped
+    ;;
+
+    stop-cluster-healthcheck )
+      local usage="USAGE: wb backend $op RUN-DIR"
+      local dir=${1:?$usage}; shift
+      local task=${1:?$usage}; shift
+      local task_dir="${dir}"/healthcheck/"${task}"
+      if test -f "${task_dir}"/started && !(test -f "${task_dir}"/stopped || test -f "${task_dir}"/quit)
+      then
+        if backend_nomad is-task-program-running "${dir}" "${task}" healthcheck
+        then
+          if ! backend_nomad task-program-stop "${dir}" "${task}" healthcheck
+          then
+            msg "$(yellow "WARNING: Program \"healthcheck\" inside Task \"${task}\" failed to stop")"
+          else
+            touch "${task_dir}"/stopped
+            msg "$(green "supervisord program \"healthcheck\" inside Nomad Task \"${task}\" down!")"
+          fi
+        else
+          touch "${task_dir}"/quit
+          if backend_nomad is-task-program-failed "${dir}" "${task}" healthcheck
+          then
+            local generator_task=$(envjqr 'generator_task_name')
+            # If the node quits (due to `--shutdown_on_slot_synced X` or
+            # `--shutdown_on_block_synced X`) the generator quits with an error.
+            local generator_can_fail=$(jq ".\"${task}\".shutdown_on_slot_synced or .\"${task}\".shutdown_on_block_synced" "${dir}"/node-specs.json)
+            if test "${generator_task}" != "${task}" || test "${generator_can_fail}" = "false" || backend_nomad is-task-program-running "${dir}" "${task}" "${task}"
+            then
+              # Do not fail here, because nobody will be able to stop the cluster!
+              msg "$(red "FATAL: \"healthcheck\" inside Task \"${task}\" quit unexpectedly")"
+            else
+              msg "$(yellow "INFO: Program \"healthcheck\" inside Task \"${task}\" failed, but expected when \"${task}\" automatically exits first and makes \"generator\" fail")"
+            fi
+          else
+            msg "$(yellow "WARNING: Program \"healthcheck\" inside Task \"${task}\" was not running, should it?")"
+          fi
+        fi
+      fi
     ;;
 
     stop-cluster-generator )
@@ -807,8 +881,44 @@ backend_nomad() {
       # TODO: Make it in parallel ?
       msg "Fetch logs ..."
 
-      # Download generator logs.
-      ##########################
+      # Download healthcheck(s) logs. ##########################################
+      ##########################################################################
+      # Remove "live" symlinks before downloading the "originals"
+      if test "${nomad_environment}" != "cloud"
+      then
+        for node in $(jq_tolist 'keys' "${dir}"/node-specs.json)
+        do
+          rm -f "${dir}"/healthcheck/"${node}"/{stdout,stderr,exit_code}
+          rm -f "${dir}"/supervisor/"${node}"/supervisord.log
+        done
+      fi
+      # Download retry "infinite" loop.
+      local healthchecks_array
+      healthchecks_array="$(jq_tolist 'keys' "$dir"/node-specs.json)"
+      while test -n "${healthchecks_array:-}"
+      do
+        local Healthchecks_jobs_array=()
+        for node in ${healthchecks_array[*]}
+        do
+          backend_nomad download-logs-healthcheck "${dir}" "${node}" &
+          Healthchecks_jobs_array+=("$!")
+        done
+        if test -n "${Healthchecks_jobs_array:-}" # If = () "unbound variable" error
+        then
+          # Wait until all jobs finish, don't use `wait_fail_any` that kills
+          # Returns the exit code of the last job, ignore it!
+          wait "${Healthchecks_jobs_array[@]}" || true
+        fi
+        # Fetch the nodes that don't have all the log files in its directory
+        healthchecks_array="$(backend_nomad stop-cluster-download-healthchecks "${dir}")"
+        if test -n "${healthchecks_array:-}"
+        then
+          msg "Retrying Healthcheck(s) [${healthchecks_array[@]}] logs download"
+        fi
+      done
+      msg "$(green "Finished downloading Healthcheck(s) logs")"
+      # Download generator logs. ###############################################
+      ##########################################################################
       # Remove "live" symlinks before downloading the "originals"
       if test "${nomad_environment}" != "cloud"
       then
@@ -821,8 +931,8 @@ backend_nomad() {
         msg "Retrying \"generator\" logs download"
       done
       msg "$(green "Finished downloading \"generator\" logs")"
-      # Download node(s) logs.
-      ########################
+      # Download node(s) logs. #################################################
+      ##########################################################################
       # Remove "live" symlinks before downloading the "originals"
       if test "${nomad_environment}" != "cloud"
       then
@@ -858,8 +968,8 @@ backend_nomad() {
         fi
       done
       msg "$(green "Finished downloading node(s) logs")"
-      # Download tracer(s) logs.
-      ##########################
+      # Download tracer(s) logs. ###############################################
+      ##########################################################################
       if jqtest ".node.tracer" "${dir}"/profile.json
       then
         # Remove "live" symlinks before downloading the "originals"
@@ -900,7 +1010,7 @@ backend_nomad() {
               wait "${tracers_jobs_array[@]}" || true
             fi
             # Fetch the nodes that don't have all the log files in its directory
-            tracers_array="$(backend_nomad stop-cluster-download-nodes "${dir}")"
+            tracers_array="$(backend_nomad stop-cluster-download-tracers "${dir}")"
             if test -n "${tracers_array:-}"
             then
               msg "Retrying tracer(s) [${tracers_array[@]}] logs download"
@@ -936,10 +1046,11 @@ backend_nomad() {
       fi
 
       # TODO: Check downloads
-      # ls run/current/nomad/{node-{0..51},explorer}/{stdout,stderr}            || msg ""
-      # ls run/current/{node-{0..51},explorer}/{exit_code,stdout,stderr}        || msg ""
-      # ls run/current/{node-{0..51},explorer}/{exit_code,stdout,stderr}        || msg ""
-      # ls run/current/tracer/{node-{0..51},explorer}/{exit_code,stdout,stderr} || msg ""
+      # ls run/current/nomad/{node-{0..51},explorer}/{stdout,stderr}                 || msg ""
+      # ls run/current/tracer/{node-{0..51},explorer}/{exit_code,stdout,stderr}      || msg ""
+      # ls run/current/{node-{0..51},explorer}/{exit_code,stdout,stderr}             || msg ""
+      # ls run/current/generator/{exit_code,stdout,stderr}                           || msg ""
+      # ls run/current/healthcheck/{node-{0..51},explorer}/{exit_code,stdout,stderr} || msg ""
 
       msg "$(green "Finished fetching logs")"
     ;;
@@ -1037,6 +1148,58 @@ backend_nomad() {
       echo "${tracers_array[@]}"
     ;;
 
+    # Array of nodes that don't have all the log files in its directory
+    stop-cluster-download-healthchecks )
+      local usage="USAGE: wb backend $op RUN-DIR"
+      local dir=${1:?$usage}; shift
+      local healthchecks_array=()
+      for node in $(jq_tolist 'keys' "${dir}"/node-specs.json)
+      do
+        local healthcheck_ok="true"
+        # Check the existance of all the wanted files:
+        if ! test -f "${dir}"/healthcheck/"${node}"/exit_code
+        then
+          healthcheck_ok="false"
+        fi
+        if ! test -f "${dir}"/healthcheck/"${node}"/stdout
+        then
+          healthcheck_ok="false"
+        fi
+        if ! test -f "${dir}"/healthcheck/"${node}"/stderr
+        then
+          healthcheck_ok="false"
+        fi
+        if ! test -f "${dir}"/nomad/"${node}"/stdout
+        then
+          healthcheck_ok="false"
+        fi
+        if ! test -f "${dir}"/nomad/"${node}"/stderr
+        then
+          healthcheck_ok="false"
+        fi
+        if ! test -f "${dir}"/supervisor/"${node}"/supervisord.log
+        then
+          healthcheck_ok="false"
+        fi
+        # Below like errors can end in truncated files, a proper flag is used!
+        # failed to exec into task: read tcp 10.0.0.115:33840->3.72.231.105:443: read: connection reset by peer
+        # tar: Unexpected EOF in archive
+        # tar: Unexpected EOF in archive
+        # tar: Error is not recoverable: exiting now
+        if test -f "${dir}"/healthcheck/"${node}"/download_failed
+        then
+          healthcheck_ok="false"
+        fi
+        # If any error add this healthcheck to the array
+        if test "${healthcheck_ok}" = "false"
+        then
+          healthchecks_array+=("${node}")
+        fi
+      done
+      # Return array
+      echo "${healthchecks_array[@]}"
+    ;;
+
     cleanup-cluster )
       local usage="USAGE: wb backend $op RUN-DIR"
       local dir=${1:?$usage}; shift
@@ -1054,18 +1217,21 @@ backend_nomad() {
 
     ############################################################################
     # Start/stop individual cluster "programs" functions:
-    # - start-node      RUN-DIR NODE-NAME
-    # - start-generator RUN-DIR
-    # - start-tracer    RUN-DIR              (Nomad backend specific subcommand)
-    # - wait-node       RUN-DIR NODE_NAME    (Nomad backend specific subcommand)
-    # - wait-tracer     RUN-DIR TASK-NAME    (Nomad backend specific subcommand)
-    # - stop-node       RUN-DIR NODE-NAME
-    # - start-nodes     RUN-DIR
-    # - start-tracers   RUN-DIR              (Nomad backend specific subcommand)
+    # - start-node         RUN-DIR NODE-NAME
+    # - start-generator    RUN-DIR
+    # - start-tracer       RUN-DIR           (Nomad backend specific subcommand)
+    # - start-healthcheck  RUN-DIR TASK-NAME (Nomad backend specific subcommand)
+    # - wait-node          RUN-DIR NODE_NAME (Nomad backend specific subcommand)
+    # - wait-tracer        RUN-DIR TASK-NAME (Nomad backend specific subcommand)
+    # - stop-node          RUN-DIR NODE-NAME
+    # - start-nodes        RUN-DIR
+    # - start-tracers      RUN-DIR           (Nomad backend specific subcommand)
+    # - start-healthchecks RUN-DIR
     #
     # TODO:
-    # - stop-generator  RUN-DIR              (Nomad backend specific subcommand)
-    # - stop-tracer     RUN-DIR              (Nomad backend specific subcommand)
+    # - stop-generator     RUN-DIR TASK-NAME (Nomad backend specific subcommand)
+    # - stop-tracer        RUN-DIR TASK-NAME (Nomad backend specific subcommand)
+    # - stop-healthcheck   RUN-DIR TASK-NAME (Nomad backend specific subcommand)
     ############################################################################
     # * Functions in the backend "interface" must use `fatal` when errors!
 
@@ -1334,6 +1500,68 @@ backend_nomad() {
       fi
     ;;
 
+    # Called by "start-healthchecks" that has no exit trap, don't use fatal here!
+    start-healthcheck ) # Nomad backend specific subcommands
+      local usage="USAGE: wb backend $op RUN-DIR TASK"
+      local dir=${1:?$usage};  shift
+      local task=${1:?$usage}; shift
+
+      if ! backend_nomad task-program-start "${dir}" "${task}" healthcheck
+      then
+        msg "$(red "FATAL: Program \"healthcheck\" inside Nomad Task \"${task}\" startup failed")"
+        # TODO: Let the download fail when everything fails?
+        backend_nomad download-logs-healthcheck "${dir}" "${task}" || true
+        # Should show the output/log of `supervisord` (runs as "entrypoint").
+        msg "$(yellow "${dir}/nomad/${task}/stdout:")"
+        cat                                                             \
+          <(echo "-------------------- log start --------------------") \
+          "${dir}"/nomad/"${task}"/stdout                               \
+          <(echo "-------------------- log end   --------------------")
+        msg "$(yellow "${dir}/nomad/${task}/stderr:")"
+        cat                                                             \
+          <(echo "-------------------- log start --------------------") \
+          "${dir}"/nomad/"${task}"/stderr                               \
+          <(echo "-------------------- log end   --------------------")
+        # Depending on when the start command failed, logs may not be available!
+        if test -f "${dir}"/healthcheck/"${task}"/stdout
+        then
+          msg "$(yellow "${dir}/healthcheck/${task}/stdout:")"
+          cat                                                           \
+          <(echo "-------------------- log start --------------------") \
+          "${dir}"/healthcheck/"${task}"/stdout                         \
+          <(echo "-------------------- log end   --------------------")
+        fi
+        # Depending on when the start command failed, logs may not be available!
+        if test -f "${dir}"/healthcheck/"${task}"/stderr
+        then
+          msg "$(yellow "${dir}/healthcheck/${task}/stderr:")"
+          cat                                                             \
+            <(echo "-------------------- log start --------------------") \
+            "${dir}"/healthcheck/"${task}"/stderr                         \
+            <(echo "-------------------- log end   --------------------")
+        fi
+        # Let "start" parse the response code and handle the cleanup!
+        msg "$(red "Failed to start program \"healthcheck\" inside Nomad Task \"${task}\"")"
+        return 1
+      else
+        local nomad_environment=$(envjqr 'nomad_environment')
+        if test "${nomad_environment}" != "cloud"
+        then
+          ln -s                                                                 \
+            ../../nomad/alloc/"${task}"/local/run/current/healthcheck/stdout    \
+            "${dir}"/healthcheck/"${task}"/stdout
+          ln -s                                                                 \
+            ../../nomad/alloc/"${task}"/local/run/current/healthcheck/stderr    \
+            "${dir}"/healthcheck/"${task}"/stderr
+          ln -s                                                                 \
+            ../../nomad/alloc/"${task}"/local/run/current/healthcheck/exit_code \
+            "${dir}"/healthcheck/"${task}"/exit_code
+        fi
+        # It was "intentionally started and should not automagically stop" flag!
+        touch "${dir}"/healthcheck/"${task}"/started
+      fi
+    ;;
+
     # Called by "start-node" that has no exit trap, don't use fatal here!
     wait-node )
       local usage="USAGE: wb backend $op RUN-DIR [NODE-NAME]"
@@ -1554,6 +1782,38 @@ backend_nomad() {
       fi
     ;;
 
+    # Called by `scenario.sh` with the exit trap (`scenario_setup_exit_trap`) set!
+    start-healthchecks )
+      local usage="USAGE: wb backend $op RUN-DIR"
+      local dir=${1:?$usage}; shift
+
+      local jobs_array=()
+      local nodes=($(jq_tolist keys "$dir"/node-specs.json))
+      for node in ${nodes[*]}
+      do
+        backend_nomad start-healthcheck "${dir}" "${node}" &
+        jobs_array+=("$!")
+      done
+      # Wait and check!
+      if test -n "${jobs_array}"
+      then
+        if ! wait_fail_any "${jobs_array[@]}"
+        then
+          fatal "Failed to start healthcheck(s)"
+          return 1
+        else
+          for node in ${nodes[*]}
+          do
+            if ! test -f "${dir}"/healthcheck/"${node}"/started
+            then
+              fatal "Healthcheck for \"${node}\" failed to start!"
+            fi
+          done
+        fi
+      fi
+      return 0
+    ;;
+
     ############################################################################
     # Cluster "wait" functions:
     # - get-node-socket-path    RUN-DIR NODE-NAME (Will break when cloud running)
@@ -1716,6 +1976,50 @@ backend_nomad() {
     ;;
 
     # For debugging when something fails, downloads and prints details!
+    download-logs-healthcheck )
+      local usage="USAGE: wb backend pass $op RUN-DIR TASK-NAME"
+      local dir=${1:?$usage}; shift
+      local task=${1:?$usage}; shift
+      local download_ok="true"
+      # Should show the output/log of `supervisord` (runs as "entrypoint").
+      msg "$(blue Fetching) $(yellow "entrypoint's stdout and stderr") of Nomad $(yellow "Task \"${task}\"") ..."
+      backend_nomad task-entrypoint-stdout "${dir}" "${task}" \
+      > "${dir}"/nomad/"${task}"/stdout                       \
+      || download_ok="false"
+      backend_nomad task-entrypoint-stderr "${dir}" "${task}" \
+      > "${dir}"/nomad/"${task}"/stderr                       \
+      || download_ok="false"
+      # If the entrypoint was ran till the end, this file should be available!
+      msg "$(blue Fetching) $(yellow supervisord.log) of Nomad $(yellow "Task \"${task}\"") ..."
+      backend_nomad task-file-contents "${dir}" "${task}"    \
+        /local/run/current/supervisor/supervisord.log        \
+      > "${dir}"/supervisor/"${task}"/supervisord.log        \
+      || download_ok="false"
+      # Downloads "exit_code", "stdout", "stderr" and GHC files.
+      # Depending on when the start command failed, logs may not be available!
+      backend_nomad download-zstd-healthcheck "${dir}" "${task}" \
+      || download_ok="false"
+      # Return
+      if test "${download_ok}" = "false"
+      then
+        msg "$(red "Failed to download \"healthcheck\" run files from \"${task}\"")"
+        # Below like errors can end in truncated files, a proper flag is needed!
+        # failed to exec into task: read tcp 10.0.0.115:33840->3.72.231.105:443: read: connection reset by peer
+        # tar: Unexpected EOF in archive
+        # tar: Unexpected EOF in archive
+        # tar: Error is not recoverable: exiting now
+        touch "${dir}"/healthcheck/"${task}"/download_failed
+        return 1
+      else
+        if test -f "${dir}"/healthcheck/"${task}"/download_failed
+        then
+          rm "${dir}"/healthcheck/"${task}"/download_failed
+        fi
+        return 0
+      fi
+    ;;
+
+    # For debugging when something fails, downloads and prints details!
     download-logs-generator )
       local usage="USAGE: wb backend pass $op RUN-DIR TASK-NAME"
       local dir=${1:?$usage}; shift
@@ -1866,6 +2170,20 @@ backend_nomad() {
           return 0
         fi
       fi
+    ;;
+
+    download-zstd-healthcheck )
+      local usage="USAGE: wb backend pass $op RUN-DIR TASK-NAME"
+      local dir=${1:?$usage}; shift
+      local task=${1:?$usage}; shift
+
+      msg "$(blue Fetching) $(yellow "\"healthcheck\"") run files from Nomad $(yellow "Task \"${task}\"") ..."
+      # TODO: Add compression, either "--zstd" or "--xz"
+        backend_nomad task-exec-program-run-files-tar-zstd        \
+          "${dir}" "${task}" "healthcheck"                        \
+      | tar --extract                                             \
+          --directory="${dir}"/healthcheck/"${task}"/ --file=-    \
+          --no-same-owner --no-same-permissions
     ;;
 
     download-zstd-generator )
@@ -2062,6 +2380,15 @@ backend_nomad() {
           > "${dir}"/nomad/tracer/networking.json
         fi
       fi
+    ;;
+
+    download-config-healthcheck )
+      local usage="USAGE: wb backend pass $op RUN-DIR NODE-NAME"
+      local dir=${1:?$usage}; shift
+      local node=${1:?$usage}; shift
+      backend_nomad task-file-contents "${dir}" "${node}" \
+        /local/run/current/healthcheck/start.sh           \
+      > "${dir}"/healthcheck/"${node}"/start.sh
     ;;
 
     ## Nomad job tasks supervisord queries

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -2537,6 +2537,7 @@ backend_nomad() {
               -o -name "*.eventlog"                      \
               -o -name "*.gcstats"                       \
               -o -name "*.log"                           \
+              -o -name "start.sh.debug"                  \
             \)                                           \
             -printf \"%P\\n\"                            \
         |                                                \

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -98,6 +98,9 @@ backend_nomadcloud() {
       setenvjqstr 'nomad_environment'   "cloud"
       setenvjqstr 'one_tracer_per_node' "true" # TODO: Not implemented yet!
 
+      # Cloud runs always run the generator inside Nomad Task "explorer"
+      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
+
       backend_nomadcloud setenv-nomadcloud "${profile_container_specs_file}"
     ;;
 

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -47,6 +47,10 @@ backend_nomadcloud() {
       backend_nomad stop-node            "$@"
     ;;
 
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
+    ;;
+
     start-generator )
       backend_nomad start-generator      "$@"
     ;;

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -266,7 +266,6 @@ backend_nomadcloud() {
           ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
           ## https://aws.amazon.com/ec2/instance-types/c5/
           # Nomad:
-          ## - cpu.reservablecores  = 8
           ## - cpu.arch:            = amd64
           ## - cpu.frequency:       = 3400
           ## - cpu.modelname:       = Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
@@ -278,7 +277,7 @@ backend_nomadcloud() {
           ## Optimistic: 1,396 MiB / 15,545 MiB Total
           local resources='{
               "cores":      8
-            , "memory":     12000
+            , "memory":     13000
             , "memory_max": 15000
           }'
             jq \
@@ -287,14 +286,29 @@ backend_nomadcloud() {
               "${dir}"/nomad/nomad-job.json \
           | \
             sponge "${dir}"/nomad/nomad-job.json
-          # Fix for region mismatches
-          ###########################
-          # There are USx16 and APx18 and we need USx17 and APx17
+          # The explorer node: Using an "m5.4xlarge" instance type
+          ## - cpu.arch             = amd64
+          ## - cpu.frequency        = 3100
+          ## - cpu.modelname        = Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+          ## - cpu.numcores         = 16
+          ## - cpu.reservablecores  = 16
+          ## - cpu.totalcompute     = 54400
+          ## - memory.totalbytes    = 65900154880
+          # Node ID: 00db7a3a-a05b-7ae0-2b2a-b50b9db139a4
+          # client named "ip-10-24-30-90.eu-central-1.compute.internal"
+          local explorer_resources='{
+              "cores":      16
+            , "memory":     29000
+            , "memory_max": 31000
+          }'
             jq \
-              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"node-49\"][\"affinity\"][\"value\"] = \"ap-southeast-2\"" \
+              --argjson resources "${explorer_resources}" \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"explorer\"][\"task\"] |= with_entries( .value.resources = \$resources )" \
               "${dir}"/nomad/nomad-job.json \
           | \
             sponge "${dir}"/nomad/nomad-job.json
+          # Fix for region mismatches
+          ###########################
           # We use "us-east-2" and they use "us-east-1"
             jq \
               ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -47,6 +47,10 @@ backend_nomadexec() {
       backend_nomad stop-node            "$@"
     ;;
 
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
+    ;;
+
     start-generator )
       backend_nomad start-generator      "$@"
     ;;

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -97,6 +97,9 @@ backend_nomadexec() {
       setenvjqstr 'profile_container_specs_file' "${profile_container_specs_file}"
       setenvjqstr 'nomad_environment'   "local"
       setenvjqstr 'one_tracer_per_node' "true"
+
+      # Local runs always run the generator inside Nomad Task "node-0"
+      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
     ;;
 
     # Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.

--- a/nix/workbench/backend/nomad/podman.sh
+++ b/nix/workbench/backend/nomad/podman.sh
@@ -97,6 +97,9 @@ backend_nomadpodman() {
       setenvjqstr 'profile_container_specs_file' "${profile_container_specs_file}"
       setenvjqstr 'nomad_environment'   "local"
       setenvjqstr 'one_tracer_per_node' "false"
+
+      # Local runs always run the generator inside Nomad Task "node-0"
+      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
     ;;
 
     # Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.

--- a/nix/workbench/backend/nomad/podman.sh
+++ b/nix/workbench/backend/nomad/podman.sh
@@ -47,6 +47,10 @@ backend_nomadpodman() {
       backend_nomad stop-node            "$@"
     ;;
 
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
+    ;;
+
     start-generator )
       backend_nomad start-generator      "$@"
     ;;

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -86,6 +86,9 @@ let
         command        = "${command}";
         stdout_logfile = "${stateDir}/tracer/stdout";
         stderr_logfile = "${stateDir}/tracer/stderr";
+        # Set these values to 0 to indicate an unlimited log size / no rotation.
+        stdout_logfile_maxbytes = 0;
+        stderr_logfile_maxbytes = 0;
         stopasgroup    = true;
         killasgroup    = true;
         autostart      = false;
@@ -104,6 +107,9 @@ let
         command        = "${command}";
         stdout_logfile = "${stateDir}/${nodeName}/stdout";
         stderr_logfile = "${stateDir}/${nodeName}/stderr";
+        # Set these values to 0 to indicate an unlimited log size / no rotation.
+        stdout_logfile_maxbytes = 0;
+        stderr_logfile_maxbytes = 0;
         stopasgroup    = false;
         killasgroup    = false;
         autostart      = false;
@@ -123,6 +129,9 @@ let
         command        = "${command}";
         stdout_logfile = "${stateDir}/generator/stdout";
         stderr_logfile = "${stateDir}/generator/stderr";
+        # Set these values to 0 to indicate an unlimited log size / no rotation.
+        stdout_logfile_maxbytes = 0;
+        stderr_logfile_maxbytes = 0;
         stopasgroup    = false;
         killasgroup    = false;
         autostart      = false;
@@ -141,6 +150,9 @@ let
         command        = "${command}";
         stdout_logfile = "${stateDir}/healthcheck/stdout";
         stderr_logfile = "${stateDir}/healthcheck/stderr";
+        # Set these values to 0 to indicate an unlimited log size / no rotation.
+        stdout_logfile_maxbytes = 0;
+        stderr_logfile_maxbytes = 0;
         stopasgroup    = false;
         killasgroup    = false;
         autostart      = false;

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -29,12 +29,45 @@ let
   ## Refer to:
   ## - http://supervisord.org/configuration.html
   supervisorConf =
+    ##
+    ## [unix_http_server] Section Settings
+    ##
+    ## Refer to:
+    ## - http://supervisord.org/configuration.html#unix-http-server-section-settings
+    lib.attrsets.optionalAttrs (unixHttpServerPort != null) {
+      unix_http_server = {
+        file = unixHttpServerPort;
+        chmod = "0777";
+      };
+    }
+    ##
+    ## [inet_http_server] Section Settings
+    ##
+    ## Refer to:
+    ## - http://supervisord.org/configuration.html#inet-http-server-section-settings
+    //
+    lib.attrsets.optionalAttrs (inetHttpServerPort != null) {
+      inet_http_server = {
+        port = inetHttpServerPort;
+      };
+    }
+    //
     {
+      ##
+      ## [supervisord] Section Settings
+      ##
+      ## Refer to:
+      ## http://supervisord.org/configuration.html#supervisord-section-settings
       supervisord = {
         logfile = "${stateDir}/supervisor/supervisord.log";
         pidfile = "${stateDir}/supervisor/supervisord.pid";
         strip_ansi = true;
       };
+      ##
+      ## [supervisorctl] Section Settings
+      ##
+      ## Refer to:
+      ## http://supervisord.org/configuration.html#supervisorctl-section-settings
       supervisorctl = {};
       "rpcinterface:supervisor" = {
         "supervisor.rpcinterface_factory" = "supervisor.rpcinterface:make_main_rpcinterface";
@@ -45,24 +78,6 @@ let
     ##
     ## Refer to:
     ## - http://supervisord.org/configuration.html#program-x-section-settings
-    //
-    {
-      "program:generator" = {
-        # "command" below assumes "directory" is set accordingly.
-        directory      = "${stateDir}/generator";
-        command        = "${command}";
-        stdout_logfile = "${stateDir}/generator/stdout";
-        stderr_logfile = "${stateDir}/generator/stderr";
-        stopasgroup    = false;
-        killasgroup    = false;
-        autostart      = false;
-        autorestart    = false;
-        # Don't attempt any restart!
-        startretries   = 0;
-        # Seconds it needs to stay running to consider the start successful
-        startsecs      = 5;
-      };
-    }
     //
     lib.attrsets.optionalAttrs withTracer
     {
@@ -100,29 +115,25 @@ let
         startsecs      = 5;
       })
     nodeSpecs))
-    ##
-    ## [unix_http_server] Section Settings
-    ##
-    ## Refer to:
-    ## - http://supervisord.org/configuration.html#unix-http-server-section-settings
     //
-    lib.attrsets.optionalAttrs (unixHttpServerPort != null) {
-      unix_http_server = {
-        file = unixHttpServerPort;
-        chmod = "0777";
+    {
+      "program:generator" = {
+        # "command" below assumes "directory" is set accordingly.
+        directory      = "${stateDir}/generator";
+        command        = "${command}";
+        stdout_logfile = "${stateDir}/generator/stdout";
+        stderr_logfile = "${stateDir}/generator/stderr";
+        stopasgroup    = false;
+        killasgroup    = false;
+        autostart      = false;
+        autorestart    = false;
+        # Don't attempt any restart!
+        startretries   = 0;
+        # Seconds it needs to stay running to consider the start successful
+        startsecs      = 5;
       };
     }
-    ##
-    ## [inet_http_server] Section Settings
-    ##
-    ## Refer to:
-    ## - http://supervisord.org/configuration.html#inet-http-server-section-settings
-    //
-    lib.attrsets.optionalAttrs (inetHttpServerPort != null) {
-      inet_http_server = {
-        port = inetHttpServerPort;
-      };
-    };
+    ;
 
 in {
   value = supervisorConf;

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -133,6 +133,24 @@ let
         startsecs      = 5;
       };
     }
+    //
+    {
+      "program:healthcheck" = {
+        # "command" below assumes "directory" is set accordingly.
+        directory      = "${stateDir}/healthcheck";
+        command        = "${command}";
+        stdout_logfile = "${stateDir}/healthcheck/stdout";
+        stderr_logfile = "${stateDir}/healthcheck/stderr";
+        stopasgroup    = false;
+        killasgroup    = false;
+        autostart      = false;
+        autorestart    = false;
+        # Don't attempt any restart!
+        startretries   = 0;
+        # Seconds it needs to stay running to consider the start successful
+        startsecs      = 5;
+      };
+    }
     ;
 
 in {

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -2,6 +2,7 @@
 , lib
 , stateDir
 , nodeSpecs
+, withGenerator
 , withTracer
 , unixHttpServerPort ? null
 , inetHttpServerPort ? null
@@ -114,6 +115,7 @@ let
       })
     nodeSpecs))
     //
+    lib.attrsets.optionalAttrs withGenerator
     {
       "program:generator" = {
         # "command" below assumes "directory" is set accordingly.

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -14,15 +14,13 @@ let
   # may run in the most unexpected places where we can't asume what is or isn't
   # included in $PATH. Just make sure pkgs.bashInteractive is in the nix store.
   sh = "${pkgs.bashInteractive}/bin/sh";
-  # Same as above for `sh` applies for pkgs.coreutils.
-  touch = "${pkgs.coreutils}/bin/touch";
   # We can't obtain the exit codes using `supervisorctl status`, it returns zero
   # when RUNNING and non-zero for STOPPED, EXITED, FATAL, and UNKNOWN, so as we
   # are not using any "autorestart" like functionality supervisord programs are
   # echoing their exit code after the script to a file named `exit_code` that is
-  # created empty just before starting the script.
+  # created and/or emptied before every script run.
   # Warning: This command assumes the "directory" is set correctly.
-  command = "${sh} -c \"${touch} ./exit_code; ./start.sh; echo \"$?\" > ./exit_code\"";
+  command = "${sh} -c \":> ./exit_code; ./start.sh; echo \"$?\" > ./exit_code\"";
   ##
   ## supervisorConf :: SupervisorConf
   ##

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -20,7 +20,7 @@ let
   # echoing their exit code after the script to a file named `exit_code` that is
   # created and/or emptied before every script run.
   # Warning: This command assumes the "directory" is set correctly.
-  command = "${sh} -c \":> ./exit_code; ./start.sh; echo \"$?\" > ./exit_code\"";
+  command = "${sh} -c ':> ./exit_code; ./start.sh; exit_code=\"''$?\"; echo \"''$exit_code\" > ./exit_code; exit \"''$exit_code\"'";
   ##
   ## supervisorConf :: SupervisorConf
   ##

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -41,6 +41,7 @@ let
         { inherit pkgs lib stateDir;
           # Create a `supervisord.conf`
           nodeSpecs = profileData.node-specs.value;
+          withGenerator = true;
           withTracer = profileData.value.node.tracer;
           inetHttpServerPort = "127.0.0.1:9001";
         };

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -186,6 +186,27 @@ EOF
         echo -n $state_dir/$node_name/node.socket
         ;;
 
+    start-healthchecks )
+        local usage="USAGE: wb backend $op RUN-DIR"
+        local dir=${1:?$usage}; shift
+
+        while test $# -gt 0
+        do case "$1" in
+               --* ) msg "FATAL:  unknown flag '$1'"; usage_supervisor;;
+               * ) break;; esac; shift; done
+
+        ls -l $dir/{tracer/tracer,node-{0,1}/node}.socket || true
+        if ! supervisorctl start healthcheck
+        then progress "supervisor" "$(red fatal: failed to start) $(white healthcheck)"
+             echo "$(red healthcheck stdout) -----------------------------------" >&2
+             cat "$dir"/healthcheck/stdout
+             echo "$(red healthcheck stderr) -----------------------------------" >&2
+             cat "$dir"/healthcheck/stderr
+             echo "$(white -------------------------------------------------)" >&2
+             fatal "could not start $(white supervisord)"
+        fi
+        backend_supervisor save-child-pids "$dir";;
+
     start-generator )
         local usage="USAGE: wb backend $op RUN-DIR"
         local dir=${1:?$usage}; shift
@@ -275,7 +296,7 @@ EOF
         local dir=${1:?$usage}; shift
 
         msg "supervisor:  resetting cluster state in:  $dir"
-        rm -f $dir/*/std{out,err} $dir/node-*/*.socket $dir/*/logs/* 2>/dev/null || true
+        rm -f $dir/*/std{out,err} $dir/*/exit_code $dir/node-*/*.socket $dir/*/logs/* 2>/dev/null || true
         rm -fr $dir/node-*/state-cluster/;;
 
     save-child-pids )

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -147,7 +147,9 @@ EOF
         local usage="USAGE: wb backend $op RUN-DIR"
         local dir=${1:?$usage}; shift
 
-        if ! supervisord --config  "$dir"/supervisor/supervisord.conf $@
+        # Avoid buffer related problems with stdout and stderr disabling buffering
+        # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
+        if ! PYTHONUNBUFFERED=TRUE supervisord --config  "$dir"/supervisor/supervisord.conf $@
         then progress "supervisor" "$(red fatal: failed to start) $(white supervisord)"
              echo "$(red supervisord.conf) --------------------------------" >&2
              cat "$dir"/supervisor/supervisord.conf

--- a/nix/workbench/genesis/genesis.sh
+++ b/nix/workbench/genesis/genesis.sh
@@ -201,6 +201,7 @@ case "$op" in
 
         jq '
           to_entries
+        | map( select(.value.kind == "pool") )
         | map
           ({ key:   (.value.i | tostring)
            , value:

--- a/nix/workbench/lib.sh
+++ b/nix/workbench/lib.sh
@@ -247,7 +247,7 @@ git_repo_commit_description() {
 wait_fail_any () {
   local processes=("$@")
   # There are any processes left?
-  if test -n "${processes[*]}"
+  if test -n "${processes[*]:-}"
   then
     local wait_exit_status
     local exited_process
@@ -263,7 +263,7 @@ wait_fail_any () {
       fi
     done
     # Something else to wait for?
-    if test -n "${processes_p[*]}"
+    if test -n "${processes_p[*]:-}"
     then
       # Keep waiting or kill 'em all ?'
       if test "${wait_exit_status}" -eq 0

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -715,7 +715,7 @@ def all_profile_variants:
     }
 
 ## Cardano World QA cluster: 52 nodes, 3 regions, value variant
-  , $cw_perf_base * $cardano_world_perf *
+  , $cw_perf_base * $cardano_world_perf * $costmodel_v8_preview *
     { name: "cw-perf-value"
     }
 

--- a/nix/workbench/profile/profile.nix
+++ b/nix/workbench/profile/profile.nix
@@ -51,6 +51,15 @@ rec {
             inherit runJq nodeSpecs;
           })
         tracer-service;
+
+      inherit
+        (pkgs.callPackage
+          ../service/healthcheck.nix
+          {
+            inherit backend profile;
+            inherit runJq nodeSpecs;
+          })
+        healthcheck-service;
     };
 
   ## WARNING:  IFD !!
@@ -96,7 +105,8 @@ rec {
         })
         node-services
         generator-service
-        tracer-service;
+        tracer-service
+        healthcheck-service;
     };
 
   profileData = { profile }:
@@ -136,11 +146,18 @@ rec {
             config               = config.JSON;
             start                = startupScript.JSON;
           };
+        healthcheckService =
+          with profile.healthcheck-service;
+          __toJSON
+          { name                 = "healthcheck";
+            start                = startupScript.JSON;
+          };
         passAsFile =
           [
             "nodeServices"
             "generatorService"
             "tracerService"
+            "healthcheckService"
             "topologyJson"
             "topologyDot"
           ];
@@ -154,6 +171,7 @@ rec {
       cp    $nodeServicesPath             $out/node-services.json
       cp    $generatorServicePath         $out/generator-service.json
       cp    $tracerServicePath            $out/tracer-service.json
+      cp    $healthcheckServicePath       $out/healthcheck-service.json
       ''
   // profile;
 

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -1045,6 +1045,7 @@ run_instantiate_rundir_profile_services() {
     local svcs=$dir/profile/node-services.json
     local gtor=$dir/profile/generator-service.json
     local trac=$dir/profile/tracer-service.json
+    local hche=$dir/profile/healthcheck-service.json
 
     for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
     do local node_dir="$dir"/$node
@@ -1068,4 +1069,8 @@ run_instantiate_rundir_profile_services() {
     cp $(jq '."service-config"'                -r $trac) "$trac_dir"/service-config.json
     cp $(jq '."config"'                        -r $trac) "$trac_dir"/config.json
     cp $(jq '."start"'                         -r $trac) "$trac_dir"/start.sh
+
+    local hche_dir="$dir"/healthcheck
+    mkdir -p                                    "$hche_dir"
+    cp $(jq '."start"'                         -r $hche) "$hche_dir"/start.sh
 }

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -74,7 +74,7 @@ case "$op" in
         # `chaindb` explorer:
         local explorer=(
             mainnet-chunks-with-snapshot-at-slot
-            "$dir"/node-1/run/current/node-1/db-testnet
+            "$dir"/node-1/db
             $(jq '.chaindb.ledger_snapshot.explorer'       $p)
             $(jq '.chaindb.mainnet_chunks.explorer'        $p)
         )
@@ -83,7 +83,7 @@ case "$op" in
         # `chaindb` server:
         local chaindb_server=(
             mainnet-chunks-with-snapshot-at-slot
-            "$dir"/node-0/run/current/node-0/db-testnet
+            "$dir"/node-0/db
             $(jq '.chaindb.ledger_snapshot.chaindb_server' $p)
             $(jq '.chaindb.mainnet_chunks.chaindb_server'  $p)
         )

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -56,6 +56,7 @@ case "$op" in
         scenario_setup_exit_trap     "$dir"
         backend start-nodes          "$dir"
         backend start-generator      "$dir"
+        backend start-healthchecks   "$dir"
 
         scenario_setup_workload_termination   "$dir"
         backend wait-pools-stopped   "$dir"

--- a/nix/workbench/service/generator.nix
+++ b/nix/workbench/service/generator.nix
@@ -152,10 +152,11 @@ let
                 (__toJSON service.nodeConfig);
       };
 
-      runScript = {
+      runScript = rec {
         # TODO / FIXME
         # the string '...' is not allowed to refer to a store path (such as '')
         # value = service.decideRunScript service;
+        value = __fromJSON (__readFile JSON);
         JSON  = jsonFilePretty "generator-run-script.json"
                 (service.decideRunScript service);
       };

--- a/nix/workbench/service/generator.nix
+++ b/nix/workbench/service/generator.nix
@@ -10,6 +10,13 @@
 with pkgs.lib;
 
 let
+  # If there is an "explorer" node, the generator will run there!
+  # TODO: Repeated code, add the generator's node name to profile.json
+  runningNode = if builtins.hasAttr "explorer" nodeSpecs
+    then "explorer"
+    else "node-0"
+  ;
+
   # We're reusing configuration from a cluster node.
   exemplarNode = node-services."node-0";
 
@@ -23,8 +30,8 @@ let
         sigKey         = "../genesis/utxo-keys/utxo1.skey";
         runScriptFile  = "run-script.json";
         ## path to the config and socket of the locally running node.
-        nodeConfigFile = "../node-0/config.json";
-        localNodeSocketPath = "../node-0/node.socket";
+        nodeConfigFile = "../${runningNode}/config.json";
+        localNodeSocketPath = "../${runningNode}/node.socket";
       } // optionalAttrs profile.node.tracer {
         tracerSocketPath = "../tracer/tracer.socket";
       } // optionalAttrs backend.useCabalRun {

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -17,23 +17,743 @@ let
       bashInteractive = pkgs.bashInteractive;
       coreutils       = pkgs.coreutils;
       supervisor      = pkgs.supervisor;
+      grep            = pkgs.gnugrep;
+      jq              = pkgs.jq;
+      cardano-cli     = pkgs.cardanoNodePackages.cardano-cli;
     in {
       startupScript = rec {
         JSON = pkgs.writeScript "startup-healthcheck.sh" value;
+        jqFilter = "";
+        # Assumptions:
+        # - Command `date` and node's log use the same timezone!
         value = ''
           #!${bashInteractive}/bin/sh
 
-          # Store the entrypoint env vars for debugging purposes
-          ${coreutils}/bin/env > /local/healthcheck.env
+          # Set script globals #################################################
+          ######################################################################
 
-          # Only needed for "exec" ?
-          if test "''${TASK_DRIVER}" = "exec"
+          # Strict runtime
+          ################
+          # e:        Immediately exit if any command has a non-zero exit status
+          # u:        Reference to non previously defined variables is an error
+          # pipefail: Any failed command in a pipeline is used as return code
+          set -euo pipefail
+
+          # Fetch profile parameters
+          ##########################
+          network_magic=$(${jq}/bin/jq      .genesis.network_magic      ../profile.json)
+          slot_duration=$(${jq}/bin/jq      .genesis.slot_duration      ../profile.json)
+          epoch_length=$(${jq}/bin/jq       .genesis.epoch_length       ../profile.json)
+          active_slots_coeff=$(${jq}/bin/jq .genesis.active_slots_coeff ../profile.json)
+          #active_slots="$((epoch_length * active_slots_coeff))"
+          ${coreutils}/bin/echo "profile.json:"
+          ${coreutils}/bin/echo "- network_magic:      ''${network_magic}"
+          ${coreutils}/bin/echo "- slot_duration:      ''${slot_duration}"
+          ${coreutils}/bin/echo "- epoch_length:       ''${epoch_length}"
+          ${coreutils}/bin/echo "- active_slots_coeff: ''${active_slots_coeff}"
+          #${coreutils}/bin/echo "- active_slots:       ''${active_slots}"
+
+          # Fetch node names (Including "explorer" nodes)
+          ###############################################
+          node_specs_nodes=$(${jq}/bin/jq --raw-output "keys | join (\" \")"      ../node-specs.json)
+          node_specs_pools=$(${jq}/bin/jq 'map(select(.kind == "pool")) | length' ../node-specs.json)
+          ${coreutils}/bin/echo "node-specs.json:"
+          ${coreutils}/bin/echo "- Nodes: [''${node_specs_nodes[*]}]"
+          ${coreutils}/bin/echo "- Pools: ''${node_specs_pools}"
+
+          # Look for available nodes and allocate healthcheck
+          ###################################################
+          nodes=()
+          now=$(${coreutils}/bin/date +%s)
+          for node in ''${node_specs_nodes[*]}
+          do
+            if test -d "../''${node}"
+            then
+              nodes+=("''${node}")
+              # Create healthcheck directory inside available node directories
+              ${coreutils}/bin/mkdir "../''${node}/healthcheck"
+              # TODO: Store the `+RTS --info`
+              # Save the starting time
+              ${coreutils}/bin/echo "''${now}" > "../''${node}/healthcheck/start_time"
+            fi
+          done
+          ${coreutils}/bin/echo "Found deployed nodes:"
+          ${coreutils}/bin/echo "- Nodes: [''${nodes[*]}]"
+
+          # Look for the generator
+          ########################
+          if test -d "../generator"
           then
-            cd "''${TASK_WORKDIR}"
+            ${coreutils}/bin/echo "Found deployed generator"
+          else
+            ${coreutils}/bin/echo "Found no deployed generator"
           fi
 
-          sleep 100000
-          '';
+          # Main ###############################################################
+          ######################################################################
+
+          # The main function, called at the end of the file/script.
+          function healthcheck() {
+            # Start the healthcheck infinite loop
+            trap "${coreutils}/bin/echo \"trap PIPE\" >&2" PIPE
+            msg "Started!"
+            # Do a one and only networking/latency test!
+            for node in ''${nodes[*]}
+            do
+              latency_topology_producers "''${node}"
+            done
+            while true
+            do
+              for node in ''${nodes[*]}
+              do
+                healthcheck_node "''${node}"
+              done
+              healthcheck_generator
+              ${coreutils}/bin/sleep 5 # Enough?
+            done
+            trap - PIPE
+          }
+
+          ######################################################################
+
+          function latency_topology_producers() {
+            local node=$1
+            msg "Latencies using 'cardano-cli ping' of \"''${node}\"'s Producers"
+            local topology_path="../''${node}/topology.json"
+            local keys=$(${jq}/bin/jq --raw-output '.Producers | keys | join (" ")' "''${topology_path}")
+            for key in ''${keys[*]}
+            do
+              local host=$(${jq}/bin/jq --raw-output ".Producers[''${key}].addr" "''${topology_path}")
+              local port=$(${jq}/bin/jq --raw-output ".Producers[''${key}].port" "''${topology_path}")
+              msg "'cardano-cli ping' of \"''${host}:''${port}\""
+              # If the ping fails the whole script must fail!
+              ${cardano-cli}/bin/cardano-cli ping \
+                --magic "''${network_magic}"      \
+                --count 3                         \
+                --json                            \
+                --host "''${host}"                \
+                --port "''${port}"
+            done
+          }
+
+          function healthcheck_node() {
+            local node=$1
+            if is_program_running "''${node}"
+            then
+              # The node is running! ###########################################
+              ##################################################################
+              # Don't query the node's tip everytime once it got past slot 0!!!!
+              # This avoids consuming the node's resources in "random" and also
+              # avoids the corner case were the "tip" returns empty when
+              # shutdown is requested / terminate signal was already sent.
+              local synced_flag_path="../''${node}/healthcheck/synced"
+              if ! test -f "''${synced_flag_path}"
+              then
+                # The node was not flagged as synced! ##########################
+                ################################################################
+                if ! is_node_synced_and_past_slot_zero "''${node}"
+                then
+                  # The node is still not synced! ##############################
+                  ##############################################################
+                  local now=$(${coreutils}/bin/date +%s)
+                  local start_time=$(${coreutils}/bin/cat "../''${node}/healthcheck/start_time")
+                  if test $((now - start_time)) -ge 180
+                  then
+                    exit_healthcheck "''${node}: More than 3m waiting for slot 0"
+                  fi
+                else
+                  # The node is now synced! ####################################
+                  ##############################################################
+                  ${coreutils}/bin/touch "''${synced_flag_path}"
+                fi
+              else
+                # The node was already flagged as synced! ######################
+                ################################################################
+                # TODO: healthcheck_node_forge "''${node}"
+                healthcheck_node_block "''${node}"
+                healthcheck_node_txs   "''${node}"
+              fi
+            fi
+          }
+
+          function healthcheck_generator() {
+            # Only checks that the generator has not exited with errors
+            is_program_running "generator" || true
+          }
+
+          function is_program_running() {
+            local program=$1
+            local exit_code_path="../''${program}/exit_code"
+            # File exists and is a regular file?
+            if ! test -f "''${exit_code_path}"
+            then
+              # The program was not even started! ##############################
+              ##################################################################
+              false
+            else
+              # The program was started! #######################################
+              ##################################################################
+              # File exists and has a size greater than zero?
+              if test -s "''${exit_code_path}"
+              then
+                # The program exited! ##########################################
+                ################################################################
+                local exit_code
+                exit_code="$(${coreutils}/bin/cat "''${exit_code_path}")"
+                # Program failed with non-zero exit code?
+                if test "''${exit_code}" != "0"
+                then
+                  # The program exited with a non-zero exit code! ##############
+                  ##############################################################
+                  # Exit!
+                  exit_healthcheck \
+                    "Program \"''${program}\" exited with a non-zero exit code!"
+                else
+                  # The program exited with a zero exit code! ##################
+                  ##############################################################
+                  # Only output a message, don't exit!
+                  msg \
+                    "Program \"''${program}\" exited with a zero exit code!"
+                  false
+                fi
+              else
+                # The program is running! ######################################
+                ################################################################
+                true
+              fi
+            fi
+          }
+
+          # `cardano-cli query tip` responses:
+          # {
+          #     "epoch": 0,
+          #     "era": "Babbage",
+          #     "slotInEpoch": 0,
+          #     "slotsToEpochEnd": 600,
+          #     "syncProgress": "100.00"
+          # }
+          # {
+          #     "block": 1,
+          #     "epoch": 0,
+          #     "era": "Babbage",
+          #     "hash": "9777....8833",
+          #     "slot": 22,
+          #     "slotInEpoch": 22,
+          #     "slotsToEpochEnd": 578,
+          #     "syncProgress": "100.00"
+          # }
+          function is_node_synced_and_past_slot_zero() {
+            local node=$1
+            local socket_path="../''${node}/node.socket"
+            local db_path="../''${node}/db/"
+            # Socket and db folder exist?
+            if ! test -S "''${socket_path}" || ! test -d "''${db_path}"
+            then
+              false
+            else
+              local tip block slot
+              # Returns nothing/empty/"" when the node is exiting
+              tip=$(${cardano-cli}/bin/cardano-cli query tip \
+                --testnet-magic "''${network_magic}"         \
+                --socket-path "../''${node}/node.socket"
+              )
+              block=$(${coreutils}/bin/echo "''${tip}" | ${jq}/bin/jq .block)
+              slot=$(${coreutils}/bin/echo  "''${tip}" | ${jq}/bin/jq .slot)
+              # Block greater than or qeual to zero!
+              if test -n "''${block}" && test "''${block}" != "null" && test "''${block}" -ge 0
+              then
+                # Slot greater than zero!
+                if test -n "''${slot}" && test "''${slot}" != "null" && test "''${slot}" -gt 0
+                then
+                  true
+                else
+                  false
+                fi
+              else
+                false
+              fi
+            fi
+          }
+
+          function healthcheck_node_forge() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_forged
+            last_forged=$(last_block_forged "''${node}")
+            if test -z "''${last_forged}"
+            then
+              start_time=$(${coreutils}/bin/cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                exit_healthcheck "''${node}: More than 5m with no blocks forged at all"
+              fi
+            else
+              ${coreutils}/bin/echo "''${last_forged}" > "../''${node}/healthcheck/last_forged"
+              start_time=$(${coreutils}/bin/echo "''${last_forged}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 120
+              then
+                exit_healthcheck "''${node}: More than 2m with no newer blocks forged"
+              fi
+            fi
+          }
+
+          function healthcheck_node_block() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_block
+            last_block=$(last_block_transmitted "''${node}")
+            if test -z "''${last_block}"
+            then
+              start_time=$(${coreutils}/bin/cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                exit_healthcheck "''${node}: More than 5m without a first block sent or received"
+              fi
+            else
+              ${coreutils}/bin/echo "''${last_block}" > "../''${node}/healthcheck/last_block"
+              start_time=$(${coreutils}/bin/echo "''${last_block}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 180
+              then
+                exit_healthcheck "''${node}: More than 3m with no newer blocks sent or received\n''${last_block}"
+              fi
+            fi
+          }
+
+          function healthcheck_node_txs() {
+            local node=$1
+            local start_time
+            local now=$(${coreutils}/bin/date +%s)
+            local last_txs
+            last_txs=$(last_block_with_txs "''${node}")
+            if test -z "''${last_txs}"
+            then
+              start_time=$(${coreutils}/bin/cat "../''${node}/healthcheck/start_time")
+              if test $((now - start_time)) -ge 300
+              then
+                exit_healthcheck "''${node}: More than 5m without a first block with transactions"
+              fi
+            else
+              ${coreutils}/bin/echo "''${last_txs}" > "../''${node}/healthcheck/last_txs"
+              start_time=$(${coreutils}/bin/echo "''${last_txs}" | ${jq}/bin/jq .at)
+              if test $((now - start_time)) -ge 180
+              then
+                exit_healthcheck "''${node}: More than 3m with no newer blocks with transactions\n''${last_txs}"
+              fi
+            fi
+          }
+
+          # Helper/auxiliary functions!
+          ######################################################################
+
+          # Gets the last "matching" JSON message from a Node's stdout file.
+          #
+          # To avoid reading the whole node's "stdout" file its contents are
+          # reversed using `tac` (assuming `tac` is efficient) and piped to
+          # `jq --unbuffered` that uses its "minimal support for I/O" using
+          # 'inputs' to control over when inputs are read in combination with
+          # the null input option '--null-input' to prevent one input from being
+          # read implicitly.
+          # With all these, we can efficiently select the first occurrence like
+          # this: "nth(0; inputs | select( INSERT_BLOCK_QUERY ))"
+          #
+          # Note that the log file is composed of one JSON object per line were
+          # 'inputs' read one by one and we are using `--compact-output` to make
+          # sure every output log message matched by `jq` is contained within a
+          # line.
+          #
+          # Also, the stdout of the node starts with some text that's echoed by
+          # node's start.sh script that is not valid JSON, so we `grep` for
+          # "{"at": ... }". We still need to check the exit code of these
+          # functions just in case because if it fails a query may have failed
+          # and the healthcheck should fail. This is tricky because when 'jq'
+          # finishes and exists `tac` or `grep` may throw the following error:
+          # "writing output failed: Broken pipe"
+          #
+          # Finally the "at" time has format "2023-05-16 19:57:19.0231Z" and I
+          # can't parse it using any standard `date` format so I'm stripping the
+          # milliseconds part and converting to Unix time (Integer). This has to
+          # be done after filtering for "null" inputs that are the output of
+          # 'nth(0;...)', if not an error occurs.
+          #
+          # $1: node name
+          # $2: jq's query string
+          function jq_node_stdout_last() {
+            local node=$1
+            local select=$2
+            local stdout_path="../''${node}/stdout"
+            local ans return_code=0 pipe_status=(0 0 0 0)
+            ans="$( \
+                  { ${coreutils}/bin/tac "''${stdout_path}" 2>/dev/null; } \
+                | \
+                  { ${grep}/bin/grep -E  "^{\"at\":.*}$"    2>/dev/null; } \
+                | \
+                  ${jq}/bin/jq                             \
+                    --compact-output                       \
+                    --unbuffered                           \
+                    --null-input                           \
+                    "nth(0; inputs | select(''${select}))" \
+                | \
+                  ${jq}/bin/jq \
+                    '   select( . != null )
+                      |
+                        (
+                             .at
+                          |=
+                             (.[:20] | strptime("%Y-%m-%d %H:%M:%S.") | mktime)
+                        )
+                    ' \
+              || \
+                { return_code="$?"; pipe_status="''${PIPESTATUS[@]}"; } \
+            )"
+            if test "''${return_code}" == 0
+            then
+               ${coreutils}/bin/echo "''${ans}"
+            else
+              # Ignore "writing output failed: Broken pipe"
+              if test "''${pipe_status[2]}" != 0 || test "''${pipe_status[3]}" != 0 || test "''${return_code}" != 141
+              then
+                exit_22 "jq error: jq_node_stdout_last: ''${node}"
+              else
+                ${coreutils}/bin/echo "''${ans}"
+              fi
+            fi
+          }
+
+          # This one exists with "write error: Broken pipe"
+          # To do this the stdout file is reversed using `tac`, `jq` is applied
+          # and its answers fetched using `head --lines=1`. To avoid reading the
+          # whole file (and assuming `tac` is efficient) `jq` is called with
+          # `--unbuffered`.
+          # To avoid "Error: writing output failed: Broken pipe"!" we use
+          # `tail -n +1` between `jq` and `head`, is smart enough to check
+          # standard output and closes the pipe down cleanly.
+          function jq_node_stdout_last_v0() {
+            local node=$1
+            local select=$2
+            local stdout_path="../''${node}/stdout"
+            local ans return_code=0 pipe_status=(0 0 0 0 0)
+            ans="$( \
+                  { ${coreutils}/bin/tac "''${stdout_path}" 2>/dev/null; } \
+                | \
+                  { ${grep}/bin/grep -E  "^{\"at\":.*}$"    2>/dev/null; } \
+                | \
+                  ${jq}/bin/jq            \
+                    --compact-output      \
+                    --unbuffered          \
+                    "select(''${select})" \
+                | \
+                  { ${coreutils}/bin/head --lines=+1        2>/dev/null; } \
+                | \
+                  ${jq}/bin/jq \
+                    '
+                        .at
+                      |=
+                        (.[:20] | strptime("%Y-%m-%d %H:%M:%S.") | mktime)
+                    ' \
+              || \
+                { return_code="$?"; pipe_status="''${PIPESTATUS[@]}"; } \
+            )"
+            if test "''${return_code}" == 0
+            then
+               ${coreutils}/bin/echo "''${ans}"
+            else
+              # Ignore "writing output failed: Broken pipe"
+              if test "''${pipe_status[2]}" != 0 || test "''${pipe_status[4]}" != 0 || test "''${return_code}" != 141
+              then
+                exit_22 "jq error: jq_node_stdout_last_v0: ''${node}"
+              else
+                ${coreutils}/bin/echo "''${ans}"
+              fi
+            fi
+          }
+
+          # {
+          #   "at": "2023-06-01 21:26:14.0025Z",
+          #   "ns": "Forge.Loop.NodeIsLeader",
+          #   "data": {
+          #     "kind": "TraceNodeIsLeader",
+          #     "slot": 995
+          #   },
+          #   "sev": "Info",
+          #   "thread": "34",
+          #   "host": "ip-10-24-123-88.eu-central-1.compute.internal"
+          # }
+          function last_node_is_leader() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Forge.Loop.NodeIsLeader")
+                and
+                (.data.kind?               == "TraceNodeIsLeader")
+                and
+                (.data.slot?               != null)
+              '
+            then
+              exit_22 "jq error: last_node_is_leader: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-16 15:02:46.0051Z",
+          #   "ns": "Forge.Loop.AdoptedBlock",
+          #   "data": {
+          #     "blockHash": "26ab7db1ca55e69885665f625262118ef7db99172be6d3591ad2a8e9bfeabffa",
+          #     "blockSize": 864,
+          #     "kind": "TraceAdoptedBlock",
+          #     "slot": 627
+          #   },
+          #   "sev": "Info",
+          #   "thread": "34",
+          #   "host": "ip-10-24-123-88.eu-central-1.compute.internal"
+          # }
+          function last_block_forged() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Forge.Loop.AdoptedBlock")
+                and
+                (.data.blockHash?          != null)
+                and
+                (.data.kind?               == "TraceAdoptedBlock")
+              '
+            then
+              exit_22 "jq error: last_block_forged: ''${node}"
+            fi
+          }
+
+          # Block sent:
+          # {
+          #   "at": "2023-05-17 16:00:57.0222Z",
+          #   "ns": "BlockFetch.Server.SendBlock",
+          #   "data": {
+          #     "block": "dde....414",
+          #     "kind": "BlockFetchServer"
+          #   },
+          #   "sev": "Info",
+          #   "thread": "67",
+          #   "host": "localhost"
+          # }
+          # Block received:
+          # {
+          #   "at": "2023-05-17 16:00:57.0246Z",
+          #   "ns": "BlockFetch.Remote.Receive.Block",
+          #   "data": {
+          #     "kind": "Recv",
+          #     "msg": {
+          #       "agency": "ServerAgency TokStreaming",
+          #       "blockHash": "dde....414",
+          #       "blockSize": 64334,
+          #       "kind": "MsgBlock",
+          #       "txIds": [
+          #         "60e....6ec",
+          #         ...
+          #         "95d....165"
+          #       ]
+          #     },
+          #     "peer": {
+          #       "connectionId": "127.0.0.1:37117 127.0.0.1:30000"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "77",
+          #   "host": "localhost"
+          # }
+
+          function last_block_transmitted() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (
+                  (.ns                     == "BlockFetch.Server.SendBlock")
+                  and
+                  (.data.block?            != null)
+                  and
+                  (.data.kind?             == "BlockFetchServer")
+                ) or (
+                  (.ns                     == "BlockFetch.Remote.Receive.Block")
+                  and
+                  (.data.kind?             == "Recv")
+                  and
+                  (.data.msg?.blockHash    != null)
+                  and
+                  (.data.msg?.kind         == "MsgBlock")
+                )
+              '
+            then
+              exit_22 "jq error: last_block_transmitted: ''${node}"
+            fi
+          }
+
+          function last_block_sent() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Server.SendBlock")
+                and
+                (.data.block?              != null)
+                and
+                (.data.kind?               == "BlockFetchServer")
+              '
+            then
+              exit_22 "jq error: last_block_sent: ''${node}"
+            fi
+          }
+
+          function last_block_received() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Remote.Receive.Block")
+                and
+                (.data.kind?               == "Recv")
+                and
+                (.data.msg?.blockHash      != null)
+                and
+                (.data.msg?.kind           == "MsgBlock")
+              '
+            then
+              exit_22 "jq error: last_block_received: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-17 16:00:57.0246Z",
+          #   "ns": "BlockFetch.Remote.Receive.Block",
+          #   "data": {
+          #     "kind": "Recv",
+          #     "msg": {
+          #       "agency": "ServerAgency TokStreaming",
+          #       "blockHash": "dde....414",
+          #       "blockSize": 64334,
+          #       "kind": "MsgBlock",
+          #       "txIds": [
+          #         "60e....6ec",
+          #         ...
+          #         "95d....165"
+          #       ]
+          #     },
+          #     "peer": {
+          #       "connectionId": "127.0.0.1:37117 127.0.0.1:30000"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "77",
+          #   "host": "localhost"
+          # }
+          function last_block_with_txs() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "BlockFetch.Remote.Receive.Block")
+                and
+                (.data.kind?               == "Recv")
+                and
+                (.data.msg?.blockHash      != null)
+                and
+                (.data.msg?.kind           == "MsgBlock")
+                and
+                (.data.msg?.txIds          != null)
+                and
+                (.data.msg?.txIds          != [])
+              '
+            then
+              exit_22 "jq error: last_block_with_txs: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-17 16:00:08.3351Z",
+          #   "ns": "Mempool.AddedTx",
+          #   "data": {
+          #     "kind": "TraceMempoolAddedTx",
+          #     "mempoolSize": {
+          #       "bytes": 1328,
+          #       "numTxs": 1
+          #     },
+          #     "tx": {
+          #       "txid": "3d724466"
+          #     }
+          #   },
+          #   "sev": "Info",
+          #   "thread": "66",
+          #   "host": "localhost"
+          # }
+          function last_mempool_txs_added() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Mempool.AddedTx")
+                and
+                (.data.kind?               == "TraceMempoolAddedTx")
+                and
+                (.data.mempoolSize?.numTxs >= 1)
+              '
+            then
+              exit_22 "jq error: last_mempool_txs_added: ''${node}"
+            fi
+          }
+
+          # {
+          #   "at": "2023-05-31 20:01:06.0238Z",
+          #   "ns": "Shutdown.Requesting",
+          #   "data": {
+          #     "kind": "RequestingShutdown",
+          #     "reason": "spawnLimitTerminator: reached target block BlockNo 3"
+          #   },
+          #   "sev": "Warning",
+          #   "thread": "38",
+          #   "host": "localhost"
+          # }
+          function last_shutdown_requesting() {
+            local node=$1
+            if ! jq_node_stdout_last "''${node}" \
+              '
+                (.ns                       == "Shutdown.Requesting")
+                and
+                (.data.kind?               == "RequestingShutdown")
+              '
+            then
+              exit_22 "jq error: last_shutdown_requesting: ''${node}"
+            fi
+          }
+
+          function msg {
+            # Outputs to stdout, unbuffered if not the message may be lost!
+            ${coreutils}/bin/stdbuf -o0 \
+              ${bashInteractive}/bin/sh -c \
+                "${coreutils}/bin/echo -e \"$(${coreutils}/bin/date --rfc-3339=seconds): $1\""
+          }
+
+          function exit_healthcheck {
+            # Outputs to stdout and stderr, unbuffered if not message may be lost!
+            ${coreutils}/bin/stdbuf -o0 -e0 \
+              ${bashInteractive}/bin/sh -c \
+                "${coreutils}/bin/echo -e \"$(${coreutils}/bin/date --rfc-3339=seconds): $1\" | ${coreutils}/bin/tee /dev/stderr"
+            exit 1
+          }
+
+          function exit_22 {
+            # Outputs to stdout and stderr, unbuffered if not message may be lost!
+            ${coreutils}/bin/stdbuf -o0 -e0 \
+              ${bashInteractive}/bin/sh -c \
+                "${coreutils}/bin/echo -e \"$(${coreutils}/bin/date --rfc-3339=seconds): $1\" | ${coreutils}/bin/tee /dev/stderr"
+            exit 22
+          }
+
+          if test -n "''${NOMAD_DEBUG:-}"
+          then
+            DEBUG_FILE="$(${coreutils}/bin/dirname "$(${coreutils}/bin/readlink -f "$0")")"/"$0".debug
+            echo "Using debug file ''${DEBUG_FILE}" >&2
+            exec 5> "''${DEBUG_FILE}"
+            BASH_XTRACEFD="5"
+            PS4='$LINENO: '
+            set -x
+          fi
+
+          healthcheck $@
+        '';
       };
     })
     nodeSpecs.value;

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -1,0 +1,41 @@
+{ pkgs
+, runJq
+, backend
+, profile
+, nodeSpecs
+}:
+
+with pkgs.lib;
+
+let
+  ##
+  ## generator-service :: (TracerConfig, NixosServiceConfig, Config, StartScript)
+  ##
+  healthcheck-service =
+    (nodeSpecs:
+    let
+      bashInteractive = pkgs.bashInteractive;
+      coreutils       = pkgs.coreutils;
+      supervisor      = pkgs.supervisor;
+    in {
+      startupScript = rec {
+        JSON = pkgs.writeScript "startup-healthcheck.sh" value;
+        value = ''
+          #!${bashInteractive}/bin/sh
+
+          # Store the entrypoint env vars for debugging purposes
+          ${coreutils}/bin/env > /local/healthcheck.env
+
+          # Only needed for "exec" ?
+          if test "''${TASK_DRIVER}" = "exec"
+          then
+            cd "''${TASK_WORKDIR}"
+          fi
+
+          sleep 100000
+          '';
+      };
+    })
+    nodeSpecs.value;
+in
+  { inherit healthcheck-service; }

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -56,6 +56,7 @@ let
       inherit isProducer port;
 
       nodeId         = i;
+      databasePath   = "db";
       socketPath     = "node.socket";
       topology       = "topology.json";
       nodeConfigFile = "config.json";

--- a/nix/workbench/topology/topology.sh
+++ b/nix/workbench/topology/topology.sh
@@ -96,6 +96,13 @@ case "${op}" in
         sponge "$outdir"/topology.json
         ;;
 
+    # For the value profile returns:
+    # {
+    # "0":1,
+    # "1":1,
+    # ...
+    # "51":1
+    # }
     density-map )
         local usage="USAGE:  wb topology density-map NODE-SPECS-JSON"
         local node_specs_json=${1:?$usage}
@@ -103,12 +110,15 @@ case "${op}" in
         args=(--slurpfile node_specs "$node_specs_json"
               --null-input --compact-output
              )
+        # Filter the explorer node if not {...,"52":0}
         jq ' $node_specs[0]
-           | map
-             ({ key:   "\(.i)"
-              , value: ((.pools) // 0)
-              })
-           | from_entries
+          | to_entries
+          | map( select(.value.kind == "pool") )
+          | map
+            ({ key:   "\(.value.i)"
+             , value: ((.value.pools) // 0)
+             })
+          | from_entries
            ' "${args[@]}";;
 
     projection-for )


### PR DESCRIPTION
Workbench enhancement tailored for cloud/Nomad deployments
 
- Add a healthcheck service that test nodes' connections and monitors runs
- Deploy the generator only inside the Nomad Task that will run it
- Make in which node the generators runs a parameter
- Use the same name for all nodes' db folders
- Fixes for the `exit_code` file of the supervisord programs
- Run supervisord unbuffered and do not rotate log files
- Misc fixes, mostly for cloud runs with an `explorer` node that was not previously used in the workbench

The healthcheck is backend agnostic, uses the same code for the `supervisord` backend and the `nomad` backend. Added as an extra supervisord "program" and controlled using `supervisorctl` (workbench clusters use the use the "supervisord" model).
The initial idea was to use Nomad's builtin `service -> check` functionality but it won't be 100% compatible/interchangeable with local runs using the `supervisord` backend and critical business logic, like when to start it/how to control it, will be delegated to Nomad. Plus, Nomad needs `consul` to configure "check"s and that means an extra dependency for local runs.