### PR TITLE
Use `cryptoInit` instead of `sodiumInit`

### DIFF
--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -12,7 +12,7 @@ import           Cardano.CLI.Environment (getEnvCli)
 import           Cardano.CLI.Parsers (opts, pref)
 import           Cardano.CLI.Run (renderClientCommandError, runClientCommand)
 import           Cardano.CLI.TopHandler
-import qualified Cardano.Crypto.Libsodium as Crypto
+import qualified Cardano.Crypto.Init as Crypto
 #ifdef UNIX
 import           System.Posix.Files
 #endif
@@ -21,10 +21,10 @@ import qualified GHC.IO.Encoding as GHC
 
 main :: IO ()
 main = toplevelExceptionHandler $ do
+  Crypto.cryptoInit
+
   envCli <- getEnvCli
 
-  -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
-  Crypto.sodiumInit
   GHC.mkTextEncoding "UTF-8" >>= GHC.setLocaleEncoding
 #ifdef UNIX
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -202,6 +202,7 @@ test-suite cardano-cli-test
                       , cardano-api-gen ^>= 8.1.0.2
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
+                      , cardano-crypto-class ^>= 2.1
                       , cardano-node
                       , cardano-slotting ^>= 0.1
                       , containers
@@ -242,6 +243,7 @@ test-suite cardano-cli-golden
                       , cardano-api ^>= 8.1.0.1
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
+                      , cardano-crypto-class ^>= 2.1
                       , cardano-crypto-wrapper ^>= 1.5.1
                       , cardano-ledger-byron ^>= 1.0
                       , cborg

--- a/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
@@ -11,8 +11,12 @@ import qualified Test.Golden.Key
 import qualified Test.Golden.Shelley
 import qualified Test.Golden.TxView
 
+import qualified Cardano.Crypto.Init as Crypto
+
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
   defaultMain

--- a/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
@@ -19,8 +19,12 @@ import           Hedgehog.Main (defaultMain)
 
 import           Test.Gen.Cardano.Api.Empty ()
 
+import qualified Cardano.Crypto.Init as Crypto
+
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
   defaultMain

--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -4,14 +4,17 @@ import           Cardano.Chairman.Commands
 import           Control.Monad
 import           Options.Applicative
 
+import qualified Cardano.Crypto.Init as Crypto
+
 main :: IO ()
-main = join
-  . customExecParser
-    ( prefs (showHelpOnEmpty <> showHelpOnError)
-    )
-  $ info (commands <**> helper)
-    (  fullDesc
-    <> progDesc "Chairman checks Cardano clusters for progress and consensus."
-    <> header "Chairman sits in a room full of Shelley nodes, and checks \
-              \if they are all behaving ..."
-    )
+main = do
+  Crypto.cryptoInit
+
+  join
+    . customExecParser (prefs (showHelpOnEmpty <> showHelpOnError))
+    $ info (commands <**> helper) $ mconcat
+      [ fullDesc
+      , progDesc "Chairman checks Cardano clusters for progress and consensus."
+      , header "Chairman sits in a room full of Shelley nodes, and checks \
+                \if they are all behaving ..."
+      ]

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -42,6 +42,7 @@ executable cardano-node-chairman
                         -rtsopts
                         "-with-rtsopts=-T"
   build-depends:        cardano-api
+                      , cardano-crypto-class ^>= 2.1
                       , cardano-git-rev
                       , cardano-node
                       , cardano-prelude
@@ -68,6 +69,7 @@ test-suite chairman-tests
   type:                 exitcode-stdio-1.0
 
   build-depends:        cardano-testnet
+                      , cardano-crypto-class ^>= 2.1
                       , directory
                       , filepath
                       , hedgehog

--- a/cardano-node-chairman/test/Main.hs
+++ b/cardano-node-chairman/test/Main.hs
@@ -16,6 +16,8 @@ import qualified Test.Tasty.Ingredients as T
 import qualified Spec.Chairman.Cardano
 import qualified Spec.Network
 
+import qualified Cardano.Crypto.Init as Crypto
+
 tests :: IO T.TestTree
 tests = do
   let t0 = H.testPropertyNamed "isPortOpen False" (fromString "isPortOpen False") Spec.Network.hprop_isPortOpen_False
@@ -36,6 +38,8 @@ ingredients = T.defaultIngredients
 
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
 

--- a/cardano-node-chairman/testnet/Main.hs
+++ b/cardano-node-chairman/testnet/Main.hs
@@ -8,6 +8,9 @@ import           System.IO (IO)
 import           Testnet.Commands
 
 main :: IO ()
-main = join $ customExecParser
-  (prefs $ showHelpOnEmpty <> showHelpOnError)
-  (info (commands <**> helper) idm)
+main = do
+  Crypto.cryptoInit
+
+  join $ customExecParser
+    (prefs $ showHelpOnEmpty <> showHelpOnError)
+    (info (commands <**> helper) idm)

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -20,9 +20,13 @@ import           Cardano.Node.Run (runNode)
 import           Cardano.Node.Tracing.Documentation (TraceDocumentationCmd (..),
                    parseTraceDocumentationCmd, runTraceDocumentationCmd)
 
-main :: IO ()
-main = toplevelExceptionHandler $ do
+import qualified Cardano.Crypto.Init as Crypto
 
+main :: IO ()
+main = do
+  Crypto.cryptoInit
+
+  toplevelExceptionHandler $ do
     cmd <- Opt.customExecParser p opts
 
     case cmd of

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -217,6 +217,7 @@ executable cardano-node
   autogen-modules:      Paths_cardano_node
 
   build-depends:        base >= 4.14 && < 4.17
+                      , cardano-crypto-class
                       , cardano-git-rev
                       , cardano-node
                       , optparse-applicative-fork
@@ -233,6 +234,7 @@ test-suite cardano-node-test
                       , aeson >= 1.5.6.0
                       , bytestring
                       , cardano-api ^>= 8.1.0.1
+                      , cardano-crypto-class
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-slotting >= 0.1

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -70,7 +70,7 @@ import           Cardano.BM.Data.Transformers (setHostname)
 import           Cardano.BM.Trace
 import           Paths_cardano_node (version)
 
-import qualified Cardano.Crypto.Libsodium as Crypto
+import qualified Cardano.Crypto.Init as Crypto
 
 import           Cardano.Node.Configuration.Logging (LoggingLayer (..), createLoggingLayer,
                    nodeBasicInfo, shutdownLoggingLayer)
@@ -115,7 +115,7 @@ import           Cardano.Node.Protocol.Types
 import           Cardano.Node.Queries
 import           Cardano.Node.TraceConstraints (TraceConstraints)
 import           Cardano.Tracing.Tracers
-import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing(..))
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
 {- HLINT ignore "Fuse concatMap/map" -}
 {- HLINT ignore "Redundant <$>" -}
@@ -127,8 +127,7 @@ runNode
 runNode cmdPc = do
     installSigTermHandler
 
-    -- TODO: Remove sodiumInit: https://github.com/input-output-hk/cardano-base/issues/175
-    Crypto.sodiumInit
+    Crypto.cryptoInit
 
     configYamlPc <- parseNodeConfigurationFP . getLast $ pncConfigFile cmdPc
 

--- a/cardano-node/test/cardano-node-test.hs
+++ b/cardano-node/test/cardano-node-test.hs
@@ -15,8 +15,12 @@ import qualified Test.Cardano.Node.Json
 import qualified Test.Cardano.Node.POM
 import qualified Test.Cardano.Tracing.OrphanInstances.HardFork
 
+import qualified Cardano.Crypto.Init as Crypto
+
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
   runTests

--- a/cardano-submit-api/app/Main.hs
+++ b/cardano-submit-api/app/Main.hs
@@ -1,11 +1,15 @@
 module Main where
 
 import           Cardano.CLI.Environment (getEnvCli)
+import qualified Cardano.Crypto.Init as Crypto
 import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
 
 import qualified Options.Applicative as Opt
 
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   envCli <- getEnvCli
+
   runTxSubmitWebapi =<< Opt.execParser (opts envCli)

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -16,6 +16,7 @@ category:               Cardano,
                         Web,
 build-type:             Simple
 extra-source-files:     CHANGELOG.md
+
 common project-config
   default-language:     Haskell2010
   build-depends:        base >= 4.14 && < 4.17
@@ -86,6 +87,7 @@ executable cardano-submit-api
   build-depends:        base >= 4.14 && < 4.17
                       , optparse-applicative-fork >= 0.16.1.0
                       , cardano-cli
+                      , cardano-crypto-class ^>= 2.1
                       , cardano-submit-api
 
 test-suite unit
@@ -94,3 +96,4 @@ test-suite unit
   main-is:              test.hs
   hs-source-dirs:       test
   build-depends:        base >= 4.14 && < 4.17
+                      , cardano-crypto-class ^>= 2.1

--- a/cardano-submit-api/test/test.hs
+++ b/cardano-submit-api/test/test.hs
@@ -1,4 +1,9 @@
 import qualified System.IO as IO
 
+import qualified Cardano.Crypto.Init as Crypto
+
 main :: IO ()
-main = IO.putStrLn "cardano-tx-submit test"
+main = do
+  Crypto.cryptoInit
+
+  IO.putStrLn "cardano-tx-submit test"

--- a/cardano-testnet/app/cardano-testnet.hs
+++ b/cardano-testnet/app/cardano-testnet.hs
@@ -1,10 +1,14 @@
 module Main where
 
+import qualified Cardano.Crypto.Init as Crypto
+
 import           Options.Applicative
 import           Testnet.Parsers
 
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   tNetCmd <- customExecParser
                (prefs $ showHelpOnEmpty <> showHelpOnError)
                (info (commands <**> helper) idm)

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -106,6 +106,7 @@ executable cardano-testnet
   main-is:              cardano-testnet.hs
 
   build-depends:        cardano-testnet
+                      , cardano-crypto-class
                       , optparse-applicative-fork
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
@@ -127,6 +128,7 @@ test-suite cardano-testnet-golden
                       , bytestring
                       , cardano-api
                       , cardano-cli:cardano-cli-test-lib
+                      , cardano-crypto-class
                       , cardano-testnet
                       , filepath
                       , hedgehog
@@ -167,6 +169,7 @@ test-suite cardano-testnet-test
                       , cardano-api ^>= 8.1.0.1
                       , cardano-api-gen ^>= 8.1.0.2
                       , cardano-cli
+                      , cardano-crypto-class
                       , cardano-testnet
                       , containers
                       , directory

--- a/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
@@ -17,6 +17,8 @@ import qualified Test.Tasty.Ingredients as T
 import qualified Test.Golden.Testnet.Config
 import qualified Test.Golden.Testnet.Help
 
+import qualified Cardano.Crypto.Init as Crypto
+
 tests :: IO TestTree
 tests = pure $ T.testGroup "Golden tests"
   [ H.testPropertyNamed "golden_DefaultConfig" (fromString "golden_DefaultConfig") Test.Golden.Testnet.Config.goldenDefaultConfigYaml
@@ -29,6 +31,8 @@ ingredients = T.defaultIngredients
 
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
   args <- E.getArgs

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -22,6 +22,8 @@ import qualified Testnet.Util.Ignore as H
 
 import           Test.Gen.Cardano.Api.Empty ()
 
+import qualified Cardano.Crypto.Init as Crypto
+
 tests :: IO TestTree
 tests = pure $ T.testGroup "test/Spec.hs"
   [ T.testGroup "Spec"
@@ -49,6 +51,8 @@ ingredients = T.defaultIngredients
 
 main :: IO ()
 main = do
+  Crypto.cryptoInit
+
   hSetBuffering stdout LineBuffering
   hSetEncoding stdout utf8
   args <- E.getArgs


### PR DESCRIPTION
# Description

Add the call to `cryptoInit` to various components including tests where they haven't been previously.

See https://github.com/input-output-hk/cardano-base/issues/175

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
