### PR TITLE
Remove node team from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,6 @@ cardano-cli/README.md                                         @Jimbo4350 @newhog
 # Release manager added for notification on dependency updates
 cabal.project                                                 @Jimbo4350 @newhoggy @carbolymer @LaurenceIO
 
-# General reviewers per PR
-#                        Duncan   Jordan     Erik   John      Jared         Carlos
-*                        @dcoutts @Jimbo4350 @erikd @newhoggy @carbolymer @JaredCorduan @CarlosLopezDeLara
 
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
@@ -32,11 +29,11 @@ nix/                                                          @input-output-hk/d
 *.nix                                                         @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
 flake.lock                                                    @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
 
-.buildkite                                                    @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-.github                                                       @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-ci/                                                           @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-configuration/                                                @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-bors.toml                                                     @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-docker-compose.yml                                            @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devx-core-tech @input-output-hk/devops
-cardano-node/src/Cardano/Node/Tracing/                        @Jimbo4350 @newhoggy @carbolymer @deepfire @jutaro @coot
-cardano-node/src/Cardano/Tracing/OrphanInstances/             @Jimbo4350 @newhoggy @carbolymer @input-output-hk/devops @coot
+.buildkite                                                    @input-output-hk/devx-core-tech @input-output-hk/devops
+.github                                                       @input-output-hk/devx-core-tech @input-output-hk/devops
+ci/                                                           @input-output-hk/devx-core-tech @input-output-hk/devops
+configuration/                                                @input-output-hk/devx-core-tech @input-output-hk/devops
+bors.toml                                                     @input-output-hk/devx-core-tech @input-output-hk/devops
+docker-compose.yml                                            @input-output-hk/devx-core-tech @input-output-hk/devops
+cardano-node/src/Cardano/Node/Tracing/                        @deepfire @jutaro @coot
+cardano-node/src/Cardano/Tracing/OrphanInstances/             @input-output-hk/devops @coot


### PR DESCRIPTION
# Description

The CODEOWNERS file was originally created to prevent unauthorized changes to `cardano-cli` and `cardano-api`. With the removal of [cardano-api](https://github.com/input-output-hk/cardano-api) and (soon to be) [cardano-cli](https://github.com/input-output-hk/cardano-cli) from cardano-node, there is no need for the node team to be gate keepers of the node as a whole. We can be requested to review PRs on an "as needed" basis.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
