### PR TITLE
trace packages: bump version number

### DIFF
--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                2.0.0
+version:                2.0.1
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-forward
-version:                2.0.0
+version:                2.0.1
 synopsis:               The forwarding protocols library for cardano node.
 description:            The library providing typed protocols for forwarding different
                         information from the cardano node to an external application.

--- a/trace-resources/trace-resources.cabal
+++ b/trace-resources/trace-resources.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-resources
-version:                0.2.0.0
+version:                0.2.0.1
 synopsis:               Package for tracing resources for linux, mac and windows
 description:            Package for tracing resources for linux, mac and windows.
 category:               Cardano,


### PR DESCRIPTION
# Description

The following packages need their patch number increased:
* trace-dispatcher
* trace-forward
* trace-resources

These changes are already present on the release branch `release/8.1.x`, but still need to be added to trunk.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
