### PR TITLE
Remove duplicate --testnet-magic flag

### DIFF
--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -17,9 +17,8 @@ import           Testnet.Run (runTestnet)
 import           Testnet.Util.Cli
 import           Testnet.Util.Runtime (readNodeLoggingFormat)
 
-data BabbageOptions = BabbageOptions
-  { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: BabbageTestnetOptions
+newtype BabbageOptions = BabbageOptions
+  { testnetOptions :: BabbageTestnetOptions
   } deriving (Eq, Show)
 
 optsTestnet :: Parser BabbageTestnetOptions
@@ -62,15 +61,7 @@ optsTestnet = BabbageTestnetOptions
       )
 
 optsBabbage :: Parser BabbageOptions
-optsBabbage = BabbageOptions
-  <$> optional
-      ( OA.option auto
-        (   long "testnet-magic"
-        <>  help "Testnet magic"
-        <>  metavar "INT"
-        )
-      )
-  <*> optsTestnet
+optsBabbage = BabbageOptions <$> optsTestnet
 
 runBabbageOptions :: BabbageOptions -> IO ()
 runBabbageOptions options =

--- a/cardano-testnet/src/Parsers/Byron.hs
+++ b/cardano-testnet/src/Parsers/Byron.hs
@@ -13,21 +13,12 @@ import           Testnet.Byron
 import           Testnet.Run (runTestnet)
 import           Testnet.Util.Cli
 
-data ByronOptions = ByronOptions
-  { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: TestnetOptions
+newtype ByronOptions = ByronOptions
+  { testnetOptions :: TestnetOptions
   } deriving (Eq, Show)
 
 optsByron :: Parser ByronOptions
-optsByron = ByronOptions
-  <$> optional
-      ( OA.option auto
-        (   long "testnet-magic"
-        <>  help "Testnet magic"
-        <>  metavar "INT"
-        )
-      )
-  <*> optsTestnet
+optsByron = ByronOptions <$> optsTestnet
 
 optsTestnet :: Parser TestnetOptions
 optsTestnet = TestnetOptions

--- a/cardano-testnet/src/Parsers/Shelley.hs
+++ b/cardano-testnet/src/Parsers/Shelley.hs
@@ -18,9 +18,8 @@ import           Testnet.Util.Cli
 import           Testnet.Utils
 
 
-data ShelleyOptions = ShelleyOptions
-  { maybeTestnetMagic :: Maybe Int
-  , testnetOptions :: ShelleyTestnetOptions
+newtype ShelleyOptions = ShelleyOptions
+  { testnetOptions :: ShelleyTestnetOptions
   } deriving (Eq, Show)
 
 optsTestnet :: Parser ShelleyTestnetOptions
@@ -78,15 +77,7 @@ optsTestnet = ShelleyTestnetOptions
       )
 
 optsShelley :: Parser ShelleyOptions
-optsShelley = ShelleyOptions
-  <$> optional
-      ( OA.option auto
-        (   long "testnet-magic"
-        <>  help "Testnet magic"
-        <>  metavar "INT"
-        )
-      )
-  <*> optsTestnet
+optsShelley = ShelleyOptions <$> optsTestnet
 
 runShelleyOptions :: ShelleyOptions -> IO ()
 runShelleyOptions options =

--- a/cardano-testnet/src/Testnet/Util/Cli.hs
+++ b/cardano-testnet/src/Testnet/Util/Cli.hs
@@ -142,9 +142,9 @@ cliByronSigningKeyAddress tmp testnetMagic (File key) destPath = do
 
 pNetworkId :: Parser Int
 pNetworkId =
-  Opt.option (bounded "TESTNET_MAGIC")
-     $ mconcat [ Opt.long "testnet-magic"
-               , Opt.metavar "INT"
-               , Opt.help "Specify a testnet magic id."
-               ]
+  Opt.option (bounded "TESTNET_MAGIC") $ mconcat
+    [ Opt.long "testnet-magic"
+    , Opt.metavar "INT"
+    , Opt.help "Specify a testnet magic id."
+    ]
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -19,8 +19,7 @@ Usage: cardano-testnet cardano [--num-bft-nodes COUNT]
 
   Start a testnet in any era
 
-Usage: cardano-testnet byron [--testnet-magic INT]
-                               [--num-bft-nodes COUNT]
+Usage: cardano-testnet byron [--num-bft-nodes COUNT]
                                [--slot-duration MILLISECONDS]
                                --testnet-magic INT
                                [--security-param INT]
@@ -30,8 +29,7 @@ Usage: cardano-testnet byron [--testnet-magic INT]
 
   Start a Byron testnet
 
-Usage: cardano-testnet shelley [--testnet-magic INT]
-                                 [--num-praos-nodes COUNT]
+Usage: cardano-testnet shelley [--num-praos-nodes COUNT]
                                  [--num-pool-nodes COUNT]
                                  [--active-slots-coeff DOUBLE]
                                  [--security-param INT]
@@ -43,8 +41,7 @@ Usage: cardano-testnet shelley [--testnet-magic INT]
 
   Start a Shelley testnet
 
-Usage: cardano-testnet babbage [--testnet-magic INT]
-                                 [--num-spo-nodes COUNT]
+Usage: cardano-testnet babbage [--num-spo-nodes COUNT]
                                  [--slot-duration MILLISECONDS]
                                  [--security-param INT]
                                  --testnet-magic INT

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/babbage.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/babbage.cli
@@ -1,5 +1,4 @@
-Usage: cardano-testnet babbage [--testnet-magic INT]
-                                 [--num-spo-nodes COUNT]
+Usage: cardano-testnet babbage [--num-spo-nodes COUNT]
                                  [--slot-duration MILLISECONDS]
                                  [--security-param INT]
                                  --testnet-magic INT
@@ -9,7 +8,6 @@ Usage: cardano-testnet babbage [--testnet-magic INT]
   Start a babbage testnet
 
 Available options:
-  --testnet-magic INT      Testnet magic
   --num-spo-nodes COUNT    Number of SPO nodes (default: 3)
   --slot-duration MILLISECONDS
                            Slot duration (default: 200)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/byron.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/byron.cli
@@ -1,5 +1,4 @@
-Usage: cardano-testnet byron [--testnet-magic INT]
-                               [--num-bft-nodes COUNT]
+Usage: cardano-testnet byron [--num-bft-nodes COUNT]
                                [--slot-duration MILLISECONDS]
                                --testnet-magic INT
                                [--security-param INT]
@@ -10,7 +9,6 @@ Usage: cardano-testnet byron [--testnet-magic INT]
   Start a Byron testnet
 
 Available options:
-  --testnet-magic INT      Testnet magic
   --num-bft-nodes COUNT    Number of BFT nodes (default: 3)
   --slot-duration MILLISECONDS
                            Slot duration (default: 2000)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/shelley.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/shelley.cli
@@ -1,5 +1,4 @@
-Usage: cardano-testnet shelley [--testnet-magic INT]
-                                 [--num-praos-nodes COUNT]
+Usage: cardano-testnet shelley [--num-praos-nodes COUNT]
                                  [--num-pool-nodes COUNT]
                                  [--active-slots-coeff DOUBLE]
                                  [--security-param INT]
@@ -12,7 +11,6 @@ Usage: cardano-testnet shelley [--testnet-magic INT]
   Start a Shelley testnet
 
 Available options:
-  --testnet-magic INT      Testnet magic
   --num-praos-nodes COUNT  Number of PRAOS nodes (default: 2)
   --num-pool-nodes COUNT   Number of pool nodes (default: 1)
   --active-slots-coeff DOUBLE


### PR DESCRIPTION
# Description

The duplicate flag meant that the flag needed to be specified twice.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
