### PR TITLE
Add `--conway-era` flag

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
@@ -19,30 +19,38 @@ import qualified Options.Applicative as Opt
 
 pCardanoEra :: Parser AnyCardanoEra
 pCardanoEra = asum
-  [ Opt.flag' (AnyCardanoEra ByronEra)
-      (  Opt.long "byron-era"
-      <> Opt.help "Specify the Byron era"
-      )
-  , Opt.flag' (AnyCardanoEra ShelleyEra)
-      (  Opt.long "shelley-era"
-      <> Opt.help "Specify the Shelley era"
-      )
-  , Opt.flag' (AnyCardanoEra AllegraEra)
-      (  Opt.long "allegra-era"
-      <> Opt.help "Specify the Allegra era"
-      )
-  , Opt.flag' (AnyCardanoEra MaryEra)
-      (  Opt.long "mary-era"
-      <> Opt.help "Specify the Mary era"
-      )
-  , Opt.flag' (AnyCardanoEra AlonzoEra)
-      (  Opt.long "alonzo-era"
-      <> Opt.help "Specify the Alonzo era"
-      )
-  , Opt.flag' (AnyCardanoEra BabbageEra)
-      (  Opt.long "babbage-era"
-      <> Opt.help "Specify the Babbage era (default)"
-      )
+  [ Opt.flag' (AnyCardanoEra ByronEra) $ mconcat
+    [ Opt.long "byron-era"
+    , Opt.help "Specify the Byron era"
+    ]
+  , Opt.flag' (AnyCardanoEra ShelleyEra) $ mconcat
+    [ Opt.long "shelley-era"
+    , Opt.help "Specify the Shelley era"
+    ]
+  , Opt.flag' (AnyCardanoEra AllegraEra) $ mconcat
+    [ Opt.long "allegra-era"
+    , Opt.help "Specify the Allegra era"
+    ]
+  , Opt.flag' (AnyCardanoEra MaryEra) $ mconcat
+    [ Opt.long "mary-era"
+    , Opt.help "Specify the Mary era"
+    ]
+  , Opt.flag' (AnyCardanoEra AlonzoEra) $ mconcat
+    [ Opt.long "alonzo-era"
+    , Opt.help "Specify the Alonzo era"
+    ]
+  , Opt.flag' (AnyCardanoEra BabbageEra) $ mconcat
+    [ Opt.long "babbage-era"
+    , Opt.help "Specify the Babbage era (default)"
+    ]
+  , Opt.flag' (AnyCardanoEra ConwayEra) $ mconcat
+    [ Opt.long "conway-era"
+    , Opt.help "Specify the Conway era"
+    ]
+
+  -- NEW-ERA-ADD-NEW: When a new era is added, add a new flag here.
+  -- NEW-ERA-SET-DEFAULT: When a new era is working, select a new default above and below.
+
     -- Default for now:
   , pure (AnyCardanoEra BabbageEra)
   ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -562,6 +562,7 @@ Usage: cardano-cli transaction build-raw
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             [--script-valid | --script-invalid]
             (--tx-in TX-IN
@@ -680,6 +681,7 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             [ --shelley-mode
             | --byron-mode [--epoch-slots SLOTS]
@@ -845,6 +847,7 @@ Usage: cardano-cli transaction calculate-min-required-utxo
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             --protocol-params-file FILE
             --tx-out ADDRESS VALUE
@@ -870,6 +873,7 @@ Usage: cardano-cli transaction calculate-min-value
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             --protocol-params-file FILE
             --tx-out ADDRESS VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli transaction build-raw
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             [--script-valid | --script-invalid]
             (--tx-in TX-IN
@@ -123,6 +124,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             [ --shelley-mode
             | --byron-mode [--epoch-slots SLOTS]
@@ -123,6 +124,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --shelley-mode           For talking to a node running in Shelley-only mode.
   --byron-mode             For talking to a node running in Byron-only mode.
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli transaction calculate-min-required-utxo
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             --protocol-params-file FILE
             --tx-out ADDRESS VALUE
@@ -30,6 +31,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli transaction calculate-min-value
             | --mary-era
             | --alonzo-era
             | --babbage-era
+            | --conway-era
             ]
             --protocol-params-file FILE
             --tx-out ADDRESS VALUE
@@ -30,6 +31,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -8,6 +8,7 @@ Usage: cardano-testnet cardano [--num-bft-nodes COUNT]
                                  | --mary-era
                                  | --alonzo-era
                                  | --babbage-era
+                                 | --conway-era
                                  ]
                                  [--epoch-length MILLISECONDS]
                                  [--slot-length SECONDS]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -6,6 +6,7 @@ Usage: cardano-testnet cardano [--num-bft-nodes COUNT]
                                  | --mary-era
                                  | --alonzo-era
                                  | --babbage-era
+                                 | --conway-era
                                  ]
                                  [--epoch-length MILLISECONDS]
                                  [--slot-length SECONDS]
@@ -28,6 +29,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --epoch-length MILLISECONDS
                            Epoch length (default: 1500)
   --slot-length SECONDS    Slot length (default: 0.2)


### PR DESCRIPTION
# Description

Add `--conway-era` flag.

There is still an unresolved error that will be resolved separately:

```bash
cardano-cli transaction build --conway-era --testnet-magic 42 --tx-in 'bf1e7a5edbd698b7b19f88a2761161247c31d0a0a989394f6e9ff51b450d72b2#0' --tx-out 'addr_test1vzvgd5ezqhwde7qjl428kkvaqnlfx3hvd27kcn4ahxc2zssc7d7he+300000000' --change-address addr_test1vqyug3rskwm2nur6zsdnwqznrs4gdqlp275pqqzrtuuxc0cmr6wc0 --out-file tx.raw

cardano-cli: Prelude.undefined
CallStack (from HasCallStack):
  error, called at libraries/base/GHC/Err.hs:79:14 in base:GHC.Err
  undefined, called at src/Cardano/Ledger/Conway/TxBody.hs:311:18 in crdn-ldgr-cnwy-1.2.0.0-d7c84ea9:Cardano.Ledger.Conway.TxBody
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
