### PR TITLE
Updated cardano-cli ping command

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-05-10T10:34:57Z
-  , cardano-haskell-packages 2023-05-31T18:00:00Z
+  , cardano-haskell-packages 2023-06-12T12:19:29Z
 
 packages:
     cardano-cli

--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for cardano-cli
 
+## next version
+
+- `cardano-cli ping`: timestamp format changed to `ISO8601`
+- `cardano-cli ping`: support `NodeToNodeV_11`, `NodeToNodeV_12` and `NodeToClientV_16`.
+- `cardano-cli ping`: added `--query-versions` flag, instread of doing version
+  negotiation the remote side will reply with its set of supported versions.
+
 ## 8.1.0
 
 - Delete deprecated shelley command group

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -123,7 +123,7 @@ library
                       , cardano-ledger-core >= 1.2
                       , cardano-ledger-conway >= 1.1
                       , cardano-ledger-shelley >= 1.1.1
-                      , cardano-ping ^>= 0.1.0.1
+                      , cardano-ping ^>= 0.2.0.4
                       , cardano-prelude
                       , cardano-protocol-tpraos >= 1.0
                       , cardano-slotting ^>= 0.1

--- a/cardano-cli/src/Cardano/CLI/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Ping.hs
@@ -50,24 +50,26 @@ maybeUnixSockEndPoint = \case
   UnixSockEndPoint sock -> Just sock
 
 data PingCmd = PingCmd
-  { pingCmdCount    :: !Word32
-  , pingCmdEndPoint :: !EndPoint
-  , pingCmdPort     :: !String
-  , pingCmdMagic    :: !Word32
-  , pingCmdJson     :: !Bool
-  , pingCmdQuiet    :: !Bool
+  { pingCmdCount           :: !Word32
+  , pingCmdEndPoint        :: !EndPoint
+  , pingCmdPort            :: !String
+  , pingCmdMagic           :: !Word32
+  , pingCmdJson            :: !Bool
+  , pingCmdQuiet           :: !Bool
+  , pingOptsHandshakeQuery :: !Bool
   } deriving (Eq, Show)
 
 pingClient :: Tracer IO CNP.LogMsg -> Tracer IO String -> PingCmd -> [CNP.NodeVersion] -> AddrInfo -> IO ()
 pingClient stdout stderr cmd = CNP.pingClient stdout stderr opts
   where opts = CNP.PingOpts
-          { CNP.pingOptsQuiet     = pingCmdQuiet cmd
-          , CNP.pingOptsJson      = pingCmdJson cmd
-          , CNP.pingOptsCount     = pingCmdCount cmd
-          , CNP.pingOptsHost      = maybeHostEndPoint (pingCmdEndPoint cmd)
-          , CNP.pingOptsUnixSock  = maybeUnixSockEndPoint (pingCmdEndPoint cmd)
-          , CNP.pingOptsPort      = pingCmdPort cmd
-          , CNP.pingOptsMagic     = pingCmdMagic cmd
+          { CNP.pingOptsQuiet          = pingCmdQuiet cmd
+          , CNP.pingOptsJson           = pingCmdJson cmd
+          , CNP.pingOptsCount          = pingCmdCount cmd
+          , CNP.pingOptsHost           = maybeHostEndPoint (pingCmdEndPoint cmd)
+          , CNP.pingOptsUnixSock       = maybeUnixSockEndPoint (pingCmdEndPoint cmd)
+          , CNP.pingOptsPort           = pingCmdPort cmd
+          , CNP.pingOptsMagic          = pingCmdMagic cmd
+          , CNP.pingOptsHandshakeQuery = pingOptsHandshakeQuery cmd
           }
 
 runPingCmd :: PingCmd -> ExceptT PingClientCmdError IO ()
@@ -89,7 +91,7 @@ runPingCmd options = do
       return ([addr], CNP.supportedNodeToClientVersions $ pingCmdMagic options)
 
   -- Logger async thread handle
-  laid <- liftIO . async $ CNP.logger msgQueue $ pingCmdJson options
+  laid <- liftIO . async $ CNP.logger msgQueue (pingCmdJson options) (pingOptsHandshakeQuery options)
   -- Ping client thread handles
   caids <- forM addresses $ liftIO . async . pingClient (Tracer $ doLog msgQueue) (Tracer doErrLog) options versions
   res <- L.zip addresses <$> mapM (liftIO . waitCatch) caids
@@ -194,5 +196,11 @@ pPing = PingCmd
         [ Opt.long "quiet"
         , Opt.short 'q'
         , Opt.help "Quiet flag, CSV/JSON only output"
+        ]
+      )
+  <*> ( Opt.switch $ mconcat
+        [ Opt.long "query-versions"
+        , Opt.short 'Q'
+        , Opt.help "Query the supported protocol versions using the handshake protocol and terminate the connection."
         ]
       )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1339,6 +1339,7 @@ Usage: cardano-cli ping [-c|--count COUNT]
             [-m|--magic MAGIC]
             [-j|--json]
             [-q|--quiet]
+            [-Q|--query-versions]
 
   Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli ping [-c|--count COUNT]
             [-m|--magic MAGIC]
             [-j|--json]
             [-q|--quiet]
+            [-Q|--query-versions]
 
   Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
 
@@ -17,4 +18,6 @@ Available options:
   -m,--magic MAGIC         Network magic.
   -j,--json                JSON output flag.
   -q,--quiet               Quiet flag, CSV/JSON only output
+  -Q,--query-versions      Query the supported protocol versions using the
+                           handshake protocol and terminate the connection.
   -h,--help                Show this help text

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1685550653,
-        "narHash": "sha256-PC0QBZJmOhkYNeAfCqCpUM7qGNJId6NEdsapsIzEkXM=",
+        "lastModified": 1686574356,
+        "narHash": "sha256-TZE2rU20mAnaWke8F8kp4ioMAqzxxeCRdxkYGrUdiG8=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "31da3df2b4dfb5a19ca4dbd23e6279c892307ca2",
+        "rev": "e3a5b6fc05b4be54534b8dfdf3195b9b0fa89ccc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`cardano-cli ping` command compatible with `cardano-node-8.1.0`.