### PR TITLE
CODEOWNERS: update to only have groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,39 +1,31 @@
-# Technical writers
-README.*                                                      @Jimbo4350 @newhoggy @carbolymer @olgahryniuk
-cardano-cli/README.md                                         @Jimbo4350 @newhoggy @carbolymer @olgahryniuk
+# catch-all
 
-# Release manager added for notification on dependency updates
-cabal.project                                                 @Jimbo4350 @newhoggy @carbolymer @LaurenceIO
-
+* @input-output-hk/cardano-sl
 
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
 
-
-
+# Technical writers
 # /doc folder and README.* needs to be owned by @docs-access
-doc/                                                          @input-output-hk/docs-access
+doc/                                                          @input-output-hk/docs-access @input-output-hk/cardano-sl
+README.*                                                      @input-output-hk/docs-access @input-output-hk/cardano-sl
+CONTRIBUTING.rst                                              @input-output-hk/docs-access @input-output-hk/cardano-sl
 
-README.*                                                      @input-output-hk/docs-access
+# Perf/Tracing
+bench/                                                        @input-output-hk/performance-tracing
+nix/workbench/                                                @input-output-hk/performance-tracing
+trace-dispatcher/                                             @input-output-hk/performance-tracing
+trace-forward/                                                @input-output-hk/performance-tracing
+trace-resources/                                              @input-output-hk/performance-tracing
+Makefile                                                      @input-output-hk/performance-tracing
+*.mk                                                          @input-output-hk/performance-tracing
 
-bench/                                                        @deepfire @jutaro @mgmeier @fmaste @cleverca22
-cardano-tracer/                                               @deepfire
-nix/workbench/                                                @deepfire @jutaro @mgmeier @fmaste
-trace-dispatcher/                                             @deepfire @jutaro @mgmeier
-trace-forward/                                                @deepfire @jutaro @mgmeier
-trace-resources/                                              @deepfire @jutaro @mgmeier
-Makefile                                                      @deepfire @mgmeier @fmaste
-*.mk                                                          @deepfire @mgmeier @fmaste
-
-nix/                                                          @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
-*.nix                                                         @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
-flake.lock                                                    @input-output-hk/devx-core-tech @input-output-hk/devops @deepfire @mgmeier @fmaste
-
-.buildkite                                                    @input-output-hk/devx-core-tech @input-output-hk/devops
-.github                                                       @input-output-hk/devx-core-tech @input-output-hk/devops
-ci/                                                           @input-output-hk/devx-core-tech @input-output-hk/devops
-configuration/                                                @input-output-hk/devx-core-tech @input-output-hk/devops
-bors.toml                                                     @input-output-hk/devx-core-tech @input-output-hk/devops
-docker-compose.yml                                            @input-output-hk/devx-core-tech @input-output-hk/devops
-cardano-node/src/Cardano/Node/Tracing/                        @deepfire @jutaro @coot
-cardano-node/src/Cardano/Tracing/OrphanInstances/             @input-output-hk/devops @coot
+# DevOps
+nix/                                                          @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+*.nix                                                         @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+flake.lock                                                    @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+.buildkite                                                    @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+.github                                                       @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+ci/                                                           @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+configuration/                                                @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+docker-compose.yml                                            @input-output-hk/core-tech-devx @input-output-hk/core-tech-release


### PR DESCRIPTION
* removes deepfire
* makes cardano-sl group primary owner
* switches devops -> core-tech-release
* fixes devx group name

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
