### PR TITLE
Don't retry testnet when failed

### DIFF
--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -61,7 +61,7 @@ runTestnet tn = do
 
 
 testnetProperty :: (H.Conf -> H.Integration ()) -> H.Property
-testnetProperty tn = H.integrationRetryWorkspace 2 "testnet" $ \workspaceDir -> do
+testnetProperty tn = H.integrationWorkspace "testnet" $ \workspaceDir -> do
   conf <- H.mkConf workspaceDir
 
   -- Fork a thread to keep alive indefinitely any resources allocated by testnet.

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -5,6 +5,7 @@
 module Testnet.Property.Utils
   ( integration
   , integrationRetryWorkspace
+  , integrationWorkspace
   , isLinux
 
   , QueryTipOutput(..)
@@ -65,6 +66,12 @@ integrationRetryWorkspace :: HasCallStack => Int -> FilePath -> (FilePath -> H.I
 integrationRetryWorkspace n workspaceName f = GHC.withFrozenCallStack $
   integration $ H.retry n $ \i ->
     H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
+
+-- | The 'FilePath' in '(FilePath -> H.Integration ())' is the work space directory.
+-- This is created (and returned) via 'H.workspace'.
+integrationWorkspace :: HasCallStack => FilePath -> (FilePath -> H.Integration ()) -> H.Property
+integrationWorkspace workspaceName f = GHC.withFrozenCallStack $
+  integration $ H.runFinallies $ H.workspace workspaceName f
 
 isLinux :: Bool
 isLinux = os == "linux"


### PR DESCRIPTION
# Description

We need to retry when running flaky tests, but not when spinning up testnets on their own.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
