### PR TITLE
Trigger workflows on `pull_request`

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -1,7 +1,7 @@
 name: Check cabal files
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 jobs:

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -1,7 +1,7 @@
 name: Check git dependencies
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 jobs:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -1,7 +1,7 @@
 name: Check HLint
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 jobs:

--- a/.github/workflows/check-nix-config.yml
+++ b/.github/workflows/check-nix-config.yml
@@ -1,7 +1,7 @@
 name: Check nix configuration
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 jobs:

--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -1,7 +1,7 @@
 name: Haskell Linux CI
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
   # DO NOT DELETE.

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,7 +1,7 @@
 name: Haskell Windows & Mac CI
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
   # DO NOT DELETE.

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -1,7 +1,7 @@
 name: Check Markdown links
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 jobs:

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -1,7 +1,7 @@
 name: Check Stylish Haskell
 
 on:
-  push:
+  pull_request: # Required for workflows to be able to be approved from forks
   merge_group:
 
 # When pushing branches (and/or updating PRs), we do want to cancel previous


### PR DESCRIPTION
# Description

I believe this is required for workflows to be able to be approved from forks.

`push` only triggers a workflow when a push is made to the repository which does not happen for forks.

`pull_request` triggers when a PR is made to the repository regardless of if it was made from the same repository or a fork.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
