### PR TITLE
CODEOWNERS: add core-tech for .github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@ nix/                                                          @input-output-hk/c
 *.nix                                                         @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 flake.lock                                                    @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 .buildkite                                                    @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-.github/workflows                                             @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+.github/workflows                                             @input-output-hk/core-tech-devx @input-output-hk/core-tech-release @input-output-hk/core-tech
 ci/                                                           @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 configuration/                                                @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 docker-compose.yml                                            @input-output-hk/core-tech-devx @input-output-hk/core-tech-release


### PR DESCRIPTION
# Description

Add @input-output-hk/core-tech to `.github/workflows` directory.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
