### PR TITLE
Report payment address and UTxOs in testnets

### DIFF
--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -8,6 +8,7 @@
 module Testnet.Runtime
   ( LeadershipSlot(..)
   , NodeLoggingFormat(..)
+  , PaymentKeyInfo(..)
   , PaymentKeyPair(..)
   , StakingKeyPair(..)
   , TmpAbsolutePath(..)
@@ -71,7 +72,7 @@ data TestnetRuntime = TestnetRuntime
   , testnetMagic :: Int
   , bftNodes :: [NodeRuntime]
   , poolNodes :: [PoolNode]
-  , wallets :: [PaymentKeyPair]
+  , wallets :: [PaymentKeyInfo]
   , delegators :: [Delegator]
   }
 
@@ -101,6 +102,11 @@ data PoolNodeKeys = PoolNodeKeys
 data PaymentKeyPair = PaymentKeyPair
   { paymentVKey :: FilePath
   , paymentSKey :: FilePath
+  } deriving (Eq, Show)
+
+data PaymentKeyInfo = PaymentKeyInfo
+  { paymentKeyInfoPair :: PaymentKeyPair
+  , paymentKeyInfoAddr :: Text
   } deriving (Eq, Show)
 
 data StakingKeyPair = StakingKeyPair

--- a/cardano-testnet/src/Testnet/Start/Babbage.hs
+++ b/cardano-testnet/src/Testnet/Start/Babbage.hs
@@ -23,6 +23,7 @@ import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
+import qualified Data.Text as Text
 import qualified Data.Time.Clock as DTC
 import           System.FilePath.Posix ((</>))
 import qualified System.Info as OS
@@ -32,12 +33,13 @@ import           Cardano.Api
 import qualified Testnet.Conf as H
 import           Testnet.Defaults
 import           Testnet.Filepath
-import           Testnet.Process.Run (execCli_)
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run (execCli', execCli_)
 import qualified Testnet.Property.Assert as H
 import           Testnet.Property.Utils
-import           Testnet.Runtime (Delegator (..), NodeLoggingFormat (..), PaymentKeyPair (..),
-                   PoolNode (PoolNode), PoolNodeKeys (..), StakingKeyPair (..), TestnetRuntime (..),
-                   startNode)
+import           Testnet.Runtime (Delegator (..), NodeLoggingFormat (..), PaymentKeyInfo (..),
+                   PaymentKeyPair (..), PoolNode (PoolNode), PoolNodeKeys (..), StakingKeyPair (..),
+                   TestnetRuntime (..), poolSprockets, startNode)
 import qualified Testnet.Start.Byron as Byron
 
 import qualified Hedgehog as H
@@ -132,9 +134,25 @@ babbageTestnet testnetOptions (H.Conf tempAbsPath) = do
       }
 
   wallets <- forM [1..3] $ \idx -> do
-    pure $ PaymentKeyPair
-      { paymentSKey = tempAbsPath' </> "utxo-keys/utxo" <> show @Int idx <> ".skey"
-      , paymentVKey = tempAbsPath' </> "utxo-keys/utxo" <> show @Int idx <> ".vkey"
+    let paymentSKeyFile = tempAbsPath' </> "utxo-keys/utxo" <> show @Int idx <> ".skey"
+    let paymentVKeyFile = tempAbsPath' </> "utxo-keys/utxo" <> show @Int idx <> ".vkey"
+    let paymentAddrFile = tempAbsPath' </> "utxo-keys/utxo" <> show @Int idx <> ".addr"
+
+    execCli_
+      [ "address", "build"
+      , "--payment-verification-key-file", paymentVKeyFile
+      , "--testnet-magic", show @Int testnetMagic
+      , "--out-file", paymentAddrFile
+      ]
+
+    paymentAddr <- H.readFile paymentAddrFile
+
+    pure $ PaymentKeyInfo
+      { paymentKeyInfoPair = PaymentKeyPair
+        { paymentSKey = paymentSKeyFile
+        , paymentVKey = paymentVKeyFile
+        }
+      , paymentKeyInfoAddr = Text.pack paymentAddr
       }
 
   delegators <- forM [1..3] $ \idx -> do
@@ -323,16 +341,31 @@ babbageTestnet testnetOptions (H.Conf tempAbsPath) = do
 
   H.noteShowIO_ DTC.getCurrentTime
 
-  forM_ wallets $ \wallet -> do
-    H.cat $ paymentSKey wallet
-    H.cat $ paymentVKey wallet
+  let runtime = TestnetRuntime
+        { configurationFile
+        , shelleyGenesisFile = genesisShelleyDir </> "genesis.json"
+        , testnetMagic
+        , poolNodes
+        , wallets = wallets
+        , bftNodes = []
+        , delegators = delegators
+        }
 
-  return TestnetRuntime
-    { configurationFile
-    , shelleyGenesisFile = genesisShelleyDir </> "genesis.json"
-    , testnetMagic
-    , poolNodes
-    , wallets = wallets
-    , bftNodes = []
-    , delegators = delegators
-    }
+  let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  execConfig <- H.headM (poolSprockets runtime) >>= H.mkExecConfig tempBaseAbsPath
+
+  forM_ wallets $ \wallet -> do
+    H.cat $ paymentSKey $ paymentKeyInfoPair wallet
+    H.cat $ paymentVKey $ paymentKeyInfoPair wallet
+
+    utxos <- execCli' execConfig
+      [ "query", "utxo"
+      , "--address", Text.unpack $ paymentKeyInfoAddr wallet
+      , "--cardano-mode"
+      , "--testnet-magic", show @Int testnetMagic
+      ]
+
+    H.note_ utxos
+
+  pure runtime


### PR DESCRIPTION
# Description

When the testnet is run, the payment address and UTxOs for those addresses will be printed.

## Babbage

```
    358 ┃   forM_ wallets $ \wallet -> do
    359 ┃     H.cat $ paymentSKey $ paymentKeyInfoPair wallet
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo1.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo1.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "58202893c5b2bb6ee7b5950084daef6f9c4333d9ac86b38dc7689418a0e9627d9c2d"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo2.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo2.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "5820ecac6b989b5ddf02d897efda54a7d3defcc3f3ceddc83d0474db3f62a9ad723c"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo3.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo3.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "5820f637a30e094e7c079d6ecbee5d08a8af4f7108f7c4575bc0eb30388c751c00aa"
        ┃     │ }
        ┃     │
    360 ┃     H.cat $ paymentVKey $ paymentKeyInfoPair wallet
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo1.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo1.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "582084d1eb6bfbf7c6443fc2de63b5aae4db7d983afba44dd8be1f06049563e26e2b"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo2.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo2.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "582020dd895380a240818a6ec670e88679e1a95c6b6e77429d2def1ea1abd1fbcb7a"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo3.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-a677072d209eeffc/utxo-keys/utxo3.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "58202875092d8d0ccd25f9fc6a55a5b3c3a391378714a164fa910f858c0fa1af0ee5"
        ┃     │ }
        ┃     │
    361 ┃
    362 ┃     utxos <- execCli' execConfig
    363 ┃       [ "query", "utxo"
    364 ┃       , "--address", Text.unpack $ paymentKeyInfoAddr wallet
    365 ┃       , "--cardano-mode"
    366 ┃       , "--testnet-magic", show @Int testnetMagic
    367 ┃       ]
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vptly9f96nt83lvyl4pn4wqtvu3kfu3qhd8phr9uz4x08aqjcn6ld --cardano-mode --testnet-magic 42
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vzul6c6qu5deds5dkj4esag8eetsrma7x86r80k79vpc55s7z0fp2 --cardano-mode --testnet-magic 42
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vq7tuzafklsghxy8rdfk4s9qapw6a70lf70fpht0vh7cvjswgeva8 --cardano-mode --testnet-magic 42
    368 ┃
    369 ┃     H.note_ utxos
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ 11504318ecd8b49a6680e0c567c180d153778c9712820c69df2c7b67ea7efd6a     0        300000000000 lovelace + TxOutDatumNone
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ c2748dcaccac6e21e0ec130090db9f643c78e017a2d62212c4852a800387451b     0        300000000000 lovelace + TxOutDatumNone
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ 1e8cb1ac669ccc55d028a8d11bc06d7b28a4d5defac5eb2d62b9ac3d7f648884     0        300000000000 lovelace + TxOutDatumNone
    370 ┃
    371 ┃   pure runtime
```

## Conway

```
    362 ┃   forM_ wallets $ \wallet -> do
    363 ┃     H.cat $ paymentSKey $ paymentKeyInfoPair wallet
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo1.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo1.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "5820a34bb57c812a59dccd2b76de135fe57fdc39fc6ea1d0bfcb283e112cb10a9e26"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo2.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo2.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "582086de94d7272e4536a91b4bd0ced4706a75831c1d272b73725f88a421a612bc6a"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo3.skey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo3.skey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOSigningKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Signing Key",
        ┃     │     "cborHex": "58202cbb8eab56b3d342beec5bb56e071f3f22518d922ab04f8e4bdb33067e470db6"
        ┃     │ }
        ┃     │
    364 ┃     H.cat $ paymentVKey $ paymentKeyInfoPair wallet
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo1.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo1.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "582008666fd95926c2871bbf61d87d648ca6fbde85497d9f786644438dd8a08559e8"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo2.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo2.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "582024ef5a129668a7eeb3c4397756516a83a25a2bc77035224e8e26a688123e82cb"
        ┃     │ }
        ┃     │
        ┃     │ Reading file: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo3.vkey
        ┃     │ ━━━━ File: /private/tmp/nix-shell.Sv7Vsx/testnet-test-ad240a73f2471776/utxo-keys/utxo3.vkey ━━━━
        ┃     │ {
        ┃     │     "type": "GenesisUTxOVerificationKey_ed25519",
        ┃     │     "description": "Genesis Initial UTxO Verification Key",
        ┃     │     "cborHex": "582023cf14d100a1cffee165a9b550a5509cb1adde4114c31ff691519bc4a6ad906d"
        ┃     │ }
        ┃     │
    365 ┃
    366 ┃     utxos <- execCli' execConfig
    367 ┃       [ "query", "utxo"
    368 ┃       , "--address", Text.unpack $ paymentKeyInfoAddr wallet
    369 ┃       , "--cardano-mode"
    370 ┃       , "--testnet-magic", show @Int testnetMagic
    371 ┃       ]
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vz9mm0jd77v0y7p28uux57sa88t57dqg43ye8kutuzm80ecrmen8n --cardano-mode --testnet-magic 42
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vzvhlwpmtvgwxpe2udxshfnhy944ph8l6kg0qy9kzrsgy9qmemst2 --cardano-mode --testnet-magic 42
        ┃       │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli query utxo --address addr_test1vzdxm95ly3d5vwg7t69mscdau06quusj0ncassv9nm0akdqhxzy29 --cardano-mode --testnet-magic 42
    372 ┃
    373 ┃     H.note_ utxos
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ be7bc711f545803a86f598d8b05a542331bf47971f99b69bde5a8fb271a12dbb     0        300000000000 lovelace + TxOutDatumNone
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ 39f77d534687c0658f199834763fda049b429893172c30df7aee28b3abf30440     0        300000000000 lovelace + TxOutDatumNone
        ┃     │                            TxHash                                 TxIx        Amount
        ┃     │ --------------------------------------------------------------------------------------
        ┃     │ d017cbd7195807b27e9a99f3a0cdcafe18e988be0aac77cc5268843bdd0ae7bf     0        300000000000 lovelace + TxOutDatumNone
    374 ┃
    375 ┃   pure runtime
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
