### PR TITLE
Transaction integration test for Conway

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-06-20"
+      CABAL_CACHE_VERSION: "2023-06-30"
 
       # Modify this value to "invalidate" the secp cache.
       SECP_CACHE_VERSION: "2022-12-30"

--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-06-20"
+      CABAL_CACHE_VERSION: "2023-06-30"
 
       # Modify this value to "invalidate" the secp cache.
       SECP_CACHE_VERSION: "2022-12-30"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-06-20"
+      CABAL_CACHE_VERSION: "2023-06-30"
 
       # Modify this value to "invalidate" the secp cache.
       SECP_CACHE_VERSION: "2022-12-30"

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -27,7 +27,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-06-20"
+      CABAL_CACHE_VERSION: "2023-06-30"
 
       STYLISH_HASKELL_VERSION: "0.14.4.0"
 

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -72,7 +72,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api ^>= 8.7
+    , cardano-api ^>= 8.8
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        >=1.0.0

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -72,7 +72,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api ^>= 8.2
+    , cardano-api ^>= 8.7
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        >=1.0.0

--- a/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -1,6 +1,7 @@
 {- HLINT ignore "Eta reduce" -}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Benchmarking.OuroborosImports
   (
@@ -44,8 +45,8 @@ import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesis)
 
 type CardanoBlock = Consensus.CardanoBlock StandardCrypto
 
-toProtocolInfo :: SomeConsensusProtocol -> ProtocolInfo IO CardanoBlock
-toProtocolInfo (SomeConsensusProtocol CardanoBlockType info) = protocolInfo info
+toProtocolInfo :: SomeConsensusProtocol -> ProtocolInfo CardanoBlock
+toProtocolInfo (SomeConsensusProtocol CardanoBlockType info) = fst $ protocolInfo @IO info
 toProtocolInfo _ = error "toProtocolInfo unknown protocol"
 
 protocolToTopLevelConfig :: SomeConsensusProtocol -> TopLevelConfig CardanoBlock

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -99,7 +99,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.8
                       , cardano-binary
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data
@@ -194,7 +194,7 @@ test-suite tx-generator-apitest
                       , filepath
                       , optparse-applicative-fork
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-node
                       , plutus-tx
                       , transformers
@@ -210,7 +210,7 @@ test-suite tx-generator-apitest
                      , filepath
                      , optparse-applicative-fork
                      , cardano-api ^>= 8.8
-                     , cardano-cli ^>= 8.2
+                     , cardano-cli ^>= 8.3
                      , cardano-node
                      , transformers
                      , transformers-except

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -195,6 +195,7 @@ test-suite tx-generator-apitest
                       , optparse-applicative-fork
                       , cardano-api ^>= 8.8
                       , cardano-cli ^>= 8.3
+                      , cardano-ledger-shelley
                       , cardano-node
                       , plutus-tx
                       , transformers

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -125,7 +125,7 @@ library
                       , optparse-applicative-fork
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5
-                      , ouroboros-consensus-diffusion >= 0.5.1
+                      , ouroboros-consensus-diffusion >= 0.7.0
                       , ouroboros-network ^>= 0.8.1.0
                       , ouroboros-network-api
                       , ouroboros-network-framework

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                       , attoparsec
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
@@ -193,7 +193,7 @@ test-suite tx-generator-apitest
                       , bytestring
                       , filepath
                       , optparse-applicative-fork
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-node
                       , plutus-tx
@@ -209,7 +209,7 @@ test-suite tx-generator-apitest
                      , bytestring
                      , filepath
                      , optparse-applicative-fork
-                     , cardano-api ^>= 8.2
+                     , cardano-api ^>= 8.5
                      , cardano-cli ^>= 8.2
                      , cardano-node
                      , transformers

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                       , attoparsec
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
@@ -193,7 +193,7 @@ test-suite tx-generator-apitest
                       , bytestring
                       , filepath
                       , optparse-applicative-fork
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-cli ^>= 8.2
                       , cardano-node
                       , plutus-tx
@@ -209,7 +209,7 @@ test-suite tx-generator-apitest
                      , bytestring
                      , filepath
                      , optparse-applicative-fork
-                     , cardano-api ^>= 8.5
+                     , cardano-api ^>= 8.7
                      , cardano-cli ^>= 8.2
                      , cardano-node
                      , transformers

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                       , attoparsec
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
@@ -193,7 +193,7 @@ test-suite tx-generator-apitest
                       , bytestring
                       , filepath
                       , optparse-applicative-fork
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-cli ^>= 8.2
                       , cardano-node
                       , plutus-tx
@@ -209,7 +209,7 @@ test-suite tx-generator-apitest
                      , bytestring
                      , filepath
                      , optparse-applicative-fork
-                     , cardano-api ^>= 8.7
+                     , cardano-api ^>= 8.8
                      , cardano-cli ^>= 8.2
                      , cardano-node
                      , transformers

--- a/cabal.project
+++ b/cabal.project
@@ -108,6 +108,24 @@ package snap-server
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-ledger
+  tag: 7ccedcc09654a55bb7b146fc6176e6fd2a624653
+  --sha256: 1a4m7m7ry7mvlvrd45lp8aila9y3yz3x6m15j16h3m43mz6mnfzr
+  subdir:
+    eras/conway/impl
+    eras/conway/test-suite
+    libs/cardano-ledger-pretty
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  tag: 7a6356763a62ba8b7cc1b3f9b27449657ae6a36f
+  --sha256: 0py2fxc3d960hvkb8whn5rmywbbbcgkgc4sl7pl80zyk1l54l6sz
+  subdir:
+    ouroboros-consensus-cardano
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/cardano-cli
   tag: aa59030250e1e48ac91ca60ad678cbf38e91068a
   --sha256: sha256-O3Hhd6YeZn/bFtBR9DH7WI70E2TTSI+fvg9WMEAPpK0=

--- a/cabal.project
+++ b/cabal.project
@@ -127,17 +127,9 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: aa59030250e1e48ac91ca60ad678cbf38e91068a
-  --sha256: sha256-O3Hhd6YeZn/bFtBR9DH7WI70E2TTSI+fvg9WMEAPpK0=
+  tag: 5c55df77f83d98ac32e6022bc186aae5d219ebfd
+  --sha256: 08hnj3s5nxmmkysal2vw1lnsn5f8myyh36lczdk09bbpymkpczl2
   subdir:
     cardano-cli
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-api
-  tag: 33f92b4f0387a1ccad1684263905464407a1e21c
-  --sha256: sha256-KO9KyzF1VfZQrbdsPpbhqUvU+GyTPNwLspAN0EQffKc=
-  subdir:
-    cardano-api
 
 allow-newer: text

--- a/cabal.project
+++ b/cabal.project
@@ -122,3 +122,4 @@ source-repository-package
   subdir:
     cardano-api
 
+allow-newer: text

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-05-10T10:34:57Z
-  , cardano-haskell-packages 2023-06-15T12:05:43Z
+  , cardano-haskell-packages 2023-07-02T00:00:00Z
 
 packages:
   cardano-client-demo
@@ -32,9 +32,6 @@ packages:
   trace-dispatcher
   trace-resources
   trace-forward
-
-extra-packages:
-  cardano-cli
 
 package cardano-api
   ghc-options: -Werror
@@ -112,35 +109,16 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: 3fbf9e18a5c44043982b9382d357502d8fe5a78d
+  tag: b2938135e7839449b3e4ddd594fa235ff47a19fc
   --sha256: sha256-Q1pXMt4P2QOTUjQIj3Y7sVHoLvxItklnhN9rhNRYyTc=
   subdir:
     cardano-cli
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: d639fbdacaf9abd47db28250964d5168743b3520
-  --sha256: sha256-Um0QL6LGpTqyb5iW/VFRpQk+YgMVjcEHI2UQ+nqqbIo=
-  subdir:
-    ouroboros-consensus
-    ouroboros-consensus-diffusion
-    ouroboros-consensus-cardano
-    ouroboros-consensus-protocol
-
-source-repository-package
-  type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: a5aff8c19063f8679b757cdc15b44239065d5815
+  tag: 1ff60d1c343d703f90a5ec789d2d2524c30397f8
   --sha256: sha256-GWrck5RLD3uP68uesrVh6bszyCJI2z+a09sTsbFzaUE=
   subdir:
     cardano-api
 
--- Needed because consensus uses it
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/io-sim
-  tag: ec202298c420378ef90b3fc0126c39e0f52290a3
-  --sha256: 1p6pn83kwp66x2m0cw9a27blfcpmw0lrra72qd0pi5bj3v1bcrl9
-  subdir:
-    strict-mvar

--- a/cabal.project
+++ b/cabal.project
@@ -109,8 +109,8 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: 5c55df77f83d98ac32e6022bc186aae5d219ebfd
-  --sha256: 08hnj3s5nxmmkysal2vw1lnsn5f8myyh36lczdk09bbpymkpczl2
+  tag: c8f07d82a65015e2a67c9e1a3019c629e584fab0
+  --sha256: 1zbmh3d45dsxfcb6hpdqrivi4y75yfc9arnlpakfypfjc073jh6n
   subdir:
     cardano-cli
 

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-07-03T00:00:00Z
-  , cardano-haskell-packages 2023-07-07T12:00:00Z
+  , cardano-haskell-packages 2023-07-07T12:30:00Z
 
 packages:
   cardano-client-demo
@@ -109,7 +109,7 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: b2938135e7839449b3e4ddd594fa235ff47a19fc
+  tag: aa59030250e1e48ac91ca60ad678cbf38e91068a 
   --sha256: sha256-Q1pXMt4P2QOTUjQIj3Y7sVHoLvxItklnhN9rhNRYyTc=
   subdir:
     cardano-cli
@@ -117,7 +117,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: 1ff60d1c343d703f90a5ec789d2d2524c30397f8
+  tag: 511ea889d439e02a5c084418b44a4ddacf32686f
   --sha256: sha256-GWrck5RLD3uP68uesrVh6bszyCJI2z+a09sTsbFzaUE=
   subdir:
     cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-05-10T10:34:57Z
+  , hackage.haskell.org 2023-07-02T00:00:00Z
   , cardano-haskell-packages 2023-07-02T00:00:00Z
 
 packages:

--- a/cabal.project
+++ b/cabal.project
@@ -109,8 +109,8 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: c8f07d82a65015e2a67c9e1a3019c629e584fab0
-  --sha256: 1zbmh3d45dsxfcb6hpdqrivi4y75yfc9arnlpakfypfjc073jh6n
+  tag: 2765510abe155a6931526f49d8b62bdf90d81b40
+  --sha256: 00x0xpz2c79q7rifhmdhvcgzdfryzh5xk08c5bgikdkb2462sqfx
   subdir:
     cardano-cli
 

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-07-03T00:00:00Z
-  , cardano-haskell-packages 2023-07-07T12:30:00Z
+  , cardano-haskell-packages 2023-07-07T18:00:00Z
 
 packages:
   cardano-client-demo
@@ -109,8 +109,8 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-cli
-  tag: aa59030250e1e48ac91ca60ad678cbf38e91068a 
-  --sha256: sha256-Q1pXMt4P2QOTUjQIj3Y7sVHoLvxItklnhN9rhNRYyTc=
+  tag: aa59030250e1e48ac91ca60ad678cbf38e91068a
+  --sha256: sha256-O3Hhd6YeZn/bFtBR9DH7WI70E2TTSI+fvg9WMEAPpK0=
   subdir:
     cardano-cli
 
@@ -118,7 +118,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
   tag: 511ea889d439e02a5c084418b44a4ddacf32686f
-  --sha256: sha256-GWrck5RLD3uP68uesrVh6bszyCJI2z+a09sTsbFzaUE=
+  --sha256: sha256-gdmu3NfL4ewp13ayQ1VOSfJzMn3OEFOK+AU8yTTHKks=
   subdir:
     cardano-api
 

--- a/cabal.project
+++ b/cabal.project
@@ -108,3 +108,39 @@ package snap-server
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-cli
+  tag: 3fbf9e18a5c44043982b9382d357502d8fe5a78d
+  --sha256: sha256-Q1pXMt4P2QOTUjQIj3Y7sVHoLvxItklnhN9rhNRYyTc=
+  subdir:
+    cardano-cli
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  tag: d639fbdacaf9abd47db28250964d5168743b3520
+  --sha256: sha256-Um0QL6LGpTqyb5iW/VFRpQk+YgMVjcEHI2UQ+nqqbIo=
+  subdir:
+    ouroboros-consensus
+    ouroboros-consensus-diffusion
+    ouroboros-consensus-cardano
+    ouroboros-consensus-protocol
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-api
+  tag: a5aff8c19063f8679b757cdc15b44239065d5815
+  --sha256: sha256-GWrck5RLD3uP68uesrVh6bszyCJI2z+a09sTsbFzaUE=
+  subdir:
+    cardano-api
+
+-- Needed because consensus uses it
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/io-sim
+  tag: ec202298c420378ef90b3fc0126c39e0f52290a3
+  --sha256: 1p6pn83kwp66x2m0cw9a27blfcpmw0lrra72qd0pi5bj3v1bcrl9
+  subdir:
+    strict-mvar

--- a/cabal.project
+++ b/cabal.project
@@ -108,24 +108,6 @@ package snap-server
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 7ccedcc09654a55bb7b146fc6176e6fd2a624653
-  --sha256: 1a4m7m7ry7mvlvrd45lp8aila9y3yz3x6m15j16h3m43mz6mnfzr
-  subdir:
-    eras/conway/impl
-    eras/conway/test-suite
-    libs/cardano-ledger-pretty
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 7a6356763a62ba8b7cc1b3f9b27449657ae6a36f
-  --sha256: 0py2fxc3d960hvkb8whn5rmywbbbcgkgc4sl7pl80zyk1l54l6sz
-  subdir:
-    ouroboros-consensus-cardano
-
-source-repository-package
-  type: git
   location: https://github.com/input-output-hk/cardano-cli
   tag: 5c55df77f83d98ac32e6022bc186aae5d219ebfd
   --sha256: 08hnj3s5nxmmkysal2vw1lnsn5f8myyh36lczdk09bbpymkpczl2

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-07-02T00:00:00Z
-  , cardano-haskell-packages 2023-07-02T00:00:00Z
+  , hackage.haskell.org 2023-07-03T00:00:00Z
+  , cardano-haskell-packages 2023-07-07T12:00:00Z
 
 packages:
   cardano-client-demo

--- a/cabal.project
+++ b/cabal.project
@@ -17,6 +17,8 @@ index-state:
   , cardano-haskell-packages 2023-07-08T04:00:00Z
 
 packages:
+  -- cardano-api
+  -- cardano-cli
   cardano-client-demo
   cardano-git-rev
   cardano-node

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-07-03T00:00:00Z
-  , cardano-haskell-packages 2023-07-07T18:00:00Z
+  , cardano-haskell-packages 2023-07-08T04:00:00Z
 
 packages:
   cardano-client-demo
@@ -117,8 +117,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: 511ea889d439e02a5c084418b44a4ddacf32686f
-  --sha256: sha256-gdmu3NfL4ewp13ayQ1VOSfJzMn3OEFOK+AU8yTTHKks=
+  tag: 33f92b4f0387a1ccad1684263905464407a1e21c
+  --sha256: sha256-KO9KyzF1VfZQrbdsPpbhqUvU+GyTPNwLspAN0EQffKc=
   subdir:
     cardano-api
 

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -257,7 +257,7 @@ main = do
              _era)
            state -> do
              let getGoSnapshot = L.unStake . L.ssStake . L.ssStakeGo . L.esSnapshots . L.nesEs
-                 getBalances = UM.rewView
+                 getBalances = UM.rewardMap
                              . L.dsUnified
                              . L.certDState
                              . L.lsCertState
@@ -342,7 +342,7 @@ main = do
       TxCertificatesNone    -> return ()
       TxCertificates _ cs _ -> mapM_ msg $ mapMaybe (targetedCert t epochNo slotNo) cs
 
-    targetedCert :: StakeCredential -> EpochNo -> SlotNo -> Certificate -> Maybe (Event c)
+    targetedCert :: StakeCredential -> EpochNo -> SlotNo -> Certificate era -> Maybe (Event c)
     targetedCert t epochNo slotNo = \case
       StakeAddressRegistrationCertificate cred ->
         if t == cred then Just (StakeRegistrationEvent epochNo slotNo) else Nothing

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -342,20 +343,25 @@ main = do
       TxCertificates _ cs _ -> mapM_ msg $ mapMaybe (targetedCert t epochNo slotNo) cs
 
     targetedCert :: StakeCredential -> EpochNo -> SlotNo -> Certificate -> Maybe (Event c)
-    targetedCert t epochNo slotNo (StakeAddressRegistrationCertificate cred)   =
-      if t == cred then Just (StakeRegistrationEvent epochNo slotNo) else Nothing
-    targetedCert t epochNo slotNo (StakeAddressDeregistrationCertificate cred) =
-      if t == cred then Just (StakeDeRegistrationEvent epochNo slotNo) else Nothing
-    targetedCert t _epochNo slotNo (StakeAddressPoolDelegationCertificate cred pool) =
-      if t == cred then Just (DelegationEvent slotNo pool) else Nothing
-    targetedCert t _epochNo slotNo (StakePoolRegistrationCertificate pool)      =
-      inPoolCert t slotNo pool
-    targetedCert _ _ _ (StakePoolRetirementCertificate _ _)              = Nothing
-    targetedCert _ _ _ GenesisKeyDelegationCertificate {}                = Nothing
-    targetedCert t epochNo slotNo (MIRCertificate pot (StakeAddressesMIR mir)) =
-      inMir t epochNo slotNo mir pot
-    targetedCert _ _ _ (MIRCertificate _ (SendToReservesMIR _))          = Nothing
-    targetedCert _ _ _ (MIRCertificate _ (SendToTreasuryMIR _))          = Nothing
+    targetedCert t epochNo slotNo = \case
+      StakeAddressRegistrationCertificate cred ->
+        if t == cred then Just (StakeRegistrationEvent epochNo slotNo) else Nothing
+      StakeAddressDeregistrationCertificate cred ->
+        if t == cred then Just (StakeDeRegistrationEvent epochNo slotNo) else Nothing
+      StakeAddressPoolDelegationCertificate cred pool ->
+        if t == cred then Just (DelegationEvent slotNo pool) else Nothing
+      StakePoolRegistrationCertificate pool ->
+        inPoolCert t slotNo pool
+      StakePoolRetirementCertificate _ _ -> Nothing
+      GenesisKeyDelegationCertificate {} -> Nothing
+      MIRCertificate pot (StakeAddressesMIR mir) ->
+        inMir t epochNo slotNo mir pot
+      MIRCertificate _ (SendToReservesMIR _) -> Nothing
+      MIRCertificate _ (SendToTreasuryMIR _) -> Nothing
+
+      -- TODO CIP-1694 These are also delegation events.  Should there be new events for these?
+      CommitteeDelegationCertificate _ _ -> Nothing
+      CommitteeHotKeyDeregistrationCertificate _ -> Nothing
 
     stakeCredentialFromStakeAddress (StakeAddress _ cred) = fromShelleyStakeCredential cred
 

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -31,7 +31,7 @@ executable scan-blocks-pipelined
   import:               project-config
   main-is:              ScanBlocksPipelined.hs
   build-depends:        cardano-api
-                      , cardano-ledger-byron ^>= 1.0
+                      , cardano-ledger-byron ^>= 1.0.0.1
                       , cardano-slotting ^>= 0.1
                       , filepath
                       , time
@@ -40,7 +40,7 @@ executable chain-sync-client-with-ledger-state
   import:               project-config
   main-is:              ChainSyncClientWithLedgerState.hs
   build-depends:        cardano-api
-                      , cardano-ledger-byron ^>= 1.0
+                      , cardano-ledger-byron ^>= 1.0.0.1
                       , cardano-slotting ^>= 0.1
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Chairman.Commands.Run
   ( cmdRun
@@ -120,7 +121,7 @@ run RunOpts
 
   let (k , nId) = case p of
             SomeConsensusProtocol _ runP ->
-              let ProtocolInfo { pInfoConfig } = Api.protocolInfo runP
+              let ProtocolInfo { pInfoConfig } = fst $ Api.protocolInfo @IO runP
               in ( Consensus.configSecurityParam pInfoConfig
                  , fromNetworkMagic . getNetworkMagic $ Consensus.configBlock pInfoConfig
                  )

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -72,7 +72,7 @@ test-suite chairman-tests
                       , cardano-crypto-class ^>= 2.1
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.5.1
+                      , hedgehog-extras ^>= 0.4.7.0
                       , network
                       , process
                       , random

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -88,5 +88,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.2
+                      , cardano-cli:cardano-cli ^>= 8.3
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -234,7 +234,7 @@ test-suite cardano-node-test
                       , aeson >= 1.5.6.0
                       , bytestring
                       , cardano-crypto-class
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-slotting >= 0.1

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -234,7 +234,7 @@ test-suite cardano-node-test
                       , aeson >= 1.5.6.0
                       , bytestring
                       , cardano-crypto-class
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-slotting >= 0.1

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -150,7 +150,7 @@ library
                       , cardano-ledger-core
                       , cardano-ledger-shelley
                       , cardano-prelude
-                      , cardano-protocol-tpraos >= 1.0.2
+                      , cardano-protocol-tpraos >= 1.0.3.1
                       , cardano-slotting >= 0.1.1
                       , cborg ^>= 0.2.4
                       , containers

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -175,8 +175,8 @@ library
                       , network-mux >= 0.4
                       , nothunks
                       , optparse-applicative-fork
-                      , ouroboros-consensus >= 0.6
-                      , ouroboros-consensus-cardano >= 0.5
+                      , ouroboros-consensus >= 0.9
+                      , ouroboros-consensus-cardano >= 0.7
                       , ouroboros-consensus-diffusion >= 0.7
                       , ouroboros-consensus-protocol >= 0.5
                       , ouroboros-network-api
@@ -235,7 +235,7 @@ test-suite cardano-node-test
                       , aeson >= 1.5.6.0
                       , bytestring
                       , cardano-crypto-class
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-slotting >= 0.1
@@ -246,10 +246,10 @@ test-suite cardano-node-test
                       , hedgehog-extras
                       , iproute
                       , mtl
-                      , ouroboros-consensus
+                      , ouroboros-consensus >= 0.9
                       , ouroboros-consensus-cardano
                       , ouroboros-consensus-diffusion >= 0.7
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.1.1
                       , ouroboros-network-api
                       , text >= 2.0
                       , time

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -143,6 +143,7 @@ library
                       , cardano-git-rev
                       , cardano-ledger-alonzo
                       , cardano-ledger-allegra
+                      , cardano-ledger-api
                       , cardano-ledger-babbage
                       , cardano-ledger-byron
                       , cardano-ledger-conway

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -177,7 +177,7 @@ library
                       , optparse-applicative-fork
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5
-                      , ouroboros-consensus-diffusion >= 0.5.1
+                      , ouroboros-consensus-diffusion >= 0.7
                       , ouroboros-consensus-protocol >= 0.5
                       , ouroboros-network-api
                       , ouroboros-network ^>= 0.8.1.1
@@ -191,7 +191,7 @@ library
                       , si-timers
                       , stm
                       , strict-stm
-                      , text
+                      , text >= 2.0
                       , time
                       , trace-dispatcher ^>= 2.0
                       , trace-forward ^>= 2.0
@@ -222,7 +222,7 @@ executable cardano-node
                       , cardano-git-rev
                       , cardano-node
                       , optparse-applicative-fork
-                      , text
+                      , text >= 2.0
 
 test-suite cardano-node-test
   import:               project-config
@@ -248,10 +248,10 @@ test-suite cardano-node-test
                       , mtl
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano
-                      , ouroboros-consensus-diffusion
+                      , ouroboros-consensus-diffusion >= 0.7
                       , ouroboros-network ^>= 0.8.1.0
                       , ouroboros-network-api
-                      , text
+                      , text >= 2.0
                       , time
                       , transformers
                       , vector

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Configuration.Logging
   ( LoggingLayer (..)
@@ -329,7 +330,7 @@ nodeBasicInfo :: NodeConfiguration
               -> IO [LogObject Text]
 nodeBasicInfo nc (SomeConsensusProtocol whichP pForInfo) nodeStartTime' = do
   meta <- mkLOMeta Notice Public
-  let cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  let cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
       protocolDependentItems =
         case whichP of
           Api.ByronBlockType ->

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -87,6 +87,8 @@ data NodeConfiguration
        , ncValidateDB      :: !Bool
        , ncShutdownConfig  :: !ShutdownConfig
 
+       , ncStartAsNonProducingNode :: !Bool
+
         -- Protocol-specific parameters:
        , ncProtocolConfig :: !NodeProtocolConfiguration
 
@@ -158,6 +160,8 @@ data PartialNodeConfiguration
        , pncProtocolFiles   :: !(Last ProtocolFilepaths)
        , pncValidateDB      :: !(Last Bool)
        , pncShutdownConfig  :: !(Last ShutdownConfig)
+
+       , pncStartAsNonProducingNode :: !(Last Bool)
 
          -- Protocol-specific parameters:
        , pncProtocolConfig :: !(Last NodeProtocolConfiguration)
@@ -309,6 +313,7 @@ instance FromJSON PartialNodeConfiguration where
            , pncProtocolFiles = mempty
            , pncValidateDB = mempty
            , pncShutdownConfig = mempty
+           , pncStartAsNonProducingNode = Last $ Just False
            , pncMaybeMempoolCapacityOverride
            , pncProtocolIdleTimeout
            , pncTimeWaitTimeout
@@ -466,6 +471,7 @@ defaultPartialNodeConfiguration =
     , pncProtocolFiles = mempty
     , pncValidateDB = Last $ Just False
     , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing Nothing
+    , pncStartAsNonProducingNode = Last $ Just False
     , pncProtocolConfig = mempty
     , pncMaxConcurrencyBulkSync = mempty
     , pncMaxConcurrencyDeadline = mempty
@@ -500,6 +506,7 @@ makeNodeConfiguration pnc = do
   topologyFile <- lastToEither "Missing TopologyFile" $ pncTopologyFile pnc
   databaseFile <- lastToEither "Missing DatabaseFile" $ pncDatabaseFile pnc
   validateDB <- lastToEither "Missing ValidateDB" $ pncValidateDB pnc
+  startAsNonProducingNode <- lastToEither "Missing StartAsNonProducingNode" $ pncStartAsNonProducingNode pnc
   protocolConfig <- lastToEither "Missing ProtocolConfig" $ pncProtocolConfig pnc
   loggingSwitch <- lastToEither "Missing LoggingSwitch" $ pncLoggingSwitch pnc
   logMetrics <- lastToEither "Missing LogMetrics" $ pncLogMetrics pnc
@@ -555,6 +562,7 @@ makeNodeConfiguration pnc = do
                    Nothing -> ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing Nothing
              , ncValidateDB = validateDB
              , ncShutdownConfig = shutdownConfig
+             , ncStartAsNonProducingNode = startAsNonProducingNode
              , ncProtocolConfig = protocolConfig
              , ncSocketConfig = socketConfig
              , ncDiffusionMode = diffusionMode

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -16,7 +16,6 @@ module Cardano.Node.Configuration.TopologyP2P
   , NodeHostIPv6Address(..)
   , NodeSetup(..)
   , PeerAdvertise(..)
-  , UseLedger(..)
   , nodeAddressToSockAddr
   , readTopologyFile
   , readTopologyFileOrError
@@ -27,7 +26,6 @@ where
 import           Control.Exception (IOException)
 import qualified Control.Exception as Exception
 import           Control.Exception.Base (Exception (..))
-import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
@@ -39,7 +37,6 @@ import           Data.Word (Word64)
 import           "contra-tracer" Control.Tracer (Tracer, traceWith)
 
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Cardano.Node.Configuration.NodeAddress
 import           Cardano.Node.Configuration.Topology (TopologyError (..))
@@ -49,26 +46,6 @@ import           Cardano.Node.Types
 import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
-
-
-
--- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
--- 'ToJSON' instances.
---
--- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
--- chain root peers.
---
-newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
-
-instance FromJSON UseLedger where
-  parseJSON (Data.Aeson.Number n) =
-    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
-              else return $ UseLedger   DontUseLedger
-  parseJSON _ = mzero
-
-instance ToJSON UseLedger where
-  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
-  toJSON (UseLedger DontUseLedger)               = Number (-1)
 
 data NodeSetup = NodeSetup
   { nodeId          :: !Word64

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -62,6 +62,7 @@ nodeRunParser = do
   shelleyVRFFile  <- optional parseVrfKeyFilePath
   shelleyCertFile <- optional parseOperationalCertFilePath
   shelleyBulkCredsFile <- optional parseBulkCredsFilePath
+  startAsNonProducingNode <- lastOption parseStartAsNonProducingNode
 
   -- Node Address
   nIPv4Address <- lastOption parseHostIPv4Addr
@@ -102,6 +103,7 @@ nodeRunParser = do
            , pncValidateDB = validate
            , pncShutdownConfig =
                Last . Just $ ShutdownConfig (getLast shutdownIPC) (getLast shutdownOnLimit)
+           , pncStartAsNonProducingNode = startAsNonProducingNode
            , pncProtocolConfig = mempty
            , pncMaxConcurrencyBulkSync = mempty
            , pncMaxConcurrencyDeadline = mempty
@@ -312,6 +314,14 @@ parseVrfKeyFilePath =
         <> help "Path to the VRF signing key."
         <> completer (bashCompleter "file")
     )
+
+parseStartAsNonProducingNode :: Parser Bool
+parseStartAsNonProducingNode =
+  switch (
+    long "start-as-non-producing-node"
+      <> help ("Start the node as a non block producing node even if "
+            ++ "credentials are specified.")
+  )
 
 -- TODO revisit because it sucks
 parseSnapshotInterval :: Parser SnapshotInterval

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -13,14 +13,15 @@ module Cardano.Node.Protocol.Types
 
 import qualified Cardano.Api as Api
 
-import           Control.DeepSeq (NFData)
-import           Data.Aeson
-import           GHC.Generics (Generic)
-import           NoThunks.Class (NoThunks)
-
 import           Cardano.Node.Orphans ()
 import           Cardano.Node.Queries (HasKESInfo, HasKESMetricsData)
 import           Cardano.Node.TraceConstraints (TraceConstraints)
+
+import           Control.DeepSeq (NFData)
+import           Data.Aeson
+import           GHC.Generics (Generic)
+
+import           NoThunks.Class (NoThunks)
 
 
 data Protocol = ByronProtocol

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -60,5 +60,5 @@ data SomeConsensusProtocol where
                                           , TraceConstraints blk
                                           )
                            => Api.BlockType blk
-                           -> Api.ProtocolInfoArgs IO blk
+                           -> Api.ProtocolInfoArgs blk
                            -> SomeConsensusProtocol

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -82,7 +82,7 @@ import           Ouroboros.Consensus.Util.Orphans ()
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
-import           Ouroboros.Network.NodeToNode (RemoteConnectionId, RemoteAddress)
+import           Ouroboros.Network.NodeToNode (RemoteAddress, RemoteConnectionId)
 
 --
 -- * TxId -> ByteString projection
@@ -249,7 +249,7 @@ instance LedgerQueries (Shelley.ShelleyBlock protocol era) where
     . Shelley.shelleyLedgerState
   ledgerDelegMapSize =
       UM.size
-    . UM.Delegations
+    . UM.SPoolUView
     . Shelley.dsUnified
     . Shelley.certDState
     . Shelley.lsCertState

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -402,6 +402,8 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
           , rnTraceNTC       = nodeToClientTracers tracers
           , rnProtocolInfo   = pInfo
           , rnNodeKernelHook = \registry nodeKernel -> do
+              -- set the initial block forging
+              snd (Api.protocolInfo runP) >>= setBlockForging nodeKernel
               maybeSpawnOnSlotSyncedShutdownHandler
                 (ncShutdownConfig nc)
                 (shutdownTracer tracers)

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -160,7 +160,7 @@ runNode cmdPc = do
     let networkMagic :: Api.NetworkMagic =
           case p of
             SomeConsensusProtocol _ runP ->
-              let ProtocolInfo { pInfoConfig } = Api.protocolInfo runP
+              let ProtocolInfo { pInfoConfig } = fst $ Api.protocolInfo @IO runP
               in getNetworkMagic $ Consensus.configBlock pInfoConfig
 
     case p of
@@ -193,13 +193,13 @@ handleNodeWithTracers
   -> NodeConfiguration
   -> SomeConsensusProtocol
   -> Api.NetworkMagic
-  -> Api.ProtocolInfoArgs IO blk
+  -> Api.ProtocolInfoArgs blk
   -> IO ()
 handleNodeWithTracers cmdPc nc p networkMagic runP = do
   -- This IORef contains node kernel structure which holds node kernel.
   -- Used for ledger queries and peer connection status.
   nodeKernelData <- mkNodeKernelData
-  let ProtocolInfo { pInfoConfig = cfg } = Api.protocolInfo runP
+  let ProtocolInfo { pInfoConfig = cfg } = fst $ Api.protocolInfo @IO runP
   case ncEnableP2P nc of
     SomeNetworkP2PMode p2pMode -> do
       let fp = maybe  "No file path found!"
@@ -325,7 +325,7 @@ handlePeersListSimple tr nodeKern = forever $ do
 
 handleSimpleNode
   :: forall blk p2p . Api.Protocol IO blk
-  => Api.ProtocolInfoArgs IO blk
+  => Api.ProtocolInfoArgs blk
   -> NetworkP2PMode p2p
   -> Tracers RemoteConnectionId LocalConnectionId blk p2p
   -> NodeConfiguration
@@ -344,7 +344,7 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
     traceWith (startupTracer tracers)
       StartupDBValidation
 
-  let pInfo = Api.protocolInfo runP
+  let pInfo = fst $ Api.protocolInfo @IO runP
 
   (publicIPv4SocketOrAddr, publicIPv6SocketOrAddr, localSocketOrPath) <- do
     result <- runExceptT (gatherConfiguredSockets $ ncSocketConfig nc)

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -49,6 +49,7 @@ import           Cardano.Logging
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import           Cardano.Node.Protocol (ProtocolInstantiationError)
 
 import           Cardano.Git.Rev (gitRev)
 import           Paths_cardano_node (version)
@@ -76,6 +77,17 @@ data StartupTrace blk =
   | StartupSocketConfigError SocketConfigError
 
   | StartupDBValidation
+
+  -- | Log that the block forging is being updated
+  | BlockForgingUpdate
+
+  -- | Protocol instantiation error when updating block forging
+  | BlockForgingUpdateError ProtocolInstantiationError
+
+  -- | Mismatched block type
+  | BlockForgingBlockTypeMismatch
+       Api.SomeBlockType -- ^ expected
+       Api.SomeBlockType -- ^ provided
 
   -- | Log that the network configuration is being updated.
   --

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Startup where
 
@@ -199,7 +200,7 @@ prepareNodeInfo nc (SomeConsensusProtocol whichP pForInfo) tc nodeStartTime = do
     , niSystemStartTime = systemStartTime
     }
  where
-  cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
 
   systemStartTime :: UTCTime
   systemStartTime =

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -79,7 +79,7 @@ data StartupTrace blk =
   | StartupDBValidation
 
   -- | Log that the block forging is being updated
-  | BlockForgingUpdate
+  | BlockForgingUpdate EnabledBlockForging
 
   -- | Protocol instantiation error when updating block forging
   | BlockForgingUpdateError ProtocolInstantiationError
@@ -133,7 +133,9 @@ data StartupTrace blk =
   | BIByron BasicInfoByron
   | BINetwork BasicInfoNetwork
 
-
+data EnabledBlockForging = EnabledBlockForging
+                         | DisabledBlockForging
+                         deriving (Eq, Show)
 
 data BasicInfoCommon = BasicInfoCommon {
     biConfigPath    :: FilePath

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -19,12 +19,10 @@ import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerError)
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent, LedgerUpdate, LedgerWarning)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, HasTxId, HasTxs (..))
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                   (HasNetworkProtocolVersion (BlockNodeToClientVersion, BlockNodeToNodeVersion))
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion (
-                   HasNetworkProtocolVersion(BlockNodeToClientVersion, BlockNodeToNodeVersion))
-
-
 
 -- | Tracing-related constraints for monitoring purposes.
 type TraceConstraints blk =

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -2,17 +2,19 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
 module Cardano.Node.TraceConstraints (TraceConstraints) where
 
 
-import           Data.Aeson
-
 import           Cardano.BM.Tracing (ToObject)
+import           Cardano.Ledger.Credential
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Ledger.Keys
 import           Cardano.Logging (LogFormatting)
 import           Cardano.Node.Queries (ConvertTxId, GetKESInfo (..), HasKESInfo (..),
                    HasKESMetricsData (..), LedgerQueries)
 import           Cardano.Tracing.HasIssuer (HasIssuer)
-
 import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateUpdateError,
                    Header)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
@@ -23,6 +25,9 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                    (HasNetworkProtocolVersion (BlockNodeToClientVersion, BlockNodeToNodeVersion))
 import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
+
+import           Data.Aeson
+import           Data.Set
 
 -- | Tracing-related constraints for monitoring purposes.
 type TraceConstraints blk =
@@ -60,5 +65,5 @@ type TraceConstraints blk =
     , LogFormatting (ValidationErr (BlockProtocol blk))
     , LogFormatting (CannotForge blk)
     , LogFormatting (ForgeStateUpdateError blk)
-
+    , LogFormatting (Set (Credential 'Staking StandardCrypto))
     )

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -1006,10 +1006,10 @@ instance ( ShelleyBasedEra era
       --   , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXOW" era))
          , LogFormatting (PredicateFailure (Core.EraRule "TALLY" era))
-         , LogFormatting (PredicateFailure (Ledger.EraRule "CERTS" era))
+        -- , LogFormatting (PredicateFailure (Ledger.EraRule "CERTS" era))
          ) => LogFormatting (Conway.ConwayLedgerPredFailure era) where
   forMachine v (Conway.ConwayUtxowFailure f) = forMachine v f
-  forMachine v (Conway.ConwayCertsFailure f) = forMachine v f
+  forMachine _v (Conway.ConwayCertsFailure _f) = error "TODO: Conway era" --forMachine v f
   forMachine v (Conway.ConwayTallyFailure f) = forMachine v f
 
 instance ( ShelleyBasedEra era

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -248,11 +248,11 @@ instance ( ShelleyBasedEra era
          , ToJSON (Core.AuxiliaryDataHash (Ledger.EraCrypto era))
          , LogFormatting (PredicateFailure (ShelleyUTXO era))
          , LogFormatting (PredicateFailure (ShelleyUTXOW era))
-         , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
+      --   , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXOW" era))
          ) => LogFormatting (ShelleyLedgerPredFailure era) where
   forMachine dtal (UtxowFailure f)  = forMachine dtal f
-  forMachine dtal (DelegsFailure f) = forMachine dtal f
+  forMachine _dtal (DelegsFailure _f) = error "TODO" -- forMachine dtal f
 
 instance ( ShelleyBasedEra era
          , Ledger.EraCrypto era ~ StandardCrypto
@@ -1003,7 +1003,7 @@ instance ( Ledger.Era era
 --------------------------------------------------------------------------------
 
 instance ( ShelleyBasedEra era
-         , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
+      --   , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXOW" era))
          , LogFormatting (PredicateFailure (Core.EraRule "TALLY" era))
          , LogFormatting (PredicateFailure (Ledger.EraRule "CERTS" era))

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -261,9 +261,9 @@ instance ( ShelleyBasedEra era
          ) => LogFormatting (AlonzoUtxowPredFailure era) where
   forMachine dtal (ShelleyInAlonzoUtxowPredFailure utxoPredFail) =
     forMachine dtal utxoPredFail
-  forMachine _ (MissingRedeemers scripts) =
+  forMachine _ (MissingRedeemers _scripts) =
     mconcat [ "kind" .= String "MissingRedeemers"
-             , "scripts" .= renderMissingRedeemers scripts
+             , "scripts" .= String "TODO: Conway era" -- TODO: Conway era - need to parameterize renderMissingRedeemers over the era
              ]
   forMachine _ (MissingRequiredDatums required received) =
     mconcat [ "kind" .= String "MissingRequiredDatums"
@@ -303,25 +303,25 @@ renderScriptIntegrityHash (Just witPPDataHash) =
   Aeson.String . Crypto.hashToTextAsHex $ SafeHash.extractHash witPPDataHash
 renderScriptIntegrityHash Nothing = Aeson.Null
 
-renderScriptHash :: ScriptHash StandardCrypto -> Text
-renderScriptHash = Api.serialiseToRawBytesHexText . Api.fromShelleyScriptHash
+_renderScriptHash :: ScriptHash StandardCrypto -> Text
+_renderScriptHash = Api.serialiseToRawBytesHexText . Api.fromShelleyScriptHash
 
-renderMissingRedeemers :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto)] -> Aeson.Value
-renderMissingRedeemers scripts = Aeson.object $ map renderTuple  scripts
+_renderMissingRedeemers :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto)] -> Aeson.Value
+_renderMissingRedeemers scripts = Aeson.object $ map renderTuple  scripts
  where
   renderTuple :: (Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto) -> Aeson.Pair
   renderTuple (scriptPurpose, sHash) =
-    Aeson.fromText (renderScriptHash sHash) .= renderScriptPurpose scriptPurpose
+    Aeson.fromText (_renderScriptHash sHash) .= _renderScriptPurpose scriptPurpose
 
-renderScriptPurpose :: Alonzo.ScriptPurpose StandardCrypto -> Aeson.Value
-renderScriptPurpose (Alonzo.Minting pid) =
-  Aeson.object [ "minting" .= toJSON pid]
-renderScriptPurpose (Alonzo.Spending txin) =
-  Aeson.object [ "spending" .= Api.fromShelleyTxIn txin]
-renderScriptPurpose (Alonzo.Rewarding rwdAcct) =
-  Aeson.object [ "rewarding" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
-renderScriptPurpose (Alonzo.Certifying cert) =
-  Aeson.object [ "certifying" .= toJSON (Api.textEnvelopeDefaultDescr $ Api.fromShelleyCertificate cert)]
+_renderScriptPurpose :: Alonzo.ScriptPurpose StandardCrypto -> Aeson.Value
+_renderScriptPurpose (Alonzo.Minting _pid) =
+  Aeson.object [ "minting" .= String "TODO: Conway era" ] -- toJSON pid
+_renderScriptPurpose (Alonzo.Spending _txin) =
+  Aeson.object [ "spending" .= String "TODO: Conway era" ] -- Api.fromShelleyTxIn txin
+_renderScriptPurpose (Alonzo.Rewarding _rwdAcct) =
+  Aeson.object [ "rewarding" .= String "TODO: Conway era"] -- Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)
+_renderScriptPurpose (Alonzo.Certifying _cert) =
+  Aeson.object [ "certifying" .= String "TODO: Conway era" ] -- toJSON (Api.textEnvelopeDefaultDescr $ Api.fromShelleyCertificate cert)
 
 
 instance ( ShelleyBasedEra era
@@ -527,7 +527,7 @@ instance ( ShelleyBasedEra era
              , "targetPool" .= targetPool
              ]
   forMachine _dtal (WithdrawalsNotInRewardsDELEGS incorrectWithdrawals) =
-    mconcat [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
+    mconcat [ "kind" .= String "WithdrawalsNotInRewardsCERTS"
              , "incorrectWithdrawals" .= incorrectWithdrawals
              ]
   forMachine dtal (DelplFailure f) = forMachine dtal f
@@ -644,23 +644,6 @@ instance LogFormatting (ShelleyPoolPredFailure era) where
              , "poolID" .= String (textShow hashSize)
              , "error" .= String "The stake pool metadata hash is too large"
              ]
-
--- Apparently this should never happen according to the Shelley exec spec
-  forMachine _dtal (WrongCertificateTypePOOL index) =
-    case index of
-      0 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
-                    , "error" .= String "Wrong certificate type: Delegation certificate"
-                    ]
-      1 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
-                    , "error" .= String "Wrong certificate type: MIR certificate"
-                    ]
-      2 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
-                    , "error" .= String "Wrong certificate type: Genesis certificate"
-                    ]
-      k -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
-                    , "certificateType" .= k
-                    , "error" .= String "Wrong certificate type: Unknown certificate type"
-                    ]
 
   forMachine _dtal (WrongNetworkPOOL networkId listedNetworkId poolId) =
     mconcat [ "kind" .= String "WrongNetworkPOOL"
@@ -955,9 +938,9 @@ instance ( ToJSON (Alonzo.CollectError (Ledger.EraCrypto era))
              , "isvalidating" .= isValidating
              , "reason" .= reason
              ]
-  forMachine _ (Alonzo.CollectErrors errors) =
+  forMachine _ (Alonzo.CollectErrors _errors) =
     mconcat [ "kind" .= String "CollectErrors"
-             , "errors" .= errors
+             , "errors" .= String "TODO: Conway era" --errors
              ]
   forMachine dtal (Alonzo.UpdateFailure pFailure) =
     forMachine dtal pFailure
@@ -1023,9 +1006,10 @@ instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Core.EraRule "DELEGS" era))
          , LogFormatting (PredicateFailure (Core.EraRule "UTXOW" era))
          , LogFormatting (PredicateFailure (Core.EraRule "TALLY" era))
+         , LogFormatting (PredicateFailure (Ledger.EraRule "CERTS" era))
          ) => LogFormatting (Conway.ConwayLedgerPredFailure era) where
   forMachine v (Conway.ConwayUtxowFailure f) = forMachine v f
-  forMachine v (Conway.ConwayDelegsFailure f) = forMachine v f
+  forMachine v (Conway.ConwayCertsFailure f) = forMachine v f
   forMachine v (Conway.ConwayTallyFailure f) = forMachine v f
 
 instance ( ShelleyBasedEra era
@@ -1042,13 +1026,13 @@ instance ( ShelleyBasedEra era
 
 instance ( ShelleyBasedEra era
          , LogFormatting (PredicateFailure (Ledger.EraRule "CERT" era))
-         ) => LogFormatting (Conway.ConwayDelegsPredFailure era) where
+         ) => LogFormatting (Conway.ConwayCertsPredFailure era) where
   forMachine _ (Conway.DelegateeNotRegisteredDELEG poolID) =
     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
             , "poolID" .= String (textShow poolID)
             ]
-  forMachine _ (Conway.WithdrawalsNotInRewardsDELEGS rs) =
-    mconcat [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
+  forMachine _ (Conway.WithdrawalsNotInRewardsCERTS rs) =
+    mconcat [ "kind" .= String "WithdrawalsNotInRewardsCERTS"
              , "rewardAccounts" .= rs
             ]
   forMachine dtal (Conway.CertFailure certFailure) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -15,7 +15,7 @@ import           Data.Text (pack)
 import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
-import           Cardano.Node.Configuration.TopologyP2P (UseLedger (..))
+import           Cardano.Node.Types (UseLedger(..))
 
 import qualified Data.List as List
 import qualified Ouroboros.Network.Diffusion as ND

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing -Wno-orphans #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Node.Tracing.Tracers.Startup
 
@@ -68,7 +69,7 @@ getStartupInfo
   -> IO [StartupTrace blk]
 getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
   nodeStartTime <- getCurrentTime
-  let cfg = pInfoConfig $ Api.protocolInfo pForInfo
+  let cfg = pInfoConfig $ fst $ Api.protocolInfo @IO pForInfo
       basicInfoCommon = BICommon $ BasicInfoCommon {
                 biProtocol = pack . show $ ncProtocol nc
               , biVersion  = pack . showVersion $ version

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -17,6 +17,7 @@ module Cardano.Node.Types
   , MaxConcurrencyBulkSync(..)
   , MaxConcurrencyDeadline(..)
     -- * Networking
+  , UseLedger(..)
   , TopologyFile(..)
   , NodeDiffusionMode (..)
     -- * Consensus protocol configuration
@@ -38,6 +39,8 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word16, Word8)
 
+import           Control.Monad (MonadPlus (..))
+
 import           Cardano.Api
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
@@ -46,6 +49,7 @@ import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 --TODO: things will probably be clearer if we don't use these newtype wrappers and instead
 -- use records with named fields in the CLI code.
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
 -- | Errors for the cardano-config module.
 data ConfigError =
@@ -273,6 +277,25 @@ data NodeHardForkProtocolConfiguration =
      , npcTestConwayHardForkAtVersion       :: Maybe Word
      }
   deriving (Eq, Show)
+
+-- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
+-- 'ToJSON' instances.
+--
+-- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
+-- chain root peers.
+--
+newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
+
+instance FromJSON UseLedger where
+  parseJSON (Data.Aeson.Number n) =
+    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
+              else return $ UseLedger   DontUseLedger
+  parseJSON _ = mzero
+
+instance ToJSON UseLedger where
+  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
+  toJSON (UseLedger DontUseLedger)               = Number (-1)
+
 
 newtype TopologyFile = TopologyFile
   { unTopology :: FilePath }

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -39,8 +39,8 @@ import           Network.TypedProtocol.Core (PeerHasAgency (..))
 import           Network.Mux (MiniProtocolNum (..), MuxTrace (..), WithMuxBearer (..))
 import           Network.Socket (SockAddr (..))
 
-import           Cardano.Node.Configuration.TopologyP2P (UseLedger (..))
 import           Cardano.Node.Queries (ConvertTxId)
+import           Cardano.Node.Types (UseLedger(..))
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.Render
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -85,6 +85,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 
 
+
 {- HLINT ignore "Use :" -}
 
 --

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -239,14 +239,14 @@ instance ( ShelleyBasedEra era
 instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (ShelleyUTXO era))
          , ToObject (PredicateFailure (ShelleyUTXOW era))
-         , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
+     --    , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
          , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
          ) => ToObject (ShelleyLedgerPredFailure era) where
   toObject verb (UtxowFailure f) = toObject verb f
   toObject verb (DelegsFailure f) = toObject verb f
 
 instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
+        -- , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
          , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
          , ToObject (PredicateFailure (Core.EraRule "TALLY" era))
          , ToObject (PredicateFailure (Ledger.EraRule "CERTS" era))
@@ -791,8 +791,6 @@ instance Core.Crypto crypto => ToObject (OverlayPredicateFailure crypto) where
              , "actual" .= actual
              , "expected" .= expected ]
   toObject verb (OcertFailure f) = toObject verb f
-
---instance ToObject (PredicateFailure (Core.EraRule "DELEGS" (Ledger.ConwayEra Ledger.StandardCrypto))) where
 
 
 instance ToObject (OcertPredicateFailure crypto) where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -243,16 +243,16 @@ instance ( ShelleyBasedEra era
          , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
          ) => ToObject (ShelleyLedgerPredFailure era) where
   toObject verb (UtxowFailure f) = toObject verb f
-  toObject verb (DelegsFailure f) = toObject verb f
+  toObject _verb (DelegsFailure _f) = error "TODO: Conway era" --toObject verb f
 
 instance ( ShelleyBasedEra era
         -- , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
          , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
          , ToObject (PredicateFailure (Core.EraRule "TALLY" era))
-         , ToObject (PredicateFailure (Ledger.EraRule "CERTS" era))
+       --  , ToObject (PredicateFailure (Ledger.EraRule "CERTS" era))
          ) => ToObject (Conway.ConwayLedgerPredFailure era) where
   toObject verb (Conway.ConwayUtxowFailure f) = toObject verb f
-  toObject verb (Conway.ConwayCertsFailure f) = toObject verb f
+  toObject _verb (Conway.ConwayCertsFailure _f) = error "TODO: Conway era" -- toObject verb f
   toObject verb (Conway.ConwayTallyFailure f) = toObject verb f
 
 instance ( ShelleyBasedEra era

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
@@ -5,17 +6,74 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans  #-}
 
 module Cardano.Tracing.OrphanInstances.Shelley () where
+
+import           Cardano.Api (textShow)
+import qualified Cardano.Api as Api
+import qualified Cardano.Api.Shelley as Api
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
+import qualified Cardano.Ledger.Allegra.Rules as Allegra
+import qualified Cardano.Ledger.Allegra.Scripts as Allegra
+import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
+import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure (..), AlonzoUtxoPredFailure,
+                   AlonzoUtxosPredFailure, AlonzoUtxowPredFailure (..))
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
+import qualified Cardano.Ledger.Api as Ledger
+import           Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
+import           Cardano.Ledger.BaseTypes (activeSlotLog, strictMaybeToMaybe)
+import           Cardano.Ledger.Chain
+import           Cardano.Ledger.Conway.Governance (govActionIdToText)
+import           Cardano.Ledger.Conway.Rules ()
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Core as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Crypto as Core
+import qualified Cardano.Ledger.SafeHash as SafeHash
+import           Cardano.Ledger.Shelley.API
+import           Cardano.Ledger.Shelley.Rules
+import           Cardano.Node.Tracing.Tracers.KESInfo ()
+import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
+import           Cardano.Protocol.TPraos.BHeader (LastAppliedBlock, labBlockNo)
+import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
+import           Cardano.Protocol.TPraos.Rules.OCert
+import           Cardano.Protocol.TPraos.Rules.Overlay
+import           Cardano.Protocol.TPraos.Rules.Prtcl
+import           Cardano.Protocol.TPraos.Rules.Tickn
+import           Cardano.Protocol.TPraos.Rules.Updn
+import           Cardano.Slotting.Block (BlockNo (..))
+import           Cardano.Tracing.OrphanInstances.Common
+import           Cardano.Tracing.OrphanInstances.Consensus ()
+import           Cardano.Tracing.Render (renderTxId)
+import qualified Ouroboros.Consensus.Cardano.Block as Consensus
+import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as SupportsMempool
+import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
+import qualified Ouroboros.Consensus.Protocol.Praos as Praos
+import           Ouroboros.Consensus.Protocol.TPraos (TPraosCannotForge (..))
+import           Ouroboros.Consensus.Shelley.Ledger hiding (TxId)
+import           Ouroboros.Consensus.Shelley.Ledger.Inspect
+import qualified Ouroboros.Consensus.Shelley.Protocol.Praos as Praos
+import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockNo, blockSlot)
+import           Ouroboros.Network.Point (WithOrigin, withOriginToMaybe)
 
 import           Data.Aeson (Value (..), object)
 import qualified Data.Aeson as Aeson
@@ -26,64 +84,6 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
-import           Cardano.Api (textShow)
-import qualified Cardano.Api as Api
-import qualified Cardano.Api.Shelley as Api
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import           Cardano.Node.Tracing.Tracers.KESInfo ()
-import           Cardano.Slotting.Block (BlockNo (..))
-import           Cardano.Tracing.OrphanInstances.Common
-import           Cardano.Tracing.OrphanInstances.Consensus ()
-import           Cardano.Tracing.Render (renderTxId)
-
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import qualified Ouroboros.Consensus.Ledger.SupportsMempool as SupportsMempool
-import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockNo, blockSlot)
-import           Ouroboros.Network.Point (WithOrigin, withOriginToMaybe)
-
-import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
-import qualified Ouroboros.Consensus.Protocol.Praos as Praos
-import           Ouroboros.Consensus.Protocol.TPraos (TPraosCannotForge (..))
-import           Ouroboros.Consensus.Shelley.Ledger hiding (TxId)
-import           Ouroboros.Consensus.Shelley.Ledger.Inspect
-import qualified Ouroboros.Consensus.Shelley.Protocol.Praos as Praos
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.Allegra.Scripts as Allegra
-import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
-import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
-import qualified Cardano.Ledger.Api as Ledger
-import           Cardano.Ledger.BaseTypes (activeSlotLog, strictMaybeToMaybe)
-import           Cardano.Ledger.Chain
-import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Crypto as Core
-import qualified Cardano.Ledger.SafeHash as SafeHash
-import           Cardano.Protocol.TPraos.BHeader (LastAppliedBlock, labBlockNo)
-import           Cardano.Protocol.TPraos.Rules.OCert
-import           Cardano.Protocol.TPraos.Rules.Overlay
-import           Cardano.Protocol.TPraos.Rules.Tickn
-import           Cardano.Protocol.TPraos.Rules.Updn
-
--- TODO: this should be exposed via Cardano.Api
-import           Cardano.Ledger.Shelley.API
-
-import           Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import qualified Cardano.Ledger.Allegra.Rules as Allegra
-import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure (..), AlonzoUtxoPredFailure,
-                   AlonzoUtxosPredFailure, AlonzoUtxowPredFailure (..))
-import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import           Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
-import qualified Cardano.Ledger.Babbage.Rules as Babbage
-import           Cardano.Ledger.Conway.Governance (govActionIdToText)
-import qualified Cardano.Ledger.Conway.Rules as Conway
-import           Cardano.Ledger.Shelley.Rules
-import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
-import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
-import           Cardano.Protocol.TPraos.Rules.Prtcl
 
 {- HLINT ignore "Use :" -}
 
@@ -92,7 +92,9 @@ import           Cardano.Protocol.TPraos.Rules.Prtcl
 --
 -- NOTE: this list is sorted in roughly topological order.
 
-instance ShelleyBasedEra era => ToObject (GenTx (ShelleyBlock protocol era)) where
+instance
+  ( Consensus.ShelleyBasedEra ledgerera
+  ) => ToObject (GenTx (ShelleyBlock protocol ledgerera)) where
   toObject _ tx = mconcat [ "txid" .= Text.take 8 (renderTxId (txId tx)) ]
 
 instance ToJSON (SupportsMempool.TxId (GenTx (ShelleyBlock protocol era))) where
@@ -107,9 +109,9 @@ instance ShelleyCompatible protocol era => ToObject (Header (ShelleyBlock protoc
 --      , "delegate" .= condense (headerSignerVk h)
         ]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
-         ) => ToObject (ApplyTxError era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "LEDGER" ledgerera))
+  ) => ToObject (ApplyTxError ledgerera) where
   toObject verb (ApplyTxError predicateFailures) =
     mconcat $ map (toObject verb) predicateFailures
 
@@ -127,24 +129,43 @@ instance Core.Crypto crypto => ToObject (TPraosCannotForge crypto) where
       , "actual" .= coreNodeVRFHash
       ]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Ledger.EraRule "BBODY" era))
-         ) => ToObject (ShelleyLedgerError era) where
+instance
+  ( ToObject (PredicateFailure (Ledger.EraRule "BBODY" ledgerera))
+  ) => ToObject (ShelleyLedgerError ledgerera) where
   toObject verb (BBodyError (BlockTransitionError fs)) =
     mconcat [ "kind" .= String "BBodyError"
              , "failures" .= map (toObject verb) fs
              ]
 
-instance ( ShelleyBasedEra era
-         , ToJSON (Ledger.PParamsUpdate era)
-         ) => ToObject (ShelleyLedgerUpdate era) where
+instance
+  ( Ledger.Era ledgerera
+  , ToJSON (Ledger.PParamsUpdate ledgerera)
+  ) => ToObject (ShelleyLedgerUpdate ledgerera) where
   toObject verb (ShelleyUpdatedProtocolUpdates updates) =
     mconcat [ "kind" .= String "ShelleyUpdatedProtocolUpdates"
              , "updates" .= map (toObject verb) updates
              ]
+instance  
+  ( Show (PredicateFailure (Ledger.EraRule "DELEG" era))
+  , Show (PredicateFailure (Ledger.EraRule "POOL" era))
+  , Show (PredicateFailure (Ledger.EraRule "VDEL" era))
+  ) => ToObject (Conway.ConwayCertPredFailure era) where
+  toObject _verb cfail =
+    mconcat [ "kind" .= String "ConwayCertPredFailure"
+            , "failure" .= show cfail -- TODO: Conway era - render in a nicer way
+            ]
 
-instance (Ledger.Era era, ToJSON (Ledger.PParamsUpdate era))
-         => ToObject (ProtocolUpdate era) where
+instance ToObject (Set (Credential 'Staking StandardCrypto)) where
+  toObject _verb creds =
+    mconcat [ "kind" .= String "StakeCreds"
+             , "stakeCreds" .= map show (Set.toList creds) -- TODO: Conway era - render in a nicer way
+             ]
+
+
+instance
+  ( Ledger.Era ledgerera
+  , ToJSON (Ledger.PParamsUpdate ledgerera)
+  ) => ToObject (ProtocolUpdate ledgerera) where
   toObject verb ProtocolUpdate{protocolUpdateProposal, protocolUpdateState} =
     mconcat [ "proposal" .= toObject verb protocolUpdateProposal
              , "state"    .= toObject verb protocolUpdateState
@@ -212,9 +233,9 @@ instance ToObject (PrtlSeqFailure crypto) where
              , "currentBlockHash" .= String (textShow currentHash)
              ]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Ledger.EraRule "LEDGERS" era))
-         ) => ToObject (ShelleyBbodyPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Ledger.EraRule "LEDGERS" ledgerera))
+  ) => ToObject (ShelleyBbodyPredFailure ledgerera) where
   toObject _verb (WrongBlockBodySizeBBODY actualBodySz claimedBodySz) =
     mconcat [ "kind" .= String "WrongBlockBodySizeBBODY"
              , "actualBlockBodySize" .= actualBodySz
@@ -228,64 +249,67 @@ instance ( ShelleyBasedEra era
   toObject verb (LedgersFailure f) = toObject verb f
 
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (ShelleyUTXO era))
-         , ToObject (PredicateFailure (ShelleyUTXOW era))
-         , ToObject (PredicateFailure (Core.EraRule "LEDGER" era))
-         ) => ToObject (ShelleyLedgersPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (ShelleyUTXO ledgerera))
+  , ToObject (PredicateFailure (ShelleyUTXOW ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "LEDGER" ledgerera))
+  ) => ToObject (ShelleyLedgersPredFailure ledgerera) where
   toObject verb (LedgerFailure f) = toObject verb f
 
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (ShelleyUTXO era))
-         , ToObject (PredicateFailure (ShelleyUTXOW era))
-     --    , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
-         , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
-         ) => ToObject (ShelleyLedgerPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (ShelleyUTXO ledgerera))
+  , ToObject (PredicateFailure (ShelleyUTXOW ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "DELEGS" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "UTXOW" ledgerera))
+  ) => ToObject (ShelleyLedgerPredFailure ledgerera) where
   toObject verb (UtxowFailure f) = toObject verb f
   toObject _verb (DelegsFailure _f) = error "TODO: Conway era" --toObject verb f
 
-instance ( ShelleyBasedEra era
-        -- , ToObject (PredicateFailure (Core.EraRule "DELEGS" era))
-         , ToObject (PredicateFailure (Core.EraRule "UTXOW" era))
-         , ToObject (PredicateFailure (Core.EraRule "TALLY" era))
-       --  , ToObject (PredicateFailure (Ledger.EraRule "CERTS" era))
-         ) => ToObject (Conway.ConwayLedgerPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "CERTS" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "UTXOW" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "TALLY" ledgerera))
+  , ToObject (Set (Credential 'Staking (Consensus.EraCrypto ledgerera)))
+  ) => ToObject (Conway.ConwayLedgerPredFailure ledgerera) where
   toObject verb (Conway.ConwayUtxowFailure f) = toObject verb f
-  toObject _verb (Conway.ConwayCertsFailure _f) = error "TODO: Conway era" -- toObject verb f
+  toObject verb (Conway.ConwayCertsFailure f) = toObject verb f
   toObject verb (Conway.ConwayTallyFailure f) = toObject verb f
+  toObject verb (Conway.ConwayWdrlNotDelegatedToDRep f) = toObject verb f
 
-instance ( ShelleyBasedEra era
-         ) => ToObject (Conway.ConwayTallyPredFailure era) where
-  toObject _ (Conway.VoterDoesNotHaveRole credential voteRole) =
-    mconcat [ "kind" .= String "VoterDoesNotHaveRole"
-            , "credential" .= textShow credential
-            , "voteRole" .= textShow voteRole
-            ]
+
+instance ToObject (Conway.ConwayTallyPredFailure era) where
   toObject _ (Conway.GovernanceActionDoesNotExist govActionId) =
     mconcat [ "kind" .= String "GovernanceActionDoesNotExist"
             , "govActionId" .= govActionIdToText govActionId
             ]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Ledger.EraRule "CERT" era))
-         ) => ToObject (Conway.ConwayCertsPredFailure era) where
-  toObject _ (Conway.DelegateeNotRegisteredDELEG poolID) =
-    mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
-             , "poolID" .= String (textShow poolID)
-            ]
-  toObject _ (Conway.WithdrawalsNotInRewardsCERTS rs) =
-    mconcat [ "kind" .= String "WithdrawalsNotInRewardsCERTS"
-             , "rewardAccounts" .= rs
-            ]
-  toObject v (Conway.CertFailure certFailure) =
-    toObject v certFailure
+  -- TODO: Implement
+instance ToObject (Conway.ConwayCertsPredFailure era) where
+  toObject _ _ = mempty
 
-instance ( ShelleyBasedEra era
-         , ToObject (PPUPPredFailure era)
-         , ToObject (PredicateFailure (Ledger.EraRule "UTXO" era))
-         , Ledger.EraCrypto era ~ StandardCrypto
-         ) => ToObject (AlonzoUtxowPredFailure era) where
+-- instance
+--   ( ToObject (PredicateFailure (Ledger.EraRule "CERT" ledgerera))
+--   ) => ToObject (Conway.ConwayDelegsPredFailure ledgerera) where
+--   toObject _ (Conway.DelegateeNotRegisteredDELEG poolID) =
+--     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
+--              , "poolID" .= String (textShow poolID)
+--             ]
+--   toObject _ (Conway.WithdrawalsNotInRewardsDELEGS rs) =
+--     mconcat [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
+--              , "rewardAccounts" .= rs
+--             ]
+--   toObject v (Conway.CertFailure certFailure) =
+--     toObject v certFailure
+
+instance
+  ( ToObject (PPUPPredFailure ledgerera)
+  , ToObject (PredicateFailure (Ledger.EraRule "UTXO" ledgerera))
+  , Ledger.EraCrypto ledgerera ~ StandardCrypto
+  , Show (Ledger.Value ledgerera)
+  , ToJSON (Ledger.Value ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  ) => ToObject (AlonzoUtxowPredFailure ledgerera) where
   toObject v (ShelleyInAlonzoUtxowPredFailure utxoPredFail) =
     toObject v utxoPredFail
   toObject _ (MissingRedeemers _scripts) =
@@ -328,30 +352,44 @@ renderScriptIntegrityHash (Just witPPDataHash) =
   Aeson.String . Crypto.hashToTextAsHex $ SafeHash.extractHash witPPDataHash
 renderScriptIntegrityHash Nothing = Aeson.Null
 
-_renderScriptHash :: ScriptHash StandardCrypto -> Text
-_renderScriptHash = Api.serialiseToRawBytesHexText . Api.fromShelleyScriptHash
 
-_renderMissingRedeemers :: [(Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto)] -> Aeson.Value
+_renderMissingRedeemers :: ()
+  => Ledger.EraCrypto ledgerera ~ StandardCrypto
+  => [(Alonzo.ScriptPurpose ledgerera, ScriptHash StandardCrypto)]
+  -> Aeson.Value
 _renderMissingRedeemers scripts = Aeson.object $ map renderTuple  scripts
- where
-  renderTuple :: (Alonzo.ScriptPurpose StandardCrypto, ScriptHash StandardCrypto) -> Aeson.Pair
-  renderTuple (scriptPurpose, sHash) =
-    Aeson.fromText (_renderScriptHash sHash) .= _renderScriptPurpose scriptPurpose
+  where
+    renderTuple :: ()
+      => Ledger.EraCrypto ledgerera ~ StandardCrypto
+      => (Alonzo.ScriptPurpose ledgerera, ScriptHash StandardCrypto)
+      -> Aeson.Pair
+    renderTuple (scriptPurpose, sHash) =
+      Aeson.fromText (renderScriptHash sHash) .= renderScriptPurpose scriptPurpose
 
-_renderScriptPurpose :: Alonzo.ScriptPurpose StandardCrypto -> Aeson.Value
-_renderScriptPurpose (Alonzo.Minting _pid) =
-  Aeson.object [ "minting" .= String "TODO: Conway era" ] -- toJSON pid
-_renderScriptPurpose (Alonzo.Spending _txin) =
-  Aeson.object [ "spending" .= String "TODO: Conway era" ] -- Api.fromShelleyTxIn txin
-_renderScriptPurpose (Alonzo.Rewarding _rwdAcct) =
-  Aeson.object [ "rewarding" .= String "TODO: Conway era" ] -- Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)
-_renderScriptPurpose (Alonzo.Certifying _cert) =
-  Aeson.object [ "certifying" .= String "TODO: Conway era" ] -- toJSON (Api.textEnvelopeDefaultDescr $ Api.fromShelleyCertificate cert)
+    renderScriptHash :: ScriptHash StandardCrypto -> Text
+    renderScriptHash = Api.serialiseToRawBytesHexText . Api.fromShelleyScriptHash
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (ShelleyUTXO era))
-         , ToObject (PredicateFailure (Core.EraRule "UTXO" era))
-         ) => ToObject (ShelleyUtxowPredFailure era) where
+renderScriptPurpose :: ()
+  => Ledger.EraCrypto ledgerera ~ StandardCrypto
+  => Alonzo.ScriptPurpose ledgerera
+  -> Aeson.Value
+renderScriptPurpose = \case
+  Alonzo.Minting pid ->
+    Aeson.object [ "minting" .= toJSON pid]
+  Alonzo.Spending txin ->
+    Aeson.object [ "spending" .= Api.fromShelleyTxIn txin]
+  Alonzo.Rewarding rwdAcct ->
+    Aeson.object [ "rewarding" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
+  Alonzo.Certifying _cert ->
+    Aeson.object
+      [ "certifying" .= toJSON @String "TODO CIP-1694 unimplemented" -- toJSON (Api.textEnvelopeDefaultDescr $ Api.fromShelleyCertificate sbe cert)
+      ]
+
+instance
+  ( ToObject (PredicateFailure (ShelleyUTXO ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "UTXO" ledgerera))
+  , Core.Crypto (Ledger.EraCrypto ledgerera)
+  ) => ToObject (ShelleyUtxowPredFailure ledgerera) where
   toObject _verb (ExtraneousScriptWitnessesUTXOW extraneousScripts) =
     mconcat [ "kind" .= String "InvalidWitnessesUTXOW"
              , "extraneousScripts" .= extraneousScripts
@@ -394,10 +432,13 @@ instance ( ShelleyBasedEra era
     mconcat [ "kind" .= String "InvalidMetadata"
              ]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PPUPPredFailure era)
-         )
-      => ToObject (ShelleyUtxoPredFailure era) where
+instance
+  ( ToObject (PPUPPredFailure ledgerera)
+  , Show (Ledger.Value ledgerera)
+  , ToJSON (Ledger.Value ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  , Core.Crypto (Ledger.EraCrypto ledgerera)
+  ) => ToObject (ShelleyUtxoPredFailure ledgerera) where
   toObject _verb (BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -462,9 +503,13 @@ instance ToJSON Allegra.ValidityInterval where
       mbfield SNothing  = []
       mbfield (SJust x) = [x]
 
-instance ( ShelleyBasedEra era
-         , ToObject (PPUPPredFailure era)
-         ) => ToObject (AllegraUtxoPredFailure era) where
+instance
+  ( ToObject (PPUPPredFailure ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  , Show (Ledger.Value ledgerera)
+  , ToJSON (Ledger.Value ledgerera)
+  , Core.Crypto (Ledger.EraCrypto ledgerera)
+  ) => ToObject (AllegraUtxoPredFailure ledgerera) where
   toObject _verb (Allegra.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -550,9 +595,10 @@ instance Ledger.Era era => ToObject (ShelleyPpupPredFailure era) where
              ]
 
 
-instance ( ShelleyBasedEra era
-         , ToObject (PredicateFailure (Core.EraRule "DELPL" era))
-         ) => ToObject (ShelleyDelegsPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "DELPL" ledgerera))
+  , Core.Crypto (Ledger.EraCrypto ledgerera)
+  ) => ToObject (ShelleyDelegsPredFailure ledgerera) where
   toObject _verb (DelegateeNotRegisteredDELEG targetPool) =
     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
              , "targetPool" .= targetPool
@@ -564,9 +610,10 @@ instance ( ShelleyBasedEra era
   toObject verb (DelplFailure f) = toObject verb f
 
 
-instance ( ToObject (PredicateFailure (Core.EraRule "POOL" era))
-         , ToObject (PredicateFailure (Core.EraRule "DELEG" era))
-         ) => ToObject (ShelleyDelplPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "POOL" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "DELEG" ledgerera))
+  ) => ToObject (ShelleyDelplPredFailure ledgerera) where
   toObject verb (PoolFailure f) = toObject verb f
   toObject verb (DelegFailure f) = toObject verb f
 
@@ -675,6 +722,23 @@ instance ToObject (ShelleyPoolPredFailure era) where
              , "error" .= String "The stake pool metadata hash is too large"
              ]
 
+-- Apparently this should never happen according to the Shelley exec spec
+  -- toObject _verb (WrongCertificateTypePOOL index) =
+  --   case index of
+  --     0 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
+  --                   , "error" .= String "Wrong certificate type: Delegation certificate"
+  --                   ]
+  --     1 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
+  --                   , "error" .= String "Wrong certificate type: MIR certificate"
+  --                   ]
+  --     2 -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
+  --                   , "error" .= String "Wrong certificate type: Genesis certificate"
+  --                   ]
+  --     k -> mconcat [ "kind" .= String "WrongCertificateTypePOOL"
+  --                   , "certificateType" .= k
+  --                   , "error" .= String "Wrong certificate type: Unknown certificate type"
+  --                   ]
+
   toObject _verb (WrongNetworkPOOL networkId listedNetworkId poolId) =
     mconcat [ "kind" .= String "WrongNetworkPOOL"
              , "networkId" .= String (textShow networkId)
@@ -683,18 +747,20 @@ instance ToObject (ShelleyPoolPredFailure era) where
              , "error" .= String "Wrong network ID in pool registration certificate"
              ]
 
-instance ( ToObject (PredicateFailure (Core.EraRule "NEWEPOCH" era))
-         , ToObject (PredicateFailure (Core.EraRule "RUPD" era))
-         ) => ToObject (ShelleyTickPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "NEWEPOCH" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "RUPD" ledgerera))
+  ) => ToObject (ShelleyTickPredFailure ledgerera) where
   toObject verb (NewEpochFailure f) = toObject verb f
   toObject verb (RupdFailure f) = toObject verb f
 
 instance ToObject TicknPredicateFailure where
   toObject _verb x = case x of {} -- no constructors
 
-instance ( ToObject (PredicateFailure (Core.EraRule "EPOCH" era))
-         , ToObject (PredicateFailure (Core.EraRule "MIR" era))
-         ) => ToObject (ShelleyNewEpochPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "EPOCH" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "MIR" ledgerera))
+  ) => ToObject (ShelleyNewEpochPredFailure ledgerera) where
   toObject verb (EpochFailure f) = toObject verb f
   toObject verb (MirFailure f) = toObject verb f
   toObject _verb (CorruptRewardUpdate update) =
@@ -702,24 +768,25 @@ instance ( ToObject (PredicateFailure (Core.EraRule "EPOCH" era))
              , "update" .= String (textShow update) ]
 
 
-instance ( ToObject (PredicateFailure (Core.EraRule "POOLREAP" era))
-         , ToObject (PredicateFailure (Core.EraRule "SNAP" era))
-         , ToObject (UpecPredFailure era)
-         ) => ToObject (ShelleyEpochPredFailure era) where
+instance
+  ( ToObject (PredicateFailure (Core.EraRule "POOLREAP" ledgerera))
+  , ToObject (PredicateFailure (Core.EraRule "SNAP" ledgerera))
+  , ToObject (UpecPredFailure ledgerera)
+  ) => ToObject (ShelleyEpochPredFailure ledgerera) where
   toObject verb (PoolReapFailure f) = toObject verb f
   toObject verb (SnapFailure f) = toObject verb f
   toObject verb (UpecFailure f) = toObject verb f
 
 
-instance ToObject (ShelleyPoolreapPredFailure era) where
+instance ToObject (ShelleyPoolreapPredFailure ledgerera) where
   toObject _verb x = case x of {} -- no constructors
 
 
-instance ToObject (ShelleySnapPredFailure era) where
+instance ToObject (ShelleySnapPredFailure ledgerera) where
   toObject _verb x = case x of {} -- no constructors
 
 -- TODO: Need to elaborate more on this error
-instance ToObject (ShelleyNewppPredFailure era) where
+instance ToObject (ShelleyNewppPredFailure ledgerera) where
   toObject _verb (UnexpectedDepositPot outstandingDeposits depositPot) =
     mconcat [ "kind" .= String "UnexpectedDepositPot"
              , "outstandingDeposits" .= String (textShow outstandingDeposits)
@@ -727,11 +794,11 @@ instance ToObject (ShelleyNewppPredFailure era) where
              ]
 
 
-instance ToObject (ShelleyMirPredFailure era) where
+instance ToObject (ShelleyMirPredFailure ledgerera) where
   toObject _verb x = case x of {} -- no constructors
 
 
-instance ToObject (ShelleyRupdPredFailure era) where
+instance ToObject (ShelleyRupdPredFailure ledgerera) where
   toObject _verb x = case x of {} -- no constructors
 
 
@@ -884,11 +951,14 @@ instance ToObject (ShelleyUpecPredFailure era) where
 --------------------------------------------------------------------------------
 
 
-instance ( Ledger.Era era
-         , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" era))
-         , ToObject (PPUPPredFailure era)
-         , ShelleyBasedEra era
-         ) => ToObject (AlonzoUtxoPredFailure era) where
+instance
+  ( Ledger.Era ledgerera
+  , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" ledgerera))
+  , ToObject (PPUPPredFailure ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  , Show (Ledger.Value ledgerera)
+  , ToJSON (Ledger.Value ledgerera)
+  ) => ToObject (AlonzoUtxoPredFailure ledgerera) where
   toObject _verb (Alonzo.BadInputsUTxO badInputs) =
     mconcat [ "kind" .= String "BadInputsUTxO"
              , "badInputs" .= badInputs
@@ -986,9 +1056,10 @@ instance ( Ledger.Era era
   toObject _verb Alonzo.NoCollateralInputs =
     mconcat [ "kind" .= String "NoCollateralInputs" ]
 
-instance ( ToJSON (Alonzo.CollectError (Ledger.EraCrypto era))
-         , ToObject (PPUPPredFailure era)
-         ) => ToObject (AlonzoUtxosPredFailure era) where
+instance
+  ( ToJSON (Alonzo.CollectError ledgerera)
+  , ToObject (PPUPPredFailure ledgerera)
+  ) => ToObject (AlonzoUtxosPredFailure ledgerera) where
   toObject _ (Alonzo.ValidationTagMismatch isValidating reason) =
     mconcat [ "kind" .= String "ValidationTagMismatch"
              , "isvalidating" .= isValidating
@@ -1003,14 +1074,17 @@ instance ( ToJSON (Alonzo.CollectError (Ledger.EraCrypto era))
 
 deriving newtype instance ToJSON Alonzo.IsValid
 
-instance ToJSON (Alonzo.CollectError StandardCrypto) where
+instance
+  ( Core.Crypto (Ledger.EraCrypto ledgerera)
+  , Ledger.EraCrypto ledgerera ~ StandardCrypto
+  ) => ToJSON (Alonzo.CollectError ledgerera) where
   toJSON cError =
     case cError of
       Alonzo.NoRedeemer sPurpose ->
         object
           [ "kind" .= String "CollectError"
           , "error" .= String "NoRedeemer"
-          , "scriptpurpose" .= _renderScriptPurpose sPurpose
+          , "scriptpurpose" .= renderScriptPurpose sPurpose
           ]
       Alonzo.NoWitness _sHash ->
         object
@@ -1076,9 +1150,10 @@ instance ToJSON Alonzo.FailureDescription where
         -- , "reconstructionDetail" .= bs
         ]
 
-instance ( Ledger.Era era
-         , Show (PredicateFailure (Ledger.EraRule "LEDGERS" era))
-         ) => ToObject (AlonzoBbodyPredFailure era) where
+instance
+  ( Ledger.Era ledgerera
+  , Show (PredicateFailure (Ledger.EraRule "LEDGERS" ledgerera))
+  ) => ToObject (AlonzoBbodyPredFailure ledgerera) where
   toObject _ err = mconcat [ "kind" .= String "AlonzoBbodyPredFail"
                             , "error" .= String (textShow err)
                             ]
@@ -1087,11 +1162,15 @@ instance ( Ledger.Era era
 -- Babbage related
 --------------------------------------------------------------------------------
 
-instance ( ShelleyBasedEra era
-         , ToObject (ShelleyUtxowPredFailure era)
-         , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" era))
-         , ToObject (PPUPPredFailure era)
-         ) => ToObject (BabbageUtxoPredFailure era) where
+instance
+  ( Ledger.Era ledgerera
+  , ToObject (ShelleyUtxowPredFailure ledgerera)
+  , ToObject (PredicateFailure (Ledger.EraRule "UTXOS" ledgerera))
+  , ToObject (PPUPPredFailure ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  , Show (Ledger.Value ledgerera)
+  , ToJSON (Ledger.Value ledgerera)
+  ) => ToObject (BabbageUtxoPredFailure ledgerera) where
   toObject v err =
     case err of
       Babbage.AlonzoInBabbageUtxoPredFailure alonzoFail ->
@@ -1107,12 +1186,15 @@ instance ( ShelleyBasedEra era
                 , "outputs" .= outputs
                 ]
 
-instance ( Ledger.Era era
-         , ShelleyBasedEra era
-         , Ledger.EraCrypto era ~ StandardCrypto
-         , ToObject (PPUPPredFailure era)
-         , ToObject (PredicateFailure (Ledger.EraRule "UTXO" era))
-         ) => ToObject (BabbageUtxowPredFailure era) where
+instance
+  ( Ledger.Era ledgerera
+  , Ledger.EraCrypto ledgerera ~ StandardCrypto
+  , Show (Ledger.Value ledgerera)
+  , ToObject (PPUPPredFailure ledgerera)
+  , ToObject (PredicateFailure (Ledger.EraRule "UTXO" ledgerera))
+  , ToJSON (Ledger.Value ledgerera)
+  , ToJSON (Ledger.TxOut ledgerera)
+  ) => ToObject (BabbageUtxowPredFailure ledgerera) where
   toObject v err =
     case err of
       Babbage.AlonzoInBabbageUtxowPredFailure alonzoFail ->
@@ -1230,6 +1312,7 @@ instance ToJSON ShelleyNodeToClientVersion where
   toJSON ShelleyNodeToClientVersion5 = String "ShelleyNodeToClientVersion5"
   toJSON ShelleyNodeToClientVersion6 = String "ShelleyNodeToClientVersion6"
   toJSON ShelleyNodeToClientVersion7 = String "ShelleyNodeToClientVersion7"
+  toJSON ShelleyNodeToClientVersion8 = String "ShelleyNodeToClientVersion8"
 
 --------------------------------------------------------------------------------
 -- Helper functions

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -22,12 +22,13 @@ import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Vector as Vector
 
+import           Cardano.Node.Types (UseLedger(..))
 import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPAddress (..),
                    NodeHostIPv4Address (..), NodeHostIPv6Address (..), NodeIPAddress,
                    NodeIPv4Address, NodeIPv6Address)
 import           Cardano.Node.Configuration.TopologyP2P (LocalRootPeersGroup (..),
                    LocalRootPeersGroups (..), NetworkTopology (..), NodeSetup (..),
-                   PeerAdvertise (..), PublicRootPeers (..), RootConfig (..), UseLedger (..))
+                   PeerAdvertise (..), PublicRootPeers (..), RootConfig (..))
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -52,9 +52,10 @@ testPartialYamlConfig =
     { pncProtocolConfig = Last . Just
                         . NodeProtocolConfigurationShelley
                         $ NodeShelleyProtocolConfiguration
-                            (GenesisFile "dummmy-genesis-file") Nothing
+                            (GenesisFile "dummmsy-genesis-file") Nothing
     , pncSocketConfig = Last . Just $ SocketConfig (Last Nothing) mempty mempty mempty
     , pncShutdownConfig = Last Nothing
+    , pncStartAsNonProducingNode = Last $ Just False
     , pncDiffusionMode = Last Nothing
     , pncSnapshotInterval = mempty
     , pncExperimentalProtocolsEnabled = Last Nothing
@@ -88,6 +89,7 @@ testPartialCliConfig =
   PartialNodeConfiguration
     { pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
     , pncShutdownConfig = Last . Just $ ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
+    , pncStartAsNonProducingNode = Last $ Just $ False
     , pncConfigFile   = mempty
     , pncTopologyFile = mempty
     , pncDatabaseFile = mempty
@@ -123,6 +125,7 @@ eExpectedConfig = do
   return $ NodeConfiguration
     { ncSocketConfig = SocketConfig mempty mempty mempty mempty
     , ncShutdownConfig = ShutdownConfig Nothing (Just . ASlot $ SlotNo 42)
+    , ncStartAsNonProducingNode = False
     , ncConfigFile = ConfigYamlFilePath "configuration/cardano/mainnet-config.json"
     , ncTopologyFile = TopologyFile "configuration/cardano/mainnet-topology.json"
     , ncDatabaseFile = DbFile "mainnet/db/"

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -41,7 +41,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.8
                       , cardano-binary
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-crypto-class ^>= 2.1
                       , cardano-ledger-byron ^>= 1.0
                       , formatting
@@ -86,7 +86,7 @@ executable cardano-submit-api
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T -I0"
   build-depends:        base >= 4.14 && < 4.17
                       , optparse-applicative-fork >= 0.16.1.0
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-crypto-class ^>= 2.1
                       , cardano-submit-api
 

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-binary
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -43,7 +43,7 @@ library
                       , cardano-binary
                       , cardano-cli ^>= 8.3
                       , cardano-crypto-class ^>= 2.1
-                      , cardano-ledger-byron ^>= 1.0
+                      , cardano-ledger-byron ^>= 1.0.0.1
                       , formatting
                       , http-media
                       , iohk-monitoring

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
@@ -176,7 +176,7 @@ test-suite cardano-testnet-test
   build-depends:        aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.5
+                      , cardano-api ^>= 8.7
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-testnet

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
@@ -86,7 +86,7 @@ library
                         Testnet.Process.Cli
                         Testnet.Process.Run
                         Testnet.Runtime
-                        Testnet.Topology 
+                        Testnet.Topology
 
   other-modules:        Parsers.Babbage
                         Parsers.Byron
@@ -176,7 +176,7 @@ test-suite cardano-testnet-test
   build-depends:        aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.2
+                      , cardano-api ^>= 8.5
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-testnet

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
@@ -176,7 +176,7 @@ test-suite cardano-testnet-test
   build-depends:        aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.7
+                      , cardano-api ^>= 8.8
                       , cardano-cli ^>= 8.2
                       , cardano-crypto-class
                       , cardano-testnet

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -35,7 +35,7 @@ library
                       , ansi-terminal
                       , bytestring
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo
@@ -149,7 +149,7 @@ test-suite cardano-testnet-golden
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.2
+                      , cardano-cli:cardano-cli ^>= 8.3
                       , cardano-submit-api:cardano-submit-api
                       , cardano-testnet:cardano-testnet
 
@@ -177,7 +177,7 @@ test-suite cardano-testnet-test
                       , async
                       , bytestring
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.2
+                      , cardano-cli ^>= 8.3
                       , cardano-crypto-class
                       , cardano-testnet
                       , containers
@@ -194,6 +194,6 @@ test-suite cardano-testnet-test
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.2
+                      , cardano-cli:cardano-cli ^>= 8.3
                       , cardano-submit-api:cardano-submit-api
                       , cardano-testnet:cardano-testnet

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -165,6 +165,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
                         Cardano.Testnet.Test.Cli.Babbage.Transaction
                         Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
+                        Cardano.Testnet.Test.Cli.Conway.Transaction
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
                         Cardano.Testnet.Test.FoldBlocks

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -51,7 +51,7 @@ library
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.5.1
+                      , hedgehog-extras ^>= 0.4.7.0
                       , mtl
                       , optparse-applicative-fork
                       , ouroboros-network ^>= 0.8.1.0
@@ -138,7 +138,7 @@ test-suite cardano-testnet-golden
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.5.1
+                      , hedgehog-extras ^>= 0.4.7.0
                       , process
                       , regex-compat
                       , tasty
@@ -163,6 +163,7 @@ test-suite cardano-testnet-test
   other-modules:        Cardano.Testnet.Test.Cli.Alonzo.LeadershipSchedule
                         Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
                         Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
+                        Cardano.Testnet.Test.Cli.Babbage.Transaction
                         Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
@@ -184,7 +185,7 @@ test-suite cardano-testnet-test
                       , directory
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.5.1
+                      , hedgehog-extras ^>= 0.4.7.0
                       , process
                       , tasty
                       , text

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -33,6 +33,7 @@ import           Cardano.Api hiding (Value)
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
@@ -188,7 +189,7 @@ mkTopologyConfig i numBftNodes' allPorts True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 
 testnet :: TestnetOptions -> H.Conf -> H.Integration [String]

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -45,6 +45,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPo
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Aeson as J
@@ -180,7 +181,7 @@ mkTopologyConfig numNodes allPorts port True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 cardanoTestnet :: CardanoTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
 cardanoTestnet testnetOptions H.Conf {H.tempAbsPath} = do

--- a/cardano-testnet/src/Testnet/Start/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Start/Shelley.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPo
 import           Cardano.Api hiding (Value)
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
+import           Cardano.Node.Types (UseLedger(..))
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.List as L
@@ -152,7 +153,7 @@ mkTopologyConfig numPraosNodes allPorts port True = J.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (P2P.UseLedger DontUseLedger)
+        (UseLedger DontUseLedger)
 
 shelleyTestnet :: ShelleyTestnetOptions -> H.Conf -> H.Integration TestnetRuntime
 shelleyTestnet testnetOptions H.Conf {H.tempAbsPath} = do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
+{- HLINT ignore "Redundant return" -}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Use let" -}
+
+module Cardano.Testnet.Test.Cli.Babbage.Transaction
+  ( hprop_transaction
+  ) where
+
+import           Prelude
+
+import           Control.Monad (void)
+import qualified Data.Aeson as Aeson
+import           Data.Function
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Time.Clock as DTC
+import           GHC.Stack (callStack)
+import           System.FilePath ((</>))
+import qualified System.Info as SYS
+
+import           Cardano.Api
+import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Cardano.Testnet
+
+import           Hedgehog
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Concurrent as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
+hprop_transaction :: Property
+hprop_transaction = H.integrationRetryWorkspace 2 "babbage-transaction" $ \tempAbsBasePath' -> do
+  H.note_ SYS.os
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let
+    tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
+    testnetOptions = BabbageOnlyTestnetOptions $ babbageDefaultTestnetOptions
+      { babbageNodeLoggingFormat = NodeLoggingFormatAsJson
+      }
+
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets
+    } <- testnet testnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+
+  tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
+
+  H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
+    void $ execCli' execConfig
+      [ "query", "tip"
+      , "--testnet-magic", show @Int testnetMagic
+      , "--out-file", work </> "current-tip.json"
+      ]
+
+    tipJson <- H.leftFailM . H.readJsonFile $ work </> "current-tip.json"
+    tip <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @QueryTipLocalStateOutput tipJson
+
+    currEpoch <- case mEpoch tip of
+      Nothing -> H.failMessage callStack "cardano-cli query tip returned Nothing for EpochNo"
+      Just currEpoch -> return currEpoch
+
+    H.note_ $ "Current Epoch: " <> show currEpoch
+    H.assert $ currEpoch > 2
+
+  wallet0 <- H.indexM 0 wallets
+  wallet1 <- H.indexM 1 wallets
+
+  utxoBeforeFile <- H.note $ work </> "utxo-before.json"
+  utxoAfterFile <- H.note $ work </> "utxo-after.json"
+
+  void $ execCli' execConfig
+    [ "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--cardano-mode"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--out-file", utxoBeforeFile
+    ]
+
+  utxoBeforeJson <- H.leftFailM $ H.readJsonFile utxoBeforeFile
+
+  UTxO utxoBeforeMap <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @(UTxO ConwayEra) utxoBeforeJson
+
+  txinsBefore <- H.noteShow $ Map.keys utxoBeforeMap
+
+  txin <- H.noteShow =<< H.headM txinsBefore
+
+  wallet0Addr   <- pure $ wallet0 & paymentKeyInfoAddr & Text.unpack
+  wallet1Addr   <- pure $ wallet1 & paymentKeyInfoAddr & Text.unpack
+  wallet0SKFile <- pure $ wallet0 & paymentKeyInfoPair  & paymentSKey
+
+  void $ execCli' execConfig
+    [ "transaction", "build"
+    , "--babbage-era"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--change-address", wallet0Addr
+    , "--tx-in", Text.unpack $ renderTxIn txin
+    , "--tx-out", wallet1Addr <> "+" <> show @Int 5000000
+    , "--out-file", work </> "transfer.tx.raw"
+    ]
+
+  void $ execCli
+    [ "transaction", "sign"
+    , "--tx-body-file", work </> "transfer.tx.raw"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--signing-key-file", wallet0SKFile
+    , "--out-file", work </> "transfer.tx.signed"
+    ]
+
+  H.noteM_ $ execCli' execConfig
+    [ "transaction", "submit"
+    , "--tx-file", work </> "transfer.tx.signed"
+    , "--testnet-magic", show @Int testnetMagic
+    ]
+
+  H.threadDelay $ 2 * 1000000
+
+  void $ execCli' execConfig
+    [ "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--cardano-mode"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--out-file", utxoAfterFile
+    ]
+
+  utxoAfterJson <- H.leftFailM $ H.readJsonFile utxoAfterFile
+
+  UTxO utxoAfterMap <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @(UTxO ConwayEra) utxoAfterJson
+
+  txinsAfter <- H.noteShow $ Map.keys utxoAfterMap
+
+  -- This means the txin got spent, which serves as confirmation the transaction was processed
+  H.assert $ txinsBefore /= txinsAfter

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Transaction.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{- HLINT ignore "Redundant id" -}
+{- HLINT ignore "Redundant return" -}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Use let" -}
+
+module Cardano.Testnet.Test.Cli.Conway.Transaction
+  ( hprop_transaction
+  ) where
+
+import           Prelude
+
+import           Control.Monad (void)
+import qualified Data.Aeson as Aeson
+import           Data.Function
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Time.Clock as DTC
+import           GHC.Stack (callStack)
+import           System.FilePath ((</>))
+import qualified System.Info as SYS
+
+import           Cardano.Api
+import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Cardano.Testnet
+
+import           Hedgehog
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Concurrent as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
+hprop_transaction :: Property
+hprop_transaction = H.integrationRetryWorkspace 2 "conway-transaction" $ \tempAbsBasePath' -> do
+  H.note_ SYS.os
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let
+    tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
+    testnetOptions = ConwayOnlyTestnetOptions $ conwayDefaultTestnetOptions
+      { conwayNodeLoggingFormat = NodeLoggingFormatAsJson
+      }
+
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets
+    } <- testnet testnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+
+  tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
+
+  H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
+    void $ execCli' execConfig
+      [ "query", "tip"
+      , "--testnet-magic", show @Int testnetMagic
+      , "--out-file", work </> "current-tip.json"
+      ]
+
+    tipJson <- H.leftFailM . H.readJsonFile $ work </> "current-tip.json"
+    tip <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @QueryTipLocalStateOutput tipJson
+
+    currEpoch <- case mEpoch tip of
+      Nothing -> H.failMessage callStack "cardano-cli query tip returned Nothing for EpochNo"
+      Just currEpoch -> return currEpoch
+
+    H.note_ $ "Current Epoch: " <> show currEpoch
+    H.assert $ currEpoch > 2
+
+  wallet0 <- H.indexM 0 wallets
+  wallet1 <- H.indexM 1 wallets
+
+  utxoBeforeFile <- H.note $ work </> "utxo-before.json"
+  utxoAfterFile <- H.note $ work </> "utxo-after.json"
+
+  void $ execCli' execConfig
+    [ "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--cardano-mode"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--out-file", utxoBeforeFile
+    ]
+
+  utxoBeforeJson <- H.leftFailM $ H.readJsonFile utxoBeforeFile
+
+  UTxO utxoBeforeMap <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @(UTxO ConwayEra) utxoBeforeJson
+
+  txinsBefore <- H.noteShow $ Map.keys utxoBeforeMap
+
+  txin <- H.noteShow =<< H.headM txinsBefore
+
+  wallet0Addr   <- pure $ wallet0 & paymentKeyInfoAddr & Text.unpack
+  wallet1Addr   <- pure $ wallet1 & paymentKeyInfoAddr & Text.unpack
+  wallet0SKFile <- pure $ wallet0 & paymentKeyInfoPair  & paymentSKey
+
+  void $ execCli' execConfig
+    [ "transaction", "build"
+    , "--conway-era"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--change-address", wallet0Addr
+    , "--tx-in", Text.unpack $ renderTxIn txin
+    , "--tx-out", wallet1Addr <> "+" <> show @Int 5000000
+    , "--out-file", work </> "transfer.tx.raw"
+    ]
+
+  void $ execCli
+    [ "transaction", "sign"
+    , "--tx-body-file", work </> "transfer.tx.raw"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--signing-key-file", wallet0SKFile
+    , "--out-file", work </> "transfer.tx.signed"
+    ]
+
+  H.noteM_ $ execCli' execConfig
+    [ "transaction", "submit"
+    , "--tx-file", work </> "transfer.tx.signed"
+    , "--testnet-magic", show @Int testnetMagic
+    ]
+
+  H.threadDelay $ 2 * 1000000
+
+  void $ execCli' execConfig
+    [ "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--cardano-mode"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--out-file", utxoAfterFile
+    ]
+
+  utxoAfterJson <- H.leftFailM $ H.readJsonFile utxoAfterFile
+
+  UTxO utxoAfterMap <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @(UTxO ConwayEra) utxoAfterJson
+
+  txinsAfter <- H.noteShow $ Map.keys utxoAfterMap
+
+  -- This means the txin got spent, which serves as confirmation the transaction was processed
+  H.assert $ txinsBefore /= txinsAfter

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -10,6 +10,7 @@ import           Test.Tasty (TestTree)
 
 import qualified Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
 import qualified Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
+import qualified Cardano.Testnet.Test.Cli.Babbage.Transaction
 import qualified Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
@@ -36,6 +37,7 @@ tests = pure $ T.testGroup "test/Spec.hs"
     , T.testGroup "Babbage"
       [ H.ignoreOnWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule
       , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
+      , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
       ]
     , T.testGroup "Conway"
       [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -12,6 +12,7 @@ import qualified Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
 import qualified Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.Babbage.Transaction
 import qualified Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
+import qualified Cardano.Testnet.Test.Cli.Conway.Transaction
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
@@ -41,6 +42,7 @@ tests = pure $ T.testGroup "test/Spec.hs"
       ]
     , T.testGroup "Conway"
       [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
+      , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Conway.Transaction.hprop_transaction
       ]
       -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
       -- as a result of the kes-period-info output to stdout.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1686832558,
-        "narHash": "sha256-ShN++GEuj09VR2Q4zGNM9IGTKk+xfXnl8BXQG7tGQOA=",
+        "lastModified": 1688739041,
+        "narHash": "sha256-1ji5gb5c7e/dMvwMIGjNfkDF1AOCMVdiFrSN+xUQpzw=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "bc32b60d563860e2dab2a66ea558699ce72c7c29",
+        "rev": "ba9bfea00fa468dc4c18de2ab0b7d3c7cb4a35ef",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1688739041,
-        "narHash": "sha256-1ji5gb5c7e/dMvwMIGjNfkDF1AOCMVdiFrSN+xUQpzw=",
+        "lastModified": 1688785309,
+        "narHash": "sha256-L0MiYzUMsmJ3lpxIwCKuTxTbJEFL9LQEj0dqpdqYxlo=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "ba9bfea00fa468dc4c18de2ab0b7d3c7cb4a35ef",
+        "rev": "67098780791aa67f98d47aa8c7e1fca8da698d29",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1688785309,
-        "narHash": "sha256-L0MiYzUMsmJ3lpxIwCKuTxTbJEFL9LQEj0dqpdqYxlo=",
+        "lastModified": 1688793078,
+        "narHash": "sha256-HfOVYupLwcxzOmdaW2XFDGOXhZ242To2YG0w/Km3lmM=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "67098780791aa67f98d47aa8c7e1fca8da698d29",
+        "rev": "2735cffa7fdca54aab57a2d08d0a85ccaf8de440",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -603,11 +603,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1685492843,
-        "narHash": "sha256-X8dNs5Gfc2ucfaWAgZ1VmkpBB4Cb44EQZu0b7tkvz2Y=",
+        "lastModified": 1688603318,
+        "narHash": "sha256-rXEPjf6pecyl0mIpK6xk3Vp/lKxWiCUfw6PMU+7utjY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e7407bab324eb2445bda58c5ffac393e80dda1e4",
+        "rev": "a5604f20c9446451d4f1fd3ad4c160240069833a",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -24,6 +24,10 @@ let
       # extra-compilers
       flake.variants = lib.genAttrs ["ghc927"] (x: {compiler-nix-name = x;});
       cabalProjectLocal = ''
+        repository cardano-haskell-packages-local
+          url: file:${CHaP}
+          secure: True
+        active-repositories: hackage.haskell.org, cardano-haskell-packages-local
         allow-newer: terminfo:base
       '' + lib.optionalString pkgs.stdenv.hostPlatform.isWindows ''
         -- When cross compiling we don't have a `ghc` package

--- a/scripts/conway/submit-new-constitution.sh
+++ b/scripts/conway/submit-new-constitution.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+# Unofficial bash strict mode.
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -u
+set -o pipefail
+
+# Make sure you have run mkfiles.sh first to create the stake pool key with stake
+
+conwaydir=scripts/conway
+stakepoolvkey=example/pools/cold1.vkey
+
+# 2. Create new constitution governance action
+
+cardano-cli governance action create-action create-constitution \
+  --governance-action-deposit 1000000 \
+  --stake-verification-key-file $stakepoolvkey \
+  --constitution "Give all the money to Jordan" \
+  --out-file $conwaydir/test.constitution
+  
+# 4. Build tx with proposal
+
+

--- a/scripts/conway/test.constitution
+++ b/scripts/conway/test.constitution
@@ -1,0 +1,5 @@
+{
+    "type": "Governance proposal",
+    "description": "",
+    "cborHex": "841a000f4240581cb015a5c95f9e6f563d58cdcc43d0e86f3eddecde506f1102af33505682055820be2d1c4ae568abb3e8c55a092cc758befeeffda05428720062f9ae6d0ffc557af6"
+}

--- a/scripts/lite/example-build-cmd.sh
+++ b/scripts/lite/example-build-cmd.sh
@@ -35,20 +35,19 @@ changeaddr=addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljy
 targetaddr=addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4
 
 $CARDANO_CLI transaction build \
-  --babbage-era \
+  --conway-era \
   --cardano-mode \
-  --cli-format \
   --testnet-magic "$TESTNET_MAGIC" \
   --change-address "$changeaddr" \
   --tx-in $txin \
   --tx-out "$targetaddr+10000000" \
   --out-file $WORK/build.body
 
-$CARDANO_CLI transaction witness \
+$CARDANO_CLI transaction sign \
   --tx-body-file $WORK/build.body \
   --testnet-magic "$TESTNET_MAGIC" \
   --signing-key-file $UTXO_SKEY \
-  --out-file $WORK/witness.tx
+  --out-file $WORK/build.tx
 
 # SUBMIT
 $CARDANO_CLI transaction submit --tx-file $WORK/build.tx --testnet-magic "$TESTNET_MAGIC"


### PR DESCRIPTION
# Description

This is able to reproduce the following failure:

```
                ┃     │ Command: /Users/jky/wrk/iohk/cardano-node/dist-newstyle/build/aarch64-osx/ghc-8.10.7/cardano-cli-8.2.0/x/cardano-cli/build/cardano-cli/cardano-cli transaction build --conway-era --testnet-magic 42 --change-address addr_test1vr3fve99ezeaecqmrswan5ek5ws2887mdwgu32d2e30dq5s8de334 --tx-in 440f56d873977c40beabc1909c07f391e10d04b4f0adbd7c5bd7c748754f5c01#0 --tx-out addr_test1vze00fff5757gzhscvwhljlw354nfn7af9qmks0wgm0lfequmhrkl+5000000 --out-file /private/tmp/nix-shell.ap5Zw2/conway-transaction-no-retries-test-555b8f708e7a51d4/work/transfer.tx.raw
                ┃     │ Process exited with non-zero exit-code
                ┃     │ ━━━━ command ━━━━
                ┃     │ cardano-cli transaction build --conway-era --testnet-magic 42 --change-address addr_test1vr3fve99ezeaecqmrswan5ek5ws2887mdwgu32d2e30dq5s8de334 --tx-in 440f56d873977c40beabc1909c07f391e10d04b4f0adbd7c5bd7c748754f5c01#0 --tx-out addr_test1vze00fff5757gzhscvwhljlw354nfn7af9qmks0wgm0lfequmhrkl+5000000 --out-file /private/tmp/nix-shell.ap5Zw2/conway-transaction-no-retries-test-555b8f708e7a51d4/work/transfer.tx.raw
                ┃     │ ━━━━ stdout ━━━━
                ┃     │
                ┃     │ ━━━━ stderr ━━━━
                ┃     │
                ┃     │ cardano-cli: Prelude.undefined
                ┃     │ CallStack (from HasCallStack):
                ┃     │   error, called at libraries/base/GHC/Err.hs:79:14 in base:GHC.Err
                ┃     │   undefined, called at src/Cardano/Ledger/Conway/TxBody.hs:311:18 in crdn-ldgr-cnwy-1.2.0.0-d38e5460:Cardano.Ledger.Conway.TxBody
                ┃     │ ━━━━ exit code ━━━━
                ┃     │ 1
                ┃     ^
                ┃     │ Execute process failed
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
