### PR TITLE
Bench Nomad placement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ PROFILES_VENDOR           := dish dish-plutus dish-10M dish-10M-plutus
 # "qa" and "perf" namespaces for cardano world (world.dev.cardano.org) Nomad
 # Not all local profiles are compatible (yet) with a cloud run
 # Cloud version of "default", "ci-test" and "ci-bench"
-PROFILES_CW_QA            := cw-qa-default cw-qa-ci-test cw-qa-ci-bench
+PROFILES_CW_QA            := default-cw-qa ci-test-cw-qa ci-bench-cw-qa
 # The 52+explorer profile
-PROFILES_CW_PERF          := cw-perf-value
+PROFILES_CW_PERF          := default-cw-perf ci-test-cw-perf ci-bench-cw-perf cw-perf-value
 
 LOCAL_PROFILES += $(PROFILES_BASE)
 LOCAL_PROFILES += $(PROFILES_FAST)

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -15,9 +15,13 @@
 
 let
 
-  # Task (Container or chroot) defaults:
-  ## This values are the defaults that are stored on the job's "meta" stanza to
-  ## be able to overrided them with `jq` inside the workbench shell.
+  # Task's (Container or chroot) defaults:
+  #
+  ## Default values below are stored in the job's "meta" stanza to be able to
+  ## overrided them with 'jq' from a workbench shell. These values in "meta"
+  ## are used to programatically create a "template" with "env = true;" so they
+  ## are automagically reachable as envars inside the Task's entrypoint and
+  ## 'supervisord' programs.
   ## Values go: Nix (defaults) -> meta -> template -> envars
   #
   ## See ./oci-images.nix for further details if using the `podman` driver.
@@ -40,7 +44,7 @@ let
     then "/local"
     # This value must also be used inside the `podman` `config` stanza.
     else "/local"
-    ;
+  ;
   # Usually "*/local/run/current"
   task_statedir = "${task_workdir}${if stateDir == "" then "" else ("/" + stateDir)}";
   # A symlink to the supervisord nix-installed inside the OCI image/chroot.
@@ -68,12 +72,10 @@ let
   entrypoint =
     let
       coreutils  = containerSpecs.containerPkgs.coreutils.nix-store-path;
-      gnutar     = containerSpecs.containerPkgs.gnutar.nix-store-path;
-      zstd       = containerSpecs.containerPkgs.zstd.nix-store-path;
       supervisor = containerSpecs.containerPkgs.supervisor.nix-store-path;
     in escapeTemplate
       ''
-      # Store the entrypoint env vars for debugging purposes
+      # Store the entrypoint's envars in a file for debugging purposes.
       ${coreutils}/bin/env > /local/entrypoint.env
 
       # Only needed for "exec" ?
@@ -88,11 +90,12 @@ let
       # The SUPERVISORD_CONFIG variable must be set
       [ -z "''${SUPERVISORD_CONFIG:-}" ] && echo "SUPERVISORD_CONFIG env var must be set -- aborting" && exit 1
 
-      # Create a link to the `supervisor` Nix folder.
+      # Create symlink to 'supervisor' Nix folder so we can call it from 'ssh'
+      #  or 'nomad exec' without having to know the currently version running.
       # First check if already exists to be able to restart containers.
-      if ! test -e "$SUPERVISOR_NIX"
+      if ! test -e "''${SUPERVISOR_NIX}"
       then
-        ${coreutils}/bin/ln -s "${supervisor}" "$SUPERVISOR_NIX"
+        ${coreutils}/bin/ln -s "${supervisor}" "''${SUPERVISOR_NIX}"
       fi
 
       # The SUPERVISORD_LOGLEVEL variable defaults to "info" if not present
@@ -104,26 +107,31 @@ let
       # Start `supervisord` on the foreground.
       # Avoid buffer related problems with stdout and stderr disabling buffering
       # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
-      PYTHONUNBUFFERED=TRUE ${supervisor}/bin/supervisord --nodaemon --configuration "$SUPERVISORD_CONFIG" --loglevel="$LOGLEVEL"
+      PYTHONUNBUFFERED=TRUE ${supervisor}/bin/supervisord --nodaemon --configuration "''${SUPERVISORD_CONFIG}" --loglevel="''${LOGLEVEL}"
       ''
   ;
 
-  # About the JSON Job Specification and its odd assumptions:
+  # About the JSON Job Specification and my odd assumptions:
+  #
+  # TL;DR; We are using what HashiCorp calls an unespecified format but it's the
+  # same format the SRE team is using.
   #
   # At least in Nomad version v1.4.3, the CLI command to submit new jobs
   # (https://developer.hashicorp.com/nomad/docs/commands/job/run) says:
   # "Job files must conform to the job specification format." With this link:
   # https://developer.hashicorp.com/nomad/docs/job-specification. This is the
-  # HCL format that is heavily specified in the docs. Nice!
+  # HCL format that is heavily specified in the docs. Nice but not compatible
+  # with Nix, can't easily be used here.
   #
-  # But note that it starts saying "Nomad HCL is parsed in the command line and
-  # sent to Nomad in JSON format via the HTTP API." and here there are the API
-  # docs that have "JSON Job Specification" in its title:
+  # Hopefully note that it starts saying "Nomad HCL is parsed in the command
+  # line and sent to Nomad in JSON format via the HTTP API." and here you can
+  # see the API docs I found with "JSON Job Specification" in its title:
   # https://developer.hashicorp.com/nomad/api-docs/json-jobs
-  # well, this is the format that `nomad job run` expects if you use the `-json`
-  # argument.
+  # This is the format `nomad job run` expects when using the `-json` argument
+  # but probably incomplete/outdated because when I tried to follow it I got
+  # errors.
   #
-  # I finally found this in the HCL overview page:
+  # I finally found this explanation in the HCL overview page:
   # https://developer.hashicorp.com/nomad/docs/job-specification/hcl2
   # "Since HCL is a superset of JSON, `nomad job run example.json` will attempt
   # to parse a JSON job using the HCL parser. However, the JSON format accepted
@@ -133,9 +141,6 @@ let
   #
   # So, if you don't provide the `-json` argument it expects HCL or its JSON
   # representation: https://github.com/hashicorp/hcl/blob/main/json/spec.md
-  #
-  # We are using what HashiCorp calls an unespecified format but it the same
-  # format the SRE team is using.
 
   # The job stanza is the top-most configuration option in the job
   # specification. A job is a declarative specification of tasks that Nomad
@@ -191,7 +196,7 @@ let
 
     # Specifies a key-value map that annotates with user-defined metadata.
     meta = {
-      # Only top level "KEY=STRING" are allowed!
+      # Only top level "KEY=STRING" are allowed, no child objects/attributes!
       TASK_DRIVER = if execTaskDriver then "exec" else "podman";
       TASK_WORKDIR = task_workdir;
       TASK_STATEDIR = task_statedir;
@@ -272,43 +277,94 @@ let
 
         # The network stanza specifies the networking requirements for the task
         # group, including the network mode and port allocations.
+        # When scheduling jobs in Nomad they are provisioned across your fleet
+        # of machines along with other jobs and services. Because you don't know
+        # in advance what host your job will be provisioned on, Nomad will
+        # provide your tasks with network configuration when they start up.
         # https://developer.hashicorp.com/nomad/docs/job-specification/network
-        # TODO: Use "bridge" mode and port allocations ?
         network = {
-          # FIXME: "bridge" right now is not working. Client error is:
-          # {"@level":"error","@message":"prerun failed","@module":"client.alloc_runner","@timestamp":"2023-02-01T13:52:24.948596Z","alloc_id":"03faca46-0fdc-4ba0-01e9-50f67c088f99","error":"pre-run hook \"network\" failed: failed to create network for alloc: mkdir /var/run/netns: permission denied"}
-          # {"@level":"info","@message":"waiting for task to exit","@module":"client.alloc_runner","@timestamp":"2023-02-01T13:52:24.983021Z","alloc_id":"03faca46-0fdc-4ba0-01e9-50f67c088f99","task":"tracer"}
-          # {"@level":"info","@message":"marking allocation for GC","@module":"client.gc","@timestamp":"2023-02-01T13:52:24.983055Z","alloc_id":"03faca46-0fdc-4ba0-01e9-50f67c088f99"}
-          # {"@level":"info","@message":"node registration complete","@module":"client","@timestamp":"2023-02-01T13:52:27.489795Z"}
+          # Mode of the network. This option is only supported on Linux clients.
+          # All other operating systems use the host networking mode.
+          # The following modes are available:
+          # - none:       Task group will have an isolated network without any
+          #               network interfaces.
+          # - bridge:     Task group will have an isolated network namespace
+          #               with an interface that is bridged with the host. Note
+          #               that bridge networking is only currently supported for
+          #               the docker, exec, raw_exec, and java task drivers.
+          # - host:       Each task will join the host network namespace and a
+          #               shared network namespace is not created. This matches
+          #               the current behavior in Nomad 0.9.
+          # - cni/<name>: Task group will have an isolated network namespace
+          #               with the network configured by CNI.
+          # Actually using the interface specified on Nomad Client startup that
+          # for local runs it's forced to "lo" and whatever is automatically
+          # fingerprinted or provided for cloud runs.
+          # TODO: Use "bridge" mode for podman, this will allow to run isolated
+          # local cluster with no addresses or ports clashing.
           mode = "host";
-          port = lib.listToAttrs (
-            if portNum != 0
-            then
-              [
-                {
-                  # All names of the form node#, without the "-", instead of node-#
-                  name = portName;
-                  value =
-                    # The "podman" driver accepts "Mapped Ports", but not the "exec" driver
+          # Specifies a TCP/UDP port allocation and can be used to specify both
+          # dynamic ports and reserved ports.
+          # https://developer.hashicorp.com/nomad/docs/job-specification/network#port-parameters
+          port = lib.listToAttrs [
+            {
+              # The label assigned to the port is used to identify the port
+              # in service discovery, and used in the name of the
+              # environment variable that indicates which port your
+              # application should bind to (envar only available for the
+              # ports of current Tasks, not to resolve all port names).
+              # Names need to be "node#" instead of "node-#" (without "-").
+              name = portName;
+              value =
+                if portNum != null && portNum != 0
+                then
+                  (
+                    # Dynamic ports vs Static ports as seen by Nomad:
+                    # Most services run in your cluster should use dynamic
+                    # ports. This means that the port will be allocated
+                    # dynamically by the scheduler, and your service will have
+                    # to read an environment variable to know which port to bind
+                    # to at startup.
+                    # https://developer.hashicorp.com/nomad/docs/job-specification/network#dynamic-ports
+                    # Static ports bind your job to a specific port on the host
+                    # they are placed on. Since multiple services cannot share
+                    # a port, the port must be open in order to place your task.
+                    # https://developer.hashicorp.com/nomad/docs/job-specification/network#static-ports
+                    # Some drivers (such as Docker and QEMU) allow you to map
+                    # ports. A mapped port means that your application can
+                    # listen on a fixed port (it does not need to read the
+                    # environment variable) and the dynamic port will be mapped
+                    # to the port in your container or virtual machine.
                     # https://developer.hashicorp.com/nomad/docs/job-specification/network#mapped-ports
-                    # If you use a network in bridge mode you can use "Mapped Ports"
-                    # https://developer.hashicorp.com/nomad/docs/job-specification/network#bridge-mode
-                    if execTaskDriver
-                    then
-                      {
-                        to     = ''${toString portNum}'';
-                        static = ''${toString portNum}'';
-                      }
-                    else
-                      {
-                        to     = ''${toString portNum}'';
-                      }
-                    ;
-                }
-              ]
-            else
-              [{name = portName; value ={};}]
-          );
+                    {
+                      # Specifies the static TCP/UDP port to allocate. If
+                      # omitted, a dynamic port is chosen. We do not recommend
+                      # using static ports, except for system or specialized
+                      # jobs like load balancers.
+                      static = ''${toString portNum}'';
+
+                      # TODO: When switching the network mode to "bridge" for
+                      # podman use "Mapped Ports" to be able to run isolated
+                      # local cluster with no addresses or ports clashing.
+                      # Applicable when using "bridge" mode to configure port
+                      # to map to inside the task's network namespace. Omitting
+                      # this field or setting it to -1 sets the mapped port
+                      # equal to the dynamic port allocated by the scheduler.
+                      # The NOMAD_PORT_<label> environment variable will contain
+                      # the to value.
+                      # to = ''${toString portNum}'';
+                      # The "podman" driver accepts "Mapped Ports", but not the
+                      # "exec" driver
+                      # https://developer.hashicorp.com/nomad/docs/job-specification/network#mapped-ports
+                      # https://developer.hashicorp.com/nomad/docs/job-specification/network#bridge-mode
+                    }
+                  )
+                else
+                  # Only reserve the name!
+                  {}
+              ;
+            }
+          ];
         };
 
         # The Consul namespace in which group and task-level services within the
@@ -339,15 +395,26 @@ let
           # For benchmarking dedicated static machines in the "perf" class are
           # used and this value should be updated accordingly.
           resources = {
-            # Task can only ask for 'cpu' or 'cores' resource, not both.
-            #cpu = 512;
-            cores = 2;
-            memory = 1024*4;
-            #memory_max = 32768;
+            # Task can only ask for 'cpu' or 'cores' resource but not both.
+            cores = 2;       # cpu = 512;
+            memory = 1024*4; # memory_max = 32768;
           };
 
+          # The service block instructs Nomad to register a service with the
+          # specified provider; Nomad or Consul (we are using Nomad).
           # https://developer.hashicorp.com/nomad/docs/job-specification/service
+          #
+          # This services are used to dynamically configure the IP and ports of
+          # nodes using the "template" stanza below.
           service = {
+            # Specifies the service registration provider to use for service
+            # registrations. Valid options are either consul or nomad. All
+            # services within a single task group must utilise the same provider
+            # value.
+            # We don't use Consul to avoid having one extra dependency / thing
+            # to configure and monitor during local runs while sharing as much
+            # code as possible with cloud runs.
+            provider = "nomad";
             # Specifies the name this service will be advertised as in Consul.
             # If not supplied, this will default to the name of the job, task
             # group, and task concatenated together with a dash, like
@@ -356,22 +423,19 @@ let
             # alphanumeric and hyphen characters (i.e. [a-z0-9\-]), and be less
             # than 64 characters in length.
             name = serviceName;
-            # Specifies the service registration provider to use for service
-            # registrations. Valid options are either consul or nomad. All
-            # services within a single task group must utilise the same provider
-            # value.
-            provider = "nomad";
             # Specifies the port to advertise for this service. The value of
             # port depends on which address_mode is being used:
-            # - alloc: Advertise the mapped to value of the labeled port and the
-            # allocation address. If a to value is not set, the port falls back
-            # to using the allocated host port. The port field may be a numeric
-            # port or a port label specified in the same group's network block.
+            # - alloc:  Advertise the mapped to value of the labeled port and the
+            #           allocation address. If a to value is not set, the port
+            #           falls back to using the allocated host port. The port
+            #           field may be a numeric port or a port label specified in
+            #           the same group's network block.
             # - driver: Advertise the port determined by the driver (e.g.
-            # Docker). The port may be a numeric port or a port label specified
-            # in the driver's ports field.
-            # - host: Advertise the host port for this service. port must match
-            # a port label specified in the network block.
+            #           Docker). The port may be a numeric port or a port label
+            #           specified in the driver's ports field.
+            # - host:   Advertise the host port for this service. port must
+            #           match a port label specified in the network block.
+            # Here we use "network"->"port"->"name" specified in the Group.
             port = portName;
             # Checks of type "script" need "consul" instead of "nomad" as
             # service provider, so as healthcheck we are using a supervisord
@@ -389,6 +453,20 @@ let
           # Specifies the set of templates to render for the task. Templates can
           # be used to inject both static and dynamic configuration with data
           # populated from environment variables, Consul and Vault.
+          #
+          # We are using the template machinery to populate IP and ports.
+          # See "Dynamic Configuration":
+          # Nomad's job specification includes a template block that utilizes a
+          # Consul ecosystem tool called Consul Template. This mechanism creates
+          # a convenient way to ship configuration files that are populated from
+          # environment variables, Consul data, Vault secrets, or just general
+          # configurations within a Nomad task.
+          # For more information on Nomad's template block and how it leverages
+          # Consul Template, please see the template job specification
+          # documentation.
+          # - Template block: https://developer.hashicorp.com/nomad/docs/job-specification/template
+          # - Consul template: https://github.com/hashicorp/consul-template
+          # https://developer.hashicorp.com/nomad/docs/integrations/consul-integration#dynamic-configuration
           template = [
             # Envars
             {

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -150,14 +150,16 @@ backend_nomadcloud() {
       then
         msg $(yellow "WARNING: Amazon S3 \"AWS_ACCESS_KEY_ID\" or \"AWS_SECRET_ACCESS_KEY\" envar is not set")
         msg $(blue "INFO: Fetching \"AWS_ACCESS_KEY_ID\" and \"AWS_SECRET_ACCESS_KEY\" from SRE provided Vault for \"Performance and Tracing\"")
-        local aws_credentials="$(wb_nomad vault world aws-s3-credentials)"
+        local aws_credentials
+        aws_credentials="$(wb_nomad vault world aws-s3-credentials)"
         export AWS_ACCESS_KEY_ID=$(echo "${aws_credentials}" | jq -r .data.access_key)
         export AWS_SECRET_ACCESS_KEY=$(echo "${aws_credentials}" | jq -r .data.secret_key)
       fi
       # The Nomad job spec will contain links ("nix_installables" stanza) to
       # the Nix Flake outputs it needs inside the container, these are
       # refereced with a GitHub commit ID inside the "container-specs" file.
-      local gitrev=$(jq -r .gitrev "${profile_container_specs_file}")
+      local gitrev
+      gitrev=$(jq -r .gitrev "${profile_container_specs_file}")
       msg $(blue "INFO: Found GitHub commit with ID \"$gitrev\"")
       # Check if the Nix package was created from a dirty git tree
       if test "$gitrev" = "0000000000000000000000000000000000000000"
@@ -172,21 +174,23 @@ backend_nomadcloud() {
         then
           # Check HTTP status code for existance
           # https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit
-          local headers=$(echo "${curl_response}" | jq -s .[1])
+          local headers
+          headers=$(echo "${curl_response}" | jq -s .[1])
           if test "$(echo "${headers}" | jq .http_code)" != 200
           then
             fatal "GitHub commit \"$gitrev\" is not available online!"
           fi
           # Show returned commit info in `git log` fashion
-          local body=$(echo "${curl_response}" | jq -s .[0])
+          local body author_name author_email author_date message
+          body=$(echo "${curl_response}" | jq -s .[0])
+          author_name=$(echo $body  | jq -r .commit.author.name)
+          author_email=$(echo $body | jq -r .commit.author.email)
+          author_date=$(echo $body  | jq -r .commit.author.date)
+          message=$(echo $body      | jq -r .commit.message)
           msg $(green "commit ${gitrev}")
-          local author_name=$(echo $body | jq -r .commit.author.name)
-          local author_email=$(echo $body | jq -r .commit.author.email)
           msg $(green "Author: ${author_name} <${author_email}>")
-          local author_date=$(echo $body | jq -r .commit.author.date)
           msg $(green "Date: ${author_date}")
           msg $(green "\n")
-          local message=$(echo $body | jq -r .commit.message)
           msg $(green "\t${message}\n")
           msg $(green "\n")
         else
@@ -220,13 +224,29 @@ backend_nomadcloud() {
       backend_nomad allocate-run-nomad-job-patch-nix               "${dir}"
 
       # Set the placement info and resources accordingly
-      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      if test -z "${WB_SHELL_PROFILE}"
+      local nomad_job_name
+      nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
+      if test -z "${WB_SHELL_PROFILE:-}"
       then
         fatal "Envar \"WB_SHELL_PROFILE\" is empty!"
       else
-        # Placement:
-        ############
+        ########################################################################
+        # Fix for region mismatches ############################################
+        ########################################################################
+        # We use "us-east-2" and they use "us-east-1"
+          jq \
+            ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+            sponge "${dir}"/nomad/nomad-job.json
+          jq \
+            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+            sponge "${dir}"/nomad/nomad-job.json
+        ########################################################################
+        # Unique placement: ####################################################
+        ########################################################################
         ## "distinct_hosts": Instructs the scheduler to not co-locate any groups
         ## on the same machine. When specified as a job constraint, it applies
         ## to all groups in the job. When specified as a group constraint, the
@@ -243,19 +263,21 @@ backend_nomadcloud() {
             }
           ]
         '
+        # Adds it as a job level contraint.
           jq \
             --argjson job_constraints_array "${job_constraints_array}" \
             ".[\"job\"][\"${nomad_job_name}\"].constraint |= \$job_constraints_array" \
             "${dir}"/nomad/nomad-job.json \
         | \
           sponge "${dir}"/nomad/nomad-job.json
-        # Resources:
-        ############
+        ########################################################################
+        # Node class: ##########################################################
+        ########################################################################
         local group_constraints_array
         # "perf" profiles run on the "perf" class
         if test "${WB_SHELL_PROFILE:0:7}" = 'cw-perf'
         then
-          # Right now only "live" is using "perf" class distinct nodes!
+          # Using Performance & Tracing exclusive "perf" class distinct nodes!
           group_constraints_array='
             [
               {
@@ -265,7 +287,33 @@ backend_nomadcloud() {
               }
             ]
           '
-          # Set the resources, only for perf!
+        else
+          # Using "qa" class distinct nodes. Only "short" test allowed here.
+          group_constraints_array='
+            [
+              {
+                "operator":  "="
+              , "attribute": "${node.class}"
+              , "value":     "qa"
+              }
+            ]
+          '
+        fi
+        # Adds it as a group level contraint.
+          jq \
+            --argjson group_constraints_array "${group_constraints_array}" \
+            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
+            "${dir}"/nomad/nomad-job.json \
+        | \
+          sponge "${dir}"/nomad/nomad-job.json
+        ########################################################################
+        # Memory/resources: ####################################################
+        ########################################################################
+        # Set the resources, only for perf!
+        # When not "perf", when "cw-qa", only "short" tests are allowed.
+        if test "${WB_SHELL_PROFILE:0:7}" = 'cw-perf'
+        then
+          # Producer nodes use this specs, make sure they are available!
           # AWS:
           ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
           ## https://aws.amazon.com/ec2/instance-types/c5/
@@ -279,18 +327,36 @@ backend_nomadcloud() {
           ## - memory.totalbytes    = 16300142592
           ## Pesimistic: 1,798 MiB / 15,545 MiB Total
           ## Optimistic: 1,396 MiB / 15,545 MiB Total
-          local resources='{
+          local producer_resources='{
               "cores":      8
             , "memory":     13000
             , "memory_max": 15000
           }'
+          # Set this for every non-explorer node
             jq \
-              --argjson resources "${resources}" \
-              ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.task |= with_entries( .value.resources = \$resources ) )" \
+              --argjson producer_resources "${producer_resources}" \
+              " \
+                  .[\"job\"][\"${nomad_job_name}\"][\"group\"] \
+                |= \
+                  with_entries( \
+                    if ( .key != \"explorer\" ) \
+                    then ( \
+                        .value.task \
+                      |= \
+                        with_entries( .value.resources = \$producer_resources ) \
+                    ) else ( \
+                      . \
+                    ) end \
+                  ) \
+              " \
               "${dir}"/nomad/nomad-job.json \
           | \
             sponge "${dir}"/nomad/nomad-job.json
-          # The explorer node: Using an "m5.4xlarge" instance type
+          # The explorer node uses this specs, make sure they are available!
+          # AWS
+          ## m5.4xlarge: 8 vCPU and 16 Memory (GiB)
+          ## https://aws.amazon.com/ec2/instance-types/m5/
+          # Nomad:
           ## - cpu.arch             = amd64
           ## - cpu.frequency        = 3100
           ## - cpu.modelname        = Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
@@ -311,38 +377,157 @@ backend_nomadcloud() {
               "${dir}"/nomad/nomad-job.json \
           | \
             sponge "${dir}"/nomad/nomad-job.json
-          # Fix for region mismatches
-          ###########################
-          # We use "us-east-2" and they use "us-east-1"
-            jq \
-              ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
-              "${dir}"/nomad/nomad-job.json \
-            | \
-              sponge "${dir}"/nomad/nomad-job.json
-            jq \
-              ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
-              "${dir}"/nomad/nomad-job.json \
-            | \
-              sponge "${dir}"/nomad/nomad-job.json
-        # Non "perf" profiles run on the "qa" class
-        else
-          # Right now only testing, using "qa" class distinct nodes!
-          group_constraints_array='
-            [
-              {
-                "operator":  "="
-              , "attribute": "${node.class}"
-              , "value":     "qa"
-              }
-            ]
-          '
         fi
-          jq \
-            --argjson group_constraints_array "${group_constraints_array}" \
-            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
-            "${dir}"/nomad/nomad-job.json \
-        | \
-          sponge "${dir}"/nomad/nomad-job.json
+        ########################################################################
+        # Reproducibility: #####################################################
+        ########################################################################
+        # If value profile on "perf", using always the same placement!
+        # This means node-N always runs on the same Nomad Client/AWS EC2 machine
+        if test "${WB_SHELL_PROFILE:0:13}" = 'cw-perf-value'
+        then
+          # A file with all the available Nomad Clients is needed!
+          # This files is a list of Nomad Clients with a minimun of ".id",
+          # ".datacenter", ".attributes.platform.aws["instance-type"]",
+          # ".attributes.platform.aws.placement["availability-zone"]",
+          # ".attributes.unique.platform.aws["instance-id"]",
+          # ".attributes.unique.platform.aws.["public-ipv4"]" and
+          # ".attributes.unique.platform.aws.mac".
+          if test -z "${NOMAD_CLIENTS_FILE:-}" || ! test -f "${NOMAD_CLIENTS_FILE}"
+          then
+            fatal "No \"\$NOMAD_CLIENTS_FILE\""
+          fi
+          # For each (instance-type, datacener/region) we look incrementally for
+          # the unique AWS EC2 "instance-id" only after ordering the Nomad
+          # Clients by its unique Nomad provided "id".
+          local count_ap=0 count_eu=0 count_us=0
+          # For each Nomad Job Group
+          local groups_array
+          # Keys MUST be sorted to always get the same order for the same profile!
+          groups_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
+          for group_name in ${groups_array[*]}
+          do
+            # Obtain the datacenter as Nomad sees it, not as an AWS attributes.
+            # For example "eu-central-1" instead of "eu-central-1a".
+            local datacenter
+            datacenter=$(jq \
+              -r \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"].affinity.value" \
+              "${dir}"/nomad/nomad-job.json \
+            )
+            # For each Nomad Job Group Task
+            local tasks_array
+            # Keys MUST be sorted to always get the same order for the same profile!
+            tasks_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"task\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
+            for task_name in ${tasks_array[*]}
+            do
+              local count instance_type
+              if test "${task_name}" = "explorer"
+              then
+                # There is only one of this instance!
+                instance_type="m5.4xlarge"
+                count=0
+              else
+                # There are many of these instances and we need to always fetch
+                # them in the same order for reproducibility.
+                instance_type="c5.2xlarge"
+                if test "${datacenter}" = "ap-southeast-2"
+                then
+                  count="${count_ap}"
+                  count_ap=$(( count_ap + 1 ))
+                elif test "${datacenter}" = "eu-central-1"
+                then
+                  count="${count_eu}"
+                  count_eu=$(( count_eu + 1 ))
+                elif test "${datacenter}" = "us-east-1"
+                then
+                  count="${count_us}"
+                  count_us=$(( count_us + 1 ))
+                fi
+              fi
+              # Get the actual client for this datacenter and instance type.
+              local actual_client
+              actual_client=$(jq \
+                "   . \
+                  | \
+                    sort_by(.id) \
+                  | \
+                    map(select(.datacenter == \"${datacenter}\")) \
+                  | \
+                    map(select(.attributes.platform.aws[\"instance-type\"] == \"${instance_type}\")) \
+                  | \
+                    .[${count}] \
+                " \
+                "${NOMAD_CLIENTS_FILE}" \
+              )
+              local instance_id availability_zone public_ipv4 mac_address
+              instance_id="$( \
+                 echo "${actual_client}" \
+                | \
+                  jq -r \
+                    '.attributes.unique.platform.aws["instance-id"]' \
+              )"
+              availability_zone="$( \
+                 echo "${actual_client}" \
+                | \
+                  jq -r \
+                    '.attributes.platform.aws.placement["availability-zone"]' \
+              )"
+              public_ipv4="$( \
+                 echo "${actual_client}" \
+                | \
+                  jq -r \
+                    '.attributes.unique.platform.aws["public-ipv4"]' \
+              )"
+              mac_address="$( \
+                 echo "${actual_client}" \
+                | \
+                  jq -r \
+                    '.attributes.unique.platform.aws.mac' \
+              )"
+              # Pin the actual node to an specific Nomad Client / AWS instance
+              # by appending below constraints to the already there group
+              # constraints.
+              # We pin it to a couple of AWS specifics attributes so if SRE
+              # changes something related to Nomad Clients or AWS instances we
+              # may hopefully notice it when the job fails to start (placement
+              # errors).
+              local group_constraints_array_plus="
+                [ \
+                    { \
+                      \"attribute\": \"\${attr.platform.aws.instance-type}\" \
+                    , \"value\":     \"${instance_type}\" \
+                    } \
+                  ,
+                    { \
+                      \"attribute\": \"\${attr.platform.aws.placement.availability-zone}\" \
+                    , \"value\":     \"${availability_zone}\" \
+                    } \
+                  ,
+                    { \
+                      \"attribute\": \"\${attr.unique.platform.aws.instance-id}\" \
+                    , \"value\":     \"${instance_id}\" \
+                    } \
+                  ,
+                    { \
+                      \"attribute\": \"\${attr.unique.platform.aws.public-ipv4}\" \
+                    , \"value\":     \"${public_ipv4}\" \
+                    } \
+                  ,
+                    { \
+                      \"attribute\": \"\${attr.unique.platform.aws.mac}\" \
+                    , \"value\":     \"${mac_address}\" \
+                    } \
+                ] \
+              "
+                jq \
+                  --argjson group_constraints_array_plus "${group_constraints_array_plus}" \
+                  ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"constraint\"] |= ( . + \$group_constraints_array_plus)" \
+                  "${dir}"/nomad/nomad-job.json \
+              | \
+                sponge "${dir}"/nomad/nomad-job.json
+            done
+          done
+        fi
       fi
 
       # Store a summary of the job.
@@ -360,7 +545,8 @@ backend_nomadcloud() {
                     , "tasks":      (
                         .task | with_entries(
                           .value |= {
-                              "resources":          .resources
+                              "constraint":         .constraint
+                            , "resources":          .resources
                             , "nix_installables":   .config.nix_installables
                             , "templates":        ( .template | map(.destination) )
                           }

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -394,7 +394,7 @@ backend_nomadcloud() {
           # ".attributes.unique.platform.aws.mac".
           if test -z "${NOMAD_CLIENTS_FILE:-}" || ! test -f "${NOMAD_CLIENTS_FILE}"
           then
-            fatal "No \"\$NOMAD_CLIENTS_FILE\""
+            fatal "No \"\$NOMAD_CLIENTS_FILE\". For reproducible builds provide this file that ensures cluster nodes are always placed on the same machines, or create a new one with 'wb nomad nodes' if Nomad Clients have suffered changes and runs fail with \"placement errors\""
           fi
           # For each (instance-type, datacener/region) we look incrementally for
           # the unique AWS EC2 "instance-id" only after ordering the Nomad

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -600,6 +600,14 @@ def all_profile_variants:
   , { name: "default"
     , desc: "Default, as per nix/workbench/profile/prof0-defaults.jq"
     }
+  , $cardano_world_qa *
+    { name: "default-cw-qa"
+    , desc: "Default, but on Cardano World QA"
+    }
+  , $cardano_world_perf *
+    { name: "default-cw-perf"
+    , desc: "Default, but on Cardano World perf"
+    }
   , $plutus_base * $costmodel_v8_preview * $plutus_loop_counter *
     { name: "plutus"
     , desc: "Default with Plutus workload: CPU/memory limit saturation counter loop"
@@ -623,10 +631,6 @@ def all_profile_variants:
   , $scenario_tracer_only *
     { name: "tracer-only"
     , desc: "Idle scenario:  start only the tracer & detach from tty;  no termination"
-    }
-  , $cardano_world_qa *
-    { name: "cw-qa-default"
-    , desc: "Default, but on Cardano World QA"
     }
 
   ## Fastest profile to pass analysis: just 1 block
@@ -663,8 +667,12 @@ def all_profile_variants:
     { name: "ci-test-rtview"
     }
   , $citest_base * $cardano_world_qa *
-    { name: "cw-qa-ci-test"
+    { name: "ci-test-cw-qa"
     , desc: "ci-test, but on Cardano World QA"
+    }
+  , $citest_base * $cardano_world_perf *
+    { name: "ci-test-cw-perf"
+    , desc: "ci-test, but on Cardano World perf"
     }
 
   ## CI variants: bench duration, 15 blocks
@@ -690,8 +698,12 @@ def all_profile_variants:
     { name: "ci-bench-rtview"
     }
   , $cibench_base * $cardano_world_qa *
-    { name: "cw-qa-ci-bench"
+    { name: "ci-bench-cw-qa"
     , desc: "ci-bench but on Cardano World QA"
+    }
+  , $cibench_base * $cardano_world_perf *
+    { name: "ci-bench-cw-perf"
+    , desc: "ci-bench but on Cardano World perf"
     }
 
   ## CI variants: test duration, 3 blocks, dense10

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -45,10 +45,6 @@ def all_profile_variants:
       { utxo:                              (0.5 * $M)
       , delegators:                        (0.1 * $M)
       }
-    , generator:
-      { tps:                               1
-      , tx_count:                          10
-      }
     } as $dataset_miniature
   |
     { genesis:


### PR DESCRIPTION
Changes that allow the pinning of nodes to the same machines across Nomad Cloud runs plus more realistic runs (or as similar as possible to cardano ops)

- New workbench subcommand to create an index of available Nomad Clients
- Based on this Nomad Clients index, nodes are placed on an orderly manner by constraining AWS instance type, availability zone, instance id, public ip address and mac address. If Nomad Clients change the job fails.
- Use public IP/routing between nodes when using cardano world perf class
- Add new profiles that allow to run short tests on cardano world perf class
- Better documentation and cleanups of the Nomad Job creation