### PR TITLE
Bench nomad ssh

### DIFF
--- a/nix/workbench/backend/backend.sh
+++ b/nix/workbench/backend/backend.sh
@@ -38,21 +38,29 @@ backend() {
 local op=${1:-$(usage_backend)} # No need to shift -- backends will use the op.
 
 case "${op}" in
-    is-running )                 backend_$WB_BACKEND "$@";;
+    # Prepare functions
     setenv-defaults )            backend_$WB_BACKEND "$@";;
     allocate-run )               backend_$WB_BACKEND "$@";;
     describe-run )               backend_$WB_BACKEND "$@";;
+    # Start functions
+    is-running )                 backend_$WB_BACKEND "$@";;
+    start-cluster )              backend_$WB_BACKEND "$@";;
     deploy-genesis )             backend_$WB_BACKEND "$@";;
-    start )                      backend_$WB_BACKEND "$@";;
+    # Sceneario functions
+    start-tracers )              backend_$WB_BACKEND "$@";;
     start-nodes )                backend_$WB_BACKEND "$@";;
+    start-generator )            backend_$WB_BACKEND "$@";;
+    start-healthchecks )         backend_$WB_BACKEND "$@";;
+    # Fine grained
     start-node )                 backend_$WB_BACKEND "$@";;
     stop-node )                  backend_$WB_BACKEND "$@";;
     wait-node )                  backend_$WB_BACKEND "$@";;
     wait-node-stopped )          backend_$WB_BACKEND "$@";;
     get-node-socket-path )       backend_$WB_BACKEND "$@";;
-    start-generator )            backend_$WB_BACKEND "$@";;
-    start-healthchecks )         backend_$WB_BACKEND "$@";;
     wait-pools-stopped )         backend_$WB_BACKEND "$@";;
+    # Stop functions
+    stop-all )                   backend_$WB_BACKEND "$@";;
+    fetch-logs )                 backend_$WB_BACKEND "$@";;
     stop-cluster )               backend_$WB_BACKEND "$@";;
     cleanup-cluster )            backend_$WB_BACKEND "$@";;
 

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -269,10 +269,11 @@ let
         constraint = {
           attribute = "\${node.class}";
           operator = "=";
-          # For testing we avoid using "infra" node class as HA jobs runs there
-          # For benchmarking dedicated static machines in the "perf"
-          # class are used and this value should be updated accordingly.
-          value = "qa";
+          # For cloud benchmarking dedicated static machines in the "perf"
+          # class are used. We replicate that for local/test runs.
+          # Class "qa" nodes are also available but must be limited to short
+          # test and avoid using "infra" node class as HA jobs runs there.
+          value = "perf";
         };
 
         # The network stanza specifies the networking requirements for the task

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -1,15 +1,12 @@
 { pkgs
 , lib
 , stateDir
+, subBackendName
 # TODO: Fetch this from config services inside materialise-profile !
 , eventlogged ? true
 , ...
 }:
 let
-
-  validateNodeSpecs = { nodeSpecsValue }:
-    true
-  ;
 
   # Backend-specific Nix bits:
   materialise-profile =
@@ -31,99 +28,126 @@ let
           # The actual commit.
           gitrev = pkgs.gitrev;
           # Binaries.
-          containerPkgs = {
-            bashInteractive = rec {
-              nix-store-path  = pkgs.bashInteractive;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.bashInteractive";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            coreutils = rec {
-              nix-store-path  = pkgs.coreutils;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.coreutils";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            findutils = rec {
-              nix-store-path  = pkgs.findutils;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.findutils";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            gnutar = rec {
-              nix-store-path  = pkgs.gnutar;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.gnutar";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            zstd = rec {
-              nix-store-path  = pkgs.zstd;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.zstd";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            wget = rec {
-              nix-store-path  = pkgs.wget;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.wget";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            supervisor = rec {
-              nix-store-path  = pkgs.python3Packages.supervisor;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.python3Packages.supervisor";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            gnugrep = rec {
-              nix-store-path  = pkgs.gnugrep;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.gnugrep";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            jq = rec {
-              nix-store-path  = pkgs.jq;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "legacyPackages.x86_64-linux.jq";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
+          containerPkgs =
+            {
+              coreutils = rec {
+                nix-store-path  = pkgs.coreutils;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.coreutils";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              bashInteractive = rec {
+                nix-store-path  = pkgs.bashInteractive;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.bashInteractive";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              findutils = rec {
+                nix-store-path  = pkgs.findutils;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.findutils";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              gnutar = rec {
+                nix-store-path  = pkgs.gnutar;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.gnutar";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              zstd = rec {
+                nix-store-path  = pkgs.zstd;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.zstd";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              wget = rec {
+                nix-store-path  = pkgs.wget;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.wget";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              cacert = rec {
+                nix-store-path  = pkgs.cacert;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.cacert";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              supervisor = rec {
+                nix-store-path  = pkgs.python3Packages.supervisor;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.python3Packages.supervisor";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              gnugrep = rec {
+                nix-store-path  = pkgs.gnugrep;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.gnugrep";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              jq = rec {
+                nix-store-path  = pkgs.jq;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.jq";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+            }
+            //
             # TODO: - cardano-node.passthru.profiled
             #       - cardano-node.passthru.eventlogged
             #       - cardano-node.passthru.asserted
             # profileData.node-services."node-0".serviceConfig.value.eventlog
             # builtins.trace (builtins.attrNames profileData.node-services."node-0".serviceConfig.value.eventlog) XXXX
-            cardano-node = rec {
-              nix-store-path  = with pkgs;
-                if eventlogged
-                  then cardanoNodePackages.cardano-node.passthru.eventlogged
-                  else cardanoNodePackages.cardano-node
-              ;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output =
-                if eventlogged
-                  then "cardanoNodePackages.cardano-node.passthru.eventlogged"
-                  else "cardanoNodePackages.cardano-node"
-              ;
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            cardano-cli = rec {
-              nix-store-path  = pkgs.cardanoNodePackages.cardano-cli;
-              flake-reference = "github:input-output-hk/cardano-cli";
-              flake-output = "cardanoNodePackages.cardano-cli";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            cardano-tracer = rec {
-              nix-store-path  = pkgs.cardanoNodePackages.cardano-tracer;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "cardanoNodePackages.cardano-tracer";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-            tx-generator = rec {
-              nix-store-path  = pkgs.cardanoNodePackages.tx-generator;
-              flake-reference = "github:input-output-hk/cardano-node";
-              flake-output = "cardanoNodePackages.tx-generator";
-              installable = "${flake-reference}/${gitrev}#${flake-output}";
-            };
-          };
+            {
+              cardano-node = rec {
+                nix-store-path  = with pkgs;
+                  if eventlogged
+                    then cardanoNodePackages.cardano-node.passthru.eventlogged
+                    else cardanoNodePackages.cardano-node
+                ;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output =
+                  if eventlogged
+                    then "cardanoNodePackages.cardano-node.passthru.eventlogged"
+                    else "cardanoNodePackages.cardano-node"
+                ;
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              cardano-cli = rec {
+                nix-store-path  = pkgs.cardanoNodePackages.cardano-cli;
+                flake-reference = "github:input-output-hk/cardano-cli";
+                flake-output = "cardanoNodePackages.cardano-cli";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              cardano-tracer = rec {
+                nix-store-path  = pkgs.cardanoNodePackages.cardano-tracer;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "cardanoNodePackages.cardano-tracer";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+              tx-generator = rec {
+                nix-store-path  = pkgs.cardanoNodePackages.tx-generator;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "cardanoNodePackages.tx-generator";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+            }
+            //
+            lib.attrsets.optionalAttrs (subBackendName == "cloud") {
+              openssh_hacks = rec {
+                commit = "01076c7118939c90cb5c9d6320e9813740ec3534"; # Branch "9.3p1";
+                nix-store-path  = (__getFlake "github:fmaste/openssh-portable-hacks/${commit}").packages.x86_64-linux.openssh_hacks;
+                flake-reference = "github:fmaste/openssh-portable-hacks";
+                flake-output = "packages.x86_64-linux.openssh_hacks";
+                installable = "${flake-reference}/${commit}#${flake-output}";
+              };
+              rsync = rec {
+                nix-store-path  = pkgs.rsync;
+                flake-reference = "github:input-output-hk/cardano-node";
+                flake-output = "legacyPackages.x86_64-linux.rsync";
+                installable = "${flake-reference}/${gitrev}#${flake-output}";
+              };
+            }
+          ;
           supervisord = {
             url = "unix:///tmp/supervisor.sock";
             conf = lib.strings.concatStringsSep "/"
@@ -135,51 +159,88 @@ let
               inherit containerPkgs;
             }
           ;
-          nomadJob = {
-            inherit generatorTaskName;
-            podman = {
-              # TODO: oneTracerPerGroup
-              oneTracerPerCluster = import ./nomad-job.nix
-                { inherit pkgs lib stateDir;
-                  inherit profileData;
-                  inherit containerSpecs;
-                  # May evolve to a "cloud" flag!
-                  execTaskDriver = false;
-                  inherit generatorTaskName;
-                  oneTracerPerNode = false;
-                };
-              oneTracerPerNode = import ./nomad-job.nix
-                { inherit pkgs lib stateDir;
-                  inherit profileData;
-                  inherit containerSpecs;
-                  # May evolve to a "cloud" flag!
-                  execTaskDriver = false;
-                  inherit generatorTaskName;
-                  oneTracerPerNode = true;
-                };
-            };
-            exec = {
-              # TODO: oneTracerPerGroup
-              oneTracerPerCluster = import ./nomad-job.nix
-                { inherit pkgs lib stateDir;
-                  inherit profileData;
-                  inherit containerSpecs;
-                  # May evolve to a "cloud" flag!
-                  execTaskDriver = true;
-                  inherit generatorTaskName;
-                  oneTracerPerNode = false;
-                };
-              oneTracerPerNode = import ./nomad-job.nix
-                { inherit pkgs lib stateDir;
-                  inherit profileData;
-                  inherit containerSpecs;
-                  # May evolve to a "cloud" flag!
-                  execTaskDriver = true;
-                  inherit generatorTaskName;
-                  oneTracerPerNode = true;
-                };
-            };
-          };
+          nomadJob =
+            { inherit generatorTaskName; }
+            //
+            lib.attrsets.optionalAttrs (subBackendName == "podman") {
+              podman = {
+                # TODO: oneTracerPerGroup
+                oneTracerPerCluster = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = false;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = false;
+                    withSsh = false;
+                  };
+                oneTracerPerNode = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = false;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = true;
+                    withSsh = false;
+                  };
+              };
+            }
+            //
+            lib.attrsets.optionalAttrs (subBackendName == "exec") {
+              exec = {
+                # TODO: oneTracerPerGroup
+                oneTracerPerCluster = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = true;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = false;
+                    withSsh = false;
+                  };
+                oneTracerPerNode = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = true;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = true;
+                    withSsh = false;
+                  };
+              };
+            }
+            //
+            lib.attrsets.optionalAttrs (subBackendName == "cloud") {
+              cloud = {
+                # Always "oneTracerPerNode"
+                # TODO: oneTracerPerCluster and oneTracerPerGroup
+                nomadExec = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = true;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = true;
+                    withSsh = false;
+                  };
+                ssh = import ./nomad-job.nix
+                  { inherit pkgs lib stateDir;
+                    inherit profileData;
+                    inherit containerSpecs;
+                    # May evolve to a "cloud" flag!
+                    execTaskDriver = true;
+                    inherit generatorTaskName;
+                    oneTracerPerNode = true;
+                    withSsh = true;
+                  };
+              };
+            }
+          ;
         };
       in pkgs.runCommand "workbench-backend-output-${profileData.profileName}-nomad"
         ({

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -223,11 +223,24 @@ backend_nomad() {
 
     allocate-run-nomad-job-patch-namespace )
       local usage="USAGE: wb backend $op RUN-DIR NAMESPACE"
-      local dir=${1:?$usage};       shift
-      local namespace=${1:?$usage}; shift
+      local dir=${1:?$usage}; shift
       local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      msg "Setting Nomad job namespace to \"${namespace}\""
-      jq ".job[\"${nomad_job_name}\"][\"namespace\"] = \"${namespace}\"" "${dir}"/nomad/nomad-job.json | sponge "${dir}"/nomad/nomad-job.json
+      if test $# -gt 0 && test -n "${1}"
+      then
+        local namespace
+        namespace="${1:?$usage}"; shift
+        msg "Setting Nomad job top level namespace to \"${namespace}\""
+          jq                                                                \
+            ".job[\"${nomad_job_name}\"][\"namespace\"] = \"${namespace}\"" \
+            "${dir}"/nomad/nomad-job.json                                   \
+        | sponge "${dir}"/nomad/nomad-job.json
+      else
+        msg "Setting Nomad job top level namespace to null"
+          jq                                                                \
+            ".job[\"${nomad_job_name}\"][\"namespace\"] = null"             \
+            "${dir}"/nomad/nomad-job.json                                   \
+        | sponge "${dir}"/nomad/nomad-job.json
+      fi
     ;;
 
     allocate-run-nomad-job-patch-nix )

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -3116,7 +3116,7 @@ client {
 
   # Specifies an arbitrary string used to logically group client nodes by
   # user-defined class. This can be used during job placement as a filter.
-  node_class = "qa" # Using the "world.dev.cardano.org" testing class for "perf".
+  node_class = "perf" # Using the "world.dev.cardano.org" testing class for "perf".
 
   # "artifact" parameters (fail fast!!!)
   ######################################

--- a/nix/workbench/backend/nomad/cloud.nix
+++ b/nix/workbench/backend/nomad/cloud.nix
@@ -39,9 +39,13 @@ let
   ;
 
   # Nomad-generic "container-specs.json"
-  # Build a Nomad Job specification for each available Nomad "sub-backend".
+  # Build a Nomad Job specification for this Nomad "sub-backend".
   materialise-profile =
-    (import ../nomad.nix {inherit pkgs lib stateDir;}).materialise-profile
+    let params = {
+      inherit pkgs lib stateDir;
+      subBackendName = "cloud";
+    };
+    in (import ../nomad.nix params).materialise-profile
   ;
 
   overlay =

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -27,16 +27,24 @@ backend_nomadcloud() {
       backend_nomad is-running           "$@"
     ;;
 
-    start )
-      backend_nomad start                "$@"
+    start-cluster )
+      backend_nomad start-cluster        "$@"
     ;;
 
-    cleanup-cluster )
-      backend_nomad cleanup-cluster      "$@"
+    start-tracers )
+      backend_nomad start-tracers        "$@"
     ;;
 
     start-nodes )
       backend_nomad start-nodes          "$@"
+    ;;
+
+    start-generator )
+      backend_nomad start-generator      "$@"
+    ;;
+
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
     ;;
 
     start-node )
@@ -45,14 +53,6 @@ backend_nomadcloud() {
 
     stop-node )
       backend_nomad stop-node            "$@"
-    ;;
-
-    start-healthchecks )
-      backend_nomad start-healthchecks   "$@"
-    ;;
-
-    start-generator )
-      backend_nomad start-generator      "$@"
     ;;
 
     get-node-socket-path )
@@ -69,6 +69,14 @@ backend_nomadcloud() {
 
     wait-pools-stopped )
       backend_nomad wait-pools-stopped   "$@"
+    ;;
+
+    stop-all )
+      backend_nomad stop-all             "$@"
+    ;;
+
+    fetch-logs )
+      backend_nomad fetch-logs           "$@"
     ;;
 
     stop-cluster )
@@ -220,8 +228,8 @@ backend_nomadcloud() {
         "${dir}"/container-specs.json              \
       > "${dir}"/nomad/nomad-job.json
       # The job file is "slightly" modified (jq) to suit the running environment.
-      backend_nomad allocate-run-nomad-job-patch-namespace         "${dir}" "${NOMAD_NAMESPACE}"
-      backend_nomad allocate-run-nomad-job-patch-nix               "${dir}"
+      backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "${NOMAD_NAMESPACE}"
+      backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
 
       # Set the placement info and resources accordingly
       local nomad_job_name

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -676,6 +676,10 @@ allocate-run-nomadcloud() {
     }' \
     "${dir}"/nomad/nomad-job.json \
   > "${dir}"/nomad/nomad-job.summary.json
+
+  # Show the summary before starting the job, a precaution!
+  jq . "${dir}"/nomad/nomad-job.summary.json
+  read -p "Hit enter to continue ..."
 }
 
 deploy-genesis-nomadcloud() {

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -17,6 +17,41 @@ backend_nomadcloud() {
       echo 'nomadcloud'
     ;;
 
+    # Overrided backend "methods"
+
+    setenv-defaults )
+      local usage="USAGE: wb backend $op BACKEND-DIR"
+      local backend_dir=${1:?$usage}; shift
+      # Repeated code / envars set by all sub-backends
+      setenvjqstr 'nomad_task_driver'    "exec"
+      setenvjqstr 'nomad_environment'    "cloud"
+      setenvjqstr 'one_tracer_per_node'  "true"
+      # Cloud runs always run the generator inside Nomad Task "explorer"
+      setenvjqstr 'generator_task_name'           \
+        "$(                                       \
+          jq -r                                   \
+            .nomadJob.generatorTaskName           \
+            "${backend_dir}"/container-specs.json \
+        )"
+      # Store the location of the Nix-built "container-specs" file.
+      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
+      setenvjqstr 'profile_container_specs_file' \
+        "${backend_dir}"/container-specs.json
+      # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
+      setenv-defaults-nomadcloud         "${backend_dir}"
+    ;;
+
+    allocate-run )
+      allocate-run-nomadcloud            "$@"
+      # Does a pre allocation before calling the default/common allocation.
+      backend_nomad allocate-run         "$@"
+    ;;
+
+    deploy-genesis )
+      # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
+      deploy-genesis-nomadcloud          "$@"
+    ;;
+
     # Generic backend sub-commands, shared code between Nomad sub-backends.
 
     describe-run )
@@ -29,6 +64,16 @@ backend_nomadcloud() {
 
     start-cluster )
       backend_nomad start-cluster        "$@"
+      # start-ssh
+      local nodes=($(jq_tolist keys "${dir}"/node-specs.json))
+      for node in ${nodes[*]}
+      do
+        # TODO: Do it in parallel ?
+        if ! backend_nomad task-program-start "${dir}" "${node}" ssh
+        then
+          fatal "Failed to start ssh server: ${node}"
+        fi
+      done
     ;;
 
     start-tracers )
@@ -87,583 +132,555 @@ backend_nomadcloud() {
       backend_nomad cleanup-cluster      "$@"
     ;;
 
-    # Sets jq envars "profile_container_specs_file" ,"nomad_environment",
-    # "nomad_task_driver" and "one_tracer_per_node".
-    # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
-    setenv-defaults )
-      local usage="USAGE: wb backend $op BACKEND-DIR"
-      local backend_dir=${1:?$usage}; shift
-
-      setenvjqstr 'nomad_task_driver'   "exec"
-      setenvjqstr 'nomad_server_name'   "srv1"
-      # As one task driver runs as a normal user and the other as a root, use
-      # different names to allow restarting/reusing without cleaup, this way
-      # data folders already there can be accessed without "permission denied"
-      # errors.
-      setenvjqstr 'nomad_client_name'   "cli1-exe"
-
-      # Store the location of the Nix-built "container-specs" file.
-      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
-      local profile_container_specs_file
-      profile_container_specs_file="${backend_dir}"/container-specs.json
-      setenvjqstr 'profile_container_specs_file' "${profile_container_specs_file}"
-      setenvjqstr 'nomad_environment'   "cloud"
-      setenvjqstr 'one_tracer_per_node' "true" # TODO: Not implemented yet!
-
-      # Cloud runs always run the generator inside Nomad Task "explorer"
-      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
-
-      backend_nomadcloud setenv-nomadcloud "${profile_container_specs_file}"
-    ;;
-
-    # Checks for set the values for "NOMA..." and
-    setenv-nomadcloud )
-      local profile_container_specs_file=${1:?$usage}; shift
-      local nomad_environment
-      # If the most important `nomad` cli envars is present this is not a local
-      # test, I repeat, this is not a drill =)
-      if test -z "${NOMAD_ADDR:-}"
-      then
-        msg $(yellow "WARNING: Nomad address \"NOMAD_ADDR\" envar is not set")
-        export NOMAD_ADDR="https://nomad.world.dev.cardano.org"
-        msg $(blue "INFO: Setting \"NOMAD_ADDR\" to the SRE provided address for \"Performance and Tracing\" (\"${NOMAD_ADDR}\")")
-      else
-        if test "${NOMAD_ADDR}" != "https://nomad.world.dev.cardano.org"
-        then
-          msg $(yellow "WARNING: Nomad address \"NOMAD_ADDR\" envar is not \"https://nomad.world.dev.cardano.org\"")
-        fi
-      fi
-      # The abscence of `NOMAD_NAMESPACE` or `NOMAD_TOKEN` needs confirmation
-      if test -z "${NOMAD_NAMESPACE:-}"
-      then
-        msg $(yellow "WARNING: Nomad namespace \"NOMAD_NAMESPACE\" envar is not set")
-        export NOMAD_NAMESPACE="perf"
-        msg $(blue "INFO: Setting \"NOMAD_NAMESPACE\" to the SRE provided namespace for \"Performance and Tracing\" (\"${NOMAD_NAMESPACE}\")")
-      else
-        if test "${NOMAD_NAMESPACE}" != "perf"
-        then
-          msg $(yellow "WARNING: Nomad namespace \"NOMAD_NAMESPACE\" envar is not \"perf\"")
-        fi
-      fi
-      if test -z "${NOMAD_TOKEN:-}"
-      then
-        msg $(yellow "WARNING: Nomad token \"NOMAD_TOKEN\" envar is not set")
-        msg $(blue "INFO: Fetching a \"NOMAD_TOKEN\" from SRE provided Vault for \"Performance and Tracing\"")
-        export NOMAD_TOKEN="$(wb_nomad vault world nomad-token)"
-      fi
-      # Check all the AWS S3 envars needed for the HTTP PUT request
-      # Using same names as the AWS CLI
-      # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-      if test -z "${AWS_ACCESS_KEY_ID:-}" || test -z "${AWS_SECRET_ACCESS_KEY:-}"
-      then
-        msg $(yellow "WARNING: Amazon S3 \"AWS_ACCESS_KEY_ID\" or \"AWS_SECRET_ACCESS_KEY\" envar is not set")
-        msg $(blue "INFO: Fetching \"AWS_ACCESS_KEY_ID\" and \"AWS_SECRET_ACCESS_KEY\" from SRE provided Vault for \"Performance and Tracing\"")
-        local aws_credentials
-        aws_credentials="$(wb_nomad vault world aws-s3-credentials)"
-        export AWS_ACCESS_KEY_ID=$(echo "${aws_credentials}" | jq -r .data.access_key)
-        export AWS_SECRET_ACCESS_KEY=$(echo "${aws_credentials}" | jq -r .data.secret_key)
-      fi
-      # The Nomad job spec will contain links ("nix_installables" stanza) to
-      # the Nix Flake outputs it needs inside the container, these are
-      # refereced with a GitHub commit ID inside the "container-specs" file.
-      local gitrev
-      gitrev=$(jq -r .gitrev "${profile_container_specs_file}")
-      msg $(blue "INFO: Found GitHub commit with ID \"$gitrev\"")
-      # Check if the Nix package was created from a dirty git tree
-      if test "$gitrev" = "0000000000000000000000000000000000000000"
-      then
-        fatal "Can't run a cluster in the Nomad cloud without a publicly accessible GitHub commit ID"
-      else
-        msg "Checking if GitHub commit \"$gitrev\" is publicly accessible ..."
-        local curl_response
-        # Makes `curl` return two objects, one with the body the other with
-        # the headers, separated by a newline (`jq -s`).
-        if curl_response=$(curl --silent --show-error --write-out '%{json}' https://api.github.com/repos/input-output-hk/cardano-node/commits/"${gitrev}")
-        then
-          # Check HTTP status code for existance
-          # https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit
-          local headers
-          headers=$(echo "${curl_response}" | jq -s .[1])
-          if test "$(echo "${headers}" | jq .http_code)" != 200
-          then
-            fatal "GitHub commit \"$gitrev\" is not available online!"
-          fi
-          # Show returned commit info in `git log` fashion
-          local body author_name author_email author_date message
-          body=$(echo "${curl_response}" | jq -s .[0])
-          author_name=$(echo $body  | jq -r .commit.author.name)
-          author_email=$(echo $body | jq -r .commit.author.email)
-          author_date=$(echo $body  | jq -r .commit.author.date)
-          message=$(echo $body      | jq -r .commit.message)
-          msg $(green "commit ${gitrev}")
-          msg $(green "Author: ${author_name} <${author_email}>")
-          msg $(green "Date: ${author_date}")
-          msg $(green "\n")
-          msg $(green "\t${message}\n")
-          msg $(green "\n")
-        else
-          fatal "Could not fetch commit info from GitHub (\`curl\` error)"
-        fi
-      fi
-      # There are so many assumptions that I like having the user confirm them!
-      read -p "Hit enter to continue ..."
-    ;;
-
-    # Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
-    allocate-run )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-
-      # Copy the container specs file (container-specs.json)
-      # This is the output file of the Nix derivation
-      local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
-      # Create a nicely sorted and indented copy
-      jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
-
-      # Create nomad folder and copy the Nomad job spec file to run.
-      mkdir -p "${dir}"/nomad
-      # Select which version of the Nomad job spec file we are running and
-      # create a nicely sorted and indented copy it "nomad/nomad-job.json".
-      jq -r ".nomadJob.exec.oneTracerPerNode"      \
-        "${dir}"/container-specs.json              \
-      > "${dir}"/nomad/nomad-job.json
-      # The job file is "slightly" modified (jq) to suit the running environment.
-      backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "${NOMAD_NAMESPACE}"
-      backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
-
-      # Set the placement info and resources accordingly
-      local nomad_job_name
-      nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      ##########################################################################
-      # Profile name dependent changes #########################################
-      ##########################################################################
-      # "cw-perf-*" profiles are profiles that only run on Cardano World's Nomad
-      # Nodes of class "perf".
-      # Other cloud profiles are for example "ci-test-cw-qa", "ci-test-cw-perf",
-      # "ci-test-cw-qa", "ci-test-cw-perf". "qa" means that they run on Nomad
-      # nodes that belong to the "qa" class, runs on these should be limited to
-      # short tests and must never use the "infra" class where HA jobs runs.
-      if test -z "${WB_SHELL_PROFILE:-}"
-      then
-        fatal "Envar \"WB_SHELL_PROFILE\" is empty!"
-      else
-        ########################################################################
-        # Fix for region mismatches ############################################
-        ########################################################################
-        # We use "us-east-2" and they use "us-east-1"
-          jq \
-            ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
-            "${dir}"/nomad/nomad-job.json \
-        | \
-            sponge "${dir}"/nomad/nomad-job.json
-          jq \
-            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
-            "${dir}"/nomad/nomad-job.json \
-        | \
-            sponge "${dir}"/nomad/nomad-job.json
-        ########################################################################
-        # Unique placement: ####################################################
-        ########################################################################
-        ## "distinct_hosts": Instructs the scheduler to not co-locate any groups
-        ## on the same machine. When specified as a job constraint, it applies
-        ## to all groups in the job. When specified as a group constraint, the
-        ## effect is constrained to that group. This constraint can not be
-        ## specified at the task level. Note that the attribute parameter should
-        ## be omitted when using this constraint.
-        ## https://developer.hashicorp.com/nomad/docs/job-specification/constraint#distinct_hosts
-        local job_constraints_array
-        job_constraints_array='
-          [
-            {
-              "operator":  "distinct_hosts"
-            , "value":     "true"
-            }
-          ]
-        '
-        # Adds it as a job level contraint.
-          jq \
-            --argjson job_constraints_array "${job_constraints_array}" \
-            ".[\"job\"][\"${nomad_job_name}\"].constraint |= \$job_constraints_array" \
-            "${dir}"/nomad/nomad-job.json \
-        | \
-          sponge "${dir}"/nomad/nomad-job.json
-        ########################################################################
-        # Node class: ##########################################################
-        ########################################################################
-        local group_constraints_array
-        # "perf" class nodes are the default unless the profile name contains
-        # "cw-qa", we try to limit the usage of Nomad nodes that are not
-        # dedicated Perf team nodes.
-        # But also, we have to be careful that "perf" runs do not overlap. We
-        # are making "perf" class nodes runs can't clash because service names
-        # and resources definitions currently won't allow that to happen but
-        # still a new "perf" run may mess up a previously running cluster.
-        if echo "${WB_SHELL_PROFILE}" | grep --quiet "cw-qa"
-        then
-          # Using "qa" class distinct nodes. Only "short" test allowed here.
-          group_constraints_array='
-            [
-              {
-                "operator":  "="
-              , "attribute": "${node.class}"
-              , "value":     "qa"
-              }
-            ]
-          '
-        else
-          # Using Performance & Tracing exclusive "perf" class distinct nodes!
-          group_constraints_array='
-            [
-              {
-                "operator":  "="
-              , "attribute": "${node.class}"
-              , "value":     "perf"
-              }
-            ]
-          '
-        fi
-        # Adds it as a group level contraint.
-          jq \
-            --argjson group_constraints_array "${group_constraints_array}" \
-            ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
-            "${dir}"/nomad/nomad-job.json \
-        | \
-          sponge "${dir}"/nomad/nomad-job.json
-        ########################################################################
-        # Memory/resources: ####################################################
-        ########################################################################
-        # Set the resources, only for perf!
-        # When not "perf", when "cw-qa", only "short" tests are allowed on
-        # whatever resources we are given.
-        if echo "${WB_SHELL_PROFILE}" | grep --quiet "cw-perf"
-        then
-          # Producer nodes use this specs, make sure they are available!
-          # AWS:
-          ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
-          ## https://aws.amazon.com/ec2/instance-types/c5/
-          # Nomad:
-          ## - cpu.arch:            = amd64
-          ## - cpu.frequency:       = 3400
-          ## - cpu.modelname:       = Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
-          ## - cpu.numcores:        = 8
-          ## - cpu.reservablecores: = 8
-          ## - cpu.totalcompute:    = 27200
-          ## - memory.totalbytes    = 16300142592
-          ## Pesimistic: 1,798 MiB / 15,545 MiB Total
-          ## Optimistic: 1,396 MiB / 15,545 MiB Total
-          local producer_resources='{
-              "cores":      8
-            , "memory":     13000
-            , "memory_max": 15000
-          }'
-          # Set this for every non-explorer node
-            jq \
-              --argjson producer_resources "${producer_resources}" \
-              " \
-                  .[\"job\"][\"${nomad_job_name}\"][\"group\"] \
-                |= \
-                  with_entries( \
-                    if ( .key != \"explorer\" ) \
-                    then ( \
-                        .value.task \
-                      |= \
-                        with_entries( .value.resources = \$producer_resources ) \
-                    ) else ( \
-                      . \
-                    ) end \
-                  ) \
-              " \
-              "${dir}"/nomad/nomad-job.json \
-          | \
-            sponge "${dir}"/nomad/nomad-job.json
-          # The explorer node uses this specs, make sure they are available!
-          # AWS
-          ## m5.4xlarge: 8 vCPU and 16 Memory (GiB)
-          ## https://aws.amazon.com/ec2/instance-types/m5/
-          # Nomad:
-          ## - cpu.arch             = amd64
-          ## - cpu.frequency        = 3100
-          ## - cpu.modelname        = Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
-          ## - cpu.numcores         = 16
-          ## - cpu.reservablecores  = 16
-          ## - cpu.totalcompute     = 54400
-          ## - memory.totalbytes    = 65900154880
-          # Node ID: 00db7a3a-a05b-7ae0-2b2a-b50b9db139a4
-          # client named "ip-10-24-30-90.eu-central-1.compute.internal"
-          local explorer_resources='{
-              "cores":      16
-            , "memory":     29000
-            , "memory_max": 31000
-          }'
-            jq \
-              --argjson resources "${explorer_resources}" \
-              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"explorer\"][\"task\"] |= with_entries( .value.resources = \$resources )" \
-              "${dir}"/nomad/nomad-job.json \
-          | \
-            sponge "${dir}"/nomad/nomad-job.json
-        fi
-        ########################################################################
-        # Reproducibility: #####################################################
-        ########################################################################
-        # If value profile on "perf", using always the same placement!
-        # This means node-N always runs on the same Nomad Client/AWS EC2 machine
-        if test "${WB_SHELL_PROFILE:0:13}" = 'cw-perf-value'
-        then
-          # A file with all the available Nomad Clients is needed!
-          # This files is a list of Nomad Clients with a minimun of ".id",
-          # ".datacenter", ".attributes.platform.aws["instance-type"]",
-          # ".attributes.platform.aws.placement["availability-zone"]",
-          # ".attributes.unique.platform.aws["instance-id"]",
-          # ".attributes.unique.platform.aws.["public-ipv4"]" and
-          # ".attributes.unique.platform.aws.mac".
-          if test -z "${NOMAD_CLIENTS_FILE:-}" || ! test -f "${NOMAD_CLIENTS_FILE}"
-          then
-            fatal "No \"\$NOMAD_CLIENTS_FILE\". For reproducible builds provide this file that ensures cluster nodes are always placed on the same machines, or create a new one with 'wb nomad nodes' if Nomad Clients have suffered changes and runs fail with \"placement errors\""
-          fi
-          # For each (instance-type, datacener/region) we look incrementally for
-          # the unique AWS EC2 "instance-id" only after ordering the Nomad
-          # Clients by its unique Nomad provided "id".
-          local count_ap=0 count_eu=0 count_us=0
-          # For each Nomad Job Group
-          local groups_array
-          # Keys MUST be sorted to always get the same order for the same profile!
-          groups_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
-          for group_name in ${groups_array[*]}
-          do
-            # Obtain the datacenter as Nomad sees it, not as an AWS attributes.
-            # For example "eu-central-1" instead of "eu-central-1a".
-            local datacenter
-            datacenter=$(jq \
-              -r \
-              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"].affinity.value" \
-              "${dir}"/nomad/nomad-job.json \
-            )
-            # For each Nomad Job Group Task
-            local tasks_array
-            # Keys MUST be sorted to always get the same order for the same profile!
-            tasks_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"task\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
-            for task_name in ${tasks_array[*]}
-            do
-              local count instance_type
-              if test "${task_name}" = "explorer"
-              then
-                # There is only one of this instance!
-                instance_type="m5.4xlarge"
-                count=0
-              else
-                # There are many of these instances and we need to always fetch
-                # them in the same order for reproducibility.
-                instance_type="c5.2xlarge"
-                if test "${datacenter}" = "ap-southeast-2"
-                then
-                  count="${count_ap}"
-                  count_ap=$(( count_ap + 1 ))
-                elif test "${datacenter}" = "eu-central-1"
-                then
-                  count="${count_eu}"
-                  count_eu=$(( count_eu + 1 ))
-                elif test "${datacenter}" = "us-east-1"
-                then
-                  count="${count_us}"
-                  count_us=$(( count_us + 1 ))
-                fi
-              fi
-              # Get the actual client for this datacenter and instance type.
-              local actual_client
-              actual_client=$(jq \
-                "   . \
-                  | \
-                    sort_by(.id) \
-                  | \
-                    map(select(.datacenter == \"${datacenter}\")) \
-                  | \
-                    map(select(.attributes.platform.aws[\"instance-type\"] == \"${instance_type}\")) \
-                  | \
-                    .[${count}] \
-                " \
-                "${NOMAD_CLIENTS_FILE}" \
-              )
-              local instance_id availability_zone public_ipv4 mac_address
-              instance_id="$( \
-                 echo "${actual_client}" \
-                | \
-                  jq -r \
-                    '.attributes.unique.platform.aws["instance-id"]' \
-              )"
-              availability_zone="$( \
-                 echo "${actual_client}" \
-                | \
-                  jq -r \
-                    '.attributes.platform.aws.placement["availability-zone"]' \
-              )"
-              public_ipv4="$( \
-                 echo "${actual_client}" \
-                | \
-                  jq -r \
-                    '.attributes.unique.platform.aws["public-ipv4"]' \
-              )"
-              mac_address="$( \
-                 echo "${actual_client}" \
-                | \
-                  jq -r \
-                    '.attributes.unique.platform.aws.mac' \
-              )"
-              # Pin the actual node to an specific Nomad Client / AWS instance
-              # by appending below constraints to the already there group
-              # constraints.
-              # We pin it to a couple of AWS specifics attributes so if SRE
-              # changes something related to Nomad Clients or AWS instances we
-              # may hopefully notice it when the job fails to start (placement
-              # errors).
-              local group_constraints_array_plus="
-                [ \
-                    { \
-                      \"attribute\": \"\${attr.platform.aws.instance-type}\" \
-                    , \"value\":     \"${instance_type}\" \
-                    } \
-                  ,
-                    { \
-                      \"attribute\": \"\${attr.platform.aws.placement.availability-zone}\" \
-                    , \"value\":     \"${availability_zone}\" \
-                    } \
-                  ,
-                    { \
-                      \"attribute\": \"\${attr.unique.platform.aws.instance-id}\" \
-                    , \"value\":     \"${instance_id}\" \
-                    } \
-                  ,
-                    { \
-                      \"attribute\": \"\${attr.unique.platform.aws.public-ipv4}\" \
-                    , \"value\":     \"${public_ipv4}\" \
-                    } \
-                  ,
-                    { \
-                      \"attribute\": \"\${attr.unique.platform.aws.mac}\" \
-                    , \"value\":     \"${mac_address}\" \
-                    } \
-                ] \
-              "
-                jq \
-                  --argjson group_constraints_array_plus "${group_constraints_array_plus}" \
-                  ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"constraint\"] |= ( . + \$group_constraints_array_plus)" \
-                  "${dir}"/nomad/nomad-job.json \
-              | \
-                sponge "${dir}"/nomad/nomad-job.json
-            done
-          done
-        fi
-      fi
-
-      # Store a summary of the job.
-      jq \
-        '{
-            "namespace":   ( .job["workbench-cluster-job"].namespace   )
-          , "datacenters": ( .job["workbench-cluster-job"].datacenters )
-          , "constraint":  ( .job["workbench-cluster-job"].constraint  )
-          , "groups":      (
-                .job["workbench-cluster-job"].group
-              | with_entries(
-                  .value |= {
-                      "constraint": .constraint
-                    , "affinity":   .affinity
-                    , "tasks":      (
-                        .task | with_entries(
-                          .value |= {
-                              "constraint":         .constraint
-                            , "resources":          .resources
-                            , "nix_installables":   .config.nix_installables
-                            , "templates":        ( .template | map(.destination) )
-                          }
-                        )
-                      )
-                  }
-                )
-            )
-        }' \
-        "${dir}"/nomad/nomad-job.json \
-      > "${dir}"/nomad/nomad-job.summary.json
-
-      backend_nomad allocate-run "${dir}"
-    ;;
-
-    # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
-    deploy-genesis )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-
-      # Create genesis tar file
-      local genesis_file_name="${nomad_job_name}.tar.zst"
-      msg "$(blue Creating) $(yellow "\"${genesis_file_name}\"") ..."
-      # TODO: These files are link to file that don't exist!
-      rm "${dir}"/genesis/profile.json
-      rm "${dir}"/genesis/stake-delegator-keys
-      find -L "${dir}"/genesis -printf "%P\n"         \
-        | tar --create --zstd                         \
-          --dereference --hard-dereference            \
-          --file="${dir}"/"${genesis_file_name}"      \
-          --owner=65534 --group=65534 --mode="u=rwx"  \
-          --directory="${dir}"/genesis --files-from=-
-
-      # Upload genesis tar file
-      local s3_region="eu-central-1"
-      local s3_host="s3.${s3_region}.amazonaws.com";
-      local s3_bucket_name="iog-cardano-perf";
-      local s3_access_key="${AWS_ACCESS_KEY_ID}";
-      local s3_access_key_secret="${AWS_SECRET_ACCESS_KEY}"
-      local s3_storage_class="STANDARD"
-      local return_code=0
-      msg "$(blue Uploading) $(yellow "\"${genesis_file_name}\"") to $(yellow "\"s3://${s3_bucket_name}/\"") ..."
-      aws s3 cp                                                               \
-        "${dir}"/"${genesis_file_name}"                                       \
-        s3://"${s3_bucket_name}"                                              \
-        --content-type "application/zstd"                                     \
-        --region "${s3_region}"                                               \
-        --expected-size "$(stat --printf=%s "${dir}"/"${genesis_file_name}")" \
-      || return_code="$?"
-      # https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html#using-s3-commands-managing-objects-copy
-      # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/cp.html
-      if test "${return_code}" = "0"
-      then
-        # A server response was obtained.
-        msg "$(green "File \"${genesis_file_name}\" uploaded successfully")"
-      else
-        msg "$(red "FATAL: Upload to Amazon S3 failed")"
-        local nomad_agents_were_already_running=$(envjqr 'nomad_agents_were_already_running')
-        if test "${nomad_agents_were_already_running}" = "false"
-        then
-          wb_nomad agents stop "${server_name}" "${client_name}" "exec"
-        fi
-        backend_nomad stop-nomad-job "${dir}"
-        fatal "Failed to upload genesis"
-      fi
-
-      # Generic download from every node.
-      local uri="https://${s3_bucket_name}.${s3_host}/${genesis_file_name}"
-      if ! backend_nomad deploy-genesis-wget "${dir}" "${uri}"
-      then
-        # File kept for debugging!
-        fatal "Deploy of genesis \"${uri}\" failed"
-      else
-        msg "$(green "Genesis \"${uri}\" deployed successfully")"
-        # Don't keep the file once ready, it's not free!
-        msg "$(blue Removing) genesis file from $(yellow "\"s3://${s3_bucket_name}\"") ..."
-        aws s3 rm                                         \
-          s3://"${s3_bucket_name}"/"${genesis_file_name}" \
-          --region "${s3_region}"                         \
-        || true
-        # Reminder to remove old files.
-        msg "Still available files at $(yellow "\"s3://${s3_bucket_name}\""):"
-        aws s3 ls                   \
-          s3://"${s3_bucket_name}"/ \
-          --region "${s3_region}"
-      fi
-    ;;
-
     * )
       backend_nomad "${op}" "$@"
     ;;
 
   esac
 
+}
+
+# Sets jq envars "profile_container_specs_file" ,"nomad_environment",
+# "nomad_task_driver" and "one_tracer_per_node".
+setenv-defaults-nomadcloud() {
+  local backend_dir="${1}"
+
+  local profile_container_specs_file
+  profile_container_specs_file="${backend_dir}"/container-specs.json
+
+  # If the most important `nomad` cli envars is present this is not a local
+  # test, I repeat, this is not a drill =)
+  if test -z "${NOMAD_ADDR:-}"
+  then
+    msg $(yellow "WARNING: Nomad address \"NOMAD_ADDR\" envar is not set")
+    export NOMAD_ADDR="https://nomad.world.dev.cardano.org"
+    msg $(blue "INFO: Setting \"NOMAD_ADDR\" to the SRE provided address for \"Performance and Tracing\" (\"${NOMAD_ADDR}\")")
+  else
+    if test "${NOMAD_ADDR}" != "https://nomad.world.dev.cardano.org"
+    then
+      msg $(yellow "WARNING: Nomad address \"NOMAD_ADDR\" envar is not \"https://nomad.world.dev.cardano.org\"")
+    fi
+  fi
+  # The abscence of `NOMAD_NAMESPACE` or `NOMAD_TOKEN` needs confirmation
+  if test -z "${NOMAD_NAMESPACE:-}"
+  then
+    msg $(yellow "WARNING: Nomad namespace \"NOMAD_NAMESPACE\" envar is not set")
+    export NOMAD_NAMESPACE="perf"
+    msg $(blue "INFO: Setting \"NOMAD_NAMESPACE\" to the SRE provided namespace for \"Performance and Tracing\" (\"${NOMAD_NAMESPACE}\")")
+  else
+    if test "${NOMAD_NAMESPACE}" != "perf"
+    then
+      msg $(yellow "WARNING: Nomad namespace \"NOMAD_NAMESPACE\" envar is not \"perf\"")
+    fi
+  fi
+  if test -z "${NOMAD_TOKEN:-}"
+  then
+    msg $(yellow "WARNING: Nomad token \"NOMAD_TOKEN\" envar is not set")
+    msg $(blue "INFO: Fetching a \"NOMAD_TOKEN\" from SRE provided Vault for \"Performance and Tracing\"")
+    export NOMAD_TOKEN="$(wb_nomad vault world nomad-token)"
+  fi
+  # Check all the AWS S3 envars needed for the HTTP PUT request
+  # Using same names as the AWS CLI
+  # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+  if test -z "${AWS_ACCESS_KEY_ID:-}" || test -z "${AWS_SECRET_ACCESS_KEY:-}"
+  then
+    msg $(yellow "WARNING: Amazon S3 \"AWS_ACCESS_KEY_ID\" or \"AWS_SECRET_ACCESS_KEY\" envar is not set")
+    msg $(blue "INFO: Fetching \"AWS_ACCESS_KEY_ID\" and \"AWS_SECRET_ACCESS_KEY\" from SRE provided Vault for \"Performance and Tracing\"")
+    local aws_credentials
+    aws_credentials="$(wb_nomad vault world aws-s3-credentials)"
+    export AWS_ACCESS_KEY_ID=$(echo "${aws_credentials}" | jq -r .data.access_key)
+    export AWS_SECRET_ACCESS_KEY=$(echo "${aws_credentials}" | jq -r .data.secret_key)
+  fi
+  # The Nomad job spec will contain links ("nix_installables" stanza) to
+  # the Nix Flake outputs it needs inside the container, these are
+  # refereced with a GitHub commit ID inside the "container-specs" file.
+  local gitrev
+  gitrev=$(jq -r .gitrev "${profile_container_specs_file}")
+  msg $(blue "INFO: Found GitHub commit with ID \"$gitrev\"")
+  # Check if the Nix package was created from a dirty git tree
+  if test "$gitrev" = "0000000000000000000000000000000000000000"
+  then
+    fatal "Can't run a cluster in the Nomad cloud without a publicly accessible GitHub commit ID"
+  else
+    msg "Checking if GitHub commit \"$gitrev\" is publicly accessible ..."
+    local curl_response
+    # Makes `curl` return two objects, one with the body the other with
+    # the headers, separated by a newline (`jq -s`).
+    if curl_response=$(curl --silent --show-error --write-out '%{json}' https://api.github.com/repos/input-output-hk/cardano-node/commits/"${gitrev}")
+    then
+      # Check HTTP status code for existance
+      # https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit
+      local headers
+      headers=$(echo "${curl_response}" | jq -s .[1])
+      if test "$(echo "${headers}" | jq .http_code)" != 200
+      then
+        fatal "GitHub commit \"$gitrev\" is not available online!"
+      fi
+      # Show returned commit info in `git log` fashion
+      local body author_name author_email author_date message
+      body=$(echo "${curl_response}" | jq -s .[0])
+      author_name=$(echo $body  | jq -r .commit.author.name)
+      author_email=$(echo $body | jq -r .commit.author.email)
+      author_date=$(echo $body  | jq -r .commit.author.date)
+      message=$(echo $body      | jq -r .commit.message)
+      msg $(green "commit ${gitrev}")
+      msg $(green "Author: ${author_name} <${author_email}>")
+      msg $(green "Date: ${author_date}")
+      msg $(green "\n")
+      msg $(green "\t${message}\n")
+      msg $(green "\n")
+    else
+      fatal "Could not fetch commit info from GitHub (\`curl\` error)"
+    fi
+  fi
+  # There are so many assumptions that I like having the user confirm them!
+  read -p "Hit enter to continue ..."
+}
+
+# Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
+allocate-run-nomadcloud() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+
+  # Copy the container specs file (container-specs.json)
+  # This is the output file of the Nix derivation
+  local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
+  # Create a nicely sorted and indented copy
+  jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
+
+  # Create nomad folder and copy the Nomad job spec file to run.
+  mkdir -p "${dir}"/nomad
+  # Select which version of the Nomad job spec file we are running and
+  # create a nicely sorted and indented copy it "nomad/nomad-job.json".
+  jq -r ".nomadJob.exec.oneTracerPerNode"      \
+    "${dir}"/container-specs.json              \
+  > "${dir}"/nomad/nomad-job.json
+  # The job file is "slightly" modified (jq) to suit the running environment.
+  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "${NOMAD_NAMESPACE}"
+  backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
+
+  # Set the placement info and resources accordingly
+  local nomad_job_name
+  nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
+  ##########################################################################
+  # Profile name dependent changes #########################################
+  ##########################################################################
+  # "cw-perf-*" profiles are profiles that only run on Cardano World's Nomad
+  # Nodes of class "perf".
+  # Other cloud profiles are for example "ci-test-cw-qa", "ci-test-cw-perf",
+  # "ci-test-cw-qa", "ci-test-cw-perf". "qa" means that they run on Nomad
+  # nodes that belong to the "qa" class, runs on these should be limited to
+  # short tests and must never use the "infra" class where HA jobs runs.
+  if test -z "${WB_SHELL_PROFILE:-}"
+  then
+    fatal "Envar \"WB_SHELL_PROFILE\" is empty!"
+  else
+    ########################################################################
+    # Fix for region mismatches ############################################
+    ########################################################################
+    # We use "us-east-2" and they use "us-east-1"
+      jq \
+        ".[\"job\"][\"${nomad_job_name}\"][\"datacenters\"] |= [\"eu-central-1\", \"us-east-1\", \"ap-southeast-2\"]" \
+        "${dir}"/nomad/nomad-job.json \
+    | \
+        sponge "${dir}"/nomad/nomad-job.json
+      jq \
+        ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries( if (.value.affinity.value == \"us-east-2\") then (.value.affinity.value |= \"us-east-1\") else (.) end )" \
+        "${dir}"/nomad/nomad-job.json \
+    | \
+        sponge "${dir}"/nomad/nomad-job.json
+    ########################################################################
+    # Unique placement: ####################################################
+    ########################################################################
+    ## "distinct_hosts": Instructs the scheduler to not co-locate any groups
+    ## on the same machine. When specified as a job constraint, it applies
+    ## to all groups in the job. When specified as a group constraint, the
+    ## effect is constrained to that group. This constraint can not be
+    ## specified at the task level. Note that the attribute parameter should
+    ## be omitted when using this constraint.
+    ## https://developer.hashicorp.com/nomad/docs/job-specification/constraint#distinct_hosts
+    local job_constraints_array
+    job_constraints_array='
+      [
+        {
+          "operator":  "distinct_hosts"
+        , "value":     "true"
+        }
+      ]
+    '
+    # Adds it as a job level contraint.
+      jq \
+        --argjson job_constraints_array "${job_constraints_array}" \
+        ".[\"job\"][\"${nomad_job_name}\"].constraint |= \$job_constraints_array" \
+        "${dir}"/nomad/nomad-job.json \
+    | \
+      sponge "${dir}"/nomad/nomad-job.json
+    ########################################################################
+    # Node class: ##########################################################
+    ########################################################################
+    local group_constraints_array
+    # "perf" class nodes are the default unless the profile name contains
+    # "cw-qa", we try to limit the usage of Nomad nodes that are not
+    # dedicated Perf team nodes.
+    # But also, we have to be careful that "perf" runs do not overlap. We
+    # are making "perf" class nodes runs can't clash because service names
+    # and resources definitions currently won't allow that to happen but
+    # still a new "perf" run may mess up a previously running cluster.
+    if echo "${WB_SHELL_PROFILE}" | grep --quiet "cw-qa"
+    then
+      # Using "qa" class distinct nodes. Only "short" test allowed here.
+      group_constraints_array='
+        [
+          {
+            "operator":  "="
+          , "attribute": "${node.class}"
+          , "value":     "qa"
+          }
+        ]
+      '
+    else
+      # Using Performance & Tracing exclusive "perf" class distinct nodes!
+      group_constraints_array='
+        [
+          {
+            "operator":  "="
+          , "attribute": "${node.class}"
+          , "value":     "perf"
+          }
+        ]
+      '
+    fi
+    # Adds it as a group level contraint.
+      jq \
+        --argjson group_constraints_array "${group_constraints_array}" \
+        ".[\"job\"][\"${nomad_job_name}\"][\"group\"] |= with_entries(.value.constraint = \$group_constraints_array)" \
+        "${dir}"/nomad/nomad-job.json \
+    | \
+      sponge "${dir}"/nomad/nomad-job.json
+    ########################################################################
+    # Memory/resources: ####################################################
+    ########################################################################
+    # Set the resources, only for perf!
+    # When not "perf", when "cw-qa", only "short" tests are allowed on
+    # whatever resources we are given.
+    if echo "${WB_SHELL_PROFILE}" | grep --quiet "cw-perf"
+    then
+      # Producer nodes use this specs, make sure they are available!
+      # AWS:
+      ## c5.2xlarge: 8 vCPU and 16 Memory (GiB)
+      ## https://aws.amazon.com/ec2/instance-types/c5/
+      # Nomad:
+      ## - cpu.arch:            = amd64
+      ## - cpu.frequency:       = 3400
+      ## - cpu.modelname:       = Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
+      ## - cpu.numcores:        = 8
+      ## - cpu.reservablecores: = 8
+      ## - cpu.totalcompute:    = 27200
+      ## - memory.totalbytes    = 16300142592
+      ## Pesimistic: 1,798 MiB / 15,545 MiB Total
+      ## Optimistic: 1,396 MiB / 15,545 MiB Total
+      local producer_resources='{
+          "cores":      8
+        , "memory":     13000
+        , "memory_max": 15000
+      }'
+      # Set this for every non-explorer node
+        jq \
+          --argjson producer_resources "${producer_resources}" \
+          " \
+              .[\"job\"][\"${nomad_job_name}\"][\"group\"] \
+            |= \
+              with_entries( \
+                if ( .key != \"explorer\" ) \
+                then ( \
+                    .value.task \
+                  |= \
+                    with_entries( .value.resources = \$producer_resources ) \
+                ) else ( \
+                  . \
+                ) end \
+              ) \
+          " \
+          "${dir}"/nomad/nomad-job.json \
+      | \
+        sponge "${dir}"/nomad/nomad-job.json
+      # The explorer node uses this specs, make sure they are available!
+      # AWS
+      ## m5.4xlarge: 8 vCPU and 16 Memory (GiB)
+      ## https://aws.amazon.com/ec2/instance-types/m5/
+      # Nomad:
+      ## - cpu.arch             = amd64
+      ## - cpu.frequency        = 3100
+      ## - cpu.modelname        = Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+      ## - cpu.numcores         = 16
+      ## - cpu.reservablecores  = 16
+      ## - cpu.totalcompute     = 54400
+      ## - memory.totalbytes    = 65900154880
+      # Node ID: 00db7a3a-a05b-7ae0-2b2a-b50b9db139a4
+      # client named "ip-10-24-30-90.eu-central-1.compute.internal"
+      local explorer_resources='{
+          "cores":      16
+        , "memory":     29000
+        , "memory_max": 31000
+      }'
+        jq \
+          --argjson resources "${explorer_resources}" \
+          ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"explorer\"][\"task\"] |= with_entries( .value.resources = \$resources )" \
+          "${dir}"/nomad/nomad-job.json \
+      | \
+        sponge "${dir}"/nomad/nomad-job.json
+    fi
+    ########################################################################
+    # Reproducibility: #####################################################
+    ########################################################################
+    # If value profile on "perf", using always the same placement!
+    # This means node-N always runs on the same Nomad Client/AWS EC2 machine
+    if test "${WB_SHELL_PROFILE:0:13}" = 'cw-perf-value'
+    then
+      # A file with all the available Nomad Clients is needed!
+      # This files is a list of Nomad Clients with a minimun of ".id",
+      # ".datacenter", ".attributes.platform.aws["instance-type"]",
+      # ".attributes.platform.aws.placement["availability-zone"]",
+      # ".attributes.unique.platform.aws["instance-id"]",
+      # ".attributes.unique.platform.aws.["public-ipv4"]" and
+      # ".attributes.unique.platform.aws.mac".
+      if test -z "${NOMAD_CLIENTS_FILE:-}" || ! test -f "${NOMAD_CLIENTS_FILE}"
+      then
+        fatal "No \"\$NOMAD_CLIENTS_FILE\". For reproducible builds provide this file that ensures cluster nodes are always placed on the same machines, or create a new one with 'wb nomad nodes' if Nomad Clients have suffered changes and runs fail with \"placement errors\""
+      fi
+      # For each (instance-type, datacener/region) we look incrementally for
+      # the unique AWS EC2 "instance-id" only after ordering the Nomad
+      # Clients by its unique Nomad provided "id".
+      local count_ap=0 count_eu=0 count_us=0
+      # For each Nomad Job Group
+      local groups_array
+      # Keys MUST be sorted to always get the same order for the same profile!
+      groups_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
+      for group_name in ${groups_array[*]}
+      do
+        # Obtain the datacenter as Nomad sees it, not as an AWS attributes.
+        # For example "eu-central-1" instead of "eu-central-1a".
+        local datacenter
+        datacenter=$(jq \
+          -r \
+          ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"].affinity.value" \
+          "${dir}"/nomad/nomad-job.json \
+        )
+        # For each Nomad Job Group Task
+        local tasks_array
+        # Keys MUST be sorted to always get the same order for the same profile!
+        tasks_array=$(jq -S -r ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"task\"] | keys | sort | join (\" \")" "${dir}"/nomad/nomad-job.json)
+        for task_name in ${tasks_array[*]}
+        do
+          local count instance_type
+          if test "${task_name}" = "explorer"
+          then
+            # There is only one of this instance!
+            instance_type="m5.4xlarge"
+            count=0
+          else
+            # There are many of these instances and we need to always fetch
+            # them in the same order for reproducibility.
+            instance_type="c5.2xlarge"
+            if test "${datacenter}" = "ap-southeast-2"
+            then
+              count="${count_ap}"
+              count_ap=$(( count_ap + 1 ))
+            elif test "${datacenter}" = "eu-central-1"
+            then
+              count="${count_eu}"
+              count_eu=$(( count_eu + 1 ))
+            elif test "${datacenter}" = "us-east-1"
+            then
+              count="${count_us}"
+              count_us=$(( count_us + 1 ))
+            fi
+          fi
+          # Get the actual client for this datacenter and instance type.
+          local actual_client
+          actual_client=$(jq \
+            "   . \
+              | \
+                sort_by(.id) \
+              | \
+                map(select(.datacenter == \"${datacenter}\")) \
+              | \
+                map(select(.attributes.platform.aws[\"instance-type\"] == \"${instance_type}\")) \
+              | \
+                .[${count}] \
+            " \
+            "${NOMAD_CLIENTS_FILE}" \
+          )
+          local instance_id availability_zone public_ipv4 mac_address
+          instance_id="$( \
+             echo "${actual_client}" \
+            | \
+              jq -r \
+                '.attributes.unique.platform.aws["instance-id"]' \
+          )"
+          availability_zone="$( \
+             echo "${actual_client}" \
+            | \
+              jq -r \
+                '.attributes.platform.aws.placement["availability-zone"]' \
+          )"
+          public_ipv4="$( \
+             echo "${actual_client}" \
+            | \
+              jq -r \
+                '.attributes.unique.platform.aws["public-ipv4"]' \
+          )"
+          mac_address="$( \
+             echo "${actual_client}" \
+            | \
+              jq -r \
+                '.attributes.unique.platform.aws.mac' \
+          )"
+          # Pin the actual node to an specific Nomad Client / AWS instance
+          # by appending below constraints to the already there group
+          # constraints.
+          # We pin it to a couple of AWS specifics attributes so if SRE
+          # changes something related to Nomad Clients or AWS instances we
+          # may hopefully notice it when the job fails to start (placement
+          # errors).
+          local group_constraints_array_plus="
+            [ \
+                { \
+                  \"attribute\": \"\${attr.platform.aws.instance-type}\" \
+                , \"value\":     \"${instance_type}\" \
+                } \
+              ,
+                { \
+                  \"attribute\": \"\${attr.platform.aws.placement.availability-zone}\" \
+                , \"value\":     \"${availability_zone}\" \
+                } \
+              ,
+                { \
+                  \"attribute\": \"\${attr.unique.platform.aws.instance-id}\" \
+                , \"value\":     \"${instance_id}\" \
+                } \
+              ,
+                { \
+                  \"attribute\": \"\${attr.unique.platform.aws.public-ipv4}\" \
+                , \"value\":     \"${public_ipv4}\" \
+                } \
+              ,
+                { \
+                  \"attribute\": \"\${attr.unique.platform.aws.mac}\" \
+                , \"value\":     \"${mac_address}\" \
+                } \
+            ] \
+          "
+            jq \
+              --argjson group_constraints_array_plus "${group_constraints_array_plus}" \
+              ".[\"job\"][\"${nomad_job_name}\"][\"group\"][\"${group_name}\"][\"constraint\"] |= ( . + \$group_constraints_array_plus)" \
+              "${dir}"/nomad/nomad-job.json \
+          | \
+            sponge "${dir}"/nomad/nomad-job.json
+        done
+      done
+    fi
+  fi
+
+  # Store a summary of the job.
+  jq \
+    '{
+        "namespace":   ( .job["workbench-cluster-job"].namespace   )
+      , "datacenters": ( .job["workbench-cluster-job"].datacenters )
+      , "constraint":  ( .job["workbench-cluster-job"].constraint  )
+      , "groups":      (
+            .job["workbench-cluster-job"].group
+          | with_entries(
+              .value |= {
+                  "constraint": .constraint
+                , "affinity":   .affinity
+                , "tasks":      (
+                    .task | with_entries(
+                      .value |= {
+                          "constraint":         .constraint
+                        , "resources":          .resources
+                        , "nix_installables":   .config.nix_installables
+                        , "templates":        ( .template | map(.destination) )
+                      }
+                    )
+                  )
+              }
+            )
+        )
+    }' \
+    "${dir}"/nomad/nomad-job.json \
+  > "${dir}"/nomad/nomad-job.summary.json
+}
+
+deploy-genesis-nomadcloud() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+  local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
+
+  # Create genesis tar file
+  local genesis_file_name="${nomad_job_name}.tar.zst"
+  msg "$(blue Creating) $(yellow "\"${genesis_file_name}\"") ..."
+  # TODO: These files are link to file that don't exist!
+  rm "${dir}"/genesis/profile.json
+  rm "${dir}"/genesis/stake-delegator-keys
+  find -L "${dir}"/genesis -printf "%P\n"         \
+    | tar --create --zstd                         \
+      --dereference --hard-dereference            \
+      --file="${dir}"/"${genesis_file_name}"      \
+      --owner=65534 --group=65534 --mode="u=rwx"  \
+      --directory="${dir}"/genesis --files-from=-
+
+  # Upload genesis tar file
+  local s3_region="eu-central-1"
+  local s3_host="s3.${s3_region}.amazonaws.com";
+  local s3_bucket_name="iog-cardano-perf";
+  local s3_access_key="${AWS_ACCESS_KEY_ID}";
+  local s3_access_key_secret="${AWS_SECRET_ACCESS_KEY}"
+  local s3_storage_class="STANDARD"
+  local return_code=0
+  msg "$(blue Uploading) $(yellow "\"${genesis_file_name}\"") to $(yellow "\"s3://${s3_bucket_name}/\"") ..."
+  aws s3 cp                                                               \
+    "${dir}"/"${genesis_file_name}"                                       \
+    s3://"${s3_bucket_name}"                                              \
+    --content-type "application/zstd"                                     \
+    --region "${s3_region}"                                               \
+    --expected-size "$(stat --printf=%s "${dir}"/"${genesis_file_name}")" \
+  || return_code="$?"
+  # https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html#using-s3-commands-managing-objects-copy
+  # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/cp.html
+  if test "${return_code}" = "0"
+  then
+    # A server response was obtained.
+    msg "$(green "File \"${genesis_file_name}\" uploaded successfully")"
+  else
+    msg "$(red "FATAL: Upload to Amazon S3 failed")"
+    local nomad_agents_were_already_running=$(envjqr 'nomad_agents_were_already_running')
+    if test "${nomad_agents_were_already_running}" = "false"
+    then
+      wb_nomad agents stop "${server_name}" "${client_name}" "exec"
+    fi
+    backend_nomad stop-nomad-job "${dir}"
+    fatal "Failed to upload genesis"
+  fi
+
+  # Generic download from every node.
+  local uri="https://${s3_bucket_name}.${s3_host}/${genesis_file_name}"
+  if ! backend_nomad deploy-genesis-wget "${dir}" "${uri}"
+  then
+    # File kept for debugging!
+    fatal "Deploy of genesis \"${uri}\" failed"
+  else
+    msg "$(green "Genesis \"${uri}\" deployed successfully")"
+    # Don't keep the file once ready, it's not free!
+    msg "$(blue Removing) genesis file from $(yellow "\"s3://${s3_bucket_name}\"") ..."
+    aws s3 rm                                         \
+      s3://"${s3_bucket_name}"/"${genesis_file_name}" \
+      --region "${s3_region}"                         \
+    || true
+    # Reminder to remove old files.
+    msg "Still available files at $(yellow "\"s3://${s3_bucket_name}\""):"
+    aws s3 ls                   \
+      s3://"${s3_bucket_name}"/ \
+      --region "${s3_region}"
+  fi
 }

--- a/nix/workbench/backend/nomad/exec.nix
+++ b/nix/workbench/backend/nomad/exec.nix
@@ -52,9 +52,13 @@ let
   ;
 
   # Nomad-generic "container-specs.json"
-  # Build a Nomad Job specification for each available Nomad "sub-backend".
+  # Build a Nomad Job specification for this Nomad "sub-backend".
   materialise-profile =
-    (import ../nomad.nix {inherit pkgs lib stateDir;}).materialise-profile
+    let params = {
+      inherit pkgs lib stateDir;
+      subBackendName = "exec";
+    };
+    in (import ../nomad.nix params).materialise-profile
   ;
 
   overlay =

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -27,16 +27,24 @@ backend_nomadexec() {
       backend_nomad is-running           "$@"
     ;;
 
-    start )
-      backend_nomad start                "$@"
+    start-cluster )
+      backend_nomad start-cluster        "$@"
     ;;
 
-    cleanup-cluster )
-      backend_nomad cleanup-cluster      "$@"
+    start-tracers )
+      backend_nomad start-tracers        "$@"
     ;;
 
     start-nodes )
       backend_nomad start-nodes          "$@"
+    ;;
+
+    start-generator )
+      backend_nomad start-generator      "$@"
+    ;;
+
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
     ;;
 
     start-node )
@@ -45,14 +53,6 @@ backend_nomadexec() {
 
     stop-node )
       backend_nomad stop-node            "$@"
-    ;;
-
-    start-healthchecks )
-      backend_nomad start-healthchecks   "$@"
-    ;;
-
-    start-generator )
-      backend_nomad start-generator      "$@"
     ;;
 
     get-node-socket-path )
@@ -69,6 +69,14 @@ backend_nomadexec() {
 
     wait-pools-stopped )
       backend_nomad wait-pools-stopped   "$@"
+    ;;
+
+    stop-all )
+      backend_nomad stop-all             "$@"
+    ;;
+
+    fetch-logs )
+      backend_nomad fetch-logs           "$@"
     ;;
 
     stop-cluster )

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -162,8 +162,10 @@ allocate-run-nomadexec() {
     "${dir}"/container-specs.json              \
   > "${dir}"/nomad/nomad-job.json
   # The job file is "slightly" modified (jq) to suit the running environment.
-  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
-  backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
+  ## Empty the global namespace. Local runs ignore "${NOMAD_NAMESPACE:-}"
+  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}"
+  # Will set the /nix/store paths from ".nix-store-path" in container-specs.json
+  backend_nomad allocate-run-nomad-job-patch-nix "${dir}"
 }
 
 deploy-genesis-nomadexec() {

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -17,6 +17,41 @@ backend_nomadexec() {
       echo 'nomadexec'
     ;;
 
+    # Overrided backend "methods"
+
+    setenv-defaults )
+      local usage="USAGE: wb backend $op BACKEND-DIR"
+      local backend_dir=${1:?$usage}; shift
+      # Repeated code / envars set by all sub-backends
+      setenvjqstr 'nomad_task_driver'    "exec"
+      setenvjqstr 'nomad_environment'    "local"
+      setenvjqstr 'one_tracer_per_node'  "true"
+      # Local runs always run the generator inside Nomad Task "node-0"
+      setenvjqstr 'generator_task_name'           \
+        "$(                                       \
+          jq -r                                   \
+            .nomadJob.generatorTaskName           \
+            "${backend_dir}"/container-specs.json \
+        )"
+      # Store the location of the Nix-built "container-specs" file.
+      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
+      setenvjqstr 'profile_container_specs_file' \
+        "${backend_dir}"/container-specs.json
+      # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
+      setenv-defaults-nomadexec          "${backend_dir}"
+    ;;
+
+    allocate-run )
+      allocate-run-nomadexec             "$@"
+      # Does a pre allocation before calling the default/common allocation.
+      backend_nomad allocate-run         "$@"
+    ;;
+
+    deploy-genesis )
+      # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
+      deploy-genesis-nomadexec           "$@"
+    ;;
+
     # Generic backend sub-commands, shared code between Nomad sub-backends.
 
     describe-run )
@@ -87,111 +122,94 @@ backend_nomadexec() {
       backend_nomad cleanup-cluster      "$@"
     ;;
 
-    # Sets jq envars "profile_container_specs_file" ,"nomad_environment",
-    # "nomad_task_driver" and "one_tracer_per_node".
-    # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
-    setenv-defaults )
-      local usage="USAGE: wb backend $op BACKEND-DIR"
-      local backend_dir=${1:?$usage}; shift
-
-      setenvjqstr 'nomad_task_driver'   "exec"
-      setenvjqstr 'nomad_server_name'   "srv1"
-      # As one task driver runs as a normal user and the other as a root, use
-      # different names to allow restarting/reusing without cleaup, this way
-      # data folders already there can be accessed without "permission denied"
-      # errors.
-      setenvjqstr 'nomad_client_name'   "cli1-exe"
-
-      # Store the location of the Nix-built "container-specs" file.
-      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
-      local profile_container_specs_file
-      profile_container_specs_file="${backend_dir}"/container-specs.json
-      setenvjqstr 'profile_container_specs_file' "${profile_container_specs_file}"
-      setenvjqstr 'nomad_environment'   "local"
-      setenvjqstr 'one_tracer_per_node' "true"
-
-      # Local runs always run the generator inside Nomad Task "node-0"
-      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
-    ;;
-
-    # Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
-    allocate-run )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-
-      # Copy the container specs file (container-specs.json)
-      # This is the output file of the Nix derivation
-      local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
-      # Create a nicely sorted and indented copy
-      jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
-
-      # Create nomad folder and copy the Nomad job spec file to run.
-      mkdir -p "${dir}"/nomad
-      # Select which version of the Nomad job spec file we are running and
-      # create a nicely sorted and indented copy it "nomad/nomad-job.json".
-      jq -r ".nomadJob.exec.oneTracerPerNode"      \
-        "${dir}"/container-specs.json              \
-      > "${dir}"/nomad/nomad-job.json
-      # The job file is "slightly" modified (jq) to suit the running environment.
-      backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
-      backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
-
-      backend_nomad allocate-run "${dir}"
-    ;;
-
-    # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
-    deploy-genesis )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-      local server_name=$(envjqr 'nomad_server_name')
-      local client_name=$(envjqr 'nomad_client_name')
-
-      # Add genesis to HTTP cache server
-      local nomad_agents_were_already_running=$(envjqr 'nomad_agents_were_already_running')
-      if ! wb_nomad webfs is-running
-      then
-        msg "$(blue Starting) a local $(yellow "HTTP server")"
-        if ! wb_nomad webfs start
-        then
-          if test "${nomad_agents_were_already_running}" = "false"
-          then
-            msg "$(red "Startup of webfs failed, cleaning up ...")"
-            wb_nomad agents stop "${server_name}" "${client_name}" "exec"
-            backend_nomad stop-nomad-job "${dir}"
-          fi
-          fatal "Failed to start a local HTTP server"
-        fi
-      else
-        msg "$(blue Reusing) already running local $(yellow "HTTP server")"
-      fi
-      msg "$(blue Creating) $(yellow "\"${nomad_job_name}.tar.zst\"") ..."
-      if ! wb_nomad webfs add-genesis-dir "${dir}"/genesis "${nomad_job_name}"
-      then
-        if test "${nomad_agents_were_already_running}" = "false"
-        then
-          msg "$(red "Startup of webfs failed, cleaning up ...")"
-          wb_nomad agents stop "${server_name}" "${client_name}" "exec"
-          backend_nomad stop-nomad-job "${dir}"
-        fi
-        fatal "Failed to add genesis file to local HTTP server"
-      else
-        msg "$(green "File \"${nomad_job_name}.tar.zst\" created successfully and ready to deploy")"
-      fi
-      # Generic download from every node.
-      local uri="http://127.0.0.1:12000/${nomad_job_name}.tar.zst"
-      if ! backend_nomad deploy-genesis-wget "${dir}" "${uri}"
-      then
-        fatal "Deploy of genesis \"${uri}\" failed"
-      else
-        msg "$(green "Genesis \"${uri}\" deployed successfully")"
-      fi
-    ;;
-
     * )
       backend_nomad "${op}" "$@"
     ;;
 
   esac
 
+}
+
+# Sets jq envars "profile_container_specs_file" ,"nomad_environment",
+# "nomad_task_driver" and "one_tracer_per_node".
+setenv-defaults-nomadexec() {
+  local backend_dir="${1}"
+
+  setenvjqstr 'nomad_server_name'   "srv1"
+  # As one task driver runs as a normal user and the other as a root, use
+  # different names to allow restarting/reusing without cleaup, this way
+  # data folders already there can be accessed without "permission denied"
+  # errors.
+  setenvjqstr 'nomad_client_name'   "cli1-exe"
+}
+
+# Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
+allocate-run-nomadexec() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+
+  # Copy the container specs file (container-specs.json)
+  # This is the output file of the Nix derivation
+  local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
+  # Create a nicely sorted and indented copy
+  jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
+
+  # Create nomad folder and copy the Nomad job spec file to run.
+  mkdir -p "${dir}"/nomad
+  # Select which version of the Nomad job spec file we are running and
+  # create a nicely sorted and indented copy it "nomad/nomad-job.json".
+  jq -r ".nomadJob.exec.oneTracerPerNode"      \
+    "${dir}"/container-specs.json              \
+  > "${dir}"/nomad/nomad-job.json
+  # The job file is "slightly" modified (jq) to suit the running environment.
+  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
+  backend_nomad allocate-run-nomad-job-patch-nix       "${dir}"
+}
+
+deploy-genesis-nomadexec() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+  local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
+  local server_name=$(envjqr 'nomad_server_name')
+  local client_name=$(envjqr 'nomad_client_name')
+
+  # Add genesis to HTTP cache server
+  local nomad_agents_were_already_running=$(envjqr 'nomad_agents_were_already_running')
+  if ! wb_nomad webfs is-running
+  then
+    msg "$(blue Starting) a local $(yellow "HTTP server")"
+    if ! wb_nomad webfs start
+    then
+      if test "${nomad_agents_were_already_running}" = "false"
+      then
+        msg "$(red "Startup of webfs failed, cleaning up ...")"
+        wb_nomad agents stop "${server_name}" "${client_name}" "exec"
+        backend_nomad stop-nomad-job "${dir}"
+      fi
+      fatal "Failed to start a local HTTP server"
+    fi
+  else
+    msg "$(blue Reusing) already running local $(yellow "HTTP server")"
+  fi
+  msg "$(blue Creating) $(yellow "\"${nomad_job_name}.tar.zst\"") ..."
+  if ! wb_nomad webfs add-genesis-dir "${dir}"/genesis "${nomad_job_name}"
+  then
+    if test "${nomad_agents_were_already_running}" = "false"
+    then
+      msg "$(red "Startup of webfs failed, cleaning up ...")"
+      wb_nomad agents stop "${server_name}" "${client_name}" "exec"
+      backend_nomad stop-nomad-job "${dir}"
+    fi
+    fatal "Failed to add genesis file to local HTTP server"
+  else
+    msg "$(green "File \"${nomad_job_name}.tar.zst\" created successfully and ready to deploy")"
+  fi
+  # Generic download from every node.
+  local uri="http://127.0.0.1:12000/${nomad_job_name}.tar.zst"
+  if ! backend_nomad deploy-genesis-wget "${dir}" "${uri}"
+  then
+    fatal "Deploy of genesis \"${uri}\" failed"
+  else
+    msg "$(green "Genesis \"${uri}\" deployed successfully")"
+  fi
 }

--- a/nix/workbench/backend/nomad/podman.nix
+++ b/nix/workbench/backend/nomad/podman.nix
@@ -71,9 +71,13 @@ let
   ;
 
   # Nomad-generic "container-specs.json"
-  # Build a Nomad Job specification for each available Nomad "sub-backend".
+  # Build a Nomad Job specification for this Nomad "sub-backend".
   materialise-profile =
-    (import ../nomad.nix {inherit pkgs lib stateDir;}).materialise-profile
+    let params = {
+      inherit pkgs lib stateDir;
+      subBackendName = "podman";
+    };
+    in (import ../nomad.nix params).materialise-profile
   ;
 
   overlay =

--- a/nix/workbench/backend/nomad/podman.sh
+++ b/nix/workbench/backend/nomad/podman.sh
@@ -163,7 +163,8 @@ allocate-run-nomadpodman() {
     "${dir}"/container-specs.json              \
   > "${dir}"/nomad/nomad-job.json
   # The job file is "slightly" modified (jq) to suit the running environment.
-  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
+  ## Empty the global namespace. Local runs ignore "${NOMAD_NAMESPACE:-}"
+  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}"
   podman_create_image "${dir}"
   # Make sure the "genesis-volume" dir is present when the Nomad job is
   # started because with the podman task driver (always local, not used for

--- a/nix/workbench/backend/nomad/podman.sh
+++ b/nix/workbench/backend/nomad/podman.sh
@@ -17,6 +17,41 @@ backend_nomadpodman() {
       echo 'nomadpodman'
     ;;
 
+    # Overrided backend "methods"
+
+    setenv-defaults )
+      local usage="USAGE: wb backend $op BACKEND-DIR"
+      local backend_dir=${1:?$usage}; shift
+      # Repeated code / envars set by all sub-backends
+      setenvjqstr 'nomad_task_driver'    "podman"
+      setenvjqstr 'nomad_environment'    "local"
+      setenvjqstr 'one_tracer_per_node'  "false"
+      # Local runs always run the generator inside Nomad Task "node-0"
+      setenvjqstr 'generator_task_name'           \
+        "$(                                       \
+          jq -r                                   \
+            .nomadJob.generatorTaskName           \
+            "${backend_dir}"/container-specs.json \
+        )"
+      # Store the location of the Nix-built "container-specs" file.
+      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
+      setenvjqstr 'profile_container_specs_file' \
+        "${backend_dir}"/container-specs.json
+      # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
+      setenv-defaults-nomadpodman        "${backend_dir}"
+    ;;
+
+    allocate-run )
+      allocate-run-nomadpodman           "$@"
+      # Does a pre allocation before calling the default/common allocation.
+      backend_nomad allocate-run         "$@"
+    ;;
+
+    deploy-genesis )
+      # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
+      deploy-genesis-nomadpodman         "$@"
+    ;;
+
     # Generic backend sub-commands, shared code between Nomad sub-backends.
 
     describe-run )
@@ -87,108 +122,93 @@ backend_nomadpodman() {
       backend_nomad cleanup-cluster      "$@"
     ;;
 
-    # Sets jq envars "profile_container_specs_file" ,"nomad_environment",
-    # "nomad_task_driver" and "one_tracer_per_node".
-    # It "overrides" completely `backend_nomad`'s `setenv-defaults`.
-    setenv-defaults )
-      local usage="USAGE: wb backend $op BACKEND-DIR"
-      local backend_dir=${1:?$usage}; shift
-
-      setenvjqstr 'nomad_task_driver'   "podman"
-      setenvjqstr 'nomad_server_name'   "srv1"
-      # As one task driver runs as a normal user and the other as a root, use
-      # different names to allow restarting/reusing without cleaup, this way
-      # data folders already there can be accessed without "permission denied"
-      # errors.
-      setenvjqstr 'nomad_client_name'   "cli1-pod"
-
-      # Store the location of the Nix-built "container-specs" file.
-      # TODO/FIXME: This is the only way to be able to later copy it to "$dir" ?
-      local profile_container_specs_file
-      profile_container_specs_file="${backend_dir}"/container-specs.json
-      setenvjqstr 'profile_container_specs_file' "${profile_container_specs_file}"
-      setenvjqstr 'nomad_environment'   "local"
-      setenvjqstr 'one_tracer_per_node' "false"
-
-      # Local runs always run the generator inside Nomad Task "node-0"
-      setenvjqstr 'generator_task_name' "$(jq -r .nomadJob.generatorTaskName "${profile_container_specs_file}")"
-    ;;
-
-    # Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
-    allocate-run )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-
-      # Copy the container specs file (container-specs.json)
-      # This is the output file of the Nix derivation
-      local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
-      # Create a nicely sorted and indented copy
-      jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
-
-      # Create nomad folder and copy the Nomad job spec file to run.
-      mkdir -p "${dir}"/nomad
-      # Select which version of the Nomad job spec file we are running and
-      # create a nicely sorted and indented copy it "nomad/nomad-job.json".
-      jq -r ".nomadJob.podman.oneTracerPerCluster" \
-        "${dir}"/container-specs.json              \
-      > "${dir}"/nomad/nomad-job.json
-      # The job file is "slightly" modified (jq) to suit the running environment.
-      backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
-      podman_create_image "${dir}"
-      # Make sure the "genesis-volume" dir is present when the Nomad job is
-      # started because with the podman task driver (always local, not used for
-      # cloud) these directories are going to be mounted by adding them to the
-      # "volume" stanza.
-      mkdir "${dir}"/genesis-volume
-      # It needs to mount the tracer directory if "one_tracer_per_node" is
-      # false and mount the genesis and CARDANO_MAINNET_MIRROR (if needed).
-      nomad_job_file_create_mounts "${dir}"
-
-      backend_nomad allocate-run   "${dir}"
-    ;;
-
-    # It "overrides" completely `backend_nomad`'s `deploy-genesis`.
-    deploy-genesis )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      # The "$dir/genesis-volume" folder is mounted to "run/local/genesis"
-      # inside the container that for security reasons does not follow symlinks,
-      # so everything is copied from the generated/patched genesis in
-      # "$dir/genesis" to "$dir/genesis-volume"
-      mkdir "${dir}"/genesis-volume/byron
-      mkdir "${dir}"/genesis-volume/utxo-keys
-      mkdir "${dir}"/genesis-volume/node-keys
-      cp -a "${dir}"/genesis/genesis.alonzo.json        \
-            "${dir}"/genesis-volume/genesis.alonzo.json
-      cp -a "${dir}"/genesis/genesis.conway.json        \
-            "${dir}"/genesis-volume/genesis.conway.json
-      cp -a "${dir}"/genesis/genesis-shelley.json       \
-            "${dir}"/genesis-volume/genesis-shelley.json
-      cp -a "${dir}"/genesis/byron/genesis.json         \
-            "${dir}"/genesis-volume/byron/genesis.json
-      cp -a                                             \
-            "${dir}"/genesis/utxo-keys/*.skey           \
-            "${dir}"/genesis-volume/utxo-keys/
-      cp -a                                             \
-            "${dir}"/genesis/utxo-keys/*.vkey           \
-            "${dir}"/genesis-volume/utxo-keys/
-      cp -a                                             \
-            "${dir}"/genesis/node-keys/*.skey           \
-            "${dir}"/genesis-volume/node-keys/
-      cp -a                                             \
-            "${dir}"/genesis/node-keys/*.vkey           \
-            "${dir}"/genesis-volume/node-keys/
-      cp -a                                             \
-            "${dir}"/genesis/node-keys/*.opcert         \
-            "${dir}"/genesis-volume/node-keys/
-    ;;
-
     * )
       backend_nomad "${op}" "$@"
     ;;
 
   esac
 
+}
+
+# Sets jq envars "profile_container_specs_file" ,"nomad_environment",
+# "nomad_task_driver" and "one_tracer_per_node".
+# It "overrides" completely `backend_nomad`'s `setenv-defaults`.
+setenv-defaults-nomadpodman() {
+  local backend_dir="${1}"
+
+  setenvjqstr 'nomad_server_name'   "srv1"
+  # As one task driver runs as a normal user and the other as a root, use
+  # different names to allow restarting/reusing without cleaup, this way
+  # data folders already there can be accessed without "permission denied"
+  # errors.
+  setenvjqstr 'nomad_client_name'   "cli1-pod"
+}
+
+# Sub-backend specific allocs and calls `backend_nomad`'s `allocate-run`.
+allocate-run-nomadpodman() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+
+  # Copy the container specs file (container-specs.json)
+  # This is the output file of the Nix derivation
+  local profile_container_specs_file=$(envjqr 'profile_container_specs_file')
+  # Create a nicely sorted and indented copy
+  jq . "${profile_container_specs_file}" > "${dir}"/container-specs.json
+
+  # Create nomad folder and copy the Nomad job spec file to run.
+  mkdir -p "${dir}"/nomad
+  # Select which version of the Nomad job spec file we are running and
+  # create a nicely sorted and indented copy it "nomad/nomad-job.json".
+  jq -r ".nomadJob.podman.oneTracerPerCluster" \
+    "${dir}"/container-specs.json              \
+  > "${dir}"/nomad/nomad-job.json
+  # The job file is "slightly" modified (jq) to suit the running environment.
+  backend_nomad allocate-run-nomad-job-patch-namespace "${dir}" "default"
+  podman_create_image "${dir}"
+  # Make sure the "genesis-volume" dir is present when the Nomad job is
+  # started because with the podman task driver (always local, not used for
+  # cloud) these directories are going to be mounted by adding them to the
+  # "volume" stanza.
+  mkdir "${dir}"/genesis-volume
+  # It needs to mount the tracer directory if "one_tracer_per_node" is
+  # false and mount the genesis and CARDANO_MAINNET_MIRROR (if needed).
+  nomad_job_file_create_mounts "${dir}"
+}
+
+# It "overrides" completely `backend_nomad`'s `deploy-genesis`.
+deploy-genesis-nomadpodman() {
+  local usage="USAGE: wb backend $op RUN-DIR"
+  local dir=${1:?$usage}; shift
+  # The "$dir/genesis-volume" folder is mounted to "run/local/genesis"
+  # inside the container that for security reasons does not follow symlinks,
+  # so everything is copied from the generated/patched genesis in
+  # "$dir/genesis" to "$dir/genesis-volume"
+  mkdir "${dir}"/genesis-volume/byron
+  mkdir "${dir}"/genesis-volume/utxo-keys
+  mkdir "${dir}"/genesis-volume/node-keys
+  cp -a "${dir}"/genesis/genesis.alonzo.json        \
+        "${dir}"/genesis-volume/genesis.alonzo.json
+  cp -a "${dir}"/genesis/genesis.conway.json        \
+        "${dir}"/genesis-volume/genesis.conway.json
+  cp -a "${dir}"/genesis/genesis-shelley.json       \
+        "${dir}"/genesis-volume/genesis-shelley.json
+  cp -a "${dir}"/genesis/byron/genesis.json         \
+        "${dir}"/genesis-volume/byron/genesis.json
+  cp -a                                             \
+        "${dir}"/genesis/utxo-keys/*.skey           \
+        "${dir}"/genesis-volume/utxo-keys/
+  cp -a                                             \
+        "${dir}"/genesis/utxo-keys/*.vkey           \
+        "${dir}"/genesis-volume/utxo-keys/
+  cp -a                                             \
+        "${dir}"/genesis/node-keys/*.skey           \
+        "${dir}"/genesis-volume/node-keys/
+  cp -a                                             \
+        "${dir}"/genesis/node-keys/*.vkey           \
+        "${dir}"/genesis-volume/node-keys/
+  cp -a                                             \
+        "${dir}"/genesis/node-keys/*.opcert         \
+        "${dir}"/genesis-volume/node-keys/
 }
 
 podman_create_image() {

--- a/nix/workbench/backend/nomad/podman.sh
+++ b/nix/workbench/backend/nomad/podman.sh
@@ -27,16 +27,24 @@ backend_nomadpodman() {
       backend_nomad is-running           "$@"
     ;;
 
-    start )
-      backend_nomad start                "$@"
+    start-cluster )
+      backend_nomad start-cluster        "$@"
     ;;
 
-    cleanup-cluster )
-      backend_nomad cleanup-cluster      "$@"
+    start-tracers )
+      backend_nomad start-tracers        "$@"
     ;;
 
     start-nodes )
       backend_nomad start-nodes          "$@"
+    ;;
+
+    start-generator )
+      backend_nomad start-generator      "$@"
+    ;;
+
+    start-healthchecks )
+      backend_nomad start-healthchecks   "$@"
     ;;
 
     start-node )
@@ -45,14 +53,6 @@ backend_nomadpodman() {
 
     stop-node )
       backend_nomad stop-node            "$@"
-    ;;
-
-    start-healthchecks )
-      backend_nomad start-healthchecks   "$@"
-    ;;
-
-    start-generator )
-      backend_nomad start-generator      "$@"
     ;;
 
     get-node-socket-path )
@@ -69,6 +69,14 @@ backend_nomadpodman() {
 
     wait-pools-stopped )
       backend_nomad wait-pools-stopped   "$@"
+    ;;
+
+    stop-all )
+      backend_nomad stop-all             "$@"
+    ;;
+
+    fetch-logs )
+      backend_nomad fetch-logs           "$@"
     ;;
 
     stop-cluster )

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -4,6 +4,7 @@
 , nodeSpecs
 , withGenerator
 , withTracer
+, withSsh
 , unixHttpServerPort ? null
 , inetHttpServerPort ? null
 }:
@@ -150,6 +151,28 @@ let
         command        = "${command}";
         stdout_logfile = "${stateDir}/healthcheck/stdout";
         stderr_logfile = "${stateDir}/healthcheck/stderr";
+        # Set these values to 0 to indicate an unlimited log size / no rotation.
+        stdout_logfile_maxbytes = 0;
+        stderr_logfile_maxbytes = 0;
+        stopasgroup    = false;
+        killasgroup    = false;
+        autostart      = false;
+        autorestart    = false;
+        # Don't attempt any restart!
+        startretries   = 0;
+        # Seconds it needs to stay running to consider the start successful
+        startsecs      = 5;
+      };
+    }
+    //
+    lib.attrsets.optionalAttrs withSsh
+    {
+      "program:ssh" = {
+        # "command" below assumes "directory" is set accordingly.
+        directory      = "${stateDir}/ssh";
+        command        = "${command}";
+        stdout_logfile = "${stateDir}/ssh/stdout";
+        stderr_logfile = "${stateDir}/ssh/stderr";
         # Set these values to 0 to indicate an unlimited log size / no rotation.
         stdout_logfile_maxbytes = 0;
         stderr_logfile_maxbytes = 0;

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -43,6 +43,7 @@ let
           nodeSpecs = profileData.node-specs.value;
           withGenerator = true;
           withTracer = profileData.value.node.tracer;
+          withSsh = false;
           inetHttpServerPort = "127.0.0.1:9001";
         };
       in pkgs.runCommand "workbench-backend-output-${profileData.profileName}-supervisor"

--- a/nix/workbench/nomad.sh
+++ b/nix/workbench/nomad.sh
@@ -657,7 +657,9 @@ EOL
           local usage="USAGE: wb nomad ${op} ${subop} SERVER-NAME"
           local name=${1:?$usage}; shift
           local config_file=$(wb_nomad server config-file-path "${name}")
-          pgrep --delimiter ' ' --full "nomad.*${config_file}.*"
+          # Make it Mac compatible by only using shorthand options:
+          # `-d` instead of `--delimiter` and `-f` instead of `--full`
+          pgrep -d ' ' -f "nomad.*${config_file}.*"
           # Clean up is only done by the `stop` subcommand!
           # No `rm "${pid_file}"` if not running.
         ;;
@@ -668,7 +670,9 @@ EOL
           local pid_file=$(wb_nomad server pid-filepath "${name}")
           local config_file=$(wb_nomad server config-file-path "${name}")
           # It's running if we haven't PROPERLY stopped it or PIDs exist!
-          test -f "${pid_file}" || test $(pgrep --count --full "nomad.*${config_file}.*") -gt 0
+          # `pgrep` piped to `wc -l` instead "--count" to make it Mac comptible
+          # Also only shorthand options: like `-f` instead of `--full`
+          test -f "${pid_file}" || test $(pgrep -f "nomad.*${config_file}.*" | wc -l) -gt 0
         ;;
 ####### server -> start )#######################################################
         start )
@@ -879,7 +883,9 @@ EOL
           local usage="USAGE: wb nomad ${op} ${subop} CLIENT-NAME"
           local name=${1:?$usage}; shift
           local config_file=$(wb_nomad client config-file-path "${name}")
-          pgrep --delimiter ' ' --full "nomad.*${config_file}.*"
+          # Make it Mac compatible by only using shorthand options:
+          # `-d` instead of `--delimiter` and `-f` instead of `--full`
+          pgrep -d ' ' -f "nomad.*${config_file}.*"
           # Clean up is only done by the `stop` subcommand!
           # No `rm "${pid_file}"` if not running.
         ;;
@@ -890,7 +896,9 @@ EOL
           local pid_file=$(wb_nomad client pid-filepath "${name}")
           local config_file=$(wb_nomad client config-file-path "${name}")
           # It's running if we haven't PROPERLY stopped it or PIDs exist!
-          test -f "${pid_file}" || test $(pgrep --count --full "nomad.*${config_file}.*") -gt 0
+          # `pgrep` piped to `wc -l` instead "--count" to make it Mac comptible
+          # Also only shorthand options: like `-f` instead of `--full`
+          test -f "${pid_file}" || test $(pgrep -f "nomad.*${config_file}.*" | wc -l) -gt 0
         ;;
 ####### client -> start )#######################################################
         # Agent is started with `-network-interface lo` if not without a proper
@@ -1317,7 +1325,9 @@ EOF
         pids-array )
           local usage="USAGE: wb nomad ${op} ${subop}"
           local state_dir=$(wb_nomad webfs state-dir-path)
-          pgrep --delimiter ' ' --full "webfsd.*${state_dir}"/webfsd.log
+          # Make it Mac compatible by only using shorthand options:
+          # `-d` instead of `--delimiter` and `-f` instead of `--full`
+          pgrep -d ' ' -f "webfsd.*${state_dir}"/webfsd.log
           # Clean up is only done by the `stop` subcommand!
           # No `rm "${pid_file}"` if not running.
         ;;
@@ -1326,7 +1336,9 @@ EOF
           local pid_file=$(wb_nomad webfs pid-filepath)
           local state_dir=$(wb_nomad webfs state-dir-path)
           # It's running if we haven't PROPERLY stopped it or PIDs exist!
-          test -f "${pid_file}" && test $(pgrep --count --full "webfsd.*${state_dir}"/webfsd.log) -gt 0
+          # `pgrep` piped to `wc -l` instead "--count" to make it Mac comptible
+          # Also only shorthand options: like `-f` instead of `--full`
+          test -f "${pid_file}" && test $(pgrep -f "webfsd.*${state_dir}"/webfsd.log | wc -l) -gt 0
         ;;
         start )
           local usage="USAGE: wb nomad ${op} ${subop}"

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -475,13 +475,22 @@ EOF
         ln -s "$profile_data"/topology.json        "$dir"
         ln -s "$profile_data"/topology.dot         "$dir"
 
-        if test "${WB_BACKEND:0:5}" != 'nomad' # Doesn't start with "nomad"
-        then run_instantiate_rundir_profile_services "$dir"; fi
-
-        ## 5. populate the directory with backend specifics:
+        ## 5. backend specifics allocations:
         backend allocate-run "$dir" "${backend_args[@]}"
 
-        ## 6. allocate genesis time
+        ## 6. to be able to deploy the genesis the cluster must be started
+        #     because Nomad uses `nomad exec wget`
+        # FIXME: the problem is that supervisor uses "run/current" in its
+        #        configuration and a "meta.json" is needed to pass `run check`
+        #        that is called by `run set-current`. This error is only showing
+        #        a "FATAL" message and not exiting by pure chance (bash error
+        #        supression because of a command called inside `local`). So
+        #        we ignore it as a temporary solution because all the bash
+        #        cleaup needed to fix this will take too long.
+        run set-current "$run" 2>/dev/null || true
+        backend start-cluster "$dir"
+
+        ## 7. allocate genesis time
         ##    NOTE: The genesis time is different from the tag time.
         progress "run | time" "allocating time:"
         local timing=$(profile allocate-time "$dir"/profile.json)
@@ -521,13 +530,16 @@ EOF
         cp "$dir"/genesis/genesis-shelley.json "$dir"/genesis-shelley.json
         cp "$dir"/genesis/genesis.alonzo.json  "$dir"/genesis.alonzo.json
         echo >&2
+
+        ## 8. deploy genesis
         progress "run | genesis" "deploying.."
         backend deploy-genesis "$dir"
 
+        ## 9. everything needed to start-[tracers|nodes|generator] should be
+        ##    ready
         progress "run" "allocated $(with_color white $run) @ $dir"
         run     describe "$run"
         profile describe "$dir"/profile.json
-        run  set-current "$run"
         ;;
 
     allocate-from-machine-run-slice | alloc-from-mrs )
@@ -787,6 +799,9 @@ EOF
         local scenario=${scenario_override:-$(jq -r .scenario "$dir"/profile.json)}
         scenario "$scenario" "$dir"
 
+        backend fetch-logs     "$dir"
+        backend stop-cluster   "$dir"
+
         run compat-meta-fixups "$run"
         ;;
 
@@ -817,7 +832,7 @@ EOF
           } * .
         '
         backend cleanup-cluster "$dir"
-        run start          "$@" "$run"
+        run start-cluster  "$@" "$run"
 
         msg "cluster re-started in the same run directory: $dir"
         ;;
@@ -1037,35 +1052,4 @@ run_ls_sets_cmd() {
           find -L . -mindepth 3 -maxdepth 3 -type f -name meta.json -exec dirname \{\} \; |
           cut -d/ -f2 |
           sort -u || true'
-}
-
-run_instantiate_rundir_profile_services() {
-    local dir=${1:?run_instantiate_rundir_profile_services arg1: expects a run directory}; shift
-
-    local svcs=$dir/profile/node-services.json
-    local gtor=$dir/profile/generator-service.json
-    local trac=$dir/profile/tracer-service.json
-    local hche=$dir/profile/healthcheck-service.json
-
-    for node in $(jq_tolist 'keys' "$dir"/node-specs.json)
-    do local node_dir="$dir"/$node
-       mkdir -p                                          "$node_dir"
-       cp $(jq '."'"$node"'"."start"'          -r $svcs) "$node_dir"/start.sh
-       cp $(jq '."'"$node"'"."config"'         -r $svcs) "$node_dir"/config.json
-       cp $(jq '."'"$node"'"."topology"'       -r $svcs) "$node_dir"/topology.json
-    done
-
-    local gen_dir="$dir"/generator
-    mkdir -p                                              "$gen_dir"
-    cp $(jq '."start"'                         -r $gtor)  "$gen_dir"/start.sh
-    cp $(jq '."config"'                        -r $gtor)  "$gen_dir"/run-script.json
-
-    local trac_dir="$dir"/tracer
-    mkdir -p                                    "$trac_dir"
-    cp $(jq '."start"'                        -r $trac) "$trac_dir"/start.sh
-    cp $(jq '."config"'                        -r $trac) "$trac_dir"/config.json
-
-    local hche_dir="$dir"/healthcheck
-    mkdir -p                                    "$hche_dir"
-    cp $(jq '."start"'                        -r $hche) "$hche_dir"/start.sh
 }

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -30,39 +30,47 @@ fi
 
 case "$op" in
     idle )
-        backend start                "$dir"
+        backend start-tracers        "$dir"
         backend start-nodes          "$dir"
         ;;
 
     tracer-only )
-        backend start                "$dir"
+        backend start-tracers        "$dir"
         ;;
 
     fixed )
-        backend start                "$dir"
+        backend start-tracers        "$dir"
 
-        scenario_setup_exit_trap     "$dir"
+        scenario_setup_exit_trap              "$dir"
         scenario_setup_workload_termination   "$dir"
+        # Trap start
+        ############
         backend start-nodes          "$dir"
         backend wait-pools-stopped   "$dir"
+        # Trap end
+        ##########
         scenario_cleanup_termination
 
-        backend stop-cluster         "$dir"
+        backend stop-all             "$dir"
         ;;
 
     fixed-loaded )
-        backend start                "$dir"
+        backend start-tracers        "$dir"
 
         scenario_setup_exit_trap     "$dir"
+        # Trap start
+        ############
         backend start-nodes          "$dir"
         backend start-generator      "$dir"
         backend start-healthchecks   "$dir"
-
         scenario_setup_workload_termination   "$dir"
+        # Trap end
+        ##########
+
         backend wait-pools-stopped   "$dir"
         scenario_cleanup_termination
 
-        backend stop-cluster         "$dir"
+        backend stop-all             "$dir"
         ;;
 
     chainsync )
@@ -70,7 +78,7 @@ case "$op" in
         # `backend start` because the node-#, generator and tracer directories
         # may be created after the nomad job has started (are symlinks to the
         # containers directories).
-        backend start "$dir"
+        backend start-tracers "$dir"
 
         # `chaindb` explorer:
         local explorer=(
@@ -104,7 +112,7 @@ case "$op" in
         backend wait-node-stopped "$dir" 'node-1'
         scenario_cleanup_exit_trap
 
-        backend stop-cluster      "$dir"
+        backend stop-all          "$dir"
 
         analysis_trace_frequencies 'current'
         ;;
@@ -116,6 +124,8 @@ __scenario_exit_trap_dir=
 scenario_exit_trap() {
     echo >&2
     msg "scenario:  $(with_color yellow exit trap triggered)"
+    backend stop-all     "$__scenario_exit_trap_dir"
+    backend fetch-logs   "$__scenario_exit_trap_dir"
     backend stop-cluster "$__scenario_exit_trap_dir"
 }
 

--- a/nix/workbench/service/ssh.nix
+++ b/nix/workbench/service/ssh.nix
@@ -1,0 +1,455 @@
+{ pkgs
+, bashInteractive
+, coreutils
+, openssh_hacks
+}:
+
+with pkgs.lib;
+
+let
+  pid_file             = "/local/run/current/ssh/sshd.pid";
+  listen_address       = "0.0.0.0";
+  port                 = 32000;
+  host_key             = "/local/run/current/ssh/sshd.id_ed25519";
+  # Inside SRE's Nomad Clients, runs as 'nobody' and group ID '65534':
+  # $ nomad alloc exec XXX /nix/store/XXX-coreutils-9.1/bin/whoami
+  # nobody
+  # $ nomad alloc exec XXX /nix/store/XXX-coreutils-9.1/bin/groups
+  # /nix/store/XXX-coreutils-9.1/bin/groups: cannot find name for group ID 65534
+  # 65534
+  user                 = "nobody";
+  authorized_keys_file = "/local/run/current/ssh/%u.id_ed25519.pub";
+in {
+
+  start = rec {
+    JSON = pkgs.writeScript "startup-ssh.sh" value;
+    value = ''
+      #!${bashInteractive}/bin/sh
+
+      # Strict runtime
+      ################
+      # e:        Immediately exit if any command has a non-zero exit status
+      # u:        Reference to non previously defined variables is an error
+      # pipefail: Any failed command in a pipeline is used as return code
+      set -euo pipefail
+
+      # Running as ...
+      ${coreutils}/bin/echo "Running as (whoami): $(${coreutils}/bin/whoami)"
+
+      # -D
+      # When this option is specified, sshd will not detach and does not become
+      # a daemon. This allows easy monitoring of sshd.
+      # -e
+      # Write debug logs to standard error instead of the system log so
+      # supervisord can use it the same it does with the other programs.
+      # -f config_file
+      # Specifies the name  of the configuration file. The default is
+      # /etc/ssh/sshd_config. sshd refuses to start if there is no configuration
+      # file.
+      ${openssh_hacks}/bin/sshd -D -e -f /local/run/current/ssh/sshd_config
+    '';
+  };
+
+  config = rec {
+    JSON = pkgs.writeScript "sshd_config" value;
+    # To run inside the isolated environment created by Nomad it needs:
+    # - StrictModes no:      This or setting a proper home for the `nobody`
+    #                        user.
+    # - ShellPath BASH:      Use a patched OpenSSH that allows to bypass the
+    #                        "/bin/nologin" like shells in /etc/passdw.
+    # - PermitLockedAccount: Use a patched OpenSSH that allows to bypass locked
+    #                        accounts (passwords with "!", "LK", etc).
+    value = ''
+      # Specifies what environment variables sent by the client will be
+      # copied into the session's environ(7). See SendEnv and SetEnv in
+      # ssh_config(5) for how to configure the client. The TERM environment
+      # variable is always accepted whenever the client requests a
+      # pseudo-terminal as it is required by the protocol. Variables are
+      # specified by name, which may contain  the  wildcard  characters `*'
+      # and `?'. Multiple environment variables may be separated by
+      # whitespace or spread across multiple AcceptEnv directives. Be warned
+      # that some environment variables could be used to bypass restricted
+      # user environments. For this reason, care should be taken in the use
+      # of this directive. The default is not to accept any environment
+      # variables.
+      AcceptEnv LANG LC_*
+
+      # Specifies  which  address  family should be used by sshd(8). Valid
+      # arguments are any (the default), inet (use IPv4 only), or inet6 (use
+      # IPv6 only).
+      AddressFamily inet
+
+      # Specifies whether ssh-agent(1) forwarding is permitted. The default
+      # is "yes". Note that disabling agent forwarding does not improve
+      # security unless users are also denied shell access, as they can
+      # always install their own for‐warders.
+      AllowAgentForwarding no
+
+      # This keyword can be followed by a list of group name patterns,
+      # separated by spaces. If specified, login is allowed only for users
+      # whose primary group or supplementary group list matches one of the
+      # patterns. Only group names are valid; a numerical group ID is not
+      # recognized. By default, login is allowed for all groups. The
+      # allow/deny groups directives are processed in the following order:
+      # DenyGroups, AllowGroups.
+      # See PATTERNS in ssh_config(5) for more information on patterns.
+      # AllowGroups
+
+      # Specifies whether StreamLocal (Unix-domain socket) forwarding is
+      # permitted. The available options are yes (the default) or all to
+      # allow StreamLocal forwarding, no to prevent all StreamLocal
+      # forwarding, local to allow local (from the perspective of ssh(1))
+      # forwarding only or remote to allow remote forwarding only. Note that
+      # disabling StreamLocal forwarding does not improve security unless
+      # users are also denied shell access, as they can always install their
+      # own forwarders.
+      AllowStreamLocalForwarding no
+
+      # Specifies whether TCP forwarding is permitted. The available options
+      # are yes (the default) or all to allow TCP forwarding, no to prevent
+      # all TCP forwarding, local to allow local (from the perspective of
+      # ssh(1)) forwarding only or remote to allow remote forwarding only.
+      # Note that disabling TCP forwarding does not improve security unless
+      # users are also denied shell access, as they can always install their
+      # own forwarders.
+      AllowTcpForwarding no
+
+      # This keyword can be followed by a list of user name patterns,
+      # separated by spaces. If specified, login is allowed only for user
+      # names that match one of the patterns. Only user names are valid; a
+      # numerical user ID is not recognized. By default, login is allowed
+      # for all users. If the pattern takes the form USER@HOST then USER and
+      # HOST are separately checked, restricting logins to particular users
+      # from particular hosts. HOST criteria may additionally contain
+      # addresses to match in CIDR address/masklen format. The allow/deny
+      # users directives are processed in the following order: DenyUsers,
+      # AllowUsers.
+      # See PATTERNS in ssh_config(5) for more information on patterns.
+      AllowUsers ${user}
+
+      # Specifies the authentication methods that must be successfully
+      # completed for a user to be granted access. This option must be
+      # followed by one or more lists of comma-separated authentication
+      # method names, or by the single string any to indicate the default
+      # behaviour of accepting any single authentication method. If the
+      # default is overridden, then successful authentication requires
+      # completion of every method in at least one of these lists.
+      # For example, Qq publickey,password publickey,keyboard-interactive
+      # would require the user to complete public key authentication,
+      # followed by either password or keyboard interactive authentication.
+      # Only methods that are next in one or more lists are offered at each
+      # stage, so for this example it  would not be possible to attempt
+      # password or keyboard-interactive authentication before public key.
+      # For keyboard interactive authentication it is also possible to
+      # restrict authentication to a specific device by appending a colon
+      # followed by the device identifier bsdauth or pam. depending on the
+      # server configuration. For example, Qq keyboard-interactive:bsdauth
+      # would restrict keyboard interactive authentication to the bsdauth
+      # device.
+      # If the publickey method is listed more than once, sshd(8) verifies
+      # that keys that have been used successfully are not reused for
+      # subsequent authentications. For example, Qq publickey,publickey
+      # requires successful authentication using two different public keys.
+      # Note that each authentication method listed should also be
+      # explicitly enabled in the configuration.
+      # The available authentication methods are: Qq gssapi-with-mic,
+      # Qq hostbased, Qq keyboard-interactive, Qq none (used for access to
+      # password-less accounts when PermitEmptyPasswords is enabled),
+      # Qq password and Qq publickey.
+      AuthenticationMethods publickey
+
+      # AuthorizedKeysCommand
+      # AuthorizedKeysCommandUser
+
+      # Specifies the file that contains the public keys used for user
+      # authentication. The format is described in the AUTHORIZED_KEYS FILE
+      # FORMAT section of sshd(8). Arguments to AuthorizedKeysFile accept
+      # the tokens described in the TOKENS section. After expansion,
+      # AuthorizedKeysFile is taken to be an absolute path or one relative
+      # to the user's home directory. Multiple files may be listed,
+      # separated by whitespace. Alternately this option may be set to none
+      # to skip checking for user keys in files. The default is
+      # Qq  .ssh/authorized_keys .ssh/authorized_keys2 .
+      AuthorizedKeysFile ${authorized_keys_file}
+
+      # AuthorizedPrincipalsCommand
+      # AuthorizedPrincipalsCommandUser
+      # AuthorizedPrincipalsFile
+
+      # The contents of the specified file are sent to the remote user
+      # before authentication is allowed. If the argument is none then no
+      # banner is displayed.
+      # By default, no banner is displayed.
+      Banner none
+
+      # CASignatureAlgorithms
+
+      # Specifies the pathname of a directory to chroot(2) to after
+      # authentication. At session startup sshd(8) checks that all
+      # components of the pathname are root-owned directories which are not
+      # writable by any other user or group. After the chroot, sshd(8)
+      # changes the working directory to the user's home directory.
+      # Arguments to ChrootDirectory accept the tokens described in the
+      # TOKENS section.
+      # The ChrootDirectory must contain the necessary files and directories
+      # to support the user's session. For an interactive session this
+      # requires at least a shell, typically sh(1), and basic /dev nodes
+      # such as null(4), zero(4), stdin(4), stdout(4), stderr(4), and tty(4)
+      # devices. For file transfer sessions using SFTP no additional
+      # configuration of the environment is necessary if the in-process
+      # sftp-server is used, though sessions which use logging may require
+      # /dev/log inside the chroot directory on some operating systems (see
+      # sftp-server(8) for details).
+      # For safety, it is very important that the directory hierarchy be
+      # prevented from modification by other processes on the system
+      # (especially those outside the jail). Misconfiguration can lead to
+      # unsafe environments which sshd(8) cannot detect.
+      ChrootDirectory none
+
+      # Ciphers
+
+      # Sets the number of client alive messages which may be sent without
+      # sshd(8) receiving any messages back from the client. If this
+      # threshold is reached while client alive messages are being sent,
+      # sshd will disconnect the client, terminating the session. It is
+      # important to note that the use of client alive messages is very
+      # different from TCPKeepAlive. The client alive messages are sent
+      # through the encrypted channel and therefore will not be spoofable.
+      # The TCP keepalive option enabled by TCPKeepAlive is spoofable. The
+      # client alive mechanism is valuable when the client or server depend
+      # on knowing when a connection has become unresponsive.
+      # The default value is 3. If ClientAliveInterval is set to 15, and
+      # ClientAliveCountMax is left at the default, unresponsive SSH clients
+      # will be disconnected after approximately 45 seconds. Setting a zero
+      # ClientAliveCountMax disables connection termination.
+      ClientAliveCountMax 3
+
+      # Sets a timeout interval in seconds after which if no data has been
+      # received from the client, sshd(8) will send a message through the
+      # encrypted channel to request a response from the client. The default
+      # is 0, indicating that  these messages will not be sent to the
+      # client.
+      ClientAliveInterval 30
+
+      # Specifies whether compression is enabled after the user has
+      # authenticated successfully. The argument must be yes, delayed (a
+      # legacy synonym for yes) or no. The default is yes.
+      Compression yes
+
+      # DenyGroups
+      # DenyUsers
+
+      # Disables all forwarding features, including X11, ssh-agent(1), TCP
+      # and StreamLocal. This option overrides all other forwarding-related
+      # options and may simplify restricted configurations.
+      DisableForwarding yes
+
+      # ExposeAuthInfo
+      # FingerprintHash
+
+      # Forces the execution of the command specified by ForceCommand,
+      # ignoring any command supplied by the client and ~/.ssh/rc if
+      # present. The command is invoked by using the user's login shell
+      # with the -c option. This applies to shell, command, or subsystem
+      # execution. It is most useful inside a Match block. The command
+      # originally supplied by the client is available in the
+      # SSH_ORIGINAL_COMMAND environment variable. Specifying a command of
+      # internal-sftp will force the use of an in-process SFTP server that
+      # requires no support files when used with ChrootDirectory. The
+      # default is none.
+      # TODO:
+      # ForceCommand ${bashInteractive}/bin/sh -c "''${SSH_ORIGINAL_COMMAND}"
+
+      # GatewayPorts
+      # GSSAPIAuthentication
+      # GSSAPICleanupCredentials
+      # GSSAPIStrictAcceptorCheck
+      # HostbasedAcceptedAlgorithms
+
+      # Specifies whether rhosts or /etc/hosts.equiv authentication together
+      # with successful public key client host authentication is allowed
+      # (host-based authentication). The default is no.
+      HostbasedAuthentication no
+
+      # HostbasedUsesNameFromPacketOnly
+      # HostCertificate
+
+      # Specifies a file containing a private host key used by SSH. The
+      # defaults are /etc/ssh/ssh_host_ecdsa_key,
+      # /etc/ssh/ssh_host_ed25519_key and /etc/ssh/ssh_host_rsa_key.
+      # Note that sshd(8) will refuse to use a file if it is
+      # group/world-accessible and that the HostKeyAlgorithms option
+      # restricts which of the keys are actually used by sshd(8).
+      # It is possible to have multiple host key files. It is also possible
+      # to specify public host key files instead. In this case operations on
+      # the  private key will be delegated to an ssh-agent(1).
+      HostKey ${host_key}
+
+      # HostKeyAgent
+      # HostKeyAlgorithms
+      # IgnoreRhosts
+      # IgnoreUserKnownHosts
+      # Include
+      # IPQoS
+
+      # Specifies whether to allow keyboard-interactive authentication. All
+      # authentication styles from login.conf(5) are supported. The default
+      # is yes. The argument to this keyword must be yes or no.
+      # ChallengeResponseAuthentication is a deprecated alias for this.
+      KbdInteractiveAuthentication no
+
+      # KerberosAuthentication
+      # KerberosGetAFSToken
+      # KerberosOrLocalPasswd
+      # KerberosTicketCleanup
+      # KexAlgorithms
+
+      # Specifies the local addresses sshd(8) should listen on. The
+      # following forms may be used:
+      #  ListenAddress hostname | address [rdomain domain]
+      #  ListenAddress hostname:port [rdomain domain]
+      #  ListenAddress IPv4_address:port [rdomain domain]
+      #  ListenAddress [hostname | address]:port [rdomain domain]
+      # The optional rdomain qualifier requests sshd(8) listen in an
+      # explicit routing domain. If port is not specified, sshd will listen
+      # on the address and all Port options specified. The default is to
+      # listen on all local addresses on the current default routing domain.
+      # Multiple ListenAddress options are permitted. For more information
+      # on routing domains, see rdomain(4).
+      ListenAddress ${listen_address}
+
+      # LoginGraceTime 8
+      # LogLevel
+      # LogVerbose
+      # MACs
+      # Match
+      # MaxAuthTries
+
+      # Specifies the maximum number of open shell, login or subsystem
+      # (e.g. sftp) sessions permitted per network connection. Multiple
+      # sessions may be established by clients that support connection
+      # multiplexing. Setting MaxSessions to 1 will effectively disable
+      # session multiplexing, whereas setting it to 0 will prevent all
+      # shell, login and subsystem sessions while still permitting
+      # forwarding. The default is 10.
+      MaxSessions 10
+
+      # MaxStartups 2:30:10
+      # ModuliFile
+
+      # Specifies whether password authentication is allowed. The default is
+      # yes.
+      PasswordAuthentication no
+
+      # PermitEmptyPasswords
+      # PermitListen
+      # PermitOpen
+
+      # Specifies whether root can log in using ssh(1). The argument must be
+      # yes, prohibit-password, forced-commands-only, or no. The default is
+      # prohibit-password.
+      # If this option is set to prohibit-password (or its deprecated alias,
+      # without-password), password and keyboard-interactive authentication
+      # are disabled for root.
+      # If this option is set to forced-commands-only, root login with
+      # public key authentication will be allowed, but only if the command
+      # option has been specified (which may be useful for taking remote
+      # backups even if root login is normally not allowed). All other
+      # authentication methods are disabled for root.
+      # If this option is set to no, root is not allowed to log in.
+      PermitRootLogin no
+
+      # PermitTTY yes
+      # PermitTunnel
+      # PermitUserEnvironment
+      # PermitUserRC
+      # PerSourceMaxStartups
+      # PerSourceNetBlockSize
+
+      # Specifies the file that contains the process ID of the SSH daemon,
+      # or none to not write one.  The default is /run/sshd.pid.
+      PidFile ${pid_file}
+
+      # Specifies the port number that sshd(8) listens on. The default is
+      # 22. Multiple options of this type are permitted. See also
+      # ListenAddress.
+      Port ${toString port}
+
+      # PrintLastLog
+      # PrintMotd
+      # PubkeyAcceptedAlgorithms
+      # PubkeyAuthOptions
+
+      # Specifies whether public key authentication is allowed. The default
+      # is yes.
+      PubkeyAuthentication yes
+
+      # RekeyLimit
+      # RequiredRSASize
+      # RevokedKeys
+      # RDomain
+      # SecurityKeyProvider
+
+      # Specifies one or more environment variables to set in child sessions
+      # started by sshd(8) as NAME=VALUE. The environment value may be
+      # quoted (e.g. if it contains whitespace characters). Environment
+      # variables set by SetEnv override the default environment and any
+      # variables specified by the user via AcceptEnv or
+      # PermitUserEnvironment.
+      # SetEnv
+
+      # StreamLocalBindMask
+      # StreamLocalBindUnlink
+
+      # Specifies whether sshd(8) should check file modes and ownership of
+      # the user's files and home directory before accepting login. This is
+      # normally desirable because novices sometimes accidentally leave
+      # their directory or files world-writable. The default is yes. Note
+      # that this does not apply to ChrootDirectory, whose permissions and
+      # ownership are checked unconditionally.
+      StrictModes no
+
+      # Configures an external subsystem (e.g. file transfer daemon).
+      # Arguments should be a subsystem name and a command (with optional
+      # arguments) to execute upon subsystem request.
+      # The command sftp-server implements the SFTP file transfer subsystem.
+      # Alternately the name internal-sftp implements an in-process SFTP
+      # server. This may simplify configurations using ChrootDirectory to
+      # force  a  different filesystem root on clients.
+      # By default no subsystems are defined.
+      # Subsystem sftp /usr/lib/openssh/sftp-server
+      # TODO:
+      # Subsystem nomad ${bashInteractive}/bin/sh -c "''${SSH_ORIGINAL_COMMAND}"
+
+      # SyslogFacility
+
+      # Specifies whether the system should send TCP keepalive messages to
+      # the other side. If they are sent, death of the connection or crash
+      # of one of the machines will be properly noticed. However, this means
+      # that connections will die if the route is down temporarily, and some
+      # people find it annoying. On the other hand, if TCP keepalives are
+      # not sent, sessions may hang indefinitely on the server, leaving Qq
+      # ghost users and consuming server resources.
+      # The default is "yes" (to send TCP keepalive messages), and the
+      # server will notice if the network goes down or the client host
+      # crashes. This avoids infinitely hanging sessions.
+      # To disable TCP keepalive messages, the value should be set to no.
+      TCPKeepAlive no
+
+      # TrustedUserCAKeys
+      # UseDNS
+      # UsePAM
+      # VersionAddendum
+      # X11DisplayOffset
+      # X11Forwarding
+      # X11UseLocalhost
+      # XAuthLocation
+
+      # From https://github.com/fmaste/openssh-portable-hacks
+      Match User nobody
+        ShellPath ${bashInteractive}/bin/bash
+        PermitLockedAccount yes
+    '';
+  };
+
+}


### PR DESCRIPTION
- When using the Nomad Cloud backend a custom OpenSSH server that can run inside the Nomad Task isolated namespace is added.
- When SSH is enabled logs are fetched directly from the Nomad Clients using rsync (the Nomad Server was the intermediary when doing `nomad alloc fs`).
- Removed cluster start/stop logic from the scenarios. Now the scenarios only start/stop cluster components, nodes/generator/tracers/healthchecks.
- Added functions `start-tracers`, `stop-all` and `fetch-logs` that were implicit when calling `start-cluster` and/or `stop-cluster`.
- Now the exit trap explicitly calls `stop-all` and `fetch-logs` that are either extra steps or not implicit when using the Nomad backend.
- Now the healthcheck service only emits warnings for no blocks / empty blocks timeouts. Plus other fixes.
- Make, only the wait loop, more resilient to networking errors.
- A fix for an error where a cluster may unintentionally run in "qa" class Nomad Nodes.
- Changes that make the workbench Mac compatible
- Clean ups to make more verbose the object like inheritance of Nomad sub-backends scripts.
- Towards a new SRE-built Nomad cluster: Changes the make the Nomad Cloud backend work with different Nomad clusters.

