### PR TITLE
input-output-hk/cardano-cli#85 Fix node crashing in babbage

### DIFF
--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -134,8 +134,8 @@ instance
   ) => ToObject (ShelleyLedgerError ledgerera) where
   toObject verb (BBodyError (BlockTransitionError fs)) =
     mconcat [ "kind" .= String "BBodyError"
-             , "failures" .= map (toObject verb) fs
-             ]
+            , "failures" .= map (toObject verb) fs
+            ]
 
 instance
   ( Ledger.Era ledgerera
@@ -264,7 +264,7 @@ instance
   , ToObject (PredicateFailure (Core.EraRule "UTXOW" ledgerera))
   ) => ToObject (ShelleyLedgerPredFailure ledgerera) where
   toObject verb (UtxowFailure f) = toObject verb f
-  toObject _verb (DelegsFailure _f) = error "TODO: Conway era" --toObject verb f
+  toObject verb (DelegsFailure f) = toObject verb f
 
 instance
   ( ToObject (PredicateFailure (Core.EraRule "CERTS" ledgerera))
@@ -284,23 +284,17 @@ instance ToObject (Conway.ConwayTallyPredFailure era) where
             , "govActionId" .= govActionIdToText govActionId
             ]
 
-  -- TODO: Implement
-instance ToObject (Conway.ConwayCertsPredFailure era) where
-  toObject _ _ = mempty
+instance
+  ( Core.Crypto (Consensus.EraCrypto era)
+  , ToObject (PredicateFailure (Ledger.EraRule "CERT" era))
+  ) => ToObject (Conway.ConwayCertsPredFailure era) where
+  toObject verb = \case
+    Conway.DelegateeNotRegisteredDELEG targetPool ->
+      mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG" , "targetPool" .= targetPool ]
+    Conway.WithdrawalsNotInRewardsCERTS incorrectWithdrawals ->
+      mconcat [ "kind" .= String "WithdrawalsNotInRewardsCERTS" , "incorrectWithdrawals" .= incorrectWithdrawals ]
+    Conway.CertFailure f -> toObject verb f
 
--- instance
---   ( ToObject (PredicateFailure (Ledger.EraRule "CERT" ledgerera))
---   ) => ToObject (Conway.ConwayDelegsPredFailure ledgerera) where
---   toObject _ (Conway.DelegateeNotRegisteredDELEG poolID) =
---     mconcat [ "kind" .= String "DelegateeNotRegisteredDELEG"
---              , "poolID" .= String (textShow poolID)
---             ]
---   toObject _ (Conway.WithdrawalsNotInRewardsDELEGS rs) =
---     mconcat [ "kind" .= String "WithdrawalsNotInRewardsDELEGS"
---              , "rewardAccounts" .= rs
---             ]
---   toObject v (Conway.CertFailure certFailure) =
---     toObject v certFailure
 
 instance
   ( ToObject (PPUPPredFailure ledgerera)


### PR DESCRIPTION
# Description

This PR removes "error" in ToObject instance.

Closes input-output-hk/cardano-cli#85


```
$ cardano-cli stake-address registration-certificate --babbage-era --stake-verification-key-file stake.vkey --out-file /dev/stdout      
{
    "type": "CertificateShelley",
    "description": "Stake Address Registration Certificate",
    "cborHex": "82008200581c0cbcc72d02ae24c7bbe8b6269101b544cafaab0f3b8be50d4776eb85"
}
````

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
