### PR TITLE
plutus-ledger-api: bump version

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-05-10T10:34:57Z
-  , cardano-haskell-packages 2023-06-06T08:18:38Z
+  , cardano-haskell-packages 2023-07-21T13:00:00Z
 
 packages:
     cardano-cli

--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-cli
 
+## 8.1.1 / 8.1.2
+
+- No Changes
+
 ## 8.1.0
 
 - Delete deprecated shelley command group

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.1.1
+version:                8.1.2
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,8 +1,17 @@
 # Changelog for cardano-node
 
-## 8.1.0
+## 8.1.2 -- July 2023
 
--
+- Update plutus interpreter
+
+## 8.1.1 -- June 2023
+
+- Address P2P Topology bug with non-DNS names in networking
+
+## 8.1.0 -- June 2023
+
+- Support Conway Era when ExperimentalHardForks enabled
+- `TickF` changes to improve epoch boundary
 
 ## 8.0.0 -- May 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.1.1
+version:                8.1.2
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1686070892,
-        "narHash": "sha256-0yAYqvCg2/aby4AmW0QQK9RKnU1siQczfbUC6hOU02w=",
+        "lastModified": 1689937110,
+        "narHash": "sha256-qbd7y3zJucW8GtRYVROg0HPzaXI3hAz/1vT46DE/8uI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "596cf203a0a1ba252a083a79d384325000faeb49",
+        "rev": "4e27319575bc0f0516d72d9fb4403b1f16e50833",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
