### PR TITLE
Bump network packages version

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -120,7 +120,7 @@ library
                       , optparse-generic
                       , ouroboros-consensus
                       -- for Data.SOP.Strict:
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , process
                       , quiet

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -126,7 +126,7 @@ library
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5
                       , ouroboros-consensus-diffusion >= 0.7.0
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , ouroboros-network-protocols

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-07-10T14:55:34Z
-  , cardano-haskell-packages 2023-07-16T00:00:00Z
+  , hackage.haskell.org 2023-07-21T10:12:20Z
+  , cardano-haskell-packages 2023-07-21T12:48:43Z
 
 packages:
   cardano-client-demo
@@ -102,7 +102,9 @@ write-ghc-environment-files: always
 package snap-server
   flags: +openssl
 
-allow-newer: text
+allow-newer:
+  text,
+  ekg-forward
 
 constraints:
   optparse-applicative >= 0.16.0 && < 0.16.1,

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -8,6 +8,10 @@
   `TraceLocalHandshake`, `TraceLocalInboundGovernor`, `TraceLocalServer` and
   `TraceServer`.
 
+- Added `hotValency` optional to P2P Topology files, keeping the backwards compatible
+  `valency` flag.
+- Added `warmValency` optional to P2P Topology files.
+
 ## 8.1.0
 
 -

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -180,8 +180,8 @@ library
                       , ouroboros-consensus-diffusion >= 0.7
                       , ouroboros-consensus-protocol >= 0.5
                       , ouroboros-network-api
-                      , ouroboros-network ^>= 0.8.1.1
-                      , ouroboros-network-framework >= 0.6
+                      , ouroboros-network ^>= 0.8.2.0
+                      , ouroboros-network-framework >= 0.7
                       , ouroboros-network-protocols
                       , prettyprinter
                       , prettyprinter-ansi-terminal
@@ -249,7 +249,7 @@ test-suite cardano-node-test
                       , ouroboros-consensus >= 0.9
                       , ouroboros-consensus-cardano
                       , ouroboros-consensus-diffusion >= 0.7
-                      , ouroboros-network ^>= 0.8.1.1
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , text >= 2.0
                       , time

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -52,6 +52,7 @@ import           Cardano.Node.Protocol (ProtocolInstantiationError)
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 
 import           Cardano.Git.Rev (gitRev)
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency, WarmValency)
 import           Paths_cardano_node (version)
 
 data StartupTrace blk =
@@ -108,7 +109,7 @@ data StartupTrace blk =
   -- | Log peer-to-peer network configuration, either on startup or when its
   -- updated.
   --
-  | NetworkConfig [(Int, Map RelayAccessPoint PeerAdvertise)]
+  | NetworkConfig [(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)]
                   (Map RelayAccessPoint PeerAdvertise)
                   UseLedgerAfter
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -268,10 +268,9 @@ instance LogFormatting (TracePeerSelection SockAddr) where
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= toJSONList (toList sp)
              ]
-  forMachine _dtal (TracePromoteColdLocalPeers tLocalEst aLocalEst sp) =
+  forMachine _dtal (TracePromoteColdLocalPeers tLocalEst sp) =
     mconcat [ "kind" .= String "PromoteColdLocalPeers"
              , "targetLocalEstablished" .= tLocalEst
-             , "actualLocalEstablished" .= aLocalEst
              , "selectedPeers" .= toJSONList (toList sp)
              ]
   forMachine _dtal (TracePromoteColdFailed tEst aEst p d err) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -379,6 +379,10 @@ instance LogFormatting (TracePeerSelection SockAddr) where
   forMachine _dtal (TraceChurnMode c) =
     mconcat [ "kind" .= String "ChurnMode"
              , "event" .= show c ]
+  forMachine _dtal (TraceKnownInboundConnection addr sharing) =
+    mconcat [ "kind" .= String "KnownInboundConnection"
+            , "peer" .= toJSON addr
+            , "peerSharing" .= String (pack . show $ sharing) ]
   forHuman = pack . show
 
 instance MetaTrace (TracePeerSelection SockAddr) where
@@ -442,6 +446,8 @@ instance MetaTrace (TracePeerSelection SockAddr) where
       Namespace [] ["ChurnWait"]
     namespaceFor TraceChurnMode {}             =
       Namespace [] ["ChurnMode"]
+    namespaceFor TraceKnownInboundConnection {} =
+      Namespace [] ["KnownInboundConnection"]
 
     severityFor (Namespace [] ["LocalRootPeersChanged"]) _ = Just Notice
     severityFor (Namespace [] ["TargetsChanged"]) _ = Just Notice
@@ -472,6 +478,7 @@ instance MetaTrace (TracePeerSelection SockAddr) where
     severityFor (Namespace [] ["GovernorWakeup"]) _ = Just Info
     severityFor (Namespace [] ["ChurnWait"]) _ = Just Info
     severityFor (Namespace [] ["ChurnMode"]) _ = Just Info
+    severityFor (Namespace [] ["KnownInboundConnection"]) _ = Just Info
     severityFor _ _ = Nothing
 
     documentFor (Namespace [] ["LocalRootPeersChanged"]) = Just  ""
@@ -524,6 +531,8 @@ instance MetaTrace (TracePeerSelection SockAddr) where
     documentFor (Namespace [] ["GovernorWakeup"]) = Just  ""
     documentFor (Namespace [] ["ChurnWait"]) = Just  ""
     documentFor (Namespace [] ["ChurnMode"]) = Just  ""
+    documentFor (Namespace [] ["KnownInboundConnection"]) = Just
+      "An inbound connection was added to known set of outbound governor"
     documentFor _ = Nothing
 
     allNamespaces = [
@@ -556,6 +565,7 @@ instance MetaTrace (TracePeerSelection SockAddr) where
       , Namespace [] ["GovernorWakeup"]
       , Namespace [] ["ChurnWait"]
       , Namespace [] ["ChurnMode"]
+      , Namespace [] ["KnownInboundConnection"]
       ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -512,7 +512,7 @@ ppStartupInfoTrace (NetworkConfig localRoots publicRoots useLedgerAfter) =
     pack
   $ intercalate "\n"
   [ "\nLocal Root Groups:"
-  , "  " ++ intercalate "\n  " (map (\(x,y) -> show (x, Map.assocs y))
+  , "  " ++ intercalate "\n  " (map (\(x,y,z) -> show (x, y, Map.assocs z))
                                     localRoots)
   , "Public Roots:"
   , "  " ++ intercalate "\n  " (map show $ Map.assocs publicRoots)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -7,11 +7,13 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Tracing.OrphanInstances.Network () where
 
@@ -82,7 +84,8 @@ import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (.
                    TracePeerSelection (..))
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
 import           Ouroboros.Network.PeerSelection.LedgerPeers
-import           Ouroboros.Network.PeerSelection.LocalRootPeers (LocalRootPeers)
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency (..), LocalRootPeers,
+                   WarmValency (..))
 import qualified Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS (TraceLocalRootPeers (..),
@@ -425,6 +428,7 @@ instance HasSeverityAnnotation (TracePeerSelection addr) where
       TraceGovernorWakeup        {} -> Info
       TraceChurnWait             {} -> Info
       TraceChurnMode             {} -> Info
+      TraceKnownInboundConnection {} -> Info
 
 instance HasPrivacyAnnotation (DebugPeerSelection addr)
 instance HasSeverityAnnotation (DebugPeerSelection addr) where
@@ -1357,6 +1361,17 @@ instance ToObject peer => ToObject (WithMuxBearer peer MuxTrace) where
 
 instance Aeson.ToJSONKey RelayAccessPoint where
 
+instance ToJSON HotValency where
+  toJSON (HotValency v) = toJSON v
+instance ToJSON WarmValency where
+  toJSON (WarmValency v) = toJSON v
+
+instance FromJSON HotValency where
+  parseJSON v = HotValency <$> parseJSON v
+
+instance FromJSON WarmValency where
+  parseJSON v = WarmValency <$> parseJSON v
+
 instance Show exception => ToObject (TraceLocalRootPeers RemoteAddress exception) where
   toObject _verb (TraceLocalRootDomains groups) =
     mconcat [ "kind" .= String "LocalRootDomains"
@@ -1513,10 +1528,9 @@ instance ToObject (TracePeerSelection SockAddr) where
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
-  toObject _verb (TracePromoteColdLocalPeers tLocalEst aLocalEst sp) =
+  toObject _verb (TracePromoteColdLocalPeers tLocalEst sp) =
     mconcat [ "kind" .= String "PromoteColdLocalPeers"
              , "targetLocalEstablished" .= tLocalEst
-             , "actualLocalEstablished" .= aLocalEst
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
   toObject _verb (TracePromoteColdFailed tEst aEst p d err) =
@@ -1624,6 +1638,10 @@ instance ToObject (TracePeerSelection SockAddr) where
   toObject _verb (TraceChurnMode c) =
     mconcat [ "kind" .= String "ChurnMode"
              , "event" .= show c ]
+  toObject _verb (TraceKnownInboundConnection addr sharing) =
+    mconcat [ "kind" .= String "KnownInboundConnection"
+             , "peer" .= show addr
+             , "peerSharing" .= show sharing ]
 
 -- Connection manager abstract state.  For explanation of each state see
 -- <https://hydra.iohk.io/job/Cardano/ouroboros-network/native.network-docs.x86_64-linux/latest/download/2>

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -178,7 +178,7 @@ instance HasSeverityAnnotation [TraceLabelPeer peer (FetchDecision [Point header
       fetchDecisionSeverity fd =
         case fd of
           Left FetchDeclineChainNotPlausible     -> Debug
-          Left FetchDeclineChainNoIntersection   -> Notice
+          Left FetchDeclineChainIntersectionTooDeep -> Notice
           Left FetchDeclineAlreadyFetched        -> Debug
           Left FetchDeclineInFlightThisPeer      -> Debug
           Left FetchDeclineInFlightOtherPeer     -> Debug

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -31,6 +31,7 @@ import           Cardano.Node.Configuration.TopologyP2P (LocalRootPeersGroup (..
 import           Cardano.Node.Types (UseLedger (..))
 import           Cardano.Slotting.Slot (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency (..), WarmValency (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
                    RelayAccessPoint (..))
 
@@ -175,8 +176,9 @@ genRootConfig = do
 genLocalRootPeersGroup :: Gen LocalRootPeersGroup
 genLocalRootPeersGroup = do
     ra <- genRootConfig
-    val <- Gen.int (Range.linear 0 (length (rootAccessPoints ra)))
-    return (LocalRootPeersGroup ra val)
+    hval <- Gen.int (Range.linear 0 (length (rootAccessPoints ra)))
+    wval <- WarmValency <$> Gen.int (Range.linear 0 hval)
+    return (LocalRootPeersGroup ra (HotValency hval) wval)
 
 genLocalRootPeersGroups :: Gen LocalRootPeersGroups
 genLocalRootPeersGroups =

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -51,7 +51,7 @@ library
                       , network
                       , optparse-applicative-fork ^>= 0.16.1
                       , ouroboros-consensus-cardano
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-protocols
                       , prometheus
                       , servant

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -54,7 +54,7 @@ library
                       , hedgehog-extras ^>= 0.4.7.0
                       , mtl
                       , optparse-applicative-fork ^>= 0.16.1
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , process
                       , resourcet

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -59,6 +59,7 @@ import           Testnet.Process.Run
 import           Testnet.Property.Assert
 import           Testnet.Property.Utils
 
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency (..), WarmValency (..))
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
@@ -181,7 +182,8 @@ mkTopologyConfig i numBftNodes' allPorts True = J.encode topologyP2P
     localRootPeerGroups =
       P2P.LocalRootPeersGroups
         [ P2P.LocalRootPeersGroup rootConfig
-                                  (numBftNodes' - 1)
+                                  (HotValency (numBftNodes' - 1))
+                                  (WarmValency (numBftNodes' - 1))
         ]
 
     topologyP2P :: P2P.NetworkTopology

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -70,6 +70,8 @@ import           Testnet.Runtime as TR
 import           Testnet.Start.Byron hiding (TestnetOptions (..))
 import           Testnet.Start.Shelley
 
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency (..), WarmValency (..))
+
 {- HLINT ignore "Redundant flip" -}
 {- HLINT ignore "Redundant id" -}
 {- HLINT ignore "Use let" -}
@@ -173,7 +175,8 @@ mkTopologyConfig numNodes allPorts port True = J.encode topologyP2P
     localRootPeerGroups =
       P2P.LocalRootPeersGroups
         [ P2P.LocalRootPeersGroup rootConfig
-                                  (numNodes - 1)
+                                  (HotValency (numNodes - 1))
+                                  (WarmValency (numNodes - 1))
         ]
 
     topologyP2P :: P2P.NetworkTopology

--- a/cardano-testnet/src/Testnet/Start/Shelley.hs
+++ b/cardano-testnet/src/Testnet/Start/Shelley.hs
@@ -66,6 +66,8 @@ import           Testnet.Process.Run
 import           Testnet.Property.Assert
 import           Testnet.Runtime hiding (allNodes)
 
+import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency (..), WarmValency (..))
+
 
 {- HLINT ignore "Redundant <&>" -}
 {- HLINT ignore "Redundant flip" -}
@@ -145,7 +147,8 @@ mkTopologyConfig numPraosNodes allPorts port True = J.encode topologyP2P
     localRootPeerGroups =
       P2P.LocalRootPeersGroups
         [ P2P.LocalRootPeersGroup rootConfig
-                                  (numPraosNodes - 1)
+                                  (HotValency (numPraosNodes - 1))
+                                  (WarmValency (numPraosNodes - 1))
         ]
 
     topologyP2P :: P2P.NetworkTopology

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -141,12 +141,12 @@ library
                       , directory
                       , ekg
                       , ekg-core
-                      , ekg-forward ^>= 0.3
+                      , ekg-forward ^>= 0.3.0.4
                       , extra
                       , filepath
                       , mime-mail
                       , optparse-applicative >= 0.16.0 && < 0.16.1
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , signal
@@ -208,7 +208,7 @@ library demo-forwarder-lib
                       , contra-tracer
                       , directory
                       , ekg-core
-                      , ekg-forward ^>= 0.3
+                      , ekg-forward ^>= 0.3.0.4
                       , extra
                       , filepath
                       , generic-data
@@ -299,7 +299,7 @@ test-suite cardano-tracer-test
                       , contra-tracer
                       , directory
                       , ekg-core
-                      , ekg-forward ^>= 0.3
+                      , ekg-forward ^>= 0.3.0.4
                       , extra
                       , filepath
                       , generic-data
@@ -352,13 +352,13 @@ test-suite cardano-tracer-test-ext
                       , contra-tracer
                       , directory
                       , ekg-core
-                      , ekg-forward ^>= 0.3
+                      , ekg-forward ^>= 0.3.0.4
                       , extra
                       , filepath
                       , generic-data
                       , Glob
                       , optparse-applicative-fork ^>= 0.16.1
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , process

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -81,9 +81,20 @@ A minimal version of this file looks like this:
     DNS domain `y.y.y.y` (assuming they are), and try to maintain a connection with at least `1` of the
     resolved IPs.
 
-* `valency` tells the node how many connections your node should try to pick
-  from the given group. If a DNS address is given, valency governs to how many
+* `valency` (or `hotValency`) tells the node how many connections your node should try to
+  pick from the given group. If a DNS address is given, valency governs to how many
   resolved ip addresses should we maintain active (hot) connection.
+
+- `warmValency` is an optional field similar to `valency`/`hotValency` that tells the node
+  how many peers the node should maintain as established (warm). As said, this field is
+  optional and defaults to the value set in the `valency`/`hotValency` field. The
+  `warmValency` value set should be greater than or equal to the one specified in
+  `valency`/`hotValency` otherwise `valency`/`hotValency` will be truncated to this value.
+  We recommend users to set `warmValency` value to `hotValency` + 1 in order to keep at
+  least 1 backup peer to be promoted to hot in case something happens.
+
+  Check [here](https://github.com/input-output-hk/ouroboros-network/issues/4565) for more
+  context on this `WarmValency` addition.
 
 * Local roots groups shall be non-overlapping.
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1689478915,
-        "narHash": "sha256-zXSRZ+xP1edVSC4eWXRV2CJQ+NAsnNDP3edOgYBTD/s=",
+        "lastModified": 1689944957,
+        "narHash": "sha256-yVbSo0FMJi5QWg5yuqkHE314U6FKaz2zA8nFhspM66k=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "d4981b111a1485879a53104342136612837f6bcb",
+        "rev": "2c01954d7cce23ce9e779fcdc69da63760d85215",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1688948952,
-        "narHash": "sha256-q0MqLCLYZafs1V55MPcE1ywl68/gfObjGnDYINI1yek=",
+        "lastModified": 1689899122,
+        "narHash": "sha256-1kkph+jx+XWwIpvViuJG1HeVGPs6t9FwvTi8wStxLdU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0dfc30a014e08278f3a34f43dbb3fff86b86e741",
+        "rev": "23c602d1673e018c7e40c96cd674bbd0bb60ef6c",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -52,11 +52,11 @@ library
                       , contra-tracer
                       , ekg
                       , ekg-core
-                      , ekg-forward >= 0.3.0
+                      , ekg-forward >= 0.3.0.4
                       , hostname
                       , network
                       , optparse-applicative-fork ^>= 0.16.1
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise
@@ -147,7 +147,7 @@ test-suite trace-dispatcher-test
                       , generic-data
                       , hostname
                       , optparse-applicative >= 0.16.0 && < 0.16.1
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network ^>= 0.8.2.0
                       , text
                       , stm
                       , tasty

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -64,7 +64,7 @@ library
                       , extra
                       , io-classes
                       , ouroboros-network-api >= 0.3
-                      , ouroboros-network-framework >= 0.6
+                      , ouroboros-network-framework >= 0.7
                       , serialise
                       , stm
                       , text


### PR DESCRIPTION
# Description

Compatibility with ouroboros-network-0.8.2.0

Added WarmValency option to the Topology file

Now the Topology allows the user to not only specify the HotValency of
its node's local root peers, via 'valency' ('hotValency' is now also
valid) field, but also is able to specify the WarmValency, via
'warmValency' field. This field is optional and defaults to the value
set in the 'valency'/'hotValency' field. The 'warmValency' value set
should be greater than or equal to the one specified in
'valency'/'hotValency' otherwise 'valency'/'hotValency' will be
truncated to this value. We recommend users to set 'warmValency' value to
'hotValency' + 1 in order to keep at least 1 backup peer to be promoted
to hot in case something happens.

Check https://github.com/input-output-hk/ouroboros-network/issues/4565
for more context on this WarmValency addition.