### PR TITLE
Add skipping of files using `CPP` extension in `stylish-haskell` 

### DIFF
--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -65,7 +65,11 @@ jobs:
 
         for x in $(git ls-tree --full-tree --name-only -r HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 
@@ -78,7 +82,11 @@ jobs:
         git fetch origin ${{ github.base_ref }} --unshallow
         for x in $(git diff --name-only origin/${{ github.base_ref }}..HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 

--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -4,12 +4,16 @@
 #
 # To set this script as your pre-commit hook, use the following command:
 #
-# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git-root)/.git/hooks/pre-commit
+# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git rev-parse --git-dir)/hooks/pre-commit
 #
 
 for x in $(git diff --staged --name-only --diff-filter=ACM | tr '\n' ' '); do
   if [ "${x##*.}" = "hs" ]; then
-    stylish-haskell -i "$x"
+    if grep -qE '^#' "$x"; then
+      echo "$x contains CPP.  Skipping."
+    else
+      stylish-haskell -i "$x"
+    fi
     # fail on linting issues
     hlint "$x"
   fi


### PR DESCRIPTION
# Description

Workaround for: https://github.com/haskell/stylish-haskell/issues/178

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
