### PR TITLE
8.2.0 version bumps

### DIFF
--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-topology
-version:                8.1.0
+version:                8.2.0
 synopsis:               A cardano topology generator
 description:            A cardano topology generator.
 category:               Cardano,

--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -37,6 +37,6 @@ executable cardano-topology
                       , bytestring
                       , containers
                       , graphviz
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , split
                       , text

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -116,7 +116,7 @@ library
                       , ghc
                       , gnuplot
                       , iohk-monitoring
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , optparse-generic
                       , ouroboros-consensus
                       -- for Data.SOP.Strict:
@@ -155,7 +155,7 @@ executable locli
   build-depends:        aeson
                       , cardano-prelude
                       , locli
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , text
                       , text-short
                       , transformers

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   locli
-version:                1.29
+version:                1.30
 synopsis:               Cardano log analysis CLI
 description:            Cardano log analysis CLI.
 category:               Cardano,

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   plutus-scripts-bench
-version:                1.0.0.0
+version:                1.0.0.1
 synopsis:               Plutus scripts used for benchmarking
 description:            Plutus scripts used for benchmarking.
 category:               Cardano,

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -100,5 +100,5 @@ executable gen-plutus
   build-depends:        base >=4.12 && <5
                       , bytestring
                       , filepath
-                      , optparse-applicative >= 0.16.0 && < 0.16.1
+                      , optparse-applicative
                       , plutus-scripts-bench

--- a/bench/trace-analyzer/trace-analyzer.cabal
+++ b/bench/trace-analyzer/trace-analyzer.cabal
@@ -40,7 +40,7 @@ executable trace-analyzer
   main-is:              trace-analyzer.hs
 
   build-depends:        aeson
-                      , optparse-applicative >= 0.16.0 && < 0.16.1
+                      , optparse-applicative
                       , text
                       , containers
                       , attoparsec

--- a/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -36,7 +36,7 @@ import           Cardano.Node.Configuration.Logging (LoggingLayer)
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 
 import           Cardano.Api.Shelley (CardanoMode)
-import           Cardano.CLI.Types (SigningKeyFile)
+import           Cardano.CLI.Types.Legacy (SigningKeyFile)
 
 import           Cardano.Api (BlockType (..), ConsensusModeParams (..), EpochSlots (..),
                    LocalNodeConnectInfo (..), NetworkId (..), PaymentKey, SigningKey, SocketPath,

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
@@ -20,7 +20,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import           Data.Maybe (fromMaybe)
 import           GHC.Generics (Generic)
 
-import           Cardano.CLI.Types (FileDirection (..), SigningKeyFile)
+import           Cardano.CLI.Types.Legacy (FileDirection (..), SigningKeyFile)
 import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
 import           Cardano.Node.Types (AdjustFilePaths (..))
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/Plutus.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/Plutus.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra
 import           Control.Monad.Writer (runWriter)
 
-import           Cardano.CLI.Shelley.Run.Read (readFileScriptInAnyLang)
+import           Cardano.CLI.Run.Legacy.Read (readFileScriptInAnyLang)
 
 import           Cardano.Api
 import           Cardano.Api.Shelley (PlutusScript (..), ProtocolParameters (..), fromAlonzoExUnits,

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/SigningKey.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/SigningKey.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString as BS (ByteString)
 import           Data.ByteString.Base16 as Base16 (decode)
 
 import           Cardano.Api
-import           Cardano.CLI.Types (SigningKeyFile)
+import           Cardano.CLI.Types.Legacy (SigningKeyFile)
 
 import           Cardano.TxGenerator.Types (TxGenError (..))
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -99,7 +99,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.8
                       , cardano-binary
-                      , cardano-cli ^>= 8.3
+                      , cardano-cli ^>= 8.4
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data
@@ -122,7 +122,7 @@ library
                       , mtl
                       , network
                       , network-mux
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5
                       , ouroboros-consensus-diffusion >= 0.7.0
@@ -192,9 +192,9 @@ test-suite tx-generator-apitest
                       , aeson
                       , bytestring
                       , filepath
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.3
+                      , cardano-cli ^>= 8.4
                       , cardano-node
                       , plutus-tx
                       , transformers
@@ -208,9 +208,9 @@ test-suite tx-generator-apitest
                      , aeson
                      , bytestring
                      , filepath
-                     , optparse-applicative-fork ^>= 0.16.1
+                     , optparse-applicative-fork
                      , cardano-api ^>= 8.8
-                     , cardano-cli ^>= 8.3
+                     , cardano-cli ^>= 8.4
                      , cardano-node
                      , transformers
                      , transformers-except

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   tx-generator
-version:                2.5
+version:                2.6
 synopsis:               A transaction workload generator for Cardano clusters
 description:            A transaction workload generator for Cardano clusters.
 category:               Cardano,

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-07-21T10:12:20Z
-  , cardano-haskell-packages 2023-07-21T12:48:43Z
+  , hackage.haskell.org 2023-07-27T01:34:31Z
+  , cardano-haskell-packages 2023-07-27T07:20:05Z
 
 packages:
   cardano-client-demo
@@ -38,6 +38,8 @@ package cardano-api
 
 package cardano-cli
   ghc-options: -Werror
+  -- TODO delete the following when the warning is fixed
+  ghc-options: -Wno-redundant-constraints
 
 package cardano-client-demo
   ghc-options: -Werror
@@ -105,10 +107,6 @@ package snap-server
 allow-newer:
   text,
   ekg-forward
-
-constraints:
-  optparse-applicative >= 0.16.0 && < 0.16.1,
-  cardano-api < 8.8.1
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -102,7 +102,7 @@ executable stake-credential-history
                         containers,
                         FailT,
                         microlens,
-                        optparse-applicative >= 0.16.0 && < 0.16.1,
+                        optparse-applicative,
                         ouroboros-consensus-cardano,
                         text,
                         transformers,

--- a/cardano-client-demo/cardano-client-demo.cabal
+++ b/cardano-client-demo/cardano-client-demo.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-client-demo
-version:                0.1.0.0
+version:                0.1.0.1
 synopsis:               A simple demo cardano-node client application
 description:            This is intended to demonstrate how to write simple
                         applications that interact with the cardano-node,

--- a/cardano-node-capi/cardano-node-capi.cabal
+++ b/cardano-node-capi/cardano-node-capi.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-capi
-version:                0.1.0.0
+version:                0.1.0.1
 synopsis:               FFI C library for Cardano
 description:            ffi c library around the full node.
 category:               Cardano,

--- a/cardano-node-capi/cardano-node-capi.cabal
+++ b/cardano-node-capi/cardano-node-capi.cabal
@@ -24,5 +24,5 @@ library
                       , aeson                         >= 2.1.0.0
                       , bytestring
                       , cardano-node
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
   hs-source-dirs:       src

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -49,7 +49,7 @@ executable cardano-node-chairman
                       , containers
                       , contra-tracer
                       , io-classes
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-consensus >= 0.6
                       , ouroboros-network-api >= 0.3
                       , ouroboros-network-protocols >= 0.5

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-chairman
-version:                8.1.0
+version:                8.2.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for cardano-node
 
-# next version
+# 8.2.0 -- July 2023
 
 ### node changes
 
@@ -12,9 +12,18 @@
   `valency` flag.
 - Added `warmValency` optional to P2P Topology files.
 
-## 8.1.0
+## 8.1.2 -- July 2023
 
--
+- Update plutus interpreter
+
+## 8.1.1 -- June 2023
+
+- Address P2P Topology bug with non-DNS names in networking
+
+## 8.1.0 -- June 2023
+
+- Support Conway Era when ExperimentalHardForks enabled
+- `TickF` changes to improve epoch boundary
 
 ## 8.0.0 -- May 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -174,7 +174,7 @@ library
                       , network
                       , network-mux >= 0.4
                       , nothunks
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-consensus >= 0.9
                       , ouroboros-consensus-cardano >= 0.7
                       , ouroboros-consensus-diffusion >= 0.7
@@ -221,7 +221,7 @@ executable cardano-node
                       , cardano-crypto-class
                       , cardano-git-rev
                       , cardano-node
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , text >= 2.0
 
 test-suite cardano-node-test

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.1.1
+version:                8.2.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-submit-api
-version:                3.1.2
+version:                3.1.3
 synopsis:               A web server that allows transactions to be POSTed to the cardano chain
 description:            A web server that allows transactions to be POSTed to the cardano chain.
 homepage:               https://github.com/input-output-hk/cardano-node

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -41,7 +41,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.8
                       , cardano-binary
-                      , cardano-cli ^>= 8.3
+                      , cardano-cli ^>= 8.4
                       , cardano-crypto-class ^>= 2.1
                       , cardano-ledger-byron ^>= 1.0
                       , formatting
@@ -49,7 +49,7 @@ library
                       , iohk-monitoring
                       , mtl
                       , network
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-consensus-cardano
                       , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-protocols
@@ -85,8 +85,8 @@ executable cardano-submit-api
   hs-source-dirs:       app
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T -I0"
   build-depends:        base >= 4.14 && < 4.17
-                      , optparse-applicative-fork ^>= 0.16.1
-                      , cardano-cli ^>= 8.3
+                      , optparse-applicative-fork
+                      , cardano-cli ^>= 8.4
                       , cardano-crypto-class ^>= 2.1
                       , cardano-submit-api
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -9,8 +9,8 @@ module Cardano.TxSubmit.CLI.Parsers
 
 import           Cardano.Api (File (..), SocketPath)
 
-import           Cardano.CLI.Common.Parsers
 import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.EraBased.Options.Common
 
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), TxSubmitNodeParams (..))
 import           Cardano.TxSubmit.Rest.Parsers (pWebserverConfig)

--- a/cardano-testnet/app/cardano-testnet.hs
+++ b/cardano-testnet/app/cardano-testnet.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Cardano.CLI.Environment (getEnvCli)
 import qualified Cardano.Crypto.Init as Crypto
 
 import qualified Options.Applicative as Opt
@@ -10,5 +11,6 @@ main :: IO ()
 main = do
   Crypto.cryptoInit
 
-  tNetCmd <- Opt.customExecParser pref opts
+  envCli <- getEnvCli
+  tNetCmd <- Opt.customExecParser pref (opts envCli)
   runTestnetCmd tNetCmd

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-testnet
-version:                8.1.0
+version:                8.2.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 copyright:              2021-2023 Input Output Global Inc (IOG).

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -35,7 +35,7 @@ library
                       , ansi-terminal
                       , bytestring
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.3
+                      , cardano-cli ^>= 8.4
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo
@@ -53,7 +53,7 @@ library
                       , hedgehog
                       , hedgehog-extras ^>= 0.4.7.0
                       , mtl
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , process
@@ -110,9 +110,10 @@ executable cardano-testnet
 
   main-is:              cardano-testnet.hs
 
-  build-depends:        cardano-testnet
-                      , cardano-crypto-class
-                      , optparse-applicative-fork ^>= 0.16.1
+  build-depends:        cardano-crypto-class
+                      , cardano-cli
+                      , cardano-testnet
+                      , optparse-applicative-fork
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
@@ -149,7 +150,7 @@ test-suite cardano-testnet-golden
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.3
+                      , cardano-cli:cardano-cli ^>= 8.4
                       , cardano-submit-api:cardano-submit-api
                       , cardano-testnet:cardano-testnet
 
@@ -176,7 +177,7 @@ test-suite cardano-testnet-test
                       , async
                       , bytestring
                       , cardano-api ^>= 8.8
-                      , cardano-cli ^>= 8.3
+                      , cardano-cli ^>= 8.4
                       , cardano-crypto-class
                       , cardano-testnet
                       , containers
@@ -193,6 +194,6 @@ test-suite cardano-testnet-test
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.3
+                      , cardano-cli:cardano-cli ^>= 8.4
                       , cardano-submit-api:cardano-submit-api
                       , cardano-testnet:cardano-testnet

--- a/cardano-testnet/src/Parsers/Babbage.hs
+++ b/cardano-testnet/src/Parsers/Babbage.hs
@@ -8,7 +8,7 @@ import           Prelude
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
-import           Cardano.CLI.Common.Parsers hiding (pNetworkId)
+import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Testnet.Process.Cli
 import           Testnet.Runtime (readNodeLoggingFormat)

--- a/cardano-testnet/src/Parsers/Byron.hs
+++ b/cardano-testnet/src/Parsers/Byron.hs
@@ -7,7 +7,7 @@ module Parsers.Byron
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
-import           Cardano.CLI.Common.Parsers hiding (pNetworkId)
+import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Testnet.Process.Cli
 import           Testnet.Property.Run (runTestnet)

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -5,11 +5,12 @@ module Parsers.Cardano
 
 import           Prelude
 
+import           Cardano.CLI.Environment
 import qualified Data.List as L
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
-import           Cardano.CLI.Common.Parsers hiding (pNetworkId)
+import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Testnet.Process.Cli
 import           Testnet.Property.Utils
@@ -20,10 +21,10 @@ newtype CardanoOptions = CardanoOptions
   { testnetOptions :: CardanoTestnetOptions
   } deriving (Eq, Show)
 
-optsTestnet :: Parser CardanoTestnetOptions
-optsTestnet = CardanoTestnetOptions
+optsTestnet :: EnvCli -> Parser CardanoTestnetOptions
+optsTestnet envCli = CardanoTestnetOptions
   <$> pNumBftAndSpoNodes
-  <*> pCardanoEra
+  <*> pCardanoEra envCli
   <*> OA.option auto
       (   OA.long "epoch-length"
       <>  OA.help "Epoch length"
@@ -82,8 +83,8 @@ pNumBftAndSpoNodes =
           <>  OA.value (cardanoNodes cardanoDefaultTestnetOptions)
           )
 
-optsCardano :: Parser CardanoOptions
-optsCardano = CardanoOptions <$> optsTestnet
+optsCardano :: EnvCli -> Parser CardanoOptions
+optsCardano envCli = CardanoOptions <$> optsTestnet envCli
 
-cmdCardano :: Mod CommandFields CardanoOptions
-cmdCardano = command' "cardano" "Start a testnet in any era" optsCardano
+cmdCardano :: EnvCli -> Mod CommandFields CardanoOptions
+cmdCardano envCli = command' "cardano" "Start a testnet in any era" (optsCardano envCli)

--- a/cardano-testnet/src/Parsers/Conway.hs
+++ b/cardano-testnet/src/Parsers/Conway.hs
@@ -8,7 +8,7 @@ import           Prelude
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
-import           Cardano.CLI.Common.Parsers hiding (pNetworkId)
+import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Testnet.Process.Cli
 import           Testnet.Runtime (readNodeLoggingFormat)

--- a/cardano-testnet/src/Parsers/Help.hs
+++ b/cardano-testnet/src/Parsers/Help.hs
@@ -12,7 +12,7 @@ import           Options.Applicative.Help.Types (renderHelp)
 import           Options.Applicative.Types (OptReader (..), Option (..), Parser (..))
 import qualified System.IO as IO
 
-import           Cardano.CLI.Common.Parsers
+import           Cardano.CLI.EraBased.Options.Common
 
 data HelpOptions = HelpOptions
   deriving (Eq, Show)
@@ -30,10 +30,9 @@ helpAll pprefs progn rnames parserInfo = do
     go p = case p of
       NilP _ -> return ()
       OptP optP -> case optMain optP of
-        CmdReader _ cs f -> do
-          forM_ cs $ \c ->
-            forM_ (f c) $ \subParserInfo ->
-              helpAll pprefs progn (c:rnames) subParserInfo
+        CmdReader _ cs -> do
+          forM_ cs $ \(c, subParserInfo) ->
+            helpAll pprefs progn (c:rnames) subParserInfo
         _ -> return ()
       AltP pa pb -> go pa >> go pb
       MultP pf px -> go pf >> go px

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -8,13 +8,14 @@ module Parsers.Run
   , opts
   ) where
 
+import           Cardano.CLI.Environment
 import           Data.Foldable
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 import           Parsers.Babbage as Babbage
-import           Parsers.Conway as Conway
 import           Parsers.Byron
 import           Parsers.Cardano
+import           Parsers.Conway as Conway
 import           Parsers.Help
 import           Parsers.Shelley
 import           Parsers.Version
@@ -24,8 +25,8 @@ import           Testnet.Property.Run (runTestnet)
 pref :: ParserPrefs
 pref = Opt.prefs $ showHelpOnEmpty <> showHelpOnError
 
-opts :: ParserInfo CardanoTestnetCommands
-opts = Opt.info (commands <**> helper) idm
+opts :: EnvCli -> ParserInfo CardanoTestnetCommands
+opts envCli = Opt.info (commands envCli <**> helper) idm
 
 -- TODO: Remove StartBabbageTestnet and StartShelleyTestnet
 -- by allowing the user to start testnets in any era (excluding Byron)
@@ -39,16 +40,16 @@ data CardanoTestnetCommands
   | GetVersion VersionOptions
   | Help ParserPrefs (ParserInfo CardanoTestnetCommands) HelpOptions
 
-commands :: Parser CardanoTestnetCommands
-commands =
+commands :: EnvCli -> Parser CardanoTestnetCommands
+commands envCli =
   asum
-    [ fmap StartCardanoTestnet (subparser cmdCardano)
+    [ fmap StartCardanoTestnet (subparser (cmdCardano envCli))
     , fmap StartByrontestnet (subparser cmdByron)
     , fmap StartShelleyTestnet (subparser cmdShelley)
     , fmap StartBabbageTestnet (subparser cmdBabbage)
     , fmap StartConwayTestnet (subparser cmdConway)
     , fmap GetVersion (subparser cmdVersion)
-    , fmap (Help pref opts) (subparser cmdHelp)
+    , fmap (Help pref (opts envCli)) (subparser cmdHelp)
     ]
 
 

--- a/cardano-testnet/src/Parsers/Shelley.hs
+++ b/cardano-testnet/src/Parsers/Shelley.hs
@@ -8,7 +8,7 @@ import           Prelude
 import           Options.Applicative
 import qualified Options.Applicative as OA
 
-import           Cardano.CLI.Common.Parsers hiding (pNetworkId)
+import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Testnet.Process.Cli
 import           Testnet.Property.Utils

--- a/cardano-testnet/src/Parsers/Version.hs
+++ b/cardano-testnet/src/Parsers/Version.hs
@@ -12,7 +12,7 @@ import           Paths_cardano_testnet (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
 import qualified System.IO as IO
 
-import           Cardano.CLI.Common.Parsers
+import           Cardano.CLI.EraBased.Options.Common
 
 
 data VersionOptions = VersionOptions

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -22,7 +22,7 @@ module Testnet.Property.Utils
 
 import           Cardano.Api
 
-import           Cardano.CLI.Shelley.Output
+import           Cardano.CLI.Types.Output
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad
 import           Control.Monad.IO.Class

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,70 +1,63 @@
 Usage: cardano-testnet 
-                         ( cardano
-                         | byron
-                         | shelley
-                         | babbage
-                         | conway
-                         | version
-                         | help
-                         )
+  (cardano | byron | shelley | babbage | conway | version | help)
 
 Usage: cardano-testnet cardano [--num-bft-nodes COUNT]
-                                 [--num-pool-nodes COUNT]
-                                 [ --byron-era
-                                 | --shelley-era
-                                 | --allegra-era
-                                 | --mary-era
-                                 | --alonzo-era
-                                 | --babbage-era
-                                 | --conway-era
-                                 ]
-                                 [--epoch-length MILLISECONDS]
-                                 [--slot-length SECONDS]
-                                 --testnet-magic INT
-                                 [--active-slots-coeff DOUBLE]
-                                 [--max-lovelace-supply WORD64]
-                                 [--enable-p2p BOOL]
-                                 [--nodeLoggingFormat LOGGING_FORMAT]
+  [--num-pool-nodes COUNT]
+  [ --byron-era
+  | --shelley-era
+  | --allegra-era
+  | --mary-era
+  | --alonzo-era
+  | --babbage-era
+  | --conway-era
+  ]
+  [--epoch-length MILLISECONDS]
+  [--slot-length SECONDS]
+  --testnet-magic INT
+  [--active-slots-coeff DOUBLE]
+  [--max-lovelace-supply WORD64]
+  [--enable-p2p BOOL]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a testnet in any era
 
 Usage: cardano-testnet byron [--num-bft-nodes COUNT]
-                               [--slot-duration MILLISECONDS]
-                               --testnet-magic INT
-                               [--security-param INT]
-                               [--n-poor-addresses INT]
-                               [--total-balance INT]
-                               [--enable-p2p BOOL]
+  [--slot-duration MILLISECONDS]
+  --testnet-magic INT
+  [--security-param INT]
+  [--n-poor-addresses INT]
+  [--total-balance INT]
+  [--enable-p2p BOOL]
 
   Start a Byron testnet
 
 Usage: cardano-testnet shelley [--num-praos-nodes COUNT]
-                                 [--num-pool-nodes COUNT]
-                                 [--active-slots-coeff DOUBLE]
-                                 [--security-param INT]
-                                 [--epoch-length MILLISECONDS]
-                                 [--slot-length MILLISECONDS]
-                                 --testnet-magic INT
-                                 [--max-lovelace-supply WORD64]
-                                 [--enable-p2p BOOL]
+  [--num-pool-nodes COUNT]
+  [--active-slots-coeff DOUBLE]
+  [--security-param INT]
+  [--epoch-length MILLISECONDS]
+  [--slot-length MILLISECONDS]
+  --testnet-magic INT
+  [--max-lovelace-supply WORD64]
+  [--enable-p2p BOOL]
 
   Start a Shelley testnet
 
 Usage: cardano-testnet babbage [--num-spo-nodes COUNT]
-                                 [--slot-duration MILLISECONDS]
-                                 [--security-param INT]
-                                 --testnet-magic INT
-                                 [--total-balance INT]
-                                 [--nodeLoggingFormat LOGGING_FORMAT]
+  [--slot-duration MILLISECONDS]
+  [--security-param INT]
+  --testnet-magic INT
+  [--total-balance INT]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a babbage testnet
 
 Usage: cardano-testnet conway [--num-spo-nodes COUNT]
-                                [--slot-duration MILLISECONDS]
-                                [--security-param INT]
-                                --testnet-magic INT
-                                [--total-balance INT]
-                                [--nodeLoggingFormat LOGGING_FORMAT]
+  [--slot-duration MILLISECONDS]
+  [--security-param INT]
+  --testnet-magic INT
+  [--total-balance INT]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a conway testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/babbage.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/babbage.cli
@@ -1,9 +1,9 @@
 Usage: cardano-testnet babbage [--num-spo-nodes COUNT]
-                                 [--slot-duration MILLISECONDS]
-                                 [--security-param INT]
-                                 --testnet-magic INT
-                                 [--total-balance INT]
-                                 [--nodeLoggingFormat LOGGING_FORMAT]
+  [--slot-duration MILLISECONDS]
+  [--security-param INT]
+  --testnet-magic INT
+  [--total-balance INT]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a babbage testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/byron.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/byron.cli
@@ -1,10 +1,10 @@
 Usage: cardano-testnet byron [--num-bft-nodes COUNT]
-                               [--slot-duration MILLISECONDS]
-                               --testnet-magic INT
-                               [--security-param INT]
-                               [--n-poor-addresses INT]
-                               [--total-balance INT]
-                               [--enable-p2p BOOL]
+  [--slot-duration MILLISECONDS]
+  --testnet-magic INT
+  [--security-param INT]
+  [--n-poor-addresses INT]
+  [--total-balance INT]
+  [--enable-p2p BOOL]
 
   Start a Byron testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -1,20 +1,20 @@
 Usage: cardano-testnet cardano [--num-bft-nodes COUNT]
-                                 [--num-pool-nodes COUNT]
-                                 [ --byron-era
-                                 | --shelley-era
-                                 | --allegra-era
-                                 | --mary-era
-                                 | --alonzo-era
-                                 | --babbage-era
-                                 | --conway-era
-                                 ]
-                                 [--epoch-length MILLISECONDS]
-                                 [--slot-length SECONDS]
-                                 --testnet-magic INT
-                                 [--active-slots-coeff DOUBLE]
-                                 [--max-lovelace-supply WORD64]
-                                 [--enable-p2p BOOL]
-                                 [--nodeLoggingFormat LOGGING_FORMAT]
+  [--num-pool-nodes COUNT]
+  [ --byron-era
+  | --shelley-era
+  | --allegra-era
+  | --mary-era
+  | --alonzo-era
+  | --babbage-era
+  | --conway-era
+  ]
+  [--epoch-length MILLISECONDS]
+  [--slot-length SECONDS]
+  --testnet-magic INT
+  [--active-slots-coeff DOUBLE]
+  [--max-lovelace-supply WORD64]
+  [--enable-p2p BOOL]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a testnet in any era
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/conway.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/conway.cli
@@ -1,9 +1,9 @@
 Usage: cardano-testnet conway [--num-spo-nodes COUNT]
-                                [--slot-duration MILLISECONDS]
-                                [--security-param INT]
-                                --testnet-magic INT
-                                [--total-balance INT]
-                                [--nodeLoggingFormat LOGGING_FORMAT]
+  [--slot-duration MILLISECONDS]
+  [--security-param INT]
+  --testnet-magic INT
+  [--total-balance INT]
+  [--nodeLoggingFormat LOGGING_FORMAT]
 
   Start a conway testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/shelley.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/shelley.cli
@@ -1,12 +1,12 @@
 Usage: cardano-testnet shelley [--num-praos-nodes COUNT]
-                                 [--num-pool-nodes COUNT]
-                                 [--active-slots-coeff DOUBLE]
-                                 [--security-param INT]
-                                 [--epoch-length MILLISECONDS]
-                                 [--slot-length MILLISECONDS]
-                                 --testnet-magic INT
-                                 [--max-lovelace-supply WORD64]
-                                 [--enable-p2p BOOL]
+  [--num-pool-nodes COUNT]
+  [--active-slots-coeff DOUBLE]
+  [--security-param INT]
+  [--epoch-length MILLISECONDS]
+  [--slot-length MILLISECONDS]
+  --testnet-magic INT
+  [--max-lovelace-supply WORD64]
+  [--enable-p2p BOOL]
 
   Start a Shelley testnet
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Alonzo/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Alonzo/LeadershipSchedule.hs
@@ -39,8 +39,8 @@ import qualified Testnet.Process.Run as H
 import           Cardano.Api (AlonzoEra, SerialiseAddress (serialiseAddress), UTxO (UTxO))
 import qualified Cardano.Api as Api
 import           Cardano.Api.Shelley (PoolId)
-import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (mEpoch))
-import           Cardano.CLI.Shelley.Run.Query (DelegationsAndRewards, mergeDelegsAndRewards)
+import           Cardano.CLI.Run.Legacy.Query (DelegationsAndRewards, mergeDelegsAndRewards)
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (mEpoch))
 
 import           Cardano.Testnet
 import           Testnet.Process.Run

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -16,7 +16,7 @@ module Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
   ( hprop_leadershipSchedule
   ) where
 
-import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
 import           Control.Monad (void)
 import           Data.List ((\\))
 import           Data.Text (Text)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -28,7 +28,7 @@ import           GHC.Stack (callStack)
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
 import           Cardano.Testnet
 
 import           Hedgehog (Property, (===))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -28,7 +28,7 @@ import           GHC.Stack (callStack)
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Cardano.CLI.Shelley.Output (QueryTipLocalStateOutput (..))
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
 import           Cardano.Testnet
 
 import           Hedgehog (Property, (===))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -17,8 +17,8 @@ import           Hedgehog (Property, (===))
 import           Prelude
 import           System.FilePath ((</>))
 
-import           Cardano.CLI.Shelley.Output
-import           Cardano.CLI.Shelley.Run.Query
+import           Cardano.CLI.Run.Legacy.Query
+import           Cardano.CLI.Types.Output
 
 import qualified Data.Aeson as J
 import qualified Data.Map.Strict as Map

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
@@ -5,9 +5,9 @@ import           Prelude
 import           Data.List (isInfixOf)
 import qualified GHC.Stack as GHC
 
-import           Cardano.CLI.Shelley.Output
-import           Cardano.CLI.Shelley.Run.Query
-import           Cardano.CLI.Types
+import           Cardano.CLI.Run.Legacy.Query
+import           Cardano.CLI.Types.Legacy
+import           Cardano.CLI.Types.Output
 
 import           Hedgehog (success)
 import qualified Hedgehog as H

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-tracer
-version:                0.1.0
+version:                0.1.1
 synopsis:               A service for logging and monitoring over Cardano nodes
 description:            A service for logging and monitoring over Cardano nodes.
 category:               Cardano,

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -145,7 +145,7 @@ library
                       , extra
                       , filepath
                       , mime-mail
-                      , optparse-applicative >= 0.16.0 && < 0.16.1
+                      , optparse-applicative
                       , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
@@ -184,7 +184,7 @@ executable cardano-tracer
   autogen-modules:      Paths_cardano_tracer
 
   build-depends:        cardano-tracer
-                      , optparse-applicative >= 0.16.0 && < 0.16.1
+                      , optparse-applicative
 
   ghc-options:          -threaded
                         -rtsopts
@@ -212,7 +212,7 @@ library demo-forwarder-lib
                       , extra
                       , filepath
                       , generic-data
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , tasty-quickcheck
@@ -252,7 +252,7 @@ library demo-acceptor-lib
                       , extra
                       , filepath
                       , generic-data
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network-api
                       , stm
                       , text
@@ -303,7 +303,7 @@ test-suite cardano-tracer-test
                       , extra
                       , filepath
                       , generic-data
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , stm
@@ -357,7 +357,7 @@ test-suite cardano-tracer-test-ext
                       , filepath
                       , generic-data
                       , Glob
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1689944957,
-        "narHash": "sha256-yVbSo0FMJi5QWg5yuqkHE314U6FKaz2zA8nFhspM66k=",
+        "lastModified": 1690451246,
+        "narHash": "sha256-rgSBCOcTpFFFvgf1bhE3Jt9tmpJ8ncnyXsxiTlsDHN0=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "2c01954d7cce23ce9e779fcdc69da63760d85215",
+        "rev": "2b80f8a2dc6857595281a27083a931b2ec7303b7",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1689899122,
-        "narHash": "sha256-1kkph+jx+XWwIpvViuJG1HeVGPs6t9FwvTi8wStxLdU=",
+        "lastModified": 1690331094,
+        "narHash": "sha256-xGJlmbRruW61N0rEcFn2pRlpLnE1TCKvvyz2nytYzE4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "23c602d1673e018c7e40c96cd674bbd0bb60ef6c",
+        "rev": "efc8a53a648a6a3b0973aaefc93ace7d0ddf198d",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -55,7 +55,7 @@ library
                       , ekg-forward >= 0.3.0.4
                       , hostname
                       , network
-                      , optparse-applicative-fork ^>= 0.16.1
+                      , optparse-applicative-fork
                       , ouroboros-network ^>= 0.8.2.0
                       , ouroboros-network-api
                       , ouroboros-network-framework
@@ -146,7 +146,7 @@ test-suite trace-dispatcher-test
                       , ekg-core
                       , generic-data
                       , hostname
-                      , optparse-applicative >= 0.16.0 && < 0.16.1
+                      , optparse-applicative
                       , ouroboros-network ^>= 0.8.2.0
                       , text
                       , stm

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                2.0.1
+version:                2.0.2
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package


### PR DESCRIPTION
# Description

Bumps ledger for some hotfixes. Bumps plutus for a hotfix. Bumps version of node to 8.2.0.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
