### PR TITLE
Revert Tx.hs monadic cleanup

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -310,14 +310,14 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       (toUTxOChange, addressChange) <- interpretPayMode payModeChange
       traceDebug $ "split change address : " ++ addressChange
       let
-        inToOut = return . Utils.includeChange fee coins
+        fundSource = walletSource wallet 1
+        inToOut = Utils.includeChange fee coins
         txGenerator = genTx (cardanoEra @era) protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
-      inputFunds <- liftToAction $ walletSource wallet 1
-      sourceToStore <- withTxGenError . sourceToStoreTransactionNew txGenerator inputFunds inToOut $ mangleWithChange (liftIOCreateAndStore toUTxOChange) (liftIOCreateAndStore toUTxO)
-      return . Streaming.effect . pure . Streaming.yield $ Right sourceToStore
+        sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut $ mangleWithChange toUTxOChange toUTxO
+      return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
     -- The 'SplitN' case's call chain is somewhat elaborate.
-    -- The division is done in 'Utils.inputsToOutputsWithFee' 
+    -- The division is done in 'Utils.inputsToOutputsWithFee'
     -- but things are threaded through
     -- 'Cardano.Benchmarking.Wallet.mangle' and packed into
     -- the transaction assembled by 'sourceToStoreTransactionNew'.
@@ -326,11 +326,11 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       (toUTxO, addressOut) <- interpretPayMode payMode
       traceDebug $ "SplitN output address : " ++ addressOut
       let
-        inToOut = withExceptT TxGenError . Utils.inputsToOutputsWithFee fee count
+        fundSource = walletSource wallet 1
+        inToOut = Utils.inputsToOutputsWithFee fee count
         txGenerator = genTx (cardanoEra @era) protocolParameters (TxInsCollateralNone, []) feeInEra TxMetadataNone
-      inputFunds <- liftToAction $ walletSource wallet 1
-      sourceToStore <- withTxGenError $ sourceToStoreTransactionNew txGenerator inputFunds inToOut (mangle . repeat $ liftIOCreateAndStore toUTxO)
-      return . Streaming.effect . pure . Streaming.yield $ Right sourceToStore
+        sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut (mangle $ repeat toUTxO)
+      return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
     NtoM walletName payMode inputs outputs metadataSize collateralWallet -> do
       wallet <- getEnvWallets walletName
@@ -338,27 +338,25 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
       (toUTxO, addressOut) <- interpretPayMode payMode
       traceDebug $ "NtoM output address : " ++ addressOut
       let
-        inToOut = withExceptT TxGenError . Utils.inputsToOutputsWithFee fee outputs
+        fundSource = walletSource wallet inputs
+        inToOut = Utils.inputsToOutputsWithFee fee outputs
         txGenerator = genTx (cardanoEra @era) protocolParameters collaterals feeInEra (toMetadata metadataSize)
-        previewCatcher err = do
-          traceDebug $ "Error creating Tx preview: " ++ show err
-          throwE err
-      inputFunds <- liftToAction $ walletSource wallet inputs
-      sourceToStore <- withTxGenError $ sourceToStoreTransactionNew txGenerator inputFunds inToOut (mangle . repeat $ liftIOCreateAndStore toUTxO)
+        sourceToStore = sourceToStoreTransactionNew txGenerator fundSource inToOut (mangle $ repeat toUTxO)
 
       fundPreview <- liftIO $ walletPreview wallet inputs
-      preview <- withTxGenError (sourceTransactionPreview txGenerator fundPreview inToOut (mangle . repeat $ liftIOCreateAndStore toUTxO))
-                   `catchE` previewCatcher
-      let txSize = txSizeInBytes preview
-      traceDebug $ "Projected Tx size in bytes: " ++ show txSize
-      summary_ <- getEnvSummary
-      forM_ summary_ $ \summary -> do
-        let summary' = summary {projectedTxSize = Just txSize}
-        setEnvSummary summary'
-        traceBenchTxSubmit TraceBenchPlutusBudgetSummary summary'
-      dumpBudgetSummaryIfExisting
+      case sourceTransactionPreview txGenerator fundPreview inToOut (mangle $ repeat toUTxO) of
+        Left err -> traceDebug $ "Error creating Tx preview: " ++ show err
+        Right tx -> do
+          let txSize = txSizeInBytes tx
+          traceDebug $ "Projected Tx size in bytes: " ++ show txSize
+          summary_ <- getEnvSummary
+          forM_ summary_ $ \summary -> do
+            let summary' = summary {projectedTxSize = Just txSize}
+            setEnvSummary summary'
+            traceBenchTxSubmit TraceBenchPlutusBudgetSummary summary'
+          dumpBudgetSummaryIfExisting
 
-      return . Streaming.effect . pure . Streaming.yield $ Right sourceToStore
+      return $ Streaming.effect (Streaming.yield <$> sourceToStore)
 
     Sequence l -> do
       gList <- forM l $ \g -> evalGenerator g txParams era
@@ -376,10 +374,6 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
 
   where
     feeInEra = Utils.mkTxFee fee
-    -- 'liftIOCreateAndStore' is supposed to be some indication that 'liftIO'
-    -- is applied to a 'CreateAndStore'.
-    -- This could be golfed as @((liftIO .) .)@ but it's unreadable.
-    liftIOCreateAndStore cas = second (\f x y -> liftIO (f x y)) . cas
 
 selectCollateralFunds :: forall era. IsShelleyBasedEra era
   => Maybe String
@@ -403,8 +397,6 @@ dumpToFileIO filePath tx = appendFile filePath ('\n' : show tx)
 initWallet :: String -> ActionM ()
 initWallet name = liftIO Wallet.initWallet >>= setEnvWallets name
 
--- The inner monad being 'IO' creates some programming overhead above.
--- Something like 'MonadIO' would be helpful, but the typing is tricky.
 interpretPayMode :: forall era. IsShelleyBasedEra era => PayMode -> ActionM (CreateAndStore IO era, String)
 interpretPayMode payMode = do
   networkId <- getEnvNetworkId

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -30,10 +30,8 @@ module Cardano.Benchmarking.Script.Env (
         , Error(..)
         , runActionM
         , runActionMEnv
-        , liftToAction
         , liftTxGenError
         , liftIOSafe
-        , withTxGenError
         , askIOManager
         , traceDebug
         , traceError
@@ -133,7 +131,7 @@ runActionM = runActionMEnv emptyEnv
 runActionMEnv :: Env -> ActionM ret -> IOManager -> IO (Either Error ret, Env, ())
 runActionMEnv env action iom = RWS.runRWST (runExceptT action) iom env
 
--- | 'Error' adds two cases to 'Cardano.TxGenerator.Types.TxGenError' 
+-- | 'Error' adds two cases to 'Cardano.TxGenerator.Types.TxGenError'
 -- which in turn wraps 'Cardano.Api.Error' implicit contexts to a
 -- couple of its constructors. These represent errors that might arise
 -- in the execution of a transaction with some distinctions as to the
@@ -149,17 +147,6 @@ data Error where
   WalletError :: !String     -> Error
 
 deriving instance Show Error
-
--- | This abbreviates access to the fully-qualified constructor name
--- for `Cardano.Benchmarking.Script.Env.TxGenError` and the repetitive
--- usage of `withExceptT` with that as its first argument.
-withTxGenError :: Monad m => ExceptT TxGenError m a -> ExceptT Error m a
-withTxGenError = withExceptT Cardano.Benchmarking.Script.Env.TxGenError
-
--- | This injects an `IO` action using `Either` as hand-rolled
--- exceptions into the `ActionM` monad.
-liftToAction :: IO (Either TxGenError a) -> ActionM a
-liftToAction = withTxGenError . ExceptT . liftIO
 
 -- | This throws a `TxGenError` in the `ActionM` monad.
 liftTxGenError :: TxGenError -> ActionM a

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -98,7 +98,7 @@ data Action where
   AddFund            :: !AnyCardanoEra -> !String -> !TxIn -> !Lovelace -> !String -> Action
   -- | 'WaitBenchmark' signifies a 'Control.Concurrent.Async.waitCatch'
   -- on the 'Cardano.Benchmarking.GeneratorTx.AsyncBenchmarkControl'
-  -- associated with the ID and also folds tracers into the completion. 
+  -- associated with the ID and also folds tracers into the completion.
   WaitBenchmark      :: !String -> Action
   -- | 'Submit' mostly wraps
   -- 'Cardano.Benchamrking.Script.Core.benchmarkTxStream'
@@ -108,7 +108,7 @@ data Action where
   -- 'Cardano.Benchmarking.GeneratorTx.SubmissionClient.txSubmissionClient'
   -- and functions local to that like @requestTxs@.
   Submit             :: !AnyCardanoEra -> !SubmitMode -> !TxGenTxParams -> !Generator -> Action
-  -- | 'CancelBenchmark' wraps a callback from the 
+  -- | 'CancelBenchmark' wraps a callback from the
   -- 'Cardano.Benchmarking.GeneratorTx.AsyncBenchmarkControl' type,
   -- which is a shutdown action.
   CancelBenchmark    :: !String -> Action

--- a/bench/tx-generator/src/Cardano/Benchmarking/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Types.hs
@@ -10,8 +10,8 @@ module Cardano.Benchmarking.Types
   ( module Cardano.Benchmarking.Types
   ) where
 
-import           GHC.Generics (Generic)
 import           Data.Aeson (ToJSON)
+import           GHC.Generics (Generic)
 
 
 -- | Transactions we decided to announce now.

--- a/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Wallet.hs
@@ -13,14 +13,14 @@ module Cardano.Benchmarking.Wallet
 where
 import           Prelude
 
-import           Streaming
 import           Control.Concurrent.MVar
+import           Streaming
 
 import           Cardano.Api
 
 import           Cardano.TxGenerator.FundQueue as FundQueue
-import           Cardano.TxGenerator.Types
 import           Cardano.TxGenerator.Tx
+import           Cardano.TxGenerator.Types
 import           Cardano.TxGenerator.UTxO
 
 -- | All the actual functionality of Wallet / WalletRef has been removed
@@ -122,10 +122,10 @@ mangleWithChange mkChange mkPayment outs = case outs of
 -- as the first @fkts@ argument is 'mangleWithChange' above. This
 -- is likely worth refactoring for the sake of maintainability.
 mangle :: Monad m => [ CreateAndStore m era ] -> CreateAndStoreList m era [ Lovelace ]
-mangle fkts values 
+mangle fkts values
   = (outs, \txId -> mapM_ (\f -> f txId) fs)
   where
-    (outs, fs) = unzip $ zipWith3 worker fkts values [TxIx 0 ..]
-    worker toUTxO value idx
+    (outs, fs) = unzip $ map worker $ zip3 fkts values [TxIx 0 ..]
+    worker (toUTxO, value, idx)
       = let (o, f ) = toUTxO value
-         in  (o, f idx) 
+         in  (o, f idx)

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
@@ -8,10 +7,8 @@ module  Cardano.TxGenerator.PureExample
         where
 
 import           Control.Monad (foldM)
-import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.State.Strict
 import           Data.Either (fromRight)
-import           Data.Functor.Identity (runIdentity)
 import           Data.List (foldl')
 import           Data.String (fromString)
 import           System.Exit (die)
@@ -95,16 +92,13 @@ type Generator = State FundQueue
 generateTx ::
      TxEnvironment BabbageEra
   -> Generator (Either TxGenError (Tx BabbageEra))
-generateTx TxEnvironment{..} = do
-  funds' <- consumeInputFunds
-  case funds' of
-    Left err -> pure $ Left err
-    Right funds -> runExceptT $ sourceToStoreTransaction
-                                    generator
-                                    funds
-                                    computeOutputValues
-                                    (makeToUTxOList $ repeat computeUTxO)
-                                    addNewOutputFunds
+generateTx TxEnvironment{..}
+  = sourceToStoreTransaction
+        generator
+        consumeInputFunds
+        computeOutputValues
+        (makeToUTxOList $ repeat computeUTxO)
+        addNewOutputFunds
   where
     TxFeeExplicit _ fee = txEnvFee
 
@@ -125,8 +119,8 @@ generateTx TxEnvironment{..} = do
     addNewOutputFunds :: [Fund] -> Generator ()
     addNewOutputFunds = put . foldl' insertFund emptyFundQueue
 
-    computeOutputValues :: Monad m => [Lovelace] -> ExceptT TxGenError m [Lovelace]
-    computeOutputValues = withExceptT TxGenError . inputsToOutputsWithFee fee numOfOutputs
+    computeOutputValues :: [Lovelace] -> [Lovelace]
+    computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
       where numOfOutputs = 2
 
     computeUTxO = mkUTxOVariant txEnvNetworkId signingKey
@@ -148,8 +142,6 @@ generateTxPure ::
   -> Either TxGenError (Tx BabbageEra, FundQueue)
 generateTxPure TxEnvironment{..} inQueue
   = do
-      outValues <- runIdentity . runExceptT . withExcept TxGenError . computeOutputValues $ map getFundLovelace inputs
-      let (outputs, toFunds) = makeToUTxOList (repeat computeUTxO) outValues
       (tx, txId) <- generator inputs outputs
       let outQueue = foldl' insertFund emptyFundQueue (toFunds txId)
       pure (tx, outQueue)
@@ -164,7 +156,10 @@ generateTxPure TxEnvironment{..} inQueue
         collateralFunds :: (TxInsCollateral BabbageEra, [Fund])
         collateralFunds = (TxInsCollateralNone, [])
 
-    computeOutputValues :: Monad m => [Lovelace] -> ExceptT String m [Lovelace]
+    outValues = computeOutputValues $ map getFundLovelace inputs
+    (outputs, toFunds) = makeToUTxOList (repeat computeUTxO) outValues
+
+    computeOutputValues :: [Lovelace] -> [Lovelace]
     computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
       where numOfOutputs = 2
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -7,9 +7,7 @@ module  Cardano.TxGenerator.Tx
         (module Cardano.TxGenerator.Tx)
         where
 
-import           Control.Monad.Trans.Except (ExceptT, except)
-import           Control.Monad.Trans (lift)
-import           Data.Bifunctor (bimap)
+import           Data.Bifunctor (bimap, second)
 import qualified Data.ByteString as BS (length)
 import           Data.Function ((&))
 import           Data.Maybe (mapMaybe)
@@ -37,7 +35,7 @@ type CreateAndStoreList m era split = split -> ([TxOut CtxTx era], TxId -> m ())
 
 
 -- TODO: 'sourceToStoreTransaction' et al need to be broken up
--- for the sake of maintainability.
+-- for the sake of maintainability and use the Error monad.
 
 -- | 'sourceToStoreTransaction' builds a transaction out of several
 -- arguments. "Cardano.Benchmarking.Script.PureExample" is the sole caller.
@@ -57,22 +55,30 @@ type CreateAndStoreList m era split = split -> ([TxOut CtxTx era], TxId -> m ())
 sourceToStoreTransaction ::
      Monad m
   => TxGenerator era
-  -> [Fund]
-  -> ([Lovelace] -> ExceptT TxGenError m split)
+  -> FundSource m
+  -> ([Lovelace] -> split)
   -> ToUTxOList era split
   -> FundToStoreList m                --inline to ToUTxOList
-  -> ExceptT TxGenError m (Tx era)
-sourceToStoreTransaction txGenerator inputFunds inToOut mkTxOut fundToStore = do
-  -- 'getFundLovelace' unwraps the 'TxOutValue' in a fund field so it's
-  -- all just 'Lovelace' instead of a copruduct maintaining distinctions.
-  (outputs, toFunds) <- fmap mkTxOut . inToOut $ map getFundLovelace inputFunds
-  (tx, txId) <- except $ txGenerator inputFunds outputs
-  lift . fundToStore $ toFunds txId
-  return tx
+  -> m (Either TxGenError (Tx era))
+sourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore =
+  fundSource >>= either (return . Left) go
+ where
+  go inputFunds = do
+    let
+      -- 'getFundLovelace' unwraps the 'TxOutValue' in a fund field
+      -- so it's all just 'Lovelace' instead of a coproduct
+      -- maintaining distinctions.
+      outValues = inToOut $ map getFundLovelace inputFunds
+      (outputs, toFunds) = mkTxOut outValues
+    case txGenerator inputFunds outputs of
+        Left err -> return $ Left err
+        Right (tx, txId) -> do
+          fundToStore $ toFunds txId
+          return $ Right tx
 
 -- | 'sourceToStoreTransactionNew' builds a new transaction out of
--- several things. 'Cardano.Benchmarking.Script.Core.evalGenerator' in
--- "Cardano.Benchmarking.Script.Core" is the sole caller.
+-- several things. 'Cardano.Benchmarking.Script.Core.evalGenerator'
+-- in "Cardano.Benchmarking.Script.Core" is the sole caller.
 -- @txGenerator@ is just 'genTx' partially applied in every use.
 -- @inputFunds@ for this is a list of 'Lovelace' with some extra
 -- fields to throw away and coproducts maintaining distinctions that
@@ -86,48 +92,59 @@ sourceToStoreTransaction txGenerator inputFunds inToOut mkTxOut fundToStore = do
 sourceToStoreTransactionNew ::
      Monad m
   => TxGenerator era
-  -> [Fund]
-  -> ([Lovelace] -> ExceptT TxGenError m split)
+  -> FundSource m
+  -> ([Lovelace] -> split)
   -> CreateAndStoreList m era split
-  -> ExceptT TxGenError m (Tx era)
-sourceToStoreTransactionNew txGenerator inputFunds valueSplitter toStore = do
-  (outputs, storeAction) <- fmap toStore . valueSplitter $ map getFundLovelace inputFunds
-  (tx, txId) <- except $ txGenerator inputFunds outputs
-  lift $ storeAction txId
-  return tx
+  -> m (Either TxGenError (Tx era))
+sourceToStoreTransactionNew txGenerator fundSource valueSplitter toStore =
+  fundSource >>= either (return . Left) go
+ where
+  go inputFunds = do
+    let
+      split = valueSplitter $ map getFundLovelace inputFunds
+      (outputs, storeAction) = toStore split
+    case txGenerator inputFunds outputs of
+        Left err -> return $ Left err
+        Right (tx, txId) -> do
+          storeAction txId
+          return $ Right tx
 
 -- | 'sourceTransactionPreview' is only used at one point in
 -- 'Cardano.Benchmarking.Script.Core.evalGenerator' within
 -- "Cardano.Benchmarking.Script.Core" to generate a hopefully pure
 -- transaction to examine.
--- This only constructs a preview of a transaction not intended to be
--- submitted. Funds remain unchanged by dint of a different method
--- of wallet access.
--- @txGenerator@ is the same 'genTx' partial application passed to other
--- functions here.
+-- This only constructs a preview of a transaction not intended
+-- to be submitted. Funds remain unchanged by dint of a different
+-- method of wallet access.
+-- @txGenerator@ is the same 'genTx' partial application passed
+-- to other functions here.
 -- @inputFunds@ for this is a list of 'Lovelace' with some extra
 -- fields to throw away and coproducts maintaining distinctions that
--- don't matter to these functions. This is the only argument that differs
--- from 'sourceToStoreTransactionNew', being drawn from a use of
--- 'Cardano.Benchmarking.Wallet.walletPreview'.
--- @valueSplitter@ is just 'Cardano.TxGenerator.Utils.inputsToOutputsWithFee'
--- at the sole use, with the same variable for monad lifting etc. as
--- the other companion functions.
+-- don't matter to these functions. This is the only argument that
+-- differs -- from 'sourceToStoreTransactionNew', being drawn from
+-- a use of 'Cardano.Benchmarking.Wallet.walletPreview'.
+-- @valueSplitter@ is just
+-- 'Cardano.TxGenerator.Utils.inputsToOutputsWithFee'
+-- at the sole use, with the same variable for monad lifting
+-- etc. as the other companion functions.
 -- @toStore@ is just a partial application of
--- 'Cardano.Benchmarking.Wallet.mangle' at the sole use, with the same
--- expression involving the same function returned as a product of
--- 'Cardano.Benchmarking.Wallet.createAndStore' as the nearby invocation
--- of 'sourceToStoreTransactionNew' in "Cardano.Benchmarking.Script.Core".
+-- 'Cardano.Benchmarking.Wallet.mangle' at the sole use, with the
+-- same expression involving the same function returned as a
+-- product of 'Cardano.Benchmarking.Wallet.createAndStore' as the
+-- nearby invocation of 'sourceToStoreTransactionNew' in
+-- "Cardano.Benchmarking.Script.Core".
 sourceTransactionPreview ::
-  Monad m
-  => TxGenerator era
+     TxGenerator era
   -> [Fund]
-  -> ([Lovelace] -> ExceptT TxGenError m split)
+  -> ([Lovelace] -> split)
   -> CreateAndStoreList m era split
-  -> ExceptT TxGenError m (Tx era)
-sourceTransactionPreview txGenerator inputFunds valueSplitter toStore = do
-  (outputs, _) <- fmap toStore . valueSplitter $ map getFundLovelace inputFunds
-  fmap fst . except $ txGenerator inputFunds outputs
+  -> Either TxGenError (Tx era)
+sourceTransactionPreview txGenerator inputFunds valueSplitter toStore =
+  second fst $
+    txGenerator inputFunds outputs
+ where
+  split         = valueSplitter $ map getFundLovelace inputFunds
+  (outputs, _)  = toStore split
 
 -- | 'genTx' seems to mostly be a wrapper for
 -- 'Cardano.Api.TxBody.createAndValidateTransactionBody', which uses
@@ -149,13 +166,12 @@ genTx :: forall era. ()
   -> TxMetadataInEra era
   -> TxGenerator era
 genTx _era protocolParameters (collateral, collFunds) fee metadata inFunds outputs
-  -- This use of 'Data.Bifunctor.bimap` lifts the error type to 'Env.Error'
-  -- at the same time as it adds a signature to the transaction body and
-  -- fetches the transaction ID from it too.
-  = ApiError `bimap` (\b -> (signShelleyTransaction b allKeys, getTxId b))
-        $ createAndValidateTransactionBody txBodyContent
+  = bimap
+      ApiError
+      (\b -> (signShelleyTransaction b $ map WitnessPaymentKey allKeys, getTxId b))
+      (createAndValidateTransactionBody txBodyContent)
  where
-  allKeys = mapMaybe (fmap WitnessPaymentKey . getFundKey) $ inFunds ++ collFunds
+  allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
   txBodyContent = defaultTxBodyContent
     & setTxIns (map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds)
     & setTxInsCollateral collateral

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -11,7 +11,6 @@ module  Cardano.TxGenerator.Utils
         (module Cardano.TxGenerator.Utils)
         where
 
-import           Control.Monad.Trans.Except (ExceptT, throwE)
 import           Data.Maybe (fromJust)
 
 import           Cardano.Api as Api
@@ -39,25 +38,13 @@ keyAddress networkId k
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress
 
--- TODO: old TODO comment also said to check minimumValuePerUtxo
--- A different variable may need to be consulted now.
--- | 'inputsToOutputsWithFee' is what actually does the division
--- for 'Cardano.Benchmarking.Script.Env.SplitN', but the result
--- may not be positive if the fee exceeds the total. If so, an
--- exception is thrown, but the normal exception types risk
--- circular imports, so this ended up using a string and expects
--- callers to use 'Control.Monad.Trans.Except.withExceptT' to put
--- the strings inside of tagged data structures.
-inputsToOutputsWithFee :: Monad m => Lovelace -> Int -> [Lovelace] -> ExceptT String m [Lovelace]
-inputsToOutputsWithFee fee count inputs =
-  if total < fee then throwE $ "inputsToOutputs: insufficient funds "
-                               ++ show total ++ " < " ++ show fee
-                 else return . map (quantityToLovelace . Quantity)
-                             $ (out + rest) : replicate (count-1) out
+-- TODO: check sufficient funds and minimumValuePerUtxo
+inputsToOutputsWithFee :: Lovelace -> Int -> [Lovelace] -> [Lovelace]
+inputsToOutputsWithFee fee count inputs = map (quantityToLovelace . Quantity) outputs
   where
-    total = sum inputs
-    Quantity totalAvailable = lovelaceToQuantity $ total - fee
+    (Quantity totalAvailable) = lovelaceToQuantity $ sum inputs - fee
     (out, rest) = divMod totalAvailable (fromIntegral count)
+    outputs = (out + rest) : replicate (count-1) out
 
 -- | 'includeChange' gets use made of it as a value splitter in
 -- 'Cardano.TxGenerator.Tx.sourceToStoreTransactionNew' by


### PR DESCRIPTION
# Description

Federico found some anomalies in transaction logs that I believe would be resolved with this change. The cleanup can probably wait. A TODO asked for some functions to be converted to being monadic. The testing procedures done at the time it was written didn't catch what ended up getting found recently. The reverted change didn't introduce any new functionality. The work primarily centred around preserving comments while doing it.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.