### PR TITLE
Run release-ghcr.yaml also on stable and pre-releases publish

### DIFF
--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - '**'
+  # GITHUB_SHA: Last commit in the tagged release
+  # GITHUB_REF: Tag ref of release refs/tags/<tag_name>
+  release:
+    types:
+      - published
+  # GITHUB_SHA: Last commit on the GITHUB_REF branch or tag
+  # GITHUB_REF: Branch or tag that received dispatch
+  workflow_dispatch: {}
 
 env:
   # Only to avoid some repetition


### PR DESCRIPTION
As title says.

```
  # GITHUB_SHA: Last commit in the tagged release
  # GITHUB_REF: Tag ref of release refs/tags/<tag_name>
  release:
    types:
      - published
  # GITHUB_SHA: Last commit on the GITHUB_REF branch or tag
  # GITHUB_REF: Branch or tag that received dispatch
  workflow_dispatch: {}
```

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release for details.
