### PR TITLE
Shutdown stdoutThread gracefully

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/LogTypes.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/LogTypes.hs
@@ -61,6 +61,7 @@ data BenchTracers =
   , btConnect_    :: Tracer IO SendRecvConnect
   , btSubmission2_:: Tracer IO SendRecvTxSubmission2
   , btN2N_        :: Tracer IO NodeToNodeSubmissionTrace
+  , btShutdown    :: IO ()
   }
 
 data TraceBenchTxSubmit txid

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -75,4 +75,5 @@ startProtocol configFile tracerSocket = do
     tracerSocket' = (,,) iomgr networkId `fmap` tracerSocket
 
   setEnvNetworkId networkId
+  getBenchTracers >>= liftIO . shutdownTxGenTracers
   liftIO (initTxGenTracers tracerSocket') >>= setBenchTracers

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -86,7 +86,9 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
     EKG.registerGcMetrics ekgStore
     ekgTrace <- ekgTracer (Left ekgStore)
 
-    stdoutTrace <- standardTracer
+    -- We don't shutdown the trace layer in the node so we can ignore the
+    -- shutdown action
+    (stdoutTrace, _shutdown) <- standardTracer
 
     -- We should initialize forwarding only if 'Forwarder' backend
     -- is presented in the node's configuration.

--- a/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
+++ b/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
@@ -171,7 +171,7 @@ stderrTracer =
 
 mkTracerTracer :: SeverityF -> IO (Trace IO TracerTrace)
 mkTracerTracer defSeverity = do
-  base     :: Trace IO FormattedMessage <- standardTracer
+  (base     :: Trace IO FormattedMessage, _) <- standardTracer
   metaBase :: Trace IO TracerTrace      <-
     machineFormatter Nothing base
     >>= withDetailsFromConfig


### PR DESCRIPTION
# Description

Instead of silencing a `BlockedIndefinitelyOnMVar`, this PR makes sure the thread listening in the stdoutTracer thread exits gracefully.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated.  These may include:~
- [ ] ~Any changes are noted in the `CHANGELOG.md` for affected package~ (internal change)
- [ ] ~The version bounds in `.cabal` files are updated~ (N/A)
- [ ] CI passes. See note on CI.  The following CI checks are required:
- [x] Self-reviewed the diff