### PR TITLE
Workbench | locli: analysis improvements and fixes

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   locli
-version:                1.30
+version:                1.31
 synopsis:               Cardano log analysis CLI
 description:            Cardano log analysis CLI.
 category:               Cardano,

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -113,6 +113,7 @@ library
                       , file-embed
                       , filepath
                       , fingertree
+                      , hashable
                       , ghc
                       , gnuplot
                       , iohk-monitoring

--- a/bench/locli/src/Cardano/Analysis/API/Context.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Context.hs
@@ -9,7 +9,7 @@ import Cardano.Prelude
 import Control.Monad (fail)
 
 import Data.Aeson ( FromJSON (..), ToJSON (..), Value
-                  , withObject, object, (.:), (.:?), (.=))
+                  , withObject, object, (.:), (.:?), (.=), (.!=))
 import Data.Aeson.Key qualified as AE
 import Data.Aeson.KeyMap qualified as AE
 import Data.Aeson.Types qualified as AE
@@ -108,7 +108,7 @@ unknownComponent ciName = ComponentInfo
 instance FromJSON ComponentInfo where
   parseJSON = withObject "Component" $ \v -> do
     ciName    <- v .: "name"
-    ciCommit  <- v .: "commit"
+    ciCommit  <- v .:? "commit" .!= Commit "unknown"      -- workaround for commit hash missing from manifest
     ciBranch  <- v .:? "branch"
     ciStatus  <- v .:? "status"
     ciVersion <- v .: "version"

--- a/bench/locli/src/Cardano/Analysis/MachPerf.hs
+++ b/bench/locli/src/Cardano/Analysis/MachPerf.hs
@@ -41,7 +41,7 @@ timelineFromLogObjects run@Run{genesis} (f, xs') =
   $ foldl' (timelineStep run f) zeroTimelineAccum xs
   & (aRunScalars &&& reverse . aSlotStats)
  where
-   xs = filter ((/= "DecodeError") . loKind) xs'
+   xs = filter (not . (`textRefEquals` "DecodeError") . loKind) xs'
 
    firstRelevantLogObjectTime :: UTCTime
    firstRelevantLogObjectTime = loAt (head xs) `max` systemStart genesis

--- a/bench/locli/src/Cardano/Analysis/Summary.hs
+++ b/bench/locli/src/Cardano/Analysis/Summary.hs
@@ -172,16 +172,20 @@ computeSummary sumAnalysisTime
  where
    cdfLogLineRate       = cdf stdCentiles lineRates
 
+   hostLogs =
+    rlHostLogs
+    & Map.elems
+
    (,) logObjectsEmitted textLinesEmitted =
-     rlHostLogs
-     & Map.toList
-     & fmap ((hlRawLogObjects &&& hlRawLines) . snd)
+     hostLogs
+     & fmap (hlRawLogObjects &&& hlRawLines)
      & unzip
+
    objLists = rlLogs rl <&> snd
 
    losFirsts, losLasts :: [UTCTime]
-   losFirsts  = objLists <&> loAt . Prelude.head
-   losLasts   = objLists <&> loAt . Prelude.last
+   losFirsts  = hostLogs <&> (\HostLogs{hlLogs, hlRawFirstAt} -> fromMaybe (loAt $ Prelude.head $ snd hlLogs) hlRawFirstAt)
+   losLasts   = hostLogs <&> (\HostLogs{hlLogs, hlRawLastAt}  -> fromMaybe (loAt $ Prelude.last $ snd hlLogs) hlRawLastAt)
    runtimes :: [NominalDiffTime]
    runtimes   = zipWith diffUTCTime losLasts losFirsts
    lineRates  = zipWith (/) (textLinesEmitted <&> fromIntegral)

--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -25,6 +25,7 @@ module Cardano.Unlog.LogObject
   , logObjectStreamInterpreterKeys
   , LOBody (..)
   , LOAnyType (..)
+  , readLogObjectStream
   , textRefEquals
   )
 where
@@ -65,6 +66,7 @@ data TextRef
   deriving Generic
   deriving anyclass NFData
 
+{-# NOINLINE lookupTextRef #-}
 lookupTextRef :: Int -> Text
 lookupTextRef ref = Map.findWithDefault Text.empty ref dict
   where

--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -114,6 +114,8 @@ data HostLogs a
     , hlLogs           :: (JsonLogfile, a)
     , hlFilteredSha256 :: Hash
     , hlProfile        :: [ProfileEntry I]
+    , hlRawFirstAt     :: Maybe UTCTime
+    , hlRawLastAt      :: Maybe UTCTime
     }
   deriving (Generic)
 

--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -25,6 +25,7 @@ module Cardano.Unlog.LogObject
   , logObjectStreamInterpreterKeys
   , LOBody (..)
   , LOAnyType (..)
+  , textRefEquals
   )
 where
 
@@ -36,6 +37,7 @@ import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Hashable (hash)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as LText
 import           Data.Text.Short (ShortText, fromText, toText)
@@ -53,6 +55,53 @@ import           Cardano.Util
 
 
 type Text = ShortText
+
+-- | Us of the a TextRef replaces commonly expected string parses with references
+--   into a Map, reducing memory footprint - given that large runs can contain
+--   >25mio log objects.
+data TextRef
+    = TextRef {-# UNPACK #-} !Int
+    | TextLit {-# UNPACK #-} !Text
+  deriving Generic
+  deriving anyclass NFData
+
+lookupTextRef :: Int -> Text
+lookupTextRef ref = Map.findWithDefault Text.empty ref dict
+  where
+    dict    = Map.fromList [(hash t, t) | t <- concat [allKeys, kinds, legacy]]
+    kinds   = map ("Cardano.Node." <>) allKeys
+    legacy  = map ("cardano.node." <>)
+      [ "BlockFetchClient"
+      , "BlockFetchServer"
+      , "ChainDB"
+      , "ChainSyncClient"
+      , "ChainSyncHeaderServer"
+      , "DnsSubscription"
+      , "Forge"
+      , "IpSubscription"
+      , "LeadershipCheck"
+      , "Mempool"
+      , "resources"
+      , "TxInbound"
+      ]
+    allKeys =
+      concatMap Map.keys [fst3 interpreters, snd3 interpreters, thd3 interpreters]
+      & filter (not . Text.null)
+
+toTextRef :: Text -> TextRef
+toTextRef t = let h = hash t in if Text.null (lookupTextRef h) then TextLit t else TextRef h
+
+textRefEquals :: TextRef -> Text -> Bool
+textRefEquals (TextRef i) = (== lookupTextRef i)
+textRefEquals (TextLit t) = (== t)
+
+instance Show TextRef where
+  show (TextRef i) = show $ lookupTextRef i
+  show (TextLit t) = show t
+
+instance ToJSON TextRef where
+  toJSON (TextRef i) = toJSON $ lookupTextRef i
+  toJSON (TextLit t) = toJSON t
 
 -- | Input data.
 data HostLogs a
@@ -128,7 +177,7 @@ readLogObjectStream f okDErr loAnyLimit =
     fmap (\bs ->
             AE.eitherDecode bs &
             either
-            (LogObject zeroUTCTime "Cardano.Analysis.DecodeError" "DecodeError" "" (TId "0")
+            (LogObject zeroUTCTime (TextLit "Cardano.Analysis.DecodeError") (TextLit "DecodeError") "" (TId "0")
              . LODecodeError (Text.fromByteString (LBS.toStrict bs)
                                & fromMaybe "#<ERROR decoding input fromByteString>")
               . Text.fromText
@@ -143,8 +192,8 @@ readLogObjectStream f okDErr loAnyLimit =
 data LogObject
   = LogObject
     { loAt   :: !UTCTime
-    , loNS   :: !Text
-    , loKind :: !Text
+    , loNS   :: !TextRef
+    , loKind :: !TextRef
     , loHost :: !Host
     , loTid  :: !TId
     , loBody :: !LOBody
@@ -348,6 +397,8 @@ interpreters = map3ple Map.fromList . unzip3 . fmap ent $
    map3ple :: (a -> b) -> (a,a,a) -> (b,b,b)
    map3ple f (x,y,z) = (f x, f y, f z)
 
+
+
 logObjectStreamInterpreterKeysLegacy, logObjectStreamInterpreterKeys :: [Text]
 logObjectStreamInterpreterKeysLegacy =
   logObjectStreamInterpreterKeysLegacy1 <> logObjectStreamInterpreterKeysLegacy2
@@ -457,8 +508,8 @@ instance FromJSON LogObject where
                  "The 'ns' field must be either a string, or a singleton-String vector, was: " <> show x
     LogObject
       <$> v .: "at"
-      <*> pure ns
-      <*> pure kind
+      <*> pure (toTextRef ns)
+      <*> pure (toTextRef kind)
       <*> v .: "host"
       <*> v .: "thread"
       <*> case Map.lookup  ns                                       (thd3 interpreters)

--- a/nix/workbench/analyse/analyse.sh
+++ b/nix/workbench/analyse/analyse.sh
@@ -572,8 +572,6 @@ EOF
         then remanifest_reasons+=("$(red logs modified after manifest)")
         fi
 
-        echo $(ls 2>/dev/null --sort=time $dir/node-*/*.json $dir/node-*/stdout $run_logs)
-
         if test ${#remanifest_reasons[*]} = 0
         then progress "analyse" "log manifest exists and is up to date"
         else progress "analyse" "assembling log manifest:  ${remanifest_reasons[*]}"
@@ -623,6 +621,13 @@ EOF
 
                  done
                  wait
+
+                 for mach in $(jq_tolist '.rlHostLogs | keys' $run_logs)
+                 do jq_fmutate "$run_logs" '
+                      .rlHostLogs["'"$mach"'"].hlRawFirstAt = '"$(cat $adir/logs-$mach.flt.json | head -n1 | jq .at)"'
+                    | .rlHostLogs["'"$mach"'"].hlRawLastAt  = '"$(cat $adir/logs-$mach.flt.json | tail -n1 | jq .at)"'
+                    '
+                 done
              }
         fi
 

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -116,6 +116,7 @@ in project.shellFor {
     ghc-prof-flamegraph
     sqlite-interactive
     tmux
+    pkgs.cairo
     pkgs.git
     pkgs.hlint
     pkgs.moreutils


### PR DESCRIPTION
# Description

Various improvements and fixes to P&T's analysis pipeline:
* Ability to work on truncated logs from runs exceeding expected duration
* Change of log object in-memory representation to lower RAM footprint
* Add a timeline of forges and header fetches for early detection of missing forger events
* Fix calculation of host log line rate for truncated logs
* Fix redundant re-manifesting of consolidated logs
* Fix parsing an incomplete build manifest
* Add `cairo` to workbench shell (build dependency of `beacon`)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
