### PR TITLE
nix: workbench tracing configuration

### DIFF
--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -358,11 +358,11 @@ interpreters = map3ple Map.fromList . unzip3 . fmap ent $
   , (,,,) "TraceBenchTxSubServAck" "TraceBenchTxSubServAck" "TraceBenchTxSubServAck" $
     \v -> LOTxsAcked <$> v .: "txIds"
 
-  , (,,,) "TraceTxSubmissionCollected" "TraceTxSubmissionCollected" "TraceTxSubmissionCollected" $
+  , (,,,) "TraceTxSubmissionCollected" "TraceTxSubmissionCollected" "TxSubmission.TxInbound.Collected" $
     \v -> LOTxsCollected
             <$> v .: "count"
 
-  , (,,,) "TraceTxSubmissionProcessed" "TraceTxSubmissionProcessed" "TraceTxSubmissionProcessed" $
+  , (,,,) "TraceTxSubmissionProcessed" "TraceTxSubmissionProcessed" "TxSubmission.TxInbound.Processed" $
     \v -> LOTxsProcessed
             <$> v .: "accepted"
             <*> v .: "rejected"
@@ -381,7 +381,7 @@ interpreters = map3ple Map.fromList . unzip3 . fmap ent $
     \_ -> pure LOMempoolRejectedTx
 
   -- Generator:
-  , (,,,) "TraceBenchTxSubSummary" "TraceBenchTxSubSummary" "TraceBenchTxSubSummary" $
+  , (,,,) "TraceBenchTxSubSummary" "TraceBenchTxSubSummary" "Benchmark.BenchTxSubSummary" $
     \v -> do
        x :: Object <- v .: "summary"
        LOGeneratorSummary

--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -95,10 +95,10 @@ initTxGenTracers mbForwarding = do
         configureTracers confState initialTraceConfig [tracer]
         pure $ Tracer (traceWith tracer)
 
-  benchTracer@(Tracer traceBench) <- mkTracer "benchmark"
-  n2nSubmitTracer <- mkTracer "submitN2N"
-  connectTracer <- mkTracer "connect"
-  submitTracer <- mkTracer "submit"
+  benchTracer@(Tracer traceBench) <- mkTracer "Benchmark"
+  n2nSubmitTracer <- mkTracer "SubmitN2N"
+  connectTracer <- mkTracer "Connect"
+  submitTracer <- mkTracer "Submit"
 
   traceBench $ TraceTxGeneratorVersion Version.txGeneratorVersion
 
@@ -112,8 +112,9 @@ initTxGenTracers mbForwarding = do
   prepareForwardingTracer :: IO (Maybe (Trace IO FormattedMessage))
   prepareForwardingTracer = forM mbForwarding $
     \(iomgr, networkId, tracerSocket) -> do
+        let forwardingConf = fromMaybe defaultForwarder (tcForwarder initialTraceConfig)
         (forwardSink :: ForwardSink TraceObject, dpStore) <-
-          initForwarding iomgr (tcForwarder initialTraceConfig) (toNetworkMagic networkId) Nothing $ Just (tracerSocket, Initiator)
+          initForwarding iomgr forwardingConf (toNetworkMagic networkId) Nothing $ Just (tracerSocket, Initiator)
 
         -- we need to provide NodeInfo DataPoint, to forward generator's name
         -- to the acceptor application (for example, 'cardano-tracer').
@@ -161,7 +162,7 @@ initialTraceConfig = TraceConfig {
           , setMaxDetail "connect"
           , setMaxDetail "submit"
           ]
-    , tcForwarder = defaultForwarder
+    , tcForwarder = Just defaultForwarder
     , tcNodeName = Nothing
     , tcPeerFrequency = Just 2000 -- Every 2 seconds
     , tcResourceFrequency = Just 1000 -- Every second
@@ -278,7 +279,7 @@ instance MetaTrace (TraceBenchTxSubmit TxId) where
     namespaceFor TraceBenchTxSubServCons {} = Namespace [] ["BenchTxSubServCons"]
     namespaceFor TraceBenchTxSubIdle {} = Namespace [] ["BenchTxSubIdle"]
     namespaceFor TraceBenchTxSubRateLimit {} = Namespace [] ["BenchTxSubRateLimit"]
-    namespaceFor TraceBenchTxSubSummary {} = Namespace [] ["eBenchTxSubSummary"]
+    namespaceFor TraceBenchTxSubSummary {} = Namespace [] ["BenchTxSubSummary"]
     namespaceFor TraceBenchTxSubDebug {} = Namespace [] ["BenchTxSubDebug"]
     namespaceFor TraceBenchTxSubError {} = Namespace [] ["BenchTxSubError"]
     namespaceFor TraceBenchPlutusBudgetSummary {} = Namespace [] ["BenchPlutusBudgetSummary"]
@@ -301,7 +302,7 @@ instance MetaTrace (TraceBenchTxSubmit TxId) where
         , Namespace [] ["BenchTxSubServCons"]
         , Namespace [] ["BenchTxSubIdle"]
         , Namespace [] ["BenchTxSubRateLimit"]
-        , Namespace [] ["eBenchTxSubSummary"]
+        , Namespace [] ["BenchTxSubSummary"]
         , Namespace [] ["BenchTxSubDebug"]
         , Namespace [] ["BenchTxSubError"]
         , Namespace [] ["BenchPlutusBudgetSummary"]

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -95,7 +95,8 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode = do
           -- TODO: check if this is the correct way to use withIOManager
           (forwardSink, dpStore) <- withIOManager $ \iomgr -> do
             let tracerSocketMode = Just . first unFile =<< ncTraceForwardSocket nc
-            initForwarding iomgr (tcForwarder trConfig) networkMagic (Just ekgStore) tracerSocketMode
+                forwardingConf = fromMaybe defaultForwarder (tcForwarder trConfig)
+            initForwarding iomgr forwardingConf networkMagic (Just ekgStore) tracerSocketMode
           pure (forwardTracer forwardSink, dataPointTracer dpStore)
         else
           -- Since 'Forwarder' backend isn't enabled, there is no forwarding.

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -217,7 +217,7 @@ getAllNamespaces =
         blockFetchServerNS = map (nsGetComplete . nsReplacePrefix ["BlockFetch", "Server"])
                     (allNamespaces :: [Namespace (TraceBlockFetchServerEvent blk)])
 
-        forgeKESInfoNS = map (nsGetComplete . nsReplacePrefix ["Forge"])
+        forgeKESInfoNS = map (nsGetComplete . nsReplacePrefix ["Forge", "StateInfo"])
                     (allNamespaces :: [Namespace (Consensus.TraceLabelCreds HotKey.KESInfo)])
         txInboundNS = map (nsGetComplete . nsReplacePrefix ["TxSubmission", "TxInbound"])
                         (allNamespaces :: [Namespace (BlockFetch.TraceLabelPeer
@@ -236,14 +236,7 @@ getAllNamespaces =
         forgeNS = map (nsGetComplete . nsReplacePrefix ["Forge", "Loop"])
                         (allNamespaces :: [Namespace (ForgeTracerType blk)])
 
-    -- TODO YUP
-    -- forgeTr' <-  mkCardanoTracer'
-    --             trBase trForward mbTrEKG
-    --             ["Forge", "ThreadStats"]
-    --             forgeThreadStats
-    -- configureTracers configReflection trConfig [forgeTr']
-    -- forgeThreadStatsTrDoc <- documentTracer' forgeThreadStats (forgeTr' ::
-    --   Trace IO (ForgeTracerType blk))
+        forgeStateNS = [["Forge", "StateInfo"]]
 
         blockchainTimeNS = map (nsGetComplete . nsReplacePrefix  ["BlockchainTime"])
                         (allNamespaces :: [Namespace (TraceBlockchainTimeEvent RelativeTime)])
@@ -380,7 +373,7 @@ getAllNamespaces =
                                 (allNamespaces :: [Namespace
                                   (InboundGovernorTrace Socket.SockAddr)])
         inboundGovernorTransitionsNS = map (nsGetComplete . nsReplacePrefix
-                                      ["Net", "InboundGovernor", "Remote", "Transition"])
+                                      ["Net", "InboundGovernor", "Transition"])
                                            (allNamespaces :: [Namespace
                                       (InboundGovernor.RemoteTransitionTrace Socket.SockAddr)])
         localConnectionManagerNS = map (nsGetComplete . nsReplacePrefix
@@ -449,7 +442,7 @@ getAllNamespaces =
             <> localTxSubmissionServerNS
             <> mempoolNS
             <> forgeNS
---            <> forgeThreadStatsNS
+            <> forgeStateNS
             <> blockchainTimeNS
 -- NodeToClient
             <> keepAliveClientNS

--- a/cardano-node/src/Cardano/Node/Tracing/DefaultTraceConfig.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/DefaultTraceConfig.hs
@@ -36,8 +36,8 @@ defaultCardanoConfig = emptyTraceConfig {
          [ ConfSeverity (SeverityF (Just Info))])
     ,(["Forge", "Loop"],
          [ ConfSeverity (SeverityF (Just Info))])
---     ,(["Forge", "KESInfo"],
---          [ ConfSeverity (SeverityF (Just Info))])
+    ,(["Forge", "StateInfo"],
+         [ ConfSeverity (SeverityF (Just Info))])
     ,(["Net", "InboundGovernor", "Remote"],
          [ ConfSeverity (SeverityF (Just Info))])
         -- includes ["Net", "InboundGovernor", "Remote", "Transition"]
@@ -54,18 +54,18 @@ defaultCardanoConfig = emptyTraceConfig {
     ,(["Resources"],
          [ ConfSeverity (SeverityF (Just Info))])
 
--- Limiters
-    ,(["ChainDB","AddBlockEvent","AddedBlockToQueue"],
-         [ ConfLimiter 2.0])
-    ,(["ChainDB","AddBlockEvent","AddedBlockToVolatileDB"],
-         [ ConfLimiter 2.0])
-    ,(["ChainDB","AddBlockEvent","AddBlockValidation", "ValidCandidate"],
-         [ ConfLimiter 2.0])
-    ,(["ChainDB", "CopyToImmutableDBEvent", "CopiedBlockToImmutableDB"],
-         [ ConfLimiter 2.0])
-    ,(["ChainSync","Client","DownloadedHeader"],
-         [ ConfLimiter 2.0])
-    ,(["BlockFetch", "Client", "CompletedBlockFetch"],
-        [ ConfLimiter 2.0])
+--     Limiters
+     ,(["ChainDB","AddBlockEvent","AddedBlockToQueue"],
+          [ ConfLimiter 2.0])
+     ,(["ChainDB","AddBlockEvent","AddedBlockToVolatileDB"],
+          [ ConfLimiter 2.0])
+     ,(["ChainDB","AddBlockEvent","AddBlockValidation", "ValidCandidate"],
+          [ ConfLimiter 2.0])
+     ,(["ChainDB", "CopyToImmutableDBEvent", "CopiedBlockToImmutableDB"],
+          [ ConfLimiter 2.0])
+     ,(["ChainSync","Client","DownloadedHeader"],
+          [ ConfLimiter 2.0])
+     ,(["BlockFetch", "Client", "CompletedBlockFetch"],
+          [ ConfLimiter 2.0])
     ]
   }

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -297,7 +297,7 @@ docTracers configFileName outputFileName _ _ _ = do
 
     forgeKESInfoTr  <- mkCardanoTracer
                 trBase trForward mbTrEKG
-                ["Forge"]
+                ["Forge", "StateInfo"]
     configureTracers configReflection trConfig [forgeKESInfoTr]
     forgeKESInfoTrDoc <- documentTracer (forgeKESInfoTr ::
       Trace IO (Consensus.TraceLabelCreds HotKey.KESInfo))
@@ -585,7 +585,7 @@ docTracers configFileName outputFileName _ _ _ = do
 
     inboundGovernorTransitionsTr  <-  mkCardanoTracer
       trBase trForward mbTrEKG
-      ["Net", "InboundGovernor", "Remote", "Transition"]
+      ["Net", "InboundGovernor", "Transition"]
     configureTracers configReflection trConfig [inboundGovernorTransitionsTr]
     inboundGovernorTransitionsTrDoc <- documentTracer (inboundGovernorTransitionsTr ::
        Trace IO (InboundGovernor.RemoteTransitionTrace Socket.SockAddr))

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -257,7 +257,7 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
 
     !forgeKESInfoTr  <- mkCardanoTracer
                 trBase trForward mbTrEKG
-                ["Forge"]
+                ["Forge", "StateInfo"]
     configureTracers configReflection trConfig [forgeKESInfoTr]
 
     !txInboundTr  <- mkCardanoTracer
@@ -548,7 +548,7 @@ mkDiffusionTracersExtra configReflection trBase trForward mbTrEKG _trDataPoint t
 
     !connectionManagerTransitionsTr  <-  mkCardanoTracer
       trBase trForward mbTrEKG
-      ["Net", "ConnectionManager", "Remote"]
+      ["Net", "ConnectionManager", "Transition"]
     configureTracers configReflection trConfig [connectionManagerTransitionsTr]
 
     !serverTr  <-  mkCardanoTracer

--- a/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
+++ b/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
@@ -186,7 +186,7 @@ mkTracerTracer defSeverity = do
    initialTraceConfig :: TraceConfig
    initialTraceConfig =
      TraceConfig
-     { tcForwarder         = defaultForwarder
+     { tcForwarder         = Nothing
      , tcNodeName          = Nothing
      , tcPeerFrequency     = Nothing
      , tcResourceFrequency = Nothing

--- a/cardano-tracer/test/cardano-tracer-test-ext.hs
+++ b/cardano-tracer/test/cardano-tracer-test-ext.hs
@@ -12,7 +12,7 @@ import qualified Data.List as L
 import           Data.Maybe (fromMaybe)
 import           Data.Monoid
 import qualified System.Directory as Sys
-import           System.Environment (setEnv, unsetEnv, lookupEnv)
+import           System.Environment (lookupEnv, setEnv, unsetEnv)
 import qualified System.IO as Sys
 import           System.PosixCompat.Files (fileExist)
 import qualified System.Process as Sys
@@ -128,5 +128,6 @@ getExternalTracerState TestSetup{..} ref = do
        -- For simplicity, we are always 'Initiator',
        -- so 'cardano-tracer' is always a 'Responder'.
        let tracerSocketMode = Just (unI tsSockExternal, Initiator)
-       initForwarding iomgr (tcForwarder simpleTestConfig) (unI tsNetworkMagic) Nothing tracerSocketMode
+           forwardingConf = fromMaybe defaultForwarder (tcForwarder simpleTestConfig)
+       initForwarding iomgr forwardingConf (unI tsNetworkMagic) Nothing tracerSocketMode
      pure (externalTracerHdl, forwardTracer forwardSink)

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -27,55 +27,70 @@ let
                  "Forwarder";
         };
 
-      ## These are comparision-specific config deviations from the default.
-      ##
-      ## "Resources".backends = ["EKGBackend"];
-
-      "Net.AcceptPolicy".severity = "Info";
-      "BlockFetch.Client".severity = "Info";
-      "BlockFetch.Server".severity = "Info";
-      "ChainDB".severity = "Info";
-      "ChainSync.Client".severity = "Info";
-      "ChainSync.ServerBlock".severity = "Info";
-      "ChainSync.ServerHeader".severity = "Info";
-      "Forge.Loop".severity = "Info";
-      "Net.ConnectionManager".severity = "Info";
-      "Net.Startup.DiffusionInit".severity = "Info";
-      "Net.DNSResolver".severity = "Info";
-      "Net.ErrorPolicy".severity = "Info";
-      "Net.InboundGovernor".severity = "Info";
-      "Net.Subscription.DNS".severity = "Info";
-      "Net.Subscription.IP".severity = "Info";
-      "Net.Peers".severity = "Info";
-      "Net.PeerSelection".severity = "Info";
-      "Net.Server".severity = "Info";
-      "Mempool".severity = "Info";
-      "Resources".severity= "Info";
-      "TxSubmission.TxInbound".severity = "Info";
-
-      "ChainDB.FollowerEvent.NewFollower".severity = "Debug";
-      "ChainDB.FollowerEvent.FollowerNoLongerInMem".severity = "Debug";
-      "ChainDB.AddBlockEvent.AddedBlockToQueue".severity = "Debug";
-      "ChainDB.IteratorEvent.StreamFromVolatileDB".severity = "Debug";
-      "ChainDB.GCEvent.PerformedGC".severity = "Debug";
-      "ChainDB.GCEvent.ScheduledGC".severity = "Debug";
-      "ChainDB.ImmDbEvent.CacheEvent.CurrentChunkHit".severity = "Debug";
-      "ChainDB.ImmDbEvent.CacheEvent.PastChunkHit".severity = "Debug";
-      "Forge.Loop.BlockContext".severity = "Debug";
-      "Forge.Loop.LedgerState".severity = "Debug";
-      "Forge.Loop.LedgerView".severity = "Debug";
-      "Forge.Loop.ForgingMempoolSnapshot".severity = "Debug";
-      "Forge.Loop.ForgeTickedLedgerState".severity = "Debug";
-      "TxSubmission.TxInbound.CanRequestMoreTxs".severity = "Debug";
-      "TxSubmission.TxInbound.CannotRequestMoreTxs".severity = "Debug";
-      "TxSubmission.TxInbound.Collected".severity = "Debug";
-      "TxSubmission.TxInbound.Processed".severity = "Debug";
+      ## This is a list with all tracers, adopted to the on and off state
+      ## in old tracing
+      "BlockFetch.Client".severity = "Debug";
+      "BlockFetch.Decision".severity = "Notice";
+      "BlockFetch.Remote".severity = "Notice";
+      "BlockFetch.Remote.Serialised".severity = "Notice";
+      "BlockFetch.Server".severity = "Debug";
+      "BlockchainTime".severity = "Notice";
+      "ChainDB".severity = "Debug";
+      "ChainDB.ReplayBlock.LedgerReplay".severity = "Notice";
+      "ChainSync.Client".severity = "Debug";
+      "ChainSync.Local".severity = "Notice";
+      "ChainSync.Remote".severity = "Notice";
+      "ChainSync.Remote.Serialised".severity = "Notice";
+      "ChainSync.ServerBlock".severity = "Notice";
+      "ChainSync.ServerHeader".severity = "Debug";
+      "Forge.Loop".severity = "Debug";
+      "Forge.StateInfo".severity = "Debug";
+      "Mempool".severity = "Debug";
+      "Net".severity = "Notice";
+      "Net.AcceptPolicy".severity = "Debug";
+      "Net.ConnectionManager.Local".severity = "Debug";
+      "Net.ConnectionManager.Remote".severity = "Debug";
+      "Net.DNSResolver".severity = "Notice";
+      "Net.ErrorPolicy.Local".severity = "Debug";
+      "Net.ErrorPolicy.Remote".severity = "Debug";
+      "Net.Handshake.Local".severity = "Debug";
+      "Net.Handshake.Remote".severity = "Debug";
+      "Net.InboundGovernor.Local".severity = "Debug";
+      "Net.InboundGovernor.Remote".severity = "Debug";
+      "Net.InboundGovernor.Transition".severity = "Debug";
+      "Net.Mux.Local".severity = "Notice";
+      "Net.Mux.Remote".severity = "Notice";
+      "Net.PeerSelection.Actions".severity = "Debug";
+      "Net.PeerSelection.Counters".severity = "Debug";
+      "Net.PeerSelection.Initiator".severity = "Notice";
+      "Net.PeerSelection.Responder".severity = "Notice";
+      "Net.PeerSelection.Selection".severity = "Debug";
+      "Net.Peers.Ledger".severity = "Debug";
+      "Net.Peers.List".severity = "Notice";
+      "Net.Peers.LocalRoot".severity = "Debug";
+      "Net.Peers.PublicRoot".severity = "Debug";
+      "Net.Server.Local".severity = "Debug";
+      "Net.Server.Remote".severity = "Debug";
+      "Net.Subscription.DNS".severity = "Debug";
+      "Net.Subscription.IP".severity = "Debug";
+      "NodeState".severity = "Notice";
+      "Resources".severity = "Debug";
+      "Shutdown".severity = "Notice";
+      "Startup".severity = "Notice";
+      "Startup.DiffusionInit".severity = "Debug";
+      "StateQueryServer".severity = "Notice";
+      "TxSubmission.Local".severity = "Notice";
+      "TxSubmission.LocalServer".severity = "Notice";
+      "TxSubmission.MonitorClient".severity = "Notice";
+      "TxSubmission.Remote".severity = "Notice";
+      "TxSubmission.TxInbound".severity = "Debug";
+      "TxSubmission.TxOutbound".severity = "Notice";
 
       "TraceBenchTxSubServAck".severity = "Debug";
       "TraceBenchTxSubSummary".severity = "Debug";
       "TraceTxSubmissionCollected".severity = "Debug";
       "TraceTxSubmissionProcessed".severity = "Debug";
-    };
+      };
   };
 
 

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -85,11 +85,6 @@ let
       "TxSubmission.Remote".severity = "Notice";
       "TxSubmission.TxInbound".severity = "Debug";
       "TxSubmission.TxOutbound".severity = "Notice";
-
-      "TraceBenchTxSubServAck".severity = "Debug";
-      "TraceBenchTxSubSummary".severity = "Debug";
-      "TraceTxSubmissionCollected".severity = "Debug";
-      "TraceTxSubmissionProcessed".severity = "Debug";
       };
   };
 

--- a/trace-dispatcher/examples/Examples/Configuration.hs
+++ b/trace-dispatcher/examples/Examples/Configuration.hs
@@ -48,7 +48,7 @@ config1 = TraceConfig {
           , (["tracer2","TestMessage"], [ConfSeverity (SeverityF (Just Critical))])
           , (["tracer3","TestMessage"], [ConfSeverity (SeverityF (Just Info))])
           ]
-    , tcForwarder = TraceOptionForwarder {
+    , tcForwarder = Just TraceOptionForwarder {
         tofConnQueueSize = 100
       , tofDisconnQueueSize = 1000
       , tofVerbosity = Minimum
@@ -65,7 +65,7 @@ config2 = TraceConfig {
         , (["tracer2","TestMessage"], [ConfSeverity (SeverityF (Just Warning))])
         , (["tracer3","TestMessage"], [ConfSeverity (SeverityF (Just Warning))])
         ]
-    , tcForwarder = TraceOptionForwarder {
+    , tcForwarder = Just TraceOptionForwarder {
         tofConnQueueSize = 100
       , tofDisconnQueueSize = 1000
       , tofVerbosity = Minimum

--- a/trace-dispatcher/examples/Examples/Documentation.hs
+++ b/trace-dispatcher/examples/Examples/Documentation.hs
@@ -47,7 +47,7 @@ config1 = TraceConfig {
           [ ([], [ConfSeverity (SeverityF Nothing)])
           , (["node2"], [ConfSeverity (SeverityF (Just Info))])
           ]
-    , tcForwarder = TraceOptionForwarder {
+    , tcForwarder = Just TraceOptionForwarder {
         tofConnQueueSize = 100
       , tofDisconnQueueSize = 1000
       , tofVerbosity = Minimum

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -442,7 +442,7 @@ data TraceConfig = TraceConfig {
      -- | Options specific to a certain namespace
     tcOptions   :: Map.Map [Text] [ConfigOption]
      -- | Options for the forwarder
-  , tcForwarder :: TraceOptionForwarder
+  , tcForwarder :: Maybe TraceOptionForwarder
     -- | Optional human-readable name of the node.
   , tcNodeName  :: Maybe Text
     -- | Optional peer trace frequency in milliseconds.
@@ -455,7 +455,7 @@ data TraceConfig = TraceConfig {
 emptyTraceConfig :: TraceConfig
 emptyTraceConfig = TraceConfig {
     tcOptions = Map.empty
-  , tcForwarder = defaultForwarder
+  , tcForwarder = Nothing
   , tcNodeName = Nothing
   , tcPeerFrequency = Just 2000 -- Every 2 seconds
   , tcResourceFrequency = Just 5000 -- Every five seconds


### PR DESCRIPTION
A configuration for new tracing, comparable to old tracing for benchmarks. 
In addition:
* Namespace fixes for locli
* Forwarder config changes
* Namespace fixes for: Forge.StateInfo and Net.Inbound.Governor.Transition
* No merging of TraceOption configuration. The default is picked, when the TraceOptions are empty
