### PR TITLE
Use new QueryFootprint parameter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 54105aac98596d94be805d608a60294d74e2c710
-  --sha256: 1ijfrg3161w8fzd4aqsvp2jdx0vcbbdl7h6v38h8r4ifg151384p
+  tag: b081836c84301167d2e5038ecf92fdb6a8408c06
+  --sha256: 04cpvyl0l9gqczw4f3wpl50gmwihhiqpvfpf1q9x0gjy66gcx4my
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol
@@ -81,7 +81,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: be0635fd2b4b28c7f2554120a924a4b31f17e01c
-  --sha256: 007cyw7wm0fd5cj3vxyz8r3v1hwra1rk0ksp4yqqs0f1ssbl6gxd
+  tag: edbde1e63139add04905ce313eed668e596a2f91
+  --sha256: 0dffz6w5pwjf4zqgznfaqcdc7qvg6gjbq2jq6f6g82nkqdsvwq18
   subdir:
     cardano-api

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -175,7 +175,7 @@ docTracers :: forall blk peer remotePeer.
   , Show peer
   , Show (ForgeStateUpdateError blk)
   , Show (CannotForge blk)
-  , ShowQuery (BlockQuery blk)
+  , forall fp. ShowQuery (BlockQuery blk fp)
   )
   => FilePath
   -> FilePath

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -595,7 +595,7 @@ instance (applyTxErr ~ ApplyTxErr blk, ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalTxSubmission (GenTx blk) applyTxErr))) where
   trTransformer = trStructured
 
-instance (LocalStateQuery.ShowQuery (BlockQuery blk), ToObject localPeer)
+instance (forall fp. LocalStateQuery.ShowQuery (BlockQuery blk fp), ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk)))) where
   trTransformer = trStructured
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -1340,7 +1340,7 @@ forgeStateInfoTracer p _ts tracer = Tracer $ \ev -> do
 
 nodeToClientTracers'
   :: ( ToObject localPeer
-     , ShowQuery (BlockQuery blk)
+     , forall fp. ShowQuery (BlockQuery blk fp)
      )
   => TraceSelection
   -> TracingVerbosity


### PR DESCRIPTION
# Description

Part of input-output-hk/ouroboros-consensus#205

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
