### PR TITLE
Update mkfiles.sh

### DIFF
--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -35,7 +35,7 @@ CARDANO_CLI="${CARDANO_CLI:-cardano-cli}"
 NETWORK_MAGIC=42
 SECURITY_PARAM=10
 NUM_SPO_NODES=3
-INIT_SUPPLY=10020000000
+INIT_SUPPLY=12000000
 START_TIME="$(${DATE} -d "now + 30 seconds" +%s)"
 ROOT=example
 mkdir -p "${ROOT}"
@@ -109,8 +109,8 @@ $SED -i "${ROOT}/configuration.yaml" \
 $CARDANO_CLI genesis create-staked --genesis-dir "${ROOT}" \
   --testnet-magic "${NETWORK_MAGIC}" \
   --gen-pools 3 \
-  --supply 1000000000000 \
-  --supply-delegated 1000000000000 \
+  --supply 2000000000000 \
+  --supply-delegated 240000000002 \
   --gen-stake-delegs 3 \
   --gen-utxo-keys 3
 
@@ -141,7 +141,7 @@ rm "${ROOT}/genesis/byron/genesis-wrong.json"
 
 cp "${ROOT}/genesis/shelley/genesis.json" "${ROOT}/genesis/shelley/copy-genesis.json"
 
-jq -M '. + {slotLength:0.1, securityParam:10, activeSlotsCoeff:0.1, securityParam:10, epochLength:500, maxLovelaceSupply:1000000000000, updateQuorum:2}' "${ROOT}/genesis/shelley/copy-genesis.json" > "${ROOT}/genesis/shelley/copy2-genesis.json"
+jq -M '. + {slotLength:0.1, securityParam:10, activeSlotsCoeff:0.1, securityParam:10, epochLength:500, maxLovelaceSupply:10000000000000, updateQuorum:2}' "${ROOT}/genesis/shelley/copy-genesis.json" > "${ROOT}/genesis/shelley/copy2-genesis.json"
 jq --raw-output '.protocolParams.protocolVersion.major = 7 | .protocolParams.minFeeA = 44 | .protocolParams.minFeeB = 155381 | .protocolParams.minUTxOValue = 1000000 | .protocolParams.decentralisationParam = 0.7 | .protocolParams.rho = 0.1 | .protocolParams.tau = 0.1' "${ROOT}/genesis/shelley/copy2-genesis.json" > "${ROOT}/genesis/shelley/genesis.json"
 
 rm "${ROOT}/genesis/shelley/copy2-genesis.json"


### PR DESCRIPTION
# Description

Update mkfiles.sh

The current setting on the mkfiles.sh produce a network with negative reserves; therefore as epochs advance the treasury grows negatively making it impossible to test some features. 

With this change the network starts with positive Reserves of 8159987999998 lovelace (8.159M ADA) and a max supply of 10000000000000 lovelace (10M ADA)

```
    "stateBefore": {
        "esAccountState": {
            "treasury": 0,
            "reserves": 8159987999998
```
The initial utxo distribution looks like this 

```
cardano-cli query utxo --whole-utxo --testnet-magic 42
                           TxHash                                 TxIx        Amount
--------------------------------------------------------------------------------------
14127af8533854b2a6d841121324f43f8d7aee8a36334dc8bafe442bff8dcd79     0        13333333334 lovelace + TxOutDatumNone
5ee1eb06aed5d773bac1fdfab4ad9941aa687a38970b665b2a31824bafc1c88f     0        600000000000 lovelace + TxOutDatumNone
776a293a7bb2cca8c22ca5e9633844910c6086417393efb7b61a4b1bc40f56ca     0        4000000 lovelace + TxOutDatumNone
8a93d258846c5e412095456f3ec56be58c435adc43bab9a33caf9762e130fd64     0        13333333334 lovelace + TxOutDatumNone
9b586d28a56381cda1bf38db3187c50c32c811d454e7cb99c42a745b16409b6f     0        600000000000 lovelace + TxOutDatumNone
ae2cd567f2eeee61982a393f6ee0de3583cc2b862f2652285500f8fa3f94ccf0     0        4000000 lovelace + TxOutDatumNone
ec470423fa7412db414265909c603cb2adb1aadb0b6e65483c9055e81796c5e2     0        600000000000 lovelace + TxOutDatumNone
f720ce5173b5750b35685dee3f65b4b18f596daa3b9269a4aafd980996d31236     0        4000000 lovelace + TxOutDatumNone
fc3cf3cc652f76bcc7add573c3a5466538db061d084dd21e0af5f244d56a7882     0        13333333334 lovelace + TxOutDatumNone
```

where 

* Genesis addresses hold 4 ADA each
* Delegated addresses hold 13333333334 (13,333 ADA) each. Note that these keys are not written down to disk, therefore they are not accessible for the user, this is why we are limiting the initial amount that goes to these keys. 
* Utxo keys (not delegated at the start of the system) each holds 600k ADA



 
