### PR TITLE
cardano-node: reduce orphan instances

### DIFF
--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -12,7 +12,6 @@ import           Data.Aeson.Types
 import qualified Data.Text as Text
 
 import           Cardano.BM.Data.Tracer (TracingVerbosity (..))
-import qualified Cardano.Chain.Update as Update
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
@@ -33,12 +32,6 @@ deriving instance Show TracingVerbosity
 
 instance PrintfArg SizeInBytes where
     formatArg (SizeInBytes s) = formatArg s
-
-instance FromJSON Update.ApplicationName where
-  parseJSON (String x) = pure $ Update.ApplicationName x
-  parseJSON invalid  =
-    fail $ "Parsing of application name failed due to type mismatch. "
-    <> "Encountered: " <> show invalid
 
 instance ToJSON AcceptedConnectionsLimit where
   toJSON AcceptedConnectionsLimit


### PR DESCRIPTION
Contributes to fixing https://github.com/input-output-hk/cardano-node/issues/5470

# Description

This PR starts reducing the content of the `Cardano.Node.Orphans` module.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff