### PR TITLE
workbench | tx-generator: updated reporting and tracing detail

### DIFF
--- a/bench/locli/src/Cardano/Analysis/API/Context.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Context.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Cardano.Analysis.API.Context (module Cardano.Analysis.API.Context) where
@@ -98,9 +100,10 @@ data GeneratorProfile
 
 plutusLoopScript :: GeneratorProfile -> Maybe Text
 plutusLoopScript GeneratorProfile{plutusMode, plutusAutoMode, plutus}
-  | fromMaybe False
-      ((&&) <$> plutusAutoMode <*> plutusMode)  = Just $ T.pack "Loop"
-  | otherwise                                   = ppScript `fmap` plutus
+  | Just True <- (&&) <$> plutusAutoMode <*> plutusMode
+    = Just "Loop"
+  | otherwise
+    = ppScript `fmap` plutus
 
 
 newtype Commit   = Commit  { unCommit  :: Text } deriving newtype (Eq, Show, FromJSON, ToJSON, NFData)

--- a/bench/locli/src/Cardano/Analysis/API/Metrics.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Metrics.hs
@@ -114,7 +114,7 @@ instance (KnownCDF f) => TimelineFields (Summary f)  where
       "Transaction count"
       "Number of transactions prepared for submission, but not necessarily submitted"
 
-   <> fScalar "plutusScript"           Wno Id  (IText  $ T.pack.fromMaybe "---".plutusLoopScript.sumWorkload)
+   <> fScalar "plutusScript"           Wno Id  (IText  $ fromMaybe "---".plutusLoopScript.sumWorkload)
       "Plutus script"
       "Name of th Plutus script used for smart contract workload generation, if any"
 

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script.hs
@@ -12,6 +12,7 @@ import           Prelude
 import           Control.Concurrent (threadDelay)
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           System.Mem (performGC)
 
 import           Ouroboros.Network.NodeToClient (IOManager)
 
@@ -24,22 +25,27 @@ import           Cardano.Benchmarking.Script.Types
 type Script = [Action]
 
 runScript :: Script -> IOManager -> IO (Either Error ())
-runScript script iom = runActionM execScript iom >>= \case
-  (Right a  , s ,  ()) -> do
-    cleanup s shutDownLogging
-    threadDelay 10_000_000
-    return $ Right a
-  (Left err , s  , ()) -> do
-    cleanup s (traceError (show err) >> shutDownLogging)
-    threadDelay 10_000_000
-    return $ Left err
- where
-  cleanup s a = void $ runActionMEnv s a iom
-  execScript = do
-    setProtocolParameters QueryLocalNode
-    forM_ script action
+runScript script iom = do
+  result <- go
+  performGC
+  threadDelay $ 150 * 1_000
+  return result
+  where
+    go = runActionM execScript iom >>= \case
+      (Right a  , s ,  ()) -> do
+        cleanup s shutDownLogging
+        return $ Right a
+      (Left err , s  , ()) -> do
+        cleanup s (traceError (show err) >> shutDownLogging)
+        return $ Left err
+      where
+        cleanup s a = void $ runActionMEnv s a iom
+
+        execScript = do
+          setProtocolParameters QueryLocalNode
+          forM_ script action
 
 shutDownLogging :: ActionM ()
 shutDownLogging = do
   traceError "QRT Last Message. LoggingLayer going to shutdown. 73 . . . ."
-  liftIO $ threadDelay (200 * 1_000)
+  liftIO $ threadDelay $ 350 * 1_000

--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -50,6 +51,15 @@ import           Cardano.Node.Startup
 import           Cardano.Benchmarking.LogTypes
 import           Cardano.Benchmarking.Types
 import           Cardano.Benchmarking.Version as Version
+
+pattern TracerNameBench     :: Text
+pattern TracerNameBench     = "Benchmark"
+pattern TracerNameSubmit    :: Text
+pattern TracerNameSubmit    = "Submit"
+pattern TracerNameSubmitN2N :: Text
+pattern TracerNameSubmitN2N = "SubmitN2N"
+pattern TracerNameConnect   :: Text
+pattern TracerNameConnect   = "Connect"
 
 generatorTracer ::
      (LogFormatting a, MetaTrace a)
@@ -97,10 +107,10 @@ initTxGenTracers mbForwarding = do
         configureTracers confState initialTraceConfig [tracer]
         pure tracer
 
-  benchTracer <- mkTracer "Benchmark" mbStdoutTracer mbForwardingTracer
-  n2nSubmitTracer <- mkTracer "SubmitN2N" mbStdoutTracer mbForwardingTracer
-  connectTracer <- mkTracer "Connect" mbStdoutTracer mbForwardingTracer
-  submitTracer <- mkTracer "Submit" mbStdoutTracer mbForwardingTracer
+  benchTracer     <- mkTracer TracerNameBench     mbStdoutTracer mbForwardingTracer
+  n2nSubmitTracer <- mkTracer TracerNameSubmitN2N mbStdoutTracer mbForwardingTracer
+  connectTracer   <- mkTracer TracerNameConnect   mbStdoutTracer mbForwardingTracer
+  submitTracer    <- mkTracer TracerNameSubmit    mbStdoutTracer mbForwardingTracer
 
   traceWith benchTracer (TraceTxGeneratorVersion Version.txGeneratorVersion)
 
@@ -159,10 +169,10 @@ initialTraceConfig :: TraceConfig
 initialTraceConfig = TraceConfig {
       tcOptions = Map.fromList
           [ ([], [configSilent])
-          , setMaxDetail "benchmark"
-          , (["submitN2N"], [configSilent])
-          , setMaxDetail "connect"
-          , setMaxDetail "submit"
+          , setMaxDetail TracerNameBench
+          , ([TracerNameSubmitN2N], [configSilent])
+          , setMaxDetail TracerNameConnect
+          , setMaxDetail TracerNameSubmit
           ]
     , tcForwarder = Just defaultForwarder
     , tcNodeName = Nothing

--- a/nix/workbench/ede/report.ede
+++ b/nix/workbench/ede/report.ede
@@ -9,10 +9,9 @@
 #+latex_header: \usepackage{setspace}
 #+latex_header: \onehalfspacing
 #+LATEX_COMPILER: xelatex
-#+EXPORT_FILE_NAME: {{ report.tag }}.{{ base.workload }}.pdf
+#+EXPORT_FILE_NAME: {{ report.tag }}.{{ base.fileInfix }}.pdf
 #+TITLE: {{ report.target }} against {{ base.ver }}
 #+SUBTITLE: {{ base.workload }} workload
-#+SUBTITLE: \break\small{revision} ={{ report.revision }}=
 #+AUTHOR: {{ report.author }}, Cardano Performance team
 #+DATE: {{ report.date }}
 
@@ -35,12 +34,9 @@ Hints:
 
 *** Manifest
 
-We compare {% for run in runs %}{%if !run.first%}{%if !run.last%}, {%else%} and {%endif%}{%endif%}{{ run.value.ver }}/{{ run.value.meta.era | toTitle }}{% endfor %} relative to ={{ base.ver }}=/{{ base.meta.era | toTitle }}, under {{ base.workload }} workload.
+We compare {% for run in runs %}{%if !run.first%}{%if !run.last%}, {%else%} and {%endif%}{%endif%}={{ run.value.ver }}= ({{ run.value.meta.era | toTitle }}){% endfor %} relative to ={{ base.ver }}= ({{ base.meta.era | toTitle }}), under {{ base.workload }} workload.
 
 {% include "table.ede" with table = summary %}
-
-***** Revision history
-      - rev 1, {{ report.date }}:  initial release
 
 *** Analysis
 {% for sec in analyses %}
@@ -65,9 +61,7 @@ We compare {% for run in runs %}{%if !run.first%}{%if !run.last%}, {%else%} and 
 
 ***** End-to-end propagation
 
-...
-
-@Kevin Hammond, @neil, @jared.corduan, @Damian, @nfrisby, @Jasagredo, @marcin, @Javier Franco, @carlos.lopezdelara, @disasm
+1. ...
 
 * Appendix A: charts
 


### PR DESCRIPTION
# Description

This PR
* updates reporting template(s)
* restores classifying the workload type in a downward-compatible manner
* changes `tx-generator` shutdown logic, which could sometimes result in an unjustified exit code 1 due to timing
* restores detail level of `tx-generator` trace messages

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff