### PR TITLE
Remove some workarounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -100,9 +100,6 @@ write-ghc-environment-files: always
 package snap-server
   flags: +openssl
 
-package bitvec
-   flags: -simd
-
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -263,13 +263,6 @@ let
                   export WORKDIR=$TMP/testTracerExt
               '';
             })
-          ({ lib, pkgs, ... }: lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin) {
-            # Needed for profiled builds to fix an issue loading recursion-schemes part of makeBaseFunctor
-            # that is missing from the `_p` output.  See https://gitlab.haskell.org/ghc/ghc/-/issues/18320
-            # This work around currently breaks regular builds on macOS with:
-            # <no location info>: error: ghc: ghc-iserv terminated (-11)
-            packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
-          })
           ({ lib, ... }: {
             options.packages = lib.mkOption {
               type = lib.types.attrsOf (lib.types.submodule (


### PR DESCRIPTION
# Description

The simd issue seems to only appear when using the external interpreter. We are only using the external interpereter for `plutus-core` in order to work around a weird profiling issue. The weird profiling issue seems to be gone, so we can just delete both workarounds.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff
