### PR TITLE
Allow overriding of cardano-node binary path in `mkfiles.sh`

### DIFF
--- a/scripts/babbage/mkfiles.sh
+++ b/scripts/babbage/mkfiles.sh
@@ -231,26 +231,29 @@ EOF
 
 
 for NODE in ${SPO_NODES}; do
-  (
-    echo "#!/usr/bin/env bash"
-    echo ""
-    echo "cardano-node run \\"
-    echo "  --config                          '${ROOT}/configuration.yaml' \\"
-    echo "  --topology                        '${ROOT}/${NODE}/topology.json' \\"
-    echo "  --database-path                   '${ROOT}/${NODE}/db' \\"
-    echo "  --socket-path                     '$(sprocket "${ROOT}/${NODE}/node.sock")' \\"
-    echo "  --shelley-kes-key                 '${ROOT}/${NODE}/kes.skey' \\"
-    echo "  --shelley-vrf-key                 '${ROOT}/${NODE}/vrf.skey' \\"
-    echo "  --byron-delegation-certificate    '${ROOT}/${NODE}/byron-delegation.cert' \\"
-    echo "  --byron-signing-key               '${ROOT}/${NODE}/byron-delegate.key' \\"
-    echo "  --shelley-operational-certificate '${ROOT}/${NODE}/opcert.cert' \\"
-    echo "  --port                            $(cat "${ROOT}/${NODE}/port") \\"
-    echo "  | tee -a '${ROOT}/${NODE}/node.log'"
-  ) > "${ROOT}/${NODE}.sh"
+  RUN_FILE="${ROOT}/${NODE}.sh"
+  cat << EOF > "${RUN_FILE}"
+#!/usr/bin/env bash
 
-  chmod a+x "${ROOT}/${NODE}.sh"
+CARDANO_NODE="\${CARDANO_NODE:-cardano-node}"
 
-  echo "${ROOT}/${NODE}.sh"
+\$CARDANO_NODE run \\
+  --config                          '${ROOT}/configuration.yaml' \\
+  --topology                        '${ROOT}/${NODE}/topology.json' \\
+  --database-path                   '${ROOT}/${NODE}/db' \\
+  --socket-path                     '$(sprocket "${ROOT}/${NODE}/node.sock")' \\
+  --shelley-kes-key                 '${ROOT}/${NODE}/kes.skey' \\
+  --shelley-vrf-key                 '${ROOT}/${NODE}/vrf.skey' \\
+  --byron-delegation-certificate    '${ROOT}/${NODE}/byron-delegation.cert' \\
+  --byron-signing-key               '${ROOT}/${NODE}/byron-delegate.key' \\
+  --shelley-operational-certificate '${ROOT}/${NODE}/opcert.cert' \\
+  --port                            $(cat "${ROOT}/${NODE}/port") \\
+  | tee -a '${ROOT}/${NODE}/node.log'
+EOF
+
+  chmod a+x "${RUN_FILE}"
+
+  echo "${RUN_FILE}"
 done
 
 mkdir -p "${ROOT}/run"


### PR DESCRIPTION
# Description

This change allows overriding of `cardano-node` binary path (in addition to `cardano-cli`).

Sample usage:
```bash
CARDANO_CLI=/home/mgalazyn/workspace/iohk/dist-newstyle/build/x86_64-linux/ghc-9.2.8/cardano-cli-8.9.0.0/x/cardano-cli/noopt/build/cardano-cli/cardano-cli \
  ./scripts/babbage/mkfiles.sh
CARDANO_NODE=/home/mgalazyn/workspace/iohk/dist-newstyle/build/x86_64-linux/ghc-9.2.8/cardano-node-8.4.0/x/cardano-node/noopt/build/cardano-node/cardano-node \
  ./example/run/all.sh
```


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
