### PR TITLE
workbench: fixes bug that could deploy incorrect topology files

### DIFF
--- a/nix/workbench/topology/topology.jq
+++ b/nix/workbench/topology/topology.jq
@@ -1,6 +1,7 @@
 def loopback_node_topology_from_nixops_topology($topo; $i):
-    $topo.coreNodes[$i].producers                      as $producers
-  | ($producers | map(ltrimstr("node-") | fromjson))   as $prod_indices
+    # DON'T ASSUME ANY ORDER INSIDE THE GLOBAL TOPOLOGY FILE!!!!!!!!!!!!!!!!!!!!
+    ($topo.coreNodes | map(select(.nodeId == $i)) | .[0] | .producers) as $producers
+  | ($producers | map(ltrimstr("node-") | fromjson))                   as $prod_indices
   | { Producers:
       ( $prod_indices
         | map


### PR DESCRIPTION
Inside the workbench (does not affect cardano-ops runs), individual nodes' topology files may be swapped. AFAIK this only affects profiles with different regions, all "loopback" regions profiles are not affected