### PR TITLE
bin-path.sh: be more user friendly

### DIFF
--- a/scripts/bin-path.sh
+++ b/scripts/bin-path.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
+#
+# Find the path to the built executable in the cabal plan. For example:
+#
+# ./scripts/bin-path.sh cardano-node
+#
+# Must be executed from the repository root
 
-# Find the path to the built executable in the cabal plan.
+if [[ -z "$1" ]]
+then
+  echo "This script expects exactly one argument: the name of the executable whose path is searched for."
+  echo "For example pass \"cardano-node\""
+  exit 1
+fi
+
+[[ -e "scripts" ]] || { echo "This script must be executed from the repository's root (i.e. execute ./scripts/bin-path.sh)"; exit 1; }
 
 exe="$1"
 


### PR DESCRIPTION
# Description

This PR makes `./scripts/bin-path.sh` a bit more user-friendly, by providing error messages if used erroneously.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA Any changes are noted in the `CHANGELOG.md` for affected package
- NA The version bounds in `.cabal` files are updated
- [X] CI passes.
- [X] Self-reviewed the diff