### PR TITLE
Trace full `SelectView` when changing chain (including tiebreaker VRF)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -56,3 +56,11 @@ package bitvec
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
 -- `smtp-mail` should depend on `crypton-connection` rather than `connection`!
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  tag: 1b150eb4e30965fb66dd9d2d26053175ca4cea06
+  --sha256: 1l4762121lj6z69i2crvgyk3svfx61nnxigz2d622pqvaiwzx0jp
+  subdir:
+    ouroboros-consensus

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, HasTxId
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                    (HasNetworkProtocolVersion (BlockNodeToClientVersion, BlockNodeToNodeVersion))
 import           Ouroboros.Consensus.Node.Run (RunNode, SerialiseNodeToNodeConstraints)
-import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
 
 import           Ouroboros.Network.Block (Serialised)
@@ -53,6 +53,7 @@ type TraceConstraints blk =
     , ToObject (LedgerError blk)
     , ToObject (LedgerEvent blk)
     , ToObject (OtherHeaderEnvelopeError blk)
+    , ToObject (SelectView (BlockProtocol blk))
     , ToObject (ValidationErr (BlockProtocol blk))
     , ToObject (CannotForge blk)
     , ToObject (ForgeStateUpdateError blk)
@@ -67,6 +68,7 @@ type TraceConstraints blk =
     , LogFormatting (LedgerUpdate blk)
     , LogFormatting (LedgerWarning blk)
     , LogFormatting (OtherHeaderEnvelopeError blk)
+    , LogFormatting (SelectView (BlockProtocol blk))
     , LogFormatting (ValidationErr (BlockProtocol blk))
     , LogFormatting (CannotForge blk)
     , LogFormatting (ForgeStateUpdateError blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
@@ -25,11 +25,13 @@ import qualified Data.Text as Text
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
+import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..),
                    ByronOtherHeaderEnvelopeError (..), TxId (..), byronHeaderRaw)
 import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..),
                    ProtocolUpdate (..), UpdateState (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
+import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Cardano.Api (textShow)
@@ -212,4 +214,12 @@ instance LogFormatting ByronOtherHeaderEnvelopeError where
     mconcat
       [ "kind" .= String "UnexpectedEBBInSlot"
       , "slot" .= slot
+      ]
+
+instance LogFormatting PBftSelectView where
+  forMachine _dtal (PBftSelectView blkNo isEBB) =
+    mconcat
+      [ "kind" .= String "PBftSelectView"
+      , "blockNo" .= blkNo
+      , "isEBB" .= fromIsEBB isEBB
       ]

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -240,7 +240,7 @@ traceNodeStateChainDB _scp tr ev =
         _ -> return ()
     ChainDB.TraceAddBlockEvent ev' ->
       case ev' of
-        ChainDB.AddedToCurrentChain _ (ChainDB.NewTipInfo currentTip ntEpoch sInEpoch _) _ _ -> do
+        ChainDB.AddedToCurrentChain _ (ChainDB.SelectionChangedInfo currentTip ntEpoch sInEpoch _ _ _) _ _ -> do
           -- The slot of the latest block consumed (our progress).
           let RP.RealPoint ourSlotSinceSystemStart _ = currentTip
           -- The slot corresponding to the latest wall-clock time (our target).

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -487,18 +487,18 @@ instance ( LogFormatting (Header blk)
   forMachine dtal (ChainDB.PipeliningEvent ev') =
     forMachine dtal ev'
 
-  asMetrics (ChainDB.SwitchedToAFork _warnings newTipInfo _oldChain newChain) =
+  asMetrics (ChainDB.SwitchedToAFork _warnings selChangedInfo _oldChain newChain) =
     let ChainInformation { slots, blocks, density, epoch, slotInEpoch } =
-          chainInformation newTipInfo newChain 0
+          chainInformation selChangedInfo newChain 0
     in  [ DoubleM "ChainDB.Density" (fromRational density)
         , IntM    "ChainDB.SlotNum" (fromIntegral slots)
         , IntM    "ChainDB.BlockNum" (fromIntegral blocks)
         , IntM    "ChainDB.SlotInEpoch" (fromIntegral slotInEpoch)
         , IntM    "ChainDB.Epoch" (fromIntegral (unEpochNo epoch))
         ]
-  asMetrics (ChainDB.AddedToCurrentChain _warnings newTipInfo _oldChain newChain) =
+  asMetrics (ChainDB.AddedToCurrentChain _warnings selChangedInfo _oldChain newChain) =
     let ChainInformation { slots, blocks, density, epoch, slotInEpoch } =
-          chainInformation newTipInfo newChain 0
+          chainInformation selChangedInfo newChain 0
     in  [ DoubleM "ChainDB.Density" (fromRational density)
         , IntM    "ChainDB.SlotNum" (fromIntegral slots)
         , IntM    "ChainDB.BlockNum" (fromIntegral blocks)
@@ -2013,16 +2013,16 @@ data ChainInformation = ChainInformation
 
 chainInformation
   :: forall blk. HasHeader (Header blk)
-  => ChainDB.NewTipInfo blk
+  => ChainDB.SelectionChangedInfo blk
   -> AF.AnchoredFragment (Header blk)
   -> Int64
   -> ChainInformation
-chainInformation newTipInfo frag blocksUncoupledDelta = ChainInformation
+chainInformation selChangedInfo frag blocksUncoupledDelta = ChainInformation
     { slots = unSlotNo $ fromWithOrigin 0 (AF.headSlot frag)
     , blocks = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)
     , density = fragmentChainDensity frag
-    , epoch = ChainDB.newTipEpoch newTipInfo
-    , slotInEpoch = ChainDB.newTipSlotInEpoch newTipInfo
+    , epoch = ChainDB.newTipEpoch selChangedInfo
+    , slotInEpoch = ChainDB.newTipSlotInEpoch selChangedInfo
     , blocksUncoupledDelta = blocksUncoupledDelta
     }
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -24,12 +24,14 @@ import           Cardano.Tracing.Render (renderTxId)
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
+import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..), ByronNodeToClientVersion (..),
                    ByronNodeToNodeVersion (..), ByronOtherHeaderEnvelopeError (..), TxId (..),
                    byronHeaderRaw)
 import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..),
                    ProtocolUpdate (..), UpdateState (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
+import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
@@ -221,3 +223,11 @@ instance ToJSON ByronNodeToClientVersion where
 instance ToJSON ByronNodeToNodeVersion where
   toJSON ByronNodeToNodeVersion1 = String "ByronNodeToNodeVersion1"
   toJSON ByronNodeToNodeVersion2 = String "ByronNodeToNodeVersion2"
+
+instance ToObject PBftSelectView where
+  toObject _verb (PBftSelectView blkNo isEBB) =
+    mconcat
+      [ "kind" .= String "PBftSelectView"
+      , "blockNo" .= blkNo
+      , "isEBB" .= fromIsEBB isEBB
+      ]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -86,7 +86,7 @@ import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import           Ouroboros.Consensus.Node (NetworkP2PMode (..))
 import qualified Ouroboros.Consensus.Node.Run as Consensus (RunNode)
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
-import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Util.Enclose
 
@@ -513,6 +513,7 @@ teeTraceChainTip
      , InspectLedger blk
      , ToObject (Header blk)
      , ToObject (LedgerEvent blk)
+     , ToObject (SelectView (BlockProtocol blk))
      )
   => BlockConfig blk
   -> ForgingStats
@@ -536,6 +537,7 @@ teeTraceChainTipElide
      , InspectLedger blk
      , ToObject (Header blk)
      , ToObject (LedgerEvent blk)
+     , ToObject (SelectView (BlockProtocol blk))
      )
   => TracingVerbosity
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -567,12 +567,12 @@ traceChainMetrics (Just _ekgDirect) tForks _blockConfig _fStats tr = do
     chainTipInformation :: ChainDB.TraceEvent blk -> Maybe ChainInformation
     chainTipInformation = \case
       ChainDB.TraceAddBlockEvent ev -> case ev of
-        ChainDB.SwitchedToAFork _warnings newTipInfo oldChain newChain ->
+        ChainDB.SwitchedToAFork _warnings selChangedInfo oldChain newChain ->
           let fork = not $ AF.withinFragmentBounds (AF.headPoint oldChain)
                               newChain in
-          Just $ chainInformation newTipInfo fork oldChain newChain 0
-        ChainDB.AddedToCurrentChain _warnings newTipInfo oldChain newChain ->
-          Just $ chainInformation newTipInfo False oldChain newChain 0
+          Just $ chainInformation selChangedInfo fork oldChain newChain 0
+        ChainDB.AddedToCurrentChain _warnings selChangedInfo oldChain newChain ->
+          Just $ chainInformation selChangedInfo False oldChain newChain 0
         _ -> Nothing
       _ -> Nothing
 
@@ -1533,21 +1533,21 @@ chainInformation
   => HasHeader (Header blk)
   => HasIssuer blk
   => ConvertRawHash blk
-  => ChainDB.NewTipInfo blk
+  => ChainDB.SelectionChangedInfo blk
   -> Bool
   -> AF.AnchoredFragment (Header blk) -- ^ Old fragment.
   -> AF.AnchoredFragment (Header blk) -- ^ New fragment.
   -> Int64
   -> ChainInformation
-chainInformation newTipInfo fork oldFrag frag blocksUncoupledDelta = ChainInformation
+chainInformation selChangedInfo fork oldFrag frag blocksUncoupledDelta = ChainInformation
     { slots = unSlotNo $ fromWithOrigin 0 (AF.headSlot frag)
     , blocks = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)
     , density = fragmentChainDensity frag
-    , epoch = ChainDB.newTipEpoch newTipInfo
-    , slotInEpoch = ChainDB.newTipSlotInEpoch newTipInfo
+    , epoch = ChainDB.newTipEpoch selChangedInfo
+    , slotInEpoch = ChainDB.newTipSlotInEpoch selChangedInfo
     , blocksUncoupledDelta = blocksUncoupledDelta
     , fork = fork
-    , tipBlockHash = renderHeaderHash (Proxy @blk) $ realPointHash (ChainDB.newTipPoint newTipInfo)
+    , tipBlockHash = renderHeaderHash (Proxy @blk) $ realPointHash (ChainDB.newTipPoint selChangedInfo)
     , tipBlockParentHash = renderChainHash (Text.decodeLatin1 . B16.encode . toRawHash (Proxy @blk)) $ AF.headHash oldFrag
     , tipBlockIssuerVerificationKeyHash = tipIssuerVkHash
     }


### PR DESCRIPTION
# Description

Demo for integrating https://github.com/input-output-hk/ouroboros-consensus/pull/384 (and https://github.com/input-output-hk/ouroboros-consensus/pull/398) into the next node release (8.6).

These commits can be cherry-picked onto the 8.6 integration branch.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
