### PR TITLE
bench: Remove dependency on microlens

### DIFF
--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
@@ -8,15 +8,15 @@ module Cardano.TxGenerator.Setup.NodeConfig
        (module Cardano.TxGenerator.Setup.NodeConfig)
        where
 
+import           Control.Applicative (Const (Const), getConst)
 import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Bifunctor (first)
 import           Data.Monoid
-import           Lens.Micro ((^.))
 
 import qualified Ouroboros.Consensus.Cardano as Consensus
 
 import           Cardano.Api (BlockType (..), ProtocolInfoArgs (..))
-import qualified Cardano.Ledger.Api.Transition as Ledger
+import qualified Cardano.Ledger.Api.Transition as Ledger (tcShelleyGenesisL)
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Handlers.Shutdown (ShutdownConfig (..))
 import           Cardano.Node.Protocol.Cardano
@@ -32,7 +32,7 @@ import           Cardano.TxGenerator.Types
 -- as this guarantees proper error handling when trying to create a non-Cardano protocol.
 getGenesis :: SomeConsensusProtocol -> ShelleyGenesis
 getGenesis (SomeConsensusProtocol CardanoBlockType proto)
-    = transCfg ^. Ledger.tcShelleyGenesisL
+    = getConst $ Ledger.tcShelleyGenesisL Const transCfg
   where
     ProtocolInfoArgsCardano Consensus.CardanoProtocolParams
       { Consensus.ledgerTransitionConfig = transCfg

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -120,7 +120,6 @@ library
                       , generic-monoid
                       , ghc-prim
                       , io-classes
-                      , microlens
                       , mtl
                       , network
                       , network-mux


### PR DESCRIPTION
# Description
This just unfolds the definition of (^.) in terms of Control.Applicative.Const in order to evade the import of the Lens module and link to the microlens package. The lens getter appears to be the sole accessor from data abstraction techniques used i.e. the import and export of the Shelley TransitionConfig as an abstract type by Cardano.Ledger.Api.Transition, so the explicitness and readability of the dependency removal are unfortunately limited.

It is something of a cleanup and dependency reduction at the same time.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
    It's a single commit and very small change.
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
  New tests aren't needed.
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  This minor of a change may not be changelog-worthy; if otherwise, a line can be added.
- [X] The version bounds in `.cabal` files are updated
  This isn't relevant to this change.
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
    The CI checks have yet to run, though on my system, things are okay.
- [X] Self-reviewed the diff
    Review from others was sought also, partly because the way it was done was not entirely pretty.

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
