### PR TITLE
make tx-generator selftest arg optional

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
@@ -32,7 +32,7 @@ data Command
   = Json FilePath
   | JsonHL FilePath (Maybe FilePath) (Maybe FilePath)
   | Compile FilePath
-  | Selftest FilePath
+  | Selftest (Maybe FilePath)
   | VersionCmd
 
 runCommand :: IO ()
@@ -48,7 +48,7 @@ runCommand = withIOManager $ \iocp -> do
       opts <- parseJSONFile fromJSON file
       finalOpts <- mangleTracerConfig cardanoTracerOverwrite <$> mangleNodeConfig nodeConfigOverwrite opts
 
-      Prelude.putStrLn $ 
+      Prelude.putStrLn $
           "--> initial options:\n" ++ show opts ++
         "\n--> final options:\n" ++ show finalOpts
 
@@ -60,7 +60,7 @@ runCommand = withIOManager $ \iocp -> do
       case compileOptions o of
         Right script -> BSL.putStr $ prettyPrint script
         err -> handleError err
-    Selftest outFile -> runSelftest iocp (Just outFile) >>= handleError
+    Selftest outFile -> runSelftest iocp outFile >>= handleError
     VersionCmd -> runVersionCommand
   where
   handleError :: Show a => Either a b -> IO ()
@@ -103,7 +103,7 @@ commandParser
   compileCmd :: Parser Command
   compileCmd = Compile <$> filePath "benchmarking options"
 
-  selfTestCmd = Selftest <$> filePath "output file"
+  selfTestCmd = Selftest <$> optional (filePath "output file")
 
   nodeConfigOpt :: Parser (Maybe FilePath)
   nodeConfigOpt = option (Just <$> str)


### PR DESCRIPTION
# Description

The types and other apparent signs of intent all show that the selftest command was meant to be able to have its argument omitted. Also include a little stylish-haskell cleanup.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
         There is only one commit.
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
        No tests are needed or affected.
- [X] Any changes are noted in the `CHANGELOG.md` for affected package
        The change is too minor to changelog.
- [X] The version bounds in `.cabal` files are updated
        The cabal files don't need to be changed.
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
     hlint passes locally and stylish-haskell reformatting is bundled for the file touched.
- [X] Self-reviewed the diff
        This is a relatively simple change.

# Note on CI
This is partly to try out draft pull requests.
