### PR TITLE
Integrate latest ledger, consensus, api and cli for 8.6.0 

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -72,7 +72,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api ^>= 8.25
+    , cardano-api ^>= 8.29
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        >=1.0.0

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   plutus-scripts-bench
-version:                1.0.0.4
+version:                1.0.0.5
 synopsis:               Plutus scripts used for benchmarking
 description:            Plutus scripts used for benchmarking.
 category:               Cardano,

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -121,7 +121,8 @@ dummyTxSizeInEra metadata = case createAndValidateTransactionBody (cardanoEra @e
         )
       ]
     & setTxFee (mkTxFee 0)
-    & setTxValidityRange (TxValidityNoLowerBound, mkTxValidityUpperBound 0)
+    & setTxValidityLowerBound TxValidityNoLowerBound
+    & setTxValidityUpperBound (mkTxValidityUpperBound 0)
     & setTxMetadata metadata
 
 dummyTxSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMetadata -> Int

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -109,12 +109,12 @@ metadataSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMeta
 metadataSize p m = dummyTxSize p m - dummyTxSize p Nothing
 
 dummyTxSizeInEra :: forall era . IsShelleyBasedEra era => TxMetadataInEra era -> Int
-dummyTxSizeInEra metadata = case createAndValidateTransactionBody dummyTx of
+dummyTxSizeInEra metadata = case createAndValidateTransactionBody (cardanoEra @era) dummyTx of
   Right b -> BS.length $ serialiseToCBOR b
   Left err -> error $ "metaDataSize " ++ show err
  where
   dummyTx :: TxBodyContent BuildTx era
-  dummyTx = defaultTxBodyContent
+  dummyTx = defaultTxBodyContent (cardanoEra @era)
     & setTxIns
       [ ( TxIn "dbaff4e270cfb55612d9e2ac4658a27c79da4a5271c6f90853042d1403733810" (TxIx 0)
         , BuildTxWith $ KeyWitness KeyWitnessForSpending

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -47,7 +47,7 @@ import           Cardano.Tracing.OrphanInstances.Shelley ()
 
 import           Ouroboros.Network.Protocol.TxSubmission2.Type (TokBlockingStyle (..))
 
-import           Cardano.Api
+import           Cardano.Api hiding (Active)
 import           Cardano.TxGenerator.Types (TPSRate, TxGenError)
 
 import           Cardano.Benchmarking.LogTypes

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SubmissionClient.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SubmissionClient.hs
@@ -59,7 +59,7 @@ import           Ouroboros.Network.Protocol.TxSubmission2.Client (ClientStIdle (
 import           Ouroboros.Network.Protocol.TxSubmission2.Type (BlockingReplyList (..),
                                                                 TokBlockingStyle (..), TxSizeInBytes)
 
-import           Cardano.Api
+import           Cardano.Api hiding (Active)
 import           Cardano.Api.Shelley (fromShelleyTxId, toConsensusGenTx)
 
 import           Cardano.Logging

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -111,7 +111,7 @@ addFund era wallet txIn lovelace keyName = do
   fundKey  <- getEnvKeys keyName
   let
     mkOutValue :: forall era. IsShelleyBasedEra era => AsType era -> ActionM (InAnyCardanoEra TxOutValue)
-    mkOutValue _ = return $ InAnyCardanoEra (cardanoEra @era) (lovelaceToTxOutValue lovelace)
+    mkOutValue _ = return $ InAnyCardanoEra (cardanoEra @era) (lovelaceToTxOutValue (cardanoEra @era) lovelace)
   outValue <- withEra era mkOutValue
   addFundToWallet wallet txIn outValue fundKey
 
@@ -187,7 +187,7 @@ queryRemoteProtocolParameters = do
         res <- liftIO $ queryNodeLocalState localNodeConnectInfo (Just $ chainTipToChainPoint chainTip) (QueryInEra eraInMode query)
         case res of
           Right (Right pp) -> do
-            let pp' = fromLedgerPParams shelleyEra pp 
+            let pp' = fromLedgerPParams shelleyEra pp
                 pparamsFile = "protocol-parameters-queried.json"
             liftIO $ BSL.writeFile pparamsFile $ prettyPrintOrdered pp'
             traceDebug $ "queryRemoteProtocolParameters : query result saved in: " ++ pparamsFile
@@ -296,7 +296,7 @@ evalGenerator generator txParams@TxGenTxParams{txParamFee = fee} era = do
   protocolParameters <- getProtocolParameters
   case convertToLedgerProtocolParameters (shelleyBasedEra @era) protocolParameters of
     Left err -> throwE (Env.TxGenError (ApiError err))
-    Right ledgerParameters -> 
+    Right ledgerParameters ->
       case generator of
         SecureGenesis wallet genesisKeyName destKeyName -> do
           genesis  <- getEnvGenesis

--- a/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
@@ -130,7 +130,8 @@ mkGenesisTransaction key ttl fee txins txouts
     & setTxIns (zip txins $ repeat $ BuildTxWith $ KeyWitness KeyWitnessForSpending)
     & setTxOuts txouts
     & setTxFee (mkTxFee fee)
-    & setTxValidityRange (TxValidityNoLowerBound, mkTxValidityUpperBound ttl)
+    & setTxValidityLowerBound TxValidityNoLowerBound
+    & setTxValidityUpperBound (mkTxValidityUpperBound ttl)
 
 castKey :: SigningKey PaymentKey -> SigningKey GenesisUTxOKey
 castKey (PaymentSigningKey skey) = GenesisUTxOSigningKey skey

--- a/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
@@ -61,7 +61,8 @@ genesisInitialFunds :: forall era. IsShelleyBasedEra era
   -> ShelleyGenesis
   -> [(AddressInEra era, Lovelace)]
 genesisInitialFunds networkId g
- = [ ( shelleyAddressInEra $ makeShelleyAddress networkId (fromShelleyPaymentCredential pcr) (fromShelleyStakeReference stref)
+ = [ ( shelleyAddressInEra (shelleyBasedEra @era) $
+          makeShelleyAddress networkId (fromShelleyPaymentCredential pcr) (fromShelleyStakeReference stref)
      , fromShelleyLovelace coin
      )
      | (Addr _ pcr stref, coin) <- ListMap.toList $ sgInitialFunds g
@@ -122,10 +123,10 @@ mkGenesisTransaction :: forall era .
 mkGenesisTransaction key ttl fee txins txouts
   = bimap
       ApiError
-      (`signShelleyTransaction` [WitnessGenesisUTxOKey key])
-      (createAndValidateTransactionBody txBodyContent)
+      (\b -> signShelleyTransaction (shelleyBasedEra @era) b [WitnessGenesisUTxOKey key])
+      (createAndValidateTransactionBody (cardanoEra @era) txBodyContent)
  where
-  txBodyContent = defaultTxBodyContent
+  txBodyContent = defaultTxBodyContent (cardanoEra @era)
     & setTxIns (zip txins $ repeat $ BuildTxWith $ KeyWitness KeyWitnessForSpending)
     & setTxOuts txouts
     & setTxFee (mkTxFee fee)

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -72,7 +72,7 @@ genesisValue :: TxOutValue BabbageEra
 
 (genesisTxIn, genesisValue) =
   ( TxIn "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162" (TxIx 0)
-  , lovelaceToTxOutValue $ Lovelace 90000000000000
+  , lovelaceToTxOutValue BabbageEra $ Lovelace 90000000000000
   )
 
 genesisFund :: Fund

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -177,7 +177,8 @@ genTx _era ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
     & setTxInsCollateral collateral
     & setTxOuts outputs
     & setTxFee fee
-    & setTxValidityRange (TxValidityNoLowerBound, defaultTxValidityUpperBound (cardanoEra @era))
+    & setTxValidityLowerBound TxValidityNoLowerBound
+    & setTxValidityUpperBound (defaultTxValidityUpperBound (cardanoEra @era))
     & setTxMetadata metadata
     & setTxProtocolParams (BuildTxWith (Just ledgerParameters))
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
@@ -34,13 +34,13 @@ mkUTxOVariant networkId key value
     , mkNewFund value
     )
  where
-  mkTxOut v = TxOut (keyAddress @era networkId key) (lovelaceToTxOutValue v) TxOutDatumNone ReferenceScriptNone
+  mkTxOut v = TxOut (keyAddress @era networkId key) (lovelaceToTxOutValue (cardanoEra @era) v) TxOutDatumNone ReferenceScriptNone
 
   mkNewFund :: Lovelace -> TxIx -> TxId -> Fund
   mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @era) $ FundInEra {
       _fundTxIn = TxIn txId txIx
     , _fundWitness = KeyWitness KeyWitnessForSpending
-    , _fundVal = lovelaceToTxOutValue val
+    , _fundVal = lovelaceToTxOutValue (cardanoEra @era ) val
     , _fundSigningKey = Just key
     }
 
@@ -61,6 +61,7 @@ mkUTxOScript networkId (script, txOutDatum) witness value
       case scriptLanguageSupportedInEra (cardanoEra @era) lang of
         Nothing -> error "mkUtxOScript: scriptLanguageSupportedInEra==Nothing"
         Just{} -> makeShelleyAddressInEra
+                       (shelleyBasedEra @era)
                        networkId
                        (PaymentCredentialByScript $ hashScript script')
                        NoStakeAddress
@@ -69,7 +70,7 @@ mkUTxOScript networkId (script, txOutDatum) witness value
     Nothing -> error "mkUtxOScript: scriptDataSupportedInEra==Nothing"
     Just tag -> TxOut
                   plutusScriptAddr
-                  (lovelaceToTxOutValue v)
+                  (lovelaceToTxOutValue (cardanoEra @era) v)
                   (TxOutDatumHash tag $ hashScriptDataBytes $ unsafeHashableScriptData txOutDatum)
                   ReferenceScriptNone
 
@@ -77,6 +78,6 @@ mkUTxOScript networkId (script, txOutDatum) witness value
   mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @era) $ FundInEra {
       _fundTxIn = TxIn txId txIx
     , _fundWitness = witness
-    , _fundVal = lovelaceToTxOutValue val
+    , _fundVal = lovelaceToTxOutValue (cardanoEra @era) val
     , _fundSigningKey = Nothing
     }

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -74,8 +74,8 @@ mkTxFee f = caseByronOrShelleyBasedEra
 -- | `mkTxValidityUpperBound` rules out needing the
 -- `TxValidityNoUpperBound` with the constraint of `IsShelleyBasedEra`.
 mkTxValidityUpperBound :: forall era. IsShelleyBasedEra era => SlotNo -> TxValidityUpperBound era
-mkTxValidityUpperBound =
-  TxValidityUpperBound (fromJust $ forEraMaybeEon (cardanoEra @era))
+mkTxValidityUpperBound slotNo =
+  TxValidityUpperBound (fromJust $ forEraMaybeEon (cardanoEra @era)) (Just slotNo)
 
 -- | `mkTxOutValueAdaOnly` reinterprets the `Either` returned by
 -- `multiAssetSupportedInEra` with `TxOutValue` constructors.

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -34,6 +34,7 @@ liftAnyEra f x = case x of
 keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
 keyAddress networkId k
   = makeShelleyAddressInEra
+      (shelleyBasedEra @era)
       networkId
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   tx-generator
-version:                2.8
+version:                2.9
 synopsis:               A transaction workload generator for Cardano clusters
 description:            A transaction workload generator for Cardano clusters.
 category:               Cardano,
@@ -99,7 +99,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.29
                       , cardano-binary
-                      , cardano-cli ^>= 8.12
+                      , cardano-cli ^>= 8.13
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -97,7 +97,7 @@ library
                       , attoparsec
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.25
+                      , cardano-api ^>= 8.29
                       , cardano-binary
                       , cardano-cli ^>= 8.12
                       , cardano-crypto-class

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-09-01T22:19:16Z
-  , cardano-haskell-packages 2023-10-27T12:25:48Z
+  , cardano-haskell-packages 2023-10-28T22:00:00Z
 
 packages:
   cardano-git-rev

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-09-01T22:19:16Z
-  , cardano-haskell-packages 2023-10-05T21:00:00Z
+  , cardano-haskell-packages 2023-10-27T12:25:48Z
 
 packages:
   cardano-git-rev

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-09-01T22:19:16Z
-  , cardano-haskell-packages 2023-10-28T22:00:00Z
+  , cardano-haskell-packages 2023-10-31T17:10:09Z
 
 packages:
   cardano-git-rev

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node-chairman
-version:                8.5.0
+version:                8.6.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,
@@ -44,7 +44,7 @@ executable cardano-node-chairman
   build-depends:        cardano-api
                       , cardano-crypto-class
                       , cardano-git-rev
-                      , cardano-node ^>= 8.5
+                      , cardano-node ^>= 8.6
                       , cardano-prelude
                       , containers
                       , contra-tracer
@@ -88,5 +88,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.12
+                      , cardano-cli:cardano-cli ^>= 8.13
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.25
+                      , cardano-api ^>= 8.29
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -176,8 +176,8 @@ library
                       , network-mux >= 0.4
                       , nothunks
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-consensus ^>= 0.12
-                      , ouroboros-consensus-cardano ^>= 0.10
+                      , ouroboros-consensus ^>= 0.13
+                      , ouroboros-consensus-cardano ^>= 0.11
                       , ouroboros-consensus-diffusion ^>= 0.8
                       , ouroboros-consensus-protocol
                       , ouroboros-network-api

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.5.0
+version:                8.6.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,
@@ -196,7 +196,7 @@ library
                       , strict-stm
                       , text >= 2.0
                       , time
-                      , trace-dispatcher ^>= 2.3
+                      , trace-dispatcher ^>= 2.4
                       , trace-forward ^>= 2.2
                       , trace-resources ^>= 0.2.0.2
                       , tracer-transformers

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, HasTxId
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                    (HasNetworkProtocolVersion (BlockNodeToClientVersion, BlockNodeToNodeVersion))
 import           Ouroboros.Consensus.Node.Run (RunNode, SerialiseNodeToNodeConstraints)
-import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
 
 import           Ouroboros.Network.Block (Serialised)
@@ -53,6 +53,7 @@ type TraceConstraints blk =
     , ToObject (LedgerError blk)
     , ToObject (LedgerEvent blk)
     , ToObject (OtherHeaderEnvelopeError blk)
+    , ToObject (SelectView (BlockProtocol blk))
     , ToObject (ValidationErr (BlockProtocol blk))
     , ToObject (CannotForge blk)
     , ToObject (ForgeStateUpdateError blk)
@@ -67,6 +68,7 @@ type TraceConstraints blk =
     , LogFormatting (LedgerUpdate blk)
     , LogFormatting (LedgerWarning blk)
     , LogFormatting (OtherHeaderEnvelopeError blk)
+    , LogFormatting (SelectView (BlockProtocol blk))
     , LogFormatting (ValidationErr (BlockProtocol blk))
     , LogFormatting (CannotForge blk)
     , LogFormatting (ForgeStateUpdateError blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
@@ -25,11 +25,13 @@ import qualified Data.Text as Text
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
+import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..),
                    ByronOtherHeaderEnvelopeError (..), TxId (..), byronHeaderRaw)
 import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..),
                    ProtocolUpdate (..), UpdateState (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
+import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Cardano.Api (textShow)
@@ -212,4 +214,12 @@ instance LogFormatting ByronOtherHeaderEnvelopeError where
     mconcat
       [ "kind" .= String "UnexpectedEBBInSlot"
       , "slot" .= slot
+      ]
+
+instance LogFormatting PBftSelectView where
+  forMachine _dtal (PBftSelectView blkNo isEBB) =
+    mconcat
+      [ "kind" .= String "PBftSelectView"
+      , "blockNo" .= blkNo
+      , "isEBB" .= fromIsEBB isEBB
       ]

--- a/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
@@ -353,6 +353,9 @@ instance LogFormatting (ForgeStateUpdateError blk) => LogFormatting (WrapForgeSt
 
 instance All (LogFormatting `Compose` WrapSelectView) xs => LogFormatting (HardForkSelectView xs) where
     -- elide BlockNo as it is already contained in every per-era SelectView
+    -- TODO: use level DMinimal for a textual representation without the block number,
+    -- like this: `forMachine DMinimal . getHardForkSelectView`, and update the different SelectView instances
+    -- to not print the blockNr
     forMachine dtal = forMachine dtal . dropBlockNo . getHardForkSelectView
 
 instance All (LogFormatting `Compose` WrapSelectView) xs => LogFormatting (OneEraSelectView xs) where

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -376,8 +376,8 @@ instance
     mconcat [ "kind" .= String "MissingRequiredSigners"
              , "txins" .= Set.toList txins
              ]
-  forMachine _ (NonOutputSupplimentaryDatums disallowed acceptable) =
-    mconcat [ "kind" .= String "NonOutputSupplimentaryDatums"
+  forMachine _ (NotAllowedSupplementalDatums disallowed acceptable) =
+    mconcat [ "kind" .= String "NotAllowedSupplementalDatums"
              , "disallowed" .= Set.toList disallowed
              , "acceptable" .= Set.toList acceptable
              ]

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -1139,6 +1139,10 @@ instance
     mconcat [ "kind" .= String "ExpirationEpochTooSmall"
             , "credentialsToEpoch" .= credsToEpoch
             ]
+  forMachine _ (Conway.InvalidPrevGovActionIdsInProposals proposals) =
+    mconcat [ "kind" .= String "InvalidPrevGovActionIdsInProposals"
+            , "proposals" .= proposals
+            ]
 
 instance
   ( Consensus.ShelleyBasedEra era

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -165,10 +165,6 @@ instance LogFormatting (Conway.ConwayDelegPredFailure era) where
       , "amount" .= String (textShow credential)
       , "error" .= String "DRep already registered for the stake key"
       ]
-    Conway.WrongCertificateTypeDELEG ->
-      [ "kind" .= String "WrongCertificateTypeDELEG"
-      , "error" .= String "Wrong certificate type"
-      ]
 
 instance
   ( ShelleyCompatible protocol era

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -240,7 +240,7 @@ traceNodeStateChainDB _scp tr ev =
         _ -> return ()
     ChainDB.TraceAddBlockEvent ev' ->
       case ev' of
-        ChainDB.AddedToCurrentChain _ (ChainDB.NewTipInfo currentTip ntEpoch sInEpoch _) _ _ -> do
+        ChainDB.AddedToCurrentChain _ (ChainDB.SelectionChangedInfo currentTip ntEpoch sInEpoch _ _ _) _ _ -> do
           -- The slot of the latest block consumed (our progress).
           let RP.RealPoint ourSlotSinceSystemStart _ = currentTip
           -- The slot corresponding to the latest wall-clock time (our target).

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -487,18 +487,18 @@ instance ( LogFormatting (Header blk)
   forMachine dtal (ChainDB.PipeliningEvent ev') =
     forMachine dtal ev'
 
-  asMetrics (ChainDB.SwitchedToAFork _warnings newTipInfo _oldChain newChain) =
+  asMetrics (ChainDB.SwitchedToAFork _warnings selChangedInfo _oldChain newChain) =
     let ChainInformation { slots, blocks, density, epoch, slotInEpoch } =
-          chainInformation newTipInfo newChain 0
+          chainInformation selChangedInfo newChain 0
     in  [ DoubleM "ChainDB.Density" (fromRational density)
         , IntM    "ChainDB.SlotNum" (fromIntegral slots)
         , IntM    "ChainDB.BlockNum" (fromIntegral blocks)
         , IntM    "ChainDB.SlotInEpoch" (fromIntegral slotInEpoch)
         , IntM    "ChainDB.Epoch" (fromIntegral (unEpochNo epoch))
         ]
-  asMetrics (ChainDB.AddedToCurrentChain _warnings newTipInfo _oldChain newChain) =
+  asMetrics (ChainDB.AddedToCurrentChain _warnings selChangedInfo _oldChain newChain) =
     let ChainInformation { slots, blocks, density, epoch, slotInEpoch } =
-          chainInformation newTipInfo newChain 0
+          chainInformation selChangedInfo newChain 0
     in  [ DoubleM "ChainDB.Density" (fromRational density)
         , IntM    "ChainDB.SlotNum" (fromIntegral slots)
         , IntM    "ChainDB.BlockNum" (fromIntegral blocks)
@@ -2013,16 +2013,16 @@ data ChainInformation = ChainInformation
 
 chainInformation
   :: forall blk. HasHeader (Header blk)
-  => ChainDB.NewTipInfo blk
+  => ChainDB.SelectionChangedInfo blk
   -> AF.AnchoredFragment (Header blk)
   -> Int64
   -> ChainInformation
-chainInformation newTipInfo frag blocksUncoupledDelta = ChainInformation
+chainInformation selChangedInfo frag blocksUncoupledDelta = ChainInformation
     { slots = unSlotNo $ fromWithOrigin 0 (AF.headSlot frag)
     , blocks = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)
     , density = fragmentChainDensity frag
-    , epoch = ChainDB.newTipEpoch newTipInfo
-    , slotInEpoch = ChainDB.newTipSlotInEpoch newTipInfo
+    , epoch = ChainDB.newTipEpoch selChangedInfo
+    , slotInEpoch = ChainDB.newTipSlotInEpoch selChangedInfo
     , blocksUncoupledDelta = blocksUncoupledDelta
     }
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -24,12 +24,14 @@ import           Cardano.Tracing.Render (renderTxId)
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
+import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..), ByronNodeToClientVersion (..),
                    ByronNodeToNodeVersion (..), ByronOtherHeaderEnvelopeError (..), TxId (..),
                    byronHeaderRaw)
 import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..),
                    ProtocolUpdate (..), UpdateState (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
+import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
@@ -221,3 +223,11 @@ instance ToJSON ByronNodeToClientVersion where
 instance ToJSON ByronNodeToNodeVersion where
   toJSON ByronNodeToNodeVersion1 = String "ByronNodeToNodeVersion1"
   toJSON ByronNodeToNodeVersion2 = String "ByronNodeToNodeVersion2"
+
+instance ToObject PBftSelectView where
+  toObject _verb (PBftSelectView blkNo isEBB) =
+    mconcat
+      [ "kind" .= String "PBftSelectView"
+      , "blockNo" .= blkNo
+      , "isEBB" .= fromIsEBB isEBB
+      ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -212,10 +212,6 @@ instance ToObject (Conway.ConwayDelegPredFailure era) where
       , "amount" .= String (textShow credential)
       , "error" .= String "DRep already registered for the stake key"
       ]
-    Conway.WrongCertificateTypeDELEG ->
-      [ "kind" .= String "WrongCertificateTypeDELEG"
-      , "error" .= String "Wrong certificate type"
-      ]
 
 instance ToObject (Set (Credential 'Staking StandardCrypto)) where
   toObject _verb creds =

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -380,6 +380,10 @@ instance Ledger.EraPParams era => ToObject (Conway.ConwayGovPredFailure era) whe
     mconcat [ "kind" .= String "ExpirationEpochTooSmall"
             , "credentialsToEpoch" .= credsToEpoch
             ]
+  toObject _ (Conway.InvalidPrevGovActionIdsInProposals proposals) =
+    mconcat [ "kind" .= String "InvalidPrevGovActionIdsInProposals"
+            , "proposals" .= proposals
+            ]
 
 instance
   ( Core.Crypto (Consensus.EraCrypto era)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -427,8 +427,8 @@ instance
     mconcat [ "kind" .= String "MissingRequiredSigners"
              , "txins" .= Set.toList txins
              ]
-  toObject _ (NonOutputSupplimentaryDatums disallowed acceptable) =
-    mconcat [ "kind" .= String "NonOutputSupplimentaryDatums"
+  toObject _ (NotAllowedSupplementalDatums disallowed acceptable) =
+    mconcat [ "kind" .= String "NotAllowedSupplementalDatums"
              , "disallowed" .= Set.toList disallowed
              , "acceptable" .= Set.toList acceptable
              ]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -86,7 +86,7 @@ import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import           Ouroboros.Consensus.Node (NetworkP2PMode (..))
 import qualified Ouroboros.Consensus.Node.Run as Consensus (RunNode)
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
-import           Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Util.Enclose
 
@@ -513,6 +513,7 @@ teeTraceChainTip
      , InspectLedger blk
      , ToObject (Header blk)
      , ToObject (LedgerEvent blk)
+     , ToObject (SelectView (BlockProtocol blk))
      )
   => BlockConfig blk
   -> ForgingStats
@@ -536,6 +537,7 @@ teeTraceChainTipElide
      , InspectLedger blk
      , ToObject (Header blk)
      , ToObject (LedgerEvent blk)
+     , ToObject (SelectView (BlockProtocol blk))
      )
   => TracingVerbosity
   -> MVar (Maybe (WithSeverity (ChainDB.TraceEvent blk)), Integer)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -567,12 +567,12 @@ traceChainMetrics (Just _ekgDirect) tForks _blockConfig _fStats tr = do
     chainTipInformation :: ChainDB.TraceEvent blk -> Maybe ChainInformation
     chainTipInformation = \case
       ChainDB.TraceAddBlockEvent ev -> case ev of
-        ChainDB.SwitchedToAFork _warnings newTipInfo oldChain newChain ->
+        ChainDB.SwitchedToAFork _warnings selChangedInfo oldChain newChain ->
           let fork = not $ AF.withinFragmentBounds (AF.headPoint oldChain)
                               newChain in
-          Just $ chainInformation newTipInfo fork oldChain newChain 0
-        ChainDB.AddedToCurrentChain _warnings newTipInfo oldChain newChain ->
-          Just $ chainInformation newTipInfo False oldChain newChain 0
+          Just $ chainInformation selChangedInfo fork oldChain newChain 0
+        ChainDB.AddedToCurrentChain _warnings selChangedInfo oldChain newChain ->
+          Just $ chainInformation selChangedInfo False oldChain newChain 0
         _ -> Nothing
       _ -> Nothing
 
@@ -1533,21 +1533,21 @@ chainInformation
   => HasHeader (Header blk)
   => HasIssuer blk
   => ConvertRawHash blk
-  => ChainDB.NewTipInfo blk
+  => ChainDB.SelectionChangedInfo blk
   -> Bool
   -> AF.AnchoredFragment (Header blk) -- ^ Old fragment.
   -> AF.AnchoredFragment (Header blk) -- ^ New fragment.
   -> Int64
   -> ChainInformation
-chainInformation newTipInfo fork oldFrag frag blocksUncoupledDelta = ChainInformation
+chainInformation selChangedInfo fork oldFrag frag blocksUncoupledDelta = ChainInformation
     { slots = unSlotNo $ fromWithOrigin 0 (AF.headSlot frag)
     , blocks = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)
     , density = fragmentChainDensity frag
-    , epoch = ChainDB.newTipEpoch newTipInfo
-    , slotInEpoch = ChainDB.newTipSlotInEpoch newTipInfo
+    , epoch = ChainDB.newTipEpoch selChangedInfo
+    , slotInEpoch = ChainDB.newTipSlotInEpoch selChangedInfo
     , blocksUncoupledDelta = blocksUncoupledDelta
     , fork = fork
-    , tipBlockHash = renderHeaderHash (Proxy @blk) $ realPointHash (ChainDB.newTipPoint newTipInfo)
+    , tipBlockHash = renderHeaderHash (Proxy @blk) $ realPointHash (ChainDB.newTipPoint selChangedInfo)
     , tipBlockParentHash = renderChainHash (Text.decodeLatin1 . B16.encode . toRawHash (Proxy @blk)) $ AF.headHash oldFrag
     , tipBlockIssuerVerificationKeyHash = tipIssuerVkHash
     }

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-submit-api
-version:                3.1.7
+version:                3.1.8
 synopsis:               A web server that allows transactions to be POSTed to the cardano chain
 description:            A web server that allows transactions to be POSTed to the cardano chain.
 homepage:               https://github.com/input-output-hk/cardano-node
@@ -41,7 +41,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.29
                       , cardano-binary
-                      , cardano-cli ^>= 8.12
+                      , cardano-cli ^>= 8.13
                       , cardano-crypto-class ^>= 2.1.2
                       , cardano-ledger-byron ^>= 1.0
                       , formatting

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.25
+                      , cardano-api ^>= 8.29
                       , cardano-binary
                       , cardano-cli ^>= 8.12
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.25
+                      , cardano-api ^>= 8.29
                       , cardano-cli ^>= 8.12
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
@@ -47,7 +47,7 @@ library
                       , cardano-ledger-shelley
                       , cardano-node
                       , containers
-                      , data-default-class 
+                      , data-default-class
                       , directory
                       , exceptions
                       , filepath
@@ -128,7 +128,7 @@ test-suite cardano-testnet-golden
   build-depends:        aeson
                       , aeson-pretty
                       , bytestring
-                      , cardano-api 
+                      , cardano-api
                       , cardano-crypto-class
                       , cardano-testnet
                       , exceptions

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-testnet
-version:                8.5.0
+version:                8.6.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 copyright:              2021-2023 Input Output Global Inc (IOG).
@@ -35,7 +35,7 @@ library
                       , ansi-terminal
                       , bytestring
                       , cardano-api ^>= 8.29
-                      , cardano-cli ^>= 8.12
+                      , cardano-cli ^>= 8.13
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo

--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1696471795,
-        "narHash": "sha256-aNNvjUtCGXaXSp5M/HSj1SOeLjqLyTRWYbIHqAEeUp0=",
+        "lastModified": 1698746924,
+        "narHash": "sha256-8og+vqQPEoB2KLUtN5esGMDymT+2bT/rCHZt1NAe7y0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "91f16fa8acb58b312f94977715c630d8bf77e33e",
+        "rev": "af551ca93d969d9715fa9bf86691d9a0a19e89d9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1698409315,
-        "narHash": "sha256-0h8SwdLnp/c02K9dXMlT37nTtmhgA1hKVaMjHLEtFYE=",
+        "lastModified": 1698441381,
+        "narHash": "sha256-zFDjPseeYbCQQmsnCdDzRdMiRCrjwO+2oHmrFZoE4Vg=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "9313f1f20599a693e4828600b67a19dbf7db2e30",
+        "rev": "f6076612f80e9e215f86b587e5f83087e980d3db",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1698441381,
-        "narHash": "sha256-zFDjPseeYbCQQmsnCdDzRdMiRCrjwO+2oHmrFZoE4Vg=",
+        "lastModified": 1698772188,
+        "narHash": "sha256-QiQbb08vemttpardX2nOhC1xVRcatn4Lbg/wWjoHtKg=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "f6076612f80e9e215f86b587e5f83087e980d3db",
+        "rev": "bd71312b6717eec9828614c62df42a19fdb72df7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1696538731,
-        "narHash": "sha256-oTsPiABmN7mw9hctagxzNcIDtvmyK4EuBzvMD2iXeeQ=",
+        "lastModified": 1698409315,
+        "narHash": "sha256-0h8SwdLnp/c02K9dXMlT37nTtmhgA1hKVaMjHLEtFYE=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "4276a203ed968d067b6c31c943b5bae5fc2ec4a2",
+        "rev": "9313f1f20599a693e4828600b67a19dbf7db2e30",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/src/Cardano/Logging/Consistency.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Consistency.hs
@@ -16,7 +16,7 @@ import           Cardano.Logging.Types
 -- | Warnings as a list of text
 type NSWarnings = [T.Text]
 
-  -- | A data structure for the lookup of namespaces as nested maps
+-- | A data structure for the lookup of namespaces as nested maps
 newtype NSLookup = NSLookup (Map.Map T.Text NSLookup)
   deriving Show
 

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                2.3.0
+version:                2.4.0
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package


### PR DESCRIPTION
# Description

Integration with latest ledger, consensus,  cardano-api  8.28.0.0- based. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
