### PR TITLE
Remove `ByronMode` and `ShelleyMode` support

### DIFF
--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
@@ -40,19 +40,17 @@ getGenesis (SomeConsensusProtocol CardanoBlockType proto)
 
 -- | extract the path to genesis file from a NodeConfiguration for Cardano protocol
 getGenesisPath :: NodeConfiguration -> Maybe GenesisFile
-getGenesisPath nodeConfig
- = case ncProtocolConfig nodeConfig of
-   NodeProtocolConfigurationCardano _ shelleyConfig _ _ _ -> Just $ npcShelleyGenesisFile shelleyConfig
-   _ -> Nothing
+getGenesisPath nodeConfig =
+  case ncProtocolConfig nodeConfig of
+    NodeProtocolConfigurationCardano _ shelleyConfig _ _ _ ->
+      Just $ npcShelleyGenesisFile shelleyConfig
 
 mkConsensusProtocol :: NodeConfiguration -> IO (Either TxGenError SomeConsensusProtocol)
-mkConsensusProtocol nodeConfig
-  = case ncProtocolConfig nodeConfig of
-    NodeProtocolConfigurationByron _    -> pure $ Left $ TxGenError "NodeProtocolConfigurationByron not supported"
-    NodeProtocolConfigurationShelley _  -> pure $ Left $ TxGenError "NodeProtocolConfigurationShelley not supported"
-    NodeProtocolConfigurationCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig
-        -> first ProtocolError
-            <$> runExceptT (mkSomeConsensusProtocolCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig Nothing)
+mkConsensusProtocol nodeConfig =
+  case ncProtocolConfig nodeConfig of
+    NodeProtocolConfigurationCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig ->
+      first ProtocolError
+        <$> runExceptT (mkSomeConsensusProtocolCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig Nothing)
 
 -- | Creates a NodeConfiguration from a config file;
 --   the result is devoid of any keys/credentials

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -139,15 +139,11 @@ run RunOpts
 
   return ()
  where
-  getConsensusMode :: SecurityParam -> NodeProtocolConfiguration -> AnyConsensusModeParams
+  getConsensusMode :: SecurityParam -> NodeProtocolConfiguration -> ConsensusModeParams CardanoMode
   getConsensusMode (SecurityParam k) ncProtocolConfig =
     case ncProtocolConfig of
-      NodeProtocolConfigurationByron{} ->
-        AnyConsensusModeParams $ ByronModeParams $ EpochSlots k
-      NodeProtocolConfigurationShelley{} ->
-        AnyConsensusModeParams ShelleyModeParams
       NodeProtocolConfigurationCardano{} ->
-        AnyConsensusModeParams $ CardanoModeParams $ EpochSlots k
+        CardanoModeParams $ EpochSlots k
 
   getProtocolConfiguration
     :: PartialNodeConfiguration

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -238,6 +238,7 @@ test-suite cardano-node-test
                       , aeson
                       , bytestring
                       , cardano-crypto-class
+                      , cardano-crypto-wrapper
                       , cardano-api
                       , cardano-ledger-core
                       , cardano-node

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -27,29 +27,21 @@ mkConsensusProtocol
   -> Maybe ProtocolFilepaths
   -> ExceptT ProtocolInstantiationError IO SomeConsensusProtocol
 mkConsensusProtocol ncProtocolConfig mProtocolFiles =
-    case ncProtocolConfig of
-
-      NodeProtocolConfigurationByron config ->
-        firstExceptT ByronProtocolInstantiationError $
-          mkSomeConsensusProtocolByron config mProtocolFiles
-
-      NodeProtocolConfigurationShelley config ->
-        firstExceptT ShelleyProtocolInstantiationError $
-          mkSomeConsensusProtocolShelley config mProtocolFiles
-
-      NodeProtocolConfigurationCardano byronConfig
-                                       shelleyConfig
-                                       alonzoConfig
-                                       conwayConfig
-                                       hardForkConfig ->
-        firstExceptT CardanoProtocolInstantiationError $
-          mkSomeConsensusProtocolCardano
-            byronConfig
-            shelleyConfig
-            alonzoConfig
-            conwayConfig
-            hardForkConfig
-            mProtocolFiles
+  case ncProtocolConfig of
+    NodeProtocolConfigurationCardano
+        byronConfig
+        shelleyConfig
+        alonzoConfig
+        conwayConfig
+        hardForkConfig ->
+      firstExceptT CardanoProtocolInstantiationError $
+        mkSomeConsensusProtocolCardano
+          byronConfig
+          shelleyConfig
+          alonzoConfig
+          conwayConfig
+          hardForkConfig
+          mProtocolFiles
 
 ------------------------------------------------------------------------------
 -- Errors

--- a/cardano-node/src/Cardano/Node/Protocol/Types.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Types.hs
@@ -24,14 +24,10 @@ import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 
 
-data Protocol = ByronProtocol
-              | ShelleyProtocol
-              | CardanoProtocol
+data Protocol = CardanoProtocol
   deriving (Eq, Generic)
 
 instance Show Protocol where
-  show ByronProtocol = "Byron"
-  show ShelleyProtocol = "Shelley"
   show CardanoProtocol = "Byron; Shelley"
 
 deriving instance NFData Protocol
@@ -40,18 +36,8 @@ deriving instance NoThunks Protocol
 instance FromJSON Protocol where
   parseJSON =
     withText "Protocol" $ \str -> case str of
-
-      -- The new names
-      "Byron" -> pure ByronProtocol
-      "Shelley" -> pure ShelleyProtocol
       "Cardano" -> pure CardanoProtocol
-
-      -- The old names
-      "RealPBFT" -> pure ByronProtocol
-      "TPraos" -> pure ShelleyProtocol
-
-      _ -> fail $ "Parsing of Protocol failed. "
-                <> show str <> " is not a valid protocol"
+      _ -> fail $ "Parsing of Protocol failed. " <> show str <> " is not a valid protocol"
 
 data SomeConsensusProtocol where
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -123,13 +123,12 @@ newtype GenesisHash = GenesisHash (Crypto.Hash Crypto.Blake2b_256 ByteString)
   deriving newtype (Eq, Show, ToJSON, FromJSON)
 
 data NodeProtocolConfiguration =
-       NodeProtocolConfigurationByron   NodeByronProtocolConfiguration
-     | NodeProtocolConfigurationShelley NodeShelleyProtocolConfiguration
-     | NodeProtocolConfigurationCardano NodeByronProtocolConfiguration
-                                        NodeShelleyProtocolConfiguration
-                                        NodeAlonzoProtocolConfiguration
-                                        NodeConwayProtocolConfiguration
-                                        NodeHardForkProtocolConfiguration
+  NodeProtocolConfigurationCardano
+    NodeByronProtocolConfiguration
+    NodeShelleyProtocolConfiguration
+    NodeAlonzoProtocolConfiguration
+    NodeConwayProtocolConfiguration
+    NodeHardForkProtocolConfiguration
   deriving (Eq, Show)
 
 data NodeShelleyProtocolConfiguration =
@@ -302,19 +301,13 @@ newtype TopologyFile = TopologyFile
   deriving newtype (Show, Eq)
 
 instance AdjustFilePaths NodeProtocolConfiguration where
-
-  adjustFilePaths f (NodeProtocolConfigurationByron pc) =
-    NodeProtocolConfigurationByron (adjustFilePaths f pc)
-
-  adjustFilePaths f (NodeProtocolConfigurationShelley pc) =
-    NodeProtocolConfigurationShelley (adjustFilePaths f pc)
-
   adjustFilePaths f (NodeProtocolConfigurationCardano pcb pcs pca pcc pch) =
-    NodeProtocolConfigurationCardano (adjustFilePaths f pcb)
-                                     (adjustFilePaths f pcs)
-                                     (adjustFilePaths f pca)
-                                     (adjustFilePaths f pcc)
-                                     pch
+    NodeProtocolConfigurationCardano
+      (adjustFilePaths f pcb)
+      (adjustFilePaths f pcs)
+      (adjustFilePaths f pca)
+      (adjustFilePaths f pcc)
+      pch
 
 instance AdjustFilePaths NodeByronProtocolConfiguration where
   adjustFilePaths f x@NodeByronProtocolConfiguration {

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -9,6 +9,7 @@ import           Data.Monoid (Last (..))
 import           Data.Text (Text)
 import           Data.Time.Clock (secondsToDiffTime)
 
+import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic (..))
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
@@ -44,15 +45,72 @@ prop_sanityCheck_POM =
       Left err -> failWith Nothing $ "Partial Options Monoid sanity check failure: " <> err
       Right config -> config === expectedConfig
 
+testNodeByronProtocolConfiguration :: NodeByronProtocolConfiguration
+testNodeByronProtocolConfiguration =
+  NodeByronProtocolConfiguration
+    { npcByronGenesisFile                   = GenesisFile "dummmy-genesis-file"
+    , npcByronGenesisFileHash               = Nothing
+    , npcByronReqNetworkMagic               = RequiresNoMagic
+    , npcByronPbftSignatureThresh           = Nothing
+    , npcByronSupportedProtocolVersionMajor = 0
+    , npcByronSupportedProtocolVersionMinor = 0
+    , npcByronSupportedProtocolVersionAlt   = 0
+    }
+
+testNodeShelleyProtocolConfiguration :: NodeShelleyProtocolConfiguration
+testNodeShelleyProtocolConfiguration =
+  NodeShelleyProtocolConfiguration
+    { npcShelleyGenesisFile     = GenesisFile "dummmy-genesis-file"
+    , npcShelleyGenesisFileHash = Nothing
+    }
+
+testNodeAlonzoProtocolConfiguration :: NodeAlonzoProtocolConfiguration
+testNodeAlonzoProtocolConfiguration =
+  NodeAlonzoProtocolConfiguration
+    { npcAlonzoGenesisFile      = GenesisFile "dummmy-genesis-file"
+    , npcAlonzoGenesisFileHash  = Nothing
+    }
+
+testNodeConwayProtocolConfiguration :: NodeConwayProtocolConfiguration
+testNodeConwayProtocolConfiguration =
+  NodeConwayProtocolConfiguration
+    { npcConwayGenesisFile      = GenesisFile "dummmy-genesis-file"
+    , npcConwayGenesisFileHash  = Nothing
+    }
+
+testNodeHardForkProtocolConfiguration :: NodeHardForkProtocolConfiguration
+testNodeHardForkProtocolConfiguration =
+  NodeHardForkProtocolConfiguration
+    { npcExperimentalHardForksEnabled = True
+    , npcTestShelleyHardForkAtEpoch   = Nothing
+    , npcTestShelleyHardForkAtVersion = Nothing
+    , npcTestAllegraHardForkAtEpoch   = Nothing
+    , npcTestAllegraHardForkAtVersion = Nothing
+    , npcTestMaryHardForkAtEpoch      = Nothing
+    , npcTestMaryHardForkAtVersion    = Nothing
+    , npcTestAlonzoHardForkAtEpoch    = Nothing
+    , npcTestAlonzoHardForkAtVersion  = Nothing
+    , npcTestBabbageHardForkAtEpoch   = Nothing
+    , npcTestBabbageHardForkAtVersion = Nothing
+    , npcTestConwayHardForkAtEpoch    = Nothing
+    , npcTestConwayHardForkAtVersion  = Nothing
+    }
+
+testNodeProtocolConfiguration :: NodeProtocolConfiguration
+testNodeProtocolConfiguration =
+  NodeProtocolConfigurationCardano
+    testNodeByronProtocolConfiguration
+    testNodeShelleyProtocolConfiguration
+    testNodeAlonzoProtocolConfiguration
+    testNodeConwayProtocolConfiguration
+    testNodeHardForkProtocolConfiguration
+
 -- | Example partial configuration theoretically created from a
 -- config yaml file.
 testPartialYamlConfig :: PartialNodeConfiguration
 testPartialYamlConfig =
   PartialNodeConfiguration
-    { pncProtocolConfig = Last . Just
-                        . NodeProtocolConfigurationShelley
-                        $ NodeShelleyProtocolConfiguration
-                            (GenesisFile "dummmy-genesis-file") Nothing
+    { pncProtocolConfig = Last $ Just testNodeProtocolConfiguration
     , pncSocketConfig = Last . Just $ SocketConfig (Last Nothing) mempty mempty mempty
     , pncShutdownConfig = Last Nothing
     , pncStartAsNonProducingNode = Last $ Just False
@@ -137,9 +195,7 @@ eExpectedConfig = do
     , ncDatabaseFile = DbFile "mainnet/db/"
     , ncProtocolFiles = ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing Nothing
     , ncValidateDB = True
-    , ncProtocolConfig = NodeProtocolConfigurationShelley
-                           $ NodeShelleyProtocolConfiguration
-                             (GenesisFile "dummmy-genesis-file") Nothing
+    , ncProtocolConfig = testNodeProtocolConfiguration
     , ncDiffusionMode = InitiatorAndResponderDiffusionMode
     , ncSnapshotInterval = RequestedSnapshotInterval $ secondsToDiffTime 100
     , ncExperimentalProtocolsEnabled = True

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -145,19 +145,9 @@ getStartTime
   => FilePath -> TestnetRuntime -> m UTCTime
 getStartTime tempRootPath TestnetRuntime{configurationFile} = withFrozenCallStack $ H.evalEither <=< H.evalIO . runExceptT $ do
   byronGenesisFile <-
-    decodeNodeConfiguration configurationFile >>=
-      \case
-        NodeProtocolConfigurationCardano NodeByronProtocolConfiguration{npcByronGenesisFile} _ _ _ _ ->
-          pure $ unGenesisFile npcByronGenesisFile
-        NodeProtocolConfigurationByron NodeByronProtocolConfiguration{npcByronGenesisFile} ->
-          pure $ unGenesisFile npcByronGenesisFile
-        unsupported ->
-          throwError $ unwords
-            [ "cannot find byron configuration path in"
-            , configurationFile
-            , "- found instead:"
-            , show unsupported
-            ]
+    decodeNodeConfiguration configurationFile >>= \case
+      NodeProtocolConfigurationCardano NodeByronProtocolConfiguration{npcByronGenesisFile} _ _ _ _ ->
+        pure $ unGenesisFile npcByronGenesisFile
   let byronGenesisFilePath = tempRootPath </> byronGenesisFile
   G.gdStartTime . G.configGenesisData <$> decodeGenesisFile byronGenesisFilePath
   where


### PR DESCRIPTION
# Description

This remove `ByronMode` and `ShelleyMode` support so that the node can only run in `CardanoMode`.

These modes still exist in cardano-api. They are removed in cardano-node first to minimise dependency risk.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
