### PR TITLE
Include commits from source-repos in workbench manifest

### DIFF
--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -9,7 +9,7 @@ with lib;
 
 let
   # recover CHaP location from cardano's project
-  chapPackages = "${cardanoNodeProject.args.inputMap."https://input-output-hk.github.io/cardano-haskell-packages"}/foliage/packages.json";
+  chap = cardanoNodeProject.args.inputMap."https://input-output-hk.github.io/cardano-haskell-packages";
   # build plan as computed by nix
   nixPlanJson = cardanoNodeProject.plan-nix.json;
 
@@ -31,8 +31,8 @@ let
         wrapProgram "$out/bin/wb"                \
           --argv0 wb                             \
           --prefix PATH ":" ${makeBinPath tools} \
-          --set WB_CHAP_PACKAGES ${chapPackages} \
-          --set WB_NIX_PLAN      ${nixPlanJson}
+          --set WB_CHAP_PATH ${chap}             \
+          --set WB_NIX_PLAN ${nixPlanJson}
       '';
 
       installPhase = ''

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -19,7 +19,7 @@ with lib;
 let
 
     # recover CHaP location from cardano's project
-    chapPackages = "${project.args.inputMap."https://input-output-hk.github.io/cardano-haskell-packages"}/foliage/packages.json";
+    chap = project.args.inputMap."https://input-output-hk.github.io/cardano-haskell-packages";
 
     # build plan as computed by nix
     nixPlanJson = project.plan-nix.json;
@@ -52,7 +52,7 @@ in project.shellFor {
       workbenchDevMode
       ''
     export WB_CARDANO_NODE_REPO_ROOT=$(git rev-parse --show-toplevel)
-    export WB_CHAP_PACKAGES=${chapPackages}
+    export WB_CHAP_PATH=${chap}
     export WB_NIX_PLAN=${nixPlanJson}
     export WB_EXTRA_FLAGS=
 

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -222,7 +222,7 @@ start()
        local manifest=$(manifest collect-from-checkout  \
                             "$node_source"              \
                             "$node_rev"                 \
-                            ${WB_MANIFEST_PACKAGES[*]}
+                            "${WB_MANIFEST_PACKAGES[@]}"
                        )
        manifest render "$manifest"
 


### PR DESCRIPTION
Currently `wb manifest` obtains a git commit hash of packages from chap by matching them by package-id.

This gives the wrong result if a package comes from a source-repository-package stanza. The package-id would match something on chap but the commit hash would be a different one.

This PR reworks the logic of `wb manifest` such that srp are correcntly identified and reported.

Unfortunately there are issues in both cabal-mode and nix mode:

In a workbench shell in cabal mode, many dependencies will be pre-installed, in that case we cannot tell where it came from. To simplify, we take the following approach:
- if it is from a source-repo use that
- otherwise see if it matches any package on chap
- otherwise return null
This means that in case a package exists on both hackage and chap, we will always report the commit from chap.

In nix mode; haskell.nix erases the location of source-repository-packages during the build so, nix-build-srps will again miss their hash.
