### PR TITLE
cardano-testnet: Remove `ExperimentalHardForksEnabled` from eras where it is not needed

### DIFF
--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -206,29 +206,25 @@ defaultYamlHardforkViaConfig era =
       ByronEra -> []
       ShelleyEra ->
         map (uncurry KeyMapAeson.singleton)
-          [ ("ExperimentalHardForksEnabled", Aeson.Bool True)
-          , ("ExperimentalProtocolsEnabled", Aeson.Bool True)
+          [ ("ExperimentalProtocolsEnabled", Aeson.Bool True)
           , ("TestShelleyHardForkAtEpoch", Aeson.Number 0)
           ]
       AllegraEra ->
         map (uncurry KeyMapAeson.singleton)
-          [ ("ExperimentalHardForksEnabled", Aeson.Bool True)
-          , ("ExperimentalProtocolsEnabled", Aeson.Bool True)
+          [ ("ExperimentalProtocolsEnabled", Aeson.Bool True)
           , ("TestShelleyHardForkAtEpoch", Aeson.Number 0)
           , ("TestAllegraHardForkAtEpoch", Aeson.Number 0)
           ]
       MaryEra ->
         map (uncurry KeyMapAeson.singleton)
-          [ ("ExperimentalHardForksEnabled", Aeson.Bool True)
-          , ("ExperimentalProtocolsEnabled", Aeson.Bool True)
+          [ ("ExperimentalProtocolsEnabled", Aeson.Bool True)
           , ("TestShelleyHardForkAtEpoch", Aeson.Number 0)
           , ("TestAllegraHardForkAtEpoch", Aeson.Number 0)
           , ("TestMaryHardForkAtEpoch", Aeson.Number 0)
           ]
       AlonzoEra ->
         map (uncurry KeyMapAeson.singleton)
-          [ ("ExperimentalHardForksEnabled", Aeson.Bool True)
-          , ("ExperimentalProtocolsEnabled", Aeson.Bool True)
+          [ ("ExperimentalProtocolsEnabled", Aeson.Bool True)
           , ("TestShelleyHardForkAtEpoch", Aeson.Number 0)
           , ("TestAllegraHardForkAtEpoch", Aeson.Number 0)
           , ("TestMaryHardForkAtEpoch", Aeson.Number 0)
@@ -236,8 +232,7 @@ defaultYamlHardforkViaConfig era =
           ]
       BabbageEra ->
         map (uncurry KeyMapAeson.singleton)
-          [ ("ExperimentalHardForksEnabled", Aeson.Bool True)
-          , ("ExperimentalProtocolsEnabled", Aeson.Bool True)
+          [ ("ExperimentalProtocolsEnabled", Aeson.Bool True)
           , ("TestShelleyHardForkAtEpoch", Aeson.Number 0)
           , ("TestAllegraHardForkAtEpoch", Aeson.Number 0)
           , ("TestMaryHardForkAtEpoch", Aeson.Number 0)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/allegra_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/allegra_node_default_config.json
@@ -5,7 +5,6 @@
     "EnableLogMetrics": false,
     "EnableLogging": true,
     "EnableP2P": false,
-    "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,
     "LastKnownBlockVersion-Major": 3,

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/alonzo_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/alonzo_node_default_config.json
@@ -5,7 +5,6 @@
     "EnableLogMetrics": false,
     "EnableLogging": true,
     "EnableP2P": false,
-    "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,
     "LastKnownBlockVersion-Major": 5,

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/babbage_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/babbage_node_default_config.json
@@ -5,7 +5,6 @@
     "EnableLogMetrics": false,
     "EnableLogging": true,
     "EnableP2P": false,
-    "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,
     "LastKnownBlockVersion-Major": 8,

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/mary_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/mary_node_default_config.json
@@ -5,7 +5,6 @@
     "EnableLogMetrics": false,
     "EnableLogging": true,
     "EnableP2P": false,
-    "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,
     "LastKnownBlockVersion-Major": 4,

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/shelley_node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/shelley_node_default_config.json
@@ -5,7 +5,6 @@
     "EnableLogMetrics": false,
     "EnableLogging": true,
     "EnableP2P": false,
-    "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,
     "LastKnownBlockVersion-Major": 2,


### PR DESCRIPTION
# Description

Remove `ExperimentalHardForksEnabled` setting from eras where it is not needed.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
