### PR TITLE
Use GHC 8.10.7 by default

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -20,9 +20,9 @@ let
     {
       src = ../.;
       name = "cardano-node";
-      compiler-nix-name = lib.mkDefault "ghc963";
+      compiler-nix-name = lib.mkDefault "ghc8107";
       # extra-compilers
-      flake.variants = lib.genAttrs ["ghc928" "ghc8107"] (x: {compiler-nix-name = x;});
+      flake.variants = lib.genAttrs ["ghc928" "ghc963"] (x: {compiler-nix-name = x;});
       cabalProjectLocal = ''
         repository cardano-haskell-packages-local
           url: file:${CHaP}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -83,7 +83,9 @@ in with final;
   };
 
   haskell-language-server = haskell-nix.tool compiler-nix-name "haskell-language-server" rec {
-    src = haskell-nix.sources."hls-2.3";
+    src = {
+      ghc8107 = haskell-nix.sources."hls-2.2";
+    }.${compiler-nix-name} or haskell-nix.sources."hls-2.3";
     cabalProject = builtins.readFile (src + "/cabal.project");
     sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };


### PR DESCRIPTION
Stick with GHC 8.10.7 until we have performance results for the GHC 9.6.3.  Keeps GHC 9.6.3 in CI as a variant.