### PR TITLE
cardano-node: use ouroboros-network-protocols-0.5.2

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -183,7 +183,7 @@ library
                       , ouroboros-network-api
                       , ouroboros-network ^>= 0.9.1
                       , ouroboros-network-framework
-                      , ouroboros-network-protocols
+                      , ouroboros-network-protocols < 0.5.3.0
                       , prettyprinter
                       , prettyprinter-ansi-terminal
                       , psqueues


### PR DESCRIPTION
# Description

`ouroboros-network-protocols-0.5.3.0` breaks the performance cluster; it needs
to be included with `ouroboros-network-0.10`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
