### PR TITLE
imp: nixos node svc topo moved to /etc to allow svc SIGHUP

### DIFF
--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -240,6 +240,7 @@ let
       systemd.services = mkOption {};
       assertions = [];
       users = mkOption {};
+      environment = mkOption {};
     };
   in pkgs.writeScript "run-${svcName}" ''
     #!${pkgs.runtimeShell}

--- a/nix/workbench/service/generator.nix
+++ b/nix/workbench/service/generator.nix
@@ -100,6 +100,7 @@ let
       systemd.sockets = mkOption {};
       users = mkOption {};
       assertions = mkOption {};
+      environment = mkOption {};
     };
     eval = let
       extra = {

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -164,6 +164,7 @@ let
       systemd.sockets = mkOption {};
       users = mkOption {};
       assertions = mkOption {};
+      environment = mkOption {};
     };
     eval = let
       extra = {

--- a/nix/workbench/service/tracer.nix
+++ b/nix/workbench/service/tracer.nix
@@ -41,6 +41,7 @@ let
         systemd.sockets = mkOption {};
         users = mkOption {};
         assertions = mkOption {};
+        environment = mkOption {};
       };
       eval =
         let


### PR DESCRIPTION
# Description
* Creates a `useSystemdReload` bool option for the cardano-node nixos service, which will move the topology file(s) to `/etc/cardano-node/topology-$i.yaml` where `$i` is the instance id, and inject reload hooks into  corresponding node instance systemd services which are configured for p2p.
* The option defaults to false for backward compatibility
* Moving topology files to /etc also allows for manual topology updates when a quick test is needed and full service re-deployment isn't desired

# Checklist
- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff