### PR TITLE
Add darwin.signingUtils

### DIFF
--- a/nix/set-git-rev.nix
+++ b/nix/set-git-rev.nix
@@ -1,11 +1,19 @@
 { pkgs }:
 drv:
-pkgs.buildPackages.runCommand drv.name
+with pkgs;
+buildPackages.runCommand drv.name
 {
   inherit (drv) exeName exePath meta passthru;
-} ''
+  # this is to ensure we are re-signing macOS binaries that might have been
+  # mutilated by set-git-rev (e.g. patching in the git revision.)
+  nativeBuildInputs = lib.optionals hostPlatform.isDarwin [ darwin.signingUtils ];
+} (''
   mkdir -p $out
   cp --no-preserve=timestamps --recursive ${drv}/* $out/
   chmod -R +w $out/bin
-  ${pkgs.pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev "${pkgs.gitrev}" $out/bin/*
-''
+  ${pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev "${gitrev}" $out/bin/*
+'' + lib.optionalString hostPlatform.isDarwin ''
+  for exe in $out/bin/*; do
+    signIfRequired "$exe"
+  done
+'')


### PR DESCRIPTION
Thanks to @KtorZ for noticing this.

on macOS:
```
$ nix build .#cardano-node -L
```
should produce `./result/bin/cardano-node`.

Prior to this change
```
$ codesign --verify ./result/bin/cardano-node 
./result/bin/cardano-node: invalid signature (code or signature have been modified)
```
after this change
```
$ codesign --verify ./result/bin/cardano-node -v
./result/bin/cardano-node: valid on disk
./result/bin/cardano-node: satisfies its Designated Requirement
```