### PR TITLE
Bump CHaP

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -73,7 +73,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api ^>= 8.33
+    , cardano-api ^>= 8.35
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        >=1.0.0

--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -109,7 +109,7 @@ metadataSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMeta
 metadataSize p m = dummyTxSize p m - dummyTxSize p Nothing
 
 dummyTxSizeInEra :: forall era . IsShelleyBasedEra era => TxMetadataInEra era -> Int
-dummyTxSizeInEra metadata = case createAndValidateTransactionBody (cardanoEra @era) dummyTx of
+dummyTxSizeInEra metadata = case createAndValidateTransactionBody (shelleyBasedEra @era) dummyTx of
   Right b -> BS.length $ serialiseToCBOR b
   Left err -> error $ "metaDataSize " ++ show err
  where

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -35,12 +35,11 @@ import qualified Data.Text as Text (unpack)
 import           Prelude
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (PlutusScriptOrReferenceInput (..),
-                   ProtocolParameters, ShelleyLedgerEra,
-                   convertToLedgerProtocolParameters, protocolParamMaxTxExUnits,
+import           Cardano.Api.Shelley (PlutusScriptOrReferenceInput (..), ProtocolParameters,
+                   ShelleyLedgerEra, convertToLedgerProtocolParameters, protocolParamMaxTxExUnits,
                    protocolParamPrices)
 
-import           Cardano.Logging hiding(LocalSocket)
+import           Cardano.Logging hiding (LocalSocket)
 
 import qualified Cardano.Ledger.Core as Ledger
 
@@ -504,7 +503,7 @@ makePlutusContext ScriptSpec{..} = do
     ScriptInAnyLang lang (PlutusScript version script') ->
       let
         scriptWitness :: ScriptWitness WitCtxTxIn era
-        scriptWitness = case scriptLanguageSupportedInEra (cardanoEra @era) lang of
+        scriptWitness = case scriptLanguageSupportedInEra (shelleyBasedEra @era) lang of
           Nothing -> error $ "runPlutusBenchmark: " ++ show version ++ " not supported in era: " ++ show (cardanoEra @era)
           Just scriptLang -> PlutusScriptWitness
                               scriptLang

--- a/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Genesis.hs
@@ -124,7 +124,7 @@ mkGenesisTransaction key ttl fee txins txouts
   = bimap
       ApiError
       (\b -> signShelleyTransaction (shelleyBasedEra @era) b [WitnessGenesisUTxOKey key])
-      (createAndValidateTransactionBody (cardanoEra @era) txBodyContent)
+      (createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
  where
   txBodyContent = defaultTxBodyContent (cardanoEra @era)
     & setTxIns (zip txins $ repeat $ BuildTxWith $ KeyWitness KeyWitnessForSpending)

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -169,7 +169,7 @@ genTx _era ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
   = bimap
       ApiError
       (\b -> (signShelleyTransaction (shelleyBasedEra @era) b $ map WitnessPaymentKey allKeys, getTxId b))
-      (createAndValidateTransactionBody (cardanoEra @era) txBodyContent)
+      (createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
  where
   allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
   txBodyContent = defaultTxBodyContent (cardanoEra @era)

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -132,16 +132,16 @@ data TxGenError where
   TxGenError      :: !String -> TxGenError
 
 instance Show TxGenError where
-  show (ApiError e) = prettyToString $ "ApiError " <> parens (prettyError e)
-  show (ProtocolError e) = prettyToString $ "ProtocolError " <> parens (prettyError e)
-  show (PlutusError e) = prettyToString $ "ProtocolError " <> parens (pshow e)
-  show (TxGenError e) = prettyToString $ "ApiError " <> parens (pshow e)
+  show (ApiError e) = docToString $ "ApiError " <> parens (prettyError e)
+  show (ProtocolError e) = docToString $ "ProtocolError " <> parens (prettyError e)
+  show (PlutusError e) = docToString $ "ProtocolError " <> parens (pshow e)
+  show (TxGenError e) = docToString $ "ApiError " <> parens (pshow e)
 
 instance Semigroup TxGenError where
   TxGenError a <> TxGenError b  = TxGenError (a <> b)
-  TxGenError a <> b             = TxGenError (a <> prettyToString (pshow b))
-  a            <> TxGenError b  = TxGenError (prettyToString (pshow a) <> b)
-  a            <> b             = TxGenError $ prettyToString (pshow a <> pshow b)
+  TxGenError a <> b             = TxGenError (a <> docToString (pshow b))
+  a            <> TxGenError b  = TxGenError (docToString (pshow a) <> b)
+  a            <> b             = TxGenError $ docToString (pshow a <> pshow b)
 
 instance Error TxGenError where
   prettyError = \case

--- a/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
@@ -58,7 +58,7 @@ mkUTxOScript networkId (script, txOutDatum) witness value
  where
   plutusScriptAddr = case script of
     ScriptInAnyLang lang script' ->
-      case scriptLanguageSupportedInEra (cardanoEra @era) lang of
+      case scriptLanguageSupportedInEra (shelleyBasedEra @era) lang of
         Nothing -> error "mkUtxOScript: scriptLanguageSupportedInEra==Nothing"
         Just{} -> makeShelleyAddressInEra
                        (shelleyBasedEra @era)

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -100,7 +100,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.35
                       , cardano-binary
-                      , cardano-cli ^>= 8.16
+                      , cardano-cli ^>= 8.16.0.1
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -98,9 +98,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.33
+                      , cardano-api ^>= 8.35
                       , cardano-binary
-                      , cardano-cli ^>= 8.15
+                      , cardano-cli ^>= 8.16
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-11-09T23:50:15Z
-  , cardano-haskell-packages 2023-11-17T22:33:04Z
+  , cardano-haskell-packages 2023-11-29T20:24:39Z
 
 packages:
   cardano-git-rev

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -117,7 +117,7 @@ run RunOpts
 
   p :: SomeConsensusProtocol <-
     case eitherSomeProtocol of
-      Left err -> putStrLn (prettyToString $ prettyError err) >> exitFailure
+      Left err -> putStrLn (docToString $ prettyError err) >> exitFailure
       Right p  -> pure p
 
   let (k , nId) = case p of

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -89,5 +89,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.16
+                      , cardano-cli:cardano-cli ^>= 8.16.0.1
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -89,5 +89,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.15
+                      , cardano-cli:cardano-cli ^>= 8.16
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -137,7 +137,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.33
+                      , cardano-api ^>= 8.35
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -42,7 +42,7 @@ import           "contra-tracer" Control.Tracer
 import           Data.Either (partitionEithers)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, mapMaybe, fromMaybe)
+import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Monoid (Last (..))
 import           Data.Proxy (Proxy (..))
 import           Data.Text (Text, breakOn, pack)
@@ -78,9 +78,8 @@ import           Cardano.Node.Configuration.Logging (LoggingLayer (..), createLo
                    nodeBasicInfo, shutdownLoggingLayer)
 import           Cardano.Node.Configuration.NodeAddress
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
-                   PartialNodeConfiguration (..), SomeNetworkP2PMode (..),
-                   defaultPartialNodeConfiguration, makeNodeConfiguration, parseNodeConfigurationFP,
-                   TimeoutOverride (..))
+                   PartialNodeConfiguration (..), SomeNetworkP2PMode (..), TimeoutOverride (..),
+                   defaultPartialNodeConfiguration, makeNodeConfiguration, parseNodeConfigurationFP)
 import           Cardano.Node.Startup
 import           Cardano.Node.Tracing.API
 import           Cardano.Node.Tracing.StateRep (NodeState (NodeKernelOnline))
@@ -104,9 +103,9 @@ import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), Co
                    PeerSelectionTargets (..), RemoteAddress)
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Subscription (DnsSubscriptionTarget (..),
                    IPSubscriptionTarget (..))
-import           Ouroboros.Network.Protocol.ChainSync.Codec
 
 import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                    gatherConfiguredSockets, getSocketOrSocketInfoAddr)
@@ -163,7 +162,7 @@ runNode cmdPc = do
 
     p :: SomeConsensusProtocol <-
       case eitherSomeProtocol of
-        Left err -> putStrLn (prettyToString (Api.prettyError err)) >> exitFailure
+        Left err -> putStrLn (docToString (Api.prettyError err)) >> exitFailure
         Right p  -> pure p
 
     let networkMagic :: Api.NetworkMagic =

--- a/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
+++ b/cardano-node/test/Test/Cardano/Node/FilePermissions.hs
@@ -69,7 +69,7 @@ createFileWithOwnerPermissions :: HasTextEnvelope a => File () Out -> a -> Prope
 createFileWithOwnerPermissions targetfp value = do
   result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions targetfp $ textEnvelopeToJSON Nothing value
   case result of
-    Left err -> failWith Nothing $ prettyToString $ prettyError @(FileError ()) err
+    Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
     Right () -> return ()
 
 #ifdef UNIX

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.33
+                      , cardano-api ^>= 8.35
                       , cardano-binary
-                      , cardano-cli ^>= 8.15
+                      , cardano-cli ^>= 8.16
                       , cardano-crypto-class ^>= 2.1.2
                       , cardano-ledger-byron ^>= 1.0
                       , formatting

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -41,7 +41,7 @@ library
                       , bytestring
                       , cardano-api ^>= 8.35
                       , cardano-binary
-                      , cardano-cli ^>= 8.16
+                      , cardano-cli ^>= 8.16.0.1
                       , cardano-crypto-class ^>= 2.1.2
                       , cardano-ledger-byron ^>= 1.0
                       , formatting

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -35,7 +35,7 @@ library
                       , ansi-terminal
                       , bytestring
                       , cardano-api ^>= 8.35
-                      , cardano-cli ^>= 8.16
+                      , cardano-cli ^>= 8.16.0.1
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,8 +34,8 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.33
-                      , cardano-cli ^>= 8.15
+                      , cardano-api ^>= 8.35
+                      , cardano-cli ^>= 8.16
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -157,7 +157,7 @@ getStartTime tempRootPath TestnetRuntime{configurationFile} = withFrozenCallStac
       partialNodeCfg <- ExceptT $ A.eitherDecodeFileStrict' file
       fmap ncProtocolConfig . liftEither . makeNodeConfiguration $ defaultPartialNodeConfiguration <> partialNodeCfg
     decodeGenesisFile :: FilePath -> ExceptT String IO G.Config
-    decodeGenesisFile fp = withExceptT (prettyToString . prettyError) $
+    decodeGenesisFile fp = withExceptT (docToString . prettyError) $
       Byron.readGenesis (GenesisFile fp) Nothing RequiresNoMagic
 
 readNodeLoggingFormat :: String -> Either String NodeLoggingFormat

--- a/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Util.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Util.hs
@@ -123,7 +123,7 @@ checkTextEnvelopeFormat tve reference created = GHC.withFrozenCallStack $ do
                       => Either (FileError TextEnvelopeError) TextEnvelope
                       -> m TextEnvelope
    handleTextEnvelope (Right refTextEnvelope) = return refTextEnvelope
-   handleTextEnvelope (Left fileErr) = failWithCustom GHC.callStack Nothing . prettyToString . prettyError $ fileErr
+   handleTextEnvelope (Left fileErr) = failWithCustom GHC.callStack Nothing . docToString . prettyError $ fileErr
 
    typeTitleEquivalence :: (MonadTest m, HasCallStack) => TextEnvelope -> TextEnvelope -> m ()
    typeTitleEquivalence (TextEnvelope refType refTitle _)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
@@ -22,15 +22,15 @@ prop_op_cert_valid_kes_period opCertFp output =
     case qKesOpCertIntervalInformation output of
       OpCertWithinInterval{} -> success
       info@OpCertStartingKesPeriodIsInTheFuture{} ->
-        failMessage GHC.callStack . prettyToString
+        failMessage GHC.callStack . docToString
           $ "Expected OpCertWithinInterval but got: OpCertStartingKesPeriodIsInTheFuture\n"
           <> renderOpCertIntervalInformation opCertFp info
       info@OpCertExpired{} ->
-        failMessage GHC.callStack . prettyToString
+        failMessage GHC.callStack . docToString
           $ "Expected OpCertWithinInterval but got: OpCertExpired\n"
           <> renderOpCertIntervalInformation opCertFp info
       info@OpCertSomeOtherError{} ->
-        failMessage GHC.callStack . prettyToString
+        failMessage GHC.callStack . docToString
           $ "Expected OpCertWithinInterval but got: OpCertSomeOtherError\n"
           <> renderOpCertIntervalInformation opCertFp info
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -100,7 +100,7 @@ hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' ->
 
   -- 2. Create Alonzo genesis
   alonzoBabbageTestGenesisJsonTargetFile <- H.noteShow $ tempAbsPath' </> shelleyDir </> "genesis.alonzo.spec.json"
-  gen <- H.evalEither $ first (prettyToString . prettyError) defaultAlonzoGenesis
+  gen <- H.evalEither $ first (docToString . prettyError) defaultAlonzoGenesis
   H.evalIO $ LBS.writeFile alonzoBabbageTestGenesisJsonTargetFile $ encode gen
 
   -- 2. Create Conway genesis

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1701253812,
-        "narHash": "sha256-Cm47K4OeinrufxdwlLkPOnDrghJ7cOLxJrtmAhvd2+c=",
+        "lastModified": 1701312600,
+        "narHash": "sha256-/MTnIoV1WrcrpQR6QGEWDpjWp64/HVzhd2C4mOCSiwQ=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "46639a56b5450baaa960a095967f4f47355e9a9c",
+        "rev": "d9eb29ea71f7df56251a3e0d7f5e336dae3f0ba9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1700478527,
-        "narHash": "sha256-SI3YRmzGhQoG6gcF8esEK8fYRRV5hDfMslPVZHyBduY=",
+        "lastModified": 1701253812,
+        "narHash": "sha256-Cm47K4OeinrufxdwlLkPOnDrghJ7cOLxJrtmAhvd2+c=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "d3f7b7ba387c14d23b88fea331bb393ea7079b1c",
+        "rev": "46639a56b5450baaa960a095967f4f47355e9a9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description
Bump CHaP index to include cardano-api-8.35.0.0 and cardano-cli-8.16.0.0

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
