### PR TITLE
Transaction submission test via `cardano-submit-api`

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -88,6 +88,7 @@ library
                         Testnet.Process.Cli
                         Testnet.Process.Run
                         Testnet.Runtime
+                        Testnet.SubmitApi
 
   other-modules:        Parsers.Cardano
                         Parsers.Help
@@ -168,11 +169,13 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Misc
                         Cardano.Testnet.Test.Node.LedgerEvents
                         Cardano.Testnet.Test.Node.Shutdown
+                        Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson
                       , async
+                      , base16-bytestring
                       , bytestring
                       , cardano-api
                       , cardano-cli
@@ -183,6 +186,8 @@ test-suite cardano-testnet-test
                       , filepath
                       , hedgehog
                       , hedgehog-extras
+                      , http-conduit
+                      , lens-aeson
                       , microlens
                       , process
                       , tasty

--- a/cardano-testnet/src/Testnet/SubmitApi.hs
+++ b/cardano-testnet/src/Testnet/SubmitApi.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- HLINT ignore "Redundant id" -}
+{- HLINT ignore "Redundant return" -}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Use let" -}
+{- HLINT ignore "Redundant <&>" -}
+
+module Testnet.SubmitApi
+  ( SubmitApiConf (..)
+  , withSubmitApi
+  ) where
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+
+import qualified Testnet.Process.Run as H
+
+import qualified Cardano.Testnet as H
+import           Data.Functor ((<&>))
+import           Hedgehog.Extras (Integration)
+import           Hedgehog.Extras.Stock (Sprocket (..))
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Test.Process as H
+import qualified System.IO as IO
+import qualified System.Process as IO
+
+data SubmitApiConf = SubmitApiConf
+  { tempAbsPath :: FilePath
+  , configPath :: FilePath
+  , epochSlots :: Int
+  , sprocket :: Sprocket
+  , testnetMagic :: Int
+  , port :: Int
+  } deriving (Eq, Show)
+
+withSubmitApi :: SubmitApiConf -> [String] -> Integration () -> Integration ()
+withSubmitApi
+    SubmitApiConf
+      { tempAbsPath
+      , configPath
+      , epochSlots
+      , sprocket
+      , testnetMagic
+      , port
+      } args f = do
+  let logDir = makeLogDir $ TmpAbsolutePath tempAbsPath
+      tempBaseAbsPath = H.makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath
+
+  nodeStdoutFile <- H.noteTempFile logDir "submit-api.stdout.log"
+  nodeStderrFile <- H.noteTempFile logDir "submit-api.stderr.log"
+
+  hNodeStdout <- H.evalIO $ IO.openFile nodeStdoutFile IO.WriteMode
+  hNodeStderr <- H.evalIO $ IO.openFile nodeStderrFile IO.WriteMode
+
+  (_, _, _, hProcess, _) <- H.createProcess =<<
+    ( H.procSubmitApi
+      ( [ "--config", configPath
+        , "--cardano-mode"
+        , "--epoch-slots", show @Int epochSlots
+        , "--socket-path", IO.sprocketArgumentName sprocket
+        , "--testnet-magic", show @Int testnetMagic
+        , "--port", show @Int port
+        ]
+        <> args
+      ) <&>
+      ( \cp -> cp
+        { IO.std_in = IO.CreatePipe
+        , IO.std_out = IO.UseHandle hNodeStdout
+        , IO.std_err = IO.UseHandle hNodeStderr
+        , IO.cwd = Just tempBaseAbsPath
+        }
+      )
+    )
+
+  H.onFailure $ H.evalIO $ IO.terminateProcess hProcess
+
+  H.noteShow_ =<< H.getPid hProcess
+
+  f
+
+  H.evalIO $ IO.terminateProcess hProcess

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- HLINT ignore "Redundant id" -}
+{- HLINT ignore "Redundant return" -}
+{- HLINT ignore "Use head" -}
+{- HLINT ignore "Use let" -}
+{- HLINT ignore "Functor law" -}
+
+module Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
+  ( hprop_transaction
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad (void)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           System.FilePath ((</>))
+import qualified System.Info as SYS
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+
+import qualified Cardano.Api.Ledger.Lens as A
+import qualified Data.Map as Map
+import           Network.HTTP.Simple
+import           Testnet.Components.SPO
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
+import qualified Cardano.Api.Ledger as L
+import qualified Data.Aeson.Lens as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.List as List
+import qualified Hedgehog.Extras as H
+import           Lens.Micro
+import           Testnet.SubmitApi
+
+hprop_transaction :: Property
+hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transaction" $ \tempAbsBasePath' -> do
+  H.note_ SYS.os
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let
+    sbe = ShelleyBasedEraBabbage
+    era = toCardanoEra sbe
+    tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
+    options = cardanoDefaultTestnetOptions
+      { cardanoNodes = cardanoDefaultTestnetNodeOptions
+      , cardanoSlotLength = 0.1
+      , cardanoNodeEra = AnyCardanoEra era -- TODO: We should only support the latest era and the upcoming era
+      }
+
+  TestnetRuntime
+    { configurationFile
+    , testnetMagic
+    , poolNodes
+    , wallets
+    } <- cardanoTestnet options conf
+
+  poolNode1 <- H.headM poolNodes
+
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+
+  void $ procSubmitApi
+    [ "--config", configurationFile
+    , "--testnet-magic", show @Int testnetMagic
+    , "--socket-path", "FILEPATH"
+    ]
+
+  txbodyFp <- H.note $ work </> "tx.body"
+  txbodySignedFp <- H.note $ work </> "tx.body.signed"
+  txbodySignedBinFp <- H.note $ work </> "tx.body.signed.bin"
+
+  void $ execCli' execConfig
+    [ "babbage", "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+    , "--cardano-mode"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--out-file", work </> "utxo-1.json"
+    ]
+
+  utxo1Json <- H.leftFailM . H.readJsonFile $ work </> "utxo-1.json"
+  UTxO utxo1 <- H.noteShowM $ H.noteShowM $ decodeEraUTxO sbe utxo1Json
+  txin1 <- H.noteShow =<< H.headM (Map.keys utxo1)
+
+  void $ execCli' execConfig
+    [ "babbage", "transaction", "build"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+    , "--tx-in", Text.unpack $ renderTxIn txin1
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr (head wallets)) <> "+" <> show @Int 5_000_001
+    , "--out-file", txbodyFp
+    ]
+
+  void $ execCli' execConfig
+    [ "babbage", "transaction", "sign"
+    , "--testnet-magic", show @Int testnetMagic
+    , "--tx-body-file", txbodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 0
+    , "--out-file", txbodySignedFp
+    ]
+
+  let submitApiConf = SubmitApiConf
+        { tempAbsPath = unTmpAbsPath tempAbsPath
+        , configPath = configurationFile
+        , epochSlots = 2
+        , sprocket = poolSprocket1
+        , port = 8090
+        , testnetMagic
+        }
+
+  withSubmitApi submitApiConf [] $ do
+    H.threadDelay 1_000_000
+
+    txBodySigned <- H.leftFailM $ H.readJsonFile txbodySignedFp
+
+    cborHex <- H.nothingFail $ txBodySigned ^? Aeson.key "cborHex" . Aeson._String
+
+    let txBs = Base16.decodeLenient (Text.encodeUtf8 cborHex)
+
+    H.evalIO $ BS.writeFile txbodySignedBinFp txBs
+
+    request <- H.evalM $ parseRequest "POST http://localhost:8090/api/submit/tx"
+      <&> setRequestBodyFile txbodySignedBinFp
+      <&> setRequestHeader "Content-Type" ["application/cbor"]
+
+    response <- H.evalM $ httpLbs request
+
+    getResponseStatusCode response === 202
+
+  H.byDurationM 1 10 "Expected UTxO found" $ do
+    void $ execCli' execConfig
+      [ "babbage", "query", "utxo"
+      , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+      , "--cardano-mode"
+      , "--testnet-magic", show @Int testnetMagic
+      , "--out-file", work </> "utxo-2.json"
+      ]
+
+    utxo2Json <- H.leftFailM . H.readJsonFile $ work </> "utxo-2.json"
+    UTxO utxo2 <- H.noteShowM $ H.noteShowM $ decodeEraUTxO sbe utxo2Json
+    txouts2 <- H.noteShow $ L.unCoin . txOutValueLovelace . txOutValue . snd <$> Map.toList utxo2
+
+    H.assert $ 5_000_001 `List.elem` txouts2
+
+txOutValue :: TxOut ctx era -> TxOutValue era
+txOutValue (TxOut _ v _ _) = v
+
+txOutValueLovelace ::TxOutValue era -> L.Coin
+txOutValueLovelace = \case
+  TxOutValueShelleyBased sbe v -> v ^. A.adaAssetL sbe
+  TxOutValueByron (Lovelace v) -> L.Coin v

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -130,7 +130,7 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
         }
 
   withSubmitApi submitApiConf [] $ \uriBase -> do
-    H.threadDelay 1_000_000
+    H.threadDelay 5_000_000
 
     txBodySigned <- H.leftFailM $ H.readJsonFile txbodySignedFp
 

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -13,6 +13,7 @@ import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
 import qualified Cardano.Testnet.Test.Node.LedgerEvents
 import qualified Cardano.Testnet.Test.Node.Shutdown
+import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 
 import           Prelude
 
@@ -28,28 +29,35 @@ import qualified Testnet.Property.Run as H
 tests :: IO TestTree
 tests = pure $ T.testGroup "test/Spec.hs"
   [ T.testGroup "Spec"
-    [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
-    , H.ignoreOnWindows "LedgerEvents" Cardano.Testnet.Test.Node.LedgerEvents.hprop_ledger_events_sanity_check
-    , H.ignoreOnWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
-    -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
-    -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
-    , T.testGroup "Babbage"
-        -- TODO: Babbage --next leadership schedule still fails. Once this fix is propagated to the cli (https://github.com/input-output-hk/cardano-api/pull/274)
-        -- this should remedy. Double check and make sure we have re-enabled it and remove this comment.
-        [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
-        , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
-        , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
+      [ T.testGroup "CLI"
+        [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
+        , H.ignoreOnWindows "LedgerEvents" Cardano.Testnet.Test.Node.LedgerEvents.hprop_ledger_events_sanity_check
+        , H.ignoreOnWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
+        -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
+        -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
+        , T.testGroup "Babbage"
+            -- TODO: Babbage --next leadership schedule still fails. Once this fix is propagated to the cli (https://github.com/input-output-hk/cardano-api/pull/274)
+            -- this should remedy. Double check and make sure we have re-enabled it and remove this comment.
+            [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
+            , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
+            , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
+            ]
+        -- TODO: Conway -  Re-enable when create-staked is working in conway again
+        --, T.testGroup "Conway"
+        --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
+        --  ]
+          -- Ignored on Windows due to <stdout>: cosmmitBuffer: invalid argument (invalid character)
+          -- as a result of the kes-period-info output to stdout.
+        , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
+        , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
+        , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
         ]
-    -- TODO: Conway -  Re-enable when create-staked is working in conway again
-    --, T.testGroup "Conway"
-    --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
-    --  ]
-      -- Ignored on Windows due to <stdout>: cosmmitBuffer: invalid argument (invalid character)
-      -- as a result of the kes-period-info output to stdout.
-    , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
-    , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
-    , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
-    ]
+      ]
+  , T.testGroup "SubmitApi"
+      [ T.testGroup "Babbage"
+          [ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
+          ]
+      ]
   ]
 
 ingredients :: [T.Ingredient]

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -176,6 +176,8 @@ let
             let
               exportCliPath = "export CARDANO_CLI=${config.hsPkgs.cardano-cli.components.exes.cardano-cli}/bin/cardano-cli${pkgs.stdenv.hostPlatform.extensions.executable}";
               exportNodePath = "export CARDANO_NODE=${config.hsPkgs.cardano-node.components.exes.cardano-node}/bin/cardano-node${pkgs.stdenv.hostPlatform.extensions.executable}";
+              exportSubmitApiPath = "export CARDANO_SUBMIT_API=${config.hsPkgs.cardano-submit-api.components.exes.cardano-submit-api}/bin/cardano-submit-api${pkgs.stdenv.hostPlatform.extensions.executable}";
+              exportChairmanPath = "export CARDANO_NODE_CHAIRMAN=${config.hsPkgs.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman${pkgs.stdenv.hostPlatform.extensions.executable}";
               mainnetConfigFiles = [
                 "configuration/cardano/mainnet-config.yaml"
                 "configuration/cardano/mainnet-config.json"
@@ -216,7 +218,8 @@ let
                 ''
                   ${exportCliPath}
                   ${exportNodePath}
-                  export CARDANO_NODE_CHAIRMAN=${config.hsPkgs.cardano-node-chairman.components.exes.cardano-node-chairman}/bin/cardano-node-chairman${pkgs.stdenv.hostPlatform.extensions.executable}
+                  ${exportSubmitApiPath}
+                  ${exportChairmanPath}
                   export CARDANO_NODE_SRC=${filteredProjectBase}
                 '';
               # cardano-testnet depends on cardano-node, cardano-cli, cardano-submit-api and some config files

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -169,6 +169,7 @@ let
             # add shell completion:
             packages.cardano-node.components.exes.cardano-node.postInstall = postInstall "cardano-node";
             packages.cardano-cli.components.exes.cardano-cli.postInstall = postInstall "cardano-cli";
+            packages.cardano-submit-api.components.exes.cardano-submit-api.postInstall = postInstall "cardano-submit-api";
             packages.cardano-topology.components.exes.cardano-topology.postInstall = postInstall "cardano-topology";
             packages.locli.components.exes.locli.postInstall = postInstall "locli";
           })
@@ -218,7 +219,6 @@ let
                 ''
                   ${exportCliPath}
                   ${exportNodePath}
-                  ${exportSubmitApiPath}
                   ${exportChairmanPath}
                   export CARDANO_NODE_SRC=${filteredProjectBase}
                 '';
@@ -244,7 +244,7 @@ let
                 ''
                   ${exportCliPath}
                   ${exportNodePath}
-                  export CARDANO_SUBMIT_API=${config.hsPkgs.cardano-submit-api.components.exes.cardano-submit-api}/bin/cardano-submit-api${pkgs.stdenv.hostPlatform.extensions.executable}
+                  ${exportSubmitApiPath}
                   export CARDANO_NODE_SRC=${filteredProjectBase}
                 ''
                 # the cardano-testnet-tests, use sockets stored in a temporary directory


### PR DESCRIPTION
# Description

This adds transaction submission test that is done via `cardano-submit-api`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
